### PR TITLE
fix(harness): a cut operator redirect and dropped prior work both say so (#420)

### DIFF
--- a/src/company/steer.rs
+++ b/src/company/steer.rs
@@ -37,8 +37,15 @@ use std::sync::{Arc, Mutex};
 use crate::ports::types::CompanyId;
 
 /// The maximum instruction length an operator redirect carries, in **chars**
-/// (not bytes — truncation is codepoint-safe). A redirect longer than this is
-/// truncated at the route boundary before it ever reaches an agent turn.
+/// (not bytes — any cut here is codepoint-safe).
+///
+/// **Single capping authority**: the steer route is the one place that decides
+/// an over-long redirect's fate, and it *refuses* one — `400`, naming the actual
+/// length and this limit — rather than quietly halving what the agent will act
+/// on. The operator is synchronously present and can shorten the text.
+/// [`cap_redirect`] remains as defense-in-depth for any path that reaches a turn
+/// without crossing that route, and when it does cut it says so. Route
+/// validates; helper marks.
 pub const MAX_REDIRECT_CHARS: usize = 2000;
 
 /// What an operator asked us to do to an in-flight run.
@@ -51,8 +58,9 @@ pub enum SteerAction {
     /// Stop the current attempt and re-run it with an appended operator
     /// instruction. Bounded per dispatch (see the harness disposition).
     Redirect {
-        /// The operator's fresh instruction, already codepoint-capped to
-        /// [`MAX_REDIRECT_CHARS`] at the route boundary.
+        /// The operator's fresh instruction, verbatim. The route already
+        /// refused anything longer than [`MAX_REDIRECT_CHARS`], so what an
+        /// agent sees here is the whole of what the operator typed.
         instruction: String,
     },
 }
@@ -299,11 +307,49 @@ impl Drop for RegistrationGuard {
     }
 }
 
+/// The suffix [`cap_redirect`] appends when it has to cut, naming how many
+/// characters went missing so a truncated redirect is never byte-indistinguishable
+/// from a complete one.
+fn truncation_marker(dropped: usize) -> String {
+    format!(" […{dropped} chars truncated]")
+}
+
 /// Codepoint-safe truncation of an operator redirect instruction to
-/// [`MAX_REDIRECT_CHARS`]. Never splits a multi-byte character (unlike a byte
-/// slice), so a redirect ending in an emoji or accented letter can't panic.
+/// [`MAX_REDIRECT_CHARS`], **marking** whatever it drops.
+///
+/// This is defense-in-depth, not the enforcement point: the steer route refuses
+/// an over-long redirect outright (see [`MAX_REDIRECT_CHARS`]), so in the normal
+/// path this is the identity function. It exists for the paths that re-apply the
+/// bound without crossing the route — the harness caps the instruction again on
+/// every redirect dispatch — and there it must not cut silently, or a halved
+/// instruction reads to the agent (and to the audit trail) exactly like a
+/// complete one.
+///
+/// The result never exceeds [`MAX_REDIRECT_CHARS`] characters: the marker's own
+/// width is subtracted before the cut, so the cap this claims to honour is the
+/// cap it honours. Cutting counts characters, never bytes, so an instruction
+/// ending in an emoji or accented letter can't split a codepoint (or panic).
 pub fn cap_redirect(instruction: &str) -> String {
-    instruction.chars().take(MAX_REDIRECT_CHARS).collect()
+    let total = instruction.chars().count();
+    if total <= MAX_REDIRECT_CHARS {
+        return instruction.to_string();
+    }
+    // The marker names the dropped count, and the dropped count depends on how
+    // much room the marker itself takes — so settle it by fixpoint. Each pass
+    // either agrees with the previous one (done) or shrinks `keep` by the digit
+    // the growing count needs, so this terminates in a pass or two.
+    let mut keep = MAX_REDIRECT_CHARS;
+    let marker = loop {
+        let marker = truncation_marker(total - keep);
+        let room = MAX_REDIRECT_CHARS.saturating_sub(marker.chars().count());
+        if room >= keep {
+            break marker;
+        }
+        keep = room;
+    };
+    let mut out: String = instruction.chars().take(keep).collect();
+    out.push_str(&marker);
+    out
 }
 
 #[cfg(test)]
@@ -415,11 +461,49 @@ mod tests {
     }
 
     #[test]
+    fn cap_redirect_is_identity_under_the_cap() {
+        let exact: String = "a".repeat(MAX_REDIRECT_CHARS);
+        assert_eq!(
+            cap_redirect(&exact),
+            exact,
+            "an at-limit redirect is verbatim"
+        );
+        assert_eq!(cap_redirect("short"), "short");
+        assert_eq!(cap_redirect(""), "");
+    }
+
+    #[test]
+    fn cap_redirect_marks_how_much_it_dropped() {
+        let long: String = "a".repeat(MAX_REDIRECT_CHARS + 500);
+        let capped = cap_redirect(&long);
+        assert!(
+            capped.chars().count() <= MAX_REDIRECT_CHARS,
+            "the cap reserves room for its own marker, got {} chars",
+            capped.chars().count()
+        );
+        // The marker names the real loss: kept + dropped is the whole input.
+        let (head, tail) = capped.rsplit_once(" […").expect("a cut redirect is marked");
+        let dropped: usize = tail
+            .trim_end_matches(" chars truncated]")
+            .parse()
+            .expect("the marker names a count");
+        assert_eq!(
+            head.chars().count() + dropped,
+            long.chars().count(),
+            "shown + dropped accounts for every input character"
+        );
+    }
+
+    #[test]
     fn cap_redirect_is_codepoint_safe() {
+        // A multi-byte codepoint straddling the limit must be cut on a character
+        // boundary, not panic the way a byte slice would.
         let long: String = "é".repeat(MAX_REDIRECT_CHARS + 50);
         let capped = cap_redirect(&long);
-        assert_eq!(capped.chars().count(), MAX_REDIRECT_CHARS);
-        // Byte length is a clean multiple of 2 (é is 2 bytes) — no split codepoint.
-        assert_eq!(capped.len(), MAX_REDIRECT_CHARS * 2);
+        assert!(capped.chars().count() <= MAX_REDIRECT_CHARS);
+        assert!(capped.ends_with("chars truncated]"));
+        let head: String = capped.chars().take_while(|c| *c == 'é').collect();
+        // The surviving head is whole `é`s — 2 bytes each, no split codepoint.
+        assert_eq!(head.len(), head.chars().count() * 2);
     }
 }

--- a/src/harness/memory_loop.rs
+++ b/src/harness/memory_loop.rs
@@ -40,32 +40,49 @@ pub const OUTCOME_LABEL_PREFIX: &str = "task-outcome";
 /// returned anything.
 ///
 /// With no hits the message is returned unchanged, so a cold-start turn (empty
-/// memory) is byte-identical to the pre-loop behaviour.
+/// memory) is byte-identical to the pre-loop behaviour. With hits, the preamble
+/// always accounts for **all** of them: whatever the budget could not carry is
+/// named in a count marker, so "prior work was suppressed" never reads to the
+/// model like "no prior work exists".
 pub fn inject(message: &str, hits: &[ChunkHit]) -> String {
+    inject_within(message, hits, MAX_HISTORY_CHARS)
+}
+
+/// [`inject`] with the total-preamble budget as a parameter, so the
+/// nothing-fits path is reachable in a test without a 2000-character fixture.
+fn inject_within(message: &str, hits: &[ChunkHit], history_budget: usize) -> String {
     if hits.is_empty() {
         return message.to_string();
     }
     let mut out = String::from("## Relevant prior work\n");
     // Bound both each snippet and the total preamble so a few large stored
     // replies can't blow the context window (see MAX_* constants).
-    let mut remaining = MAX_HISTORY_CHARS;
-    let mut injected = false;
+    let mut remaining = history_budget;
+    let mut skipped = 0usize;
     for hit in hits {
         let snippet = truncate_chars(hit.snippet.trim(), MAX_SNIPPET_CHARS);
         let cost = snippet.chars().count() + 3; // "- " + "\n"
         if cost > remaining {
-            break;
+            // Skip, don't stop: a later, smaller hit may still fit, and every
+            // hit that doesn't is accounted for by the marker below.
+            skipped += 1;
+            continue;
         }
         out.push_str("- ");
         out.push_str(&snippet);
         out.push('\n');
         remaining -= cost;
-        injected = true;
     }
-    // Every hit was empty or over budget — fall back to the bare message so a
-    // cold-equivalent turn stays unchanged.
-    if !injected {
-        return message.to_string();
+    if skipped > 0 {
+        // Deliberately charged to nobody: this one short line sits *outside*
+        // `history_budget`, because the budget exists to bound retrieved text
+        // and the marker is our own accounting. Letting it compete for room
+        // would mean the marker could itself be the thing squeezed out — the
+        // exact silence it exists to prevent. It also guarantees the
+        // all-oversized case still emits a preamble rather than a bare message.
+        out.push_str(&format!(
+            "- […{skipped} more prior result(s) omitted for space]\n"
+        ));
     }
     out.push_str("\n## Task\n");
     out.push_str(message);
@@ -74,11 +91,19 @@ pub fn inject(message: &str, hits: &[ChunkHit]) -> String {
 
 /// Truncates `s` to at most `max` characters (on a char boundary), appending an
 /// ellipsis when anything was dropped.
+///
+/// The ellipsis is budgeted *inside* `max`: taking `max` characters and then
+/// appending returns `max + 1`, so the cap would quietly exceed the bound it
+/// advertises. Cutting counts characters, never bytes, so a multibyte snippet
+/// can't split a codepoint.
 fn truncate_chars(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();
     }
-    let head: String = s.chars().take(max).collect();
+    if max == 0 {
+        return String::new();
+    }
+    let head: String = s.chars().take(max - 1).collect();
     format!("{head}…")
 }
 
@@ -124,6 +149,39 @@ mod test {
     }
 
     #[test]
+    fn a_truncated_snippet_reserves_room_for_its_own_ellipsis() {
+        let big = "x".repeat(10_000);
+        let cut = truncate_chars(&big, MAX_SNIPPET_CHARS);
+        assert_eq!(
+            cut.chars().count(),
+            MAX_SNIPPET_CHARS,
+            "the marker is budgeted inside the cap, not added on top of it"
+        );
+        assert!(cut.ends_with('…'));
+        // Multibyte input cuts on a character boundary, never mid-codepoint.
+        let multibyte = "é".repeat(10_000);
+        let cut = truncate_chars(&multibyte, MAX_SNIPPET_CHARS);
+        assert_eq!(cut.chars().count(), MAX_SNIPPET_CHARS);
+    }
+
+    /// The count the "omitted for space" marker names, if the preamble has one.
+    fn omitted_count(out: &str) -> Option<usize> {
+        let line = out.lines().find(|l| l.contains("omitted for space"))?;
+        line.trim_start_matches("- […")
+            .split_whitespace()
+            .next()?
+            .parse()
+            .ok()
+    }
+
+    /// Lines carrying an actual retrieved snippet (not the marker).
+    fn shown_count(out: &str) -> usize {
+        out.lines()
+            .filter(|l| l.starts_with("- ") && !l.contains("omitted for space"))
+            .count()
+    }
+
+    #[test]
     fn inject_stops_at_the_total_history_budget() {
         // Many mid-size snippets: the injected preamble stays within budget.
         let hits: Vec<ChunkHit> = (0..50).map(|_| hit(&"y".repeat(400))).collect();
@@ -133,6 +191,49 @@ mod test {
             injected <= MAX_HISTORY_CHARS + MAX_SNIPPET_CHARS,
             "history is budget-capped, got {injected} injected chars"
         );
+    }
+
+    #[test]
+    fn inject_names_how_many_hits_the_budget_dropped() {
+        let hits: Vec<ChunkHit> = (0..50).map(|_| hit(&"y".repeat(400))).collect();
+        let out = inject("go", &hits);
+        let shown = shown_count(&out);
+        assert!(shown > 0, "some prior work fits in the budget");
+        assert!(shown < 50, "not all of it does — this is the drop path");
+        assert_eq!(
+            omitted_count(&out),
+            Some(50 - shown),
+            "every hit is either shown or counted: {out}"
+        );
+    }
+
+    #[test]
+    fn inject_accounts_for_every_nearly_fitting_hit() {
+        // Sized so the budget runs out partway through rather than cleanly.
+        let hits: Vec<ChunkHit> = (0..9).map(|i| hit(&"z".repeat(230 + i))).collect();
+        let out = inject("go", &hits);
+        let shown = shown_count(&out);
+        let omitted = omitted_count(&out).unwrap_or(0);
+        assert_eq!(shown + omitted, 9, "no hit vanishes unaccounted: {out}");
+        let injected = out.chars().count() - "go".chars().count();
+        assert!(
+            injected <= MAX_HISTORY_CHARS + MAX_SNIPPET_CHARS,
+            "still budget-capped, got {injected} injected chars"
+        );
+    }
+
+    #[test]
+    fn inject_with_nothing_fitting_still_says_prior_work_existed() {
+        // A budget too small for any hit: the preamble must still appear
+        // carrying only the marker, so suppression is distinguishable from a
+        // genuinely cold memory.
+        let hits: Vec<ChunkHit> = (0..3).map(|_| hit("a stored outcome")).collect();
+        let out = inject_within("go", &hits, 2);
+        assert!(out.starts_with("## Relevant prior work\n"), "{out}");
+        assert_eq!(omitted_count(&out), Some(3), "{out}");
+        assert_eq!(shown_count(&out), 0, "nothing fit: {out}");
+        assert!(out.trim_end().ends_with("go"));
+        assert_ne!(out, "go", "a suppressed preamble is not a bare message");
     }
 
     #[test]

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -20,7 +20,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
-use crate::company::steer::{InflightEntry, SteerAction, SteerError, cap_redirect};
+use crate::company::steer::{InflightEntry, MAX_REDIRECT_CHARS, SteerAction, SteerError};
 use crate::error::OpenCompanyError;
 use crate::ports::tasks::{
     BOARD_COLUMNS, COLUMN_TODO, TaskRecord, cap_discussion, is_board_column,
@@ -1656,8 +1656,9 @@ async fn list_inflight(company: ScopedCompany) -> Result<Json<Vec<InflightCard>>
 /// `POST …/tasks/{task_id}/steer` — apply an operator steer to an in-flight run.
 ///
 /// Validation (all `400`): unknown action; `cancel` without `confirm: true`;
-/// `redirect` without a non-empty `instruction`. An unknown key is `404`; a card
-/// that exists but is not in flight is `409`. On accept the run's control is set,
+/// `redirect` without a non-empty `instruction`; `redirect` with an instruction
+/// longer than [`MAX_REDIRECT_CHARS`]. An unknown key is `404`; a card that
+/// exists but is not in flight is `409`. On accept the run's control is set,
 /// a best-effort [`CompanyEvent::TaskSteered`] is journaled, and the route
 /// returns `202 Accepted` (the disposition lands on the card asynchronously).
 async fn steer_task(
@@ -1682,8 +1683,19 @@ async fn steer_task(
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
                 .ok_or_else(|| bad("redirect requires a non-empty instruction"))?;
+            // Refuse rather than silently cap. The operator is synchronously
+            // present and the console surfaces this 400, so telling them the
+            // instruction is too long beats handing the agent a halved one that
+            // reads — in the turn and in the audit trail — exactly like the
+            // whole of what they typed. Count characters, never bytes.
+            let chars = instruction.chars().count();
+            if chars > MAX_REDIRECT_CHARS {
+                return Err(bad(&format!(
+                    "redirect instruction is {chars} characters; the limit is {MAX_REDIRECT_CHARS}"
+                )));
+            }
             SteerAction::Redirect {
-                instruction: cap_redirect(instruction),
+                instruction: instruction.to_string(),
             }
         }
         other => return Err(bad(&format!("unknown steer action '{other}'"))),
@@ -1854,5 +1866,187 @@ mod durations_test {
     fn a_reader_clock_behind_the_host_does_not_go_backwards() {
         let d = TaskDurations::compute(&[entry(T0, "dispatched", None)], None, T0 + 300_000);
         assert_eq!(d.worked_at(T0), 300_000);
+    }
+}
+
+/// The redirect bound at the route boundary: an operator who typed too much is
+/// told so, and one who typed exactly the limit gets every character through.
+#[cfg(test)]
+mod steer_redirect_test {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::company::steer::InflightKind;
+    use crate::ports::types::{CompanyId, CompanyRecord, EventSeq};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    fn manifest() -> CompanyManifest {
+        toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .unwrap()
+    }
+
+    /// A company with one run already in flight under the key `active`, so the
+    /// steer route reaches its accept path. The caller must hold the returned
+    /// registration guard: dropping it deregisters the run.
+    async fn state_with_inflight_run(
+        home: &std::path::Path,
+    ) -> (AppState, crate::company::steer::RegistrationGuard) {
+        use crate::ports::CompanyStore;
+        let id = CompanyId::new("acme");
+        FsCompanyStore::new(home.to_path_buf())
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let guard = runtime.steer().register(
+            &id,
+            InflightEntry {
+                key: "active".into(),
+                task_id: Some("active".into()),
+                kind: InflightKind::Task,
+                title: "Active".into(),
+                agent_id: "ceo".into(),
+                started_at_millis: 1,
+                pending_action: None,
+            },
+        );
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        (state, guard)
+    }
+
+    async fn steer(state: &AppState, body: Value) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method("POST")
+            .uri("/api/v1/company/tasks/active/steer")
+            .header("content-type", "application/json")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .body(Body::from(body.to_string()))
+            .unwrap();
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    /// The instruction the run's audit event recorded, if any.
+    async fn journaled_redirect(state: &AppState) -> Option<String> {
+        let company = CompanyId::new("acme");
+        let runtime = state.registry().get(&company).unwrap();
+        runtime
+            .events()
+            .read_from(&company, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap()
+            .into_iter()
+            .find_map(|stored| match stored.event {
+                CompanyEvent::TaskSteered { instruction, .. } => instruction,
+                _ => None,
+            })
+    }
+
+    #[tokio::test]
+    async fn an_over_length_redirect_is_refused_naming_the_bound() {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-steer-")
+            .tempdir()
+            .unwrap();
+        let (state, _inflight) = state_with_inflight_run(home.path()).await;
+
+        let too_long = "a".repeat(MAX_REDIRECT_CHARS + 1);
+        let (status, body) = steer(
+            &state,
+            json!({"action": "redirect", "instruction": too_long}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let message = body["error"].as_str().unwrap_or_default();
+        assert!(
+            message.contains(&MAX_REDIRECT_CHARS.to_string()),
+            "the refusal names the limit: {message}"
+        );
+        assert!(
+            message.contains(&(MAX_REDIRECT_CHARS + 1).to_string()),
+            "the refusal names the actual length: {message}"
+        );
+        assert!(
+            journaled_redirect(&state).await.is_none(),
+            "a refused redirect never reaches the run or the audit trail"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_over_length_multibyte_redirect_is_refused_not_split() {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-steer-")
+            .tempdir()
+            .unwrap();
+        let (state, _inflight) = state_with_inflight_run(home.path()).await;
+
+        // Every character is 2 bytes, so a byte-indexed bound would land
+        // mid-codepoint and panic. The route counts characters.
+        let too_long = "é".repeat(MAX_REDIRECT_CHARS + 1);
+        let (status, body) = steer(
+            &state,
+            json!({"action": "redirect", "instruction": too_long}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert!(
+            body["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(&(MAX_REDIRECT_CHARS + 1).to_string()),
+            "length is counted in characters, not bytes: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_at_limit_redirect_is_accepted_verbatim() {
+        let home = tempfile::Builder::new()
+            .prefix("opencompany-steer-")
+            .tempdir()
+            .unwrap();
+        let (state, _inflight) = state_with_inflight_run(home.path()).await;
+
+        let exact = "a".repeat(MAX_REDIRECT_CHARS);
+        let (status, _) = steer(&state, json!({"action": "redirect", "instruction": exact})).await;
+        assert_eq!(status, StatusCode::ACCEPTED);
+        assert_eq!(
+            journaled_redirect(&state).await.as_deref(),
+            Some(exact.as_str()),
+            "an at-limit instruction reaches the run whole — no cut, no marker"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes items 1 and 2 of #420. (Item 3 is already fixed on `main`; item 4 is a separate change.)

Both are the same defect: text is cut and the reader is never told, so a truncated thing is byte-indistinguishable from a complete one.

**An operator redirect over 2000 characters was silently capped.** It was applied at the route and again in the brain, so a cut redirect looked complete both to the agent acting on it and in the audit trail of what the operator asked for.

The fix refuses at the route rather than capping: the operator is synchronously present, so they can be told and shorten it, which is strictly better than the system guessing which half they meant. `cap_redirect` stays as defense-in-depth but now names how much it dropped.

**Retrieved prior work was dropped from an agent's context with no note.** The history budget stopped at the first hit that did not fit, silently — routinely losing the last hit on a warm turn. Worse, when *no* hit fitted, the preamble was omitted entirely, making "prior work exists but was suppressed" identical to "there is no prior work". The agent could not tell which, and neither could anyone reading the prompt.

Now the skipped count is stated, and a nothing-fits turn still emits the preamble carrying the marker.

## API Or Behavior Changes

**A redirect over the limit is now a 400 instead of a silent cap.** That is the intended change: anything relying on being quietly truncated will now be told. The limit itself is unchanged.

Cold start in the memory loop — no prior hits at all — returns the message byte-identically. That path has a pinning test and it stays green.

Two smaller corrections made along the way, both instances of a cap exceeding the bound it advertises: `cap_redirect` and `truncate_chars` each took `max` and *then* appended a suffix, returning `max + 1`. Both now budget the suffix inside the cap.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2336 passed, 0 failed, 2 ignored
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

Nine tests added: an over-length redirect returns 400 naming the bound **and** nothing reaches the run or the audit trail; a multi-byte over-length redirect returns 400 without panicking; an exactly-at-limit redirect is accepted and journaled verbatim; marker, identity-under-cap and codepoint safety on the helper; 50 oversized hits produce a marker whose count equals what was dropped; nearly-fitting hits account for every hit as shown or counted; nothing-fits emits the preamble rather than a bare message.

**One check is owed that I could not run here.** The redirect refusal has a UI surface — the operator types it. Someone should confirm the console renders the 400 and preserves the typed text so it can be shortened, rather than swallowing it or leaving the composer pending. Backend proof is not sufficient for that half.

## Documentation

The single-capping-authority rule — the route validates, the helper marks — is documented on the limit constant and on the helper, since the two now have different jobs.

**Worth knowing for whoever picks up the rest of #420:** the sweep found this family is widespread, and one instance is load-bearing. `cap_discussion` in `src/ports/tasks.rs` silently truncates a discussion post over 4000 characters with no marker, and the thread is read back in full on every detail poll — so a cut post reads as complete. Its own doc justifies truncate-over-reject *by citing the steer instruction as precedent*, which this PR just invalidated. There are also five more instances of the cap-exceeds-its-own-bound shape, and `src/runtime/delegation.rs` is the one that already gets it right if a house pattern is wanted.
