### PR TITLE
ci: run the integration suite in the lane that has its features (#475)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,13 +184,47 @@ jobs:
       - name: Clippy (openhuman, tinycortex)
         run: cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
 
-      # `--lib` is LOAD-BEARING — do not widen it to a bare `cargo test`. There
-      # is no `tests/` directory, and the only other runnable target the feature
-      # set unlocks is the `live_company_turn` example, which dials a real
-      # inference backend and needs a credential. The build step above already
-      # proves it compiles; this step must never try to run it.
+      # `--tests` is LOAD-BEARING IN BOTH DIRECTIONS. Do not narrow it back to
+      # `--lib`, and do not widen it to a bare `cargo test`.
+      #
+      # Issue #475, why not `--lib`. `--lib` selects the library's unit tests and
+      # nothing else, so every integration target under `tests/` is excluded from
+      # this job — and this is the only job that has the features those targets
+      # need. The `Rust` job does select them (a bare `cargo test` includes
+      # `tests/`), but at DEFAULT features, where `one_card_per_message.rs`'s
+      # `#![cfg(feature = "openhuman")]` empties the file. One job had the
+      # feature and not the target, the other had the target and not the feature,
+      # so the 11-case suite that proves one operator message opens exactly one
+      # card (#463/#466) was built by nothing and ran nowhere: `cargo test
+      # --locked --test one_card_per_message` reported `0 passed`. A revert of
+      # the fix it guards would have been caught by no check in this file.
+      #
+      # This step's stated justification used to be "there is no `tests/`
+      # directory". That was a FACT ABOUT THE TREE, and #466 falsified it the day
+      # it merged, silently — nothing fails when a comment stops being true. The
+      # reason below is a property of the target selection instead, so it cannot
+      # expire the same way.
+      #
+      # Why not a bare `cargo test`: its default selection additionally runs the
+      # library's DOCTESTS, a distinct compile and link of the whole tree under
+      # this feature set for coverage the `rust` job's `cargo test` already
+      # provides, and it builds every example — including `live_company_turn`,
+      # whose `required-features = ["openhuman"]` this lane satisfies and which
+      # exists to dial a real inference backend with a real credential. `--tests`
+      # selects exactly the targets that assert: the lib and bin unit tests, plus
+      # every integration target under `tests/`, present and future.
       - name: Test (openhuman, tinycortex)
-        run: cargo test --locked --features openhuman,tinycortex --lib
+        run: cargo test --locked --features openhuman,tinycortex --tests
+
+      # The guard for the next one (issue #475). The step above runs whatever
+      # `tests/` holds, but "ran the target" and "the target ran anything" are
+      # different claims: a file whose crate-level `cfg` is not satisfied still
+      # builds, still links, and still exits 0 having executed nothing. That is
+      # exactly how a whole suite sat in the tree for weeks looking like
+      # coverage. This asserts a NUMBER per integration target, so the silent
+      # zero becomes a red check, and prints the counts into the run log.
+      - name: Assert every integration target actually runs
+        run: scripts/ci/assert-integration-targets-run.sh openhuman,tinycortex
 
       # Catches the combination traps no single feature set can: most often a
       # mandatory struct field constructed differently across feature arms.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,7 +52,15 @@ the crate error type from `src/error.rs`.
 
 Add focused tests with every behavior change. Keep tests near the module they
 exercise unless they verify cross-module behavior, in which case place them in
-the consuming module or a future `tests/` directory.
+the consuming module or in `tests/` as an integration target.
+
+A new file under `tests/` is not covered until a CI job both selects it and
+enables the features its crate-level `cfg` needs (issue #475). A target missing
+either builds, runs and reports zero without failing anything. The gated `Rust
+(openhuman, tinycortex)` job runs `--tests` and then asserts a non-zero count
+per target via `scripts/ci/assert-integration-targets-run.sh`; if your target
+needs a feature set no lane builds, add the lane and run that script there too
+rather than loosening the `cfg`.
 
 Maintain at least 80% coverage for meaningful library behavior. Document any
 intentionally untested edge case in the PR description.

--- a/scripts/ci/assert-integration-targets-run.sh
+++ b/scripts/ci/assert-integration-targets-run.sh
@@ -1,0 +1,118 @@
+#!/bin/sh
+#
+# Assert that every integration target under `tests/` actually executes tests
+# in the CI lane that builds it. Issue #475.
+#
+# The failure this exists to catch is not a red test. It is a target that
+# compiles, links, runs and reports zero. A file whose crate-level attribute is
+# `#![cfg(feature = "openhuman")]` produces a perfectly healthy test binary in a
+# lane without that feature — it just contains nothing. `cargo test` prints
+# `0 passed; 0 failed` and exits 0, and a suite everybody believes is guarding
+# an invariant guards nothing. That is how `tests/one_card_per_message.rs`, the
+# 11-case regression suite for #463, sat in the tree with no runner: the default
+# lane had the target but not the feature, the gated lane had the feature but
+# passed `--lib`, which selects no target under `tests/` at all.
+#
+# So this checks a NUMBER, not a configuration. Configuration can look right and
+# be vacuous; a count cannot.
+#
+# Usage:
+#   scripts/ci/assert-integration-targets-run.sh [features]
+#
+# `features` is the comma-separated feature list of the lane being asserted,
+# defaulting to the set the gated CI job builds. Cargo features are additive and
+# that set is a superset of the default one, so a target that runs in the `Rust`
+# job necessarily runs here too — asserting on one lane covers them all.
+#
+# A target that legitimately needs a feature this lane does not have will fail
+# here. That is the intended outcome, and the message at the bottom says what to
+# do about it: give this lane the feature, or add a lane that has it. Do NOT
+# relax the target's `cfg` to make this pass — a test that runs only because it
+# was stripped of the code it needs is the same vacuum in a different disguise.
+#
+# Requires `jq` (present on `ubuntu-latest`; `brew install jq` locally).
+
+set -eu
+
+FEATURES="${1:-openhuman,tinycortex}"
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}"
+
+if ! command -v jq > /dev/null 2>&1; then
+  echo "assert-integration-targets-run: jq is required but not installed" >&2
+  exit 1
+fi
+
+WORK=$(mktemp -d)
+trap 'rm -rf "${WORK}"' EXIT
+
+# `cargo metadata` rather than a glob over `tests/*.rs`: the manifest decides
+# what a target is, and an explicit `[[test]]` entry may name a path this
+# directory does not contain.
+cargo metadata --locked --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(.name == "opencompany") | .targets[]
+           | select(.kind | index("test")) | .name' \
+  | sort > "${WORK}/targets"
+
+if [ ! -s "${WORK}/targets" ]; then
+  echo "No integration targets under tests/. Nothing to assert."
+  exit 0
+fi
+
+echo "Integration targets under --features ${FEATURES}:"
+echo
+
+failed=0
+
+# Redirected from a file, not piped: a `while` on the right of a pipe runs in a
+# subshell and `failed` would not survive the loop.
+while IFS= read -r target; do
+  [ -n "${target}" ] || continue
+
+  if ! cargo test --locked --features "${FEATURES}" --test "${target}" -- --list \
+    > "${WORK}/listing" 2>&1; then
+    cat "${WORK}/listing" >&2
+    echo >&2
+    echo "  ${target}: FAILED TO BUILD under --features ${FEATURES}" >&2
+    failed=1
+    continue
+  fi
+
+  # `--list` prints one `some::test_name: test` line per test case.
+  count=$(grep -c ': test$' "${WORK}/listing" || true)
+
+  if [ "${count}" -eq 0 ]; then
+    echo "  ${target}: 0 tests  <-- RUNS NOWHERE"
+    failed=1
+  else
+    echo "  ${target}: ${count} tests"
+  fi
+done < "${WORK}/targets"
+
+echo
+
+if [ "${failed}" -ne 0 ]; then
+  cat >&2 << EOF
+One or more integration targets executed nothing in this lane.
+
+A target that builds but reports zero tests is not covered by CI, however green
+the run looks. Its crate-level cfg is unsatisfied by --features ${FEATURES}, so
+CI compiles an empty binary and reports success.
+
+Fix the WIRING, not the test:
+
+  * add the feature the target needs to the gated job in
+    .github/workflows/ci.yml, if it belongs on that lane; or
+  * add a job that builds the feature set the target needs, and run this script
+    there too with that job's feature list.
+
+Do not delete or weaken the target's #![cfg(...)] to make this pass. That
+removes the code under test rather than running it, which is the failure this
+check exists to name.
+EOF
+  exit 1
+fi
+
+echo "Every integration target executed at least one test."


### PR DESCRIPTION
## Summary

Fixes #475.

`tests/one_card_per_message.rs` — the 11-case regression suite from #466 that proves one operator message opens exactly one card — was built by nothing in CI. Not "runs and passes". Never built.

| Job | Command | Why it missed |
|---|---|---|
| `Rust` | `cargo test --locked` | selects integration targets, but at **default** features, where the file's `#![cfg(feature = "openhuman")]` empties it → 0 tests |
| `Rust (openhuman, tinycortex)` | `cargo test --locked --features openhuman,tinycortex --lib` | has the feature, but `--lib` selects **no** target under `tests/` → never built |

One job had the feature and not the target; the other had the target and not the feature.

**The wiring is what changed, not the test.** The suite genuinely needs `openhuman` — that is what pulls the harness pool, the hosted inference provider and `reqwest` — so its `cfg` is untouched. What changed is the lane that has those features:

1. **`--lib` → `--tests`** on the gated job. `--tests` selects every target with `test = true`: the lib and bin unit tests, plus every integration target under `tests/`, present and future. It still excludes the two things the old flag was defending against, so the combination problem the comment warned about is not reintroduced:
   - the library's **doctests**, which a bare `cargo test` runs — a distinct compile and link of the whole tree under this feature set, for coverage the `rust` job's `cargo test` already provides;
   - the **examples**, which a bare `cargo test` builds — including `live_company_turn`, whose `required-features = ["openhuman"]` this lane satisfies and which exists to dial a real inference backend with a real credential.

2. **The load-bearing comment is rewritten.** Its stated justification was *"There is no `tests/` directory."* That was a **fact about the tree**, and #466 falsified it the day it merged — silently, because nothing fails when a comment stops being true. The replacement is a property of the **target selection** instead, which cannot expire the same way, and it records why `--lib` was wrong so the next reader does not narrow it back.

3. **A guard so the next one is loud.** New `scripts/ci/assert-integration-targets-run.sh`, run as a step on the gated job. It enumerates integration targets from `cargo metadata` (not a glob over `tests/*.rs` — the manifest is what decides what a target is, and an explicit `[[test]]` entry may name a path this directory does not contain), runs each with `-- --list`, and **fails when any reports 0 tests**, printing the count per target into the run log.

   It asserts a **number**, not a configuration, and that distinction is the whole point. A file whose crate-level `cfg` is unsatisfied still builds, still links, and still exits 0 having executed nothing; a config that "looks right" cannot rule that out, and a count can. Its failure message directs the reader to add the feature to a lane or add a lane — and explicitly **not** to relax the target's `cfg`, since a test that runs only because it was stripped of the code it needs is the same vacuum in a different disguise.

4. **`AGENTS.md`** carried the same expired claim ("a future `tests/` directory"). Corrected, with a short paragraph telling contributors that a new file under `tests/` is not covered until a lane both selects it **and** enables the features its `cfg` needs.

### Did any OTHER integration target fall in the same hole?

**I checked, and `tests/one_card_per_message.rs` is genuinely the only one.** `tests/` contains exactly one file; `Cargo.toml` declares no `[[test]]` entries (so autodiscovery is the only source of integration targets) and no benches; the single `[[example]]`, `live_company_turn`, is deliberately never run. So there was one target in the hole, not several — and the new guard is what keeps that answer honest, because it is derived from `cargo metadata` at run time rather than from this sentence.

### Side effect, named deliberately

`--tests` also runs the four `src/bin/opencompany.rs` unit tests under `openhuman,tinycortex`, where previously only the default `rust` job ran them. They are home-resolution and arg-parsing tests with no feature-dependent behaviour, so this is extra coverage rather than new surface; it is called out here rather than left to appear unexplained in a log.

## API Or Behavior Changes

None. CI wiring, one shell script, and documentation. No Rust source changed, so no runtime behavior, no public API, and no user-facing surface is touched.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI. (No `.rs` file changed by this PR.)
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI.

What *was* verified locally, offline:

- `sh -n scripts/ci/assert-integration-targets-run.sh` — clean.
- The script's control flow, driven end to end against a stub `cargo` on `PATH`: the non-zero-count case prints `one_card_per_message: N tests` and exits 0; the zero-count case prints `one_card_per_message: 0 tests  <-- RUNS NOWHERE`, prints the remediation block to stderr, and exits 1.
- The `jq` selector against synthetic `cargo metadata` JSON: it picks only the `opencompany` package's `kind: ["test"]` targets, ignoring `lib`, `bin`, `example`, and targets belonging to vendored packages.

### The numbers this issue asks for

**Before** (measured in #475, on the commands the two jobs actually ran):

```
cargo test --locked --test one_card_per_message
  → 0 passed; 0 failed          # Rust job: default features, the file cfg's away

cargo test --locked --features openhuman,tinycortex --lib
  → the suite is not among the targets built at all
```

**After** — the count is emitted by CI on this branch, in two places:

- the `Test (openhuman, tinycortex)` step, which now runs `one_card_per_message` and reports its result;
- the `Assert every integration target actually runs` step, which prints `one_card_per_message: 11 tests` and fails the job if that number is ever 0.

The CI run on this PR is the link for both. The measurement quoted in the issue for the same feature set is `11 passed; 0 failed`.

### Acceptance list from the issue

- **"Reverting #466's fix turns a CI job red."** Not demonstrated by an actual revert run — that would need a throwaway branch and a second full gated build, which was not authorised for this change. What *is* demonstrated is the mechanism that revert relies on: the suite now executes in a lane that has its features, with its case count asserted non-zero, where before it executed nowhere. I am happy to push a scratch branch with #466 reverted and link the red run if a reviewer wants the demonstration on the record.
- **"`tests/one_card_per_message.rs` reports 11 passing in CI logs, not 0."** The gated job runs it and the guard step prints the count. See the CI run on this PR.
- **"Adding a new integration target that no job runs fails a check rather than passing quietly."** That is `scripts/ci/assert-integration-targets-run.sh`. Because it enumerates from `cargo metadata` rather than from a checked-in list, a target added tomorrow is covered without anyone remembering to register it.
- **"Where the change unblocks browser specs, run them against a live host."** Does not apply: nothing here touches the console, the Playwright suite, or any runtime surface. No browser spec is unblocked or affected by this diff.

## Documentation

`AGENTS.md` — corrected the expired "a future `tests/` directory" wording and added where integration tests go plus what makes one actually covered. The CI rationale itself lives in the workflow comments, next to the flag they defend, which is where the claim that expired was; the repo has no separate CI document to keep in sync.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded feature-gated Rust testing to include library, binary, and integration tests.
  * Added validation to ensure every integration test target runs at least one test.
  * Improved failure reporting for missing or non-executing integration coverage.

* **Documentation**
  * Updated testing guidance for cross-module and integration tests.
  * Documented required CI configuration and coverage validation expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->