### PR TITLE
fix(store): a torn ledger line, unshared write locks, a log flood, and a /tmp keyring (#387, #388, #449, #451)

### DIFF
--- a/src/app/journal.rs
+++ b/src/app/journal.rs
@@ -29,9 +29,20 @@
 //!   condition it would retry against cannot resolve itself while the process
 //!   lives, because the mount is read-only for the lifetime of the pod.
 //!
-//! Only the resolved *path* is reported at startup. No environment value other
-//! than `OPENHUMAN_WORKSPACE` is read here and none is echoed, so the startup
+//! Only the resolved *path* is reported at startup. The only environment values
+//! read here are `OPENHUMAN_WORKSPACE` and — for the temp-directory guard below
+//! — the platform's temp-dir variable, and neither is echoed, so the startup
 //! line cannot carry credential material.
+//!
+//! # The keyring rides the same root
+//!
+//! `pin_keyring` registers the resolved root as the vendored runtime's
+//! *keyring* directory too, so secret material lands beside the journal rather
+//! than in whatever its own fallback chain reaches — a chain that ends, if no
+//! home directory resolves, at `/tmp` with no log line at all (issue #451). The
+//! export above happens to steer it correctly today, but only because nothing
+//! has touched the keyring yet; registering says it outright instead of relying
+//! on startup order.
 
 use std::path::{Path, PathBuf};
 
@@ -184,6 +195,130 @@ pub async fn prepare(data_dir: &Path) -> Result<JournalRoot> {
     Ok(resolved)
 }
 
+// ---------------------------------------------------------------------------
+// Keyring pin (issue #451)
+// ---------------------------------------------------------------------------
+
+/// Where the vendored keyring writes its secret material, once [`pin_keyring`]
+/// has registered it.
+#[cfg(feature = "openhuman")]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct KeyringPin {
+    dir: PathBuf,
+    source: RootSource,
+    temporary: bool,
+}
+
+#[cfg(feature = "openhuman")]
+impl KeyringPin {
+    /// The directory the vendored keyring will resolve to.
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    /// Whether the pinned directory sits under the system temp directory — see
+    /// [`pin_keyring`] for why that is reported rather than refused.
+    pub fn is_temporary(&self) -> bool {
+        self.temporary
+    }
+
+    /// The one-line startup report: which directory holds the credentials, and
+    /// the caveat when that directory is temporary.
+    pub fn summary(&self) -> String {
+        let base = format!(
+            "keyring: {} (pinned, from {})",
+            self.dir.display(),
+            self.source.as_str()
+        );
+        if self.temporary {
+            format!(
+                "{base} — WARNING: this is under the system temp directory. \
+                 Credentials stored here can be removed by the OS at any time, \
+                 and connected accounts will silently need reconnecting. Point \
+                 {} at a durable volume for anything but local development.",
+                self.source.as_str()
+            )
+        } else {
+            base
+        }
+    }
+}
+
+/// Whether `dir` lies inside `temp_dir`.
+///
+/// Component-wise by construction ([`Path::starts_with`] compares whole
+/// components), so `/tmpfoo` is not treated as being under `/tmp`.
+#[cfg(feature = "openhuman")]
+fn under_temp_dir(dir: &Path, temp_dir: &Path) -> bool {
+    dir.starts_with(temp_dir)
+}
+
+/// Registers `root` as the vendored keyring's workspace, so credential storage
+/// lands beside the journal instead of wherever its own fallback chain ends up.
+///
+/// # Why register rather than rely on the export
+///
+/// The vendored resolver
+/// (`keyring::store::workspace_dir_for_file_backend`) tries, in order: a
+/// directory registered through its `init_workspace` seam, then
+/// `OPENHUMAN_WORKSPACE`, then the user's home directory — and if it cannot
+/// find a home directory at all, `/tmp`, at no log level whatsoever.
+///
+/// [`prepare`] already exports `OPENHUMAN_WORKSPACE`, so today a hosted tenant
+/// happens to land in the data dir. That is safe **by accident**: the resolved
+/// value is cached in a `OnceLock`, so whichever code touches the keyring first
+/// fixes the answer for the life of the process. Nothing enforces that the
+/// export happens before that first touch — it holds because of the order two
+/// unrelated pieces of startup currently run in, which is not a property anyone
+/// is checking when they move code around. If a touch ever lands first, secret
+/// material silently goes to `$HOME` (the read-only root filesystem in a tenant)
+/// or to `/tmp`, with no error and no log line to say so.
+///
+/// Registering explicitly removes the ordering dependency instead of restating
+/// it: after this call the first branch of the resolver matches, so the env-var
+/// branch, the home branch and the `/tmp` branch are all unreachable regardless
+/// of what runs when. `init_workspace` is idempotent-by-first-writer (it logs at
+/// debug and ignores a second call), and this is called once from `serve`.
+///
+/// # Loudness, not refusal
+///
+/// A pinned root under the system temp directory earns a `warn!` naming the path
+/// and what it costs — not a refusal. Pointing `OPENCOMPANY_DATA_DIR` at a temp
+/// path is a legitimate thing to do in local development and in tests; the
+/// defect this addresses was never that credentials *could* be temporary, it was
+/// that they could become temporary in **silence**.
+///
+/// # Owed upstream
+///
+/// The `/tmp` fallback itself still exists in `vendor/openhuman` and should be
+/// removed there — a keyring that cannot resolve a durable directory should
+/// fail loudly rather than quietly choosing world-readable scratch space. That
+/// is a vendored-crate change and is out of scope here; this function makes the
+/// fallback unreachable for `opencompany serve`, which is the half this crate
+/// can own.
+#[cfg(feature = "openhuman")]
+pub fn pin_keyring(root: &JournalRoot) -> KeyringPin {
+    let dir = root.root().to_path_buf();
+    openhuman_core::openhuman::keyring::init_workspace(&dir);
+
+    let temporary = under_temp_dir(&dir, &std::env::temp_dir());
+    if temporary {
+        tracing::warn!(
+            keyring = %dir.display(),
+            knob = root.source().as_str(),
+            "[keyring] secret material is being stored under the system temp directory; \
+             the OS may remove it at any time and connected accounts will silently need \
+             reconnecting — point the data directory at a durable volume outside local development",
+        );
+    }
+
+    KeyringPin {
+        dir,
+        source: root.source(),
+        temporary,
+    }
+}
+
 /// Creates `root` and confirms a file can actually be written inside it.
 ///
 /// `create_dir_all` alone is not proof: it succeeds silently when the directory
@@ -242,6 +377,14 @@ mod test {
     /// The data dir the child compares against.
     #[cfg(feature = "openhuman")]
     const SEAM_DATA_DIR_ENV: &str = "OC_JOURNAL_SEAM_DATA_DIR";
+
+    /// The child test the keyring-pin test re-invokes this binary to run.
+    #[cfg(feature = "openhuman")]
+    const KEYRING_CHILD_TEST: &str = "app::journal::test::keyring_pin_child";
+
+    /// The data dir the keyring-pin child pins against.
+    #[cfg(feature = "openhuman")]
+    const KEYRING_DATA_DIR_ENV: &str = "OC_KEYRING_PIN_DATA_DIR";
 
     #[test]
     fn absent_env_roots_the_journal_in_the_data_dir() {
@@ -533,6 +676,130 @@ mod test {
             ),
             other => panic!("unknown seam role {other:?}"),
         }
+    }
+
+    /// The temp-dir guard compares whole components, so a sibling directory
+    /// whose name merely starts with the temp dir's is not "inside" it.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn the_temp_dir_guard_compares_components_not_prefixes() {
+        let temp = Path::new("/tmp");
+
+        assert!(under_temp_dir(Path::new("/tmp/oc/openhuman"), temp));
+        assert!(under_temp_dir(temp, temp), "the temp dir itself counts");
+        assert!(
+            !under_temp_dir(Path::new("/tmpfoo/openhuman"), temp),
+            "a name that merely begins with the temp dir's is a different directory"
+        );
+        assert!(!under_temp_dir(Path::new("/data/openhuman"), temp));
+        assert!(!under_temp_dir(Path::new("/var/lib/oc"), temp));
+    }
+
+    /// With `OPENHUMAN_WORKSPACE` unset, the vendored keyring must **still**
+    /// resolve to the data-dir root — i.e. `$HOME` and its `/tmp` fallback are
+    /// unreachable because the directory was registered, not inferred (#451).
+    ///
+    /// The negative half is what makes this worth running: the child's `HOME`
+    /// points somewhere real and writable, so if the pin did nothing the
+    /// resolver would happily answer with `$HOME/.openhuman` and the assertion
+    /// would fail rather than pass vacuously.
+    ///
+    /// Run in a **child process** for the same reason the vendored-seam test
+    /// above is: the registration is a process-global `OnceLock` set-once, so it
+    /// cannot be undone between tests, and `HOME` cannot be varied in-process
+    /// without racing every other environment reader in this binary.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn pinning_keeps_the_keyring_out_of_home_without_the_env_var() {
+        let data_dir = scratch_root("keyring-pin");
+        // Deliberately a sibling of the data dir, not a child, so "did the
+        // keyring land under the data dir?" cannot be satisfied by $HOME.
+        let home = scratch_root("keyring-pin-home");
+        std::fs::create_dir_all(&data_dir).unwrap();
+        std::fs::create_dir_all(&home).unwrap();
+
+        let out = std::process::Command::new(std::env::current_exe().unwrap())
+            .args([KEYRING_CHILD_TEST, "--exact", "--ignored", "--nocapture"])
+            .env(KEYRING_DATA_DIR_ENV, &data_dir)
+            .env("HOME", &home)
+            // The whole point: the pin must work with the seam variable absent.
+            .env_remove(OPENHUMAN_WORKSPACE_ENV)
+            .output()
+            .expect("spawn the keyring-pin child process");
+
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let detail = format!(
+            "--- child stdout ---\n{stdout}\n--- child stderr ---\n{}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(out.status.success(), "{detail}");
+        // A filter that stops matching makes libtest run nothing and still exit
+        // 0, so success alone would be a vacuous pass.
+        assert!(
+            stdout.contains("1 passed"),
+            "the child must have actually run the assertion, not filtered it \
+             away — is {KEYRING_CHILD_TEST} still the right path?\n{detail}"
+        );
+
+        std::fs::remove_dir_all(&data_dir).ok();
+        std::fs::remove_dir_all(&home).ok();
+    }
+
+    /// The assertion half of the keyring-pin test, executed in the child process
+    /// the test above spawns. Ignored so a normal run never picks it up, and
+    /// inert unless the parent set the data dir, so a bare
+    /// `cargo test -- --ignored` cannot fail on a missing environment.
+    #[cfg(feature = "openhuman")]
+    #[test]
+    #[ignore = "spawned by pinning_keeps_the_keyring_out_of_home_without_the_env_var"]
+    fn keyring_pin_child() {
+        let Ok(data_dir) = std::env::var(KEYRING_DATA_DIR_ENV) else {
+            return;
+        };
+        let data_dir = PathBuf::from(data_dir);
+        assert!(
+            std::env::var(OPENHUMAN_WORKSPACE_ENV).is_err(),
+            "the parent must unset the seam variable — the registration, not the \
+             export, is what this test proves"
+        );
+
+        let expected = resolve(None, &data_dir);
+        let pin = pin_keyring(&expected);
+        assert_eq!(pin.dir(), expected.root());
+
+        let resolved = openhuman_core::openhuman::keyring::store::workspace_dir_for_file_backend();
+        assert_eq!(
+            resolved,
+            expected.root(),
+            "the vendored keyring must answer with the registered root"
+        );
+        assert!(
+            resolved.starts_with(&data_dir),
+            "secret material must resolve inside the data dir, got {}",
+            resolved.display()
+        );
+
+        // The home fallback is real and writable here, so this is the branch the
+        // pin actually displaced — and `/tmp` sits one step further down the
+        // same chain.
+        let home = PathBuf::from(std::env::var("HOME").expect("the parent sets HOME"));
+        assert!(
+            !resolved.starts_with(&home),
+            "the keyring must not fall back to $HOME once a root is registered"
+        );
+
+        // The data dir is scratch space under the system temp dir, so the
+        // loudness guard fires — and it warns rather than refusing, which is why
+        // `pin_keyring` returned at all.
+        assert!(
+            pin.is_temporary(),
+            "a root under the system temp dir must be flagged"
+        );
+        assert!(
+            pin.summary().contains("WARNING"),
+            "the startup line must carry the caveat: {}",
+            pin.summary()
+        );
     }
 
     /// Puts an owner-writable mode back on `dir` so the test's own cleanup can

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -870,6 +870,24 @@ async fn main() -> Result<()> {
             // warning above: the default `EnvFilter` would swallow an `info!`.
             let journal = opencompany::app::journal::prepare(&data_root).await?;
             println!("{}", journal.summary());
+            // Register the same root as the vendored keyring's directory, so
+            // credential storage cannot resolve to `$HOME` — or, further down
+            // the same fallback chain, to `/tmp` at no log level (issue #451).
+            // The export above already steers it there in practice, but only
+            // because nothing has touched the keyring yet; the resolved value is
+            // cached in a `OnceLock`, so the guarantee rests on startup ordering
+            // nobody is checking. Registering says it outright.
+            //
+            // Here, and not later: this runs before any company runtime, agent
+            // harness or HTTP listener exists, so the pin cannot lose a race to
+            // a first keyring touch. `println!` for the same reason as the lines
+            // around it — the default `EnvFilter` would swallow an `info!`, and
+            // an operator needs to be able to see where the credentials live.
+            #[cfg(feature = "openhuman")]
+            println!(
+                "{}",
+                opencompany::app::journal::pin_keyring(&journal).summary()
+            );
             // Soft disk-quota alerting. Hard enforcement is the container /
             // StorageClass layer's job (EFS access point, k8s ResourceQuota);
             // here we surface an operator-visible warning when a workspace

--- a/src/feedback/store.rs
+++ b/src/feedback/store.rs
@@ -17,9 +17,21 @@ use crate::ports::generate_id;
 use crate::store::paths::Bundle;
 
 /// A per-company append-only store of [`FeedbackItem`]s.
+///
+/// Holds no lock of its own. Writes serialise on the process-wide, **path-keyed**
+/// registry in [`store::fs`](crate::store::fs) (issue #388) — see
+/// [`path_lock`](crate::store::fs::path_lock) for the two limits that registry
+/// accepts by construction (absolutising is not canonicalising; a second process
+/// is outside any in-process lock's reach, and write atomicity is what keeps
+/// that case safe).
+///
+/// It used to hold a bare `TokioMutex<()>` field, which is a weaker thing than
+/// it looks: [`new`](Self::new) mints a fresh mutex per call, so two stores over
+/// one bundle each held their own and serialised against nothing. That mattered
+/// because [`update_status`](Self::update_status) is a read-modify-write — an
+/// append landing between its read and its rename was erased outright.
 pub struct FeedbackStore {
     path: PathBuf,
-    write_lock: TokioMutex<()>,
 }
 
 impl FeedbackStore {
@@ -27,8 +39,12 @@ impl FeedbackStore {
     pub fn new(bundle: &Bundle) -> Self {
         Self {
             path: bundle.feedback_items_jsonl(),
-            write_lock: TokioMutex::new(()),
         }
+    }
+
+    /// The process-wide write lock for this store's log.
+    fn write_lock(&self) -> std::sync::Arc<TokioMutex<()>> {
+        crate::store::fs::path_lock(&self.path)
     }
 
     /// Appends a feedback item to the log.
@@ -44,7 +60,8 @@ impl FeedbackStore {
     /// `store::fs::append_line`; the feedback store was the remaining twin.
     pub async fn append(&self, item: &FeedbackItem) -> Result<()> {
         let line = serde_json::to_string(item)?;
-        let _guard = self.write_lock.lock().await;
+        let lock = self.write_lock();
+        let _guard = lock.lock().await;
         if let Some(parent) = self.path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
@@ -73,7 +90,8 @@ impl FeedbackStore {
     /// Records a filed issue's URL and status against an item, rewriting the log
     /// atomically. Closing-the-loop uses this to track status changes.
     pub async fn update_status(&self, id: &str, url: &str, status: &str) -> Result<()> {
-        let _guard = self.write_lock.lock().await;
+        let lock = self.write_lock();
+        let _guard = lock.lock().await;
         let mut items = self.list_unlocked().await?;
         for item in &mut items {
             if item.id == id {
@@ -205,6 +223,76 @@ mod test {
         // The other item is untouched.
         let other = all.iter().find(|i| i.id == a.id).unwrap();
         assert!(other.filed_issue_url.is_none());
+        tokio::fs::remove_dir_all(bundle.dir()).await.ok();
+    }
+
+    /// Two feedback stores over one bundle must not erase each other's writes
+    /// (issue #388).
+    ///
+    /// `update_status` is a read-modify-write: it reads the whole log, edits one
+    /// item in memory, and rewrites the file atomically. An append that lands
+    /// between that read and the rename is **gone** — the rewrite replaces the
+    /// file with a snapshot taken before it existed.
+    ///
+    /// The lock that was supposed to prevent this was a bare
+    /// `TokioMutex<()>` **field** on `FeedbackStore`, so it only ever serialised
+    /// one instance against itself. `FeedbackStore::new(&bundle)` takes a bundle
+    /// and builds a fresh mutex every time, so two call sites over one company —
+    /// a console request handler and the closing-the-loop poller, say — hold two
+    /// unrelated locks over one file and serialise against nothing. Keying the
+    /// lock on the *path* in a process-wide registry is what makes the two
+    /// instances meet.
+    #[tokio::test]
+    async fn two_feedback_stores_over_one_bundle_do_not_erase_each_others_writes() {
+        let (_root, bundle) = tmp_bundle();
+        // Two independently-constructed stores over the same bundle.
+        let appender = std::sync::Arc::new(FeedbackStore::new(&bundle));
+        let updater = std::sync::Arc::new(FeedbackStore::new(&bundle));
+
+        // Seed one item so the updater has something to rewrite around.
+        let seed = item("seed");
+        updater.append(&seed).await.unwrap();
+
+        const APPENDS: usize = 32;
+        const UPDATES: usize = 8;
+        let mut set = tokio::task::JoinSet::new();
+        for i in 0..APPENDS {
+            let store = appender.clone();
+            set.spawn(async move { store.append(&item(&format!("note-{i}"))).await });
+        }
+        for i in 0..UPDATES {
+            let store = updater.clone();
+            let id = seed.id.clone();
+            set.spawn(async move {
+                store
+                    .update_status(&id, &format!("https://example/issues/{i}"), "open")
+                    .await
+            });
+        }
+        while let Some(res) = set.join_next().await {
+            res.expect("task joins").expect("write succeeds");
+        }
+
+        let all = appender.list().await.expect("no corrupt lines");
+        let mut notes: Vec<String> = all.iter().map(|i| i.operator_words.clone()).collect();
+        notes.sort();
+        let mut want: Vec<String> = (0..APPENDS).map(|i| format!("note-{i}")).collect();
+        want.push("seed".to_string());
+        want.sort();
+        assert_eq!(
+            notes, want,
+            "a whole-file rewrite must not erase an append that raced it — every \
+             item written by either instance has to survive"
+        );
+
+        // The update itself still landed, so serialising did not cost the write.
+        let updated = all.iter().find(|i| i.id == seed.id).expect("seed survives");
+        assert!(
+            updated.filed_issue_url.is_some(),
+            "the status update must be recorded"
+        );
+        assert_eq!(updated.issue_status.as_deref(), Some("open"));
+
         tokio::fs::remove_dir_all(bundle.dir()).await.ok();
     }
 

--- a/src/feedback/store.rs
+++ b/src/feedback/store.rs
@@ -19,11 +19,10 @@ use crate::store::paths::Bundle;
 /// A per-company append-only store of [`FeedbackItem`]s.
 ///
 /// Holds no lock of its own. Writes serialise on the process-wide, **path-keyed**
-/// registry in [`store::fs`](crate::store::fs) (issue #388) — see
-/// [`path_lock`](crate::store::fs::path_lock) for the two limits that registry
-/// accepts by construction (absolutising is not canonicalising; a second process
-/// is outside any in-process lock's reach, and write atomicity is what keeps
-/// that case safe).
+/// registry in `store::fs` (issue #388) — see `store::fs::path_lock` for the two
+/// limits that registry accepts by construction (absolutising is not
+/// canonicalising; a second process is outside any in-process lock's reach, and
+/// write atomicity is what keeps that case safe).
 ///
 /// It used to hold a bare `TokioMutex<()>` field, which is a weaker thing than
 /// it looks: [`new`](Self::new) mints a fresh mutex per call, so two stores over

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -664,6 +664,58 @@ fn is_transient_empty_response(err: &anyhow::Error) -> bool {
         .contains("empty response")
 }
 
+/// What a workspace-ensure attempt should say, given what the last attempt for
+/// the same agent said (issue #449).
+///
+/// The attempt itself is per dispatch and stays that way — see
+/// [`note_workspace_attempt`](HarnessPool::note_workspace_attempt) for why
+/// memoising it is the wrong fix. Only the *reporting* is edge-triggered.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum WorkspaceReport {
+    /// The first failure since this agent was last healthy: report it.
+    Failed,
+    /// Still failing, and already reported: say nothing.
+    StillFailing,
+    /// Working again after a reported failure: say so once, so a reader who saw
+    /// the error learns it ended.
+    Recovered,
+    /// Working, and was already working: say nothing.
+    StillHealthy,
+}
+
+impl WorkspaceReport {
+    /// Whether this transition has anything to log at all.
+    pub(crate) fn is_silent(self) -> bool {
+        matches!(self, Self::StillFailing | Self::StillHealthy)
+    }
+}
+
+/// Folds one attempt's outcome into the set of currently-failing keys and
+/// returns what to report.
+///
+/// Pure but for the `failing` set it edits, so the whole state machine is
+/// testable without a model, a roster or a filesystem. `failing` holds exactly
+/// the keys whose last attempt failed **and** whose failure has been reported;
+/// `failed` is this attempt's outcome.
+fn workspace_report<K>(failing: &mut HashSet<K>, key: &K, failed: bool) -> WorkspaceReport
+where
+    K: std::hash::Hash + Eq + Clone,
+{
+    if failed {
+        // `insert` returns false when the key was already there — i.e. the
+        // previous attempt failed and was already reported.
+        if failing.insert(key.clone()) {
+            WorkspaceReport::Failed
+        } else {
+            WorkspaceReport::StillFailing
+        }
+    } else if failing.remove(key) {
+        WorkspaceReport::Recovered
+    } else {
+        WorkspaceReport::StillHealthy
+    }
+}
+
 /// A pool of live agents, one roster per company.
 pub struct HarnessPool {
     agents: RwLock<HashMap<CompanyId, Vec<Arc<CompanyAgent>>>>,
@@ -722,6 +774,19 @@ pub struct HarnessPool {
     /// A company that never sets an override keeps an empty set and a stable
     /// fingerprint — no rebuild, byte-identical to the pre-#343 behaviour.
     budget_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// The `(company, agent)` pairs whose last workspace-ensure failed and whose
+    /// failure has already been reported (issue #449).
+    ///
+    /// Not a memo of the *attempt* — see
+    /// [`note_workspace_attempt`](Self::note_workspace_attempt). Purely a record
+    /// of what has already been said, so an unmountable volume produces one
+    /// error line instead of one per turn forever.
+    ///
+    /// A `std::sync::Mutex` rather than a `tokio::sync::RwLock` like its
+    /// neighbours: the critical section is a single hash lookup with no `await`
+    /// in it, so the async lock would buy nothing and cost a scheduling point on
+    /// the dispatch path.
+    workspace_failures: std::sync::Mutex<HashSet<(CompanyId, String)>>,
 }
 
 impl Default for HarnessPool {
@@ -754,7 +819,42 @@ impl HarnessPool {
             composio_fingerprints: RwLock::new(HashMap::new()),
             skill_fingerprints: RwLock::new(HashMap::new()),
             budget_fingerprints: RwLock::new(HashMap::new()),
+            workspace_failures: std::sync::Mutex::new(HashSet::new()),
         }
+    }
+
+    /// Records one workspace-ensure outcome for `(company, agent)` and returns
+    /// what it should say.
+    ///
+    /// **The attempt stays per dispatch.** The obvious fix for a repeating log
+    /// line — remember that this agent's workspace was already handled and stop
+    /// trying — is the wrong one in both directions, and this is why the
+    /// suppression is on the reporting rather than on the work:
+    ///
+    /// * Memoising **success** means a data dir wiped or restored *after* the
+    ///   first successful turn is never noticed again, and every relative file
+    ///   write is refused for the life of the process — the exact regression
+    ///   issue #409 added the per-dispatch retry to prevent.
+    /// * Memoising **failure** means a volume that mounts a second late never
+    ///   recovers, because nothing ever tries again.
+    ///
+    /// Both trade a noisy log for a broken agent. The retry is cheap (two
+    /// syscalls on the already-exists path, against a turn about to call a
+    /// model) and it is what makes the condition self-healing, so it keeps
+    /// running every time. What changes is that a persistent failure is stated
+    /// once rather than once per turn.
+    fn note_workspace_attempt(
+        &self,
+        company: &CompanyId,
+        agent_id: &str,
+        failed: bool,
+    ) -> WorkspaceReport {
+        let key = (company.clone(), agent_id.to_string());
+        let mut failing = self
+            .workspace_failures
+            .lock()
+            .expect("workspace-failure set poisoned");
+        workspace_report(&mut failing, &key, failed)
     }
 
     /// Ensures a company's roster is built and cached.
@@ -1230,15 +1330,38 @@ impl HarnessPool {
         // not: an agent with no file grant runs a perfectly good turn without
         // this directory. The `error!` (not `warn!`) records the one condition
         // under which the misdirecting guard message can still be reached, so it
-        // is greppable next to the refusal it explains.
-        if let Err(error) = build::ensure_agent_workspace(&deps.workspace_root, company, agent_id) {
-            tracing::error!(
-                company = %company,
-                agent = agent_id,
-                workspace = %build::agent_workspace(&deps.workspace_root, company, agent_id).display(),
-                %error,
-                "[harness] could not create the agent workspace before dispatch; relative file writes will be refused (the refusal will read as a workspace escape, but the cause is this missing directory)"
-            );
+        // is greppable next to the refusal it explains. Both of those are the
+        // right calls and issue #449 does not change either.
+        //
+        // What #449 changes is only how often it is *said*. A workspace root
+        // that cannot be written — a volume that failed to mount, a path that
+        // resolves onto a file — fails identically on every dispatch, so the
+        // unconditional `error!` emitted one byte-identical line per turn,
+        // forever, with nothing distinguishing the thousandth from the first.
+        // The state is edge-triggered instead: the first failure reads exactly
+        // as it did before, the repeats are silent, and a recovery gets one
+        // `info!` so a reader who saw the error learns when it ended. The
+        // attempt itself still runs every dispatch — see
+        // `note_workspace_attempt` for why memoising it would be a regression.
+        let attempt = build::ensure_agent_workspace(&deps.workspace_root, company, agent_id);
+        let report = self.note_workspace_attempt(company, agent_id, attempt.is_err());
+        if !report.is_silent() {
+            let workspace = build::agent_workspace(&deps.workspace_root, company, agent_id);
+            match attempt {
+                Err(error) => tracing::error!(
+                    company = %company,
+                    agent = agent_id,
+                    workspace = %workspace.display(),
+                    %error,
+                    "[harness] could not create the agent workspace before dispatch; relative file writes will be refused (the refusal will read as a workspace escape, but the cause is this missing directory)"
+                ),
+                Ok(_) => tracing::info!(
+                    company = %company,
+                    agent = agent_id,
+                    workspace = %workspace.display(),
+                    "[harness] agent workspace is available again; the earlier creation failure has cleared and relative file writes work"
+                ),
+            }
         }
 
         // Plan-level total-token ceiling (issue #188): a HARD dispatch refusal
@@ -2262,6 +2385,155 @@ description = "Builds the product."
         assert!(
             matches!(err, OpenCompanyError::CompanyNotFound(_)),
             "{err:?}"
+        );
+    }
+
+    // --- Workspace-ensure log edge-triggering (issue #449) -------------------
+
+    /// The whole transition table, exhaustively: a broken volume must produce
+    /// one error line and then nothing, and a recovery must be announced once.
+    #[test]
+    fn workspace_report_is_edge_triggered() {
+        let mut failing: HashSet<&str> = HashSet::new();
+
+        // First failure speaks.
+        assert_eq!(
+            workspace_report(&mut failing, &"a", true),
+            WorkspaceReport::Failed
+        );
+        // Every repeat is silent — this is the flood #449 is about.
+        for _ in 0..100 {
+            assert_eq!(
+                workspace_report(&mut failing, &"a", true),
+                WorkspaceReport::StillFailing
+            );
+        }
+        // Recovery speaks exactly once.
+        assert_eq!(
+            workspace_report(&mut failing, &"a", false),
+            WorkspaceReport::Recovered
+        );
+        assert_eq!(
+            workspace_report(&mut failing, &"a", false),
+            WorkspaceReport::StillHealthy
+        );
+        // A healthy agent that was never failing says nothing on its first
+        // attempt either — a working workspace has never been worth a line.
+        assert_eq!(
+            workspace_report(&mut failing, &"never-failed", false),
+            WorkspaceReport::StillHealthy
+        );
+        // And it can fail again later: the edge re-arms.
+        assert_eq!(
+            workspace_report(&mut failing, &"a", true),
+            WorkspaceReport::Failed
+        );
+
+        assert!(
+            WorkspaceReport::StillFailing.is_silent() && WorkspaceReport::StillHealthy.is_silent(),
+            "only the repeats are silent"
+        );
+        assert!(
+            !WorkspaceReport::Failed.is_silent() && !WorkspaceReport::Recovered.is_silent(),
+            "both edges must be reported"
+        );
+    }
+
+    /// Two agents interleaved: one failing, one healthy. Each key's edge is its
+    /// own — a second agent's failure must not be swallowed by the first's, and
+    /// a second agent's recovery must not clear the first's failure.
+    #[test]
+    fn workspace_report_tracks_each_key_separately() {
+        let mut failing: HashSet<&str> = HashSet::new();
+
+        assert_eq!(
+            workspace_report(&mut failing, &"ceo", true),
+            WorkspaceReport::Failed
+        );
+        // A different agent failing is its own first failure, not a repeat.
+        assert_eq!(
+            workspace_report(&mut failing, &"engineer", true),
+            WorkspaceReport::Failed
+        );
+        assert_eq!(
+            workspace_report(&mut failing, &"ceo", true),
+            WorkspaceReport::StillFailing
+        );
+        // One recovers; the other stays failing and stays silent.
+        assert_eq!(
+            workspace_report(&mut failing, &"engineer", false),
+            WorkspaceReport::Recovered
+        );
+        assert_eq!(
+            workspace_report(&mut failing, &"ceo", true),
+            WorkspaceReport::StillFailing
+        );
+        assert_eq!(
+            workspace_report(&mut failing, &"ceo", false),
+            WorkspaceReport::Recovered
+        );
+        assert!(failing.is_empty(), "a recovered key leaves no residue");
+    }
+
+    /// The real dispatch path against a workspace root that cannot hold a
+    /// directory, driven through [`HarnessPool::run`] rather than the helper.
+    ///
+    /// The root is pointed at a **file**, which makes `create_dir_all` fail
+    /// deterministically on every platform (`ENOTDIR` / its Windows equivalent)
+    /// without needing permission bits a CI root user would ignore.
+    ///
+    /// Asserts the reporting state, not the log text: this test binary already
+    /// installs a global `tracing` subscriber elsewhere
+    /// (`runtime::workflow_scheduler`) and asserts it wins that race, so a
+    /// second global capture here would make whichever test lost panic. The
+    /// state is what decides whether a line is emitted, so pinning it pins the
+    /// line count — three dispatches, one report.
+    #[tokio::test]
+    async fn a_broken_workspace_root_reports_once_across_repeated_dispatches() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A regular file where the workspace tree is expected.
+        let not_a_dir = dir.path().join("workspace-root");
+        std::fs::write(&not_a_dir, b"this is a file, not a directory").unwrap();
+
+        let mut fx = fixture();
+        fx.deps.workspace_root = not_a_dir.clone();
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &fx.deps).await.expect("ensure");
+
+        // Sanity: the condition really is a hard, repeatable failure.
+        assert!(
+            build::ensure_agent_workspace(&not_a_dir, &rec.id, "ceo").is_err(),
+            "the test root must actually be unusable, or this proves nothing"
+        );
+
+        for turn in 0..3 {
+            pool.run(&rec.id, "ceo", "hi", &fx.deps, None)
+                .await
+                .unwrap_or_else(|e| panic!("turn {turn} still runs without a workspace: {e:?}"));
+        }
+
+        // The turns ran — a missing workspace is not fatal, which #449 does not
+        // change — and the failure is recorded exactly once.
+        let failing = pool.workspace_failures.lock().unwrap();
+        assert_eq!(
+            failing.len(),
+            1,
+            "one failing agent, tracked once, however many turns it takes"
+        );
+        assert!(failing.contains(&(rec.id.clone(), "ceo".to_string())));
+        drop(failing);
+
+        // The next dispatch after the first is silent: only turn 1 spoke.
+        assert_eq!(
+            pool.note_workspace_attempt(&rec.id, "ceo", true),
+            WorkspaceReport::StillFailing,
+            "dispatches after the first must not re-emit the error"
+        );
+        // And when the volume comes back, one line says so.
+        assert_eq!(
+            pool.note_workspace_attempt(&rec.id, "ceo", false),
+            WorkspaceReport::Recovered
         );
     }
 

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -496,6 +496,22 @@ fn jsonl<T: Serialize>(items: &[T]) -> Result<String> {
 }
 
 /// Parses every non-empty JSONL line of `path`, skipping an absent file.
+///
+/// **Import stays strict, by decision** (issue #387). The boot path now tolerates
+/// a damaged ledger line — see
+/// [`read_jsonl_lenient`](crate::store::fs::read_jsonl_lenient) — and this reader
+/// deliberately does not follow it. The two are not the same situation:
+///
+/// * Boot has no alternative. The bundle is the company's only copy, refusing to
+///   read it strands the tenant, and skipping keeps the bytes on disk for repair.
+/// * Import does have one. The bundle being read is an *incoming* archive whose
+///   source still exists, and refusing it costs nothing but a retry with a good
+///   bundle. Half-importing instead would mint a company whose ledger silently
+///   disagrees with the archive it claims to be, with no record of what was
+///   dropped — an inconsistency that outlives the damaged file.
+///
+/// So a corrupt archive fails the import outright. That is the correct answer
+/// here, and it should not be "fixed" to match the boot path.
 async fn read_jsonl<T: serde::de::DeserializeOwned>(path: &Path) -> Result<Vec<T>> {
     let contents = match tokio::fs::read_to_string(path).await {
         Ok(contents) => contents,

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -94,6 +94,26 @@ pub(crate) async fn read_optional(path: &Path) -> Result<String> {
 }
 
 /// Parses every non-empty JSONL line of `path` into `T`, skipping absent files.
+///
+/// **Strict**: one unparseable line fails the whole read. That is the right
+/// default for everything that still uses it, and it is a decision rather than
+/// an oversight (issue #387):
+///
+/// * **Read-modify-write callers must stay strict.** `evict` and `mark_read`
+///   read a file here and then [`write_atomic`] it back. A tolerant read would
+///   drop the damaged line from the in-memory vector, and the rewrite would then
+///   erase it from disk — turning recoverable damage into permanent deletion,
+///   silently. See [`read_jsonl_lenient`] for the same boundary stated from the
+///   other side.
+/// * **Request-time read-only callers stay strict too.** A failed inbox or
+///   context read surfaces as one failed request the operator can retry and
+///   report; it does not cost a company its boot. Making those tolerant is a
+///   separate judgement about each surface's error budget, and it is not made
+///   here.
+///
+/// Only the *boot* path — the ledger read in [`FsCompanyStore::load`] — is
+/// tolerant, because there the failure is not one request but the whole
+/// company, and the console that would repair the file is behind the boot.
 pub(crate) async fn read_jsonl<T>(path: &Path) -> Result<Vec<T>>
 where
     T: serde::de::DeserializeOwned,
@@ -107,6 +127,92 @@ where
         out.push(serde_json::from_str(line)?);
     }
     Ok(out)
+}
+
+/// A JSONL line [`read_jsonl_lenient`] could not parse: quarantined in place,
+/// never deleted.
+///
+/// Carries where the line is, how big it is, and what the parser rejected —
+/// and **never the line's contents**. A ledger memo is free text a person or an
+/// agent wrote; echoing it into a log to explain a parse failure would put
+/// arbitrary tenant prose into the container log. The 1-based line number and
+/// the byte length are enough for an operator to find the line by hand.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SkippedLine {
+    /// The line's 1-based number in the file.
+    pub(crate) line: usize,
+    /// The line's length in bytes, as it sits on disk.
+    pub(crate) bytes: usize,
+    /// What the parse rejected. `serde_json`'s message is positional
+    /// ("EOF while parsing a string at line 1 column 74") and quotes no input.
+    pub(crate) message: String,
+}
+
+/// Parses every non-empty JSONL line of `path` into `T`, **skipping** the lines
+/// that will not parse and reporting them rather than failing the read.
+///
+/// Returns the values that did parse, oldest first, plus one [`SkippedLine`]
+/// per line that did not. An absent file is an empty read, as in [`read_jsonl`].
+///
+/// Bytes are read and decoded per line, not through `read_to_string`. A torn
+/// write can split a multi-byte codepoint, and a whole-file UTF-8 decode fails
+/// on that one bad byte — losing the entire file to damage confined to a single
+/// line. Decoding lossily per line keeps the damage where it is. This mirrors
+/// [`RuntimeJournal::load`](crate::runtime::journal::RuntimeJournal::load),
+/// which reached the same conclusion for the journal (issue #386).
+///
+/// # Tolerance boundary — do not widen it
+///
+/// **A read-modify-write consumer must never call this.** Skipping is only safe
+/// because the bytes stay on disk: the caller drops the line from its in-memory
+/// view and a person can still repair the file. A caller that reads here and
+/// then rewrites the file atomically would write back exactly the lines that
+/// parsed, deleting the damaged one for good — converting a recoverable fault
+/// into silent, permanent data loss, which is strictly worse than the failed
+/// boot this function exists to prevent. Rewriters ([`FsMemoryStore::evict`],
+/// [`FsInboxStore::mark_read`]) stay on strict [`read_jsonl`], where a damaged
+/// line aborts the rewrite instead of laundering it.
+///
+/// The one caller today is the ledger read in [`FsCompanyStore::load`]. A ledger
+/// entry is descriptive accounting: dropping one from a boot-time view
+/// misreports spend until the file is repaired, which is recoverable and
+/// visible. It is not an at-most-once safety key — the journal's
+/// `EffectExecuted` records are, and they are handled separately and more
+/// carefully for exactly that reason.
+pub(crate) async fn read_jsonl_lenient<T>(path: &Path) -> Result<(Vec<T>, Vec<SkippedLine>)>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let contents = match tokio::fs::read(path).await {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok((Vec::new(), Vec::new())),
+        Err(e) => return Err(io_err(path, e)),
+    };
+
+    let mut out = Vec::new();
+    let mut skipped = Vec::new();
+    for (index, raw) in contents.split(|b| *b == b'\n').enumerate() {
+        // Lossy on purpose: an invalid byte becomes U+FFFD, the line then fails
+        // to parse as JSON, and it lands on the same skip-and-report path as any
+        // other unreadable line instead of aborting the whole read.
+        let line = String::from_utf8_lossy(raw);
+        let line = line.as_ref();
+        if line.trim().is_empty() {
+            continue;
+        }
+        match serde_json::from_str(line) {
+            Ok(value) => out.push(value),
+            Err(error) => skipped.push(SkippedLine {
+                line: index + 1,
+                // The on-disk length, not the lossily-decoded one: U+FFFD is
+                // three bytes and would inflate the count for exactly the lines
+                // an operator is trying to locate.
+                bytes: raw.len(),
+                message: error.to_string(),
+            }),
+        }
+    }
+    Ok((out, skipped))
 }
 
 /// Atomically writes `contents` to `path` via a temp file + rename.
@@ -228,7 +334,34 @@ impl CompanyStore for FsCompanyStore {
             serde_json::from_str(&meta_src)?
         };
 
-        let ledger = read_jsonl::<LedgerEntry>(&bundle.ledger_jsonl()).await?;
+        // The ledger is read leniently, and this is the only place in the fs
+        // backend that is (issue #387). Every other read here is either a
+        // rewriter — where skipping would delete the damaged line on write-back
+        // — or a request-time reader, where a failure costs one request. This
+        // one is neither: it is on the boot path, so a single malformed
+        // accounting line used to take the whole company down, and the repair
+        // console an operator would use sits behind the boot it killed.
+        //
+        // The skipped lines stay on disk untouched. Nothing in `load` writes,
+        // and `append_ledger` only appends, so the file after a tolerated boot
+        // is byte-identical to the file before it.
+        let ledger_path = bundle.ledger_jsonl();
+        let (ledger, skipped) = read_jsonl_lenient::<LedgerEntry>(&ledger_path).await?;
+        if let Some(first) = skipped.first() {
+            // `error!`, not `warn!`: the company is running on an incomplete
+            // ledger, so its reported spend is wrong until someone repairs the
+            // file. Loud once per load, naming the file and the first bad line —
+            // never the line's contents, which are operator/agent free text.
+            tracing::error!(
+                company = %id,
+                ledger = %ledger_path.display(),
+                skipped = skipped.len(),
+                first_line = first.line,
+                first_bytes = first.bytes,
+                error = %first.message,
+                "[store] ledger lines could not be parsed; they were skipped so the company can still boot, and left on disk for repair — reported spend is incomplete until they are fixed"
+            );
+        }
 
         Ok(Some(CompanyRecord {
             id: id.clone(),
@@ -1025,6 +1158,131 @@ mod test {
         let loaded = store.load(&id).await.unwrap().unwrap();
         assert_eq!(loaded.ledger.len(), 3);
         assert_eq!(loaded.ledger[2].memo, "entry 2");
+    }
+
+    /// A company with a damaged ledger still boots, and the damage is
+    /// quarantined rather than deleted (issue #387).
+    ///
+    /// Before this, `read_jsonl` parsed inside its loop, so the first bad line
+    /// returned `Err` from `FsCompanyStore::load`, the builder propagated it,
+    /// and one torn accounting line made the company unbootable — with the
+    /// console that would repair it sitting behind the boot it killed.
+    ///
+    /// Four lines, two of them damaged in the two ways a torn write actually
+    /// produces: JSON that stops mid-value, and a byte sequence that is not
+    /// UTF-8 at all. The second is the reason this reads bytes rather than a
+    /// `String`: a whole-file decode would fail on that one byte and lose all
+    /// four lines to damage confined to one.
+    #[tokio::test]
+    async fn a_damaged_ledger_line_is_skipped_and_left_on_disk() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let store = FsCompanyStore::new(&root);
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: sample_manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+
+        // The memo text the report must never echo. Distinctive enough that a
+        // substring search cannot pass by accident.
+        const MEMO_TWO: &str = "acquire-northwind-holdings";
+        const MEMO_THREE: &str = "settle-quarterly-invoice";
+
+        let mut bytes: Vec<u8> = Vec::new();
+        // 1. Intact.
+        bytes.extend_from_slice(
+            br#"{"at_millis":1,"kind":"inference.spend","amount_usd":1.0,"memo":"first entry"}"#,
+        );
+        bytes.push(b'\n');
+        // 2. A torn write: the JSON stops in the middle of the memo string.
+        bytes.extend_from_slice(
+            format!(
+                r#"{{"at_millis":2,"kind":"inference.spend","amount_usd":2.0,"memo":"{MEMO_TWO}"#
+            )
+            .as_bytes(),
+        );
+        bytes.push(b'\n');
+        // 3. Invalid UTF-8 in a structural position, so the lossy U+FFFD lands
+        //    where a key is expected and the line cannot parse. (Damage *inside*
+        //    a string would decode to a valid — if mangled — record, which is
+        //    the recoverable case and deliberately not skipped.)
+        bytes.extend_from_slice(br#"{"at_millis":3,"#);
+        bytes.push(0xFF);
+        bytes.extend_from_slice(
+            format!(r#""kind":"inference.spend","amount_usd":3.0,"memo":"{MEMO_THREE}"}}"#)
+                .as_bytes(),
+        );
+        bytes.push(b'\n');
+        // 4. Intact.
+        bytes.extend_from_slice(
+            br#"{"at_millis":4,"kind":"inference.spend","amount_usd":4.0,"memo":"fourth entry"}"#,
+        );
+        bytes.push(b'\n');
+
+        let path = Bundle::new(root.clone(), &id).ledger_jsonl();
+        tokio::fs::write(&path, &bytes).await.unwrap();
+
+        // The company boots, carrying the entries that survived.
+        let loaded = store
+            .load(&id)
+            .await
+            .expect("a damaged ledger line must not fail the load")
+            .expect("the company exists");
+        assert_eq!(
+            loaded.ledger.len(),
+            2,
+            "the two intact entries load; the two damaged ones are skipped"
+        );
+        assert_eq!(loaded.ledger[0].memo, "first entry");
+        assert_eq!(loaded.ledger[1].memo, "fourth entry");
+
+        // The report locates the damage without quoting it.
+        let (entries, skipped) = read_jsonl_lenient::<LedgerEntry>(&path).await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            skipped.iter().map(|s| s.line).collect::<Vec<_>>(),
+            vec![2, 3],
+            "the report names the 1-based line numbers of the damaged lines"
+        );
+        for entry in &skipped {
+            assert!(
+                entry.bytes > 0,
+                "the report carries the on-disk line length"
+            );
+            assert!(
+                !entry.message.is_empty(),
+                "the report says what was rejected"
+            );
+            for memo in [MEMO_TWO, MEMO_THREE] {
+                assert!(
+                    !entry.message.contains(memo),
+                    "a memo is free text and must never reach the report: {:?}",
+                    entry.message
+                );
+            }
+        }
+
+        // Quarantine, not repair: the file is untouched, so an operator can
+        // still recover the damaged lines by hand.
+        let after = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(
+            after, bytes,
+            "loading must not rewrite the ledger — skipping a line the reader \
+             could not parse must never become deleting it"
+        );
     }
 
     #[tokio::test]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -4,6 +4,8 @@
 //! manifest, JSONL for append-only logs, content-addressed blobs for context).
 //! Appends are the hot path and never rewrite the whole file; per-path
 //! `tokio::sync::Mutex` locks serialize concurrent writers within a process.
+//! Those locks live in one process-wide registry ([`path_lock`]) rather than on
+//! each store, so two instances over one bundle actually meet (issue #388).
 
 use std::collections::HashMap;
 use std::ops::Range;
@@ -54,6 +56,56 @@ impl PathLocks {
         let mut map = self.inner.lock().expect("path-lock map poisoned");
         map.entry(path.to_path_buf()).or_default().clone()
     }
+}
+
+/// Every filesystem store's write locks, shared by every instance in the
+/// process (issue #388).
+///
+/// The locks these replaced were **fields** on `FsCompanyStore`, `FsEventLog`,
+/// `FsMemoryStore`, `FsContextStore`, `FsInboxStore` and `FsOps` — so two stores
+/// over one bundle serialised against nothing, which is the state those types
+/// have always been in and which nothing stopped a caller reaching: each
+/// constructor takes a root and builds a fresh registry. A `static` is the only
+/// thing two independently-constructed instances can share.
+///
+/// The damage that let through was not theoretical. `FsEventLog::append`
+/// derives the next sequence from the current line count and then appends, so
+/// two unsynchronised instances hand out the **same** `seq` — breaking every
+/// consumer that treats it as an identity. And the read-modify-write sites
+/// (`FsMemoryStore::evict`, `FsInboxStore::mark_read`, and the whole-file
+/// rewrites in [`FsOps`](crate::store::fs_ops::FsOps)) replace the file with a
+/// snapshot, so an append that raced one of them was simply erased.
+///
+/// Mirrors the precedent
+/// [`JOURNAL_WRITE_LOCKS`](crate::runtime::journal) set for the runtime journal
+/// in issue #386, deliberately including its caveats — see [`path_lock`].
+static FS_WRITE_LOCKS: std::sync::LazyLock<PathLocks> =
+    std::sync::LazyLock::new(PathLocks::default);
+
+/// The process-wide write lock for `path`.
+///
+/// Keyed on the **absolutised** path, so a relative and an absolute spelling of
+/// one file meet on the same lock instead of racing.
+///
+/// Two limits, both by construction rather than oversight:
+///
+/// * **Absolutising is not canonicalising.** `std::path::absolute` is purely
+///   lexical: it never touches the filesystem, so it does not resolve symlinks
+///   and it does not collapse `..` across one. Two spellings that differ by a
+///   symlinked ancestor therefore land on two different locks. Resolving that
+///   would mean a `canonicalize` syscall on every append — on the hot path, for
+///   a case no caller in this crate produces (every path is built by
+///   [`Bundle`] from one configured root). What keeps the missed case from
+///   tearing is [`append_line`]'s single `O_APPEND` write, not this lock.
+/// * **In-process only.** A second *process* over the same
+///   `OPENCOMPANY_DATA_DIR` is outside any in-process lock's reach, and no
+///   amount of `static` fixes that. Write atomicity is what keeps that case
+///   safe: appends are one `O_APPEND` write and rewrites go through
+///   [`write_atomic`]'s temp-file-plus-rename. That bounds the damage to a lost
+///   update, never a torn file. Real cross-process exclusion would need file
+///   locking, which is a separate change with a separate portability argument.
+pub(crate) fn path_lock(path: &Path) -> Arc<TokioMutex<()>> {
+    FS_WRITE_LOCKS.get(&std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf()))
 }
 
 /// Appends one line (a `\n` is added) to `path`, creating the file if absent.
@@ -293,16 +345,12 @@ impl Default for Meta {
 #[derive(Clone)]
 pub struct FsCompanyStore {
     root: PathBuf,
-    locks: PathLocks,
 }
 
 impl FsCompanyStore {
     /// Creates a store rooted at `root` (the OpenCompany home).
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
-            locks: PathLocks::default(),
-        }
+        Self { root: root.into() }
     }
 
     fn bundle(&self, id: &CompanyId) -> Bundle {
@@ -444,7 +492,7 @@ impl CompanyStore for FsCompanyStore {
         let bundle = self.bundle(id);
         bundle.ensure_dirs().await?;
         let path = bundle.ledger_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         append_line(&path, &serde_json::to_string(&entry)?).await
     }
@@ -459,7 +507,18 @@ impl CompanyStore for FsCompanyStore {
 #[derive(Clone)]
 pub struct FsEventLog {
     root: PathBuf,
-    locks: PathLocks,
+    /// Live subscribers, keyed by company.
+    ///
+    /// **Deliberately per-instance, and not part of issue #388's fix.** The
+    /// write locks moved to a process-wide registry because two instances over
+    /// one file must exclude each other. This map is the opposite kind of state:
+    /// it is a fan-out to the subscribers *this* instance handed streams to, and
+    /// nothing about durability or ordering depends on two instances sharing it.
+    /// A subscriber that misses an event because it subscribed through the other
+    /// instance is a delivery gap in a best-effort live feed, recoverable by
+    /// [`read_from`](EventLog::read_from) against the durable log — not the
+    /// silent write loss the lock change fixes. Making it global would give one
+    /// company's stream process-global lifetime for a much weaker reason.
     senders: Arc<StdMutex<HashMap<CompanyId, broadcast::Sender<StoredEvent>>>>,
 }
 
@@ -468,7 +527,6 @@ impl FsEventLog {
     pub fn new(root: impl Into<PathBuf>) -> Self {
         Self {
             root: root.into(),
-            locks: PathLocks::default(),
             senders: Arc::new(StdMutex::new(HashMap::new())),
         }
     }
@@ -491,7 +549,7 @@ impl EventLog for FsEventLog {
         let bundle = self.bundle(id);
         bundle.ensure_dirs().await?;
         let path = bundle.events_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
 
         // The next sequence is the current line count; held under the lock so
@@ -550,16 +608,12 @@ impl EventLog for FsEventLog {
 #[derive(Clone)]
 pub struct FsMemoryStore {
     root: PathBuf,
-    locks: PathLocks,
 }
 
 impl FsMemoryStore {
     /// Creates a memory store rooted at `root` (the OpenCompany home).
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
-            locks: PathLocks::default(),
-        }
+        Self { root: root.into() }
     }
 
     fn bundle(&self, id: &CompanyId) -> Bundle {
@@ -573,7 +627,7 @@ impl MemoryStore for FsMemoryStore {
         let bundle = self.bundle(id);
         bundle.ensure_dirs().await?;
         let path = bundle.traces_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         append_line(&path, &serde_json::to_string(&trace)?).await
     }
@@ -590,7 +644,7 @@ impl MemoryStore for FsMemoryStore {
         let bundle = self.bundle(id);
         bundle.ensure_dirs().await?;
         let path = bundle.tasks_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         append_line(&path, &serde_json::to_string(&result)?).await
     }
@@ -598,7 +652,7 @@ impl MemoryStore for FsMemoryStore {
     async fn evict(&self, id: &CompanyId, policy: EvictionPolicy) -> Result<u64> {
         let bundle = self.bundle(id);
         let path = bundle.traces_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
 
         let all = read_jsonl::<CompressedTrace>(&path).await?;
@@ -653,16 +707,12 @@ struct IndexEntry {
 #[derive(Clone)]
 pub struct FsContextStore {
     root: PathBuf,
-    locks: PathLocks,
 }
 
 impl FsContextStore {
     /// Creates a context store rooted at `root` (the OpenCompany home).
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
-            locks: PathLocks::default(),
-        }
+        Self { root: root.into() }
     }
 
     fn bundle(&self, id: &CompanyId) -> Bundle {
@@ -683,7 +733,7 @@ impl ContextStore for FsContextStore {
             .map_err(|e| io_err(&blob_path, e))?;
 
         let index_path = bundle.context_index_jsonl();
-        let lock = self.locks.get(&index_path);
+        let lock = path_lock(&index_path);
         let _guard = lock.lock().await;
         let entry = IndexEntry {
             addr: addr.clone(),
@@ -816,16 +866,12 @@ impl SecretStore for FsSecretStore {
 #[derive(Clone)]
 pub struct FsInboxStore {
     root: PathBuf,
-    locks: PathLocks,
 }
 
 impl FsInboxStore {
     /// Creates an inbox store rooted at `root` (the OpenCompany home).
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
-            locks: PathLocks::default(),
-        }
+        Self { root: root.into() }
     }
 
     fn bundle(&self, id: &CompanyId) -> Bundle {
@@ -871,7 +917,7 @@ impl InboxStore for FsInboxStore {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.inbox_meta_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut map = self.load_meta(company).await?;
         map.insert(key.to_string(), meta.clone());
@@ -899,7 +945,7 @@ impl InboxStore for FsInboxStore {
         bundle.ensure_dirs().await?;
         let path = bundle.inbox_jsonl();
         let line = serde_json::to_string(msg)?;
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         append_line(&path, &line).await
     }
@@ -911,7 +957,7 @@ impl InboxStore for FsInboxStore {
         ids: Option<&[String]>,
     ) -> Result<u64> {
         let path = self.bundle(company).inbox_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut all = read_jsonl::<EmailRecord>(&path).await?;
         for record in all.iter_mut() {
@@ -1034,6 +1080,79 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_context_chunk_stamps(Arc::new(FsContextStore::new(&root))).await;
+    }
+
+    /// Two event logs over one data root must not hand out the same sequence
+    /// number (issue #388).
+    ///
+    /// `EventLog::append` computes the next `seq` by counting the lines already
+    /// in the file, then appends. That read-then-append is only atomic under a
+    /// lock, and the lock used to be a **field** on `FsEventLog` — so two
+    /// instances over one bundle serialised against nothing, both read the same
+    /// count, and both wrote the same `seq`. A duplicate sequence number breaks
+    /// every consumer that treats it as an identity: `read_from`'s `seq >=`
+    /// cursor silently replays, and the console's resume-from-seq skips.
+    ///
+    /// Nothing stops a second instance being constructed — `FsEventLog::new`
+    /// takes a root and is called wherever one is needed — so this is reachable
+    /// without any exotic setup, which is exactly what makes it worth a lock in
+    /// the registry rather than a convention.
+    #[tokio::test]
+    async fn two_event_logs_over_one_root_never_reuse_a_sequence() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        // Two independently-constructed logs over the same data root — the shape
+        // a second runtime, a maintenance task, or an export job produces.
+        let first = Arc::new(FsEventLog::new(&root));
+        let second = Arc::new(FsEventLog::new(&root));
+        let id = CompanyId::new("acme");
+
+        const N: u64 = 32;
+        let mut set = tokio::task::JoinSet::new();
+        for i in 0..N {
+            let log = if i % 2 == 0 {
+                first.clone()
+            } else {
+                second.clone()
+            };
+            let id = id.clone();
+            set.spawn(async move {
+                log.append(
+                    &id,
+                    CompanyEvent::OperatorMessage {
+                        parent: None,
+                        text: format!("event {i}"),
+                        by: None,
+                        chat: None,
+                    },
+                )
+                .await
+                .expect("append succeeds")
+            });
+        }
+        let mut handed_out = Vec::new();
+        while let Some(res) = set.join_next().await {
+            handed_out.push(res.expect("task joins").value());
+        }
+
+        handed_out.sort_unstable();
+        assert_eq!(
+            handed_out,
+            (0..N).collect::<Vec<_>>(),
+            "the sequences handed to callers must be unique and dense — a repeat \
+             means two instances read the same line count before either appended"
+        );
+
+        // And the same must hold for what actually landed on disk.
+        let stored = first.read_from(&id, EventSeq::new(0), 1024).await.unwrap();
+        assert_eq!(stored.len() as u64, N, "every append is on disk");
+        let mut persisted: Vec<u64> = stored.iter().map(|e| e.seq.value()).collect();
+        persisted.sort_unstable();
+        assert_eq!(
+            persisted,
+            (0..N).collect::<Vec<_>>(),
+            "the persisted sequences must be unique and dense too"
+        );
     }
 
     /// The fs backend's migration path: index lines written before

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -4,7 +4,7 @@
 //! manifest, JSONL for append-only logs, content-addressed blobs for context).
 //! Appends are the hot path and never rewrite the whole file; per-path
 //! `tokio::sync::Mutex` locks serialize concurrent writers within a process.
-//! Those locks live in one process-wide registry ([`path_lock`]) rather than on
+//! Those locks live in one process-wide registry (`path_lock`) rather than on
 //! each store, so two instances over one bundle actually meet (issue #388).
 
 use std::collections::HashMap;

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -37,7 +37,7 @@ use crate::ports::types::CompanyId;
 use crate::ports::usage::{UsageMeter, UsageSample, retention_cutoff};
 use crate::ports::users::{InviteRecord, UserRecord, UserStore};
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
-use crate::store::fs::{PathLocks, append_line, io_err, read_jsonl, read_optional, write_atomic};
+use crate::store::fs::{append_line, io_err, path_lock, read_jsonl, read_optional, write_atomic};
 use crate::store::paths::Bundle;
 
 /// One filesystem store implementing every WS3 console port over a company
@@ -46,16 +46,12 @@ use crate::store::paths::Bundle;
 #[derive(Clone)]
 pub struct FsOps {
     root: PathBuf,
-    locks: PathLocks,
 }
 
 impl FsOps {
     /// Creates an ops store rooted at `root` (the OpenCompany home).
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self {
-            root: root.into(),
-            locks: PathLocks::default(),
-        }
+        Self { root: root.into() }
     }
 
     fn bundle(&self, id: &CompanyId) -> Bundle {
@@ -79,7 +75,7 @@ impl TaskStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.tasks_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut tasks = load_json_vec::<TaskRecord>(&path).await?;
         match tasks.iter_mut().find(|t| t.id == task.id) {
@@ -91,7 +87,7 @@ impl TaskStore for FsOps {
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).tasks_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut tasks = load_json_vec::<TaskRecord>(&path).await?;
         let before = tasks.len();
@@ -136,7 +132,7 @@ impl UserStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.users_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut users = load_json_vec::<UserRecord>(&path).await?;
         // Email is unique per company: a second id holding one address would
@@ -160,7 +156,7 @@ impl UserStore for FsOps {
 
     async fn delete_user(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).users_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut users = load_json_vec::<UserRecord>(&path).await?;
         let before = users.len();
@@ -193,7 +189,7 @@ impl UserStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.user_invites_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut invites = load_json_vec::<InviteRecord>(&path).await?;
         if invites
@@ -214,7 +210,7 @@ impl UserStore for FsOps {
 
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).user_invites_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut invites = load_json_vec::<InviteRecord>(&path).await?;
         let before = invites.len();
@@ -237,7 +233,7 @@ impl SessionStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.user_sessions_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut sessions = load_json_vec::<SessionRecord>(&path).await?;
         // A repeated token hash would mean the CSPRNG repeated (or a caller
@@ -275,7 +271,7 @@ impl SessionStore for FsOps {
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).user_sessions_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut sessions = load_json_vec::<SessionRecord>(&path).await?;
         let before = sessions.len();
@@ -289,7 +285,7 @@ impl SessionStore for FsOps {
 
     async fn delete_for_user(&self, company: &CompanyId, user_id: &str) -> Result<u64> {
         let path = self.bundle(company).user_sessions_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut sessions = load_json_vec::<SessionRecord>(&path).await?;
         let before = sessions.len();
@@ -303,7 +299,7 @@ impl SessionStore for FsOps {
 
     async fn purge_expired(&self, company: &CompanyId, now_millis: u64) -> Result<u64> {
         let path = self.bundle(company).user_sessions_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut sessions = load_json_vec::<SessionRecord>(&path).await?;
         let before = sessions.len();
@@ -326,7 +322,7 @@ impl LoginCodeStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.login_codes_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut codes = load_json_vec::<LoginCodeRecord>(&path).await?;
         codes.push(code.clone());
@@ -357,7 +353,7 @@ impl LoginCodeStore for FsOps {
         // on one code cannot both mint a session. This holds within a process;
         // the fs backend is single-process by construction (one bundle, one
         // host), which is the same assumption every other fs store makes.
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut codes = load_json_vec::<LoginCodeRecord>(&path).await?;
         let Some(code) = codes
@@ -374,7 +370,7 @@ impl LoginCodeStore for FsOps {
 
     async fn delete_for_email(&self, company: &CompanyId, email: &str) -> Result<u64> {
         let path = self.bundle(company).login_codes_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut codes = load_json_vec::<LoginCodeRecord>(&path).await?;
         let before = codes.len();
@@ -388,7 +384,7 @@ impl LoginCodeStore for FsOps {
 
     async fn purge_expired(&self, company: &CompanyId, now_millis: u64) -> Result<u64> {
         let path = self.bundle(company).login_codes_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut codes = load_json_vec::<LoginCodeRecord>(&path).await?;
         let before = codes.len();
@@ -431,7 +427,7 @@ impl FactStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.facts_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut facts = dedup_latest(read_jsonl::<FactRecord>(&path).await?);
         match facts.iter_mut().find(|f| f.id == fact.id) {
@@ -443,7 +439,7 @@ impl FactStore for FsOps {
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).facts_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut facts = dedup_latest(read_jsonl::<FactRecord>(&path).await?);
         let before = facts.len();
@@ -488,7 +484,7 @@ impl ArtifactStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.artifacts_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut artifacts = dedup_latest(read_jsonl::<ArtifactRecord>(&path).await?);
         match artifacts.iter_mut().find(|a| a.id == artifact.id) {
@@ -500,7 +496,7 @@ impl ArtifactStore for FsOps {
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).artifacts_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut artifacts = dedup_latest(read_jsonl::<ArtifactRecord>(&path).await?);
         let before = artifacts.len();
@@ -527,7 +523,7 @@ impl RunStore for FsOps {
         // process-local — the documented fs-backend assumption everywhere in
         // this file — which is why the port's `create_run` contract calls the
         // filesystem ordinal best-effort rather than transactional.
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut runs = dedup_latest(read_jsonl::<RunRecord>(&path).await?);
         if runs.iter().any(|r| r.id == spec.id) {
@@ -572,7 +568,7 @@ impl RunStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.runs_jsonl();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut runs = dedup_latest(read_jsonl::<RunRecord>(&path).await?);
         match runs.iter_mut().find(|r| r.id == run.id) {
@@ -598,7 +594,7 @@ impl RunStore for FsOps {
         bundle.ensure_dirs().await?;
         let path = bundle.run_steps_jsonl();
         let line = serde_json::to_string(step)?;
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         // A genuine append: the trace only ever grows, and a replayed
         // `(run_id, step_seq)` is folded out at read time rather than by
@@ -627,7 +623,7 @@ impl UsageMeter for FsOps {
         bundle.ensure_dirs().await?;
         let path = bundle.usage_jsonl();
         let line = serde_json::to_string(sample)?;
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         append_line(&path, &line).await?;
         // Retention: compact `usage.jsonl` in place when it holds samples older
@@ -671,7 +667,7 @@ impl SkillStateStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.skills_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut states = load_json_vec::<SkillState>(&path).await?;
         match states.iter_mut().find(|s| s.slug == state.slug) {
@@ -683,7 +679,7 @@ impl SkillStateStore for FsOps {
 
     async fn remove(&self, company: &CompanyId, slug: &str) -> Result<bool> {
         let path = self.bundle(company).skills_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut states = load_json_vec::<SkillState>(&path).await?;
         let before = states.len();
@@ -723,7 +719,7 @@ impl WorkspaceStore for FsOps {
 
     async fn write(&self, company: &CompanyId, id: &str, content: &str) -> Result<WorkspaceNode> {
         let path = self.bundle(company).workspace_index_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut index = self.load_index(company).await?;
         let node = index
@@ -759,7 +755,7 @@ impl WorkspaceStore for FsOps {
         let bundle = self.bundle(company);
         bundle.ensure_dirs().await?;
         let path = bundle.workspace_index_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut index = self.load_index(company).await?;
         if index.contains_key(&node.id) {
@@ -816,7 +812,7 @@ impl WorkspaceStore for FsOps {
             reject_unsafe_name(name)?;
         }
         let path = self.bundle(company).workspace_index_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut index = self.load_index(company).await?;
         if !index.contains_key(id) {
@@ -869,7 +865,7 @@ impl WorkspaceStore for FsOps {
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).workspace_index_json();
-        let lock = self.locks.get(&path);
+        let lock = path_lock(&path);
         let _guard = lock.lock().await;
         let mut index = self.load_index(company).await?;
         if !index.contains_key(id) {


### PR DESCRIPTION
## Summary

Closes #387, #388, #449, #451 — four durability and observability defects in the storage and harness layers.

**#387 — one malformed ledger line stopped a company booting.** `read_jsonl` parsed inside its loop, so a single damaged accounting line made the company unbootable, and the console that could repair it sits behind the boot it killed.

A ledger entry is descriptive accounting, not an at-most-once safety key, and this project already chose tolerate-and-report for the *journal*, where a dropped line could re-fire an irreversible effect. So: skip the bad line, report it loudly, and never rewrite the file — the damaged line stays on disk for repair.

The boundary is documented rather than left to judgement: read-modify-write consumers must never use the lenient reader, because a rewriter would write back only the lines that parsed and turn recoverable damage into permanent deletion. Import stays strict too, for the same reason inverted — refusing to half-import a bundle whose source still exists is correct.

**#388 — two stores over the same files did not lock against each other.** The lock registry was a per-instance field on six types, so two instances serialised against nothing. Now process-wide and path-keyed, drawing on the same precedent the journal already set.

**#449 — a broken volume wrote one identical error line per turn, forever.** The non-fatal choice and the `error!` level are both deliberate and correct, so neither changed; the gap was the repetition. Logging is now edge-triggered: first failure speaks, repeats are silent, recovery says so.

This deliberately **declines the fix the issue proposed.** Memoising the attempt regresses in both directions — memoising success hides a later data-dir wipe, memoising failure means a late-mounting volume never recovers even though a retry would succeed. Both are self-healing behaviours worth keeping.

**#451 — the keyring could put credential material in `/tmp`, silently.** Hosted tenants were safe only *by accident*: a change made for another reason happens to set the workspace variable first, and nothing enforced that ordering. The resolved root is now pinned explicitly at startup and named in one line, and a root under the system temp dir warns loudly. Warn, not refuse — pointing at a temp path in local development is legal; the defect was the silence.

## API Or Behavior Changes

A company with a corrupt ledger line now boots and undercounts that entry, where it previously refused to start. The corrupt line is untouched on disk.

`CompanyStore::load`'s signature is unchanged, so no other backend is affected.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2335 passed, 0 failed, 3 ignored
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` and `vendor/` byte-identical to base. All four issues are backend-provable; nothing here touches `frontend/`.

**Both #388 tests were confirmed to fail on pre-fix code before the fix was applied** — sequences came back `[0,0,2,2,4,4,…]`, and 15 of 32 feedback appends were erased by a racing whole-file rewrite. A concurrency test that has never been seen to fail is not evidence.

#387's test asserts the file is **byte-identical after the load**, which is the quarantine claim rather than merely the parse claim, and that no memo text appears in the report. #451's test points `HOME` at a real writable directory with the workspace variable unset, so a pin that did nothing would resolve there and fail the assertion rather than pass vacuously.

## Documentation

Both caveats on the lock registry are stated where the registry lives: absolutise is not canonicalise, so a symlinked spelling misses and falls back on write atomicity; and it is in-process only by construction — a second process on the same data dir is outside any lock's reach.

**Owed and not done here — a vendored change.** The keyring's `/tmp` fallback still exists in `vendor/openhuman`; this makes it unreachable for `opencompany serve` but does not remove it. A bare embedded runtime with no workspace override and no resolvable home still lands credentials there, at no log level. Removing it, or at minimum making it loud, is owed upstream.

Also owed: #387's boot-level regression test. It needs `src/runtime/builder.rs`, which another branch holds; #387 is proven at the store level here and the boot assertion follows once that lands.
