### PR TITLE
fix(approvals): one turn owes one continuation, and its answer reaches the channel (#469)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -82,6 +82,7 @@ pub(crate) async fn join_follow_up(
     }
 }
 use crate::runtime::CycleRunner;
+use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::cycle::ResolveReceipt;
 use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantId, GrantScope, GrantSet, StandingGrant};
 use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, RuntimeJournal};
@@ -202,6 +203,16 @@ pub struct CompanyRuntime {
     /// ever mints, so the set stays empty and every approval keeps its
     /// pre-#243 native-execute behaviour.
     pub(crate) grants: GrantSet,
+    /// Issue #469: how many of each turn's parked approvals are still
+    /// undecided, so a turn that raised several sign-offs is continued **once**
+    /// — after the last of them lands — instead of once per decision.
+    ///
+    /// Live per-instance state, like [`grants`](Self::grants), and inherited by
+    /// a rebuilt runtime through [`RuntimeHandover`](crate::runtime::handover::RuntimeHandover)
+    /// for the same reason: a swap in the middle of a partly-decided turn must
+    /// not forget that the turn is blocked, or the next decision continues it as
+    /// though the others had never been owed.
+    pub(crate) continuations: ContinuationQueue,
     /// Held for the duration of a cycle so cycles never interleave per company.
     ///
     /// `Arc`-shared rather than owned so a rebuilt runtime can inherit the *same*
@@ -303,6 +314,7 @@ impl CompanyRuntime {
             steer: crate::company::steer::InflightRegistry::new(),
             run_supervisor: crate::runtime::RunSupervisor::new(),
             grants,
+            continuations: ContinuationQueue::default(),
             serial: Arc::new(TokioMutex::new(())),
             task_writes: Arc::new(TokioMutex::new(())),
             quiesced: Arc::new(AtomicBool::new(false)),
@@ -835,6 +847,16 @@ impl CompanyRuntime {
         self.task_writes = task_writes;
     }
 
+    /// Installs the continuation queue the builder prepared (issue #469) —
+    /// re-armed from the journal on a boot, inherited live on a rebuild.
+    ///
+    /// Set through the builder rather than [`new`](Self::new) so the ~30 direct
+    /// `CompanyRuntime::new` call sites do not each have to learn about a queue
+    /// only the approval path reads, matching how the locks are handed over.
+    pub fn adopt_continuations(&mut self, continuations: ContinuationQueue) {
+        self.continuations = continuations;
+    }
+
     /// Rejects a cycle on a runtime that is being replaced.
     ///
     /// Separate from [`ensure_running`](Self::ensure_running): that one reads a
@@ -963,11 +985,15 @@ impl CompanyRuntime {
     /// keeps every caller on one path instead of branching on a case that only
     /// arises from a double-click.
     ///
-    /// A failed follow-up is logged here rather than swallowed, because the
-    /// detached caller has nowhere to put it. It is genuinely recoverable: the
-    /// verdict and the grant are already durable, and re-approving is a safe
-    /// no-op (`ResolveOutcome::NotParked` → the already-resolved report, per
-    /// issue #243), so the operator can retry without minting a second grant.
+    /// A failed follow-up is **told to the operator**, not only logged
+    /// (issue #469, defect 4). It is genuinely recoverable: the verdict and the
+    /// grant are already durable, and re-approving is a safe no-op
+    /// (`ResolveOutcome::NotParked` → the already-resolved report, per issue
+    /// #243), so the operator can retry without minting a second grant. But
+    /// that is only useful to somebody who knows it happened, and before this
+    /// the whole report was one `tracing::error!` on a stream nobody watches:
+    /// the agent was not told the outcome and neither was the person waiting
+    /// for it.
     fn spawn_follow_up(
         self: &Arc<Self>,
         receipt: ResolveReceipt,
@@ -980,19 +1006,234 @@ impl CompanyRuntime {
                 }
                 ResolveReceipt::Settled(event) => event,
             };
-            let report = CycleRunner::new(&rt).run(vec![event]).await;
-            if let Err(error) = &report {
+            rt.continue_turn(event).await
+        })
+    }
+
+    /// Runs the continuation a settled verdict owes — **once per turn, not once
+    /// per approval** (issue #469).
+    ///
+    /// A turn that parked four calls is blocked on four decisions. Before this,
+    /// each decision spawned its own cycle, so approving all four re-ran the
+    /// same turn four times: four full agent turns over one turn's work, each
+    /// told about one decision and blind to the other three, with the later ones
+    /// finding the grants the earlier ones had already redeemed and quietly
+    /// producing nothing. The operator approved four times and got silence.
+    ///
+    /// So the decision is banked instead, and the cycle runs when the **last**
+    /// one lands, carrying every `ApprovalResolved` the turn accumulated. The
+    /// trigger is the last decision rather than a window, which is what makes
+    /// approving four at once and approving them one at a time over a minute end
+    /// in the same place. An approval whose journal line predates the turn key
+    /// is not gated and continues on its own, exactly as it used to.
+    async fn continue_turn(&self, event: CompanyEvent) -> Result<CycleReport> {
+        let CompanyEvent::ApprovalResolved { approval_id, .. } = &event else {
+            // Not a resolution, so no turn owns it. Run it as its own cycle.
+            return CycleRunner::new(self).run(vec![event]).await;
+        };
+        let approval_id = approval_id.clone();
+
+        // `Some(None)` is a park recorded before the turn key existed; `None` is
+        // an id this journal never parked. Neither is gated.
+        let turn = self.journal.approval_cycle(&approval_id).flatten();
+        let batch = match &turn {
+            Some(turn) => match self.continuations.decide(turn, Some(event)) {
+                Some(batch) => batch,
+                None => {
+                    tracing::debug!(
+                        company = %self.id,
+                        approval_id = %approval_id,
+                        turn = %turn,
+                        outstanding = self.continuations.outstanding(turn),
+                        "[approval] decision recorded; the turn is still waiting on another"
+                    );
+                    return Ok(self.still_waiting_report(turn));
+                }
+            },
+            None => vec![event],
+        };
+        if batch.is_empty() {
+            // Every approval the turn raised expired rather than being decided.
+            // The sweep already appended each `ApprovalResolved` itself, so
+            // there is nothing left to tell the brain.
+            return Ok(CycleRunner::new(self).already_resolved_report());
+        }
+        self.run_continuation(&approval_id, batch).await
+    }
+
+    /// Runs one turn's continuation over the decisions it was blocked on, and
+    /// makes sure its answer — or its failure — reaches the operator
+    /// (issue #469).
+    ///
+    /// Split from [`continue_turn`](Self::continue_turn) because the release can
+    /// also come from the TTL sweep, and a turn released by an expiry owes
+    /// exactly the same continuation, delivered exactly the same way, as one
+    /// released by the operator's last click.
+    async fn run_continuation(
+        &self,
+        approval_id: &ApprovalId,
+        batch: Vec<CompanyEvent>,
+    ) -> Result<CycleReport> {
+        match CycleRunner::new(self).run(batch).await {
+            Ok(mut report) => {
+                self.publish_continuation(approval_id, &mut report).await;
+                Ok(report)
+            }
+            Err(error) => {
                 tracing::error!(
-                    company = %rt.id,
+                    company = %self.id,
                     %error,
                     "[approval] the follow-up cycle after a resolved approval failed; \
                      the verdict and the grant are already durable, so the agent was \
                      not told the outcome — re-approving is a safe no-op and will \
                      re-run it"
                 );
+                self.announce_continuation_failure(approval_id).await;
+                Err(error)
             }
-            report
-        })
+        }
+    }
+
+    /// Journals the continuation's replies into the conversation the sign-off
+    /// was asked in, so the agent's answer actually reaches the operator
+    /// (issue #469, defect 1).
+    ///
+    /// **This is where the answer used to be lost.** The chat route journals
+    /// every reply a cycle produces as an
+    /// [`AgentReply`](CompanyEvent::AgentReply), which is what the console's
+    /// event stream projects as an `agent_reply` frame and what a reload
+    /// rebuilds the transcript from. The resolve route never did. It emitted
+    /// webhooks and, on the un-detached path, handed the replies back on the
+    /// response body — but the console's inline approval card resolves with
+    /// `detach: true`, so the body is a receipt and the replies went nowhere at
+    /// all. Nothing was broken about the cycle; its answer simply had no way to
+    /// become visible.
+    ///
+    /// The thread is the one the approval was **raised** in, not the answering
+    /// agent: a desk channel's request and a direct message to that channel's
+    /// lead are answered by the same teammate, so keying on the agent delivers a
+    /// channel's continuation into a private line nobody is watching
+    /// (issue #379's lesson, applied to the reply as well as the re-park). Every
+    /// approval in a batch came from one cycle, and that cycle had one thread,
+    /// so one lookup answers for the whole batch. Falling back to the responding
+    /// agent when the turn had no conversation behind it is the pre-existing
+    /// behaviour for exactly the cases it was already right for.
+    ///
+    /// Best-effort per reply, exactly as on the chat route: a journal failure
+    /// must not sink an answer the operator can already read on the response
+    /// body. It costs the bubble its durable id, which the console reads as "not
+    /// saved" and refuses to thread or react on — the honest degradation.
+    async fn publish_continuation(&self, approval_id: &ApprovalId, report: &mut CycleReport) {
+        let thread = self.journal.approval_thread(approval_id).flatten();
+        for response in &mut report.responses {
+            let chat_id = thread.clone().unwrap_or_else(|| response.channel.clone());
+            match self
+                .events
+                .append(
+                    &self.id,
+                    CompanyEvent::AgentReply {
+                        parent: None,
+                        chat_id,
+                        agent_id: response.channel.clone(),
+                        text: response.text.clone(),
+                        steps: response.steps.clone(),
+                        task_id: response.task_id.clone(),
+                    },
+                )
+                .await
+            {
+                Ok(seq) => response.message_id = Some(seq.value().to_string()),
+                Err(err) => tracing::warn!(
+                    company = %self.id,
+                    approval_id = %approval_id,
+                    error = %err,
+                    "[approval] the continuation answered but its reply could not be \
+                     journaled; the bubble has no durable id"
+                ),
+            }
+        }
+    }
+
+    /// Tells the operator, in the conversation they are waiting in, that the
+    /// continuation failed (issue #469, defect 4).
+    ///
+    /// Journaled as an [`AgentReply`](CompanyEvent::AgentReply) rather than sent
+    /// through [`announce_to_operator`](Self::announce_to_operator), because the
+    /// latter is a bare channel send with no event behind it — it reaches an
+    /// adapter, not the console's event stream, and not a transcript reload. The
+    /// person this is for is watching the thread they approved in.
+    ///
+    /// The wording says what is true and what to do: the decision stuck, the
+    /// work did not, and re-approving is safe.
+    async fn announce_continuation_failure(&self, approval_id: &ApprovalId) {
+        let thread = self
+            .journal
+            .approval_thread(approval_id)
+            .flatten()
+            .unwrap_or_else(|| crate::runtime::channel::OPERATOR_CHANNEL.to_string());
+        if let Err(err) = self
+            .events
+            .append(
+                &self.id,
+                CompanyEvent::AgentReply {
+                    parent: None,
+                    chat_id: thread,
+                    agent_id: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                    text: "Your approval was recorded, but the agent could not pick the work \
+                           back up. Nothing was half-done — approving again is safe and will \
+                           retry it."
+                        .to_string(),
+                    steps: Vec::new(),
+                    task_id: None,
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                company = %self.id,
+                approval_id = %approval_id,
+                error = %err,
+                "[approval] a failed continuation could not be reported to the operator"
+            );
+        }
+    }
+
+    /// The answer to a decision that lands while its turn is still blocked on
+    /// another (issue #469).
+    ///
+    /// Synthetic, like [`already_resolved_report`](CycleRunner::already_resolved_report),
+    /// and for the same reason: nothing ran, so there is nothing to report but
+    /// the fact itself. It carries a line rather than an empty body because the
+    /// un-detached caller — the Approvals page — renders the response, and
+    /// "recorded, still waiting on the rest" is the honest thing to show
+    /// somebody who has just approved one of four and would otherwise be told
+    /// nothing at all.
+    ///
+    /// Deliberately **not** journaled: it is a receipt for one request, not an
+    /// agent's reply, and four of them in a conversation would be noise over a
+    /// state the approval cards already show.
+    fn still_waiting_report(&self, turn: &str) -> CycleReport {
+        let outstanding = self.continuations.outstanding(turn);
+        CycleReport {
+            cycle_id: crate::ports::generate_id(),
+            responses: vec![crate::ports::types::OutboundMessage {
+                message_id: None,
+                task_id: None,
+                channel: crate::runtime::channel::OPERATOR_CHANNEL.to_string(),
+                text: format!(
+                    "Recorded. The agent picks this back up once the remaining {outstanding} \
+                     sign-off{} on this step {} decided.",
+                    if outstanding == 1 { "" } else { "s" },
+                    if outstanding == 1 { "is" } else { "are" },
+                ),
+                steps: Vec::new(),
+                reply_to: None,
+            }],
+            executed_effects: Vec::new(),
+            parked: Vec::new(),
+            persisted_seq: None,
+            input_seqs: Vec::new(),
+        }
     }
 
     /// Sweeps every parked approval past its TTL, resolving each to a
@@ -1007,11 +1248,38 @@ impl CompanyRuntime {
     /// append is best-effort for the same reason steer's audit is: a sweep that
     /// already denied the effect must not be undone by a log write, and the
     /// journal remains the binding audit trail either way.
-    pub async fn sweep_expired_approvals(&self) -> Result<Vec<ApprovalId>> {
+    ///
+    /// An expiry is also a **decision** as far as issue #469's continuation gate
+    /// is concerned, and has to be, or a turn that raised four sign-offs and
+    /// only ever got three would wait for a fourth that is never coming. The
+    /// turn is released here; the `ApprovalResolved` this appends is the event
+    /// the brain gets, so the release contributes no second one.
+    pub async fn sweep_expired_approvals(self: &Arc<Self>) -> Result<Vec<ApprovalId>> {
         let now = now_millis();
         let expired = self.approval_gate.sweep_expired(now);
         for id in &expired {
             self.journal.record_expired(id, now).await?;
+            // Issue #469: releasing the turn this approval was blocking, and
+            // running its continuation when this expiry was the last thing it
+            // waited on. Spawned rather than awaited: the continuation is a full
+            // agent turn behind the per-company cycle lock, and the maintenance
+            // tick this runs on fires on a minute boundary for every company.
+            if let Some(turn) = self.journal.approval_cycle(id).flatten()
+                && let Some(batch) = self.continuations.decide(&turn, None)
+                && !batch.is_empty()
+            {
+                let rt = Arc::clone(self);
+                let released = id.clone();
+                tokio::spawn(async move {
+                    if let Err(error) = rt.run_continuation(&released, batch).await {
+                        tracing::error!(
+                            company = %rt.id,
+                            %error,
+                            "[approval] the continuation released by an expiry failed"
+                        );
+                    }
+                });
+            }
             if let Err(e) = self
                 .events
                 .append(

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -282,49 +282,20 @@ impl HarnessBrain {
             }
         };
 
-        // Journal the reply so the transcript echo survives a console refresh.
-        // The bubble below is live-only — a reader that reloads the page rebuilds
-        // the thread from the event log, and without this the operator would
-        // approve, watch the agent answer, refresh, and find the answer gone.
+        // The reply is **not** journaled here (issue #469).
         //
-        // `chat_id` is the thread the approval was RAISED in (issue #379), not
-        // the agent id. Those agree for a direct message and diverge for a desk
-        // channel — a channel's request and a DM to that channel's lead are
-        // answered by the same teammate — so keying on the agent quietly
-        // delivered a channel's continuation into the lead's private line. The
-        // operator approved in one place and the work resumed in another they
-        // were not looking at, which is the whole failure this issue names.
+        // It used to be, because nothing else did: the resolve route dropped a
+        // continuation's replies on the floor, so this arm hand-wrote its own
+        // `AgentReply` to get the answer onto the event stream. That covered
+        // exactly one shape — a re-dispatch that found a grant to redeem — and
+        // left every other continuation reply invisible, including the ones this
+        // function returns `None` for and everything the default build produces.
         //
-        // Falls back to the agent when the grant carries no origin thread: a
-        // pre-#379 journal line, or an approval with no conversation behind it.
-        // That is exactly the previous behaviour, kept for exactly the cases it
-        // was already right for.
-        let reply_thread = grant
-            .origin_thread
-            .clone()
-            .unwrap_or_else(|| grant.agent.clone());
-        if let Some(events) = self.deps.events.as_ref()
-            && let Err(err) = events
-                .append(
-                    &self.record.id,
-                    CompanyEvent::AgentReply {
-                        parent: None,
-                        chat_id: reply_thread.clone(),
-                        agent_id: grant.agent.clone(),
-                        text: text.clone(),
-                        steps: Vec::new(),
-                        task_id: None,
-                    },
-                )
-                .await
-        {
-            tracing::warn!(
-                approval_id = %approval_id,
-                error = %err,
-                "[approval] failed to journal the re-issued call's reply; continuing"
-            );
-        }
-
+        // Journaling now happens once, for every continuation reply, in
+        // `CompanyRuntime::publish_continuation`, against the same thread this
+        // used (`journal.approval_thread`, issue #379's key) with the same
+        // fallback to the answering agent. Writing it here as well would post the
+        // agent's answer into the conversation twice.
         Ok(Some(OutboundMessage {
             message_id: None,
             task_id: None,
@@ -5093,114 +5064,37 @@ members = ["eng1", "eng2"]
             bubble.text
         );
 
-        // The reply is journaled under the agent's own chat thread, so the echo
-        // survives a console refresh rather than living only in this response.
-        let stored = log
-            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
+        // Journaling the reply is no longer this function's job (issue #469):
+        // the runtime journals every continuation reply once, in
+        // `CompanyRuntime::publish_continuation`, so that the answers of
+        // continuations this arm produces nothing for are not lost either. The
+        // round trip — reply journaled into the thread the sign-off was raised
+        // in, reaching the console's event stream — is covered end to end over
+        // the real router by
+        // `server::operator::test::a_continuation_answers_in_the_thread_the_sign_off_was_raised_in`.
+        assert!(
+            no_replies_journaled(&log).await,
+            "the brain must not journal the reply a second time; the runtime owns it"
+        );
+    }
+
+    /// No continuation reply was journaled by the brain itself (issue #469).
+    async fn no_replies_journaled(log: &Arc<dyn crate::ports::EventLog>) -> bool {
+        log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
             .await
-            .unwrap();
-        let replies: Vec<_> = stored
+            .unwrap()
             .iter()
-            .filter_map(|e| match &e.event {
-                CompanyEvent::AgentReply {
-                    chat_id,
-                    agent_id,
-                    text,
-                    ..
-                } => Some((chat_id.clone(), agent_id.clone(), text.clone())),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(replies.len(), 1, "the re-issued call's reply is journaled");
-        assert_eq!(
-            replies[0].0, "ceo",
-            "routed into the granting agent's thread"
-        );
-        assert_eq!(replies[0].1, "ceo");
-        assert_eq!(replies[0].2, bubble.text);
+            .all(|e| !matches!(e.event, CompanyEvent::AgentReply { .. }))
     }
 
-    /// Issue #379, and a live bug before it: the continuation must be journaled
-    /// into the thread the operator **asked in**, not the agent's own line.
-    ///
-    /// The two are the same string for a direct message and diverge for a desk
-    /// channel — the channel and a DM to that channel's lead are answered by the
-    /// same teammate — so keying on the agent quietly delivered a channel's
-    /// continuation into the lead's private DM. The operator approved in one
-    /// place and the work resumed somewhere they were not looking.
-    ///
-    /// Asserted in **both directions**, because one alone would pass on a
-    /// mistake: a desk-origin reply must not appear in the lead's DM history,
-    /// and a DM-origin reply must not appear in the desk's.
-    #[tokio::test]
-    async fn a_redeemed_grant_replies_in_the_thread_the_approval_was_raised_in() {
-        async fn replies_for(origin: Option<&str>) -> Vec<(String, String)> {
-            let dir = tempfile::tempdir().unwrap();
-            let log: Arc<dyn crate::ports::EventLog> =
-                Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
-            let requests = crate::harness::policy::ApprovalRequestQueue::default();
-            requests
-                .grants()
-                .grant(crate::runtime::grants::GrantedCall {
-                    approval_id: ApprovalId::new("appr-1"),
-                    agent: "ceo".into(),
-                    tool: "composio_execute".into(),
-                    args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
-                    at_millis: now_millis(),
-                    origin_thread: origin.map(str::to_string),
-                });
-            let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
-            brain
-                .run_cycle(
-                    cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
-                    &NoopHost,
-                )
-                .await
-                .expect("cycle runs");
-            log.read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
-                .await
-                .unwrap()
-                .iter()
-                .filter_map(|e| match &e.event {
-                    CompanyEvent::AgentReply {
-                        chat_id, agent_id, ..
-                    } => Some((chat_id.clone(), agent_id.clone())),
-                    _ => None,
-                })
-                .collect()
-        }
-
-        // Raised in a desk channel: the continuation belongs to the channel.
-        let desk = replies_for(Some("desk-finance")).await;
-        assert_eq!(desk.len(), 1);
-        assert_eq!(
-            desk[0].0, "desk-finance",
-            "a channel's approval must resume in that channel",
-        );
-        assert_ne!(
-            desk[0].0, "ceo",
-            "and must NOT land in the desk lead's private DM — the bug this fixes",
-        );
-        // The asker is still credited: only the destination changed.
-        assert_eq!(desk[0].1, "ceo");
-
-        // Raised in a direct message with that same lead: the mirror image. Same
-        // agent, different thread, and the desk channel must not see it.
-        let dm = replies_for(Some("ceo")).await;
-        assert_eq!(dm.len(), 1);
-        assert_eq!(dm[0].0, "ceo");
-        assert_ne!(
-            dm[0].0, "desk-finance",
-            "a private line's approval must not resume in the desk channel",
-        );
-
-        // No origin thread — a pre-#379 grant, or an approval with no
-        // conversation behind it. Falls back to the agent, which is exactly the
-        // previous behaviour, kept for the cases it was already right for.
-        let legacy = replies_for(None).await;
-        assert_eq!(legacy.len(), 1);
-        assert_eq!(legacy[0].0, "ceo");
-    }
+    // Issue #379's reply routing — a channel's continuation must resume in that
+    // channel and not in its lead's private DM, and the mirror — used to be
+    // pinned here, against a hand-built grant. It moved with the journaling
+    // (issue #469): the runtime journals every continuation reply once, for both
+    // grant scopes, from the same `journal.approval_thread` key this read off the
+    // grant. The both-directions mirror is now driven end to end over the real
+    // router by
+    // `server::operator::test::a_continuation_resumes_in_the_thread_it_was_raised_in_and_no_other`.
 
     /// Issue #374: a resolution that minted only a STANDING grant must still
     /// re-dispatch the agent.
@@ -5261,72 +5155,11 @@ members = ["eng1", "eng2"]
             bubble.text
         );
 
-        // And it is journaled, so the echo survives a refresh.
-        let stored = log
-            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
-            .await
-            .unwrap();
-        assert_eq!(
-            stored
-                .iter()
-                .filter(|e| matches!(e.event, CompanyEvent::AgentReply { .. }))
-                .count(),
-            1
-        );
-    }
-
-    /// The routing half of #379 holds for the broader scope too: the
-    /// continuation lands in the thread the operator asked in, not the agent's
-    /// own line.
-    #[tokio::test]
-    async fn a_standing_grant_replies_into_the_thread_it_was_raised_in() {
-        let dir = tempfile::tempdir().unwrap();
-        let log: Arc<dyn crate::ports::EventLog> =
-            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
-        let requests = crate::harness::policy::ApprovalRequestQueue::default();
-        requests
-            .grants()
-            .grant_standing(crate::runtime::grants::StandingGrant {
-                id: crate::runtime::grants::GrantId::new("g1"),
-                agent: "ceo".into(),
-                tool: "workspace_write".into(),
-                granted_by: crate::ports::types::Actor {
-                    kind: crate::ports::types::ActorKind::User,
-                    id: "user-1".into(),
-                },
-                approval_id: ApprovalId::new("appr-1"),
-                at_millis: now_millis(),
-                expires_at_millis: now_millis() + 60 * 60 * 1000,
-                // A DESK channel, whose lead is `ceo` — the exact pair that
-                // diverges.
-                origin_thread: Some("desk-ops".into()),
-            });
-        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
-
-        brain
-            .run_cycle(
-                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
-                &NoopHost,
-            )
-            .await
-            .expect("cycle runs");
-
-        let stored = log
-            .read_from(&CompanyId::new("acme"), crate::ports::EventSeq::new(0), 100)
-            .await
-            .unwrap();
-        let threads: Vec<String> = stored
-            .iter()
-            .filter_map(|e| match &e.event {
-                CompanyEvent::AgentReply { chat_id, .. } => Some(chat_id.clone()),
-                _ => None,
-            })
-            .collect();
-        assert_eq!(
-            threads,
-            vec!["desk-ops".to_string()],
-            "the work resumes where the operator approved it, not in the lead's DM"
-        );
+        // Journaling the reply belongs to the runtime now (issue #469), so the
+        // brain must not write a second copy. See
+        // `server::operator::test::a_continuation_answers_in_the_thread_the_sign_off_was_raised_in`
+        // for the round trip.
+        assert!(no_replies_journaled(&log).await);
     }
 
     /// A DENIED approval runs no turn. "No" must never re-dispatch anything.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1163,6 +1163,20 @@ impl RuntimeBuilder {
             }
         };
 
+        // Issue #469: which turns are still blocked on a decision, on exactly
+        // the same terms. A boot rebuilds it from the approvals the replay left
+        // parked; a rebuild inherits the live one, because that one also knows
+        // about decisions taken since the replay and a fresh count would ask a
+        // turn to wait for them all over again.
+        let continuations = match handover.as_ref() {
+            Some(h) => h.continuations.clone(),
+            None => {
+                let continuations = crate::runtime::continuation::ContinuationQueue::default();
+                continuations.rearm(journal.parked_turns());
+                continuations
+            }
+        };
+
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
         //   2. under the `openhuman` feature, an attached harness pool + a
@@ -1744,6 +1758,7 @@ impl RuntimeBuilder {
         if let Some(h) = handover.as_ref() {
             runtime.adopt_locks(h.serial.clone(), h.task_writes.clone());
         }
+        runtime.adopt_continuations(continuations);
 
         // MCP uses OpenHuman's process-global live connection registry. Keep a
         // runtime-owned config for this OpenCompany home so REST and agents see

--- a/src/runtime/continuation.rs
+++ b/src/runtime/continuation.rs
@@ -1,0 +1,334 @@
+//! One turn, one continuation (issue #469).
+//!
+//! A single agent turn can park several approvals — four `composio_execute`
+//! calls with different arguments is a real, reported case. Before this, each
+//! resolve spawned its own follow-up cycle, so approving all four re-ran the
+//! same turn four times. The re-runs did not race (the per-company serial lock
+//! in [`CycleRunner::run`](crate::runtime::CycleRunner::run) holds for a whole
+//! cycle, so they queued), but they were four full agent turns over one turn's
+//! worth of work, each told about one decision and blind to the other three.
+//!
+//! The missing fact was that the four belonged together. Nothing on a parked
+//! approval said so: the thread key is shared by every turn in a conversation,
+//! and the task and run keys are absent for exactly the case that matters most,
+//! a chat turn. So [`ApprovalOrigin::cycle`](crate::runtime::journal::ApprovalOrigin::cycle)
+//! now records the parking cycle, and this queue counts, per turn, how many of
+//! its approvals are still undecided.
+//!
+//! The rule it enforces: **a turn is continued once, when the last decision it
+//! was blocked on lands**, carrying every `ApprovalResolved` event the turn
+//! accumulated on the way. That is the same continuation whether the operator
+//! decides the four together or one at a time over a minute — the trigger is
+//! the last decision, not the clock, so the two orders cannot diverge.
+//!
+//! ## Why counting, and not asking the journal
+//!
+//! "Is anything from this turn still parked?" is answerable from the journal,
+//! and answering it there is racy. Resolves arrive over HTTP concurrently even
+//! though the cycles they spawn do not: two requests can each un-park their own
+//! approval and then each read a queue that looks empty, and both would run a
+//! continuation. Counting here closes that by construction — the decrement and
+//! the "was that the last one" test happen under one lock, so exactly one
+//! caller is ever handed the batch.
+//!
+//! ## What is deliberately not gated
+//!
+//! An approval with no turn key — a journal line written before #469 — is never
+//! armed, and [`decide`](ContinuationQueue::decide) hands its event straight
+//! back. Those continue on their own exactly as they always did.
+//!
+//! ## The cost, stated plainly
+//!
+//! A turn whose approvals are only *partly* decided now waits, where before it
+//! re-dispatched the approved ones immediately. That is the honest state — the
+//! turn really is still blocked — and the alternative is what this issue
+//! reports: a re-run that re-parks everything still undecided, which compounds
+//! with every decision. The wait is bounded: an undecided approval expires to a
+//! default-deny on the gate's TTL, and that expiry is a decision like any other
+//! (see [`CompanyRuntime::sweep_expired_approvals`](crate::company::runtime::CompanyRuntime::sweep_expired_approvals)),
+//! so the turn is always eventually continued rather than stranded.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::ports::types::CompanyEvent;
+
+/// What a turn is still waiting on, and what it has collected so far.
+#[derive(Default)]
+struct PendingTurn {
+    /// How many of this turn's approvals are still undecided.
+    outstanding: usize,
+    /// The `ApprovalResolved` events its decided approvals owe the brain, in
+    /// decision order. Handed to the continuation cycle as one batch.
+    decided: Vec<CompanyEvent>,
+}
+
+/// Per-turn continuation state: how many approvals each turn is still blocked
+/// on, and the decisions it has banked (issue #469).
+///
+/// Cheap to [`Clone`] — a shared handle, like every other queue in the runtime —
+/// so the parking side (the cycle host) and the resolving side (the runtime)
+/// see one set of counters.
+#[derive(Clone, Default)]
+pub struct ContinuationQueue {
+    inner: Arc<Mutex<HashMap<String, PendingTurn>>>,
+}
+
+impl ContinuationQueue {
+    /// Records that `turn` just parked one more approval.
+    ///
+    /// Called from the one place approvals are parked, so the count cannot
+    /// drift from the queue it describes.
+    pub fn arm(&self, turn: &str) {
+        self.inner
+            .lock()
+            .expect("continuation queue poisoned")
+            .entry(turn.to_string())
+            .or_default()
+            .outstanding += 1;
+    }
+
+    /// Records one decision on `turn`, banking `event` for the continuation.
+    ///
+    /// Returns `Some(batch)` **exactly when this was the last decision the turn
+    /// was blocked on** — the caller then owes one continuation cycle over the
+    /// whole batch, and the turn's state is dropped. `None` means the turn is
+    /// still waiting on another decision and the caller owes nothing.
+    ///
+    /// `event` is `None` for a decision that carries no event for the brain —
+    /// an expiry, whose `ApprovalResolved` the sweep has already appended
+    /// itself. It still counts as a decision, because it still unblocks.
+    ///
+    /// A turn this queue never armed is not gated: the event comes straight
+    /// back as a batch of one. That covers a pre-#469 journal line and a
+    /// restart that lost the counter, and in both cases it is the pre-#469
+    /// behaviour rather than a turn that never continues.
+    pub fn decide(&self, turn: &str, event: Option<CompanyEvent>) -> Option<Vec<CompanyEvent>> {
+        let mut guard = self.inner.lock().expect("continuation queue poisoned");
+        let Some(pending) = guard.get_mut(turn) else {
+            return Some(event.into_iter().collect());
+        };
+        if let Some(event) = event {
+            pending.decided.push(event);
+        }
+        pending.outstanding = pending.outstanding.saturating_sub(1);
+        if pending.outstanding > 0 {
+            return None;
+        }
+        guard.remove(turn).map(|pending| pending.decided)
+    }
+
+    /// Re-arms the counters after a journal replay, from the turn key of every
+    /// approval that is still parked — one entry per approval.
+    ///
+    /// **Idempotent**: it *sets* each turn's count to what the journal says
+    /// rather than adding to it, so replaying twice (boot loads the journal, and
+    /// [`CompanyRuntime::recover`](crate::company::runtime::CompanyRuntime::recover)
+    /// can be driven again) leaves a turn blocked on the number of decisions it
+    /// is actually blocked on. Any decisions already banked for a turn are kept:
+    /// the count is what replay knows, the bank is what this process has seen.
+    ///
+    /// A handed-over runtime inherits the live queue instead and never comes
+    /// through here — the counters there include decisions the journal has
+    /// already recorded as resolved.
+    pub fn rearm(&self, turns: impl IntoIterator<Item = String>) {
+        let mut counts: HashMap<String, usize> = HashMap::new();
+        for turn in turns {
+            *counts.entry(turn).or_default() += 1;
+        }
+        let mut guard = self.inner.lock().expect("continuation queue poisoned");
+        for (turn, count) in counts {
+            guard.entry(turn).or_default().outstanding = count;
+        }
+    }
+
+    /// How many turns are still waiting on a decision.
+    pub fn waiting(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("continuation queue poisoned")
+            .len()
+    }
+
+    /// How many decisions `turn` is still blocked on. `0` for a turn this queue
+    /// is not tracking.
+    pub fn outstanding(&self, turn: &str) -> usize {
+        self.inner
+            .lock()
+            .expect("continuation queue poisoned")
+            .get(turn)
+            .map(|p| p.outstanding)
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{Actor, ActorKind, ApprovalId, Verdict};
+
+    fn resolved(id: &str) -> CompanyEvent {
+        CompanyEvent::ApprovalResolved {
+            approval_id: ApprovalId::new(id),
+            verdict: Verdict::Approve,
+            by: Actor {
+                kind: ActorKind::Operator,
+                id: "operator".into(),
+            },
+        }
+    }
+
+    fn ids(batch: &[CompanyEvent]) -> Vec<String> {
+        batch
+            .iter()
+            .map(|e| match e {
+                CompanyEvent::ApprovalResolved { approval_id, .. } => approval_id.to_string(),
+                _ => unreachable!(),
+            })
+            .collect()
+    }
+
+    /// The keystone: four approvals from one turn owe **one** continuation, and
+    /// it carries all four decisions.
+    #[test]
+    fn a_turn_continues_once_after_its_last_decision() {
+        let q = ContinuationQueue::default();
+        for _ in 0..4 {
+            q.arm("cycle-1");
+        }
+
+        assert!(q.decide("cycle-1", Some(resolved("a"))).is_none());
+        assert!(q.decide("cycle-1", Some(resolved("b"))).is_none());
+        assert!(q.decide("cycle-1", Some(resolved("c"))).is_none());
+        let batch = q
+            .decide("cycle-1", Some(resolved("d")))
+            .expect("the last decision unblocks the turn");
+
+        assert_eq!(ids(&batch), vec!["a", "b", "c", "d"]);
+        assert_eq!(q.waiting(), 0, "the turn's state is dropped once it runs");
+    }
+
+    /// Two turns blocked at once do not unblock each other — the whole reason
+    /// the key is the parking cycle and not the thread they share.
+    #[test]
+    fn turns_are_independent() {
+        let q = ContinuationQueue::default();
+        q.arm("cycle-1");
+        q.arm("cycle-1");
+        q.arm("cycle-2");
+
+        assert!(q.decide("cycle-1", Some(resolved("a"))).is_none());
+        let second = q
+            .decide("cycle-2", Some(resolved("z")))
+            .expect("cycle-2 was blocked on one decision only");
+        assert_eq!(ids(&second), vec!["z"]);
+        assert_eq!(q.outstanding("cycle-1"), 1, "cycle-1 still waits");
+
+        let first = q.decide("cycle-1", Some(resolved("b"))).expect("unblocked");
+        assert_eq!(ids(&first), vec!["a", "b"]);
+    }
+
+    /// A turn that parked exactly one approval continues on that decision, so
+    /// the ordinary single-approval path is byte-for-byte what it was.
+    #[test]
+    fn a_single_approval_turn_continues_immediately() {
+        let q = ContinuationQueue::default();
+        q.arm("cycle-1");
+        let batch = q.decide("cycle-1", Some(resolved("a"))).expect("unblocked");
+        assert_eq!(ids(&batch), vec!["a"]);
+    }
+
+    /// An approval with no turn key — a pre-#469 journal line — is never gated.
+    #[test]
+    fn an_unarmed_turn_continues_alone() {
+        let q = ContinuationQueue::default();
+        let batch = q
+            .decide("never-armed", Some(resolved("a")))
+            .expect("an unknown turn is not a turn to wait on");
+        assert_eq!(ids(&batch), vec!["a"]);
+    }
+
+    /// An expiry carries no event of its own — the sweep appends that itself —
+    /// but it is still a decision, so it still unblocks the turn.
+    #[test]
+    fn an_expiry_counts_as_a_decision() {
+        let q = ContinuationQueue::default();
+        q.arm("cycle-1");
+        q.arm("cycle-1");
+
+        assert!(q.decide("cycle-1", Some(resolved("a"))).is_none());
+        let batch = q
+            .decide("cycle-1", None)
+            .expect("the expiry was the last thing the turn waited on");
+        assert_eq!(
+            ids(&batch),
+            vec!["a"],
+            "the expiry contributes no event, only the unblocking"
+        );
+    }
+
+    /// A turn whose every approval expired unblocks with nothing to say. The
+    /// caller must be able to tell that from "one decision arrived", because an
+    /// empty batch owes no cycle at all.
+    #[test]
+    fn a_wholly_expired_turn_yields_an_empty_batch() {
+        let q = ContinuationQueue::default();
+        q.arm("cycle-1");
+        assert_eq!(
+            q.decide("cycle-1", None).expect("unblocked"),
+            Vec::new(),
+            "nothing to tell the brain"
+        );
+    }
+
+    /// Recovery rebuilds the counters, so a restart mid-turn comes back still
+    /// knowing that turn is blocked rather than continuing it early.
+    #[test]
+    fn recovery_rearms_the_outstanding_counts() {
+        let q = ContinuationQueue::default();
+        q.rearm(vec![
+            "cycle-1".to_string(),
+            "cycle-1".to_string(),
+            "cycle-2".to_string(),
+        ]);
+        assert_eq!(q.outstanding("cycle-1"), 2);
+        assert_eq!(q.outstanding("cycle-2"), 1);
+
+        assert!(q.decide("cycle-1", Some(resolved("a"))).is_none());
+        assert!(q.decide("cycle-1", Some(resolved("b"))).is_some());
+    }
+
+    /// The decrement and the "was that the last one" test are one critical
+    /// section, so concurrent resolves cannot both be handed a batch. Exactly
+    /// one of eight threads may run the continuation.
+    #[test]
+    fn concurrent_decisions_hand_the_batch_to_exactly_one_caller() {
+        let q = ContinuationQueue::default();
+        for _ in 0..8 {
+            q.arm("cycle-1");
+        }
+
+        let batches = Arc::new(Mutex::new(Vec::new()));
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let q = q.clone();
+            let batches = Arc::clone(&batches);
+            handles.push(std::thread::spawn(move || {
+                if let Some(batch) = q.decide("cycle-1", Some(resolved(&format!("a{i}")))) {
+                    batches.lock().unwrap().push(batch);
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let batches = batches.lock().unwrap();
+        assert_eq!(batches.len(), 1, "two continuations for one turn");
+        assert_eq!(
+            batches[0].len(),
+            8,
+            "the single continuation carries every decision"
+        );
+    }
+}

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -944,6 +944,11 @@ working on):\n{}\n]",
         self.rt
             .grants
             .rehydrate_standing(self.rt.journal.replayed_standing_grants(now_millis()));
+        // Issue #469: and the turns still blocked on a decision. A restart in
+        // the middle of a partly-decided turn must come back knowing it is
+        // blocked, or its continuation fires on the next decision as though the
+        // others had never been owed.
+        self.rt.continuations.rearm(self.rt.journal.parked_turns());
         Ok(())
     }
 
@@ -1492,8 +1497,20 @@ impl<'a> CycleHostImpl<'a> {
                 now_millis(),
                 TaskLink::from_task_id(self.task_id.as_deref()),
                 self.thread_id.clone(),
+                // Issue #469: which turn is blocked on this. Recorded here
+                // because this is the one write path into the approval queue, so
+                // the count the continuation queue keeps below cannot describe a
+                // different set of approvals from the one that is parked.
+                Some(self.cycle_id.clone()),
             )
             .await?;
+        // …and armed on the live counter in the same breath. A turn that parks
+        // four calls is blocked on four decisions; the runtime holds its
+        // continuation until the last of them lands and then runs it once.
+        // Strictly after the journal write, so a crash between the two replays
+        // as "still parked" and is re-armed by recovery rather than leaving a
+        // counter for an approval no record describes.
+        self.rt.continuations.arm(&self.cycle_id);
         // Issue #379: tell every subscribed console a request just parked, so an
         // inline card can appear in the conversation *as it happens* rather than
         // on the next poll of the approvals feed.
@@ -3310,14 +3327,16 @@ mod test {
         let gate = Arc::new(
             ManifestApprovalGate::new(manifest("supervised").policy.clone()).with_ttl_millis(0),
         );
-        let rt = RuntimeBuilder::new(home.clone(), manifest("supervised"))
-            .with_brain(Arc::new(EffectBrain {
-                effect: sign_effect,
-            }))
-            .with_approvals(gate)
-            .build()
-            .await
-            .unwrap();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("supervised"))
+                .with_brain(Arc::new(EffectBrain {
+                    effect: sign_effect,
+                }))
+                .with_approvals(gate)
+                .build()
+                .await
+                .unwrap(),
+        );
 
         let report = rt
             .run_cycle(vec![CompanyEvent::OperatorMessage {
@@ -3754,6 +3773,7 @@ mod test {
                 now_millis(),
                 TaskLink::Unlinked,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -3827,6 +3847,7 @@ mod test {
                 now_millis(),
                 TaskLink::Unlinked,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -3877,7 +3898,7 @@ mod test {
                 .unwrap();
             let id = rt.approvals.park(rt.id(), effect.clone()).await.unwrap();
             rt.journal
-                .record_parked(&id, &effect, now_millis(), TaskLink::Unlinked, None)
+                .record_parked(&id, &effect, now_millis(), TaskLink::Unlinked, None, None)
                 .await
                 .unwrap();
             id

--- a/src/runtime/handover.rs
+++ b/src/runtime/handover.rs
@@ -54,6 +54,7 @@ use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;
 use crate::policy::ManifestApprovalGate;
 use crate::ports::{CompanyStore, ContextStore, EventLog, InboxStore, MemoryStore, SecretStore};
+use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::grants::GrantSet;
 use crate::runtime::journal::RuntimeJournal;
 
@@ -80,6 +81,11 @@ pub struct RuntimeHandover {
     pub(crate) journal: Arc<RuntimeJournal>,
     pub(crate) approval_gate: Arc<ManifestApprovalGate>,
     pub(crate) grants: GrantSet,
+    /// Issue #469: the turns still blocked on a decision. Live per-instance
+    /// state like the grant set — a swap mid-turn that forgot which turns were
+    /// waiting would continue the next one on its first decision instead of its
+    /// last.
+    pub(crate) continuations: ContinuationQueue,
     pub(crate) serial: Arc<TokioMutex<()>>,
     pub(crate) task_writes: Arc<TokioMutex<()>>,
     #[cfg(feature = "openhuman")]
@@ -114,6 +120,7 @@ impl CompanyRuntime {
             journal: self.journal.clone(),
             approval_gate: self.approval_gate.clone(),
             grants: self.grants.clone(),
+            continuations: self.continuations.clone(),
             serial: self.serial.clone(),
             task_writes: self.task_writes.clone(),
             #[cfg(feature = "openhuman")]

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -112,6 +112,26 @@ enum JournalRecord {
         /// `#[serde(default)]` is what lets a pre-#379 line replay.
         #[serde(default)]
         thread: Option<String>,
+        /// Which **cycle** parked it (issue #469) — the turn key.
+        ///
+        /// The three keys above all answer "what is this approval about". This
+        /// one answers "what is waiting on it", and only it can: a single turn
+        /// can park several calls, and each of the others is either shared by
+        /// turns that are not blocked on each other (a thread hosts many turns)
+        /// or absent for the case that matters most (a chat turn has no card and
+        /// no run).
+        ///
+        /// Without it, resolving four sign-offs from one turn re-ran that turn
+        /// four times, because nothing could say the four belonged together.
+        /// With it, the runtime holds the continuation until the last of a
+        /// turn's approvals is decided and then runs it once — see
+        /// [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue).
+        ///
+        /// `None` means a line written before this field existed, and falls back
+        /// to the pre-#469 behaviour of continuing that approval on its own.
+        /// `#[serde(default)]` is what lets those lines replay.
+        #[serde(default)]
+        cycle: Option<String>,
     },
     /// A parked approval that has since been resolved (approved or denied).
     ApprovalResolved {
@@ -294,6 +314,13 @@ pub struct ApprovalOrigin {
     /// still recoverable — which is what lets a follow-up cycle's own re-park
     /// stay in the channel the first sign-off was asked in.
     pub thread: Option<String>,
+    /// The **turn** that parked it: the id of the parking cycle (issue #469).
+    ///
+    /// The key that groups the several approvals one turn can raise, so the
+    /// turn is continued once — after the last of them is decided — instead of
+    /// once per decision. `None` for a pre-#469 journal line, which continues
+    /// on its own exactly as it used to.
+    pub cycle: Option<String>,
 }
 
 /// One approval currently waiting in the in-memory queue.
@@ -306,6 +333,10 @@ struct ParkedApproval {
     /// The chat thread that parked it (issue #379); `None` when no conversation
     /// produced it, or on a pre-#379 line.
     thread: Option<String>,
+    /// The turn that parked it (issue #469); `None` on a pre-#469 line. Held on
+    /// the live entry, not only in `origins`, because recovery has to re-arm the
+    /// continuation queue from exactly the approvals that are *still* waiting.
+    cycle: Option<String>,
 }
 
 /// A side effect that was **committed to run** (issue #351): what it was, which
@@ -620,6 +651,7 @@ impl RuntimeJournal {
                 at_millis,
                 task,
                 thread,
+                cycle,
             } => {
                 state.retain_approval_effect(&id, &effect);
                 state.origins.insert(
@@ -630,6 +662,7 @@ impl RuntimeJournal {
                         task: task.clone(),
                         run_id: effect.run_id.clone(),
                         thread: thread.clone(),
+                        cycle: cycle.clone(),
                     },
                 );
                 state.parked.insert(
@@ -639,6 +672,7 @@ impl RuntimeJournal {
                         at_millis,
                         task,
                         thread,
+                        cycle,
                     },
                 );
             }
@@ -726,6 +760,11 @@ impl RuntimeJournal {
     /// this" from "this host does not record conversations". Both mean no
     /// channel owns the approval, and both correctly leave it on the Approvals
     /// page alone.
+    ///
+    /// `cycle` is the parking turn (issue #469), and is what lets the runtime
+    /// continue a turn once rather than once per approval it raised. `Option`
+    /// on the same terms as `thread`: absent means "this host did not record a
+    /// turn", which falls back to continuing the approval on its own.
     pub async fn record_parked(
         &self,
         id: &ApprovalId,
@@ -733,6 +772,7 @@ impl RuntimeJournal {
         at_millis: u64,
         task: TaskLink,
         thread: Option<String>,
+        cycle: Option<String>,
     ) -> Result<()> {
         {
             let mut state = self.state.lock().expect("journal state poisoned");
@@ -744,6 +784,7 @@ impl RuntimeJournal {
                     task: Some(task.clone()),
                     run_id: effect.run_id.clone(),
                     thread: thread.clone(),
+                    cycle: cycle.clone(),
                 },
             );
             state.parked.insert(
@@ -753,6 +794,7 @@ impl RuntimeJournal {
                     at_millis,
                     task: Some(task.clone()),
                     thread: thread.clone(),
+                    cycle: cycle.clone(),
                 },
             );
             state.retain_approval_effect(id, effect);
@@ -763,8 +805,44 @@ impl RuntimeJournal {
             at_millis,
             task: Some(task),
             thread,
+            cycle,
         })
         .await
+    }
+
+    /// The turn key of every approval **still parked**, one entry per approval
+    /// (issue #469).
+    ///
+    /// Read once, at recovery, to re-arm the
+    /// [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue):
+    /// a restart in the middle of a partly-decided turn must come back still
+    /// knowing that turn is blocked, or its continuation would either fire early
+    /// or never fire at all. Approvals with no turn key (pre-#469 lines) are
+    /// omitted — they continue on their own and are never gated.
+    pub fn parked_turns(&self) -> Vec<String> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .parked
+            .values()
+            .filter_map(|p| p.cycle.clone())
+            .collect()
+    }
+
+    /// The turn that parked `id`, if it is one this journal recorded
+    /// (issue #469).
+    ///
+    /// Two levels of absence, and they mean different things — the same shape
+    /// [`approval_thread`](Self::approval_thread) uses. `None`: nothing was ever
+    /// parked under this id. `Some(None)`: parked, by a line written before the
+    /// turn key existed.
+    pub fn approval_cycle(&self, id: &ApprovalId) -> Option<Option<String>> {
+        self.state
+            .lock()
+            .expect("journal state poisoned")
+            .origins
+            .get(id)
+            .map(|o| o.cycle.clone())
     }
 
     /// The effect an approval was parked with, payload scrubbed (issue #351).
@@ -1417,6 +1495,7 @@ mod test {
                 1_000,
                 TaskLink::Task { id: "t-1".into() },
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1479,7 +1558,7 @@ mod test {
         };
 
         journal
-            .record_parked(&id, &parked, 1_000, TaskLink::Unlinked, None)
+            .record_parked(&id, &parked, 1_000, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         journal.record_resolved(&id).await.unwrap();
@@ -1521,6 +1600,7 @@ mod test {
                 1_000,
                 TaskLink::Unlinked,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1552,7 +1632,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-1");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         assert_eq!(journal.pending().len(), 1);
@@ -1595,6 +1675,7 @@ mod test {
                 1_000,
                 TaskLink::Task { id: "t-1".into() },
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -1605,12 +1686,13 @@ mod test {
                 1_100,
                 TaskLink::Task { id: "t-2".into() },
                 None,
+                None,
             )
             .await
             .unwrap();
         // No card behind it (a workflow delivery, an operator-chat turn).
         journal
-            .record_parked(&orphan, &effect(), 1_200, TaskLink::Unlinked, None)
+            .record_parked(&orphan, &effect(), 1_200, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
 
@@ -1638,6 +1720,7 @@ mod test {
                 task: Some(TaskLink::Task { id: "t-1".into() }),
                 run_id: None,
                 thread: None,
+                cycle: None,
             }),
         );
         assert_eq!(
@@ -1690,7 +1773,7 @@ mod test {
         // fact, written explicitly, and must not read back as the legacy shape.
         let fresh = ApprovalId::new("appr-new");
         journal
-            .record_parked(&fresh, &effect(), 5_000, TaskLink::Unlinked, None)
+            .record_parked(&fresh, &effect(), 5_000, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         assert_eq!(
@@ -1758,6 +1841,7 @@ mod test {
                 5_000,
                 TaskLink::Unlinked,
                 Some("desk-finance".to_string()),
+                None,
             )
             .await
             .unwrap();
@@ -1806,7 +1890,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-exp");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         assert_eq!(journal.pending().len(), 1);
@@ -1830,7 +1914,7 @@ mod test {
         let journal = RuntimeJournal::new(&path);
         let id = ApprovalId::new("appr-amend");
         journal
-            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None)
+            .record_parked(&id, &effect(), now_millis(), TaskLink::Unlinked, None, None)
             .await
             .unwrap();
 
@@ -1871,11 +1955,11 @@ mod test {
         let resolved = ApprovalId::new("appr-resolved");
         let expired = ApprovalId::new("appr-expired");
         journal
-            .record_parked(&resolved, &effect(), 1_000, TaskLink::Unlinked, None)
+            .record_parked(&resolved, &effect(), 1_000, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         journal
-            .record_parked(&expired, &effect(), 2_000, TaskLink::Unlinked, None)
+            .record_parked(&expired, &effect(), 2_000, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
 
@@ -2100,6 +2184,7 @@ mod test {
                 500,
                 TaskLink::Unlinked,
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -2130,7 +2215,7 @@ mod test {
 
         let parked_id = ApprovalId::new("appr-parked");
         journal
-            .record_parked(&parked_id, &effect(), 500, TaskLink::Unlinked, None)
+            .record_parked(&parked_id, &effect(), 500, TaskLink::Unlinked, None, None)
             .await
             .unwrap();
         journal

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -29,6 +29,11 @@ pub mod approval_display;
 pub mod assignee;
 pub mod builder;
 pub mod channel;
+/// Issue #469: one turn, one continuation. Tracks how many of a turn's parked
+/// approvals are still undecided, so resolving several sign-offs raised by the
+/// same turn re-runs that turn **once** — after the last decision — rather than
+/// once per decision. See [`continuation`].
+pub mod continuation;
 pub mod cron;
 pub mod cycle;
 /// Brain-agnostic delegation seam (issue #176): the [`RunTurn`] trait +

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -566,6 +566,7 @@ mode = "full"
                 crate::ports::now_millis(),
                 TaskLink::Unlinked,
                 None,
+                None,
             )
             .await
             .expect("journals");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -4974,4 +4974,424 @@ mod test {
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
+
+    // ---------------------------------------------------------------------
+    // Issue #469 — a turn that parks several approvals.
+    //
+    // Every test above parks exactly one, which is the case that always
+    // worked. The failure the operator hit needs more than one: four
+    // `composio_execute` calls from a single turn, all approved, and then
+    // silence. These drive that shape end to end over the real router.
+    // ---------------------------------------------------------------------
+
+    /// A brain that parks `parks` gated tool calls on one operator message and
+    /// answers each `ApprovalResolved` it is told about.
+    ///
+    /// Deliberately shaped like `HarnessBrain`'s approval arm rather than like a
+    /// convenient stub: it consults the live grant set and produces **no reply
+    /// at all** when there is no grant left to redeem, because that silent
+    /// no-op is exactly what the later of several follow-up cycles used to hit.
+    struct MultiParkBrain {
+        parks: usize,
+        /// One entry per `ApprovalResolved` the brain was handed, across all
+        /// cycles.
+        decisions: Arc<std::sync::Mutex<Vec<String>>>,
+        /// How many cycles ran in total (the first is the chat turn).
+        cycles: Arc<std::sync::atomic::AtomicUsize>,
+        /// The runtime, so the brain can reach the grant set the way the
+        /// harness's re-dispatch does. Filled by the test after the build.
+        rt: Arc<std::sync::OnceLock<Arc<CompanyRuntime>>>,
+        /// Fail the continuation cycle, to exercise defect 4.
+        fail_continuation: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::brain::Brain for MultiParkBrain {
+        async fn run_cycle(
+            &self,
+            req: crate::ports::types::CycleRequest,
+            host: &dyn crate::ports::brain::CycleHost,
+        ) -> crate::Result<crate::ports::types::CycleResult> {
+            self.cycles
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let mut responses = Vec::new();
+            for event in &req.events {
+                match event {
+                    CompanyEvent::OperatorMessage { .. } => {
+                        for i in 0..self.parks {
+                            let mut effect = gated_tool_call();
+                            effect.payload = serde_json::json!({ "tool_slug": format!("T{i}") });
+                            host.park_effect(effect).await?;
+                        }
+                    }
+                    CompanyEvent::ApprovalResolved { approval_id, .. } => {
+                        if self.fail_continuation {
+                            return Err(crate::error::OpenCompanyError::BackgroundTask(
+                                "the continuation turn fell over".into(),
+                            ));
+                        }
+                        self.decisions.lock().unwrap().push(approval_id.to_string());
+                        let rt = self.rt.get().expect("the test wires the runtime");
+                        let Some(grant) = rt.grants.peek(approval_id) else {
+                            continue;
+                        };
+                        rt.grants.consume(&grant.agent, &grant.tool, &grant.args);
+                        responses.push(crate::ports::types::OutboundMessage {
+                            message_id: None,
+                            task_id: None,
+                            channel: grant.agent.clone(),
+                            text: format!("re-issued {approval_id}"),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        });
+                    }
+                    _ => {}
+                }
+            }
+            Ok(crate::ports::types::CycleResult {
+                channel_responses: responses,
+                new_traces: vec![crate::ports::types::CompressedTrace::now(
+                    &req.cycle_id,
+                    "multi-park cycle",
+                )],
+                ledger_deltas: Vec::new(),
+                token_usage: crate::ports::types::TokenUsage::default(),
+            })
+        }
+    }
+
+    /// A company whose next turn parks four sign-offs.
+    struct MultiParkCompany {
+        app: axum::Router,
+        runtime: Arc<CompanyRuntime>,
+        approvals: Vec<ApprovalId>,
+        decisions: Arc<std::sync::Mutex<Vec<String>>>,
+        cycles: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    async fn multi_park_company(
+        home: &std::path::Path,
+        parks: usize,
+        chat: Option<&str>,
+        fail_continuation: bool,
+    ) -> MultiParkCompany {
+        let decisions = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let cycles = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let rt_slot: Arc<std::sync::OnceLock<Arc<CompanyRuntime>>> =
+            Arc::new(std::sync::OnceLock::new());
+        let state = build_state_with_brain(
+            home,
+            "running",
+            AppConfig::default(),
+            Some(Arc::new(MultiParkBrain {
+                parks,
+                decisions: decisions.clone(),
+                cycles: cycles.clone(),
+                rt: rt_slot.clone(),
+                fail_continuation,
+            })),
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let _ = rt_slot.set(runtime.clone());
+        let app = router(state);
+
+        let body = match chat {
+            Some(chat) => serde_json::json!({ "text": "do it", "chat": chat }),
+            None => serde_json::json!({ "text": "do it" }),
+        };
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/chat")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let approvals: Vec<_> = runtime
+            .pending_approvals()
+            .iter()
+            .map(|a| a.id.clone())
+            .collect();
+        assert_eq!(approvals.len(), parks, "the turn parked {parks} sign-offs");
+
+        MultiParkCompany {
+            app,
+            runtime,
+            approvals,
+            decisions,
+            cycles,
+        }
+    }
+
+    /// Every `AgentReply` in the log, as `chat_id|text` — what the console's
+    /// event stream projects as an `agent_reply` frame and what a transcript
+    /// reload rebuilds from. An empty list means the operator saw nothing.
+    async fn agent_replies(runtime: &Arc<CompanyRuntime>) -> Vec<String> {
+        use crate::ports::types::EventSeq;
+        runtime
+            .events()
+            .read_from(runtime.id(), EventSeq::new(0), 10_000)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|s| match s.event {
+                CompanyEvent::AgentReply { text, chat_id, .. } => Some(format!("{chat_id}|{text}")),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn approve_detached(id: &ApprovalId) -> Request<Body> {
+        resolve_request(id, serde_json::json!({"verdict":"approve","detach":true}))
+    }
+
+    /// Waits for the follow-up work a detached resolve spawned to settle.
+    async fn settle(runtime: &Arc<CompanyRuntime>) {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while runtime.continuations.waiting() > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("the turn never unblocked");
+        // The continuation itself runs on a spawned task; let it finish.
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+    }
+
+    /// **The keystone (issue #469).** A turn that parks four sign-offs, all
+    /// approved, produces exactly ONE continuation — and an answer the operator
+    /// can actually see.
+    ///
+    /// Before this, each resolve spawned its own follow-up cycle: four full
+    /// re-runs of one turn, each told about one decision. They did not race —
+    /// the per-company serial lock made them queue — but the later ones found
+    /// the grants the earlier ones had redeemed and produced nothing at all.
+    /// And none of it reached the operator either way, because the resolve
+    /// route never journaled a continuation's replies, so no `agent_reply`
+    /// frame was ever projected. Four approvals, four wasted turns, silence.
+    #[tokio::test]
+    async fn four_sign_offs_from_one_turn_produce_one_continuation() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 4, None, false).await;
+        let before = c.cycles.load(std::sync::atomic::Ordering::SeqCst);
+
+        let mut handles = Vec::new();
+        for id in &c.approvals {
+            let app = c.app.clone();
+            let request = approve_detached(id);
+            handles.push(tokio::spawn(
+                async move { app.oneshot(request).await.unwrap() },
+            ));
+        }
+        for handle in handles {
+            assert_eq!(handle.await.unwrap().status(), StatusCode::OK);
+        }
+        settle(&c.runtime).await;
+
+        assert_eq!(
+            c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
+            1,
+            "one turn owes one continuation, not one per approval"
+        );
+        assert_eq!(
+            c.decisions.lock().unwrap().len(),
+            4,
+            "the single continuation carries every decision, so the brain learns all four"
+        );
+        assert!(
+            c.runtime.pending_approvals().is_empty(),
+            "every sign-off was decided"
+        );
+        assert_eq!(
+            agent_replies(&c.runtime).await.len(),
+            4,
+            "the continuation's answers must reach the event stream, or the operator \
+             watches an approved action in silence"
+        );
+    }
+
+    /// The two orders an operator can decide in must end in the same place.
+    ///
+    /// Approving four at once and approving them one at a time are the same
+    /// request spread over a different span, and the gate is the last decision
+    /// rather than a time window — so neither can produce more continuations
+    /// than the other. A design that coalesced only what arrived together would
+    /// pass the test above and still re-run the turn four times here.
+    #[tokio::test]
+    async fn deciding_one_at_a_time_ends_where_deciding_all_at_once_does() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 4, None, false).await;
+        let before = c.cycles.load(std::sync::atomic::Ordering::SeqCst);
+
+        for (i, id) in c.approvals.iter().enumerate() {
+            let response = c.app.clone().oneshot(approve_detached(id)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            let ran = c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before;
+            if i < 3 {
+                assert_eq!(
+                    ran,
+                    0,
+                    "the turn is still blocked on {} more sign-off(s); continuing now \
+                     would re-park them",
+                    3 - i
+                );
+            }
+        }
+        settle(&c.runtime).await;
+
+        assert_eq!(
+            c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
+            1,
+            "the last decision unblocks the turn, and it runs once"
+        );
+        assert_eq!(c.decisions.lock().unwrap().len(), 4);
+        assert_eq!(agent_replies(&c.runtime).await.len(), 4);
+    }
+
+    /// The continuation answers in the conversation the sign-off was raised in.
+    ///
+    /// Not on the answering agent's own line: a desk channel's request and a
+    /// direct message to that channel's lead are answered by the same teammate,
+    /// so keying the reply on the agent delivers a channel's continuation into a
+    /// private thread nobody is watching (issue #379's lesson, which the reply
+    /// path had never learned — only the re-park had).
+    #[tokio::test]
+    async fn a_continuation_answers_in_the_thread_the_sign_off_was_raised_in() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 2, Some("sales"), false).await;
+
+        for id in &c.approvals {
+            let response = c.app.clone().oneshot(approve_detached(id)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+        settle(&c.runtime).await;
+
+        let replies = agent_replies(&c.runtime).await;
+        assert_eq!(replies.len(), 2, "both re-issues answered");
+        assert!(
+            replies.iter().all(|r| r.starts_with("sales|")),
+            "the continuation must land in the channel the approval was raised in, got {replies:?}"
+        );
+    }
+
+    /// **Issue #379's routing, re-homed (issue #469).** The continuation
+    /// resumes in the thread the sign-off was raised in — and in no other.
+    ///
+    /// Asserted in **both directions**, because either alone would pass on a
+    /// mistake. A desk channel's request and a direct message to that channel's
+    /// lead are answered by the same teammate, so a reply keyed on the agent
+    /// lands a channel's continuation in a private line nobody is watching, and
+    /// a reply keyed on the channel does the reverse.
+    ///
+    /// This used to be pinned inside the harness brain, against a hand-built
+    /// grant. It moved here with the journaling: the thread comes off the park
+    /// record now, so the strong version of the test is the one that lets a real
+    /// turn stamp it and a real resolve read it back.
+    #[tokio::test]
+    async fn a_continuation_resumes_in_the_thread_it_was_raised_in_and_no_other() {
+        async fn threads_for(chat: &str) -> Vec<String> {
+            let home_dir = home();
+            let c = multi_park_company(home_dir.path(), 1, Some(chat), false).await;
+            let response = c
+                .app
+                .clone()
+                .oneshot(approve_detached(&c.approvals[0]))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            settle(&c.runtime).await;
+            agent_replies(&c.runtime)
+                .await
+                .into_iter()
+                .map(|r| r.split('|').next().unwrap().to_string())
+                .collect()
+        }
+
+        // Raised in a desk channel: the continuation belongs to the channel.
+        let desk = threads_for("desk-finance").await;
+        assert_eq!(desk, vec!["desk-finance".to_string()]);
+        assert_ne!(
+            desk[0], "ceo",
+            "a channel's approval must not resume in the desk lead's private DM"
+        );
+
+        // Raised in a direct message with that same lead: the mirror image.
+        let dm = threads_for("ceo").await;
+        assert_eq!(dm, vec!["ceo".to_string()]);
+        assert_ne!(
+            dm[0], "desk-finance",
+            "a private line's approval must not resume in the desk channel"
+        );
+    }
+
+    /// A single-approval turn is unchanged: it continues on that one decision,
+    /// exactly as it did before the gate existed.
+    #[tokio::test]
+    async fn a_lone_sign_off_still_continues_on_its_own_decision() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 1, None, false).await;
+        let before = c.cycles.load(std::sync::atomic::Ordering::SeqCst);
+
+        let response = c
+            .app
+            .clone()
+            .oneshot(approve_detached(&c.approvals[0]))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        settle(&c.runtime).await;
+
+        assert_eq!(
+            c.cycles.load(std::sync::atomic::Ordering::SeqCst) - before,
+            1
+        );
+        assert_eq!(agent_replies(&c.runtime).await.len(), 1);
+    }
+
+    /// **Defect 4.** A continuation that fails tells the person waiting for it.
+    ///
+    /// The verdict and the grant are already durable at this point, so the
+    /// failure is recoverable — but only for somebody who knows it happened.
+    /// Before this the entire report was one `tracing::error!`: the agent was
+    /// not told the outcome, and neither was the operator, who saw an approval
+    /// they had granted produce nothing and had no way to tell a slow turn from
+    /// a dead one.
+    #[tokio::test]
+    async fn a_failed_continuation_tells_the_operator() {
+        let home_dir = home();
+        let c = multi_park_company(home_dir.path(), 2, Some("sales"), true).await;
+
+        for id in &c.approvals {
+            let response = c.app.clone().oneshot(approve_detached(id)).await.unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "the verdict is durable regardless of what the turn then does"
+            );
+        }
+        settle(&c.runtime).await;
+
+        let replies = agent_replies(&c.runtime).await;
+        assert_eq!(
+            replies.len(),
+            1,
+            "the operator is told exactly once that the work did not resume, got {replies:?}"
+        );
+        assert!(
+            replies[0].starts_with("sales|"),
+            "and told in the thread they approved in, got {replies:?}"
+        );
+        assert!(
+            replies[0].contains("approving again is safe"),
+            "the notice has to say what to do about it, got {replies:?}"
+        );
+    }
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4156,6 +4156,7 @@ async fn task_timeline_reports_the_wait_an_approval_actually_caused() {
             parked_at,
             TaskLink::Task { id: "t-1".into() },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4238,6 +4239,7 @@ async fn expired_approval_is_labelled_as_an_expiry_and_carries_its_wait() {
             parked_at,
             TaskLink::Task { id: "t-1".into() },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4292,6 +4294,7 @@ async fn a_wait_that_began_before_dispatch_is_clamped_to_the_run_window() {
             &parked_effect(),
             dispatched_at - 3_600_000,
             TaskLink::Task { id: "t-1".into() },
+            None,
             None,
         )
         .await
@@ -4353,6 +4356,7 @@ async fn a_currently_parked_approval_surfaces_as_a_live_wait() {
             &parked_effect(),
             parked_at,
             TaskLink::Task { id: "t-1".into() },
+            None,
             None,
         )
         .await
@@ -4455,6 +4459,7 @@ async fn a_parked_approval_appears_on_its_own_task() {
             parked_at,
             TaskLink::Task { id: "t-1".into() },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4542,6 +4547,7 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
                 dispatched_at + 5,
                 TaskLink::Task { id: owner.into() },
                 None,
+                None,
             )
             .await
             .unwrap();
@@ -4617,6 +4623,7 @@ async fn a_resolved_approval_reports_its_verdict_and_wait_on_the_tab() {
             parked_at,
             TaskLink::Task { id: "t-1".into() },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4687,6 +4694,7 @@ async fn a_task_with_no_approvals_of_its_own_reports_an_empty_list() {
                 id: "t-other".into(),
             },
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4732,6 +4740,7 @@ async fn an_unlinked_approval_is_not_absorbed_by_the_running_card() {
             &parked_effect(),
             dispatched_at + 5,
             TaskLink::Unlinked,
+            None,
             None,
         )
         .await
@@ -4805,6 +4814,7 @@ async fn the_attempt_id_outranks_the_card_link_when_both_are_present() {
             dispatched_at + 5,
             TaskLink::Unlinked,
             None,
+            None,
         )
         .await
         .unwrap();
@@ -4817,6 +4827,7 @@ async fn the_attempt_id_outranks_the_card_link_when_both_are_present() {
             &under_run("run-c"),
             dispatched_at + 6,
             TaskLink::Task { id: "t-1".into() },
+            None,
             None,
         )
         .await

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -700,7 +700,19 @@ impl DeliveryParking {
         let approval_id = self.approvals.park(company, effect.clone()).await?;
         if let Err(err) = self
             .journal
-            .record_parked(&approval_id, &effect, now_millis(), task_link, thread)
+            .record_parked(
+                &approval_id,
+                &effect,
+                now_millis(),
+                task_link,
+                thread,
+                // No turn key (issue #469): a workflow node's request is not
+                // raised by a cycle, so there is no turn holding a continuation
+                // for it. It resolves and continues on its own, exactly as it
+                // always has — the gate only ever groups approvals a single
+                // cycle parked together.
+                None,
+            )
             .await
         {
             // Roll back to "never parked". Both steps deliberately swallow their


### PR DESCRIPTION
## Summary

A turn parked **four** approvals. The operator approved all four. The agent never replied, and the chat kept insisting it was still waiting.

Closes #469.

## The issue's premise was wrong, and the real mechanism is different

#469 says four concurrent re-runs race on the shared approval queue. **They do not race.** Instrumented with a live-cycle counter over the real router: `peak_overlap=1` in every ordering. `CycleRunner::run` holds the per-company `serial` lock for the whole cycle, so the four follow-up cycles **queue**.

What actually happens is four *sequential* re-runs of one turn, each told about one decision and blind to the other three. The damage is:

- **three wasted agent turns**, and
- **grant cross-talk** — all four grants are live before the first cycle runs, so a re-issue redeeming more than its own leaves later cycles with `grants.peek → None`, which `redispatch_granted_call` treats as a legitimate silent no-op. Driven explicitly with a "greedy" first turn: four cycles, one reply, three silent.

**#439 is therefore not implicated.** A peak overlap of 1 means the pool-wide queue is only ever touched by one cycle at a time here. No per-run queue is needed and none was built.

## Where the reply was actually lost — not concurrency at all

`chat_and_emit` journals every `report.responses` bubble as `CompanyEvent::AgentReply`, which is what `project_event` turns into the `agent_reply` frame and what a transcript reload rebuilds from.

**`run_resolve` never did.** It emits webhooks and, un-detached, hands the replies back on the response body — but the console's inline approval card resolves with `detach: true`, so the body is a receipt and the replies go nowhere. `run_resolve`'s comment claiming the console "already projects and consumes" that frame is **false** for the report's responses.

The only `agent_reply` that ever reached the stream was one `redispatch_granted_call` hand-wrote inside the harness brain — harness-only, and only when a grant was peeked, which is precisely the case grant cross-talk removes.

Fixed by journaling every continuation reply once, in `CompanyRuntime::publish_continuation`, into the thread the approval was **raised** in — so it works detached or not, in both grant scopes, and in the default build. The brain's hand-written append is removed; its two reply-routing tests moved end-to-end over the real router, keeping the both-directions mirror.

## API Or Behavior Changes

**One turn, one continuation.** A parked approval now records the cycle that parked it (`ApprovalOrigin.cycle` — the id was already computed and only reaching a debug log). `ContinuationQueue` counts, per turn, how many of that turn's approvals are still undecided; each resolve banks its `ApprovalResolved`, and the cycle runs **once, on the last decision**, carrying all of them.

**Gated on the parking turn's group, not on an in-flight window.** Coalescing what arrives together passes the all-at-once test and still re-runs the turn four times when the operator clicks one at a time. The trigger has to be the last decision. Both orderings are asserted, including that nothing runs after decisions 1–3.

The decrement and the "was that the last one" test are one critical section, so two concurrent HTTP resolves cannot both be handed the batch (unit-tested with 8 threads).

**A failed continuation now journals a notice** into the thread the operator approved in — *"approving again is safe and will retry it"* — rather than only `tracing::error!`. `announce_to_operator` was not usable for this: it is a bare channel send with no event behind it, so it never reaches the stream either.

**Trade-off, stated plainly.** A partly-decided turn now waits where before it re-dispatched immediately. That is the honest state — the turn is genuinely still blocked — and the old behaviour re-parked everything undecided, compounding per decision. It is bounded: an expiry counts as a decision, so a turn is never stranded.

Two things not chased, worth knowing: approval TTL is 7 days while grant TTL is 15 minutes, so a turn abandoned half-decided will hit the "the agent didn't act within 15 minutes" notice before it unblocks. And approvals with no turn key — pre-change journal lines, workflow-node requests — are deliberately not gated and continue alone exactly as before.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2309 passed, 0 failed
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged. Frontend untouched, so no frontend gates are claimed.

**Driven live** over the real router with a real journal, event log, grant set and resolve route: four sign-offs from one turn in both orderings, desk-origin and DM-origin routing, grant cross-talk, and the failed-continuation path. **Unit-only:** the `ContinuationQueue` mechanics — ordering, independence, expiry, recovery re-arm, and the 8-thread concurrency case.

**Proof on base** (`36e4a517`), fix copied aside and sources restored — no `git stash`:

```
BASE all-at-once:   continuations=4 decisions=4 replies=0
  the continuation's answers must reach the event stream — left: 0, right: 4
  one turn owes one continuation, not one per approval — left: 4, right: 1
BASE one-at-a-time: the last decision unblocks the turn, and it runs once — left: 4, right: 1
```

## Notes for review

**The toast discrepancy is rendering, not correctness.** All four resolves fire and return 200 (`resolves_ok=4` on base). `<Toaster>` sets no `visibleToasts`, so sonner defaults to 3 with `expand={false}`; the chat path's message is a constant string for every approve, so the stack is visually indistinguishable, and each resolve also produces a competing `approval_resolved` toast — roughly two toasts per approval into three slots. Not fixed here: it is a one-line frontend change and this lane stayed Rust-only.

**The stale parked rows are view-side and belong to #464's file.** Host-side there is no gap — the `approval_resolved` frame is emitted and consumed. But `message.steps` is frozen from the chat POST body or a history reload, `decideApproval` and `onApprovalEvent` only call `feed.refresh()` (status and approvals, never transcripts), and the injected `agent_reply` carries no steps.

**One thing that lane needs from the host first: `TurnStep` carries no approval id**, so the view has no key to mark the right row resolved. That is owed before a subscribe-side fix can land, and it is the same *host does not announce* shape their mechanism already generalises.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multiple approvals for a single turn now combine into one continuation after the final decision.
  * Approval progress is preserved across runtime rebuilds and recovery.
  * Continuation responses are recorded in the originating approval thread.

* **Bug Fixes**
  * Expired approvals now release blocked work asynchronously.
  * Continuation failures produce operator-visible recovery messages.
  * Prevented duplicate continuation responses across approval paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->