### PR TITLE
test(console): run the browser suite, and give the console a unit runner (#428, #434)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,26 @@ jobs:
       - name: Test
         run: cargo test --locked
 
+      # Issue #428. The `Console E2E` job drives a REAL host, so it needs a
+      # binary. Building one over there would mean a second submodule checkout
+      # and a second cold Rust compile — minutes of wall clock to produce a
+      # thing this job has already very nearly built. `cargo test` above
+      # compiled the same graph, so this step is a link and little else.
+      #
+      # The artifact, not a job-level cache: a cache is keyed on inputs and may
+      # legitimately miss, and a missing binary here has to be a hard failure
+      # rather than a silent rebuild somewhere it does not belong.
+      - name: Build the host binary for the e2e lane
+        run: cargo build --locked --bin opencompany
+
+      - name: Upload the host binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: opencompany-debug-binary
+          path: target/debug/opencompany
+          # Consumed minutes later by one job in the same run and never again.
+          retention-days: 1
+
   # Issue #202. The `Rust` job above builds DEFAULT FEATURES ONLY, so every line
   # behind `openhuman` (`src/harness/**`, `src/workflows/**`, `src/runtime/`
   # `delegation*`, and the `live_company_turn` example) and every line behind
@@ -271,9 +291,29 @@ jobs:
       # `typecheck:e2e` covers `frontend/test/e2e/` and `playwright.config.ts`,
       # which `tsc -b` does NOT reach — `tsconfig.app.json` is `include: ["src"]`
       # — so before this the Playwright specs were compiled by nothing at all.
-      # See the header of `frontend/tsconfig.e2e.json`. This does NOT run the
-      # suite: that needs a live host and is still out of CI, per #281.
+      # See the header of `frontend/tsconfig.e2e.json`. It still does not RUN
+      # the suite; the `Console E2E` job below does that now (issue #428).
       - run: npm run typecheck:e2e
+        working-directory: frontend
+
+      # Issue #434. Same argument one directory over: `tsconfig.app.json` and
+      # `tsconfig.e2e.json` between them reach `src` and `test/e2e`, and nothing
+      # reached `test/unit`. Vitest strips types rather than checking them, so
+      # without this step a unit test could call a helper with the wrong arity
+      # and go green by coincidence — a test that cannot fail correctly is worse
+      # than no test, because it reports coverage.
+      - run: npm run typecheck:unit
+        working-directory: frontend
+
+      # The unit suite itself (issue #434). Sub-second, so it costs this job
+      # nothing and there is never a reason to reach for `--no-verify` around
+      # it. `npm test` is `vitest run`, NOT bare `vitest` — the bare form is a
+      # WATCHER and would hang the runner until the job timeout.
+      #
+      # This is the first step in CI that can prove a console function returns
+      # the right answer. `typecheck` and `build` prove the code compiles; a
+      # helper that maps A to the wrong B compiles perfectly.
+      - run: npm test
         working-directory: frontend
 
       # `build` runs `tsc -b` again but then invokes Vite, which additionally
@@ -285,3 +325,91 @@ jobs:
 
       # No lint step: the package declares no lint script. Adding one is a
       # separate decision, not something to smuggle in here.
+
+  # Issue #428. The Playwright suite was type-checked by the `Console` job above
+  # and executed by NOTHING, which is a worse blind spot than having no suite at
+  # all: seventy passing specs that nobody runs look exactly like coverage.
+  #
+  # What that cost, concretely. `workflow-edit-delete.spec.ts` referenced a
+  # fixture that was never committed, so two of its eight tests had never passed
+  # in any environment since the day they merged. Two more specs were found red
+  # on this branch — one asserting an approval confirmation whose wording #395
+  # deliberately changed, one seeding a tour-resume marker whose value moved when
+  # Connections became a page of Settings. Both had been red for weeks, and one
+  # had been filed as a product bug that does not exist. Nothing reported any of
+  # it, because nothing ran it.
+  #
+  # A SEPARATE JOB, not steps on `Console`: that job is deliberately Node-only —
+  # no submodules, no Rust toolchain, no browser — and runs in parallel with the
+  # Rust jobs precisely because it shares no setup with them. This lane needs a
+  # built host and a browser, so folding it in would slow the fast console gate
+  # to the speed of the slowest thing in the repo.
+  #
+  # `needs: rust` for the binary, and that is the ONLY reason. The host is the
+  # default feature set, which is all this suite needs — the harness company
+  # boots on the offline echo brain. Four specs that need more than that skip
+  # themselves through `test/e2e/capabilities.ts`, each naming issue #467.
+  console-e2e:
+    name: Console E2E
+    runs-on: ubuntu-latest
+    needs: rust
+    # The suite is ~5 minutes locally against a warm host. The cap is here so a
+    # wedged browser or a host that never binds fails in a quarter hour rather
+    # than burning the runner's six-hour default.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          # No `submodules`, deliberately. The binary arrives prebuilt from the
+          # `rust` job and nothing here resolves a cargo manifest, so the large
+          # `vendor/openhuman` checkout would be pure cost.
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      # `npm ci`, not `npm install` — same lockfile-fidelity argument as the
+      # `Console` job above.
+      - run: npm ci
+        working-directory: frontend
+
+      - name: Download the host binary
+        uses: actions/download-artifact@v4
+        with:
+          name: opencompany-debug-binary
+          path: target/debug
+
+      # `upload-artifact` does not preserve the executable bit, so the binary
+      # arrives as a plain file. `test/e2e/host.sh` tests for `-x` and exits
+      # with a build instruction, which would be a confusing way to learn this.
+      - name: Restore the executable bit
+        run: chmod +x target/debug/opencompany
+
+      # `--with-deps` installs the system libraries headless Chromium needs;
+      # the runner image ships neither. Chromium only: the suite pins no other
+      # engine, and installing three would triple this step for nothing.
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: frontend
+
+      # `playwright.config.ts` brings the host up itself when `PW_BASE_URL` is
+      # unset (issue #406) — building the console bundle, wiping an isolated
+      # data root under `target/e2e/`, and signing in against the harness
+      # company. So this is the whole command.
+      - name: Run the end-to-end suite
+        run: npm run e2e
+        working-directory: frontend
+
+      # A failed browser run is close to undiagnosable from a log alone. The
+      # config captures a screenshot on failure and a trace on first retry;
+      # this is what makes them reachable from the run summary.
+      - name: Upload failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-failures
+          path: frontend/test-results/
+          retention-days: 7

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -101,19 +101,50 @@ Everything is decoupled so you can embed parts elsewhere:
 ## Build
 
 ```sh
-npm run build         # tsc typecheck + vite bundle -> dist/
-npm run preview       # serve the production build
-npm run typecheck     # tsc only, over src/
-npm run typecheck:e2e # tsc only, over test/ + playwright.config.ts
+npm run build          # tsc typecheck + vite bundle -> dist/
+npm run preview        # serve the production build
+npm run typecheck      # tsc only, over src/
+npm run typecheck:e2e  # tsc only, over test/e2e/ + playwright.config.ts
+npm run typecheck:unit # tsc only, over test/unit/ + vitest.config.ts
 ```
 
-CI runs `npm ci` and all three of `typecheck`, `typecheck:e2e` and `build` in
-the `Console` job of `.github/workflows/ci.yml`.
+CI runs `npm ci`, then `typecheck`, `typecheck:e2e`, `typecheck:unit`, `test`
+and `build`, in the `Console` job of `.github/workflows/ci.yml`.
 
 `typecheck` covers `src/` and nothing else — `tsconfig.app.json` is
-`include: ["src"]`. The end-to-end suite is a separate TypeScript project
-([`tsconfig.e2e.json`](tsconfig.e2e.json)) with its own script, so a broken spec
-fails on its own rather than blocking `npm run build`.
+`include: ["src"]`. Each test suite is a separate TypeScript project with its
+own script ([`tsconfig.e2e.json`](tsconfig.e2e.json),
+[`tsconfig.unit.json`](tsconfig.unit.json)), so a broken test fails on its own
+rather than blocking `npm run build`.
+
+## Unit suite
+
+```sh
+npm test              # vitest, once — this is what CI runs
+npm run test:watch    # re-runs on change while you work
+```
+
+Pure functions only, under [`test/unit/`](test/unit). The whole suite is
+sub-second, so it runs on every push and there is never a reason to skip it.
+
+**What belongs here versus in the browser suite.** This runner is for a helper
+that maps A to B with no document, no host and no React — id reconciliation,
+channel-id derivation and the legacy-URL shim, link precedence on a card,
+timeline folding, anything that truncates or folds a value. The end-to-end suite
+below is for what is only true in a browser driving a live host: a disabled
+affordance explaining itself, a banner that must not be a toast, a redirect that
+survives a full-page navigation.
+
+The line matters because each is tempted into the other's territory. A browser
+walk *can* reach a pure helper — through six layers of render, in forty seconds,
+reporting the failure as "the board looked wrong". A unit test cannot reach a
+redirect at all. Put a helper here the moment it has a second caller or a branch
+worth naming.
+
+A test earns its place by being **seen failing** against the behaviour it
+guards. Every test in `test/unit/` was proven red by breaking its subject before
+it was trusted — a test that passes while asserting nothing is worse than no
+test, because it reports coverage.
 
 ## End-to-end suite
 
@@ -137,25 +168,40 @@ Set `PW_BASE_URL` to drive a host you brought up yourself and the config stays
 out of the way entirely: no `webServer`, and `PW_STORAGE_STATE` decides whether
 the suite signs in.
 
-**CI type-checks these specs and runs none of them** (`typecheck:e2e` is all the
-automated coverage `test/e2e/` gets). Type-checking proves a spec compiles, not
-that it holds: `workflow-edit-delete.spec.ts` spent months red against a fixture
-that was never committed, and nothing reported it. Run the suite before touching
-a view it covers.
+**CI runs this suite** in the `Console E2E` job, against a default-feature host
+built by the `Rust` job and passed across as an artifact (issue #428). It did
+not always: for a long time `typecheck:e2e` was the only automated coverage
+`test/e2e/` had, and type-checking proves a spec compiles, not that it holds.
+`workflow-edit-delete.spec.ts` spent months red against a fixture that was never
+committed; two further specs were found red against product changes that had
+been deliberate, one of which had been filed as a bug that did not exist.
+Nothing reported any of it, because nothing ran it.
+
+Run the suite before touching a view it covers — CI is a backstop, not a
+substitute for seeing your own change work.
 
 ### What a default-feature host cannot cover
 
 The host `test/e2e/host.sh` starts is the default feature set, which boots the
 offline echo brain. That is enough for the great majority of the suite, but four
 specs need an agent that actually executes — a build with the `openhuman`
-harness and a mocked inference backend — and one needs an external MCP server:
+harness and a mocked inference backend — and one needs an external MCP server.
 
-| Spec | Needs |
-|------|-------|
-| `wiring.spec.ts` | the harness + a mock LLM backend echoing `__MOCK_LLM__` |
-| `chat-to-card.spec.ts` (card chip) | an orchestrator that opens a card |
-| `workflow-run-history.spec.ts` (durable history) | a workflow run that executes |
-| `mcp.spec.ts` | `PW_MCP_SERVER` pointing at a live MCP server |
+These **skip themselves** rather than failing, through
+[`test/e2e/capabilities.ts`](test/e2e/capabilities.ts), so the CI lane is
+meaningfully green instead of permanently red. Every skip names issue #467,
+which tracks standing up the feature-gated lane that runs them for real:
+
+| Spec | Needs | Gate |
+|------|-------|------|
+| `wiring.spec.ts` | the harness + a mock LLM backend echoing `__MOCK_LLM__` | `PW_LIVE_BRAIN=1` |
+| `chat-to-card.spec.ts` (card chip) | an orchestrator that opens a card | `PW_LIVE_BRAIN=1` |
+| `workflow-run-history.spec.ts` (durable history) | a workflow run that executes | `PW_LIVE_BRAIN=1` |
+| `mcp.spec.ts` | `PW_MCP_SERVER` pointing at a live MCP server | `PW_MCP_SERVER` |
+
+A skip is a debt, not a resolution. Four of the suite's most valuable specs sit
+behind that flag, and while they do, the lane proves the console renders rather
+than that the company works.
 
 Point `PW_HOST_BINARY` at a feature-gated build, or `PW_BASE_URL` at a host you
 brought up yourself, to cover those.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -37,9 +37,66 @@
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
+        "jsdom": "^27.0.1",
         "typescript": "^5.6.3",
-        "vite": "^5.4.11"
+        "vite": "^5.4.11",
+        "vitest": "^3.2.7"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -545,6 +602,146 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.10.tgz",
+      "integrity": "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.7.tgz",
+      "integrity": "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -2069,6 +2266,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -2180,6 +2388,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.9",
@@ -2301,6 +2516,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.11.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.11.2.tgz",
@@ -2354,6 +2684,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2413,6 +2753,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -2463,6 +2813,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/body-parser": {
@@ -2583,6 +2943,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2651,6 +3021,23 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -2701,6 +3088,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/class-variance-authority": {
@@ -2965,6 +3362,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2975,6 +3386,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -3193,6 +3630,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debounce-fn": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/debounce-fn/-/debounce-fn-4.0.0.tgz",
@@ -3225,6 +3686,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3256,6 +3724,16 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deepmerge": {
@@ -3450,6 +3928,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/env-paths": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
@@ -3485,6 +3976,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -3596,6 +4094,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3656,6 +4164,16 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4099,6 +4617,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-url-attributes": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
@@ -4127,6 +4658,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -4392,6 +4951,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -4502,6 +5068,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4885,6 +5491,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5200,6 +5813,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -6223,6 +6843,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -6264,6 +6897,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -6460,6 +7110,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -6908,6 +7568,13 @@
         "node": ">= 18"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -6948,6 +7615,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -7169,6 +7849,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7225,6 +7912,13 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -7233,6 +7927,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -7366,6 +8067,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/style-to-js": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
@@ -7383,6 +8104,13 @@
       "dependencies": {
         "inline-style-parser": "0.2.7"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/systeminformation": {
       "version": "5.31.17",
@@ -7445,6 +8173,87 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.10.tgz",
+      "integrity": "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.10"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.10",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.10.tgz",
+      "integrity": "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7464,6 +8273,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/trim-lines": {
@@ -7887,6 +8722,176 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
@@ -7902,11 +8907,50 @@
         "node": "^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
@@ -7923,6 +8967,23 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview",
     "typecheck": "tsc -b --noEmit",
     "typecheck:e2e": "tsc -p tsconfig.e2e.json",
+    "typecheck:unit": "tsc -p tsconfig.unit.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "e2e": "playwright test",
     "e2e:headed": "playwright test --headed"
   },
@@ -43,7 +46,9 @@
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "jsdom": "^27.0.1",
     "typescript": "^5.6.3",
-    "vite": "^5.4.11"
+    "vite": "^5.4.11",
+    "vitest": "^3.2.7"
   }
 }

--- a/frontend/test/e2e/capabilities.ts
+++ b/frontend/test/e2e/capabilities.ts
@@ -1,0 +1,50 @@
+/**
+ * What the host under test can actually do, so a spec that needs more than the
+ * default build can say so instead of failing (issue #428).
+ *
+ * # Why these are opt-in variables and not a probe of the host
+ *
+ * A probe would be better, and there is very nearly one: `GET /tiny` reports
+ * the vendored runtime modules. It cannot be used for this. `openhuman` is
+ * reported as `enabled: true` unconditionally — the field describes the
+ * vendored *checkout*, not the `openhuman` cargo feature — so a default build
+ * answers exactly like a feature-gated one. A probe that cannot distinguish the
+ * two would skip nothing, or skip everything, and would look authoritative
+ * while doing it.
+ *
+ * So the caller declares what it brought. That is honest about where the
+ * knowledge lives: whoever built the binary and started the inference backend
+ * is the only party that knows.
+ *
+ * # These skips are not permission to leave the specs unrun
+ *
+ * Four of the suite's best specs sit behind `LIVE_BRAIN`, and they are the ones
+ * that exercise the product rather than the console's own rendering. Skipping
+ * them buys a default-feature lane that is meaningfully green — a real gate,
+ * today — and nothing more. Issue #467 tracks standing the feature-gated lane
+ * up so they run for real; every skip below names it.
+ */
+
+/**
+ * A host built with `--features openhuman,tinycortex` **and** an inference
+ * backend behind it — either the mock that echoes `__MOCK_LLM__` or one whose
+ * tool choices are scripted (`SPAWNONE`).
+ *
+ * Set `PW_LIVE_BRAIN=1` when both are true. Without them the agent harness is
+ * not compiled in at all, so a sent message is answered by nothing, a workflow
+ * node with no inference source never runs, and no orchestrator exists to open
+ * a card.
+ */
+export const LIVE_BRAIN = process.env.PW_LIVE_BRAIN === "1";
+
+/**
+ * A path to the simple MCP server script the MCP spec installs and calls.
+ * Consumed directly by that spec; re-exported here so every capability the
+ * suite has is visible in one file.
+ */
+export const MCP_SERVER = process.env.PW_MCP_SERVER;
+
+/** The reason string a `LIVE_BRAIN` skip carries, so no skip is ever bare. */
+export const LIVE_BRAIN_REASON =
+  "needs a --features openhuman,tinycortex host plus an inference backend; " +
+  "set PW_LIVE_BRAIN=1 to run. Tracked by issue #467.";

--- a/frontend/test/e2e/chat-approval-line.spec.ts
+++ b/frontend/test/e2e/chat-approval-line.spec.ts
@@ -31,6 +31,19 @@ const PARKED = [
     amount_usd: 42.5,
     at_millis: Date.now(),
     task: { link: "unlinked" },
+    // Present, and load-bearing since #395: `agent` is what makes this a
+    // blocked *harness tool call* rather than a native effect the runtime
+    // performs itself, and the console now words the confirmation differently
+    // for the two — "the agent is completing the action" only when there is an
+    // agent, "carrying it out now" when there is not.
+    //
+    // The fixture omitted it and so exercised the no-agent arm while the
+    // assertion below still named the agent one, which is why this spec went
+    // red: a deliberate copy change in #395, not a regression. A blocked tool
+    // call is also the representative case for this spec — it is the shape that
+    // actually parks in a channel — so naming the agent is the fixture getting
+    // more honest, not the assertion getting weaker.
+    agent: "ada",
   },
 ];
 

--- a/frontend/test/e2e/chat-to-card.spec.ts
+++ b/frontend/test/e2e/chat-to-card.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
 /**
  * End-to-end proof for the chat↔card edge (issue #246).
  *
@@ -83,6 +85,11 @@ test("any message on a desk thread can be added to the board", async ({ page }) 
 test("a card the orchestrator opens is chipped in chat, and survives a reload", async ({
   page,
 }) => {
+  // Only THIS test needs the scripted backend — the one above it drives the
+  // console's own "Add to board" action and passes against a default host, so
+  // the skip is per-test rather than per-file.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
   await openThread(page, /Your company/);
 
   // `SPAWNONE` is the scripted backend's cue to call `spawn_task` once.

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -1,9 +1,19 @@
 import { expect, test } from "@playwright/test";
 
+import { MCP_SERVER } from "./capabilities";
+
+// The spec self-declared this requirement and then asserted it, which turned a
+// missing fixture into a red suite rather than an absent capability. Skipping
+// is the honest report: nothing is wrong, the server was not supplied.
+test.skip(
+  !MCP_SERVER,
+  "needs PW_MCP_SERVER pointing at the simple MCP server. Tracked by issue #467.",
+);
+
 test("operator installs and calls an MCP server from the console and an agent", async ({
   page,
 }) => {
-  const serverScript = process.env.PW_MCP_SERVER;
+  const serverScript = MCP_SERVER;
   expect(
     serverScript,
     "PW_MCP_SERVER must point at the simple MCP server",

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -79,11 +79,22 @@ test("the tour resumes on the Connections stop after a redirect", async ({ page 
   // Seed exactly what `armTourResume` writes just before ConnectionsView hands
   // the browser to the provider: mid-tour, on the Connections stop, no
   // completed/skipped flag (the tour never finished).
+  //
+  // `"settings"`, NOT `"connections"`. The marker stores the stop's `view`
+  // (`TourController`'s `before` hook publishes `stop.view` through
+  // `setActiveTourStop`), and Connections became a *page of the Settings
+  // section* — the stop is `{ view: "settings", sub: "connections" }`. This
+  // spec seeded the pre-move value, which no `TOUR` stop matches, so the
+  // controller's `findIndex` returned -1 and the resume was correctly skipped.
+  // The spec had gone stale against a deliberate product change; it was not
+  // catching a resume bug. See the unit suite's `tour-resume.test.ts`, which
+  // pins the stop-view ⇄ marker coupling directly so this cannot rot again
+  // without a fast test saying so.
   await page.evaluate(
     ([k]) =>
       window.localStorage.setItem(
         k,
-        JSON.stringify({ pendingResume: { view: "connections", at: Date.now() } }),
+        JSON.stringify({ pendingResume: { view: "settings", at: Date.now() } }),
       ),
     [key],
   );
@@ -109,13 +120,20 @@ test("a stale resume marker does not hijack a later visit", async ({ page }) => 
   const key = await tourKey(page);
 
   // Older than the 15-minute TTL.
+  //
+  // `"settings"` for the same reason as above, and here it is what gives the
+  // test any force at all: seeded with the stale `"connections"` this passed
+  // whether or not the TTL was honoured, because no stop matches that view and
+  // the tour would not have resumed either way. It asserted nothing. With a
+  // view that *would* resume, the age is the only thing standing between this
+  // marker and a hijacked visit — which is the property the test names.
   await page.evaluate(
     ([k]) =>
       window.localStorage.setItem(
         k,
         JSON.stringify({
           skipped: true,
-          pendingResume: { view: "connections", at: Date.now() - 60 * 60 * 1000 },
+          pendingResume: { view: "settings", at: Date.now() - 60 * 60 * 1000 },
         }),
       ),
     [key],

--- a/frontend/test/e2e/wiring.spec.ts
+++ b/frontend/test/e2e/wiring.spec.ts
@@ -1,5 +1,11 @@
 import { expect, test } from "@playwright/test";
 
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
+// File-level: this spec exists only to prove the mocked-backend chain, so there
+// is nothing in it that a default-feature host can answer.
+test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
 /**
  * End-to-end wiring proof for the operator console.
  *
@@ -16,6 +22,22 @@ import { expect, test } from "@playwright/test";
  * The admin address must match `companies/e2e_harness/company.toml`'s
  * `[users] admins`, which is what makes the login flow succeed.
  */
+
+// The first-run product tour opens a Radix dialog over the console, and while
+// it is up every element beneath it is `aria-hidden` — so `getByRole` finds
+// nothing, including the composer's Send button. `getByPlaceholder` still
+// matches (it is an attribute selector, and Playwright's visibility model is
+// CSS-based), which is why this spec appeared to reach the composer and then
+// timed out on the very next line. Nineteen of the other specs already do this;
+// this one predates the tour and was never updated.
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
 
 test("operator console renders a mocked backend reply end to end", async ({
   page,

--- a/frontend/test/e2e/workflow-run-history.spec.ts
+++ b/frontend/test/e2e/workflow-run-history.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
 /**
  * Issue #228: the Workflows view reads a workflow's finished runs back from the
  * host's journal, so a run's outcome survives the drawer being dismissed, the
@@ -116,6 +118,12 @@ test("the run-history panel opens and shows only the selected workflow's runs", 
 test("running a workflow adds it to the durable history and it survives a reload", async ({
   page,
 }) => {
+  // Per-test: the two above read history the host already holds and pass on a
+  // default build. This one has to actually RUN the workflow, and the runner
+  // lives behind `openhuman` — with the feature off the Run button journals
+  // nothing and the poll below can only time out.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
   await page.goto("/#/workflows");
   await dismissTour(page);
 

--- a/frontend/test/unit/chat-channels.test.ts
+++ b/frontend/test/unit/chat-channels.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  channelIdForThread,
+  dmChannelId,
+  legacyDmChannelId,
+  resolveDmChannelId,
+} from "@/views/chat/model";
+import type { Desk } from "@/lib/desks";
+import type { TeamMember } from "@/lib/team";
+
+/**
+ * Channel-id derivation and the pre-#364 legacy-URL shim.
+ *
+ * Two id namespaces meet here and the console has already been wrong about it
+ * once (issue #367). Both failure modes are silent: a thread routed to a
+ * channel that does not exist drops its messages into a bucket nothing renders,
+ * and a legacy DM link that stops resolving lands the reader on an
+ * unknown-channel notice. Neither raises.
+ */
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    inboxEnabled: false,
+    ...over,
+  };
+}
+
+const ADA = member({ id: "agent-ada", name: "Ada" });
+const GRACE = member({ id: "agent-grace", name: "Grace" });
+const ROSTER = [ADA, GRACE];
+
+describe("dmChannelId", () => {
+  it("keys on the teammate's id, so a rename cannot move their DM", () => {
+    const renamed = member({ id: "agent-ada", name: "Ada Lovelace" });
+    expect(dmChannelId(renamed)).toBe(dmChannelId(ADA));
+  });
+});
+
+describe("resolveDmChannelId (the legacy-URL shim)", () => {
+  it("resolves a current DM id to itself", () => {
+    expect(resolveDmChannelId(dmChannelId(ADA), ROSTER)).toBe("dm:agent-ada");
+  });
+
+  it("resolves a bookmarked pre-#364 name-derived id to the CURRENT id", () => {
+    // The whole point of the shim: an old link in somebody's ticket still lands
+    // on Ada's DM, and what comes back is the id in use today — so nothing new
+    // is ever written under the legacy form.
+    const old = legacyDmChannelId(ADA);
+    expect(old).not.toBe(dmChannelId(ADA));
+    expect(resolveDmChannelId(old, ROSTER)).toBe("dm:agent-ada");
+  });
+
+  it("returns null for a DM this company has nobody for", () => {
+    expect(resolveDmChannelId("dm:agent-nobody", ROSTER)).toBeNull();
+  });
+
+  it("returns null for anything that is not a DM id", () => {
+    expect(resolveDmChannelId("engineering", ROSTER)).toBeNull();
+  });
+});
+
+describe("channelIdForThread (issue #367)", () => {
+  const desks: Desk[] = [
+    { id: "engineering", channel: "engineering", name: "Engineering", blurb: "" },
+  ];
+
+  it("passes a desk thread id through — a desk's channel id IS its thread id", () => {
+    expect(channelIdForThread("engineering", desks, ROSTER)).toBe("engineering");
+  });
+
+  it("maps a teammate's agent id to the console-local DM channel id", () => {
+    // The asymmetry that makes this function necessary: the host journals a DM
+    // under the teammate's agent id, but the console addresses the channel by
+    // `dm:<id>`. Routing the raw thread id would file the message under a
+    // channel that does not exist.
+    expect(channelIdForThread("agent-grace", desks, ROSTER)).toBe("dm:agent-grace");
+  });
+
+  it("returns null for a thread this company owns no channel for", () => {
+    // Explicitly not a fallback to the first channel: filing a stranger's
+    // messages into a real transcript is worse than declining to route them.
+    expect(channelIdForThread("some-other-company-thread", desks, ROSTER)).toBeNull();
+  });
+});

--- a/frontend/test/unit/chat-ids.test.ts
+++ b/frontend/test/unit/chat-ids.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hostMessageId,
+  isHostMessageId,
+  reconcileIds,
+  toHostMessageId,
+  type ChatMessage,
+} from "@/lib/chat";
+
+/**
+ * Message-id reconciliation (issue #364) — the helper issue #434 was filed
+ * over: it was correctly isolated for testing and then could not be tested,
+ * because the console had no runner.
+ *
+ * Everything here is invisible when it goes wrong. A send renders optimistically
+ * under a browser-local id and the host answers with a durable one; if the swap
+ * drops a reply's parent link, the reply does not error — it silently leaves the
+ * thread and reappears in the channel, which reads as the console having lost
+ * it. No type catches that, and a browser walk that caught it would report it as
+ * "the chat looked wrong".
+ */
+
+function message(over: Partial<ChatMessage> & Pick<ChatMessage, "id">): ChatMessage {
+  return { from: "you", text: "…", at: 1_000, ...over };
+}
+
+describe("the two id namespaces", () => {
+  it("marks a host id so it is distinguishable from a browser-local one", () => {
+    expect(hostMessageId("42")).toBe("h42");
+    expect(isHostMessageId("h42")).toBe(true);
+    // `m<n>` is the local counter and means nothing outside this tab.
+    expect(isHostMessageId("m7")).toBe(false);
+    expect(isHostMessageId(undefined)).toBe(false);
+  });
+
+  it("round-trips a host id back to the sequence the host journals under", () => {
+    expect(toHostMessageId(hostMessageId("42"))).toBe("42");
+    // A local id names nothing on the host, and must not be sent as if it did.
+    expect(toHostMessageId("m7")).toBeNull();
+    expect(toHostMessageId(undefined)).toBeNull();
+  });
+});
+
+describe("reconcileIds", () => {
+  it("replaces the optimistic id with the durable one", () => {
+    const before = [message({ id: "m1", text: "ship it" })];
+    const after = reconcileIds(before, "m1", "42");
+    expect(after[0].id).toBe("h42");
+  });
+
+  it("re-parents a reply that already pointed at the optimistic id", () => {
+    // The race this exists for: the operator opened a thread on their own
+    // bubble and replied to it before the POST resolved.
+    const before = [
+      message({ id: "m1", text: "ship it" }),
+      message({ id: "m2", text: "on it", parentId: "m1" }),
+    ];
+
+    const after = reconcileIds(before, "m1", "42");
+
+    expect(after[0].id).toBe("h42");
+    expect(after[1].parentId).toBe("h42");
+    // The reply keeps its own identity — only its parent moved.
+    expect(after[1].id).toBe("m2");
+  });
+
+  it("leaves replies to other messages alone", () => {
+    const before = [
+      message({ id: "m1" }),
+      message({ id: "m2", parentId: "m9" }),
+    ];
+    const after = reconcileIds(before, "m1", "42");
+    expect(after[1].parentId).toBe("m9");
+  });
+
+  it("returns the same array when nothing matches, so React sees no new list", () => {
+    // Identity, not equality: a fresh array on every reconcile would re-render
+    // the whole transcript for a message this list does not contain.
+    const before = [message({ id: "m1" })];
+    expect(reconcileIds(before, "m-unknown", "42")).toBe(before);
+  });
+
+  it("returns the same array when the id is already the durable one", () => {
+    const before = [message({ id: "h42" })];
+    expect(reconcileIds(before, "h42", "42")).toBe(before);
+  });
+});

--- a/frontend/test/unit/chat-timeline.test.ts
+++ b/frontend/test/unit/chat-timeline.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from "vitest";
+
+import { buildTimeline, type Channel } from "@/views/chat/model";
+import type { ChatMessage } from "@/lib/chat";
+
+/**
+ * Timeline folding by parent.
+ *
+ * A reply must be folded into its parent rather than laid out inline. When that
+ * goes wrong the transcript still renders — thread replies simply appear in the
+ * channel, out of order and stripped of the question they answer, which reads
+ * as the company talking to itself. Nothing throws, so only an assertion
+ * catches it.
+ */
+
+const CHANNEL: Channel = {
+  id: "engineering",
+  name: "engineering",
+  voice: "Engineering",
+  kind: "channel",
+  purpose: "",
+};
+
+const MINUTE = 60_000;
+/** A fixed instant, so day-boundary grouping cannot drift with the clock. */
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function message(over: Partial<ChatMessage> & Pick<ChatMessage, "id">): ChatMessage {
+  return { from: "you", text: "…", at: T0, ...over };
+}
+
+describe("buildTimeline", () => {
+  it("keeps a reply out of the channel and hangs it on its parent", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", text: "can we ship?" }),
+        message({ id: "b", text: "yes", parentId: "a" }),
+      ],
+      CHANNEL,
+    );
+
+    // One row, not two: the reply is folded, not laid out inline.
+    expect(entries).toHaveLength(1);
+    expect(entries[0].message.id).toBe("a");
+    expect(entries[0].replies.map((r) => r.id)).toEqual(["b"]);
+  });
+
+  it("keeps replies in order under their parent", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a" }),
+        message({ id: "b", parentId: "a", at: T0 + 1 }),
+        message({ id: "c", parentId: "a", at: T0 + 2 }),
+      ],
+      CHANNEL,
+    );
+    expect(entries[0].replies.map((r) => r.id)).toEqual(["b", "c"]);
+  });
+
+  it("drops a reply whose parent is not in this channel rather than promoting it", () => {
+    // A reply pointing at an id this transcript does not hold must not fall
+    // back to the channel — that is precisely the "the console lost my thread"
+    // symptom reconcileIds exists to prevent.
+    const entries = buildTimeline([message({ id: "b", parentId: "missing" })], CHANNEL);
+    expect(entries).toHaveLength(0);
+  });
+
+  it("groups consecutive lines from one sender into a run", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", from: "you", at: T0 }),
+        message({ id: "b", from: "you", at: T0 + MINUTE }),
+      ],
+      CHANNEL,
+    );
+    expect(entries[0].continuation).toBe(false);
+    expect(entries[1].continuation).toBe(true);
+  });
+
+  it("breaks the run once the grouping window has passed", () => {
+    const entries = buildTimeline(
+      [
+        message({ id: "a", from: "you", at: T0 }),
+        message({ id: "b", from: "you", at: T0 + 6 * MINUTE }),
+      ],
+      CHANNEL,
+    );
+    expect(entries[1].continuation).toBe(false);
+  });
+
+  it("ends a run after a row that carries replies", () => {
+    // Otherwise the thread's summary row sits between two lines that read as a
+    // single utterance.
+    const entries = buildTimeline(
+      [
+        message({ id: "a", from: "you", at: T0 }),
+        message({ id: "r", from: "you", at: T0 + 1, parentId: "a" }),
+        message({ id: "b", from: "you", at: T0 + MINUTE }),
+      ],
+      CHANNEL,
+    );
+    expect(entries[0].replies).toHaveLength(1);
+    expect(entries[1].continuation).toBe(false);
+  });
+
+  it("starts a new day with a divider, and never continues a run across one", () => {
+    const nextDay = T0 + 24 * 60 * MINUTE;
+    const entries = buildTimeline(
+      [
+        message({ id: "a", from: "you", at: T0 }),
+        message({ id: "b", from: "you", at: nextDay }),
+      ],
+      CHANNEL,
+    );
+    expect(entries[0].dayLabel).toBeDefined();
+    expect(entries[1].dayLabel).toBeDefined();
+    expect(entries[1].continuation).toBe(false);
+  });
+});

--- a/frontend/test/unit/chat-title.test.ts
+++ b/frontend/test/unit/chat-title.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { titleFromMessage } from "@/lib/chat";
+
+/**
+ * The board-card title derived from a chat message (issue #246).
+ *
+ * A truncation is the textbook silent-wrong-answer: it always returns a string,
+ * it always looks plausible, and the two ways it is usually wrong — overshooting
+ * the cap by the ellipsis, and cutting a surrogate pair in half — produce output
+ * that no type and no render test objects to. The second one puts a `�` on
+ * a card.
+ */
+
+const CAP = 80;
+
+describe("titleFromMessage", () => {
+  it("takes the first non-blank line, so a multi-line ask reads as a headline", () => {
+    expect(titleFromMessage("  \n\n  Draft the launch post  \nwith a link at the end")).toBe(
+      "Draft the launch post",
+    );
+  });
+
+  it("returns empty for a message with nothing in it, so the caller can refuse", () => {
+    expect(titleFromMessage("")).toBe("");
+    expect(titleFromMessage("   \n\t\n  ")).toBe("");
+  });
+
+  it("leaves a title at exactly the cap alone", () => {
+    const exact = "a".repeat(CAP);
+    expect(titleFromMessage(exact)).toBe(exact);
+    expect(Array.from(titleFromMessage(exact))).toHaveLength(CAP);
+  });
+
+  it("counts the ellipsis inside the cap rather than overshooting by one", () => {
+    // The off-by-one that shows up as a title one character over budget.
+    const long = "b".repeat(CAP + 40);
+    const title = titleFromMessage(long);
+    expect(Array.from(title)).toHaveLength(CAP);
+    expect(title.endsWith("…")).toBe(true);
+  });
+
+  it("never cuts an emoji in half", () => {
+    // Astral-plane code points are two UTF-16 units each. Slicing on `.length`
+    // instead of code points ends the title on a lone surrogate, which renders
+    // as a replacement character.
+    const emoji = "🚀".repeat(CAP + 10);
+    const title = titleFromMessage(emoji);
+
+    expect(title).not.toContain("�");
+    // No LONE surrogate survived the cut. Iterating a string yields whole code
+    // points, so a well-formed 🚀 comes through as U+1F680 and only an
+    // unpaired half lands in the surrogate range itself.
+    for (const point of title) {
+      const code = point.codePointAt(0)!;
+      expect(code >= 0xd800 && code <= 0xdfff).toBe(false);
+    }
+    expect(Array.from(title)).toHaveLength(CAP);
+  });
+});

--- a/frontend/test/unit/task-links.test.ts
+++ b/frontend/test/unit/task-links.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { extraOutputCount, primaryLink, readTaskFocus } from "@/lib/task-output";
+import type { Task, TaskOutput } from "@/api/tasks";
+
+/**
+ * Link precedence on a task card (issue #339).
+ *
+ * The precedence — artifact, else workflow, else the trace — is derived on
+ * every render rather than stored, so getting it wrong shows up as a card
+ * pointing at the *wrong* thing rather than at nothing. A card that opens a run
+ * trace when it should open the deliverable looks completely normal.
+ */
+
+function task(over: Partial<Task> = {}): Task {
+  return {
+    id: "t-1",
+    title: "Ship it",
+    column: "done",
+    priority: "medium",
+    assignee: "ada",
+    updatedAt: 0,
+    ...over,
+  };
+}
+
+function output(over: Partial<TaskOutput> = {}): TaskOutput {
+  return { runId: "run-9", atMillis: 0, ...over };
+}
+
+describe("primaryLink", () => {
+  it("prefers an artifact over everything else", () => {
+    const link = primaryLink(
+      task({
+        output: output({
+          artifacts: [{ artifactId: "a-1", version: 3, title: "Launch post", kind: "markdown" }],
+          workflows: [{ workflowId: "w-1", action: "ran", runId: "run-9" }],
+        }),
+      }),
+    );
+
+    expect(link.kind).toBe("artifact");
+    // Pinned at the revision this run wrote, not "latest".
+    expect(link.href).toBe("#/tasks/t-1?artifact=a-1&v=3");
+  });
+
+  it("falls to the workflow when there is no artifact", () => {
+    const link = primaryLink(
+      task({ output: output({ workflows: [{ workflowId: "w-1", action: "ran", runId: "run-9" }] }) }),
+    );
+    expect(link.kind).toBe("workflow");
+    expect(link.href).toBe("#/workflows/w-1?run=run-9");
+  });
+
+  it("opens the workflow with no run overlay when it was authored, not executed", () => {
+    const link = primaryLink(
+      task({ output: output({ workflows: [{ workflowId: "w-1", action: "created" }] }) }),
+    );
+    expect(link.href).toBe("#/workflows/w-1");
+  });
+
+  it("falls to the run trace when the attempt produced no deliverable", () => {
+    // Not an absence — for a message sent or a question answered, the trace IS
+    // the deliverable. This is what stops "no artifact" degrading to "no link".
+    const link = primaryLink(task({ output: output({ attempt: 2 }) }));
+    expect(link.kind).toBe("trace");
+    expect(link.href).toBe("#/tasks/t-1?run=run-9");
+    expect(link.label).toContain("attempt 2");
+  });
+
+  it("falls back to the card itself when nothing recorded an attempt", () => {
+    const link = primaryLink(task());
+    expect(link.kind).toBe("card");
+    expect(link.href).toBe("#/tasks/t-1");
+  });
+
+  it("escapes a task id that would otherwise break the address", () => {
+    const link = primaryLink(task({ id: "t/1 2" }));
+    expect(link.href).toBe("#/tasks/t%2F1%202");
+  });
+});
+
+describe("extraOutputCount", () => {
+  it("never counts the trace, which every stamped card has", () => {
+    // Counting it would put "+1 more" on every card and mean nothing.
+    expect(extraOutputCount(task({ output: output() }))).toBe(0);
+  });
+
+  it("counts only deliverables beyond the primary one", () => {
+    const two = task({
+      output: output({
+        artifacts: [
+          { artifactId: "a-1", version: 1, title: "One", kind: "markdown" },
+          { artifactId: "a-2", version: 1, title: "Two", kind: "markdown" },
+        ],
+        workflows: [{ workflowId: "w-1", action: "ran" }],
+      }),
+    });
+    expect(extraOutputCount(two)).toBe(2);
+  });
+
+  it("is zero for a card with no stamp", () => {
+    expect(extraOutputCount(task())).toBe(0);
+  });
+});
+
+describe("readTaskFocus", () => {
+  it("reads an artifact and its pinned revision", () => {
+    expect(readTaskFocus("#/tasks/t-1?artifact=a-1&v=3")).toEqual({
+      artifactId: "a-1",
+      version: 3,
+    });
+  });
+
+  it("drops a version that is not a positive integer rather than guessing", () => {
+    // Landing on the newest revision is the same place no pin at all would
+    // land, which is the sensible destination for a stale link.
+    expect(readTaskFocus("#/tasks/t-1?artifact=a-1&v=nonsense")).toEqual({ artifactId: "a-1" });
+    expect(readTaskFocus("#/tasks/t-1?artifact=a-1&v=0")).toEqual({ artifactId: "a-1" });
+    expect(readTaskFocus("#/tasks/t-1?artifact=a-1&v=-2")).toEqual({ artifactId: "a-1" });
+  });
+
+  it("reads a run focus", () => {
+    expect(readTaskFocus("#/tasks/t-1?run=run-9")).toEqual({ runId: "run-9" });
+  });
+
+  it("yields an empty focus for an address that asks for nothing", () => {
+    expect(readTaskFocus("#/tasks/t-1")).toEqual({});
+    expect(readTaskFocus("#/tasks/t-1?")).toEqual({});
+  });
+});

--- a/frontend/test/unit/tour-resume.test.ts
+++ b/frontend/test/unit/tour-resume.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { TOUR } from "@/tour/steps";
+import {
+  armTourResume,
+  clearTourResume,
+  markTourResume,
+  readTourResume,
+  setActiveTourStop,
+} from "@/tour/state";
+
+/**
+ * The onboarding tour's resume marker (issue #300), and the coupling that
+ * actually matters about it.
+ *
+ * A marker records a stop by its **view**, and the controller later finds the
+ * stop again with `TOUR.findIndex((s) => s.view === resumed)`. Those are two
+ * halves of one contract held together by a bare string, and when they drift
+ * the failure is silent by construction: `findIndex` answers `-1`, the
+ * controller's own comment says a retired stop must be dropped, so it drops it
+ * and shows nothing. An operator returning from an OAuth redirect simply does
+ * not get their tour back, and no error is raised anywhere.
+ *
+ * That drift has already happened once. Connections became a page of the
+ * Settings section — the stop is `{ view: "settings", sub: "connections" }` —
+ * and `oauth-onboarding-resume.spec.ts` went on seeding the retired
+ * `"connections"`, so the Playwright spec was red for a reason that had nothing
+ * to do with the product. Because nothing ran that suite, the red went
+ * unreported and was later filed as a product bug (#428) that does not exist.
+ *
+ * So the assertion that earns its place here is not "a marker round-trips". It
+ * is "**every** view a stop can publish is a view the lookup can find" — the
+ * mechanism is *reached*, not merely functional.
+ */
+
+const COMPANY = "acme";
+
+beforeEach(() => {
+  window.localStorage.clear();
+  setActiveTourStop(null);
+});
+
+/** The controller's own lookup, so a drift fails here rather than in a browser. */
+function stopIndexFor(view: string | null): number {
+  return view === null ? -1 : TOUR.findIndex((s) => s.view === view);
+}
+
+describe("the stop-view ⇄ resume-marker contract", () => {
+  /** The one stop that hands the browser to a third party, so the only one that arms. */
+  const connections = TOUR.find((s) => s.sub === "connections");
+
+  it("still has a Connections stop at all", () => {
+    expect(connections, "the tour should still have a Connections stop").toBeDefined();
+  });
+
+  it("pins the view the Connections stop publishes", () => {
+    // NOT a tautology, and the distinction is the whole reason this test is
+    // here. Reading `stop.view` and then looking it up in `TOUR` would pass by
+    // construction and prove nothing — the vacuous shape that let the e2e spec
+    // rot unnoticed in the first place. This pins the *literal*, because a
+    // literal is exactly what drifted: `oauth-onboarding-resume.spec.ts` seeds
+    // this string into localStorage by hand, and cannot see it change.
+    //
+    // If this fails, the tour was reorganised: update the e2e spec's seed in
+    // the same commit.
+    expect(connections!.view).toBe("settings");
+  });
+
+  it("leaves the lookup unambiguous, so a resume lands on the stop that armed it", () => {
+    // The controller resolves a marker with `findIndex` — FIRST match wins.
+    // Views are not unique across the tour (there are two `overview` stops and
+    // two `chat` stops), so this is only safe while the arming stop is the sole
+    // holder of its view. Add a second Settings stop ahead of Connections and
+    // the operator silently resumes on the wrong one; nothing else would catch
+    // that, because the tour still runs and still shows *a* stop.
+    const sharingItsView = TOUR.filter((s) => s.view === connections!.view);
+    expect(sharingItsView).toHaveLength(1);
+    expect(stopIndexFor(connections!.view)).toBe(TOUR.indexOf(connections!));
+  });
+
+  it("round-trips an armed marker through storage unchanged", () => {
+    setActiveTourStop(connections!.view);
+    armTourResume(COMPANY);
+    expect(readTourResume(COMPANY)).toBe(connections!.view);
+  });
+});
+
+describe("armTourResume", () => {
+  it("writes nothing when no tour is running", () => {
+    // What lets ConnectionsView arm unconditionally without first asking
+    // whether it is inside onboarding.
+    armTourResume(COMPANY);
+    expect(readTourResume(COMPANY)).toBeNull();
+  });
+
+  it("keeps each company's marker separate", () => {
+    setActiveTourStop("settings");
+    armTourResume(COMPANY);
+    expect(readTourResume("other-co")).toBeNull();
+    expect(readTourResume(COMPANY)).toBe("settings");
+  });
+});
+
+describe("readTourResume", () => {
+  it("treats a marker past its TTL as absent", () => {
+    markTourResume(COMPANY, "settings");
+    const key = `oc-tour:${COMPANY}`;
+    const stored = JSON.parse(window.localStorage.getItem(key)!);
+    stored.pendingResume.at = Date.now() - 16 * 60 * 1000;
+    window.localStorage.setItem(key, JSON.stringify(stored));
+
+    expect(readTourResume(COMPANY)).toBeNull();
+  });
+
+  it("honours a marker inside the TTL", () => {
+    // The other half of the boundary — without this, a TTL of zero would pass
+    // the test above and break the feature.
+    markTourResume(COMPANY, "settings");
+    expect(readTourResume(COMPANY)).toBe("settings");
+  });
+
+  it("is null once the marker is consumed, so it cannot fire on a later visit", () => {
+    markTourResume(COMPANY, "settings");
+    clearTourResume(COMPANY);
+    expect(readTourResume(COMPANY)).toBeNull();
+  });
+
+  it("keeps the completed/skipped flags when the marker is cleared", () => {
+    window.localStorage.setItem(`oc-tour:${COMPANY}`, JSON.stringify({ skipped: true }));
+    markTourResume(COMPANY, "settings");
+    clearTourResume(COMPANY);
+
+    const stored = JSON.parse(window.localStorage.getItem(`oc-tour:${COMPANY}`)!);
+    expect(stored.skipped).toBe(true);
+    expect(stored.pendingResume).toBeUndefined();
+  });
+});

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -40,5 +40,10 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["test", "playwright.config.ts"]
+  // `test/e2e`, NOT `test` — narrowed when the unit suite landed under
+  // `test/unit/` (issue #434). A bare `test` swept those files in here too,
+  // where they cannot compile: they import `vitest` and reach app modules
+  // through the `@/*` alias, and this project supplies neither. They have their
+  // own project, `tsconfig.unit.json`.
+  "include": ["test/e2e", "playwright.config.ts"]
 }

--- a/frontend/tsconfig.unit.json
+++ b/frontend/tsconfig.unit.json
@@ -1,0 +1,48 @@
+// Issue #434. Type-checks the unit suite under `test/unit/` and
+// `vitest.config.ts`.
+//
+// STANDALONE, for the same reason `tsconfig.e2e.json` is: not `composite`, and
+// deliberately NOT added to `tsconfig.json`'s `references`. A reference would
+// pull these tests into `npm run build`, so a broken test file would fail the
+// shippable console bundle. A test and the artifact it guards should be able to
+// fail independently, and CI reports them as separate steps for that reason.
+// `npm run typecheck:unit` runs this project on its own via `tsc -p`.
+//
+// Vitest itself strips types rather than checking them, so without this config
+// a test could call a helper with the wrong arity and still go green by
+// coincidence — the same blind spot #281 found in the Playwright specs, which
+// is why that suite got `tsconfig.e2e.json`.
+//
+// Unlike the e2e config this one DOES need `@/*` and the DOM lib: these tests
+// import app modules directly, and a couple of them run under jsdom (see the
+// `@vitest-environment` docblocks) to reach `localStorage`.
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node", "vite/client"],
+    // Needed even though no test renders anything: `@/tour/steps` imports its
+    // `View` type from `components/app-shell.tsx`, and TypeScript refuses to
+    // read a `.tsx` at all without this.
+    "jsx": "react-jsx",
+
+    "strict": true,
+    // Matched to `tsconfig.app.json`, so the drift this config exists to catch
+    // fails loudly: a locator left behind by a rewritten assertion, or an
+    // argument dropped from a helper.
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["test/unit", "vitest.config.ts"]
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,54 @@
+import { defineConfig } from "vitest/config";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The console's unit-test runner (issue #434).
+ *
+ * # What belongs here, and what belongs in `test/e2e/`
+ *
+ * This runner is for **pure functions**: a helper that maps A to B with no
+ * document, no host, and no React. `test/e2e/` is for everything that is only
+ * true in a browser driving a live host — a disabled affordance explaining
+ * itself, a banner that must not be a toast, a redirect that survives a
+ * full-page navigation.
+ *
+ * The line matters because the two are tempted to test each other's territory.
+ * A browser walk *can* reach a pure helper, through six layers of render, in
+ * forty seconds, and it will report the failure as "the board looked wrong".
+ * A unit test cannot reach a redirect at all. Put a helper here the moment it
+ * has a second caller or a branch worth naming; leave anything that needs a
+ * document over there.
+ *
+ * # Why this is its own config and not `vite.config.ts`
+ *
+ * `vite.config.ts` loads the React and Tailwind plugins, and this suite needs
+ * neither — it imports TypeScript modules and calls them. Keeping the config
+ * separate is what keeps the run in the low hundreds of milliseconds, which is
+ * the property issue #434 actually asked for: a gate slow enough to skip gets
+ * skipped, and a skipped gate is the problem it was filed about.
+ *
+ * The `@` alias is therefore redeclared here rather than inherited. It is the
+ * one thing this config shares with the app build, and it must not drift from
+ * `vite.config.ts` / `tsconfig.app.json`.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": resolve(here, "./src"),
+    },
+  },
+  test: {
+    // `node` by DEFAULT, jsdom only where a test says so with a
+    // `@vitest-environment jsdom` docblock. Standing up a DOM costs more than
+    // every pure test in this suite put together, and most of them have no use
+    // for one.
+    environment: "node",
+    // Scoped to `test/unit`, so a Playwright spec under `test/e2e` — which
+    // imports `@playwright/test` and needs a browser — can never be collected
+    // by this runner.
+    include: ["test/unit/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

The Playwright suite was type-checked and **never run**, so it had been red for months without anyone knowing. The console had **no test runner at all**, so pure frontend logic shipped unverified.

Together that meant nothing in the console was actually verified by CI — type-checking proves it compiles, not that it works. In one day of work on this repo, every defect found shipped with green CI, and several had *passing tests asserting the broken behaviour*.

Closes #428. Closes #434.

## The suite's true state

| | Passed | Failed | Skipped | Wall clock |
|---|---|---|---|---|
| **Before** | 71 | **6** | 2 | 5.3m |
| **After** | **73** | **0** | 6 | 1.6m |

**No test was deleted to reach green.** Every failure was triaged.

## Every failure, triaged — no product bugs, no flakes

**#428 documented 5 failures; there were 6. It also calls one of them a product bug, and that is wrong.**

- **`oauth-onboarding-resume.spec.ts:69` — a stale test, not the product bug the issue claims.** The marker stores the stop's `view`; Connections became a page of Settings (`{view: "settings", sub: "connections"}`), and the spec still seeded the retired `"connections"`. No stop matched, so the controller **correctly** declined to resume. Seeding `"settings"` makes it pass in 470ms. The resume path works.
- **`chat-approval-line.spec.ts:94` — a stale test, undocumented in the issue** because it broke *after* the issue was filed. Its fixture carried no `agent`, so it exercised the arm #395 added for a runtime-performed effect while asserting the tool-call arm.
- **`wiring`, `chat-to-card:83`, `workflow-run-history:116`, `mcp` — environment.** They need a feature-gated host and an inference backend that the default CI lane does not build. Now skipped behind `PW_LIVE_BRAIN` (`test/e2e/capabilities.ts`), **each naming #467 in its skip reason** so no skip is bare and none can quietly become permanent. Two are per-test, so their passing siblings keep running.

**Two findings beyond the failures:**

- **`wiring.spec.ts` had a latent defect masking its real dependency.** It never dismissed the first-run tour, whose dialog `aria-hidden`s the console — so the role-based Send lookup could not match, and it timed out one line *after* the composer appeared to work. Fixed; it then reached the genuine blocker.
- **`oauth-onboarding-resume.spec.ts:115` was vacuous.** Seeded with the retired view, it passed whether or not the TTL was honoured — it asserted nothing.

## The console runner (#434)

Vitest, its own config (no React/Tailwind plugins), `node` by default with jsdom per file. **50 tests in 441ms** from a clean `npm ci`. `npm test` is `vitest run` — bare `vitest` is a watcher and would hang CI.

Seeded over the helpers #434 named, chosen because a silent wrong answer there is invisible: id reconciliation and re-parenting, title truncation, channel-id derivation and its legacy shim, link precedence, timeline folding, tour resume.

**Every test was shown red first — 13 mutations, all caught, tree reverted clean.**

That discipline caught a bad test being written: the first tour test read a stop's view from `TOUR` and then looked it up in `TOUR`, so it passed by construction. Rewritten to pin the literal that actually drifted — **plus a new assertion that the arming stop is the sole holder of its view**, because the controller resolves by first match, so a second Settings stop would silently resume the wrong one. Nothing guarded that.

`tsconfig.e2e.json` swept all of `test/`, which would have broken the green `typecheck:e2e` step; narrowed to `test/e2e`. The new `typecheck:unit` immediately caught two real type errors in the new tests.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2289 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] Frontend from a clean `npm ci`: `typecheck`, `typecheck:e2e`, `typecheck:unit`, `test`, `build`

`Cargo.lock` unchanged.

## Notes for review

**This PR does not finish the job, and cannot.** The new `Console E2E` lane, plus `typecheck:unit` and `test` on `Console`, are only meaningful once they are **required checks** — and `main` currently has **no branch protection and no rulesets** (both APIs return empty), so nothing is required today, including the pre-existing `Rust` and `Console` jobs. Someone with admin needs to require **`Rust`**, **`Rust (openhuman, tinycortex)`**, **`Console`** and **`Console E2E`**. Until then these lanes are advisory — which is the state this work exists to replace.

**A cross-worktree hazard worth a shared convention.** A first "after" run showed 22 failures that were neither the changes nor flake: a sibling worktree ran `pkill -f "opencompany serve"` and killed the e2e host mid-run, so everything after the first failure was `ECONNREFUSED`. It also killed two background cargo gate runs. Any lane running a bare `pkill -f "opencompany..."` will corrupt a concurrent e2e run elsewhere on the machine — worth agreeing on scoped process cleanup before host-driven runs become routine in CI.
