### PR TITLE
fix(runtime): a prefix tool grant stops on a namespace boundary (#461)

### DIFF
--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -87,6 +87,7 @@ use crate::harness::tool_dispatcher::AttrTolerantXmlDispatcher;
 use crate::harness::toolbelt;
 use crate::ports::skills_state::SkillState;
 use crate::ports::types::CompanyId;
+use crate::runtime::tools::extends_on_boundary;
 
 /// Map a manifest cognition-tier hint to a hosted model/tier name.
 ///
@@ -613,16 +614,29 @@ fn memory_tools(memory: Arc<dyn Memory>) -> Vec<Box<dyn Tool>> {
     ]
 }
 
+/// The namespace separator for a `[tools].allow` grant: only `.`, because a
+/// namespace grant is written dotted (`docs.read`). Deliberately narrower than
+/// [`crate::runtime::tools`]'s tool-name set — `files_scratch` is not a grant
+/// under the `files` namespace, and never was.
+const NAMESPACE_SEPARATORS: &[char] = &['.'];
+
 /// Whether an agent's effective `grants` cover a tool `namespace`.
 ///
 /// Matches the bare namespace (`docs`), any glob under it (`docs.*`,
 /// `docs.read`), or the catch-all `*`. Shared with the workflow toolbelt
 /// ([`crate::workflows::caps`]) so a workflow `tool_call` is gated by the same
 /// namespace-grant rule an agent's exec tools are.
+///
+/// A thin caller of [`extends_on_boundary`] rather than its own prefix test.
+/// This matcher always required the prefix to stop on a separator (so
+/// `documentation.*` is not a grant on `docs`) while the per-tool matcher did
+/// not, and the two drifted apart unnoticed. The rule now exists once in the
+/// crate, next to [`grant_matches`](crate::runtime::tools), and cannot fork
+/// again (issue #461).
 pub(crate) fn grants_cover(grants: &[String], namespace: &str) -> bool {
-    grants.iter().any(|grant| {
-        grant == "*" || grant == namespace || grant.starts_with(&format!("{namespace}."))
-    })
+    grants
+        .iter()
+        .any(|grant| grant == "*" || extends_on_boundary(grant, namespace, NAMESPACE_SEPARATORS))
 }
 
 /// One agent's sandbox directory: `{root}/{company}/{agent}/workspace`.

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -489,6 +489,11 @@ const INTRINSIC_TOOLS: &[&str] = &[
     "run_workflow",
     "create_workflow",
     "add_agent",
+    // #186's pair. Missing here until #461 noticed the drift, so an
+    // `assign_task` / `review_task` refusal ("agent is not on the roster")
+    // rendered as a bare class instead of the sentence the tool wrote.
+    "assign_task",
+    "review_task",
 ];
 
 /// Bound on an OC-authored message surfaced as a step result.
@@ -834,6 +839,40 @@ mod tests {
              Workaround: Ask the user to approve this action, then retry. \
              Relay this to the user: explain what was blocked and why."
         )
+    }
+
+    /// The lockstep [`INTRINSIC_TOOLS`] claims, made mechanical. Every
+    /// orchestrator tool name is a `pub const`, so drift between the two lists
+    /// now fails here instead of silently downgrading a tool's own sentence to
+    /// a bare failure class (which is how `assign_task` / `review_task` sat
+    /// missing from #186 until #461).
+    #[test]
+    fn intrinsic_tools_covers_every_orchestrator_tool() {
+        use crate::harness::orchestrator::{
+            ADD_AGENT_TOOL, ASSIGN_TASK_TOOL, CREATE_WORKFLOW_TOOL, QUERY_COMPANY_TOOL,
+            REVIEW_TASK_TOOL, RUN_WORKFLOW_TOOL,
+        };
+        use crate::runtime::delegation_tools::{DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL};
+
+        let expected = [
+            QUERY_COMPANY_TOOL,
+            SPAWN_TASK_TOOL,
+            DELEGATE_TO_DESK_TOOL,
+            RUN_WORKFLOW_TOOL,
+            CREATE_WORKFLOW_TOOL,
+            ADD_AGENT_TOOL,
+            ASSIGN_TASK_TOOL,
+            REVIEW_TASK_TOOL,
+        ];
+        for name in expected {
+            assert!(
+                INTRINSIC_TOOLS.contains(&name),
+                "{name} is wired by `orchestrator_tools` but absent from INTRINSIC_TOOLS"
+            );
+        }
+        // Exact, not just covering: a name here that no longer exists upstream
+        // would surface a stale tool's output as OC-authored copy.
+        assert_eq!(INTRINSIC_TOOLS.len(), expected.len(), "{INTRINSIC_TOOLS:?}");
     }
 
     /// Reads a file out of the vendored OpenHuman checkout, for the tests that

--- a/src/runtime/tools.rs
+++ b/src/runtime/tools.rs
@@ -15,8 +15,8 @@ use crate::ports::types::{CompanyId, ToolCall, ToolResult, ToolSpec};
 /// A stub tool provider that advertises no tools and enforces grants.
 ///
 /// Grants are the manifest's company-wide `[tools].allow` globs. A tool is
-/// granted when its name matches a glob exactly, via a trailing `*` prefix
-/// match (`email.*`), or the catch-all `*`.
+/// granted when its name matches a glob exactly, via a trailing `*` prefix that
+/// ends on a **namespace boundary** (`email.*`, `file*`), or the catch-all `*`.
 #[derive(Clone, Debug, Default)]
 pub struct StubToolProvider {
     grants: Vec<String>,
@@ -33,17 +33,58 @@ impl StubToolProvider {
     }
 }
 
+/// The characters that end a namespace segment in a tool name: `.` for the
+/// dotted manifest namespaces (`email.send`), `_` for the snake_case tool names
+/// the harness registers (`file_read`), and `:` for the MCP server namespace
+/// (`mcp:notion`).
+///
+/// A trailing-`*` grant may only extend up to one of these — that is the whole
+/// difference between `file*` granting `file_read` and `file*` granting
+/// `filesystem_wipe`.
+const TOOL_NAME_SEPARATORS: &[char] = &['.', '_', ':'];
+
+/// Whether `name` *is* `prefix`, or extends it and stops on a namespace
+/// boundary drawn from `separators`.
+///
+/// The single boundary rule behind every grant match in the crate. Both the
+/// per-tool matcher ([`grant_matches`]) and the per-namespace matcher
+/// ([`grants_cover`](crate::harness::build::grants_cover)) route through it, so
+/// a grant cannot mean one thing when a tool is invoked and another when a tool
+/// family is wired — the disagreement issue #461 reported.
+///
+/// A bare `starts_with` is not the same predicate: it makes `composio_list*`
+/// cover every name merely *beginning* with those letters, and `file*` cover
+/// `filesystem_wipe`. `[tools].allow` is a permission boundary, so the prefix
+/// must land on a separator (or the grant must already end on one, as `email.*`
+/// and `mcp:*` do) before the rest of the name is accepted.
+pub(crate) fn extends_on_boundary(name: &str, prefix: &str, separators: &[char]) -> bool {
+    if name == prefix {
+        return true;
+    }
+    match name.strip_prefix(prefix) {
+        // `prefix` already carries the separator (`email.`, `mcp:`), so the
+        // whole namespace under it is inside the grant.
+        Some(_) if prefix.ends_with(separators) => true,
+        // Otherwise the name itself must break on one (`file` + `_read`).
+        Some(rest) => rest.starts_with(separators),
+        None => false,
+    }
+}
+
 /// Matches a single grant glob against a tool name.
 ///
 /// A tool is granted when the glob matches it exactly, via a trailing `*`
-/// prefix (`email.*`), or the catch-all `*`. Shared with the OpenHuman-backed
-/// provider so both enforce grants identically.
+/// prefix that ends on a namespace boundary (`email.*` → `email.send`, `file*`
+/// → `file_read` but **not** `filesystem_wipe`), or the catch-all `*`. Shared
+/// with the OpenHuman-backed provider so both enforce grants identically, and
+/// boundary-checked through [`extends_on_boundary`] so it agrees with
+/// [`grants_cover`](crate::harness::build::grants_cover).
 pub(crate) fn grant_matches(grant: &str, tool: &str) -> bool {
     if grant == "*" {
         return true;
     }
     if let Some(prefix) = grant.strip_suffix('*') {
-        return tool.starts_with(prefix);
+        return extends_on_boundary(tool, prefix, TOOL_NAME_SEPARATORS);
     }
     grant == tool
 }
@@ -118,5 +159,123 @@ mod test {
     async fn empty_catalog() {
         let provider = StubToolProvider::default();
         assert!(provider.catalog(&company()).await.unwrap().is_empty());
+    }
+
+    // --- Prefix grants stop on a namespace boundary (issue #461) -------------
+
+    /// The defect verbatim: a trailing-`*` grant used to be a bare
+    /// `starts_with`, so `file*` reached every tool whose *name* merely began
+    /// with those letters. `filesystem_wipe` is the shape that makes it a
+    /// permission bug rather than a cosmetic one.
+    #[test]
+    fn prefix_grant_stops_at_the_snake_case_boundary() {
+        assert!(grant_matches("file*", "file_read"));
+        assert!(grant_matches("file*", "file_write"));
+        // The grant itself, with nothing under it, is still covered.
+        assert!(grant_matches("file*", "file"));
+        // …but a longer *word* is a different namespace, not a sub-tool.
+        assert!(!grant_matches("file*", "filesystem_wipe"));
+        assert!(!grant_matches("file*", "filed"));
+    }
+
+    /// The issue's second example: `composio_list*` may cover the list family
+    /// and nothing else.
+    #[test]
+    fn prefix_grant_covers_only_its_own_family() {
+        assert!(grant_matches("composio_list*", "composio_list"));
+        assert!(grant_matches("composio_list*", "composio_list_apps"));
+        assert!(grant_matches("composio_list*", "composio_list_toolkits"));
+        assert!(!grant_matches("composio_list*", "composio_listen"));
+        assert!(!grant_matches("composio_list*", "composio_execute"));
+    }
+
+    /// Every grant shape the shipped `companies/*/company.toml` manifests use
+    /// keeps working exactly as before — the fix must be invisible to them.
+    #[test]
+    fn shipped_grant_shapes_are_unchanged() {
+        // Dotted namespace globs.
+        assert!(grant_matches("email.*", "email.send"));
+        assert!(grant_matches("web.*", "web.fetch"));
+        assert!(grant_matches("workspace.*", "workspace.read"));
+        assert!(!grant_matches("email.*", "payment.send"));
+        // Colon-namespaced MCP servers.
+        assert!(grant_matches("mcp:*", "mcp:notion"));
+        assert!(grant_matches("mcp:*", "mcp:any-server"));
+        assert!(grant_matches("mcp:notion", "mcp:notion"));
+        assert!(!grant_matches("mcp:notion", "mcp:slack"));
+        assert!(!grant_matches("mcp:*", "mcpx:notion"));
+        // Exact tokens and the catch-all.
+        assert!(grant_matches("composio", "composio"));
+        assert!(!grant_matches("composio", "composio.execute"));
+        assert!(grant_matches("*", "anything_at_all"));
+    }
+
+    /// A bare `*` is a broad grant, not an unlimited one: the metered
+    /// `web_search` surface (issue #238) must still be opted into by name.
+    /// Pinned here too because the boundary fix touches the same grant lists.
+    #[test]
+    fn catch_all_still_confers_no_web_search() {
+        assert!(!crate::company::grants_search_explicit(&["*".into()]));
+        assert!(crate::company::grants_search_explicit(&["search".into()]));
+    }
+
+    /// The whole point of issue #461: one rule, two matchers. Over a shared
+    /// corpus, `grant_matches` (tool names) and `grants_cover` (namespaces)
+    /// must never disagree about whether a dotted grant reaches a namespace.
+    ///
+    /// Gated with the harness, which is where `grants_cover` is compiled.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn both_matchers_agree_over_a_shared_corpus() {
+        use crate::harness::build::grants_cover;
+
+        // (grant, namespace) pairs written the way a manifest writes them.
+        let corpus = [
+            ("docs", "docs"),
+            ("docs.*", "docs"),
+            ("docs.read", "docs"),
+            ("*", "docs"),
+            ("web.*", "docs"),
+            ("documentation.*", "docs"),
+            ("doc.*", "docs"),
+            ("workspace", "workspace"),
+            ("workspace.write", "workspace"),
+            ("workspaces.write", "workspace"),
+            ("search", "search"),
+            ("searching", "search"),
+        ];
+
+        for (grant, namespace) in corpus {
+            let by_namespace = grants_cover(&[grant.to_string()], namespace);
+            // The per-tool matcher asked the same question: does this grant
+            // reach *something* in the namespace? A namespace grant is probed
+            // as the namespace's own glob.
+            let by_tool = grant_matches(&format!("{namespace}.*"), grant)
+                || grant_matches(grant, namespace)
+                || grant == "*";
+            assert_eq!(
+                by_namespace, by_tool,
+                "matchers disagree on grant {grant:?} vs namespace {namespace:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn extends_on_boundary_is_exact_prefix_or_separator() {
+        // Identity.
+        assert!(extends_on_boundary("docs", "docs", &['.']));
+        // The prefix already carries the separator.
+        assert!(extends_on_boundary("email.send", "email.", &['.']));
+        assert!(extends_on_boundary("mcp:notion", "mcp:", &[':']));
+        // The name breaks on one.
+        assert!(extends_on_boundary("docs.read", "docs", &['.']));
+        assert!(extends_on_boundary("file_read", "file", &['_']));
+        // Mid-word extension is not a boundary.
+        assert!(!extends_on_boundary("filesystem", "file", &['_']));
+        assert!(!extends_on_boundary("docs.read", "docs", &['_']));
+        // Not a prefix at all.
+        assert!(!extends_on_boundary("web.fetch", "docs", &['.']));
+        // A shorter name never covers a longer prefix.
+        assert!(!extends_on_boundary("doc", "docs", &['.']));
     }
 }


### PR DESCRIPTION
## Summary

Closes #461.

`[tools].allow` was read by two matchers that disagreed about where a prefix ends.

`grants_cover` required a `*` prefix to stop on a namespace boundary, and had a test pinning exactly that. `grant_matches` stripped the `*` and did a bare `starts_with`. Same manifest field, same operator sentence, two different answers — so `composio_list*` granted every tool whose *name merely began with those letters*, and a `file*` grant would have covered `filesystem_wipe`.

This adds one boundary rule and makes both matchers thin callers of it, so the two cannot drift apart again.

`extends_on_boundary(name, prefix, separators)` is true when the name equals the prefix, or starts with it and either the prefix already ends on a separator or the next character is one. Tool matching passes `{'.', '_', ':'}` — `.` for `email.*`, `_` for snake_case names so `file*` reaches `file_read` but not `filesystem_wipe`, `:` for `mcp:*` reaching `mcp:notion`. The `*` catch-all and exact-match arms are untouched.

## API Or Behavior Changes

**A tool grant is narrower than it was**, deliberately — that is the fix. A glob now covers the family it names rather than every name sharing its letters.

Nothing shipped regresses. Every manifest under `companies/` uses only bare `*`, exact tokens, or dot-namespaced globs (`web.*`, `docs.*`, `workspace.*`, `mcp:*`), all of which behave identically. `allow_covers` was not edited and its own test drives both matchers over the real manifests unchanged.

One asymmetry, called out for review rather than buried: `grants_cover` keeps a `.`-only separator set while `grant_matches` uses `. _ :`. Widening `grants_cover` to `_` would newly make `files_scratch` a grant under the `files` namespace, which it never was — so the narrower set is what preserves behaviour. Both sets are documented at their definitions.

Also included: `INTRINSIC_TOOLS` had drifted from `orchestrator_tools` and was missing `assign_task` and `review_task`, which downgraded those tools' own sentences to a bare failure class. Added, with a test that walks the tool-name constants so the next drift fails CI instead of going quiet.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2334 passed, 0 failed, 2 ignored
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

New coverage: `file*` matches `file_read`/`file_write` and **not** `filesystem_wipe`; `composio_list*` matches only the list family; `email.*`, `mcp:*` and bare `*` unchanged; an agreement test running both matchers over a shared corpus so they cannot diverge silently; the existing `grants_cover` boundary test passes byte-identically.

Backend-provable in full — no console surface reads either matcher, so no browser pass is owed.

## Documentation

Both matchers' doc comments rewrote the behaviour they described; the previous text documented the loose matching this fixes. No spec file covers grant prefix semantics, so there was nothing else to update.

Noted but not fixed: `planning.rs` carries a fourth hand-rolled boundary check, for `[policy]` kinds rather than tool grants. It is already boundary-correct, so it is not a defect — but it is the same shape and a candidate for the shared helper later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission matching to prevent similarly named tools or namespaces from receiving unintended access.
  * Preserved support for exact matches, wildcard grants, dotted namespaces, snake_case names, MCP namespaces, and catch-all permissions.
* **Improvements**
  * OpenCompany-authored messages from task assignment and task review tools are now surfaced directly.
  * Added broader validation to ensure tool permissions behave consistently across supported naming patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->