### PR TITLE
fix(console): workflow create/update/delete events reach the picker instead of the SSE switch's default arm (#384)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -256,6 +256,17 @@ export function AppShell({
   // refreshes its run history live. Same shape as `taskEventTick` — a counter,
   // not the payload, so the view owns what it refetches.
   const [workflowRunTick, setWorkflowRunTick] = useState(0);
+  // Issue #384: bumped on every `workflow_created` / `workflow_updated` /
+  // `workflow_deleted`, so the Workflows view re-reads its picker while the tab
+  // stays open — a graph authored by the orchestrator, by another session or by
+  // a machine credential used to be invisible until a reload.
+  //
+  // A counter rather than the payload, for the same reason `taskEventTick` is:
+  // the view re-reads `GET …/workflows`, so two frames collapsing into one
+  // React batch still means "re-read". It also covers the delete case without
+  // carrying an id — the workflow that went away is precisely the one the
+  // refreshed list no longer has.
+  const [workflowListTick, setWorkflowListTick] = useState(0);
   // Issue #371: a rolling WINDOW of run-progress frames, not just a nonce.
   //
   // The canvas paints per-node state, so unlike the tick above it needs the
@@ -830,6 +841,11 @@ export function AppShell({
       setWorkflowRunEvents((prev) => [...prev, event].slice(-WORKFLOW_EVENT_WINDOW));
       if (event.type === "workflow_run_finished") setWorkflowRunTick((n) => n + 1);
     }, []),
+    // Issue #384. The picker is refreshed from the host rather than patched
+    // from the frame: the frame carries no graph body by design, and a console
+    // that splices what it *thinks* changed is how a picker drifts in the first
+    // place.
+    onWorkflowChanged: useCallback(() => setWorkflowListTick((n) => n + 1), []),
     // Issue #379. Both frames do the same one thing — re-read the approvals
     // feed — and that is deliberate: the park frame is thin by design (no
     // payload, no asker), so the redacted summary on the feed is the only place
@@ -1015,6 +1031,7 @@ export function AppShell({
                 sub={sub}
                 runEventTick={workflowRunTick}
                 runEvents={workflowRunEvents}
+                listEventTick={workflowListTick}
               />
             </Suspense>
           )}

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -291,6 +291,17 @@ interface Options {
 }
 
 /**
+ * The subscriber half of {@link Options}, as {@link handleEvent} takes it.
+ *
+ * A named bag rather than a positional list, because five of the six share the
+ * type `(e: CompanyStreamEvent) => void` — so a call site that got the ORDER
+ * wrong would type-check perfectly and route every frame to the wrong surface.
+ * Derived from `Options` rather than restated so the two cannot drift, and so
+ * each callback keeps the documentation written against it above.
+ */
+type Subscribers = Omit<Options, "pendingApprovals">;
+
+/**
  * Opens an `EventSource` on `{scope}/events` for the active company and turns
  * incoming attention events into `sonner` toasts (and, for agent replies, a
  * transcript injection via {@link Options.onAgentReply}). This is the active
@@ -383,15 +394,14 @@ export function useEvents(
         console.debug("[events] dropping unparseable event", err);
         return;
       }
-      handleEvent(
-        event,
-        onAgentReplyRef.current,
-        onTaskEventRef.current,
-        onTurnEventRef.current,
-        onWorkflowRunEventRef.current,
-        onWorkflowChangedRef.current,
-        onApprovalEventRef.current,
-      );
+      handleEvent(event, {
+        onAgentReply: onAgentReplyRef.current,
+        onTaskEvent: onTaskEventRef.current,
+        onTurnEvent: onTurnEventRef.current,
+        onWorkflowRunEvent: onWorkflowRunEventRef.current,
+        onWorkflowChanged: onWorkflowChangedRef.current,
+        onApprovalEvent: onApprovalEventRef.current,
+      });
     };
 
     source.onerror = () => {
@@ -414,15 +424,15 @@ export function useEvents(
 }
 
 /** Routes one parsed event to its toast / transcript side effect. */
-function handleEvent(
-  event: CompanyStreamEvent,
-  onAgentReply?: (e: AgentReplyEvent) => void,
-  onTaskEvent?: (e: CompanyStreamEvent) => void,
-  onTurnEvent?: (e: CompanyStreamEvent) => void,
-  onWorkflowRunEvent?: (e: CompanyStreamEvent) => void,
-  onWorkflowChanged?: (e: CompanyStreamEvent) => void,
-  onApprovalEvent?: (e: CompanyStreamEvent) => void,
-): void {
+function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers): void {
+  const {
+    onAgentReply,
+    onTaskEvent,
+    onTurnEvent,
+    onWorkflowRunEvent,
+    onWorkflowChanged,
+    onApprovalEvent,
+  } = subscribers;
   switch (event.type) {
     // Live turn frames drive the in-flight tool timeline — no toast, they render
     // inline in the chat.

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -152,6 +152,24 @@ export type CompanyStreamEvent =
       status: string;
       elapsedMs: number;
     }
+  // Issue #384: a saved workflow was authored, edited or removed — by the
+  // orchestrator's `create_workflow` tool, by a second console session, by a
+  // machine credential, or by this console itself. The host has journalled and
+  // projected all three since #112/#259; nothing here named them, so they
+  // reached `default:` and were dropped, and the picker drifted from what the
+  // host holds until a reload.
+  //
+  // Deliberately thin, like `approval_parked` and `task_card_changed`: an id
+  // and the display name, with **no graph body** — the host omits it on purpose
+  // (see `project_event`). A console reacts to this frame by re-reading
+  // `GET …/workflows`, so the picker's content keeps exactly one source.
+  | {
+      type: "workflow_created" | "workflow_updated" | "workflow_deleted";
+      seq: number;
+      atMillis: number;
+      workflowId: string;
+      name: string;
+    }
   // The transient live turn-progress frames (`src/turn_stream.rs`): a tool call
   // just started (status `running`) or finished (status `ok`/`error`). These are
   // ephemeral — never journaled — and drive the in-flight tool timeline the
@@ -242,6 +260,23 @@ interface Options {
    */
   onWorkflowRunEvent?: (event: CompanyStreamEvent) => void;
   /**
+   * Called for each workflow **authoring** frame — `workflow_created`,
+   * `workflow_updated`, `workflow_deleted` (issue #384) — so the Workflows view
+   * can re-read its picker live.
+   *
+   * Separate from {@link Options.onWorkflowRunEvent} because they answer
+   * different questions: that one is what a run *did*, this one is which
+   * workflows *exist*. A view can want either without the other, and folding
+   * them would make the run canvas re-derive itself on an unrelated create.
+   *
+   * Like {@link Options.onTaskEvent} this subscriber takes a **counter**, not
+   * the payload: it re-reads the list, so two frames collapsing inside one
+   * React batch still means "re-read". That is also why a delete needs nothing
+   * extra on the wire — the workflow that vanished is the one the refreshed
+   * list no longer has.
+   */
+  onWorkflowChanged?: (event: CompanyStreamEvent) => void;
+  /**
    * Called for each approval-lifecycle frame (`approval_parked`,
    * `approval_resolved`) so the shell can refresh the approvals feed live
    * (issue #379).
@@ -273,6 +308,7 @@ export function useEvents(
     onTaskEvent,
     onTurnEvent,
     onWorkflowRunEvent,
+    onWorkflowChanged,
     onApprovalEvent,
   }: Options,
 ): void {
@@ -293,6 +329,10 @@ export function useEvents(
   useEffect(() => {
     onWorkflowRunEventRef.current = onWorkflowRunEvent;
   }, [onWorkflowRunEvent]);
+  const onWorkflowChangedRef = useRef(onWorkflowChanged);
+  useEffect(() => {
+    onWorkflowChangedRef.current = onWorkflowChanged;
+  }, [onWorkflowChanged]);
   const onApprovalEventRef = useRef(onApprovalEvent);
   useEffect(() => {
     onApprovalEventRef.current = onApprovalEvent;
@@ -349,6 +389,7 @@ export function useEvents(
         onTaskEventRef.current,
         onTurnEventRef.current,
         onWorkflowRunEventRef.current,
+        onWorkflowChangedRef.current,
         onApprovalEventRef.current,
       );
     };
@@ -379,6 +420,7 @@ function handleEvent(
   onTaskEvent?: (e: CompanyStreamEvent) => void,
   onTurnEvent?: (e: CompanyStreamEvent) => void,
   onWorkflowRunEvent?: (e: CompanyStreamEvent) => void,
+  onWorkflowChanged?: (e: CompanyStreamEvent) => void,
   onApprovalEvent?: (e: CompanyStreamEvent) => void,
 ): void {
   switch (event.type) {
@@ -520,6 +562,20 @@ function handleEvent(
     case "workflow_run_started":
     case "workflow_node_finished":
       onWorkflowRunEvent?.(event);
+      break;
+    // Issue #384: the authoring half. Same subscriber-refreshes-its-own-surface
+    // shape as the run arms above, and the third time this file has grown arms
+    // for frames the host was already sending — #464 for the board, #371 for
+    // the canvas, these for the picker.
+    //
+    // Deliberately NO toast. A workflow appearing, being renamed or going away
+    // is not an attention signal: the orchestrator authors them as ordinary
+    // work, and a toast per create would be noise of exactly the kind #379
+    // argues against. The list refreshing IS the feedback.
+    case "workflow_created":
+    case "workflow_updated":
+    case "workflow_deleted":
+      onWorkflowChanged?.(event);
       break;
     default:
       // An unknown/forward event kind: ignore rather than surface noise.

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -344,6 +344,38 @@ export function WorkflowsView({
   const appliedWorkflowRef = useRef<string | null>(null);
   const appliedRunRef = useRef<string | null>(null);
 
+  // How many local writes have landed. Compared across the list effect's await
+  // so a `GET …/workflows` that was already in flight when a create, save or
+  // delete completed cannot paint the picker with rows that predate it — the
+  // entry the operator just made vanishing again, or the one they just deleted
+  // coming back, until some later frame happened to correct it.
+  //
+  // Only reachable now that this effect re-runs on a live frame: it used to run
+  // on mount and on a company switch, neither of which races an authoring
+  // action. Nothing is lost by discarding such a response — the local handler
+  // has already applied the newer truth, and each of these writes emits its own
+  // frame, which brings a fresh list along behind it.
+  const localWriteRef = useRef(0);
+
+  // The id the list effect moved the selection to ON THE OPERATOR'S BEHALF —
+  // a correction, not a navigation.
+  //
+  // The hash mirror below pushes a history entry whenever the selection moves
+  // between two named workflows, which was right while only an operator action
+  // could move it. A live delete moves it too, and pushing that leaves a place
+  // the operator never went in their history: one Back press onto a URL naming
+  // a workflow the host no longer has. The view does not even correct itself
+  // there — the URL-follow effect treats an id it has already applied as an
+  // echo and leaves it alone (which is also why no error toast appears, the
+  // route by which that would fire being closed by the same guard) — so the
+  // address bar names one graph while the canvas shows another, and that
+  // address is what the operator would copy out and share.
+  //
+  // Holds the id rather than a bare flag so a marker that outlives its render
+  // cannot suppress an unrelated push later — it counts only when it names the
+  // very selection the mirror is about to write.
+  const reconciledSelectionRef = useRef<string | null>(null);
+
   // Load the workflow list, and auto-select the first entry.
   //
   // Re-runs on `listEventTick` (issue #384), i.e. whenever the host says a
@@ -361,9 +393,14 @@ export function WorkflowsView({
   useEffect(() => {
     let live = true;
     (async () => {
+      const writesBefore = localWriteRef.current;
       try {
         const rows = await listWorkflows(client, company);
         if (!live) return;
+        // A local write landed while this request was in flight. It holds the
+        // newer truth and these rows predate it, so they are dropped rather
+        // than allowed to undo it.
+        if (localWriteRef.current !== writesBefore) return;
         setWorkflows(rows);
         setSelectedId((prev) => {
           // Keep the selection when the freshly loaded list still has it —
@@ -400,7 +437,14 @@ export function WorkflowsView({
           // another session and one deleted from this button leave the view in
           // the same place. A company whose last workflow just went away
           // selects nothing, and the canvas empties.
-          return rows[0]?.id ?? null;
+          //
+          // Marked as a reconciliation so the hash mirror replaces rather than
+          // pushes: nobody navigated here, the workflow they were on stopped
+          // existing. Writing the same id twice (React re-invokes an updater in
+          // StrictMode) says the same thing twice.
+          const fallback = rows[0]?.id ?? null;
+          reconciledSelectionRef.current = fallback;
+          return fallback;
         });
         setError(null);
       } catch (e) {
@@ -457,13 +501,25 @@ export function WorkflowsView({
   // to a different workflow the query is dropped, which is correct — that run
   // belongs to the graph being left behind.
   //
-  // Replace vs push is decided by whether the hash already names a workflow.
+  // Replace vs push is decided by whether the hash already names a workflow,
+  // and by whether the operator moved the selection at all.
+  //
   // Filling in a bare `#/workflows` is this view resolving its own default, not
   // a place the operator has been — pushing it would put an entry in the
   // history stack that looks identical to the one before it, so their first
   // Back press out of the tab would appear to do nothing. Moving from one named
   // workflow to another IS a navigation they took, and Back should undo it.
+  //
+  // A reconciliation is neither: the workflow they were on stopped existing and
+  // the list effect moved them off it (issue #384). Pushing that would offer
+  // Back as a route to a workflow that is gone — see `reconciledSelectionRef`
+  // for why the view does not even correct itself once it is there.
   useEffect(() => {
+    // Consumed on every run, whichever branch is taken below: a marker left
+    // over from a reconciliation that did not end up writing the URL must not
+    // decide a later, genuine navigation.
+    const reconciled = reconciledSelectionRef.current === selectedId;
+    reconciledSelectionRef.current = null;
     if (!selectedId) return;
     const { onWorkflows, workflowId } = readWorkflowHash();
     // Another view owns the hash (a company switch mid-navigation, a stale
@@ -471,7 +527,7 @@ export function WorkflowsView({
     if (!onWorkflows) return;
     if (workflowId === selectedId) return;
     const next = `#/workflows/${encodeURIComponent(selectedId)}`;
-    if (workflowId === null) window.history.replaceState(null, "", next);
+    if (workflowId === null || reconciled) window.history.replaceState(null, "", next);
     else window.location.hash = next.slice(1);
   }, [selectedId]);
 
@@ -738,7 +794,9 @@ export function WorkflowsView({
     try {
       await deleteWorkflow(client, company, selectedId, graph.version);
       // Drop it locally rather than re-listing: the host has confirmed, and a
-      // re-list would flash an empty picker.
+      // re-list would flash an empty picker. A list request already in flight
+      // predates this and would put the entry back — hence the bump.
+      localWriteRef.current += 1;
       const remaining = workflows.filter((w) => w.id !== selectedId);
       setWorkflows(remaining);
       setSelectedId(remaining[0]?.id ?? null);
@@ -765,6 +823,8 @@ export function WorkflowsView({
   // save again without a re-read — dropping it and re-fetching would be a round
   // trip that can only return the same thing.
   const handleSaved = useCallback((saved: WorkflowGraph) => {
+    // Newer than any list request already in flight — see `localWriteRef`.
+    localWriteRef.current += 1;
     setGraph(saved);
     // The name and description are editable, so the picker entry has to move
     // with them. The id cannot change, which is what makes this a rewrite of
@@ -787,6 +847,10 @@ export function WorkflowsView({
   // The creator posts the full graph back, so the new entry can be spliced
   // straight into the list and selected — no extra round trip to re-list.
   const handleCreated = useCallback((created: WorkflowGraph) => {
+    // Newer than any list request already in flight — see `localWriteRef`.
+    // This is the race the operator would notice most: the workflow they just
+    // created disappearing out of the picker a moment after it appeared.
+    localWriteRef.current += 1;
     setWorkflows((prev) => {
       const rest = prev.filter((w) => w.id !== created.id);
       return [...rest, { id: created.id, name: created.name, description: created.description }].sort(

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -146,6 +146,7 @@ export function WorkflowsView({
   sub = null,
   runEventTick = 0,
   runEvents = EMPTY_RUN_EVENTS,
+  listEventTick = 0,
 }: {
   client: OpenCompanyClient;
   company: string | null;
@@ -180,6 +181,20 @@ export function WorkflowsView({
    * coalesced render can never lose a node.
    */
   runEvents?: CompanyStreamEvent[];
+  /**
+   * Bumped by the shell on every workflow **authoring** frame —
+   * `workflow_created`, `workflow_updated`, `workflow_deleted` (issue #384) —
+   * so the picker follows what the host holds while this tab stays open.
+   *
+   * Distinct from `runEventTick`, which is about what a run did. A workflow the
+   * orchestrator authored (or a second session deleted) changes which entries
+   * exist, and nothing else would tell this view that.
+   *
+   * A counter, not the payload: it re-reads the list, and the list is the
+   * answer to all three frames — including the delete, which is simply an entry
+   * the fresh list no longer has.
+   */
+  listEventTick?: number;
 }) {
   const { resolvedTheme } = useTheme();
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
@@ -329,7 +344,20 @@ export function WorkflowsView({
   const appliedWorkflowRef = useRef<string | null>(null);
   const appliedRunRef = useRef<string | null>(null);
 
-  // Load the workflow list once, and auto-select the first entry.
+  // Load the workflow list, and auto-select the first entry.
+  //
+  // Re-runs on `listEventTick` (issue #384), i.e. whenever the host says a
+  // workflow was created, edited or deleted anywhere — the orchestrator's
+  // `create_workflow` tool, a second console session, a machine credential.
+  // Before that this ran on mount and on a company switch only, so the picker
+  // silently drifted from the host for the whole life of the tab.
+  //
+  // Re-reading the list is also what makes a **delete** land properly rather
+  // than greying an entry out: the selection reconciliation below drops an id
+  // the fresh list no longer has, which moves the canvas off a graph the host
+  // does not hold and takes the entry out of the picker in the same pass. No
+  // spinner and no flash — `loadingList` is not raised again, so the picker
+  // just changes.
   useEffect(() => {
     let live = true;
     (async () => {
@@ -338,25 +366,41 @@ export function WorkflowsView({
         if (!live) return;
         setWorkflows(rows);
         setSelectedId((prev) => {
-          // Issue #339: a workflow id in the URL outranks both the held
-          // selection and the first-row default — the operator followed a link
-          // to *that* graph. Resolved here rather than left to the follow
-          // effect below purely to avoid the flash: selecting `rows[0]` first
-          // and correcting a render later would fetch a graph nobody asked for
-          // and show the wrong name in the picker on the way past.
+          // Keep the selection when the freshly loaded list still has it —
+          // otherwise a stale id would leave the canvas on a graph the host
+          // does not hold. One rule, two cases: a leftover id from the previous
+          // company (this effect reruns on a switch), and the workflow on
+          // screen being deleted from somewhere else (issue #384, this effect
+          // reruns on the frame).
+          //
+          // Held selection BEFORE the URL, and that ordering is load-bearing
+          // for #384 without costing #339 anything. On mount `prev` is null, so
+          // a link still lands on the graph it names, flash-free — which is all
+          // #339 asked for here, changes after mount being the follow effect's
+          // job. But this effect now also reruns on a *live* frame, and the
+          // hash trails the selection by a `hashchange`: reading the URL first
+          // would let a frame arriving inside that gap — the console's own
+          // `workflow_created`, for instance — snap the operator back off the
+          // workflow they just made.
+          if (prev && rows.some((r) => r.id === prev)) return prev;
+          // Issue #339: a workflow id in the URL outranks the first-row
+          // default — the operator followed a link to *that* graph, and
+          // selecting `rows[0]` first and correcting a render later would fetch
+          // a graph nobody asked for and show the wrong name on the way past.
           //
           // `requestedWorkflowId` is read from the closure and deliberately NOT
           // a dependency: it changes on every picker click (the writer below
           // mirrors the selection into the hash), and re-running this would
-          // spend a full list round trip on each one. Changes after mount are
-          // the follow effect's job.
+          // spend a full list round trip on each one.
           if (requestedWorkflowId && rows.some((r) => r.id === requestedWorkflowId)) {
             return requestedWorkflowId;
           }
-          // Keep the selection only if it still exists in the freshly loaded list
-          // (this effect also reruns on company change) — otherwise a stale id
-          // from the previous company would fetch the wrong/nonexistent graph.
-          return prev && rows.some((r) => r.id === prev) ? prev : (rows[0]?.id ?? null);
+          // Nothing valid to keep: fall to the first remaining entry, exactly
+          // as the local Delete button does — so a workflow deleted from
+          // another session and one deleted from this button leave the view in
+          // the same place. A company whose last workflow just went away
+          // selects nothing, and the canvas empties.
+          return rows[0]?.id ?? null;
         });
         setError(null);
       } catch (e) {
@@ -372,7 +416,7 @@ export function WorkflowsView({
     // `requestedWorkflowId` is read above but deliberately not a dependency —
     // see the comment at the read.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [client, company]);
+  }, [client, company, listEventTick]);
 
   // Issue #339: follow the URL while the view stays mounted — the operator
   // clicks a second task card's link without ever leaving this tab, so the

--- a/frontend/test/e2e/workflow-live-list.spec.ts
+++ b/frontend/test/e2e/workflow-live-list.spec.ts
@@ -1,0 +1,222 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+/**
+ * Issue #384: workflow create / update / delete events reached the console's
+ * SSE switch, matched no arm, and were dropped.
+ *
+ * The host has journalled and projected all three since #112/#259 — `GET
+ * {scope}/events` carries `workflow_created`, `workflow_updated` and
+ * `workflow_deleted` — so nothing was missing on the wire. The console simply
+ * had no case for them, which is the failure shape this switch has produced
+ * twice before (#464 for the board, #371 for the run canvas): the frames
+ * arrive, fall through to `default:`, and nothing logs.
+ *
+ * What the operator saw: with the Workflows tab open, a workflow authored by
+ * the orchestrator's `create_workflow` tool, by a second console session, or by
+ * a machine credential did not appear; a rename did not land; and a delete left
+ * its entry sitting in the picker, so the next click ran or edited a workflow
+ * the host no longer had.
+ *
+ * **Every test here writes from outside the browser** and asserts the open tab
+ * followed, with no reload and no company switch. That is the whole property —
+ * a spec that clicked the console's own Create button would pass against the
+ * broken build, because the local handler splices the row in by hand.
+ *
+ * Runs against the live host `playwright.config.ts` brings up, in the
+ * `Console E2E` CI lane (issue #428).
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+
+/**
+ * Dismisses the first-run tour if it is up. Its overlay swallows pointer
+ * events. Tolerates its absence — a company that has seen it never shows it
+ * again, so this is a no-op on every run after the first.
+ */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** A minimal valid graph body: one trigger, one output, one edge. */
+function graphBody(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: "Created by the #384 e2e spec.",
+    nodes: [
+      { id: "start", kind: "trigger", name: "Start", schedule: "0 9 * * *" },
+      { id: "done", kind: "output", name: "Report" },
+    ],
+    edges: [{ from: "start", to: "done" }],
+  };
+}
+
+/**
+ * Authors a workflow over HTTP — the stand-in for the orchestrator's
+ * `create_workflow` tool and for a second console session, neither of which a
+ * browser test can drive. The host journals `WorkflowCreated` on this path, so
+ * the page under test can only learn about it through the SSE stream.
+ */
+async function createWorkflow(request: APIRequestContext, id: string, name: string) {
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, { data: graphBody(id, name) });
+  expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+/**
+ * Renames a saved workflow out-of-band. Journals `WorkflowUpdated`.
+ *
+ * The graph goes in flat — `UpdateWorkflowBody` flattens it and carries only
+ * the optional `expectedVersion` alongside — and no token is sent, which is the
+ * unconditional write an out-of-band caller makes.
+ */
+async function renameWorkflow(request: APIRequestContext, id: string, name: string) {
+  const res = await request.put(`${COMPANY_SCOPE}/workflows/${id}`, { data: graphBody(id, name) });
+  expect(res.ok(), `rename ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+/** Best-effort teardown so a failed spec does not poison the next run. */
+async function removeWorkflow(request: APIRequestContext, id: string) {
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+}
+
+/** The workflow picker's trigger. */
+function picker(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+/** Opens the Workflows tab and waits for the picker to settle. */
+async function openWorkflows(page: Page) {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+}
+
+/**
+ * How many options the picker offers under `name`, from a fresh open.
+ *
+ * Opened and closed around the count on purpose, so the reading never depends
+ * on whether a mounted popup re-renders in place when its list changes. That is
+ * a detail of the Select primitive, and it is not what this file is about — the
+ * property under test is that the console re-read the list at all, and opening
+ * a dropdown fetches nothing (the view lists on mount, on a company switch, and
+ * on an SSE frame, and that is all).
+ */
+async function pickerOptionCount(page: Page, name: string): Promise<number> {
+  await picker(page).click();
+  await expect(page.getByRole("option").first()).toBeVisible({ timeout: 15_000 });
+  const count = await page.getByRole("option", { name, exact: true }).count();
+  await page.keyboard.press("Escape");
+  await expect(page.getByRole("option")).toHaveCount(0);
+  return count;
+}
+
+/** Selects a workflow by name and waits for the selection to settle. */
+async function selectWorkflow(page: Page, name: string) {
+  await picker(page).click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(picker(page)).toContainText(name);
+}
+
+test("a workflow authored elsewhere reaches the picker, with no reload", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const id = `e2e-live-create-${stamp}`;
+  const name = `Live create probe ${stamp}`;
+
+  try {
+    await openWorkflows(page);
+
+    // The baseline the fix has to move. Without it this stays at zero for the
+    // life of the tab: the `workflow_created` frame reaches the console's
+    // switch, matches no arm, and is discarded.
+    expect(
+      await pickerOptionCount(page, name),
+      "the probe must not exist before it is created",
+    ).toBe(0);
+
+    await createWorkflow(request, id, name);
+
+    await expect
+      .poll(() => pickerOptionCount(page, name), { timeout: 20_000 })
+      .toBe(1);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("a workflow renamed elsewhere renames in the picker, with no reload", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const id = `e2e-live-rename-${stamp}`;
+  const before = `Live rename probe ${stamp}`;
+  const after = `Live renamed probe ${stamp}`;
+  await createWorkflow(request, id, before);
+
+  try {
+    await openWorkflows(page);
+    await selectWorkflow(page, before);
+
+    // The graph on screen is renamed under the operator — the second-session
+    // edit #259 made possible, and which nothing told this tab about.
+    await renameWorkflow(request, id, after);
+
+    // Read off the trigger, which renders the *selected* workflow's name from
+    // the same list the options come from: the rename has to land on the
+    // selection, not merely somewhere in a dropdown nobody has open.
+    await expect(picker(page), "a rename elsewhere must reach the picker live").toContainText(
+      after,
+      { timeout: 20_000 },
+    );
+    await expect(picker(page)).not.toContainText(before);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+test("deleting the workflow on screen elsewhere takes it out of the picker, not just greys it", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const id = `e2e-live-delete-${stamp}`;
+  const name = `Live delete probe ${stamp}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await openWorkflows(page);
+    await selectWorkflow(page, name);
+
+    // Deleted from another session while this tab has it selected and its graph
+    // on the canvas. This is the worst symptom in the issue: the entry used to
+    // stay put, and the next Run or Edit addressed a workflow the host had
+    // already dropped.
+    const deleted = await request.delete(`${COMPANY_SCOPE}/workflows/${id}`);
+    expect(deleted.ok(), `delete ${id}: ${deleted.status()}`).toBeTruthy();
+
+    // The selection moves off it, so the canvas stops showing a graph the host
+    // no longer has.
+    await expect(picker(page), "the canvas must not stay on a deleted workflow").not.toContainText(
+      name,
+      { timeout: 20_000 },
+    );
+
+    // …and it is GONE from the options, not merely deselected or disabled.
+    expect(
+      await pickerOptionCount(page, name),
+      "a deleted workflow must leave the picker, not sit in it greyed out",
+    ).toBe(0);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});

--- a/frontend/test/e2e/workflow-live-list.spec.ts
+++ b/frontend/test/e2e/workflow-live-list.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 
 /**
  * Issue #384: workflow create / update / delete events reached the console's
@@ -99,6 +105,30 @@ async function openWorkflows(page: Page) {
 }
 
 /**
+ * Returned by {@link pickerOptionCount} when the popup could not be read at
+ * all — it never opened, or the click could not land.
+ *
+ * A sentinel rather than `0`, because `0` is a legitimate answer this file
+ * asserts twice ("the probe does not exist yet", "the deleted one is gone").
+ * Reporting an unread popup as zero would pass both of those against a console
+ * that rendered nothing whatsoever. A negative count matches no expectation:
+ * a poll keeps polling, and a direct assertion fails saying `-1`.
+ */
+const UNREADABLE = -1;
+
+/** `waitFor` reduced to a boolean — a timeout is an answer here, not a throw. */
+function settled(
+  locator: Locator,
+  state: "visible" | "hidden",
+  timeout: number,
+): Promise<boolean> {
+  return locator.waitFor({ state, timeout }).then(
+    () => true,
+    () => false,
+  );
+}
+
+/**
  * How many options the picker offers under `name`, from a fresh open.
  *
  * Opened and closed around the count on purpose, so the reading never depends
@@ -107,14 +137,40 @@ async function openWorkflows(page: Page) {
  * property under test is that the console re-read the list at all, and opening
  * a dropdown fetches nothing (the view lists on mount, on a company switch, and
  * on an SSE frame, and that is all).
+ *
+ * **Nothing in here throws**, which is a requirement and not a style: one call
+ * site runs inside `expect.poll`, and the two automated reviews on this PR
+ * disagreed about whether Playwright retries a rejected poll callback or lets
+ * the rejection end the poll. The lockfile resolves `@playwright/test` to
+ * 1.61.1 rather than the `^1.49.0` in `package.json`, so the semantics anyone
+ * reasons about here may not be the semantics that run. A callback that cannot
+ * reject is correct under either reading, and that is cheaper than settling the
+ * argument.
+ *
+ * The transient this protects against is real: the popup is opened while an
+ * SSE frame is re-rendering the list underneath it, so "no options for a
+ * moment" is an ordinary state on the way to the answer, not a failure.
  */
 async function pickerOptionCount(page: Page, name: string): Promise<number> {
-  await picker(page).click();
-  await expect(page.getByRole("option").first()).toBeVisible({ timeout: 15_000 });
-  const count = await page.getByRole("option", { name, exact: true }).count();
-  await page.keyboard.press("Escape");
-  await expect(page.getByRole("option")).toHaveCount(0);
-  return count;
+  try {
+    await picker(page).click();
+    // Not `expect(...).toBeVisible()`: that throws, and a popup that is empty
+    // for one render is exactly what this must survive.
+    if (!(await settled(page.getByRole("option").first(), "visible", 15_000))) {
+      return UNREADABLE;
+    }
+    const count = await page.getByRole("option", { name, exact: true }).count();
+    await page.keyboard.press("Escape");
+    // Best effort. The count is already read, so a popup slow to close is not
+    // worth discarding it over — and if it really is stuck, the next attempt's
+    // click fails and reports UNREADABLE rather than a wrong number.
+    await settled(page.getByRole("option").first(), "hidden", 5_000);
+    return count;
+  } catch {
+    // A click that could not land, a detached locator mid-re-render: all of it
+    // is "could not read the popup this time", never "the popup held nothing".
+    return UNREADABLE;
+  }
 }
 
 /** Selects a workflow by name and waits for the selection to settle. */
@@ -216,6 +272,54 @@ test("deleting the workflow on screen elsewhere takes it out of the picker, not 
       await pickerOptionCount(page, name),
       "a deleted workflow must leave the picker, not sit in it greyed out",
     ).toBe(0);
+  } finally {
+    await removeWorkflow(request, id);
+  }
+});
+
+/**
+ * The selection can now move without the operator moving it, which is what
+ * makes this worth pinning: the hash mirror pushes a history entry for a
+ * selection change, and that was unconditionally right while only a click could
+ * cause one.
+ *
+ * Measured as `history.length` rather than by pressing Back, because Back's
+ * destination depends on which workflow the view happened to select on mount —
+ * it could legitimately be any entry in the harness company. The stack not
+ * growing is the property itself, and it is true regardless.
+ */
+test("a delete elsewhere corrects the URL in place, without pushing history", async ({
+  page,
+  request,
+}) => {
+  const stamp = Date.now();
+  const id = `e2e-live-history-${stamp}`;
+  const name = `Live history probe ${stamp}`;
+  await createWorkflow(request, id, name);
+
+  try {
+    await openWorkflows(page);
+
+    // Picking it IS a navigation the operator made, so this one is a genuine
+    // history entry — and it is the entry the correction has to replace.
+    await selectWorkflow(page, name);
+    await expect.poll(() => page.url(), { timeout: 20_000 }).toContain(id);
+    const entriesBefore = await page.evaluate(() => window.history.length);
+
+    const deleted = await request.delete(`${COMPANY_SCOPE}/workflows/${id}`);
+    expect(deleted.ok(), `delete ${id}: ${deleted.status()}`).toBeTruthy();
+
+    // The selection moves off the deleted workflow and the hash follows it.
+    await expect.poll(() => page.url(), { timeout: 20_000 }).not.toContain(id);
+
+    // …by REPLACING that entry rather than stacking on it. A push would leave
+    // a URL naming a workflow the host no longer has one Back press away — an
+    // address the operator could copy out and share for a graph that does not
+    // exist, reached by undoing something they never did.
+    expect(
+      await page.evaluate(() => window.history.length),
+      "correcting a deleted selection must replace the history entry, not push one",
+    ).toBe(entriesBefore);
   } finally {
     await removeWorkflow(request, id);
   }


### PR DESCRIPTION
## Summary

Fixes #384.

`project_event` in `src/server/operator.rs` has emitted `workflow_created` (#112), `workflow_updated` and `workflow_deleted` (#259) for as long as those features have existed, and they arrive on the console's `EventSource` like every other frame. The console's event switch named none of the three, so all three reached `default:` and were discarded — nothing rendered, nothing logged.

With the Workflows tab open, that meant a workflow created, edited or deleted from anywhere else — the orchestrator's `create_workflow` tool, a second console session, a machine credential — did not appear, change or disappear until the tab was reloaded or the company switched. The worst of it is the delete: the entry sat in the picker looking live, and the next Run or Edit addressed a workflow the host had already dropped.

This is the third time this switch has produced the same failure — #464 for the board, #371 for the run canvas, these for the picker — so the new arms carry the note about why an unnamed event type is a silent drop.

### What the fix does

* **`frontend/src/hooks/use-events.ts`** — names the three frames on `CompanyStreamEvent` (`{seq, atMillis, workflowId, name}`, exactly what the host projects — there is no graph body on the wire, by design), adds an `onWorkflowChanged` subscriber, and adds the three switch arms.
* **`frontend/src/components/app-shell.tsx`** — bumps a `workflowListTick` on each frame and hands it to `WorkflowsView`.
* **`frontend/src/views/WorkflowsView.tsx`** — the list-load effect re-runs on that tick, so the picker re-reads `GET …/workflows`.

**A counter, not the payload**, for the reason the board's `taskEventTick` is one: the view re-reads the list, so two frames collapsing inside one React batch still mean "re-read", whereas two payloads collapsing means one is lost. It also answers the delete without an id on the wire — the workflow that went away is precisely the one the refreshed list no longer has.

**A delete leaves the picker, it does not grey out.** The selection reconciliation drops an id the fresh list does not have, which takes the entry out of the options and moves the canvas off the graph in the same pass. It falls to the first remaining entry, which is exactly what the local Delete button already does, so a delete from another session and a delete from this button leave the view in the same place; a company whose last workflow just went away selects nothing and the canvas empties.

**One ordering change inside that reconciliation**: a still-valid *held* selection is now preferred over the URL id, where the URL used to win. On mount `prev` is null, so #339's deep link still lands on the graph it names, flash-free — nothing that issue asked for is lost. But this effect now also re-runs on a live frame, and the hash trails the selection by a `hashchange`: reading the URL first would let a frame arriving inside that gap (the console's own `workflow_created`, for instance) snap the operator back off the workflow they had just made.

**No toast**, deliberately. A workflow appearing, being renamed or going away is not an attention signal — the orchestrator authors workflows as ordinary work, and a toast per create is the noise #379 argues against. The list refreshing is the whole feedback.

### Deliberately out of scope

Re-fetching the **selected graph** when it is edited elsewhere. Discriminating "the selected one changed" needs the payload, and the graph effect clears `result` and `selectedNodeId` on every run — so an unrelated create would wipe the operator's run output off the screen. "The graph moved under you" already has an owner: the #259 version token, its 409, and the persistent conflict banner with Reload, all unchanged here.

## API Or Behavior Changes

No API change. The host's wire format is untouched; this consumes frames it was already sending.

Console behaviour, all on the Workflows tab and all with the tab open:

* a workflow created elsewhere appears in the picker without a reload;
* a workflow renamed or edited elsewhere updates its picker entry;
* a workflow deleted elsewhere leaves the picker, and if it was the one on screen the selection moves off it;
* none of the three raises a toast.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

This change is console-only; no Rust source is touched.

Run locally, in `frontend/`:

* `npm run typecheck` — clean
* `npm run typecheck:e2e` — clean (covers the new spec)
* `npm run typecheck:unit` — clean
* `npm test` — 40 pass. 10 fail in `test/unit/tour-resume.test.ts`, which this branch does not touch: `window.localStorage.clear is not a function`, because this machine runs Node v25, whose built-in `localStorage` global shadows jsdom's. CI pins Node 22 (`Console` job), where the file passes on `main` and here.

### The browser walk

`frontend/test/e2e/workflow-live-list.spec.ts` — three specs, and **every one writes from outside the browser** and asserts the open tab followed with no reload and no company switch. That is the whole property: a spec that clicked the console's own Create button would pass against the broken build, because the local handler splices the row in by hand.

1. *a workflow authored elsewhere reaches the picker, with no reload* — asserts the probe is absent first (the baseline the fix has to move; before it, that count stays zero for the life of the tab), then `POST …/workflows` out-of-band, then the option appears.
2. *a workflow renamed elsewhere renames in the picker, with no reload* — selects the graph, renames it over `PUT` out-of-band, and reads the picker **trigger**, so the rename has to land on the selection rather than somewhere in a dropdown nobody has open.
3. *deleting the workflow on screen elsewhere takes it out of the picker, not just greys it* — selects it, `DELETE`s it out-of-band, asserts the selection moves off it **and** that it offers zero options under that name.

The picker is opened and closed around each reading on purpose, so no assertion depends on whether a mounted popup re-renders in place — that is a detail of the Select primitive, and opening a dropdown fetches nothing (the view lists on mount, on a company switch, and on an SSE frame, and that is all).

**Where it ran.** Not on this machine: the suite needs a host binary, and `cargo build` is prohibited on this box, so no local browser walk was performed and I am not claiming one. The specs run in the **`Console E2E`** lane (#428), which builds the host in the `rust` job, downloads it, installs Chromium and runs `npm run e2e` on every push and PR — the lane that #475 asks for. They need nothing beyond the default feature set (no run is started, so no `LIVE_BRAIN` gate), and the paths they exercise — the `…/workflows` CRUD routes, the journal append, `GET {scope}/events` — are all unfeatured. I will report what that lane says on this PR.

## Documentation

None needed. No doc enumerates the frames the console's switch handles — `docs/spec/runtime/api.md` documents the routes and the two run frames a caller needs to follow a detached run, none of which change — and the host-side projection is already documented at `src/server/operator.rs:800-832`. The reasoning for the new arms, the counter-not-payload choice and the selection ordering lives next to the code it constrains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow lists now update automatically when workflows are created, renamed, or deleted elsewhere.
  * Workflow selections remain synchronized with the available workflows without requiring a page reload.

* **Bug Fixes**
  * Removed workflows are cleared from the active selection and picker.
  * Renamed workflows now update correctly in the current view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->