### PR TITLE
fix(economy): a card queued during an outage is actually replayed, or the publish says it failed (#454)

### DIFF
--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -6,10 +6,11 @@
 //!   flag standing in for the Identity approval checkpoint) and funding covers
 //!   the registry fee — catching the `402` challenge, budget-checking, then
 //!   completing the paid registration;
-//! - publishes the Agent Card, queuing it to the [`Outbox`] (never erroring)
-//!   when tiny.place is unreachable;
+//! - publishes the Agent Card, parking it in the [`Outbox`] for the attached
+//!   replayer when tiny.place is unreachable — and erroring when no replayer is
+//!   attached, because then nothing would ever send it;
 //! - sends outbound A2A tasks, paying an x402 challenge under budget and
-//!   journaling the spend, or queuing the task when offline;
+//!   journaling the spend, and **failing** rather than queuing when offline;
 //! - quotes and pays firm requirements, **failing closed** the instant a
 //!   payment would exceed either the caller's [`BudgetScope`] or the company's
 //!   monthly ceiling, and journaling every in/out movement to the ledger.
@@ -207,6 +208,23 @@ impl AgentEconomy for TinyplaceEconomy {
         }
     }
 
+    /// Sends an outbound A2A task, and **fails** when tiny.place is unreachable
+    /// rather than deferring it.
+    ///
+    /// This is the deliberate other half of [`publish_card`](Self::publish_card)'s
+    /// contract, and the split is about money (issue #454). A card publish
+    /// degrades and replays: it is idempotent, it costs nothing, and the newest
+    /// card is always the right one to send whenever the network returns. A task
+    /// send does neither. It may carry an x402 payment, the budget scope that
+    /// authorised it belongs to the caller's cycle and is gone by flush time, and
+    /// a replay that lands after the caller already retried is a double-send —
+    /// which here means a double-spend. So the error goes back to the caller, who
+    /// is the only party holding the context to decide whether to retry it.
+    ///
+    /// Before #454 this arm did *both*: it pushed a copy onto the outbox **and**
+    /// returned the error. Nothing ever drained that copy, so it was pure
+    /// unreachable state; had anything drained it, it would have been a
+    /// background double-send with no budget behind it.
     async fn send_a2a_task(&self, to: &AgentAddr, task: A2aTask) -> Result<A2aTaskHandle> {
         let params = serde_json::json!({
             "id": generate_id(),
@@ -239,12 +257,8 @@ impl AgentEconomy for TinyplaceEconomy {
                 Ok(handle_from_response(&response, &rpc.id))
             }
             Err(OpenCompanyError::Tinyplace { code, message }) if code == "unreachable" => {
-                // Offline: queue the task and surface the error so the caller
-                // decides whether to retry.
-                self.outbox.enqueue(OutboxAction::SendTask {
-                    to: to.clone(),
-                    task,
-                });
+                // Offline: surface the error and queue nothing. The caller owns
+                // the retry decision for a task that may cost money.
                 Err(OpenCompanyError::tinyplace("unreachable", message))
             }
             Err(err) => Err(err),
@@ -638,8 +652,11 @@ mod test {
         assert_eq!(economy.outbox().len(), 1, "card queued to the outbox");
     }
 
+    /// Issue #454: an offline task send errors and queues **nothing**. The ghost
+    /// copy it used to push was unreachable state at best and a budget-less
+    /// background double-send at worst.
     #[tokio::test]
-    async fn unreachable_send_task_enqueues_and_errors() {
+    async fn unreachable_send_task_errors_without_queueing() {
         let company = CompanyId::new("acme");
         let (_dir, store) = seeded_store(&company).await;
         let mock = Arc::new(MockTinyplaceClient::new());
@@ -657,7 +674,10 @@ mod test {
             .await
             .unwrap_err();
         assert_eq!(err.code(), "tinyplace_unreachable");
-        assert_eq!(economy.outbox().len(), 1, "task queued despite the error");
+        assert!(
+            economy.outbox().is_empty(),
+            "a paid task is never deferred for background replay"
+        );
     }
 
     #[tokio::test]

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -20,6 +20,8 @@
 //! [`MockTinyplaceClient`](super::client::MockTinyplaceClient).
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use async_trait::async_trait;
 
@@ -42,6 +44,15 @@ const PAY_ASSET: &str = "USDC";
 /// The settlement network used when a firm quote is paid.
 const PAY_NETWORK: &str = "solana";
 
+/// How often an attached replayer retries the queued Agent Card.
+///
+/// There is no connectivity signal in the [`TinyplaceClient`] seam — no
+/// reconnect event, no health stream — so the first tick after the network
+/// returns *is* the reconnect drain. Inventing a listener to sharpen that is out
+/// of scope for #454; a card that is at most one interval stale is the whole
+/// point of a degrade path.
+pub const OUTBOX_REPLAY_INTERVAL: Duration = Duration::from_secs(30);
+
 /// The [`AgentEconomy`] over a [`TinyplaceClient`].
 pub struct TinyplaceEconomy {
     client: Arc<dyn TinyplaceClient>,
@@ -51,6 +62,15 @@ pub struct TinyplaceEconomy {
     monthly_cap: Option<f64>,
     going_public: bool,
     outbox: Arc<Outbox>,
+    /// Whether a background replayer is attached to this economy — i.e. whether
+    /// anything will ever send what [`Self::publish_card`] queues.
+    ///
+    /// Set by exactly one function, [`spawn_outbox_replayer`], and never
+    /// unset. That is what lets the offline publish path answer *"is my degrade
+    /// honest?"* instead of assuming it. A constructor that forgets to attach a
+    /// replayer leaves this `false`, and the publish then errors in the caller's
+    /// face rather than dropping the card in silence.
+    replayer: AtomicBool,
 }
 
 impl TinyplaceEconomy {
@@ -72,6 +92,7 @@ impl TinyplaceEconomy {
             monthly_cap,
             going_public: false,
             outbox: Arc::new(Outbox::new()),
+            replayer: AtomicBool::new(false),
         }
     }
 
@@ -83,9 +104,42 @@ impl TinyplaceEconomy {
         self
     }
 
-    /// The outbox holding actions deferred while tiny.place was unreachable.
+    /// The outbox holding the card deferred while tiny.place was unreachable.
     pub fn outbox(&self) -> &Arc<Outbox> {
         &self.outbox
+    }
+
+    /// Whether a background replayer is attached — see [`spawn_outbox_replayer`].
+    pub fn has_replayer(&self) -> bool {
+        self.replayer.load(Ordering::SeqCst)
+    }
+
+    /// Replays the queued Agent Card, if there is one.
+    ///
+    /// Empty outbox is a silent success — the replayer calls this on a timer, so
+    /// "nothing to do" is the normal case. On continued unreachability the card
+    /// goes back into the slot (unless a newer one landed meanwhile: see
+    /// [`Outbox::requeue`]) and the error is returned, so the next tick tries
+    /// again.
+    ///
+    /// A **rejection** — a `4xx` the server actually answered — is not requeued.
+    /// Retrying it every interval forever would be a hot loop against a card the
+    /// directory has already refused; the error is surfaced, and the next real
+    /// `publish_card` queues a fresh card if one is warranted.
+    pub async fn flush_outbox(&self) -> Result<()> {
+        let Some(OutboxAction::PublishCard(card)) = self.outbox.take() else {
+            return Ok(());
+        };
+        match self.client.put_agent(&self.signer.agent_id(), &card).await {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                if matches!(&err, OpenCompanyError::Tinyplace { code, .. } if code == "unreachable")
+                {
+                    self.outbox.requeue(OutboxAction::PublishCard(card));
+                }
+                Err(err)
+            }
+        }
     }
 
     /// Journals a negative (outflow) ledger movement.
@@ -152,8 +206,63 @@ impl std::fmt::Debug for TinyplaceEconomy {
             .field("monthly_cap", &self.monthly_cap)
             .field("going_public", &self.going_public)
             .field("outbox_len", &self.outbox.len())
+            .field("replayer", &self.has_replayer())
             .finish_non_exhaustive()
     }
+}
+
+/// Attaches the background Agent-Card replayer to a freshly built economy, and
+/// with it the promise that a queued card will actually be sent (issue #454).
+///
+/// **This is the only thing that sets the "a replayer is attached" flag**, which
+/// is what makes the flag mean what it says. [`TinyplaceEconomy::publish_card`]
+/// reads it to decide whether an offline publish may honestly report success, so
+/// a construction path that does not come through here degrades to a visible
+/// error instead of a silent drop. Call it on the concrete economy **before** it
+/// is type-erased into `Arc<dyn AgentEconomy>` — after that the flush surface is
+/// unreachable, which is exactly how the queue ended up with no drain.
+///
+/// # Why a weak reference
+///
+/// The task holds a [`Weak`](std::sync::Weak), not an `Arc`, and exits the first
+/// time the upgrade fails. A runtime rebuild (issue #290) constructs a fresh
+/// economy and drops the old one; with a strong reference the old economy — and
+/// its timer — would live forever, so every rebuild would leak another flusher
+/// publishing an ever-staler card over the live one. Weak makes the replayer's
+/// lifetime exactly the economy's.
+///
+/// `every` is the retry period; production passes [`OUTBOX_REPLAY_INTERVAL`].
+/// It is a parameter rather than a constant read inside so a test can exercise
+/// *this* function — the real attachment path, flag and all — without waiting
+/// out a production interval.
+pub fn spawn_outbox_replayer(economy: &Arc<TinyplaceEconomy>, every: Duration) {
+    economy.replayer.store(true, Ordering::SeqCst);
+    let company = economy.company.clone();
+    let weak = Arc::downgrade(economy);
+    tokio::spawn(async move {
+        let mut ticker = tokio::time::interval(every);
+        loop {
+            ticker.tick().await;
+            let Some(economy) = weak.upgrade() else {
+                // The economy is gone (a rebuild, or shutdown): so is its queue.
+                break;
+            };
+            if economy.outbox.is_empty() {
+                continue;
+            }
+            match economy.flush_outbox().await {
+                Ok(()) => tracing::info!(
+                    company = %company,
+                    "tiny.place: replayed the queued Agent Card; the directory entry is current"
+                ),
+                Err(err) => tracing::warn!(
+                    company = %company,
+                    error = %err,
+                    "tiny.place: replaying the queued Agent Card failed"
+                ),
+            }
+        }
+    });
 }
 
 #[async_trait]
@@ -196,12 +305,42 @@ impl AgentEconomy for TinyplaceEconomy {
         }
     }
 
+    /// Publishes the Agent Card, degrading to the outbox when tiny.place is
+    /// unreachable — **but only when something will actually drain it**
+    /// (issue #454).
+    ///
+    /// This is the inversion the whole issue turns on. The old arm queued
+    /// unconditionally and returned `Ok(())`, and nothing in the tree ever
+    /// drained that queue: `drain()`'s only caller lived in its own test module,
+    /// and the concrete economy is type-erased behind [`AgentEconomy`] the moment
+    /// it is built, so no production code could reach it even in principle. Every
+    /// card published during an outage was therefore dropped while the caller was
+    /// told it had succeeded.
+    ///
+    /// So the `Ok(())` is now *earned*: it is returned only when
+    /// [`spawn_outbox_replayer`] has attached a replayer, which makes the
+    /// sentence "queued, and it will go out" true. With no replayer the original
+    /// unreachable error propagates and nothing is queued — a constructor path
+    /// written later that forgets to attach one inherits a visible error rather
+    /// than the silent drop this issue is about. Fail-safe by construction, the
+    /// same direction as `PublishDestination::Unclaimed` in the harness publish
+    /// queue (issue #445).
     async fn publish_card(&self, _identity: &CompanyIdentity, card: &AgentCard) -> Result<()> {
         match self.client.put_agent(&self.signer.agent_id(), card).await {
             Ok(()) => Ok(()),
-            Err(OpenCompanyError::Tinyplace { code, .. }) if code == "unreachable" => {
-                // Offline: queue the card so it goes stale rather than erroring.
+            Err(OpenCompanyError::Tinyplace { code, message }) if code == "unreachable" => {
+                if !self.has_replayer() {
+                    return Err(OpenCompanyError::tinyplace("unreachable", message));
+                }
+                // Offline, and a replayer is listening: park the newest card and
+                // let it go stale rather than erroring.
                 self.outbox.enqueue(OutboxAction::PublishCard(card.clone()));
+                tracing::warn!(
+                    company = %self.company,
+                    handle = %card.handle,
+                    "tiny.place is unreachable; the Agent Card is queued for replay and the \
+                     directory entry is stale until it lands"
+                );
                 Ok(())
             }
             Err(err) => Err(err),
@@ -633,23 +772,124 @@ mod test {
         assert!(ledger_of(&store, &company).await.is_empty());
     }
 
+    fn card(handle: &str) -> AgentCard {
+        AgentCard {
+            handle: handle.to_string(),
+            ..Default::default()
+        }
+    }
+
+    /// Polls until the outbox drains, bounded so a broken replayer fails the
+    /// test instead of hanging it.
+    async fn drained_within(outbox: &Arc<Outbox>, budget: Duration) -> bool {
+        let step = Duration::from_millis(10);
+        for _ in 0..(budget.as_millis() / step.as_millis()).max(1) {
+            if outbox.is_empty() {
+                return true;
+            }
+            tokio::time::sleep(step).await;
+        }
+        outbox.is_empty()
+    }
+
+    /// Issue #454, the reachability test that matters: an economy built through
+    /// the **production spawn path** may degrade offline, and the card it queued
+    /// is genuinely sent once the network returns.
+    ///
+    /// A test that calls `flush_outbox` by hand would prove the drain works. It
+    /// would not prove the drain is ever *reached* — which is the entire defect,
+    /// since the pre-#454 drain worked fine and had no caller outside its own
+    /// test module. So nothing here touches the flush surface: the replayer's
+    /// own timer is what has to do it.
     #[tokio::test]
-    async fn unreachable_publish_card_enqueues_outbox_not_error() {
+    async fn a_spawned_replayer_queues_offline_then_actually_sends() {
         let company = CompanyId::new("acme");
         let (_dir, store) = seeded_store(&company).await;
         let mock = Arc::new(MockTinyplaceClient::new());
         mock.set_reachable(false);
-        let economy = TinyplaceEconomy::new(mock.clone(), signer(), store, company.clone(), None);
+        let economy = Arc::new(TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store,
+            company.clone(),
+            None,
+        ));
+        spawn_outbox_replayer(&economy, Duration::from_millis(20));
 
-        let card = AgentCard {
-            handle: "acme".into(),
-            ..Default::default()
-        };
         economy
-            .publish_card(&identity(&company), &card)
+            .publish_card(&identity(&company), &card("acme"))
             .await
-            .expect("publish never errors offline");
-        assert_eq!(economy.outbox().len(), 1, "card queued to the outbox");
+            .expect("an offline publish degrades once a replayer is attached");
+        assert_eq!(economy.outbox().len(), 1, "the card is queued");
+        assert_eq!(mock.count("put_agent"), 1, "one refused attempt so far");
+
+        // The network comes back. There is no reconnect signal in the client
+        // seam, so the next interval tick is the drain.
+        mock.set_reachable(true);
+        assert!(
+            drained_within(economy.outbox(), Duration::from_secs(5)).await,
+            "the replayer never drained the outbox"
+        );
+        assert!(
+            mock.count("put_agent") >= 2,
+            "the queued card was replayed onto the wire, not merely dropped"
+        );
+    }
+
+    /// The other side of the same invariant: with no replayer attached, an
+    /// offline publish is an **error** and queues nothing. This is what a
+    /// constructor path that forgets to spawn the replayer inherits — a visible
+    /// failure instead of a card dropped behind an `Ok(())`.
+    #[tokio::test]
+    async fn offline_publish_without_a_replayer_errors_and_queues_nothing() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new());
+        mock.set_reachable(false);
+        // The bare constructor: no `spawn_outbox_replayer`.
+        let economy = TinyplaceEconomy::new(mock.clone(), signer(), store, company.clone(), None);
+        assert!(!economy.has_replayer());
+
+        let err = economy
+            .publish_card(&identity(&company), &card("acme"))
+            .await
+            .unwrap_err();
+        assert_eq!(err.code(), "tinyplace_unreachable");
+        assert!(
+            economy.outbox().is_empty(),
+            "nothing is queued when nothing would drain it"
+        );
+    }
+
+    /// Newest wins: replay only ever needs the current card, so a second offline
+    /// publish replaces the first rather than stacking behind it.
+    #[tokio::test]
+    async fn a_newer_offline_card_replaces_the_queued_one() {
+        let company = CompanyId::new("acme");
+        let (_dir, store) = seeded_store(&company).await;
+        let mock = Arc::new(MockTinyplaceClient::new());
+        mock.set_reachable(false);
+        let economy = Arc::new(TinyplaceEconomy::new(
+            mock.clone(),
+            signer(),
+            store,
+            company.clone(),
+            None,
+        ));
+        // The production interval, so the replayer's timer cannot fire inside
+        // this test: what is asserted is the queue, not the drain.
+        spawn_outbox_replayer(&economy, OUTBOX_REPLAY_INTERVAL);
+
+        let identity = identity(&company);
+        economy.publish_card(&identity, &card("old")).await.unwrap();
+        economy.publish_card(&identity, &card("new")).await.unwrap();
+
+        assert_eq!(economy.outbox().len(), 1, "the outbox stays bounded");
+        assert_eq!(
+            economy.outbox().take(),
+            Some(OutboxAction::PublishCard(card("new"))),
+            "the newest card is what replay would send"
+        );
     }
 
     /// Issue #454: an offline task send errors and queues **nothing**. The ghost

--- a/src/economy/outbox.rs
+++ b/src/economy/outbox.rs
@@ -1,41 +1,60 @@
-//! An in-memory outbox of outbound tiny.place actions deferred while the
-//! network is unreachable.
+//! The one-slot outbox holding the company's Agent Card while tiny.place is
+//! unreachable — and nothing else (issue #454).
 //!
 //! When tiny.place cannot be reached, the [`TinyplaceEconomy`](super::adapter::
-//! TinyplaceEconomy) queues the action here instead of failing boot or a cycle:
-//! the published card goes stale, an outbound task waits, but the runtime keeps
-//! moving. Draining and replaying the queue is the caller's responsibility.
+//! TinyplaceEconomy) parks the card here instead of failing boot or a cycle, and
+//! the replayer attached by
+//! [`spawn_outbox_replayer`](super::adapter::spawn_outbox_replayer) publishes it
+//! once the network comes back. **Queuing is only ever done by a code path that
+//! has a replayer attached** — see [`TinyplaceEconomy::publish_card`](super::
+//! adapter::TinyplaceEconomy::publish_card). A queue nothing drains is not a
+//! degrade, it is a silent drop reported as success.
 //!
-//! In-memory only this phase; a durable, cross-restart outbox is a documented
-//! follow-up.
+//! # Why one slot, and why only the card
+//!
+//! **One slot, newest wins.** Replay only ever needs the *newest* card: the
+//! directory holds one record per agent and a `put_agent` overwrites it, so
+//! publishing an older card after a newer one is strictly wrong, and publishing
+//! both is one wasted round-trip. Collapsing to a single slot therefore bounds
+//! the queue (an outage cannot grow it) and de-duplicates it, in one move.
+//!
+//! **Only the card.** The two other actions this queue used to carry —
+//! registering a `@handle` and sending an A2A task — had no production
+//! enqueuer left once #454 removed the ghost copy `send_a2a_task` was pushing
+//! alongside the error it already returned. A paid outbound task must not be
+//! replayed in the background either: the caller owns that retry, because at
+//! flush time there is no budget scope to charge it against and a double-send is
+//! a double-spend. See [`TinyplaceEconomy::send_a2a_task`](super::adapter::
+//! TinyplaceEconomy::send_a2a_task).
+//!
+//! # Why in-memory is enough now
+//!
+//! This is memory-only and a restart drops whatever is queued — which used to be
+//! a documented follow-up and, with a card-only outbox, is no longer a loss that
+//! needs one. Boot republishes the card from the manifest
+//! ([`maybe_go_public`](crate::runtime::builder)), so a restart during an outage
+//! self-heals: the queued card is exactly the card the next boot would send.
 
 use std::sync::Mutex;
 
-use crate::ports::types::{A2aTask, AgentAddr, AgentCard};
+use crate::ports::types::AgentCard;
 
 /// One deferred outbound action.
+///
+/// Exactly one variant, and that is the invariant rather than an accident: an
+/// action belongs here only if replaying it later, unattended and without the
+/// caller, is *safe*. Publishing a card is idempotent and carries no money, so
+/// it qualifies; a paid task send does not.
 #[derive(Clone, Debug, PartialEq)]
 pub enum OutboxAction {
     /// Publish (or refresh) the company's Agent Card.
     PublishCard(AgentCard),
-    /// Claim or renew a `@handle` registration.
-    Register {
-        /// The `@handle` label to register.
-        label: String,
-    },
-    /// Send an A2A task to a counterparty.
-    SendTask {
-        /// The counterparty address.
-        to: AgentAddr,
-        /// The task to deliver.
-        task: A2aTask,
-    },
 }
 
-/// A thread-safe FIFO queue of [`OutboxAction`]s.
+/// A thread-safe single-slot outbox.
 #[derive(Default)]
 pub struct Outbox {
-    inner: Mutex<Vec<OutboxAction>>,
+    slot: Mutex<Option<OutboxAction>>,
 }
 
 impl Outbox {
@@ -44,24 +63,47 @@ impl Outbox {
         Self::default()
     }
 
-    /// Appends an action to the back of the queue.
+    /// Queues an action, **replacing** whatever was queued before it.
+    ///
+    /// Newest wins: a card published while an older one is still waiting makes
+    /// the older one obsolete, so keeping it would only publish a stale record
+    /// on the way to the current one.
     pub fn enqueue(&self, action: OutboxAction) {
-        self.inner.lock().expect("outbox poisoned").push(action);
+        *self.lock() = Some(action);
     }
 
-    /// Removes and returns every queued action, leaving the outbox empty.
-    pub fn drain(&self) -> Vec<OutboxAction> {
-        std::mem::take(&mut *self.inner.lock().expect("outbox poisoned"))
+    /// Removes and returns the queued action, leaving the outbox empty.
+    pub fn take(&self) -> Option<OutboxAction> {
+        self.lock().take()
     }
 
-    /// The number of actions currently queued.
+    /// Puts an action back after a replay attempt failed — but only if the slot
+    /// is still empty.
+    ///
+    /// The guard is the whole point. A replay takes the card out, awaits a
+    /// network call, and may come back to find that `publish_card` queued a
+    /// *newer* card in the meantime; restoring the old one unconditionally would
+    /// silently undo that write and leave the directory one revision behind for
+    /// good. Newest still wins, even against the replayer.
+    pub fn requeue(&self, action: OutboxAction) {
+        let mut slot = self.lock();
+        if slot.is_none() {
+            *slot = Some(action);
+        }
+    }
+
+    /// The number of actions currently queued — `0` or `1`.
     pub fn len(&self) -> usize {
-        self.inner.lock().expect("outbox poisoned").len()
+        usize::from(self.lock().is_some())
     }
 
-    /// Whether the outbox holds no actions.
+    /// Whether the outbox holds no action.
     pub fn is_empty(&self) -> bool {
-        self.len() == 0
+        self.lock().is_none()
+    }
+
+    fn lock(&self) -> std::sync::MutexGuard<'_, Option<OutboxAction>> {
+        self.slot.lock().expect("outbox poisoned")
     }
 }
 
@@ -69,24 +111,60 @@ impl Outbox {
 mod test {
     use super::*;
 
+    fn card(handle: &str) -> OutboxAction {
+        OutboxAction::PublishCard(AgentCard {
+            handle: handle.to_string(),
+            ..Default::default()
+        })
+    }
+
     #[test]
-    fn enqueue_len_and_drain_round_trip() {
+    fn enqueue_take_round_trip() {
         let outbox = Outbox::new();
         assert!(outbox.is_empty());
-        outbox.enqueue(OutboxAction::Register {
-            label: "acme".into(),
-        });
-        outbox.enqueue(OutboxAction::SendTask {
-            to: AgentAddr("peer".into()),
-            task: A2aTask {
-                skill: "seo.audit".into(),
-                input: serde_json::json!({}),
-            },
-        });
-        assert_eq!(outbox.len(), 2);
+        assert_eq!(outbox.len(), 0);
 
-        let drained = outbox.drain();
-        assert_eq!(drained.len(), 2);
-        assert!(outbox.is_empty(), "drain empties the queue");
+        outbox.enqueue(card("acme"));
+        assert_eq!(outbox.len(), 1);
+        assert_eq!(outbox.take(), Some(card("acme")));
+        assert!(outbox.is_empty(), "take empties the slot");
+        assert_eq!(outbox.take(), None, "an empty outbox takes nothing");
+    }
+
+    #[test]
+    fn newest_card_replaces_the_queued_one() {
+        let outbox = Outbox::new();
+        outbox.enqueue(card("old"));
+        outbox.enqueue(card("new"));
+
+        assert_eq!(outbox.len(), 1, "the queue stays bounded at one card");
+        assert_eq!(
+            outbox.take(),
+            Some(card("new")),
+            "the newest card is the one replay will send"
+        );
+    }
+
+    #[test]
+    fn requeue_restores_only_into_an_empty_slot() {
+        let outbox = Outbox::new();
+        outbox.enqueue(card("first"));
+
+        // A failed replay puts back what it took, and the slot was still empty.
+        let taken = outbox.take().expect("queued");
+        outbox.requeue(taken);
+        assert_eq!(outbox.take(), Some(card("first")));
+
+        // Same sequence, but a newer card landed while the replay was in flight:
+        // restoring must not clobber it.
+        outbox.enqueue(card("first"));
+        let taken = outbox.take().expect("queued");
+        outbox.enqueue(card("newer"));
+        outbox.requeue(taken);
+        assert_eq!(
+            outbox.take(),
+            Some(card("newer")),
+            "a failed replay never overwrites a newer card"
+        );
     }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1921,6 +1921,19 @@ async fn seed_workspace(
 ///
 /// Returns `None` unless `[place].discoverable` is set and a `@handle` is
 /// present; a missing/unreadable identity key degrades to `None` with a warning.
+///
+/// # The one place the Agent-Card replayer is attached (issue #454)
+///
+/// This function is the **only** production path that builds a concrete
+/// [`TinyplaceEconomy`], and the last point at which its outbox is still
+/// reachable: the return type erases it to `Arc<dyn AgentEconomy>`, a trait with
+/// no flush surface, which is precisely how the outbox came to have a `drain()`
+/// whose only caller lived in its own test module. So
+/// [`spawn_outbox_replayer`](crate::economy::adapter::spawn_outbox_replayer) is
+/// called here, before the erasure, and calling it is what entitles
+/// `publish_card` to answer `Ok(())` while offline. Delete the call and every
+/// offline publish starts erroring instead of lying — which is the failure
+/// direction we want, and which a test asserts.
 #[cfg(feature = "tinyplace")]
 async fn maybe_build_economy(
     manifest: &CompanyManifest,
@@ -1930,6 +1943,7 @@ async fn maybe_build_economy(
     tinyplace_api_url: Option<String>,
     going_public: bool,
 ) -> Option<Arc<dyn AgentEconomy>> {
+    use crate::economy::adapter::{OUTBOX_REPLAY_INTERVAL, spawn_outbox_replayer};
     use crate::economy::signer::load_or_create_signer;
     use crate::economy::{HttpTinyplaceClient, TinyplaceEconomy};
     use crate::store::paths::Bundle;
@@ -1950,15 +1964,21 @@ async fn maybe_build_economy(
     let base = tinyplace_api_url
         .unwrap_or_else(|| crate::app::config::DEFAULT_TINYPLACE_API_URL.to_string());
     let client = Arc::new(HttpTinyplaceClient::new(base, signer.clone()));
-    let economy = TinyplaceEconomy::new(
-        client,
-        signer,
-        store,
-        id.clone(),
-        manifest.budget.monthly_usd,
-    )
-    .going_public(going_public);
-    Some(Arc::new(economy))
+    let economy = Arc::new(
+        TinyplaceEconomy::new(
+            client,
+            signer,
+            store,
+            id.clone(),
+            manifest.budget.monthly_usd,
+        )
+        .going_public(going_public),
+    );
+    // Issue #454: attach the replayer while the concrete type is still in hand.
+    // Without this line the outbox has no drain, and `publish_card` knows it —
+    // it stops queuing and starts returning the unreachable error instead.
+    spawn_outbox_replayer(&economy, OUTBOX_REPLAY_INTERVAL);
+    Some(economy)
 }
 
 /// Default build: no tiny.place economy is linked.
@@ -2003,8 +2023,16 @@ async fn maybe_go_public(
                 .map(str::to_string)
                 .unwrap_or_else(|| format!("http://{}", crate::app::config::DEFAULT_BIND));
             let card = build_agent_card(manifest, &base);
+            // Issue #454: an error here now means the card was NOT queued and
+            // nothing will retry it — the offline-but-recoverable case returns
+            // `Ok` and logs its own "queued for replay" line from the adapter, so
+            // the two are no longer the same message.
             if let Err(err) = economy.publish_card(&identity, &card).await {
-                tracing::warn!(company = %id, "tiny.place publish_card failed ({err}); card is stale");
+                tracing::warn!(
+                    company = %id,
+                    "tiny.place publish_card failed ({err}); the card was not queued for replay, \
+                     so the directory entry stays stale until the next boot"
+                );
             } else {
                 tracing::info!(company = %id, handle = %identity.handle, "tiny.place: discoverable (public)");
             }
@@ -3212,6 +3240,71 @@ mod test {
         assert!(runtime.has_economy());
         assert_eq!(mock.count("register_name"), 1, "boot claimed the handle");
         assert_eq!(mock.count("put_agent"), 1, "boot published the card");
+    }
+
+    /// Issue #454, at the construction path that actually runs in production.
+    ///
+    /// The economy above is *injected*, so it proves nothing about how a real
+    /// company's economy is assembled. This one goes through
+    /// [`maybe_build_economy`] — the only production builder of a
+    /// [`TinyplaceEconomy`] — and asserts the property that only holds when the
+    /// outbox replayer was attached before the type erasure: an offline
+    /// `publish_card` returns `Ok`, because there is now something that will send
+    /// the card it queued.
+    ///
+    /// **This test is the guard on that one line.** Delete
+    /// `spawn_outbox_replayer(&economy, …)` from `maybe_build_economy` and the
+    /// publish below returns `tinyplace_unreachable` instead — verified by doing
+    /// exactly that.
+    #[cfg(feature = "tinyplace")]
+    #[tokio::test]
+    async fn discoverable_path_builds_an_economy_that_can_degrade_offline() {
+        use crate::economy::build_agent_card;
+        use crate::ports::CompanyStore;
+        use crate::ports::types::CompanyIdentity;
+        use crate::store::FsCompanyStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Acme"
+            handle = "acme"
+            [place]
+            discoverable = true
+            "#,
+        );
+        let id = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> = Arc::new(FsCompanyStore::new(dir.path().to_path_buf()));
+
+        // A port nothing listens on: every call is refused, which is exactly the
+        // `unreachable` condition the outbox exists for. Bound and released so
+        // the OS confirms it is free, rather than guessing a number.
+        let dead = {
+            let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            probe.local_addr().unwrap()
+        };
+
+        let economy = maybe_build_economy(
+            &manifest,
+            dir.path(),
+            &id,
+            store,
+            Some(format!("http://{dead}")),
+            true,
+        )
+        .await
+        .expect("a discoverable company with a handle gets an economy");
+
+        let identity = CompanyIdentity {
+            company: id.clone(),
+            handle: "acme".to_string(),
+        };
+        let card = build_agent_card(&manifest, "http://127.0.0.1:8080");
+        economy
+            .publish_card(&identity, &card)
+            .await
+            .expect("the built economy degrades offline, which it may only do with a replayer");
     }
 
     /// Spawns an in-process OpenAI-compatible stub that answers every


### PR DESCRIPTION
## Summary

Closes #454.

When tiny.place was unreachable, `publish_card` queued the card onto an outbox and returned `Ok(())`. **The only caller of `Outbox::drain()` in the whole tree lived inside its own `#[cfg(test)]` module.** The concrete economy is type-erased behind a trait with no flush surface, so no production code could ever reach that queue — every card published during an outage was lost, while the caller was told it succeeded.

This is the recurring defect class here: stage the work, return an unqualified success, depend on a drain that never runs. `publish.rs` (#452) is the merged template, and this follows it.

Two halves:

**A drain that exists.** A replayer is spawned where the economy is built — the single production attachment point — holding a weak reference so a runtime rebuild cannot leak it, and re-queuing on continued unreachability. The card slot is bounded to one entry, newest wins, because replay only ever needs the newest and the next boot republishes from the manifest anyway.

**A success that is true.** The unreachable arm now returns `Ok(())` only when a replayer is attached to send it. Without one it propagates the original error and queues nothing. A constructor path that forgets to spawn the replayer inherits a visible error instead of a silent drop — which is the guarantee, rather than fixing the two call sites that exist today.

`send_a2a_task` no longer queues a ghost copy alongside its `Err`. Background replay of a paid task is a double-send hazard with no budget context at flush time, so the contract splits deliberately: **a card publish degrades and replays; a task send fails and tells.**

## API Or Behavior Changes

**An offline card publish can now return an error where it previously always returned `Ok`.** That is the fix — the previous `Ok` was false whenever no replayer existed, which was always in production.

Two outbox variants with no production producer were pruned; the queue now holds exactly the one idempotent action it can honestly replay.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged. No user-facing surface — this is tiny.place wire traffic and logs — so backend proof is the whole of it.

**A test that the drain works when called is not coverage that the drain is reached**, which is exactly how this bug survived: the outbox already had a passing round-trip test and no production caller. So the assertions here are about reachability:

- built through the **production spawn path**, offline publish queues, then on reconnection the card is actually sent and the outbox empties;
- built through the **bare constructor** with no replayer, offline publish returns `Err` and queues nothing;
- a **builder-level** test asserting the discoverable path yields an economy that can degrade offline — a property that only holds while the spawn call is present.

Delete the spawn call and offline publishes start erroring instead of lying. That is the failure direction we want, and a test asserts it.

## Documentation

The outbox module doc now states the restart-loss position plainly: with a card-only queue the loss self-heals on the next boot, because the card is rebuilt from the manifest. Durable cross-restart replay remains a separate concern.

**One thing reviewers should know: CI compiles this code but never runs it.** No test or clippy lane enables the `tinyplace` feature — every job uses default features or `openhuman,tinycortex`, and the `--all-features` step is `cargo check` only. That gap is filed as #477. Until it is closed, these tests were run locally and CI's green says nothing about them.
