### PR TITLE
fix(console): one control answers to 'New workflow'

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1153,7 +1153,18 @@ export function WorkflowsView({
               </AlertDialogContent>
             </AlertDialog>
           </span>
-          <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+          {/* Issue #341: THE control named "New workflow". It is in the
+              toolbar in every state, so it is the one an operator — or a
+              screen reader, or a spec — should find under that name. The
+              empty-state call to action below is named differently on
+              purpose; two buttons answering to one name is an ambiguity
+              nothing can resolve. */}
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => setCreateOpen(true)}
+            data-testid="workflow-create"
+          >
             <Plus className="mr-1.5 size-4" />
             New workflow
           </Button>
@@ -1244,9 +1255,19 @@ export function WorkflowsView({
         ) : !selectedId ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
             <p>This company has no saved workflows yet.</p>
-            <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+            {/* Issue #341: opens the same dialog as the toolbar button, and
+                therefore must NOT carry the same name. "Create a workflow"
+                rather than "Create the first workflow" because this state is
+                also where deleting the last workflow lands, and by then there
+                is nothing first about it. */}
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => setCreateOpen(true)}
+              data-testid="workflow-create-empty"
+            >
               <Plus className="mr-1.5 size-4" />
-              New workflow
+              Create a workflow
             </Button>
           </div>
         ) : (

--- a/frontend/test/e2e/workflow-create-affordance.spec.ts
+++ b/frontend/test/e2e/workflow-create-affordance.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test, type Page, type Route } from "@playwright/test";
+
+/**
+ * Issue #341: the workflows view had **two** controls both accessible as
+ * "New workflow" — the toolbar action and the empty state's call to action.
+ *
+ * This is pinned in a browser because it is a fact about rendered output and
+ * nothing else. Both buttons call the same `setCreateOpen(true)`, so no unit
+ * test of behaviour can tell the fixed view from the broken one; the only
+ * difference is what the accessibility tree holds, which exists only once the
+ * component has rendered into a document.
+ *
+ * The assertions are deliberately written the way the failure arrived —
+ * `getByRole("button", { name: … })` with no `.first()` and no test id — so a
+ * regression fails here exactly as `strict mode violation: … resolved to 2
+ * elements` rather than silently picking one. A test id would pass over the
+ * defect, which is the whole reason #341 says the fix is in the component and
+ * not in the locator.
+ *
+ * Runs against the live host the harness brings up (see `playwright.config.ts`).
+ */
+
+/** The workflows list route, and only it — not `…/workflows/{id}` or `/run`. */
+function isWorkflowList(url: URL): boolean {
+  return /\/api\/v1\/(company|companies\/[^/]+)\/workflows$/.test(url.pathname);
+}
+
+/**
+ * Dismisses the first-run tour if it is up — its overlay swallows pointer
+ * events, so without this every spec fails on an unrelated modal. Tolerates its
+ * absence; a company that has seen it never shows it again.
+ */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+test("one control answers to 'New workflow', and clicking it opens the dialog", async ({
+  page,
+}) => {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  const create = page.getByRole("button", { name: "New workflow" });
+  await expect(create).toHaveCount(1);
+
+  // The click a strict-mode violation used to abort. Unqualified on purpose.
+  await create.click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
+});
+
+test("the empty state's call to action is reachable and distinctly named", async ({
+  page,
+}) => {
+  // The harness company ships `workflows/committed.toml`, so the empty state
+  // is unreachable by driving the console — and it is the state that carried
+  // the second button. An empty list is stubbed rather than left untested;
+  // the alternative is a spec that never renders the offending branch.
+  await page.route(
+    (url) => isWorkflowList(url),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      });
+    },
+  );
+
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  await expect(page.getByText("This company has no saved workflows yet.")).toBeVisible();
+
+  // Both controls are on screen together here. That is fine — what is not fine
+  // is them sharing a name.
+  const create = page.getByRole("button", { name: "New workflow" });
+  await expect(create).toHaveCount(1);
+
+  const emptyCta = page.getByRole("button", { name: "Create a workflow" });
+  await expect(emptyCta).toHaveCount(1);
+
+  // The call to action still does its job: same dialog, different name.
+  await emptyCta.click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
## Summary

Fixes #341.

The workflows view rendered **two** controls both accessible as `New workflow` — the toolbar action, and the empty state's call to action — so `getByRole("button", { name: "New workflow" })` resolved to 2 elements and aborted every `workflow-*.spec.ts` before its first click.

The fix is in the component, not the locator, because the ambiguity is real: a screen-reader or keyboard user meets exactly what Playwright's strict mode met, two identically named buttons with nothing to tell them apart.

- The **toolbar** action keeps the name `New workflow`. It is the control present in every state, so it is the one that should answer to that name.
- The **empty-state** call to action becomes **"Create a workflow"** and opens the same dialog. Named that rather than "Create the first workflow" because deleting the last workflow lands in this same state, and by then there is nothing first about it.
- Both gain a `data-testid` (`workflow-create`, `workflow-create-empty`) so future specs have a stable handle without needing the name to be unique twice over.

New spec `frontend/test/e2e/workflow-create-affordance.spec.ts` pins it, deliberately using the **unqualified** role locator the failure arrived on — no `.first()`, no test id — so a regression fails here as a strict-mode violation rather than silently picking one of two. It covers both list states; the empty branch is reached by stubbing the workflows list with `page.route` (the suite's existing idiom), because the harness company ships `workflows/committed.toml` and the empty state is otherwise unreachable by driving the console.

### Acceptance, item by item

- **Exactly one control answers to `New workflow`, or any second one has a distinct name.** — The toolbar action alone carries the name; the empty-state control is `Create a workflow`. Confirmed in a browser: 1 match in the populated state, 1 match in the empty state (where both buttons are on screen together).
- **`workflow-*.spec.ts` gets past the click without a strict-mode violation.** — The unqualified `getByRole(...).click()` succeeds and opens the create dialog in both states. Before the change, the same click against an empty list fails with the issue's exact message.
- **The fix is in the component, not the spec's locator.** — No existing spec's locator was touched. `workflow-dialog-feedback.spec.ts` still targets `New workflow` unqualified, and the new spec does the same on purpose.

## API Or Behavior Changes

One user-facing string: the workflows empty-state button reads **"Create a workflow"** instead of "New workflow". Same action, same dialog. No API change, no `src/` change — this is `frontend/**` and `test/e2e/**` only.

## Tests

Run in `frontend/`:

- `npm ci`
- `npm run typecheck` — clean
- `npm run typecheck:e2e` — clean
- Browser verification, before and after the change, in a real Chromium driving the real console bundle (Vite dev server) with the host API stubbed at the network layer, in both list states:

| | `role=button name="New workflow"` | unqualified `.click()` |
|---|---|---|
| **before**, list populated | 1 | opens the dialog |
| **before**, list empty | **2** | `strict mode violation: getByRole('button', { name: 'New workflow' }) resolved to 2 elements` — the issue's exact failure |
| **after**, list populated | 1 | opens the dialog |
| **after**, list empty | 1 (plus 1 × `Create a workflow`) | opens the dialog |

**What I could not run, stated rather than glossed:** the live-host walk this issue's `## Testing` section asks for. `test/e2e/host.sh` needs `target/debug/opencompany`, and a local `cargo build` is prohibited on this machine; the Playwright lane is not built in CI either (#475). So the evidence above is the real component in a real browser with a stubbed host — it reproduces the reported failure and shows it gone — but it is not a walk against a running binary. Whoever has a host up can confirm in one step: open Workflows on a company with no saved workflows and check that only one button reads "New workflow".

The Rust boxes below are ticked as required by the lane; this branch contains no Rust change at all.

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

## Documentation

No docs change needed. No doc references the workflows empty-state button label (`grep -rn "New workflow" docs/ README.md` is empty), and the reasoning for which control owns the name now lives in a comment at each of the two call sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workflow creation controls with clearer labels for toolbar and empty-state actions.
  * Both creation actions now open the workflow creation dialog.

* **Bug Fixes**
  * Ensured workflow creation buttons have distinct identifiers and predictable behavior.

* **Tests**
  * Added end-to-end coverage for workflow creation actions, empty workflow lists, and first-run tour handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->