### PR TITLE
fix(spine): a run parked on an approval parks its card instead of offering it for review (#465)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -682,6 +682,20 @@ at least one approval finishes `waiting_approval`, not `succeeded` — a person
 must act. A failed, cancelled or paused run keeps the reason it stopped;
 relabelling it "waiting on you" would hide that reason.
 
+**…and its card parks rather than landing in review (issue #465).** The status
+answers *who unblocks this*; the column answers *has the work happened yet*.
+`column_for_settled_run` therefore maps `waiting_approval` to `paused`: a run
+stopped at a call it was not allowed to make has produced nothing to accept —
+in the reported case, a desk whose *first* tool call parked, nothing at all.
+The teeth are that `in_review` is defined by the verdict consuming it
+(`review_landing_column(Approve)` writes `done`, the only route there), so a
+parked card sat one gesture from being filed as finished; #337 closed the
+automatic route to that state and this closes the manual one. The
+parked-vs-review distinction survives on `RunStatus`, which is where the console
+reads it ("Waiting on you"). This *narrows* epic #183 decision 2 rather than
+overturning it: that rule splits waiting-on-a-person from waiting-on-a-system,
+and never claimed the work had finished.
+
 **A runtime being replaced is a fifth writer.** Writer 1 mints the row before
 writer 2 can start it, so a runtime swapped in between refuses the cycle and
 settles the row itself — and the boot reaper is *not* a safe fallback mid-life.

--- a/frontend/src/api/runs.ts
+++ b/frontend/src/api/runs.ts
@@ -170,11 +170,22 @@ export function getRun(
 // Shared presentation helpers
 // ---------------------------------------------------------------------------
 
-/** A short, human word for a status. */
+/**
+ * A short, human word for a status.
+ *
+ * `waiting_approval` reads "Waiting on you" rather than "In review" (issue
+ * #465). The old wording came from the board column such an attempt used to
+ * land its card in; since that card now parks instead, "In review" here would
+ * both contradict the column beside it and repeat the claim the issue was
+ * about — that there is a result to look at, when the attempt stopped at a call
+ * it was not allowed to make. This is the wording the approvals tab and the
+ * step timeline's waiting band already use, and it is where the "who unblocks
+ * it" distinction now lives.
+ */
 export const RUN_STATUS_LABEL: Record<RunStatus, string> = {
   pending: "Queued",
   running: "Running",
-  waiting_approval: "In review",
+  waiting_approval: "Waiting on you",
   paused: "Paused",
   succeeded: "Succeeded",
   failed: "Failed",

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -130,6 +130,27 @@ function columnLabel(column: string): string {
 }
 
 /**
+ * The columns a card can sit in without any agent having run it yet — the only
+ * ones where "Not yet dispatched" is a true statement (issue #465).
+ *
+ * The worked figure is reconstructed from journaled `TaskDispatched` events, so
+ * a card that never went through the board's dispatch edge has no window to
+ * measure however much work it saw. That is most obviously the #442 card opened
+ * *by construction* for work handed straight to an agent: it is written through
+ * the task store rather than the dispatch path precisely so it cannot re-fire
+ * dispatch, so it is legitimately never "dispatched" — and it was worked all the
+ * same. Reading a missing window as "not yet dispatched" put that claim beside a
+ * status of In review, which is how the reported card managed to contradict
+ * itself in a single line.
+ *
+ * Past these columns the honest answer is that there is no timing to show, not
+ * that nothing has happened, so the slot is omitted rather than guessed at. The
+ * waiting figure beside it is unaffected and still says what the card is
+ * blocked on.
+ */
+const UNSTARTED_COLUMNS = new Set(["todo", "planning"]);
+
+/**
  * Extends a host-computed duration to `now` while its span is still open.
  *
  * The worked/waiting arithmetic — the dispatch-window pairing and the approval
@@ -593,6 +614,11 @@ function DetailHeader({
   waiting: { millis: number; live: boolean } | null;
 }) {
   const hasDispatch = worked !== null && (worked.millis > 0 || worked.live);
+  // Issue #465: "Not yet dispatched" is only sayable where it can still be true.
+  // A card past To-do/Planning has been worked whether or not a dispatch window
+  // was journaled for it, so claiming otherwise beside a settled status is the
+  // self-contradiction the report caught.
+  const neverStarted = !hasDispatch && UNSTARTED_COLUMNS.has(task.column);
   // `worked` is the whole elapsed run window; waiting sits *inside* it, so
   // working time is the remainder. Clamped at zero because the two figures come
   // from different sources (event log vs journal join) and a clock skew between
@@ -632,27 +658,29 @@ function DetailHeader({
             {task.assignee}
           </span>
         )}
-        <span className="inline-flex items-center gap-1.5">
-          <Clock className="size-3.5" />
-          {hasDispatch ? (
-            <>
-              <span className="font-medium text-foreground">
-                Worked {formatDuration(workingMs)}
-              </span>
-              {worked!.live && (
-                <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
-                  <span
-                    className="size-1.5 animate-pulse rounded-full bg-current"
-                    aria-hidden
-                  />
-                  live
+        {(hasDispatch || neverStarted) && (
+          <span className="inline-flex items-center gap-1.5">
+            <Clock className="size-3.5" />
+            {hasDispatch ? (
+              <>
+                <span className="font-medium text-foreground">
+                  Worked {formatDuration(workingMs)}
                 </span>
-              )}
-            </>
-          ) : (
-            <span>Not yet dispatched</span>
-          )}
-        </span>
+                {worked!.live && (
+                  <span className="inline-flex items-center gap-1 text-emerald-600 dark:text-emerald-400">
+                    <span
+                      className="size-1.5 animate-pulse rounded-full bg-current"
+                      aria-hidden
+                    />
+                    live
+                  </span>
+                )}
+              </>
+            ) : (
+              <span>Not yet dispatched</span>
+            )}
+          </span>
+        )}
         {showWaiting && (
           <span className="inline-flex items-center gap-1.5">
             <Hourglass className="size-3.5 text-amber-600 dark:text-amber-400" />

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1889,6 +1889,12 @@ impl HarnessBrain {
     /// steer registry, the company id, and the shared delegation queue the turn
     /// pushes onto. `HarnessDeps` never crosses the seam; it stays behind
     /// `run_turn`.
+    ///
+    /// The approval queue rides along **read-only** (issue #465): a card the
+    /// runner opens by construction is settled from the turn that filled it, and
+    /// a turn that stopped at an unauthorised call produced nothing to review.
+    /// Wired here, at the one factory, so every runner the brain builds settles
+    /// by the same rule rather than each call site remembering to.
     fn delegation_runner<'a>(&'a self, run_turn: &'a HarnessRunTurn<'a>) -> DelegationRunner<'a> {
         DelegationRunner::new(
             run_turn,
@@ -1899,6 +1905,7 @@ impl HarnessBrain {
             &self.deps.delegations,
             orchestrator::MAX_DELEGATIONS_PER_TURN,
         )
+        .with_approvals(&self.deps.approval_requests)
     }
 }
 

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -178,10 +178,18 @@ pub fn review_note(decision: ReviewDecision, note: Option<&str>) -> String {
 /// person still had to authorise the call it was waiting on.
 ///
 /// Now there is one table, keyed on the settled status, and this function is
-/// the thin adapter that reaches it: `end` → [`run_status_for`] →
-/// [`column_for_settled_run`]. The parked-approval overlay is applied by the
-/// caller through [`settled_run_status`], because only `run_task` knows how
-/// many approvals *this* attempt parked.
+/// the thin adapter that reaches it: `end` → [`settled_run_status`] →
+/// [`column_for_settled_run`].
+///
+/// # This overload assumes nothing was parked
+///
+/// `landing_column(end)` is [`settled_landing_column`]`(end, 0)`. It is the
+/// right call only where no approval can be outstanding, or where a later
+/// authoritative write will land the card again with the count in hand. **A
+/// settle that can park an approval must call [`settled_landing_column`]** —
+/// issue #465: reading the landing from the ending alone is what let a turn
+/// whose first call parked settle as a plain success and present as reviewable
+/// work it had never started.
 ///
 /// # Two deliberate losses, both wanted
 ///
@@ -201,18 +209,60 @@ pub fn review_note(decision: ReviewDecision, note: Option<&str>) -> String {
 ///
 /// [`column_for_settled_run`]: crate::ports::tasks::column_for_settled_run
 pub fn landing_column(end: TaskRunEnd) -> &'static str {
+    settled_landing_column(end, 0)
+}
+
+/// The board column a run lands its card in, given how it ended **and** whether
+/// it left an approval parked (issue #465).
+///
+/// This is [`landing_column`] with the parked-approval overlay applied — the
+/// same overlay [`settled_run_status`] applies to the attempt row, reached
+/// through the same one table. `landing_column(end)` is exactly
+/// `settled_landing_column(end, 0)`.
+///
+/// # Why the count has to reach the column
+///
+/// It already reached the *status*: a success that parked something settles
+/// [`RunStatus::WaitingApproval`]. The column was derived from
+/// [`run_status_for`] instead, which cannot produce that status, so the board
+/// was answering from an ending that had been overtaken — and a turn whose very
+/// first call parked, having produced nothing, landed in
+/// [`COLUMN_IN_REVIEW`] announcing work to check.
+///
+/// That was reachable two ways, and this closes both:
+///
+/// * `run_task`'s settle (`brain.rs`) *did* compute the parked count, but the
+///   break-point [`landing_column`] call ran first and the authoritative
+///   overwrite went to [`column_for_settled_run`] direct — correct only once
+///   that table stopped sending `WaitingApproval` to review.
+/// * the delegation seam's `settle_work_card` (issue #442's card, opened by
+///   construction for work handed to an agent) hardcoded
+///   [`Completed`](TaskRunEnd::Completed) and never consulted the count at all.
+///   That is the path in the report: a desk asked directly, its first call
+///   parked, and the card settled as a plain success.
+///
+/// Routing both through here keeps the landing one decision — the property
+/// issue #337 collapsed this module onto the port to get — rather than two
+/// call sites each remembering to apply an overlay.
+///
+/// [`column_for_settled_run`]: crate::ports::tasks::column_for_settled_run
+pub fn settled_landing_column(end: TaskRunEnd, parked_approvals: usize) -> &'static str {
     // A hand-off is explicitly NOT a settle: the delegate is running, so the
     // card keeps the column it was dispatched in and only lands once they come
     // back with something (issue #204). Handled here rather than in the mapping
     // because `run_status_for(Delegated)` is `Paused` — right for the attempt
     // row (it is waiting on something other than a person) and wrong for the
     // board (the work has changed hands, not stopped).
+    //
+    // It outranks the parked overlay too: a delegator that parked an approval
+    // still handed the work on, and the delegate is running it now.
     if matches!(end, TaskRunEnd::Delegated) {
         return COLUMN_IN_PROGRESS;
     }
     // Every other ending settles, so the mapping always answers. The fallback
     // is unreachable and exists only so this stays total without an `expect`.
-    crate::ports::tasks::column_for_settled_run(run_status_for(end)).unwrap_or(COLUMN_IN_PROGRESS)
+    crate::ports::tasks::column_for_settled_run(settled_run_status(end, parked_approvals))
+        .unwrap_or(COLUMN_IN_PROGRESS)
 }
 
 /// The [`RunStatus`] a run ending this way settles into (issue #242).
@@ -627,6 +677,95 @@ mod test {
                 "{end:?} must keep the reason it stopped rather than reading as a review"
             );
         }
+    }
+
+    /// **Issue #465.** A run that parked an approval has not produced a result,
+    /// so its card parks instead of presenting as reviewable work.
+    ///
+    /// The pairing with the row above is the whole point: the *attempt* still
+    /// settles `WaitingApproval` — "a person must act" is preserved exactly
+    /// where epic #183 decision 2 put it — while the *column* answers the other
+    /// question, has the work happened. One ending, two answers, two places.
+    #[test]
+    fn a_parked_approval_parks_the_card_instead_of_offering_it_for_review() {
+        assert_eq!(
+            settled_landing_column(TaskRunEnd::Completed, 1),
+            COLUMN_PAUSED
+        );
+        assert_eq!(
+            settled_landing_column(TaskRunEnd::RedirectsExhausted, 2),
+            COLUMN_PAUSED
+        );
+        // The run status is untouched, so the console still says who unblocks it.
+        assert_eq!(
+            settled_run_status(TaskRunEnd::Completed, 1),
+            RunStatus::WaitingApproval
+        );
+
+        // A turn that genuinely completed still reaches the reviewer.
+        assert_eq!(
+            settled_landing_column(TaskRunEnd::Completed, 0),
+            COLUMN_IN_REVIEW
+        );
+    }
+
+    /// `landing_column` is the zero-parked case of `settled_landing_column`, so
+    /// the two cannot drift into disagreeing about an ending.
+    #[test]
+    fn the_landing_is_one_decision_taken_with_or_without_a_parked_count() {
+        for end in ALL_ENDINGS {
+            assert_eq!(
+                landing_column(end),
+                settled_landing_column(end, 0),
+                "{end:?} disagrees with itself once the overlay is spelled out"
+            );
+        }
+    }
+
+    /// **The sibling sweep issue #465 asked for**, as a test rather than a note:
+    /// every ending answers *did the work happen?*, and only the ones that
+    /// answer yes may land where a reviewer can approve them to Done.
+    ///
+    /// `Delegated` is the deliberate exception — it is not an ending at all, so
+    /// it stays in progress under its delegate rather than settling anywhere.
+    #[test]
+    fn only_endings_that_produced_something_land_in_review() {
+        // Produced a result — reviewable.
+        for end in [TaskRunEnd::Completed, TaskRunEnd::RedirectsExhausted] {
+            assert_eq!(landing_column(end), COLUMN_IN_REVIEW, "{end:?}");
+        }
+        // Produced nothing to accept — must not read as reviewable work.
+        for end in [
+            TaskRunEnd::Failed,
+            TaskRunEnd::Cancelled,
+            TaskRunEnd::Paused,
+            TaskRunEnd::Delegated,
+        ] {
+            assert_ne!(
+                landing_column(end),
+                COLUMN_IN_REVIEW,
+                "{end:?} produced no result and must not offer one for review"
+            );
+        }
+        // …and neither may a success that stopped at an unauthorised call.
+        for end in ALL_ENDINGS {
+            assert_ne!(
+                settled_landing_column(end, 1),
+                COLUMN_IN_REVIEW,
+                "{end:?} left an approval outstanding and must not present as reviewable"
+            );
+        }
+    }
+
+    /// A hand-off outranks the parked overlay: the delegator may have parked an
+    /// approval, but it still handed the work on and the delegate is running it.
+    /// Parking the card here would stall a card somebody is actively working.
+    #[test]
+    fn a_hand_off_stays_in_progress_even_if_the_delegator_parked_something() {
+        assert_eq!(
+            settled_landing_column(TaskRunEnd::Delegated, 3),
+            COLUMN_IN_PROGRESS
+        );
     }
 
     /// The review stop is **not** terminal-by-accident: it is non-terminal and

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -127,7 +127,7 @@ pub fn is_board_column(column: &str) -> bool {
 /// | Settled status | Column | Why |
 /// | --- | --- | --- |
 /// | [`Succeeded`](RunStatus::Succeeded) | [`COLUMN_IN_REVIEW`] | a person accepts the result |
-/// | [`WaitingApproval`](RunStatus::WaitingApproval) | [`COLUMN_IN_REVIEW`] | a person authorises the call |
+/// | [`WaitingApproval`](RunStatus::WaitingApproval) | [`COLUMN_PAUSED`] | the run stopped short; nothing to accept yet |
 /// | [`Paused`](RunStatus::Paused) | [`COLUMN_PAUSED`] | resumed, not approved |
 /// | [`Failed`](RunStatus::Failed) | [`COLUMN_TODO`] | with the run's error on the card |
 /// | [`Cancelled`](RunStatus::Cancelled) | [`COLUMN_TODO`] | with the cancellation reason on the card |
@@ -142,11 +142,40 @@ pub fn is_board_column(column: &str) -> bool {
 /// as done would make the terminal column mean "the model stopped talking"
 /// rather than "we shipped this".
 ///
-/// The consequence is that In Review carries **two** meanings — *approve this
-/// call* and *accept this result* — which are not interchangeable. The card is
-/// what disambiguates them: every settle stamps its own reason onto the note,
-/// so an operator opening an In Review card reads whether they are authorising
-/// an action or signing off finished work rather than having to guess.
+/// # `WaitingApproval` lands in Paused, **not** in review (issue #465)
+///
+/// This row used to share [`COLUMN_IN_REVIEW`] with `Succeeded`, on the argument
+/// that "a person acts next either way; the note says which act is wanted". That
+/// made In Review carry two non-interchangeable meanings — *approve this call*
+/// and *accept this result* — and left the operator to tell them apart from the
+/// note.
+///
+/// It is not a labelling problem. **[`COLUMN_IN_REVIEW`] is defined by the
+/// verdict that consumes it**: `review_landing_column(Approve)` writes
+/// [`COLUMN_DONE`], and it is the only route there. So a run that stopped at an
+/// unauthorised call sat one click away from being filed as finished — the exact
+/// state issue #337 set out to remove when it stopped a parked run auto-landing
+/// in Done. #337 closed the automatic route and left the manual one open.
+///
+/// A run parked on an approval has not produced a reviewable result: it stopped
+/// early, and in the worst case (its *first* call parked) it produced nothing at
+/// all while the board announced work to check. So the parked case leaves the
+/// review columns entirely and lands in [`COLUMN_PAUSED`] — the board's "stopped,
+/// not finished" column, and the one column the console gives a Resume control,
+/// which is the gesture that actually puts the work back in flight once the call
+/// is authorised.
+///
+/// **This narrows epic #183 decision 2** ("Paused vs In review is decided by who
+/// unblocks it — a person must act → In review"), which is why it is written
+/// down rather than quietly contradicted. That rule separates *waiting on a
+/// person* from *waiting on a system*, and it still holds — on the
+/// [`RunStatus`], where [`WaitingApproval`](RunStatus::WaitingApproval) remains
+/// distinct from [`Paused`](RunStatus::Paused) and the console renders it
+/// "Waiting on you". What the rule does not answer is *has the work happened
+/// yet*, and that is the question the **column** asks. The two questions get two
+/// answers in two places instead of one column trying to carry both — the same
+/// split [`crate::harness::lifecycle::run_status_for`] already documents, and the
+/// same reason `landing_column(Delegated)` diverges from its run status.
 ///
 /// # Why it lives on the port
 ///
@@ -161,11 +190,13 @@ pub fn is_board_column(column: &str) -> bool {
 /// card goes rather than silently inheriting somebody else's answer.
 pub fn column_for_settled_run(status: RunStatus) -> Option<&'static str> {
     match status {
-        // A person acts next either way; the note says which act is wanted.
-        RunStatus::Succeeded | RunStatus::WaitingApproval => Some(COLUMN_IN_REVIEW),
-        // Waiting on something other than a person — resume is a plain
-        // `column → in_progress` PATCH, which re-fires dispatch.
-        RunStatus::Paused => Some(COLUMN_PAUSED),
+        // A result somebody still has to accept.
+        RunStatus::Succeeded => Some(COLUMN_IN_REVIEW),
+        // Stopped short, so there is nothing to accept yet (issue #465). Both
+        // park the card; resume is a plain `column → in_progress` PATCH, which
+        // re-fires dispatch. `WaitingApproval` keeps saying *who* unblocks it on
+        // the run status — the column only says the work has not happened.
+        RunStatus::WaitingApproval | RunStatus::Paused => Some(COLUMN_PAUSED),
         // Not reviewable work. Epic #183 §3: a card that cannot proceed returns
         // to To-do carrying the reason, never into a stuck column of its own.
         RunStatus::Failed | RunStatus::Cancelled => Some(COLUMN_TODO),
@@ -790,9 +821,11 @@ mod test {
             column_for_settled_run(RunStatus::Succeeded),
             Some(COLUMN_IN_REVIEW)
         );
+        // Issue #465: a run parked on an approval stopped short of a result, so
+        // it parks the card rather than presenting it as reviewable work.
         assert_eq!(
             column_for_settled_run(RunStatus::WaitingApproval),
-            Some(COLUMN_IN_REVIEW)
+            Some(COLUMN_PAUSED)
         );
         assert_eq!(
             column_for_settled_run(RunStatus::Paused),
@@ -837,6 +870,42 @@ mod test {
                 "{status} must not auto-advance a card to Done"
             );
         }
+    }
+
+    /// **Issue #465, stated as the rule rather than the value.** Only a run that
+    /// produced a result may land in the column a review verdict consumes.
+    ///
+    /// The teeth: `review_landing_column(Approve)` turns [`COLUMN_IN_REVIEW`]
+    /// into [`COLUMN_DONE`] in one gesture, and it is the only route to Done. A
+    /// run that stopped at an unauthorised call has produced nothing to accept —
+    /// in the reported case, nothing at all — so leaving it reviewable put
+    /// unstarted work one click from finished. #337 removed the automatic route
+    /// to that state; this removes the manual one.
+    ///
+    /// Written as a loop over "did this run produce a result" rather than as an
+    /// equality on `WaitingApproval`, so a future status that also stops short
+    /// has to answer the same question instead of inheriting a column.
+    #[test]
+    fn only_a_run_that_produced_a_result_lands_where_review_can_approve_it() {
+        for status in [
+            RunStatus::WaitingApproval,
+            RunStatus::Paused,
+            RunStatus::Failed,
+            RunStatus::Cancelled,
+        ] {
+            assert_ne!(
+                column_for_settled_run(status),
+                Some(COLUMN_IN_REVIEW),
+                "{status} produced nothing to review, so it must not present as \
+                 reviewable work a verdict could approve straight to Done"
+            );
+        }
+        // The converse, so this cannot be satisfied by emptying the column: a
+        // run that *did* produce a result still reaches the reviewer.
+        assert_eq!(
+            column_for_settled_run(RunStatus::Succeeded),
+            Some(COLUMN_IN_REVIEW)
+        );
     }
 
     /// Whatever the table says must be a column the board actually renders —

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -28,6 +28,7 @@ use crate::company::steer::{
 use crate::harness::TurnOutcome;
 use crate::harness::lifecycle::{self, TaskRunEnd};
 use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
+use crate::harness::policy::ApprovalRequestQueue;
 use crate::harness::run_trace::RunTraceSink;
 use crate::ports::tasks::COLUMN_TODO;
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
@@ -234,6 +235,16 @@ pub(crate) struct DelegationRunner<'a> {
     /// the record the moment the work changes hands. `None` for an operator chat
     /// turn, and for a dispatch whose run row could not be minted.
     run_sink: Option<Arc<RunTraceSink>>,
+    /// The cycle's approval queue, read (never written) to tell whether a turn
+    /// this runner drove parked an approval (issue #465).
+    ///
+    /// Only the count matters, taken either side of the turn: a card whose turn
+    /// stopped at an unauthorised call has produced nothing to review, and
+    /// [`settle_work_card`](Self::settle_work_card) needs to know that before it
+    /// picks a landing. Optional so the ~dozen `DelegationRunner::new` sites in
+    /// tests stay untouched; `None` reads as "nothing parked", which is the
+    /// pre-#465 behaviour and correct for any runner that cannot park.
+    approvals: Option<&'a ApprovalRequestQueue>,
 }
 
 impl<'a> DelegationRunner<'a> {
@@ -258,7 +269,25 @@ impl<'a> DelegationRunner<'a> {
             max_delegations,
             task: None,
             run_sink: None,
+            approvals: None,
         }
+    }
+
+    /// Wires the cycle's approval queue so a settle can tell whether the turn it
+    /// is recording parked an approval (issue #465).
+    ///
+    /// Without it a turn whose first tool call parked settled as a plain
+    /// success and its card landed in In Review — announcing a result to check
+    /// on work that had never started.
+    pub(crate) fn with_approvals(mut self, approvals: &'a ApprovalRequestQueue) -> Self {
+        self.approvals = Some(approvals);
+        self
+    }
+
+    /// How many approval requests are parked right now, or `0` when no queue is
+    /// wired. Differenced across a turn to attribute parks to *that* turn.
+    fn approvals_queued(&self) -> usize {
+        self.approvals.map_or(0, ApprovalRequestQueue::queued)
     }
 
     /// Scopes this runner to a dispatched card, so anything the turn spawns
@@ -326,10 +355,15 @@ impl<'a> DelegationRunner<'a> {
         let mut direct_card = self
             .open_direct_work_card(responder, message, chat_id, carded_by_handler)
             .await?;
+        // Issue #465: sampled either side of the turn so the settle below reads
+        // what *this* turn parked, not what the cycle was already holding from
+        // an earlier one.
+        let approvals_before = self.approvals_queued();
         let outcome = self
             .run_turn
             .run(self.company, responder, message, chat_id)
             .await?;
+        let parked = self.approvals_queued().saturating_sub(approvals_before);
         // The responder's own steps ride on the operator bubble; its reply is the
         // operator-facing text UNLESS a synchronous desk delegation runs, in which
         // case the relay turn's reply replaces it (below).
@@ -341,8 +375,14 @@ impl<'a> DelegationRunner<'a> {
         // change the answer this card records.
         let mut direct_card_id = None;
         if let Some(card) = direct_card.as_mut() {
-            self.settle_work_card(card, responder, TaskRunEnd::Completed, &operator_reply)
-                .await?;
+            self.settle_work_card(
+                card,
+                responder,
+                TaskRunEnd::Completed,
+                parked,
+                &operator_reply,
+            )
+            .await?;
             direct_card_id = Some(card.id.clone());
         }
         // A `spawn_task` opens a card silently; a `delegate_to_desk` runs the desk
@@ -788,15 +828,25 @@ impl<'a> DelegationRunner<'a> {
     /// Settles a card [`open_work_card`](Self::open_work_card) opened, once the
     /// turn it was tracking has ended.
     ///
-    /// The landing column comes from [`lifecycle::landing_column`] like every
-    /// other settle on this seam, so a card opened by construction is finished
-    /// by the same rule as one that came off the board: a produced answer stops
-    /// in In Review for a person, a cancelled run goes back to To-do.
+    /// The landing column comes from [`lifecycle::settled_landing_column`] like
+    /// every other settle on this seam, so a card opened by construction is
+    /// finished by the same rule as one that came off the board: a produced
+    /// answer stops in In Review for a person, a cancelled run goes back to
+    /// To-do, and a run that stopped at an unauthorised call parks.
+    ///
+    /// `parked_approvals` is how many approvals **the turn this card is
+    /// recording** left outstanding, differenced across that turn by the caller.
+    /// Issue #465: this used to be [`lifecycle::landing_column`] with a
+    /// hardcoded [`TaskRunEnd::Completed`], so a desk whose first tool call
+    /// parked settled as a plain success — the card announced a result to review
+    /// while the work had not started. The ending alone cannot see that; only
+    /// the count can.
     async fn settle_work_card(
         &self,
         card: &mut TaskRecord,
         responder: &str,
         end: TaskRunEnd,
+        parked_approvals: usize,
         body: &str,
     ) -> Result<()> {
         card.note = Some(append_note(
@@ -804,7 +854,7 @@ impl<'a> DelegationRunner<'a> {
             &lifecycle::note_attribution(end, responder),
             body,
         ));
-        card.column = lifecycle::landing_column(end).to_string();
+        card.column = lifecycle::settled_landing_column(end, parked_approvals).to_string();
         card.updated_at_millis = now_millis();
         if let Some(tasks) = self.tasks {
             tasks.upsert(self.company, card).await?;
@@ -975,6 +1025,10 @@ impl<'a> DelegationRunner<'a> {
                     },
                 );
                 let control = guard.control().clone();
+                // Issue #465, same sampling as the direct-answer path: a desk
+                // delegation whose first call parks has produced nothing to
+                // review either.
+                let approvals_before = self.approvals_queued();
                 let outcome = self
                     .run_turn
                     .run_steered(
@@ -990,6 +1044,7 @@ impl<'a> DelegationRunner<'a> {
                         self.run_sink.clone(),
                     )
                     .await?;
+                let parked = self.approvals_queued().saturating_sub(approvals_before);
                 // A cancel issued mid-flight discards the delegated reply —
                 // nothing is relayed. Flagged as a cancellation so a caller that
                 // has to explain the empty result can name the cause instead of
@@ -1004,6 +1059,7 @@ impl<'a> DelegationRunner<'a> {
                             card,
                             &member,
                             TaskRunEnd::Cancelled,
+                            parked,
                             "the run was cancelled mid-flight",
                         )
                         .await?;
@@ -1015,8 +1071,14 @@ impl<'a> DelegationRunner<'a> {
                     });
                 }
                 if let Some(card) = card.as_mut() {
-                    self.settle_work_card(card, &member, TaskRunEnd::Completed, &outcome.reply)
-                        .await?;
+                    self.settle_work_card(
+                        card,
+                        &member,
+                        TaskRunEnd::Completed,
+                        parked,
+                        &outcome.reply,
+                    )
+                    .await?;
                 }
                 // Hand the teammate's answer back to RELAY through a second
                 // orchestrator turn (the CEO-relay hand-back). Their steps ride
@@ -1413,7 +1475,7 @@ mod tests {
     use std::sync::Mutex;
 
     use crate::ports::TaskStore;
-    use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_TODO};
+    use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO};
     use crate::ports::types::LedgerEntry;
     use crate::store::FsOps;
 
@@ -1556,6 +1618,10 @@ investor update for the quarter\n]"
         reply: String,
         queues: Vec<Delegation>,
         cancel: bool,
+        /// Tool calls this turn tried to make and had parked for approval
+        /// (issue #465), pushed onto the shared approval queue exactly as the
+        /// real [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) does.
+        parks: Vec<String>,
     }
 
     impl Turn {
@@ -1570,15 +1636,26 @@ investor update for the quarter\n]"
             Self {
                 reply: reply.to_string(),
                 queues,
-                cancel: false,
+                ..Self::default()
             }
         }
 
         fn cancelled(reply: &str) -> Self {
             Self {
                 reply: reply.to_string(),
-                queues: Vec::new(),
                 cancel: true,
+                ..Self::default()
+            }
+        }
+
+        /// A turn whose **first** tool call parked for approval, so it produced
+        /// nothing: the reply is the agent saying it is blocked, not a result.
+        /// This is the shape in the issue #465 report.
+        fn parked(reply: &str, tool: &str) -> Self {
+            Self {
+                reply: reply.to_string(),
+                parks: vec![tool.to_string()],
+                ..Self::default()
             }
         }
     }
@@ -1588,6 +1665,9 @@ investor update for the quarter\n]"
     /// drain produced without a harness pool or a live model.
     struct ScriptedTurns {
         queue: DelegationQueue,
+        /// The same handle the runner reads, so a parked call is visible to the
+        /// settle exactly as it is in production (issue #465).
+        approvals: ApprovalRequestQueue,
         script: Mutex<VecDeque<Turn>>,
         calls: Mutex<Vec<(String, String)>>,
         /// The board as it looked at the START of each turn, so a test can prove
@@ -1601,6 +1681,7 @@ investor update for the quarter\n]"
         fn new(fx: &Fixture, turns: Vec<Turn>) -> Self {
             Self {
                 queue: fx.queue.clone(),
+                approvals: fx.approvals.clone(),
                 script: Mutex::new(turns.into()),
                 calls: Mutex::new(Vec::new()),
                 board_at_turn: Mutex::new(Vec::new()),
@@ -1647,6 +1728,23 @@ investor update for the quarter\n]"
                 .unwrap_or_else(|| panic!("unscripted turn: {agent_id} <- {message}"));
             for delegation in turn.queues {
                 self.queue.push(delegation);
+            }
+            for tool in turn.parks {
+                self.approvals
+                    .push(crate::harness::policy::ApprovalRequest {
+                        tool: tool.clone(),
+                        reason: "supervised".to_string(),
+                        effect: crate::ports::types::Effect {
+                            kind: tool,
+                            group: crate::ports::types::EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: serde_json::json!({}),
+                            agent: Some(agent_id.to_string()),
+                            run_id: None,
+                        },
+                    });
             }
             if turn.cancel
                 && let Some(control) = control
@@ -1742,6 +1840,10 @@ members = ["engineer"]
         tasks: Arc<dyn TaskStore>,
         queue: DelegationQueue,
         steer: InflightRegistry,
+        /// Wired into every runner, so the parked-approval overlay (issue #465)
+        /// is exercised by the whole existing suite rather than only by the
+        /// tests that park something.
+        approvals: ApprovalRequestQueue,
     }
 
     impl Fixture {
@@ -1753,6 +1855,7 @@ members = ["engineer"]
                 record: record(),
                 queue: DelegationQueue::default(),
                 steer: InflightRegistry::default(),
+                approvals: ApprovalRequestQueue::default(),
             }
         }
 
@@ -1766,6 +1869,7 @@ members = ["engineer"]
                 &self.queue,
                 orchestrator::MAX_DELEGATIONS_PER_TURN,
             )
+            .with_approvals(&self.approvals)
         }
 
         async fn cards(&self) -> Vec<TaskRecord> {
@@ -1954,6 +2058,137 @@ members = ["engineer"]
         assert_eq!(cards[0].column, COLUMN_IN_REVIEW);
         assert_eq!(cards[0].origin_chat_id.as_deref(), Some("eng_desk"));
         assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
+    }
+
+    /// **Issue #465, the reported card.** A desk asked directly, whose first
+    /// tool call parks for approval, produced nothing — so its card must not
+    /// present as reviewable work.
+    ///
+    /// This path settled with a hardcoded [`TaskRunEnd::Completed`] and never
+    /// consulted the approval queue, so the card landed in In Review announcing
+    /// a result to check on work that had not started. It now parks, which is
+    /// where the operator can see it is blocked and where the console offers the
+    /// Resume that puts it back in flight once the call is authorised.
+    #[tokio::test]
+    async fn a_desk_whose_first_call_parks_leaves_its_card_blocked_not_reviewable() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::parked(
+                "I need approval before I can read the repo",
+                "fs_read",
+            )],
+        );
+        fx.runner(&turns)
+            .handle_operator_message(
+                "frontend_engineer",
+                "read the pricing repo and write modules.md",
+                Some("eng_desk"),
+            )
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(
+            cards[0].column, COLUMN_PAUSED,
+            "a turn that parked its first call produced nothing to review"
+        );
+        assert_ne!(
+            cards[0].column, COLUMN_IN_REVIEW,
+            "In Review is what a review verdict approves straight to Done — \
+             unstarted work must never sit there"
+        );
+    }
+
+    /// The other half of the same decision: parking is what moves the landing,
+    /// not the mere presence of an approval queue. A turn that ran clean still
+    /// reaches the reviewer.
+    ///
+    /// Paired with the test above so a fix that simply stopped writing In Review
+    /// would fail here.
+    #[tokio::test]
+    async fn a_desk_that_finished_cleanly_still_lands_in_review() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("modules.md is written")]);
+        fx.runner(&turns)
+            .handle_operator_message(
+                "frontend_engineer",
+                "read the pricing repo and write modules.md",
+                Some("eng_desk"),
+            )
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards[0].column, COLUMN_IN_REVIEW, "{cards:?}");
+        assert_eq!(fx.approvals.queued(), 0, "nothing was parked");
+    }
+
+    /// An approval left over from an *earlier* turn must not park this card.
+    /// The count is differenced across the turn precisely so a queue the cycle
+    /// was already holding cannot be misread as something this turn did.
+    #[tokio::test]
+    async fn an_approval_parked_before_this_turn_does_not_park_its_card() {
+        let fx = Fixture::new();
+        // Something a previous turn parked and nobody has resolved yet.
+        fx.approvals.push(crate::harness::policy::ApprovalRequest {
+            tool: "send_email".to_string(),
+            reason: "supervised".to_string(),
+            effect: crate::ports::types::Effect {
+                kind: "send_email".to_string(),
+                group: crate::ports::types::EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({}),
+                agent: Some("someone_else".to_string()),
+                run_id: None,
+            },
+        });
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("modules.md is written")]);
+        fx.runner(&turns)
+            .handle_operator_message(
+                "frontend_engineer",
+                "read the pricing repo and write modules.md",
+                Some("eng_desk"),
+            )
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(
+            cards[0].column, COLUMN_IN_REVIEW,
+            "this turn parked nothing of its own: {cards:?}"
+        );
+    }
+
+    /// A desk **hand-off** whose turn parks has the same shape as the direct
+    /// path, and settles the same way — the delegate stopped at an unauthorised
+    /// call, so its card is blocked rather than reviewable.
+    #[tokio::test]
+    async fn a_hand_off_whose_turn_parks_also_leaves_its_card_blocked() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::queueing("on it", vec![handoff("read the pricing repo")]),
+                Turn::parked("I need approval before I can read the repo", "fs_read"),
+                Turn::reply("relayed"),
+            ],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", "map out the pricing repo", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(
+            cards[0].column, COLUMN_PAUSED,
+            "the delegate parked its first call: {cards:?}"
+        );
     }
 
     /// One message, one card. The REST chat handler already opens a To-do card


### PR DESCRIPTION
## Summary

An operator asked a desk for something. The agent's first tool call parked for approval and nothing else happened. The card's header read, on one line:

> `In review · frontend_engineer · Not yet dispatched`

**In review** means *a person should look at the result*. Nothing was produced.

Closes #465.

## This is worse than a mislabelled column

`COLUMN_IN_REVIEW` is defined by the verdict that consumes it: `review_landing_column(Approve)` writes `COLUMN_DONE`, and it is the **only** production route to Done.

So a run that stopped at a call it was never authorised to make sat **one click from being filed as finished**. That is exactly the state #337 set out to remove — it closed the automatic route to Done and left the manual one open. This closes it.

## The mechanism — two routes, and the reported card took the unnamed one

The issue guessed `landing_column(Completed)` was reached because a parked turn "appears to reach the same ending." True but incomplete:

- **Route A, the reported one.** A desk asked directly opens a card by construction (#442), written through `TaskStore::upsert` rather than the dispatch edge — deliberately, so it cannot re-fire dispatch. `handle_operator_message` then settled it with a **literal `TaskRunEnd::Completed`**, never consulting the approval queue. The parked-approval overlay exists and this seam never reached it.
- **Route B, a board-dispatched card.** The parked count *is* computed, but `column_for_settled_run` mapped `WaitingApproval` to `COLUMN_IN_REVIEW` deliberately: *"A person acts next either way; the note says which act is wanted."*

**The header's other half is a separate bug.** `worked_span` reconstructs worked time from journaled `TaskDispatched` events, and a card opened by construction never emits one — so `workedMillis: 0, workedLive: false`, which the console rendered as "Not yet dispatched." **That statement was true. "In review" was the lie.**

## API Or Behavior Changes

**A run with an outstanding approval parks its card; it does not offer it for review.**

This **narrows epic #183's decision 2 explicitly**, rather than contradicting it quietly. The rule — *who unblocks it; a person must act → In review* — still holds, and still lives on `RunStatus`, where `WaitingApproval` stays distinct from `Paused`. What it never answered is *has the work happened yet*, and that is the column's question. Two questions, two answers, two places — the same split `run_status_for` already documents, and the same reason `landing_column(Delegated)` deliberately diverges from its run status.

**Paused, not In progress** — chosen on evidence rather than analogy. Approving does **not** re-dispatch the card's run: `redispatch_granted_call` re-issues the tool call in a *chat* thread with `task_id: None`, mints no `RunRecord`, and writes no column. The card needs a human gesture either way, and Paused is the one column with a Resume control. Verified live: Resume flips `paused → in_progress`, which is the dispatch edge, minting a fresh run. `in_progress` would have offered no control and left the card stuck.

`settled_landing_column(end, parked)` is now the single authority, with `landing_column(end)` as its zero-parked case, pinned by a test so the two cannot drift.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2315 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`
- [x] Frontend `typecheck` + `build`

`Cargo.lock` unchanged. Rebased onto current `main` (#466, #471, #472 had landed) with call sites re-checked.

**Verified live** on a real host with the real console and the real projection:
- The reported header reproduced on unfixed code — `Status In review · engineer · Not yet dispatched` — plus a second contradiction on `paused`.
- After the fix, neither settled column renders the claim; `todo` still does, correctly.
- The projection input behind it: `workedMillis: 0, workedLive: false, timeline: []`.
- Resume on a paused card flips it to `in_progress`.

**Unit-only:** "a real agent's first tool call parks" is covered by four integration tests over the real `DelegationRunner` and real `ApprovalRequestQueue` — direct-desk park, hand-off park, clean-run control, and a stale park from an earlier turn — not by a live model, because no inference credential exists here and the offline echo brain does not traverse the delegation seam. **The approve-then-continue round trip is unit-only**; its board half was verified live, but a real parked call was never authorised end to end.

## Documentation

`docs/spec/runtime/ports.md` records the narrowed rule and why the column and the run status answer different questions.

## Notes for review

**One file outside the assigned set: `src/ports/tasks.rs`.** The decision belongs there — putting it anywhere else would re-create the two-table drift that #337 collapsed onto the port specifically to eliminate.

**Two things found and deliberately not fixed:**

1. `settle_work_card` still *assumes* its ending — both success sites pass a literal `Completed`, so a desk turn returning an error *string* (rather than a hard `Err`, which propagates) settles as success. The parked count is now threaded; the ending itself remains unexamined.
2. Approving genuinely does not continue the card's run. The docstring at `settled_run_status` claims "the re-dispatch that follows an approval is a *new* run" — **no production path does that today.** This PR makes it materially better (Resume now exists and works), but the automatic continuation is not implemented. Out of scope here by the issue's own framing, and it overlaps #469.
