### PR TITLE
feat(workflows): confine the copilot's answering agent to one workflow

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -310,20 +310,32 @@ scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
   `owns` to match on prefix, would break that surface — see
   [`frontend/src/api/workflow-copilot.ts`](../../../frontend/src/api/workflow-copilot.ts).
 
-  **Thread addressing isolates transcripts. It does not scope authority.**
-  These are two different things and only the first is enforced here. The
-  thread id decides who answers and where the exchange is journaled; it does
-  **not** narrow the orchestrator's context or its tool grants, which stay
-  company-wide for every `/chat` turn whatever thread it names. A caller that
-  needs the responder confined to one subject has to constrain it in the
-  prompt — which is advisory — or build a genuinely scoped agent, which this
-  seam is not.
+  **Thread addressing isolates transcripts. For every thread but one, it does
+  not scope authority.** The thread id decides who answers and where the
+  exchange is journaled; for an ordinary thread it does **not** narrow the
+  responder's context or tool grants, which stay company-wide however the turn
+  is addressed.
 
-  That is a scoping property, not an authorization one: `/chat` is already
-  authenticated and company-scoped, so an operator addressing a workflow
-  thread gains nothing they could not get by opening the Chat tab or calling
-  the workflow routes directly. The copilot therefore adds no privilege; what
-  it adds is a transcript that stays out of the team's chat.
+  **The copilot thread is the exception (issue #416).** A `chat` id matching
+  `workflow-copilot:<workflowId>` ([`company::copilot`](../../../src/company/copilot.rs))
+  makes the turn **confined**, host-side, in two places that hold independently:
+
+  - the harness runs it on an ephemeral agent with **no tools, no company
+    memory and no delegation** ([`harness::confine`](../../../src/harness/confine.rs)),
+    and skips the retrieve→inject step and the memory writeback, so the turn
+    answers from the message it was sent and leaves nothing behind. Every tool
+    call is denied by the host with a reason, so an empty toolbelt is a
+    boundary rather than an absence;
+  - the `/chat` handler does not open a board card from a copilot message, so a
+    question phrased as a request cannot leave work on the board. That half is
+    in the default build, not behind `openhuman`.
+
+  Confinement narrows one **turn**; it is not an authorization check and must
+  not be read as one. `/chat` is already authenticated and company-scoped, so
+  an operator addressing a workflow thread gains nothing they could not get by
+  opening the Chat tab or calling the workflow routes directly. What the
+  copilot adds is a transcript that stays out of the team's chat and an answer
+  drawn from one workflow rather than from everything the company knows.
 
   Two more consequences worth knowing before reusing the seam. A chat turn
   runs the **whole** company cycle, so an actionable message also opens a

--- a/frontend/src/api/workflow-copilot.ts
+++ b/frontend/src/api/workflow-copilot.ts
@@ -22,15 +22,22 @@
 //    "no cross-workflow leakage" criterion, enforced server-side rather than by
 //    this file remembering to filter.
 //
-//    **Read that precisely: it isolates TRANSCRIPTS, not authority.** The
-//    thread id picks the responder and the journal; it does not narrow the
-//    orchestrator's context or tools, which stay company-wide. Asking this
-//    copilot about another workflow is not prevented by the transport — only
-//    by the instruction in the composed prompt, which is advisory. That is a
-//    deliberate limit of reusing the chat seam rather than building a scoped
-//    agent, and it costs nothing in privilege: the operator is already
-//    authenticated to the company and can reach the same orchestrator from the
-//    Chat tab and every workflow route. See `docs/spec/runtime/api.md`.
+//    **It isolates TRANSCRIPTS.** One workflow's copilot never sees another's,
+//    and none of it appears in the team's chat.
+//
+//    Until issue #416 that was the *whole* of the scoping: the thread id picked
+//    the responder and the journal and narrowed nothing else, so the teammate
+//    answering was the company orchestrator with its full context and tools,
+//    and "answer only about this workflow" was an instruction in the prompt —
+//    advice, not a boundary. It cost nothing in privilege (the operator can
+//    reach the same orchestrator from the Chat tab), but it meant an answer
+//    about a workflow could be drawn from anywhere in the company.
+//
+//    The host now reads the thread itself. `workflow-copilot:<id>` runs a
+//    **confined turn**: an ephemeral agent with no tools, no company memory and
+//    no delegation, whose whole world is the message composed below. See
+//    `src/company/copilot.rs` (the convention) and `src/harness/confine.rs`
+//    (the boundary), plus `docs/spec/runtime/api.md`.
 // 3. **It rehydrates for free.** Because the exchange is journaled under that
 //    thread, `GET {scope}/chat/history?desk=<thread>` replays it after a reload,
 //    with no new storage and no new route.
@@ -130,7 +137,13 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
 
   const lines: string[] = [
     `You are the workflow copilot for this company, answering about ONE saved workflow.`,
-    `Answer only about this workflow. If the question is about a different workflow, or about the company generally, say so instead of guessing.`,
+    // The host confines this turn (issue #416): it runs on an agent with no
+    // tools and no company memory, so this is a description of the turn's real
+    // boundary rather than an instruction it could step outside of. Kept in the
+    // message as well as in the host-side persona so the disclosure the panel
+    // shows the operator is built from the same text that was actually sent.
+    `Everything you know about it is below. You have no tools and no access to the rest of the company, so answer from this material only.`,
+    `If the question needs a different workflow or the wider company, say which part you cannot answer here and that it has to be asked in the company chat. Do not guess, and do not claim to have looked anything up.`,
     ``,
     `## Workflow`,
     `Name: ${graph.name}`,
@@ -198,6 +211,7 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     `## What you can and cannot do`,
     `You can explain this workflow, diagnose why its runs failed, and describe in words what should change.`,
     `You CANNOT edit the workflow: this console does not apply copilot-authored changes. If a change is wanted, describe it precisely enough for a person to make it in the workflow editor. Do not claim to have made it.`,
+    `You CANNOT reach anything else in the company: no tools, no board, no teammates, no other workflow, no files. The host enforces this, so a call would be refused rather than answered.`,
   );
 
   // Joined with the marker verbatim, so `questionOf` splits on exactly the

--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -6,6 +6,11 @@
 // `@/api/workflow-copilot` for why it needs no new host route and how the
 // scoping is enforced server-side.
 //
+// Issue #416 made "scoped" true of the answering agent and not only of the
+// question: the host reads the copilot thread id and runs the turn confined —
+// no tools, no company memory, no delegation. That is what the disclosure block
+// below is allowed to claim, and it claims exactly that and no more.
+//
 // ## It says what it cannot do
 //
 // Two honesty gates, and both exist because the failure they prevent is a chat
@@ -255,42 +260,39 @@ export function CopilotPanel({
         {/* What it can see and what it cannot do, stated before the first
             question rather than discovered after it.
 
-            The first line used to end "— not other workflows", which was an
-            over-claim: what the thread buys is transcript isolation, not a
-            confined responder. The teammate answering is the company's
-            orchestrator with its ordinary company-wide context and tools, so
-            the honest claim is about what is SENT with the question, not about
-            what the responder is unable to reach. Grounding and isolation are
-            both real and both verified; confinement is not, so it is not
-            claimed. See the header of `@/api/workflow-copilot`. */}
+            This block is a claim about the host, so it changes only when the
+            host does. #405 had to *withdraw* a confinement claim: the thread
+            bought transcript isolation, not a confined responder, and the
+            teammate answering held the company's whole context and tool
+            surface. #416 built the confinement, so the claim is back — and it
+            is now the narrower, checkable one: no tools, no company context,
+            and a turn that says which part of a question it could not answer
+            rather than reaching for the rest of the company. See the header of
+            `@/api/workflow-copilot`, and `harness::confine` host-side. */}
         <div className="rounded-lg border bg-muted/30 p-2 text-[11px] leading-snug text-muted-foreground">
           <p>
             Answers are grounded in{" "}
-            <span className="font-medium text-foreground">{graph.name}</span> — its steps
-            and its recorded runs are what gets sent with your question.
+            <span className="font-medium text-foreground">{graph.name}</span>: its steps and
+            its recorded runs are what gets sent with your question.
           </p>
           <p className="mt-1.5">
-            This conversation stays with this workflow: it isn't in the company
-            chat, and another workflow's copilot can't see it. The teammate
-            answering is your company's orchestrator though, so it can still
-            draw on what it knows about the rest of the company.
+            That is also all the answer is drawn from. This turn runs{" "}
+            <span className="font-medium text-foreground">confined to this workflow</span>: no
+            tools, no company memory, and no reach into the board, your teammates or another
+            workflow. Ask something that needs the wider company and it will say so rather
+            than guess.
+          </p>
+          <p className="mt-1.5">
+            The conversation stays here too: it isn&apos;t in the company chat, and another
+            workflow&apos;s copilot can&apos;t see it.
           </p>
           <p className="mt-1.5">
             It can explain and suggest, but{" "}
-            <span className="font-medium text-foreground">it can't change the workflow</span>.
+            <span className="font-medium text-foreground">it can&apos;t change the workflow</span>
+            .
             {sourceDefined
               ? " This one is defined by a file in the company source tree, so changes belong in the company repository."
-              : " Apply a change yourself with Edit — that's the path that checks the graph and refuses a stale write."}
-          </p>
-          {/* The copilot is a company chat turn, and a chat turn that reads as
-              an instruction opens a board card. That is the host's ordinary
-              behaviour, not a copilot quirk — but an operator who was not told
-              would find a card they never asked for, so say it once, up front,
-              and frame it as what it is: how a request gets recorded when the
-              copilot itself cannot act on it. */}
-          <p className="mt-1.5">
-            Asking for a change may open a card on the board — that's how the
-            company records work to pick up.
+              : " Apply a change yourself with Edit, the path that checks the graph and refuses a stale write."}
           </p>
         </div>
 

--- a/frontend/test/unit/workflow-copilot.test.ts
+++ b/frontend/test/unit/workflow-copilot.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  composeCopilotMessage,
+  copilotThreadId,
+  questionOf,
+  type CopilotContext,
+} from "@/api/workflow-copilot";
+import type { WorkflowGraph } from "@/api/workflows";
+
+/**
+ * Issues #303 and #416.
+ *
+ * The copilot's whole boundary is carried by two strings: the thread id, which
+ * is what the host reads to decide a turn runs confined
+ * (`src/company/copilot.rs`), and the composed message, which is now the only
+ * material the answering agent has — it has no tools and no company memory, so
+ * anything not in here is not answerable.
+ *
+ * That makes both worth pinning. A thread id that stopped matching the host's
+ * prefix would silently return the copilot to the company orchestrator, with
+ * every property looking unchanged from the console's side.
+ */
+
+const graph: WorkflowGraph = {
+  id: "weekly_report",
+  name: "Weekly report",
+  description: "Assemble and send the Monday summary.",
+  nodes: [
+    {
+      id: "collect",
+      kind: "agent",
+      name: "Collect",
+      agent: "analyst",
+      summary: "Pull last week's numbers",
+    },
+    { id: "send", kind: "report", name: "Send", destination: { kind: "email", target: "team" } },
+  ],
+  edges: [{ from: "collect", to: "send" }],
+};
+
+const context: CopilotContext = { graph, runs: [], runsKnown: true };
+
+describe("copilotThreadId", () => {
+  /** The exact string `company::copilot::workflow_of_thread` parses. */
+  it("is the prefix the host confines on", () => {
+    expect(copilotThreadId("weekly_report")).toBe("workflow-copilot:weekly_report");
+  });
+});
+
+describe("composeCopilotMessage", () => {
+  it("carries the workflow's own graph as the grounding", () => {
+    const message = composeCopilotMessage(context, "why is it slow?");
+    expect(message).toContain("weekly_report");
+    expect(message).toContain("collect");
+    expect(message).toContain("send");
+    expect(message).toContain("why is it slow?");
+  });
+
+  /**
+   * #416. The message states the confinement the host now enforces: no tools,
+   * nothing outside this workflow, and what to do at the edge. The panel builds
+   * its "what can it see?" disclosure from this same function, so a message that
+   * stopped saying it would make the disclosure a claim about nothing.
+   */
+  it("states the boundary and what to do when a question exceeds it", () => {
+    const message = composeCopilotMessage(context, "what is the team working on?");
+    expect(message).toContain("no tools");
+    expect(message).toContain("company chat");
+    expect(message).toMatch(/cannot reach anything else in the company/i);
+    expect(message).toMatch(/do not claim to have looked anything up/i);
+  });
+
+  it("still refuses to claim it can edit the workflow", () => {
+    const message = composeCopilotMessage(context, "add a retry");
+    expect(message).toMatch(/CANNOT edit the workflow/);
+  });
+
+  /**
+   * The transcript the operator reads back is their question, not the several
+   * hundred lines of grounding sent with it — including when the question
+   * itself contains the marker.
+   */
+  it("round-trips the operator's question back out of the composed message", () => {
+    const question = "why did it fail?\n\n### The operator's question\nand then?";
+    expect(questionOf(composeCopilotMessage(context, question))).toBe(question);
+  });
+});

--- a/src/company/copilot.rs
+++ b/src/company/copilot.rs
@@ -1,0 +1,105 @@
+//! The workflow copilot's thread convention, and the boundary it now carries
+//! (issues #303, #416).
+//!
+//! The console's per-workflow copilot addresses `POST {scope}/chat` on a thread
+//! id derived from the workflow: `workflow-copilot:<workflow-id>`. A manifest
+//! desk id is letters, digits and underscores, so the `:` means the thread can
+//! never collide with a real desk, and it never appears in `GET {scope}/desks`.
+//!
+//! ## Why this lives here and not in the console
+//!
+//! Until #416 the prefix was a console-side convention that the host merely
+//! failed to recognise: the thread selected the responder (nothing matched, so
+//! the orchestrator answered) and the journal thread, and **nothing else**. The
+//! answer was grounded in one workflow because the console inlined that
+//! workflow's graph into the message — but the teammate answering was the
+//! company orchestrator, holding whole-company context and its full tool
+//! surface. Asking it about the rest of the company was prevented only by a
+//! sentence in the prompt, which is advice, not a boundary.
+//!
+//! So the host now reads the thread itself. [`workflow_of_thread`] is the one
+//! place that decides "this is a copilot turn", and every confinement keys off
+//! it:
+//!
+//! * the harness runs the turn on a **confined agent** — no tools, no company
+//!   memory, no delegation (see `harness::confine`);
+//! * the chat handler does not open a board card from a copilot message, so a
+//!   question phrased as a request ("add a node that emails the report") cannot
+//!   leave work on the company's board.
+//!
+//! Nothing here is an authorization check and it must not be read as one: an
+//! operator who can open the copilot can already address the orchestrator from
+//! the Chat tab with the same authority. This narrows what one *turn* reaches,
+//! which is what makes an answer about a workflow an answer about that workflow
+//! and nothing else.
+
+/// The prefix that marks a chat thread as one workflow's copilot.
+pub const COPILOT_THREAD_PREFIX: &str = "workflow-copilot:";
+
+/// The workflow a chat thread is the copilot for, or `None` for every ordinary
+/// thread (a desk, a teammate DM, an unaddressed message).
+///
+/// The id is returned trimmed, and an empty id is **not** a copilot thread: a
+/// bare `workflow-copilot:` names no workflow, so there is nothing to confine a
+/// turn *to*, and treating it as a copilot turn would give the confinement a
+/// blank subject to describe.
+pub fn workflow_of_thread(chat: Option<&str>) -> Option<&str> {
+    let id = chat?.strip_prefix(COPILOT_THREAD_PREFIX)?.trim();
+    (!id.is_empty()).then_some(id)
+}
+
+/// Whether a chat thread is a workflow copilot's.
+pub fn is_copilot_thread(chat: Option<&str>) -> bool {
+    workflow_of_thread(chat).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_the_workflow_out_of_a_copilot_thread() {
+        assert_eq!(
+            workflow_of_thread(Some("workflow-copilot:weekly_report")),
+            Some("weekly_report")
+        );
+        assert!(is_copilot_thread(Some("workflow-copilot:weekly_report")));
+    }
+
+    #[test]
+    fn an_ordinary_thread_is_not_a_copilot_thread() {
+        for chat in [None, Some("general"), Some("engineering"), Some("chief")] {
+            assert_eq!(workflow_of_thread(chat), None, "{chat:?}");
+            assert!(!is_copilot_thread(chat), "{chat:?}");
+        }
+    }
+
+    /// A desk cannot be spelled with a `:`, so nothing that merely *contains*
+    /// the marker counts: the prefix has to start the thread id. Otherwise a
+    /// desk named after the copilot would inherit a confinement meant for a
+    /// workflow that does not exist.
+    #[test]
+    fn the_prefix_must_start_the_thread_id() {
+        assert_eq!(workflow_of_thread(Some("desk-workflow-copilot:x")), None);
+        assert_eq!(workflow_of_thread(Some(" workflow-copilot:x")), None);
+    }
+
+    /// A prefix with nothing after it names no workflow. Confining a turn to
+    /// "" would produce a boundary whose subject is blank, which reads to the
+    /// operator as a copilot that has lost the workflow it was opened on.
+    #[test]
+    fn a_workflowless_prefix_is_not_a_copilot_thread() {
+        assert_eq!(workflow_of_thread(Some("workflow-copilot:")), None);
+        assert_eq!(workflow_of_thread(Some("workflow-copilot:   ")), None);
+    }
+
+    /// Ids are trimmed, so a thread built with stray whitespace still names the
+    /// workflow it meant rather than a near-miss id nothing resolves.
+    #[test]
+    fn ids_are_trimmed() {
+        assert_eq!(
+            workflow_of_thread(Some("workflow-copilot: weekly_report ")),
+            Some("weekly_report")
+        );
+    }
+}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -8,6 +8,11 @@
 pub mod composio;
 #[cfg(test)]
 mod content_test;
+// The workflow copilot's thread convention (issues #303, #416). Always
+// compiled and openhuman-free: the chat handler reads it in every build to keep
+// a copilot question from opening a board card, and the harness reads the same
+// function to decide that a turn runs confined.
+pub mod copilot;
 // How this instance obtains its TinyHumans credential (projected, rotating
 // platform token vs a static key). Always compiled: the answer decides whether a
 // company can think at all, in every build.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -24,6 +24,7 @@ use async_trait::async_trait;
 use crate::Result;
 use crate::company::steer::{InflightEntry, InflightKind, SteerAction, cap_redirect};
 use crate::harness::build::agent_workspace;
+use crate::harness::confine;
 // The note shape is shared with the ungated system paths (issue #337): the
 // backstop, the quiescing-runtime settle and the boot reaper all append their
 // reason to a card, and a second copy of it here is how one card ends up with
@@ -1927,6 +1928,46 @@ impl Brain for HarnessBrain {
         for event in &req.events {
             match event {
                 CompanyEvent::OperatorMessage { text, chat, .. } => {
+                    // Issue #416: a workflow copilot thread is answered by a
+                    // CONFINED turn, not by the company orchestrator.
+                    //
+                    // This branch is the boundary. Everything below it — the
+                    // delegation runner, the publish claim, the MCP failure
+                    // drain, the card a `spawn_task` opens — exists to let a
+                    // turn act on the company's behalf, and a copilot turn is
+                    // precisely the one that must not. So it does not fall
+                    // through to any of it: no tools ran, so there is nothing to
+                    // drain, and no desk was reachable, so there is nothing to
+                    // relay. What comes back is one bubble on this thread, which
+                    // is the whole of what the copilot was ever meant to be.
+                    if let Some(workflow_id) =
+                        crate::company::copilot::workflow_of_thread(chat.as_deref())
+                    {
+                        let confinement = confine::Confinement::workflow(workflow_id);
+                        let outcome = self
+                            .pool
+                            .run_confined(
+                                &self.record.id,
+                                &self.record.manifest.company.name,
+                                text,
+                                &self.deps,
+                                chat.as_deref(),
+                                &confinement,
+                            )
+                            .await?;
+                        channel_responses.push(OutboundMessage {
+                            message_id: None,
+                            // No card, by construction: a confined turn has no
+                            // `spawn_task` to call, and the chat handler does
+                            // not open one from a copilot message either.
+                            task_id: None,
+                            channel: "operator".to_string(),
+                            text: outcome.reply,
+                            reply_to: None,
+                            steps: outcome.steps,
+                        });
+                        continue;
+                    }
                     // Route to the addressed desk's lead, else the orchestrator.
                     let responder = self.responder_for(chat.as_deref());
                     // The chat/desk thread this turn answers — the same id the

--- a/src/harness/confine.rs
+++ b/src/harness/confine.rs
@@ -1,0 +1,415 @@
+//! Issue #416 — the **confined turn**: an agent that reaches nothing but the
+//! message it was given.
+//!
+//! ## What was wrong
+//!
+//! The per-workflow copilot (#303) sends its question to the company
+//! orchestrator on a dedicated thread. The question is *grounded* — the console
+//! inlines that workflow's graph and its recorded runs — and the exchange is
+//! isolated in the journal. But the thread only ever selected the responder and
+//! the journal thread; it did not narrow what the responder could reach. The
+//! teammate answering held the whole company's context and its full tool
+//! surface, so "answer only about this workflow" was a sentence in a prompt,
+//! and a sentence is advice.
+//!
+//! ## What a confined turn is
+//!
+//! An ephemeral agent, built for one turn and dropped afterwards, whose reach is
+//! the message and nothing else:
+//!
+//! * **No tools.** Its toolbelt is empty — not even the intrinsic memory tools
+//!   every roster agent carries, and none of the orchestrator's `query_company`
+//!   / `spawn_task` / `delegate_to_desk`. It cannot read the board, the roster,
+//!   the workspace tree, another workflow, an MCP server, the web, or a file.
+//! * **No company memory.** Its [`Memory`] is backed by [`ConfinedContext`], an
+//!   in-process store that holds nothing and answers every read empty, so the
+//!   company [`ContextStore`] is not reachable through recall. The pool
+//!   additionally skips the retrieve→inject step and the memory writeback for a
+//!   confined turn, so no prior task outcome is prepended to the message and the
+//!   exchange leaves nothing behind for a later turn to retrieve.
+//! * **Enforced, not requested.** [`ConfinedToolPolicy`] denies **every** tool
+//!   call by name whatever the belt holds. An empty belt already means the model
+//!   is offered nothing; the policy is what makes that a boundary rather than an
+//!   absence — a tool wired here by a later change, or a name the model invents,
+//!   is refused by the host with a reason, not run.
+//! * **No delegation.** The brain runs this turn directly rather than through
+//!   the delegation runner, so a confined turn cannot hand off to a desk and
+//!   have the desk do what it was not allowed to.
+//!
+//! ## What a copilot turn can still reach
+//!
+//! Exactly what the console put in the message: the workflow's name, id,
+//! description, its nodes and edges, and the summaries of its own recorded runs.
+//! Plus the operator's question, and the earlier turns of this same thread that
+//! the provider carries. Nothing else — and when a question genuinely needs
+//! company-wide context, the persona tells it to say so and point at the Chat
+//! tab rather than answer from material it does not have.
+//!
+//! Compiled only under `feature = "openhuman"`, with the rest of the harness.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use openhuman_core::openhuman as oh;
+
+use oh::agent::dispatcher::{NativeToolDispatcher, ToolDispatcher};
+use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
+use oh::agent::{Agent, AgentBuilder};
+use oh::context::prompt::SystemPromptBuilder;
+use oh::memory::traits::Memory;
+use oh::tools::Tool;
+
+use crate::error::OpenCompanyError;
+use crate::harness::HarnessDeps;
+use crate::harness::build::{ensure_agent_workspace, model_for_tier};
+use crate::harness::memory::OcMemory;
+use crate::harness::tool_dispatcher::AttrTolerantXmlDispatcher;
+use crate::ports::ContextStore;
+use crate::ports::types::{ChunkAddr, ChunkHit, ChunkMeta, CompanyId, ContextChunk};
+
+/// The agent id a confined turn runs under. Deliberately not a roster id: it
+/// names no teammate, carries no manifest grants, and cannot be addressed.
+pub const CONFINED_AGENT_ID: &str = "workflow-copilot";
+
+/// What one confined turn is confined **to**.
+///
+/// One variant today. It is an enum rather than a bare workflow id because the
+/// boundary is the reusable half of this issue: the next thing that should
+/// reason about one object without the rest of the company in scope adds a
+/// variant here and reuses the whole path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Confinement {
+    /// A copilot turn about exactly one saved workflow.
+    Workflow { id: String },
+}
+
+impl Confinement {
+    /// The confinement for a workflow copilot thread.
+    pub fn workflow(id: impl Into<String>) -> Self {
+        Self::Workflow { id: id.into() }
+    }
+
+    /// The subject, for logs and for the refusal a denied tool call carries.
+    pub fn subject(&self) -> &str {
+        match self {
+            Self::Workflow { id } => id,
+        }
+    }
+}
+
+/// A [`ContextStore`] that stores nothing and finds nothing.
+///
+/// Stands in for the company's real store so a confined agent's [`Memory`] is
+/// structurally present (openhuman requires one) and substantively empty. Reads
+/// answer empty rather than erroring: a confined turn that *fails* on recall
+/// would be a turn whose confinement is visible to the model as a fault, and
+/// "there is nothing here" is the truth anyway.
+#[derive(Debug, Default)]
+pub struct ConfinedContext;
+
+#[async_trait]
+impl ContextStore for ConfinedContext {
+    async fn put(&self, _id: &CompanyId, chunk: ContextChunk) -> crate::Result<ChunkAddr> {
+        // Accepted and dropped. The address is derived from the label so a
+        // caller that stores and immediately re-reads gets a coherent answer
+        // (nothing), rather than a store that refuses writes and turns a
+        // confined turn into an error path.
+        Ok(ChunkAddr::new(format!("confined/{}", chunk.label)))
+    }
+
+    async fn list(&self, _id: &CompanyId, _prefix: &str) -> crate::Result<Vec<ChunkMeta>> {
+        Ok(Vec::new())
+    }
+
+    async fn peek(
+        &self,
+        _id: &CompanyId,
+        _addr: &ChunkAddr,
+        _range: Option<Range<usize>>,
+    ) -> crate::Result<String> {
+        Ok(String::new())
+    }
+
+    async fn search(
+        &self,
+        _id: &CompanyId,
+        _query: &str,
+        _limit: usize,
+    ) -> crate::Result<Vec<ChunkHit>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Denies every tool call, whatever the belt holds.
+///
+/// The confined agent is built with an empty toolbelt, so in the ordinary case
+/// this policy is never consulted — nothing is offered to call. It exists for
+/// the two cases that are not ordinary: a tool wired onto this path by a later
+/// change (the belt is code, and code drifts), and a model that emits a call for
+/// a name it was never given. Both are refused here, by the host, with a reason
+/// the model can read and repeat to the operator.
+#[derive(Debug)]
+pub struct ConfinedToolPolicy {
+    confinement: Confinement,
+}
+
+impl ConfinedToolPolicy {
+    /// A policy that refuses everything outside `confinement`.
+    pub fn new(confinement: Confinement) -> Self {
+        Self { confinement }
+    }
+
+    /// The refusal a denied call carries. Names the boundary rather than saying
+    /// "denied", so a model can tell the operator what it could not do and why
+    /// instead of retrying the same call.
+    pub fn refusal(&self, tool_name: &str) -> String {
+        match &self.confinement {
+            Confinement::Workflow { id } => format!(
+                "`{tool_name}` is not available here. This turn is confined to the workflow \
+                 `{id}`: it answers from the workflow description in this message and reaches \
+                 nothing else in the company. Say what you would need and that it has to be \
+                 asked in the company chat instead."
+            ),
+        }
+    }
+}
+
+#[async_trait]
+impl ToolPolicy for ConfinedToolPolicy {
+    fn name(&self) -> &str {
+        "workflow_confined"
+    }
+
+    async fn check(&self, request: &ToolPolicyRequest) -> ToolPolicyDecision {
+        tracing::info!(
+            tool = %request.tool_name,
+            subject = %self.confinement.subject(),
+            "[confine] refusing a tool call on a confined turn"
+        );
+        ToolPolicyDecision::deny(self.refusal(&request.tool_name))
+    }
+}
+
+/// The confined agent's persona.
+///
+/// Says three things, and each is load-bearing:
+///
+/// 1. what this turn is about (one workflow, named);
+/// 2. that its whole world is the message — which is *true* now, so the model is
+///    not being asked to pretend a limit it could step outside of;
+/// 3. what to do when the question needs more than that. The issue's own design
+///    question: refusing is honest and unhelpful, answering unconfined defeats
+///    the purpose, so it answers what it can and **says which part it could
+///    not** rather than guessing from an absence.
+pub fn confined_persona(company_name: &str, confinement: &Confinement) -> String {
+    match confinement {
+        Confinement::Workflow { id } => format!(
+            "You are the workflow copilot for {company_name}, answering about ONE saved \
+             workflow (`{id}`).\n\n\
+             Everything you know about this workflow is in the message you were sent: its \
+             description, its nodes and edges, and the summaries of its own recorded runs. You \
+             have no tools and no access to the rest of the company — not its board, its \
+             teammates, its other workflows, its files, or its memory. That is deliberate: an \
+             answer about this workflow is meant to be an answer about this workflow.\n\n\
+             Answer from that material. Where the question needs something you were not given \
+             — another workflow, what a teammate is doing, the company's data — say plainly \
+             which part you cannot answer and that it has to be asked in the company chat, then \
+             answer whatever the rest of the question allows. Do not guess at company context, \
+             and do not claim to have looked anything up.\n\n\
+             You cannot change the workflow. Describe a change precisely enough for a person to \
+             make it in the workflow editor, and never claim to have made it."
+        ),
+    }
+}
+
+/// Builds the ephemeral agent a confined turn runs on.
+///
+/// Deliberately **not** [`build_agent`](crate::harness::build::build_agent) with
+/// empty grants: that path wires the intrinsic memory tools and (under the `mcp`
+/// feature) the MCP registry tools onto every agent regardless of grants, which
+/// is exactly the company reach this turn must not have. Nothing is cached — the
+/// agent is built per turn and dropped with it, so a confined turn cannot
+/// accumulate state that a later one reads.
+pub fn build_confined_agent(
+    company: &CompanyId,
+    company_name: &str,
+    confinement: &Confinement,
+    deps: &HarnessDeps,
+) -> crate::Result<Agent> {
+    // Its own sandbox directory, so nothing here can resolve into another
+    // agent's workspace. Best-effort exactly as on the roster path: an agent
+    // with no file tools runs a perfectly good turn without the directory, and
+    // this one has no file tools by construction.
+    let workspace = match ensure_agent_workspace(&deps.workspace_root, company, CONFINED_AGENT_ID) {
+        Ok(workspace) => workspace,
+        Err(error) => {
+            tracing::warn!(
+                company = %company,
+                %error,
+                "[confine] could not create the confined agent's workspace directory"
+            );
+            crate::harness::build::agent_workspace(&deps.workspace_root, company, CONFINED_AGENT_ID)
+        }
+    };
+
+    // An empty memory, not the company's. `OcMemory` over `ConfinedContext`
+    // rather than a bespoke `Memory` impl, so this path shares the adapter the
+    // rest of the harness uses and cannot drift from its semantics.
+    let memory: Arc<dyn Memory> = Arc::new(OcMemory::new(
+        company.clone(),
+        CONFINED_AGENT_ID,
+        Arc::new(ConfinedContext) as Arc<dyn ContextStore>,
+    ));
+
+    // Same transport rule as the roster path: a provider that advertises native
+    // tool calling gets the native dispatcher, everything else the attribute-
+    // tolerant XML one. It matters even with no tools, because the dispatcher
+    // also decides how a response is parsed.
+    let native_tools = deps
+        .provider
+        .profile()
+        .map(|profile| profile.tool_calling)
+        .unwrap_or(false);
+    let tool_dispatcher: Box<dyn ToolDispatcher> = if native_tools {
+        Box::new(NativeToolDispatcher)
+    } else {
+        Box::new(AttrTolerantXmlDispatcher::default())
+    };
+
+    // The conversational workload, not the orchestrator's agentic one: this turn
+    // explains a graph it was handed and calls nothing. A host-wide
+    // `model_override` still wins, exactly as it does for the roster.
+    let model = deps
+        .model_override
+        .clone()
+        .unwrap_or_else(|| model_for_tier(None));
+
+    let tools: Vec<Box<dyn Tool>> = Vec::new();
+
+    AgentBuilder::default()
+        .chat_model(deps.provider.clone() as Arc<dyn tinyagents::harness::model::ChatModel<()>>)
+        .memory(memory)
+        .tools(tools)
+        .tool_dispatcher(tool_dispatcher)
+        .tool_policy(Arc::new(ConfinedToolPolicy::new(confinement.clone())))
+        .prompt_builder(SystemPromptBuilder::for_subagent(
+            confined_persona(company_name, confinement),
+            /* omit_identity */ true,
+            /* omit_safety_preamble */ false,
+            /* omit_skills_catalog */ true,
+        ))
+        .model_name(model)
+        .workspace_dir(workspace)
+        .agent_definition_name(CONFINED_AGENT_ID.to_string())
+        .auto_save(false)
+        .build()
+        .map_err(|e| OpenCompanyError::Harness(format!("build the confined agent: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn workflow() -> Confinement {
+        Confinement::workflow("weekly_report")
+    }
+
+    /// The refusal names the tool and the workflow, and tells the model what to
+    /// do instead. A bare "denied" would have it retry the same call.
+    #[test]
+    fn the_refusal_names_the_boundary() {
+        let policy = ConfinedToolPolicy::new(workflow());
+        let refusal = policy.refusal("query_company");
+        assert!(refusal.contains("query_company"), "{refusal}");
+        assert!(refusal.contains("weekly_report"), "{refusal}");
+        assert!(refusal.contains("company chat"), "{refusal}");
+    }
+
+    /// Every tool is denied — including the intrinsic ones a roster agent always
+    /// carries, which is the reach this issue is about.
+    #[tokio::test]
+    async fn every_tool_is_denied() {
+        let policy = ConfinedToolPolicy::new(workflow());
+        for tool in [
+            "query_company",
+            "spawn_task",
+            "delegate_to_desk",
+            "memory_recall",
+            "memory_store",
+            "workspace_read",
+            "file_read",
+            "web_fetch",
+            "web_search",
+            "mcp_registry_tool_call",
+            "shell",
+            // A name no belt has ever carried: a model that invents one is
+            // refused by the same rule rather than falling through it.
+            "definitely_not_a_tool",
+        ] {
+            let decision = policy.check(&request(tool)).await;
+            match decision {
+                ToolPolicyDecision::Deny { reason } => {
+                    assert!(reason.contains(tool), "{tool}: {reason}")
+                }
+                other => panic!("{tool} was not denied: {other:?}"),
+            }
+        }
+    }
+
+    /// The persona states the boundary and what to do at its edge, because that
+    /// is the half a model acts on. The enforcement is the policy above; this is
+    /// what keeps the answer honest rather than merely tool-less.
+    #[test]
+    fn the_persona_states_the_boundary_and_the_edge_case() {
+        let persona = confined_persona("Acme", &workflow());
+        assert!(persona.contains("weekly_report"), "{persona}");
+        assert!(persona.contains("no tools"), "{persona}");
+        assert!(persona.contains("company chat"), "{persona}");
+        assert!(persona.contains("cannot change the workflow"), "{persona}");
+    }
+
+    /// The confined context is a hole: nothing written to it can be read back,
+    /// by this turn or any later one.
+    #[tokio::test]
+    async fn the_confined_context_stores_nothing() {
+        let store = ConfinedContext;
+        let company = CompanyId::new("acme");
+        store
+            .put(
+                &company,
+                ContextChunk {
+                    label: "k".into(),
+                    body: "the company's private note".into(),
+                },
+            )
+            .await
+            .expect("a confined put is accepted");
+        assert!(
+            store
+                .search(&company, "private", 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+        assert!(store.list(&company, "").await.unwrap().is_empty());
+        assert!(
+            store
+                .peek(&company, &ChunkAddr::new("confined/k"), None)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    fn request(tool_name: &str) -> ToolPolicyRequest {
+        let context = oh::agent::tool_policy::ToolCallContext::session(
+            "copilot-session",
+            "operator",
+            CONFINED_AGENT_ID,
+            "call-1",
+            0,
+        );
+        ToolPolicyRequest::new(tool_name, serde_json::json!({}), context)
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -50,6 +50,10 @@ pub mod composio_catalog;
 /// model's choices and the Composio backend are scripted. Test-only.
 #[cfg(all(test, feature = "composio"))]
 mod composio_turn_test;
+/// Issue #416: the confined turn — an ephemeral agent with no tools, no company
+/// memory and no delegation, for a question that is about one object rather than
+/// about the company. See [`confine`].
+pub mod confine;
 pub mod cost;
 /// Hosted embeddings compute for the in-pod memory engine's meaning tier (188c2).
 /// Needs the `tinycortex` crate's `EmbeddingBackend` trait, so it links only when
@@ -1188,6 +1192,139 @@ impl HarnessPool {
         .await
     }
 
+    /// The plan-level total-token ceiling, as a refusal or nothing.
+    ///
+    /// Extracted from [`run_inner`](Self::run_inner) so the confined turn
+    /// (issue #416) is gated by the *same* ceiling rather than a second copy of
+    /// the rule: a turn that reaches nothing still spends model tokens, so a
+    /// tenant past its cap must not be able to keep spending through the
+    /// copilot.
+    async fn total_ceiling_refusal(
+        company: &CompanyId,
+        agent_id: &str,
+        deps: &HarnessDeps,
+    ) -> Option<TurnOutcome> {
+        let plan = deps.plan.as_ref()?;
+        plan.total_budget?;
+        match deps.meter.as_deref() {
+            Some(meter) => {
+                let since = plan.period.period_start_millis(crate::ports::now_millis());
+                match meter.query(company, since).await {
+                    Ok(samples) => {
+                        let spent = capability_budget::tokens_in(&samples);
+                        if plan.total_exhausted(spent) {
+                            tracing::info!(
+                                company = %company,
+                                agent = agent_id,
+                                spent,
+                                "[capability-budget] total token ceiling reached; refusing dispatch (no model call) until the period resets"
+                            );
+                            return Some(TurnOutcome {
+                                reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
+                                steps: Vec::new(),
+                            });
+                        }
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            company = %company,
+                            %error,
+                            "[capability-budget] total-ceiling spend query failed; not hard-refusing — deferring to the per-namespace fail-closed roster"
+                        );
+                    }
+                }
+            }
+            None => {
+                tracing::warn!(
+                    company = %company,
+                    "[capability-budget] no usage meter; cannot enforce the total token ceiling — deferring to the per-namespace fail-closed roster"
+                );
+            }
+        }
+        None
+    }
+
+    /// Runs one **confined** turn (issue #416): an ephemeral agent with no
+    /// tools, no company memory and no roster identity, for a question about one
+    /// object rather than about the company.
+    ///
+    /// Deliberately not a variant of [`run_inner`](Self::run_inner), because the
+    /// two differ in what they are allowed to touch rather than in a flag:
+    ///
+    /// * the agent is **built here and dropped after**, so it is never in the
+    ///   pooled roster and cannot be addressed, dispatched or delegated to;
+    /// * there is **no retrieve→inject** — the company's prior task outcomes are
+    ///   not prepended to the message, so the model cannot answer from work it
+    ///   was not asked about;
+    /// * there is **no memory writeback** — the exchange leaves nothing for a
+    ///   later company turn to retrieve, so a confined conversation cannot
+    ///   become unconfined context tomorrow.
+    ///
+    /// What it does share: the plan-level token ceiling (spend is spend), live
+    /// turn streaming onto the addressed thread, and cost recording, so a
+    /// confined turn is billed and observable exactly like any other.
+    pub async fn run_confined(
+        &self,
+        company: &CompanyId,
+        company_name: &str,
+        message: &str,
+        deps: &HarnessDeps,
+        chat_id: Option<&str>,
+        confinement: &confine::Confinement,
+    ) -> crate::Result<TurnOutcome> {
+        if let Some(refusal) =
+            Self::total_ceiling_refusal(company, confine::CONFINED_AGENT_ID, deps).await
+        {
+            return Ok(refusal);
+        }
+
+        let agent = CompanyAgent {
+            agent_id: confine::CONFINED_AGENT_ID.to_string(),
+            role: "Workflow copilot".to_string(),
+            // A confined turn carries no manifest teammate, so there is no
+            // per-agent daily cap to read; the company-wide ceiling above is the
+            // one that applies to it.
+            budget_usd_daily: None,
+            agent: Mutex::new(confine::build_confined_agent(
+                company,
+                company_name,
+                confinement,
+                deps,
+            )?),
+        };
+
+        let stream_ctx = Some(crate::turn_stream::TurnStreamCtx {
+            company: company.clone(),
+            agent_id: confine::CONFINED_AGENT_ID.to_string(),
+            chat_id: chat_id
+                .map(str::to_string)
+                .unwrap_or_else(|| crate::server::ops::language::DEFAULT_DESK.to_string()),
+        });
+
+        // The message goes to the model AS SENT. This is the retrieve→inject
+        // step's absence, and it is the difference between "grounded in one
+        // workflow" and "confined to one workflow".
+        let (outcome, turn_costs) = agent
+            .run_with_steer(message, None, stream_ctx, None)
+            .await?;
+
+        let provider_slug = deps.provider.telemetry_provider_id();
+        for turn_cost in &turn_costs {
+            record_turn_cost(
+                turn_cost,
+                confine::CONFINED_AGENT_ID,
+                &provider_slug,
+                company,
+                deps.store.as_ref(),
+                deps.meter.as_deref(),
+                None,
+            )
+            .await?;
+        }
+
+        Ok(outcome)
+    }
+
     #[allow(clippy::too_many_arguments)]
     async fn run_inner(
         &self,
@@ -1260,44 +1397,8 @@ impl HarnessPool {
         // A `warn!` records the deferral. Refusing every turn on a flaky meter
         // read would be a strictly worse failure mode than letting an
         // intrinsic-tools-only turn through.
-        if let Some(plan) = deps.plan.as_ref()
-            && plan.total_budget.is_some()
-        {
-            match deps.meter.as_deref() {
-                Some(meter) => {
-                    let since = plan.period.period_start_millis(crate::ports::now_millis());
-                    match meter.query(company, since).await {
-                        Ok(samples) => {
-                            let spent = capability_budget::tokens_in(&samples);
-                            if plan.total_exhausted(spent) {
-                                tracing::info!(
-                                    company = %company,
-                                    agent = agent_id,
-                                    spent,
-                                    "[capability-budget] total token ceiling reached; refusing dispatch (no model call) until the period resets"
-                                );
-                                return Ok(TurnOutcome {
-                                    reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
-                                    steps: Vec::new(),
-                                });
-                            }
-                        }
-                        Err(error) => {
-                            tracing::warn!(
-                                company = %company,
-                                %error,
-                                "[capability-budget] total-ceiling spend query failed; not hard-refusing — deferring to the per-namespace fail-closed roster"
-                            );
-                        }
-                    }
-                }
-                None => {
-                    tracing::warn!(
-                        company = %company,
-                        "[capability-budget] no usage meter; cannot enforce the total token ceiling — deferring to the per-namespace fail-closed roster"
-                    );
-                }
-            }
+        if let Some(refusal) = Self::total_ceiling_refusal(company, agent_id, deps).await {
+            return Ok(refusal);
         }
 
         // Per-agent daily spend cap (issue #304): the same HARD, pre-model-call
@@ -2232,6 +2333,104 @@ description = "Builds the product."
             .reply;
 
         assert!(second.contains("second"));
+    }
+
+    /// Issue #416 — a confined turn reaches the company's memory neither on the
+    /// way in nor on the way out.
+    ///
+    /// The control half is what makes this a test rather than an assertion of
+    /// absence: the SAME message on the ordinary roster path pulls the seeded
+    /// chunk into the prompt (the mock provider echoes what it was sent, so the
+    /// injection is visible in the reply), and writes the turn back. The
+    /// confined path does neither, from the same store, in the same test.
+    #[tokio::test]
+    async fn a_confined_turn_neither_reads_nor_writes_company_memory() {
+        let context = Arc::new(MockContext::default());
+        let mut fx = fixture();
+        fx.deps.context = context.clone();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        // A prior outcome sitting in the company's memory. The mock store
+        // matches a chunk whose BODY contains the query, and retrieve→inject
+        // queries with the whole message — so a body built around the message is
+        // what a hit looks like here.
+        let question = "why did it fail";
+        context
+            .put(
+                &rec.id,
+                ContextChunk {
+                    label: "prior/outcome".into(),
+                    body: format!("SECRET-PAYROLL-REVIEW: {question} on Monday"),
+                },
+            )
+            .await
+            .expect("seed the company's memory");
+        let seeded = context.chunks.lock().unwrap().len();
+
+        // Control: the ordinary path injects the hit and writes the turn back.
+        let ordinary = pool
+            .run(&rec.id, "ceo", question, &fx.deps, None)
+            .await
+            .expect("the ordinary turn runs")
+            .reply;
+        assert!(
+            ordinary.contains("SECRET-PAYROLL-REVIEW"),
+            "the retrieve→inject step must be live for this test to mean anything: {ordinary}"
+        );
+        assert!(
+            context.chunks.lock().unwrap().len() > seeded,
+            "the ordinary path writes its outcome back to company memory"
+        );
+
+        let before_confined = context.chunks.lock().unwrap().len();
+        let confined = pool
+            .run_confined(
+                &rec.id,
+                "Acme",
+                question,
+                &fx.deps,
+                Some("workflow-copilot:weekly_report"),
+                &confine::Confinement::workflow("weekly_report"),
+            )
+            .await
+            .expect("the confined turn runs")
+            .reply;
+
+        assert!(
+            confined.contains(question),
+            "the confined turn still answers the question it was asked: {confined}"
+        );
+        assert!(
+            !confined.contains("SECRET-PAYROLL-REVIEW"),
+            "a confined turn must not be handed company memory: {confined}"
+        );
+        assert_eq!(
+            context.chunks.lock().unwrap().len(),
+            before_confined,
+            "a confined turn must leave nothing behind for a later turn to retrieve"
+        );
+    }
+
+    /// The confined agent is not on the roster, so nothing can address it: a
+    /// dispatch, a desk hand-off or a `chat` naming it is an unknown agent, the
+    /// same as any other name that is not a teammate.
+    #[tokio::test]
+    async fn the_confined_agent_is_not_addressable() {
+        let fx = fixture();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        let err = pool
+            .run(&rec.id, confine::CONFINED_AGENT_ID, "hi", &fx.deps, None)
+            .await
+            .expect_err("the confined agent is not a roster agent");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1063,7 +1063,20 @@ async fn run_chat(
     // sub-tasks on top). Pure questions, greetings, and acknowledgements don't
     // fire, so the board fills with work, not small talk. Best-effort: a card
     // write failure must never sink the chat reply.
-    if let Some(title) = crate::company::task_intent::detect_task_intent(&message.text) {
+    //
+    // NOT on a workflow copilot thread (issue #416). A copilot question is
+    // phrased at the workflow — "add a node that emails the report", "why does
+    // this fail on Mondays" — and the intent detector reads the first of those
+    // as a request to the company, which would put a card on the board from a
+    // conversation the operator was having *about a graph*. The confinement in
+    // the harness stops the turn from acting; this stops the route from acting
+    // on its behalf, and it holds in every build because it is here rather than
+    // behind the `openhuman` feature.
+    let confined = crate::company::copilot::is_copilot_thread(message.chat.as_deref());
+    if let Some(title) = (!confined)
+        .then(|| crate::company::task_intent::detect_task_intent(&message.text))
+        .flatten()
+    {
         // Keep the full message as the note only when the title was shortened
         // from it, so a one-line ask doesn't duplicate itself.
         let note =

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2124,6 +2124,63 @@ async fn inbox_list_and_messages_project_store() {
     assert_eq!(msgs[1]["outbound"], true);
 }
 
+/// Issue #416, the half that holds in every build: a question asked on a
+/// workflow copilot thread must not leave work on the company's board.
+///
+/// The copilot is a conversation *about a graph*, and its questions are phrased
+/// at the graph — "add a node that emails the report". The chat route's
+/// deterministic intent detector reads that as a request to the company and
+/// opens a `todo` card, which is the same class of over-reach this issue is
+/// about, reached from the route rather than from the model. The control half
+/// matters as much as the confined half: the identical sentence on an ordinary
+/// thread still opens its card, so this narrows the copilot rather than
+/// disabling a feature.
+#[tokio::test]
+async fn a_copilot_thread_question_opens_no_board_card() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    // Deliberately the most actionable phrasing the copilot invites.
+    let ask = "build a node that emails the weekly report";
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/chat",
+        Some(json!({"message": ask, "chat": "workflow-copilot:weekly_report"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        board.as_array().is_none_or(|cards| cards.is_empty()),
+        "a copilot question left work on the board: {board}"
+    );
+
+    // Control: the same sentence on the ordinary thread still opens a card, so
+    // the suppression is scoped to the copilot and not a regression of #246.
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/chat",
+        Some(json!({"message": ask})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let cards = board.as_array().expect("the board lists cards");
+    assert_eq!(
+        cards.len(),
+        1,
+        "the ordinary thread must still open exactly one card: {board}"
+    );
+}
+
 #[tokio::test]
 async fn chat_accepts_desk_id_and_replies() {
     let home_dir = home();


### PR DESCRIPTION
## Summary

Fixes #416. The per-workflow copilot's answers were grounded in one workflow; the agent answering them was not confined to it. The thread id (`workflow-copilot:<id>`) selected the responder and the journal thread and narrowed nothing else, so the responder was the company orchestrator, holding whole-company context and its full tool surface. "Answer only about this workflow" was a sentence in the composed prompt, which is advice.

This adds the missing primitive: a **confined turn**, enforced host-side.

### The new boundary, stated

A `/chat` turn addressed to `workflow-copilot:<workflowId>` now runs on an ephemeral agent built for that turn and dropped after it:

- **No tools.** Its toolbelt is empty. That includes the intrinsic `memory_store` / `memory_recall` every roster agent carries and the orchestrator's `query_company` / `spawn_task` / `delegate_to_desk`. It is deliberately **not** `build_agent` with empty grants, because that path wires the memory tools (and, under `mcp`, the MCP registry tools) onto every agent regardless of grants.
- **Enforced, not merely absent.** `ConfinedToolPolicy` denies every tool call by name, whatever the belt holds, with a refusal that names the workflow and tells the model to say what it would have needed. An empty belt is the ordinary case; the policy is what makes a tool wired here by a later change, or a name the model invents, a refusal rather than a call.
- **No company memory.** Its `Memory` is backed by `ConfinedContext`, a store that accepts a write, keeps nothing, and answers every read empty. The pool additionally skips retrieve→inject and the memory writeback for a confined turn, so no prior task outcome is prepended to the message and the exchange leaves nothing behind for a later company turn to retrieve.
- **No delegation.** The brain runs this turn directly instead of through the delegation runner, so it cannot hand off to a desk and have the desk do what it was not allowed to.
- **No board card.** `run_chat` no longer opens a `todo` card from a copilot message. This half is in the **default** build, not behind `openhuman`: a copilot question is phrased at the graph ("add a node that emails the report"), and the deterministic intent detector was reading that as a request to the company.
- **Not on the roster.** The confined agent id (`workflow-copilot`) is not addressable: dispatching or delegating to it is an unknown-agent error, exactly like any other non-teammate name.

### What a copilot turn can still reach

Exactly what the console put in the message, and nothing else:

- the workflow's name, id, description and editability;
- its nodes and edges, with each node's agent, schedule, approval flag, error/retry policy, destination and config;
- summaries of **that workflow's own** recorded runs (already a server-scoped read);
- the operator's question, and the earlier turns of this same thread that the provider carries.

It still cannot read the board, the roster, another workflow, the workspace tree, company memory, an MCP server, the web or a file, and it still cannot edit the workflow.

**When a question needs the wider company**, the issue's own design question, it answers what it can and says which part it could not answer here, pointing at the company chat. That is in both the host-side persona and the composed message, so what the panel discloses is built from the same text that was actually sent.

**This is a scoping boundary, not an authorization check, and must not be read as one.** `/chat` is already authenticated and company-scoped: an operator who can open the copilot can address the same orchestrator from the Chat tab. What changes is what one turn reaches, which is what makes #415 (propose-then-apply) safe to build on top — a copilot that can propose applyable edits while unconfined is worse than an unconfined answer.

### Where it lives

- `src/company/copilot.rs` (new, un-gated) — the thread convention. One function decides "this is a copilot turn"; both the harness and the chat route key off it.
- `src/harness/confine.rs` (new, `openhuman`) — `Confinement`, `ConfinedToolPolicy`, `ConfinedContext`, the persona, and the ephemeral agent builder.
- `HarnessPool::run_confined` — the turn itself. The plan-level total-token ceiling was extracted from `run_inner` into `total_ceiling_refusal` so both paths are gated by the *same* rule rather than by two copies: a turn that reaches nothing still spends model tokens.
- `HarnessBrain` — the branch in the `OperatorMessage` arm.
- Console: the panel's disclosure and the composed message state the boundary; the "asking for a change may open a card" line is gone, because it no longer happens.

## API Or Behavior Changes

- `POST {scope}/chat` with `chat: "workflow-copilot:<id>"` is answered by a confined agent instead of the orchestrator, and no longer opens a board card. Every other thread is byte-identical to before.
- No route, request or response shape changes. A host predating this answers the same requests the old way, so the console needs no capability check.
- New public surface: `company::copilot::{COPILOT_THREAD_PREFIX, workflow_of_thread, is_copilot_thread}`; `harness::confine::*`; `HarnessPool::run_confined`.
- The confined turn is metered and billed like any other turn (usage sample + ledger entry under the `workflow-copilot` agent id) and streams onto the same thread, so it stays visible in Usage rather than becoming an unattributed spend.

## Tests

Focused tests with the behaviour change, in the lanes CI runs:

- `src/company/copilot.rs` — the thread convention: reads the workflow id out, refuses a prefix that does not start the id, refuses a prefix naming no workflow, trims. Default build.
- `src/harness/confine.rs` — every tool denied (including `memory_recall`, `query_company`, `spawn_task`, `delegate_to_desk`, `mcp_registry_tool_call`, and a name no belt has ever carried); the refusal names the tool, the workflow and the way out; the persona states the boundary and the edge case; `ConfinedContext` stores nothing readable. `openhuman` lane.
- `src/harness/mod.rs` — `a_confined_turn_neither_reads_nor_writes_company_memory`, with the control in the same test: the same question on the ordinary roster path pulls a seeded company chunk into the prompt (visible in the mock provider's echo) and writes the outcome back; the confined path does neither, from the same store. Plus `the_confined_agent_is_not_addressable`.
- `src/server/ops/write_test.rs` — `a_copilot_thread_question_opens_no_board_card`, with the control: the identical actionable sentence on the ordinary thread still opens exactly one card. Default build, over the real HTTP stack.
- `frontend/test/unit/workflow-copilot.test.ts` — the thread id is the exact string the host confines on, and the composed message carries the boundary and the "say which part you cannot answer" instruction the panel's disclosure is built from.

Console gates run locally: `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` clean; `npm test` passes apart from `tour-resume.test.ts`, which fails identically on unmodified `upstream/main` on this machine (local Node 25 jsdom `localStorage`; CI runs Node 22) and is untouched here. `rustfmt --edition 2024 --check` clean on every Rust file changed (`cargo fmt` itself cannot run without the vendored submodules).

**Browser walk** (`#/workflows` → Copilot, real Chromium against a stub host serving the console's documented shapes, because building the Rust host is prohibited on this machine):

- the panel's pre-question disclosure now reads "This turn runs confined to this workflow: no tools, no company memory, and no reach into the board, your teammates or another workflow. Ask something that needs the wider company and it will say so rather than guess.", and the old "asking for a change may open a card on the board" line is gone;
- asking "what is the rest of the team working on?" sends on thread `workflow-copilot:weekly_report` — the exact id `company::copilot::workflow_of_thread` parses, which is the console-side half of the trigger;
- the message actually sent begins with the boundary lines ("You have no tools and no access to the rest of the company…", "say which part you cannot answer here and that it has to be asked in the company chat");
- no uncaught page errors through the walk.

**What was not run here, stated plainly.** The host-side half (a confined turn refusing a tool call on a live `--features openhuman` host) was not exercised end to end on this machine: the local build matrix is prohibited, and the e2e lane's host is the default build whose echo brain the copilot panel deliberately refuses to send to. The boundary is covered by the Rust tests above in both CI lanes; no Playwright spec is added, because one would have to bypass the panel to reach the behaviour and would then be asserting what the HTTP test already asserts.

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

## Documentation

`docs/spec/runtime/api.md` — the `/chat` thread-addressing contract said thread addressing isolates transcripts and does not scope authority. It now records the exception: the copilot thread makes the turn confined, in two places that hold independently (the harness, and the card suppression in the default build), with links to `company::copilot` and `harness::confine`, and keeps the warning that confinement narrows a turn rather than granting or checking authority.

Module docs are in the code: `src/harness/confine.rs` opens with what was wrong, what a confined turn is, and what a copilot turn can still reach.

## Answering the issue's design questions

- **What does "confined" include?** Both, and the issue's warning is why: narrowing context alone leaves a turn that can fetch what it was not given. Context is narrowed (no retrieve→inject, no company memory backend, no writeback) and tools are narrowed to none, with the policy denying by name so the narrowing cannot be undone by a later wiring change.
- **Turn or distinct agent?** A confined **turn**, on an agent built for it and thrown away. No provisioning, nothing to keep in sync with the roster, and the grant reduction is host-side rather than requested politely. The `Confinement` enum is the reusable seam: the next surface that needs to reason about one object adds a variant.
- **What does it say when a question needs company-wide context?** It answers what it can, names the part it cannot answer here, and points at the company chat. Refusing outright is honest and unhelpful; answering unconfined defeats the purpose; saying which it did is the third option the issue predicted.
