### PR TITLE
fix(approvals): a standing Composio grant covers only the provider it was shown for (#457)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -391,6 +391,15 @@ export interface StandingGrant {
   at_millis: number;
   /** Epoch-millis it stops admitting calls. */
   expires_at_millis: number;
+  /**
+   * The slice of the tool it is confined to, when the tool's name is not the
+   * whole of what it can do (#457) — a Composio toolkit like `github`.
+   *
+   * Absent for every tool whose name already says everything, and absent from
+   * an older host that predates the field. Both mean "nothing to narrow", so
+   * the row simply says what it always said.
+   */
+  scope?: string;
 }
 
 export type FeedbackCategory =

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -358,7 +358,7 @@ function StandingPermissions({
               <CardContent className="flex flex-wrap items-center gap-3 py-3">
                 <div className="min-w-0 flex-1">
                   {/* Phrased, never the raw identifier — the glossary rule. */}
-                  <p className="truncate text-sm font-medium">{toolAction(g.tool)}</p>
+                  <p className="truncate text-sm font-medium">{grantHeadline(g)}</p>
                   <p className="text-xs text-muted-foreground">
                     {askerNames.get(g.agent) ?? g.agent} ·{" "}
                     {expired ? "expired" : `expires ${untilLabel(g.expires_at_millis, now)}`} ·
@@ -386,6 +386,41 @@ function StandingPermissions({
       </div>
     </section>
   );
+}
+
+/**
+ * What one standing permission actually covers, in one line (#457).
+ *
+ * `toolAction` alone answers "which tool", which is the whole sentence for
+ * `file_write` and only half of it for `composio_execute`: that name carries
+ * every action of every connected provider, so a row reading "Act in one of its
+ * connected accounts" leaves an operator unable to tell a permission over their
+ * code host from one over their mailbox — and a permission you cannot read is
+ * one you cannot decide to revoke. When the host names a scope, the row names
+ * the provider.
+ *
+ * Composed as a suffix rather than a second phrasing table: the tool's own words
+ * stay in `lib/language`, so there is nothing here to drift out of step with it.
+ */
+function grantHeadline(g: StandingGrant): string {
+  const action = toolAction(g.tool);
+  return g.scope ? `${action} — ${providerLabel(g.scope)} only` : action;
+}
+
+/**
+ * A toolkit identifier as a person would write it: `microsoft_teams` →
+ * "Microsoft Teams".
+ *
+ * Mechanical on purpose. A lookup table of pretty provider names would render
+ * the ~30 toolkits it knew and the raw slug for everything else, and the ones it
+ * did not know would be exactly the ones added most recently.
+ */
+function providerLabel(scope: string): string {
+  return scope
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 /**

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -5133,6 +5133,7 @@ members = ["eng1", "eng2"]
                 at_millis: now_millis(),
                 expires_at_millis: now_millis() + 60 * 60 * 1000,
                 origin_thread: None,
+                scope: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -503,6 +503,15 @@ impl ApprovalPolicy {
     ///   handle. Re-classifying the live arguments keeps the grant to the shape
     ///   the operator was shown. It also means a grant replayed from a journal
     ///   line written before this change cannot admit a send.
+    /// * **The call must fall in the same slice of the tool the grant was minted
+    ///   on** (issue #457). Re-classifying keeps a send out of a read's grant,
+    ///   but every Composio read across every connected toolkit is the same
+    ///   verdict under the same tool name — so a grant minted from "read from
+    ///   GitHub" admitted a read of the company's mailbox too. The live call's
+    ///   scope is computed here and matched against what the grant recorded; an
+    ///   action the catalogue cannot place has no scope and a scoped grant
+    ///   refuses it. A grant replayed from a line written before the field
+    ///   existed is unscoped and behaves exactly as it did.
     fn standing_grant_allows(&self, tool: &str, args: &serde_json::Value) -> bool {
         let Some(agent) = self.agent.as_deref() else {
             return false;
@@ -520,11 +529,17 @@ impl ApprovalPolicy {
             );
             return false;
         }
-        let Some(grant) =
-            self.requests
-                .grants()
-                .match_standing(agent, tool, crate::ports::now_millis())
-        else {
+        // Issue #457: which slice of the tool this *live* call falls in,
+        // computed by the same function the mint side used on the parked
+        // effect's payload — one function, so the two answers cannot drift into
+        // a grant that never matches its own tool.
+        let scope = crate::policy::consequence::standing_scope_of(tool, args);
+        let Some(grant) = self.requests.grants().match_standing(
+            agent,
+            tool,
+            scope.as_deref(),
+            crate::ports::now_millis(),
+        ) else {
             return false;
         };
         log::debug!(
@@ -2366,6 +2381,20 @@ mod tests {
             at_millis: 1_000,
             expires_at_millis,
             origin_thread: None,
+            scope: None,
+        }
+    }
+
+    /// The same fixture, confined to one Composio toolkit (issue #457).
+    fn scoped_standing(
+        agent: &str,
+        tool: &str,
+        scope: &str,
+        expires_at_millis: u64,
+    ) -> crate::runtime::grants::StandingGrant {
+        crate::runtime::grants::StandingGrant {
+            scope: Some(scope.to_string()),
+            ..standing(agent, tool, expires_at_millis)
         }
     }
 
@@ -2781,6 +2810,120 @@ mod tests {
             ),
             "a send on the same tool name parks despite the grant"
         );
+    }
+
+    /// Issue #457, through the real admission path. Re-classifying the live
+    /// action (the test above) separates a read from a send; it cannot separate
+    /// one provider's read from another's, because both are reads under the same
+    /// tool name for the same teammate. The card said "read from GitHub" and the
+    /// grant has to mean that.
+    #[tokio::test]
+    async fn a_grant_scoped_to_one_provider_does_not_admit_another_providers_read() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue)
+            .with_agent("ops");
+        grants.grant_standing(scoped_standing(
+            "ops",
+            "composio_execute",
+            "github",
+            far_future(),
+        ));
+
+        // A *different* GitHub read: the operator consented to the provider, so
+        // this is inside the sentence and must keep running. Scoping by action
+        // slug instead would have re-parked here and made the grant worthless.
+        assert_eq!(
+            p.check(&request(
+                "composio_execute",
+                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" })
+            ))
+            .await,
+            ToolPolicyDecision::Allow
+        );
+
+        // A mailbox read. Also a catalogue read, also grantable, also `ops`,
+        // also `composio_execute` — every check upstream of the scope says yes.
+        assert!(
+            matches!(
+                p.check(&request(
+                    "composio_execute",
+                    serde_json::json!({ "tool": "GMAIL_FETCH_EMAILS" })
+                ))
+                .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "'read from GitHub' is not consent to read the company's mail"
+        );
+
+        // An action the catalogue cannot place has no scope to compare, so the
+        // scoped grant refuses it and it parks — unknown is a send, here too.
+        assert!(matches!(
+            p.check(&request(
+                "composio_execute",
+                serde_json::json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" })
+            ))
+            .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+
+        assert_eq!(
+            grants.standing_count(),
+            1,
+            "none of those refusals spent the permission"
+        );
+    }
+
+    /// **Replay compatibility (issue #457).** A grant journaled before the scope
+    /// field existed comes back unscoped, and an unscoped grant admits the tool
+    /// exactly as it did before — otherwise this change would silently void
+    /// every permission an operator had already granted.
+    #[tokio::test]
+    async fn a_grant_from_before_scopes_existed_still_admits_its_tool() {
+        let queue = ApprovalRequestQueue::default();
+        let grants = queue.grants();
+        let p = policy("supervised", &[], None)
+            .with_requests(queue)
+            .with_agent("ops");
+
+        // Deserialized from the pre-#457 wire shape rather than constructed, so
+        // this fails if the field ever stops defaulting.
+        let replayed: crate::runtime::grants::StandingGrant =
+            serde_json::from_value(serde_json::json!({
+                "id": "g-old",
+                "agent": "ops",
+                "tool": "composio_execute",
+                "granted_by": { "kind": "user", "id": "user-1" },
+                "approval_id": "appr-old",
+                "at_millis": 1_000,
+                "expires_at_millis": far_future(),
+            }))
+            .expect("an old journal line still replays");
+        assert_eq!(replayed.scope, None);
+        grants.grant_standing(replayed);
+
+        for slug in ["GITHUB_LIST_PULL_REQUESTS", "GMAIL_FETCH_EMAILS"] {
+            assert_eq!(
+                p.check(&request(
+                    "composio_execute",
+                    serde_json::json!({ "tool": slug })
+                ))
+                .await,
+                ToolPolicyDecision::Allow,
+                "an unscoped grant behaves exactly as it did: {slug}"
+            );
+        }
+        // …and the boundary that was always there is untouched: a send still
+        // parks, because the live re-classification runs first.
+        assert!(matches!(
+            p.check(&request(
+                "composio_execute",
+                serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" })
+            ))
+            .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
     }
 
     /// Issue #374 added the `deploy` arm. It still applies — to tools with no

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -409,6 +409,59 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     }
 }
 
+/// Which slice of a tool one standing grant is confined to (issue #457).
+///
+/// `None` for almost everything, and that is the honest answer: for a tool
+/// whose name *is* the whole of what it can do — `file_write`, `memory_store` —
+/// "this tool, for this teammate, until a deadline" already describes exactly
+/// what the operator consented to, and there is nothing left to narrow.
+///
+/// `composio_execute` is the exception the type exists for. Every Composio
+/// action across every connected toolkit arrives under that one name, so a grant
+/// keyed on the name alone turns "read from GitHub" — the sentence on the card —
+/// into "make any Composio read, anywhere". [`consequence_of`] already
+/// re-classifies the live action, so a send cannot slip through a read's grant;
+/// what it cannot see is that a *different provider's* read is a different
+/// sentence. The toolkit is that dimension, and it is the right grain: the
+/// operator agreed to a provider, not to one action slug, so a second GitHub
+/// read must still pass.
+///
+/// Read through the vendored catalogue, so a toolkit nobody has classified
+/// resolves to `None` and — per [`StandingGrant::admits_scope`] — a scoped grant
+/// refuses to admit it. Without the harness feature this is always `None`, which
+/// is safe rather than lax: that build cannot mint a Composio standing grant in
+/// the first place — `without_the_catalogue_every_composio_action_is_a_send`
+/// pins that — so there is no scoped grant there for `None` to widen.
+///
+/// [`StandingGrant::admits_scope`]: crate::runtime::grants::StandingGrant::admits_scope
+pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String> {
+    if !tool.eq_ignore_ascii_case(COMPOSIO_EXECUTE) {
+        return None;
+    }
+    let slug = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str())?;
+    composio_toolkit_of(slug)
+}
+
+/// The catalogued toolkit an action slug belongs to, or `None` when the
+/// catalogue has never heard of it.
+#[cfg(feature = "openhuman")]
+fn composio_toolkit_of(slug: &str) -> Option<String> {
+    use openhuman_core::openhuman::memory_sync::composio::providers::{
+        catalog_for_toolkit, toolkit_from_slug,
+    };
+    let toolkit = toolkit_from_slug(slug)?;
+    // The slug's prefix is *some* word for every non-empty slug, so the
+    // catalogue lookup is what separates a real toolkit from a typo.
+    catalog_for_toolkit(&toolkit).is_some().then_some(toolkit)
+}
+
+/// Without the harness feature the curated catalogue is not linked in — the same
+/// seam `composio_action_is_read` straddles, answered the same cautious way.
+#[cfg(not(feature = "openhuman"))]
+fn composio_toolkit_of(_slug: &str) -> Option<String> {
+    None
+}
+
 /// Is this Composio action slug a read, according to the provider's own
 /// curated catalogue? Unknown is **not** a read.
 #[cfg(feature = "openhuman")]
@@ -752,6 +805,90 @@ mod tests {
             Standing::Grantable,
             "the curated lookup is case-insensitive on the slug too"
         );
+    }
+
+    /// Issue #457: a standing grant on `composio_execute` has to record *which
+    /// provider*, because the card said "read from GitHub" and the tool name
+    /// says nothing at all.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn a_composio_call_is_scoped_to_its_toolkit() {
+        assert_eq!(
+            standing_scope_of(COMPOSIO_EXECUTE, &json!({ "tool": "GITHUB_LIST_BRANCHES" })),
+            Some("github".to_string())
+        );
+        // A different action in the same toolkit is the same scope — the
+        // operator agreed to a provider, not to one slug.
+        assert_eq!(
+            standing_scope_of(
+                COMPOSIO_EXECUTE,
+                &json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" })
+            ),
+            Some("github".to_string())
+        );
+        // A different provider is a different scope, which is the whole point.
+        assert_eq!(
+            standing_scope_of(COMPOSIO_EXECUTE, &json!({ "tool": "GMAIL_FETCH_EMAILS" })),
+            Some("gmail".to_string())
+        );
+        // The tool name is matched the same lowercasing way the rest of the
+        // gate matches it.
+        assert_eq!(
+            standing_scope_of(
+                "COMPOSIO_EXECUTE",
+                &json!({ "tool": "github_list_branches" })
+            ),
+            Some("github".to_string())
+        );
+    }
+
+    /// Nothing the catalogue can place is `None`, and `None` is what a scoped
+    /// grant refuses — so an unplaceable slug parks rather than riding somebody
+    /// else's permission.
+    #[test]
+    fn an_unplaceable_composio_call_has_no_scope() {
+        for args in [
+            json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" }),
+            json!({ "tool": "" }),
+            json!({ "tool": 7 }),
+            json!({ "arguments": { "owner": "acme" } }),
+            json!({}),
+        ] {
+            assert_eq!(
+                standing_scope_of(COMPOSIO_EXECUTE, &args),
+                None,
+                "nothing to narrow to: {args}"
+            );
+        }
+    }
+
+    /// Every other tool has no scope, and must not grow one by accident: the
+    /// name of `file_write` already is the whole of what it can do.
+    #[test]
+    fn a_tool_whose_name_says_everything_has_no_scope() {
+        for tool in ["file_write", "memory_store", "shell", "workspace_write"] {
+            assert_eq!(
+                standing_scope_of(tool, &json!({ "tool": "GITHUB_LIST_BRANCHES" })),
+                None,
+                "`{tool}` is not a Composio call whatever its arguments say"
+            );
+        }
+    }
+
+    /// The other side of the seam. A default build cannot mint a Composio
+    /// standing grant at all (see
+    /// `without_the_catalogue_every_composio_action_is_a_send`), so answering
+    /// "no scope" here widens nothing — there is no scoped grant to widen.
+    #[test]
+    #[cfg(not(feature = "openhuman"))]
+    fn without_the_catalogue_nothing_carries_a_scope() {
+        for slug in ["GITHUB_LIST_BRANCHES", "GMAIL_SEND_EMAIL"] {
+            assert_eq!(
+                standing_scope_of(COMPOSIO_EXECUTE, &json!({ "tool": slug })),
+                None,
+                "{slug}"
+            );
+        }
     }
 
     /// The literals above and the constants the tools themselves return are two

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -750,6 +750,12 @@ working on):\n{}\n]",
             // reply lands back in that conversation. Read off the retained
             // origin, exactly as `mint_grant` does.
             origin_thread: self.rt.journal.approval_thread(id).flatten(),
+            // Issue #457: which slice of the tool the card was actually about.
+            // Read off the **parked effect's own payload** — the arguments the
+            // operator was shown — rather than re-derived from anything live, so
+            // the grant records the sentence they consented to. `None` for every
+            // tool whose name is the whole of what it can do.
+            scope: crate::policy::consequence::standing_scope_of(&effect.kind, &effect.payload),
         };
         self.rt.journal.record_standing_granted(&grant).await?;
         tracing::debug!(
@@ -5084,6 +5090,71 @@ mod test {
         assert_eq!(
             listed[0].granted_by.id, "owner",
             "the resolving actor is recorded, not a placeholder"
+        );
+    }
+
+    /// Issue #457: the grant records **which provider the card was about**.
+    ///
+    /// `composio_execute` carries every action of every connected toolkit under
+    /// one name, so a grant that recorded only the name turned "read from
+    /// GitHub" — the sentence on the card — into "make any Composio read,
+    /// anywhere". The toolkit is read off the parked effect's own payload, so
+    /// what is stored is what the operator was shown.
+    ///
+    /// Gated on the harness feature because the toolkit comes from the vendored
+    /// catalogue; the default build cannot mint a Composio standing grant at all
+    /// (every action reads as a send there), which
+    /// `without_the_catalogue_every_composio_action_is_a_send` pins.
+    #[tokio::test]
+    #[cfg(feature = "openhuman")]
+    async fn a_standing_grant_on_a_composio_read_records_the_toolkit_it_was_shown_for() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect(
+                "ops",
+                crate::policy::consequence::COMPOSIO_EXECUTE,
+                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
+            ),
+        )
+        .await;
+
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), tool_scope())
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+
+        let listed = rt.standing_grants();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].scope.as_deref(),
+            Some("github"),
+            "the grant has to remember which account the operator was looking at"
+        );
+    }
+
+    /// The counterpart: a tool whose name already is the whole of what it can do
+    /// records no scope, so its grant matches exactly as it always did.
+    #[tokio::test]
+    async fn a_standing_grant_on_an_ordinary_tool_records_no_scope() {
+        let home_dir = tmp_home();
+        let (rt, id) = park_one_blocked_tool_call(
+            home_dir.path().to_path_buf(),
+            grantable_effect("ops", "file_write", serde_json::json!({ "path": "a" })),
+        )
+        .await;
+
+        let (_, follow_up) = rt
+            .resolve_approval_spawned(&id, Verdict::Approve, operator(), tool_scope())
+            .await
+            .unwrap();
+        let _ = crate::company::runtime::join_follow_up(follow_up).await;
+
+        assert_eq!(
+            rt.standing_grants()[0].scope,
+            None,
+            "there is nothing to narrow `file_write` to"
         );
     }
 

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -76,6 +76,14 @@
 //! re-classifies the live call before honouring a grant — see
 //! [`ApprovalPolicy::standing_grant_allows`](crate::harness::policy::ApprovalPolicy).
 //!
+//! That check keeps a send out of a read's grant, but it cannot tell one
+//! provider's read from another's: they are both reads, under the same tool
+//! name, for the same teammate. So the grant also records **which toolkit the
+//! card was about** ([`StandingGrant::scope`], issue #457). The operator
+//! consented to "read from GitHub"; without the scope the grant they got was
+//! "make any Composio read, anywhere" — broader than the sentence they agreed
+//! to, across every account the company had ever connected.
+//!
 //! ## Durability
 //!
 //! Both sets are in-memory, but their lifecycles are journaled
@@ -245,9 +253,58 @@ pub struct StandingGrant {
     /// [`agent`](Self::agent), which is right for a DM.
     #[serde(default)]
     pub origin_thread: Option<String>,
+    /// The slice of [`tool`](Self::tool) this grant is confined to, when the
+    /// tool's name is not the whole of what it can do (issue #457).
+    ///
+    /// `None` for every tool whose name already describes its consequence, and
+    /// for those it is not a missing value but the correct one: nothing about
+    /// `file_write` needs narrowing, and matching on `(agent, tool, unexpired)`
+    /// says exactly what the operator agreed to.
+    ///
+    /// `Some(toolkit)` for `composio_execute`, the one tool that carries every
+    /// action of every connected provider under a single name. The card the
+    /// operator read said "read from GitHub"; without this field the grant it
+    /// minted said "make any Composio read, anywhere", because every Composio
+    /// read matched the same `(agent, "composio_execute")` pair. Minted from the
+    /// parked effect's own payload, so what is recorded is what was shown.
+    ///
+    /// Scoped by **toolkit and not by action slug**, deliberately: the operator
+    /// consented to a provider, so a *different* GitHub read has to keep
+    /// passing. Slug-exact would re-park every new action and make the grant
+    /// worth nothing.
+    ///
+    /// `None` also on a grant replayed from a journal line written before this
+    /// field existed, where it means "unscoped" and reproduces the old
+    /// behaviour exactly — see [`admits_scope`](Self::admits_scope).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
 }
 
 impl StandingGrant {
+    /// Whether this grant admits a call whose live scope is `scope` (issue
+    /// #457).
+    ///
+    /// Three cases, and the two edges are the ones that matter:
+    ///
+    /// * **This grant has no scope** — it admits anything its `(agent, tool)`
+    ///   match already admitted. That is what makes a journal line written
+    ///   before the field existed replay into today's behaviour rather than
+    ///   into a grant that silently stopped working.
+    /// * **Scopes are equal** — the ordinary hit. A second GitHub read against a
+    ///   GitHub-scoped grant.
+    /// * **This grant is scoped and the live call has no scope** — refused. An
+    ///   action the catalogue cannot place might belong to any provider, so
+    ///   admitting it on a GitHub grant would be a guess in the permissive
+    ///   direction. It falls through and parks instead, which is the same answer
+    ///   this codebase gives an unrecognised action everywhere else: unknown is
+    ///   a send.
+    pub fn admits_scope(&self, scope: Option<&str>) -> bool {
+        match self.scope.as_deref() {
+            None => true,
+            Some(mine) => scope == Some(mine),
+        }
+    }
+
     /// Whether this grant still admits calls at `now_millis`.
     ///
     /// Strictly `<`, so the deadline instant itself is already past. Checked at
@@ -386,8 +443,17 @@ impl GrantSet {
             .insert(grant.id.clone(), grant);
     }
 
-    /// Matches an unexpired standing grant for `(agent, tool)` **without**
-    /// removing it — that is the whole difference from [`consume`](Self::consume).
+    /// Matches an unexpired standing grant for `(agent, tool, scope)`
+    /// **without** removing it — that is the whole difference from
+    /// [`consume`](Self::consume).
+    ///
+    /// `scope` is the *live* call's scope, computed from its arguments by
+    /// [`standing_scope_of`](crate::policy::consequence::standing_scope_of) and
+    /// compared against what the grant recorded at mint time (issue #457). It is
+    /// `None` for every tool whose name is the whole of what it can do, and for
+    /// a Composio action the catalogue cannot place — the second of which a
+    /// scoped grant refuses, per
+    /// [`StandingGrant::admits_scope`](StandingGrant::admits_scope).
     ///
     /// Expiry is enforced *here*, under the same lock as the match, rather than
     /// being left to the sweep. The sweep runs on the scheduler's maintenance
@@ -404,13 +470,19 @@ impl GrantSet {
         &self,
         agent: &str,
         tool: &str,
+        scope: Option<&str>,
         now_millis: u64,
     ) -> Option<StandingGrant> {
         let state = self.inner.lock().expect("grant set poisoned");
         state
             .standing
             .values()
-            .filter(|g| g.agent == agent && g.tool == tool && g.is_live_at(now_millis))
+            .filter(|g| {
+                g.agent == agent
+                    && g.tool == tool
+                    && g.admits_scope(scope)
+                    && g.is_live_at(now_millis)
+            })
             .max_by_key(|g| g.expires_at_millis)
             .cloned()
     }
@@ -654,6 +726,21 @@ mod test {
             at_millis: 1_000,
             expires_at_millis,
             origin_thread: None,
+            scope: None,
+        }
+    }
+
+    /// A grant confined to one Composio toolkit (issue #457).
+    fn scoped(
+        id: &str,
+        agent: &str,
+        tool: &str,
+        scope: &str,
+        expires_at_millis: u64,
+    ) -> StandingGrant {
+        StandingGrant {
+            scope: Some(scope.to_string()),
+            ..standing(id, agent, tool, expires_at_millis)
         }
     }
 
@@ -664,10 +751,10 @@ mod test {
         let set = GrantSet::default();
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
 
-        assert!(set.match_standing("ops", "shell", 2_000).is_some());
+        assert!(set.match_standing("ops", "shell", None, 2_000).is_some());
         // Matching does not depend on arguments at all — there are none to
         // depend on. Two different calls, same admission.
-        assert!(set.match_standing("ops", "shell", 9_999).is_some());
+        assert!(set.match_standing("ops", "shell", None, 9_999).is_some());
         assert_eq!(
             set.standing_count(),
             1,
@@ -675,8 +762,8 @@ mod test {
         );
 
         // The deadline instant itself is already past.
-        assert!(set.match_standing("ops", "shell", 10_000).is_none());
-        assert!(set.match_standing("ops", "shell", 10_001).is_none());
+        assert!(set.match_standing("ops", "shell", None, 10_000).is_none());
+        assert!(set.match_standing("ops", "shell", None, 10_001).is_none());
     }
 
     #[test]
@@ -685,25 +772,124 @@ mod test {
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
 
         assert!(
-            set.match_standing("marketing", "shell", 2_000).is_none(),
+            set.match_standing("marketing", "shell", None, 2_000)
+                .is_none(),
             "another teammate is not who the operator granted"
         );
         assert!(
-            set.match_standing("ops", "workspace_write", 2_000)
+            set.match_standing("ops", "workspace_write", None, 2_000)
                 .is_none(),
             "another tool is not what the operator granted"
         );
+    }
+
+    /// Issue #457, the discrimination that matters. A grant minted from a
+    /// GitHub read admits another GitHub read — the operator consented to a
+    /// provider, not to one action — and refuses a Gmail read. Both are
+    /// catalogue reads, so nothing upstream of this predicate tells them apart:
+    /// same agent, same tool, same grantable verdict.
+    #[test]
+    fn a_scoped_grant_admits_its_own_provider_and_refuses_another() {
+        let set = GrantSet::default();
+        set.grant_standing(scoped("g1", "ops", "composio_execute", "github", 10_000));
+
+        assert!(
+            set.match_standing("ops", "composio_execute", Some("github"), 2_000)
+                .is_some(),
+            "a second GitHub read is the sentence the operator agreed to"
+        );
+        assert!(
+            set.match_standing("ops", "composio_execute", Some("gmail"), 2_000)
+                .is_none(),
+            "'read from GitHub' is not consent to read a mailbox"
+        );
+    }
+
+    /// A call the catalogue cannot place has no scope, and a scoped grant must
+    /// not admit it: it could belong to any provider, and guessing would guess
+    /// permissively. It falls through and parks, which is what this codebase
+    /// does with every unrecognised action.
+    #[test]
+    fn a_scoped_grant_refuses_a_call_with_no_scope_at_all() {
+        let set = GrantSet::default();
+        set.grant_standing(scoped("g1", "ops", "composio_execute", "github", 10_000));
+
+        assert!(
+            set.match_standing("ops", "composio_execute", None, 2_000)
+                .is_none()
+        );
+    }
+
+    /// **Replay compatibility (issue #457).** A `StandingGrantMinted` line
+    /// written before the scope field existed deserializes with `scope: None`,
+    /// and an unscoped grant behaves exactly as it did before this change —
+    /// admitting the tool whatever the live scope is. Without this the upgrade
+    /// would silently void every permission an operator granted before it.
+    #[test]
+    fn a_grant_journaled_before_scopes_existed_replays_and_behaves_as_before() {
+        // The old wire shape, verbatim: no `scope` key anywhere.
+        let line = serde_json::json!({
+            "id": "g-old",
+            "agent": "ops",
+            "tool": "composio_execute",
+            "granted_by": { "kind": "user", "id": "user-1" },
+            "approval_id": "approval-g-old",
+            "at_millis": 1_000,
+            "expires_at_millis": 10_000,
+        });
+        let replayed: StandingGrant =
+            serde_json::from_value(line).expect("an old line still deserializes");
+        assert_eq!(replayed.scope, None, "absent means unscoped, not broken");
+
+        let set = GrantSet::default();
+        set.rehydrate_standing([replayed]);
+
+        // Unscoped: it admits the tool exactly as it did before scopes existed,
+        // whatever the live call resolves to.
+        for live in [Some("github"), Some("gmail"), None] {
+            assert!(
+                set.match_standing("ops", "composio_execute", live, 2_000)
+                    .is_some(),
+                "an unscoped grant must keep admitting: {live:?}"
+            );
+        }
+        // …and the boundaries it always had still hold.
+        assert!(
+            set.match_standing("marketing", "composio_execute", Some("github"), 2_000)
+                .is_none()
+        );
+        assert!(
+            set.match_standing("ops", "composio_execute", Some("github"), 10_000)
+                .is_none()
+        );
+    }
+
+    /// A scoped grant round-trips, and an unscoped one still writes the old
+    /// shape — so a journal read by an older build is unchanged.
+    #[test]
+    fn the_scope_round_trips_and_is_omitted_when_absent() {
+        let unscoped = serde_json::to_value(standing("g1", "ops", "shell", 10_000)).expect("json");
+        assert!(
+            unscoped.get("scope").is_none(),
+            "an unscoped grant writes the pre-#457 line: {unscoped}"
+        );
+
+        let grant = scoped("g2", "ops", "composio_execute", "github", 10_000);
+        let round: StandingGrant =
+            serde_json::from_value(serde_json::to_value(&grant).expect("json"))
+                .expect("round trip");
+        assert_eq!(round, grant);
     }
 
     #[test]
     fn revoking_a_standing_grant_stops_it_matching() {
         let set = GrantSet::default();
         set.grant_standing(standing("g1", "ops", "shell", 10_000));
-        assert!(set.match_standing("ops", "shell", 2_000).is_some());
+        assert!(set.match_standing("ops", "shell", None, 2_000).is_some());
 
         let revoked = set.revoke_standing(&GrantId::new("g1")).expect("was live");
         assert_eq!(revoked.tool, "shell");
-        assert!(set.match_standing("ops", "shell", 2_000).is_none());
+        assert!(set.match_standing("ops", "shell", None, 2_000).is_none());
         assert_eq!(set.standing_count(), 0);
         assert!(
             set.revoke_standing(&GrantId::new("g1")).is_none(),
@@ -743,7 +929,7 @@ mod test {
         assert_eq!(expired[0].id, GrantId::new("old"));
         assert_eq!(set.standing_count(), 1);
         assert!(
-            set.match_standing("ops", "workspace_write", 10_000)
+            set.match_standing("ops", "workspace_write", None, 10_000)
                 .is_some()
         );
     }
@@ -754,7 +940,9 @@ mod test {
         set.grant_standing(standing("short", "ops", "shell", 5_000));
         set.grant_standing(standing("long", "ops", "shell", 50_000));
 
-        let matched = set.match_standing("ops", "shell", 1_000).expect("matches");
+        let matched = set
+            .match_standing("ops", "shell", None, 1_000)
+            .expect("matches");
         assert_eq!(matched.id, GrantId::new("long"));
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -2089,6 +2089,7 @@ mod test {
             at_millis: 1_000,
             expires_at_millis,
             origin_thread: None,
+            scope: None,
         }
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1767,6 +1767,16 @@ struct StandingGrantDto {
     at_millis: u64,
     /// Epoch-millis it stops admitting calls.
     expires_at_millis: u64,
+    /// The slice of the tool it is confined to, when the tool's name is not the
+    /// whole of what it can do (issue #457) — a Composio toolkit, or absent.
+    ///
+    /// On the wire because a permission an operator cannot read is a permission
+    /// they cannot decide to revoke: a row saying only "act in one of its
+    /// connected accounts" does not tell them the grant reaches GitHub and not
+    /// their mailbox. Absent — not `null` — when there is nothing to narrow, so
+    /// the pre-#457 shape is byte-identical for every other tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    scope: Option<String>,
 }
 
 impl From<crate::runtime::grants::StandingGrant> for StandingGrantDto {
@@ -1778,6 +1788,7 @@ impl From<crate::runtime::grants::StandingGrant> for StandingGrantDto {
             granted_by: g.granted_by,
             at_millis: g.at_millis,
             expires_at_millis: g.expires_at_millis,
+            scope: g.scope,
         }
     }
 }
@@ -5094,6 +5105,7 @@ mod test {
                 at_millis: 1_000,
                 expires_at_millis: crate::ports::now_millis() + 60 * 60 * 1000,
                 origin_thread: None,
+                scope: None,
             });
 
         // Both addressing forms list it.


### PR DESCRIPTION
## Summary

Closes #457.

A standing grant recorded an agent and a **tool**. Every Composio read is the same tool, so one grant covered every connected toolkit: the operator read *"read from GitHub"* on the card, approved it for six hours, and what was actually minted was *"make any Composio read, anywhere"* — including from Gmail, or any account connected later.

A grant is now scoped to the toolkit the card was shown for. The scope is minted from the parked effect's own payload, so the grant records what the operator actually read, and it is checked against the live call's toolkit at admission.

A scoped grant against a slug that cannot be resolved does **not** match. It falls through and parks — consistent with the existing rule here that an unrecognisable action is treated as a send.

The scope reaches the console too, because a grant nobody can read is a grant nobody can revoke. A row now reads `Act in one of its connected accounts — Github only · finance · expires in 6h`.

## API Or Behavior Changes

**A Composio standing grant is narrower than it was.** That is the fix. Non-Composio grants are unchanged — for a tool whose name is the whole of what it can do, the scope is `None` and matching behaves exactly as before.

**Journal compatibility is preserved in both directions.** The field is `serde(default, skip_serializing_if)`, so a grant journaled before this change replays as unscoped and keeps its old behaviour, and an unscoped grant still writes the old wire shape — an older build reading a newer journal sees no new key.

One risk worth naming rather than leaving to be discovered: `match_standing` gained a scope parameter. A future third caller that passes `None` instead of computing the live scope would silently reintroduce this bug. The scope is computed by a single shared function taking `(tool, args)` — used by both the mint side and the admission side deliberately, so the two cannot drift into a grant that never matches its own tool.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2338 passed, 0 failed, 2 ignored
- [x] `cargo check --locked --all-features --all-targets`
- [x] `npm ci`, `npm run typecheck`, `npm run build`

No lint or component-test script exists in this repo; neither was run and neither is claimed. `Cargo.lock` unchanged.

The discrimination that matters is pinned twice — at the unit level and through the real policy check: a grant scoped to one provider admits a *different read from the same provider*, and refuses a read from another. `GMAIL_FETCH_EMAILS` was confirmed to be a genuine read in the catalogue first, otherwise that test would have passed for the wrong reason — refused by the grantability check rather than by the scope.

Both replay tests **deserialize pre-change JSON** rather than constructing the struct, so they fail if the field ever stops defaulting.

## Documentation

Behaviour is documented at the new scope function and on the grant field. No spec file covers standing-grant matching.

**A browser check against a live host is owed and is not done here** — the row is user-facing and I could not run the console. The sequence that proves it: connect GitHub and Gmail on a supervised company; have an agent make a GitHub read and approve it for a period; confirm the row names the provider and expiry; have the same agent make a *different* GitHub read (must run without asking); then a **Gmail read — this must park again**. If it runs, the scope is not being compared and the fix is not working. Then revoke from the row and confirm the next GitHub read parks.

Two files outside this change's scope each gained one line — `scope: None` in a test fixture — because `StandingGrant` has no `Default` and the crate does not compile without them.
