### PR TITLE
feat(workflows): the copilot proposes an edit you review and apply

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -337,9 +337,22 @@ scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
   copilot adds is a transcript that stays out of the team's chat and an answer
   drawn from one workflow rather than from everything the company knows.
 
+  **A copilot answer may carry a proposed edit (issue #415), and that adds no
+  route and no capability.** The proposal is a fenced block in the reply text —
+  a list of node/edge operations — which the *console* turns into a candidate
+  graph and applies through `PUT …/workflows/{wid}` with `expectedVersion`, the
+  same write the canvas editor performs, after the operator has read the diff
+  and pressed Apply. The confined turn still calls nothing: it emits text, and
+  a person decides. So the host needs no notion of a proposal, and a proposal
+  cannot produce a graph the editor could not have produced — including the
+  `409` a graph that moved underneath it earns.
+
   Two more consequences worth knowing before reusing the seam. A chat turn
   runs the **whole** company cycle, so an actionable message also opens a
-  board card via `company::task_intent`. And an unconfigured company answers
+  board card via `company::task_intent` — on every thread *except* a copilot
+  one, where that is suppressed (#416) precisely because the seam is being
+  reused for a conversation that is not a request to the company. And an
+  unconfigured company answers
   `200` with the echo brain's `"You said: …"` rather than an error, so a caller
   that needs a real answer must check `cognition` from `GET {scope}/inference`
   — there is no status code to catch.

--- a/frontend/src/api/workflow-copilot.ts
+++ b/frontend/src/api/workflow-copilot.ts
@@ -64,6 +64,7 @@
 // ever fails.
 
 import type { OpenCompanyClient } from "./client";
+import { PROPOSAL_FENCE } from "./workflow-proposal";
 import type {
   WorkflowGraph,
   WorkflowRunOutcome,
@@ -133,7 +134,12 @@ export interface CopilotContext {
  */
 export function composeCopilotMessage(context: CopilotContext, question: string): string {
   const { graph, runs, runsKnown } = context;
-  const editable = graph.editable === false;
+  // `editable: false` means the graph is defined by a file in the company
+  // source tree. Named for what it IS rather than for the flag's polarity: this
+  // was `editable`, holding the negation of the field it was named after, and
+  // #415 adds two more branches keyed off it (whether to describe the proposal
+  // protocol at all, and what to tell the model it may do).
+  const sourceDefined = graph.editable === false;
 
   const lines: string[] = [
     `You are the workflow copilot for this company, answering about ONE saved workflow.`,
@@ -149,7 +155,7 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     `Name: ${graph.name}`,
     `Id: ${graph.id}`,
     graph.description ? `Description: ${graph.description}` : `Description: (none)`,
-    editable
+    sourceDefined
       ? `Editable from the console: NO — this workflow is defined by a file in the company source tree (workflows/${graph.id}.toml). You can explain it, but changes have to be made in the company repository, not here.`
       : `Editable from the console: yes, through the workflow editor.`,
     ``,
@@ -210,9 +216,34 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     ``,
     `## What you can and cannot do`,
     `You can explain this workflow, diagnose why its runs failed, and describe in words what should change.`,
-    `You CANNOT edit the workflow: this console does not apply copilot-authored changes. If a change is wanted, describe it precisely enough for a person to make it in the workflow editor. Do not claim to have made it.`,
     `You CANNOT reach anything else in the company: no tools, no board, no teammates, no other workflow, no files. The host enforces this, so a call would be refused rather than answered.`,
+    // Issue #415. The proposal is DATA IN THE REPLY, not a capability: it is
+    // the operator's console that writes, through the same versioned
+    // `updateWorkflow` the editor uses, only after they have read the diff. So
+    // this instruction hands the model no reach it did not have — which is
+    // exactly why the confinement (#416) had to land first.
+    sourceDefined
+      ? `You CANNOT edit the workflow, and you must not propose an edit: this one is defined by a file in the company source tree, so the host refuses every write to it. Describe the change for someone to make in the company repository.`
+      : `You CANNOT apply a change yourself. What you CAN do is PROPOSE one: the operator reads it as a diff and applies it, or throws it away.`,
   );
+
+  if (!sourceDefined) {
+    lines.push(
+      ``,
+      `## Proposing a change`,
+      `When the operator asks for a change (and only then), end your reply with ONE fenced block of exactly this form, after your prose:`,
+      "```" + PROPOSAL_FENCE,
+      `{"summary": "one line saying what this does", "ops": [ … ]}`,
+      "```",
+      `Each op is one of:`,
+      `- {"op": "addNode", "node": {"id": "…", "kind": "…", "name": "…", …}} — a new step. Use the same fields the steps above show.`,
+      `- {"op": "updateNode", "id": "…", "set": {"field": value}} — change fields on an existing step. Only send the fields that change.`,
+      `- {"op": "removeNode", "id": "…"} — delete a step (its connections go with it).`,
+      `- {"op": "addEdge", "from": "…", "to": "…", "label": "optional"} — connect two steps.`,
+      `- {"op": "removeEdge", "from": "…", "to": "…"} — disconnect two steps.`,
+      `Rules: refer to steps by the ids listed above; never rename an id (that is a remove plus an add); propose the smallest change that answers the question; and say in your prose what the change does and why. If you are not confident enough to propose, say so and describe the change instead — a wrong proposal costs the operator more than no proposal.`,
+    );
+  }
 
   // Joined with the marker verbatim, so `questionOf` splits on exactly the
   // string this function used.

--- a/frontend/src/api/workflow-proposal.ts
+++ b/frontend/src/api/workflow-proposal.ts
@@ -1,0 +1,399 @@
+// Issue #415: the copilot proposes an edit the operator reviews and applies.
+//
+// The read-only copilot (#303) could describe a change; turning that description
+// into canvas edits was the operator's job, by hand. This module is the round
+// trip: a reply may carry a **proposal**, the console turns it into a candidate
+// graph, shows the operator what would change, and applies it through the same
+// `updateWorkflow` call the editor uses.
+//
+// ## The unit of a proposal is an operation list, not a replacement graph
+//
+// A whole replacement graph is trivial to apply and hostile to review: the
+// operator has to diff two documents to find out what the model actually
+// changed, and a model that silently drops a node it did not mention gets away
+// with it. So a proposal is a short list of node/edge operations, each naming
+// its target. That is what makes the review honest — the diff shown to the
+// operator is derived from the ops, so a change nobody proposed cannot appear in
+// it, and a proposal that touches something it never mentioned cannot exist.
+//
+// ## Validation here is a courtesy; the host is the authority
+//
+// Everything below is *shape* checking: the JSON parses, the ops are known, and
+// they refer to nodes that exist. It exists so an obviously malformed proposal
+// is refused with a stated reason instead of being sent to the host to fail,
+// and so the operator is never shown a diff the console could not compute. It
+// is deliberately NOT the graph's rulebook: applying goes through
+// `updateWorkflow`, which is the same validated, versioned write the canvas
+// editor performs, so a proposal can never produce a graph the editor could not
+// have produced. If the two disagree, the host wins and the operator sees why.
+//
+// ## Staleness is refused, never rebased
+//
+// A proposal is reasoned about ONE version of the graph. The version is stamped
+// by the console when the reply is parsed — never read from the model, which
+// has no business asserting what it was looking at — and apply refuses if the
+// graph has moved since. Two layers, and both are load-bearing: this one gives
+// the operator a sentence they can act on, and `expectedVersion` on the write
+// makes the host refuse a race this check cannot see.
+
+import type { WorkflowEdge, WorkflowGraph, WorkflowNode } from "./workflows";
+
+/**
+ * The fence a proposal arrives in. The composed copilot message asks for
+ * exactly this, and nothing else in a reply is parsed as a proposal — prose
+ * that merely describes a change stays prose.
+ */
+export const PROPOSAL_FENCE = "workflow-proposal";
+
+/** One reviewable change to the graph. */
+export type ProposalOp =
+  | { op: "addNode"; node: WorkflowNode }
+  /** Field-level, so the diff can say which fields moved rather than "changed". */
+  | { op: "updateNode"; id: string; set: Partial<WorkflowNode> }
+  | { op: "removeNode"; id: string }
+  | { op: "addEdge"; from: string; to: string; label?: string }
+  | { op: "removeEdge"; from: string; to: string };
+
+/** A parsed, shape-checked proposal, bound to the graph it was reasoned about. */
+export interface WorkflowProposal {
+  /** The model's one-line description of the change, for the card's header. */
+  summary: string;
+  ops: ProposalOp[];
+  /**
+   * The `version` of the graph this was proposed against, stamped by the
+   * console at parse time.
+   *
+   * `undefined` when the graph carried none — a host predating the version
+   * token (#259). Apply still goes through, unconditionally, exactly as a
+   * canvas edit does on such a host: the protection does not exist there, and
+   * pretending otherwise by refusing every proposal would be a different lie.
+   */
+  basedOnVersion?: string;
+}
+
+/** Why a reply's proposal block could not be used. */
+export interface ProposalProblem {
+  reason: string;
+}
+
+/** What {@link readProposal} found in one reply. */
+export interface ReadProposal {
+  /** The reply with the proposal block removed, so the card is not shown twice. */
+  prose: string;
+  proposal?: WorkflowProposal;
+  /** Present when a block was found but could not be used. */
+  problem?: ProposalProblem;
+}
+
+const FENCE_RE = new RegExp(
+  "```" + PROPOSAL_FENCE + "\\s*\\n([\\s\\S]*?)\\n?```",
+  // First block only: a reply carrying two proposals is one the operator cannot
+  // review as a unit, so the first is read and the rest stays visible as prose.
+  "",
+);
+
+/**
+ * Splits a copilot reply into prose and (at most) one proposal.
+ *
+ * A reply with no block is returned unchanged with no proposal — the ordinary
+ * case, and the whole read-only surface still works exactly as it did.
+ */
+export function readProposal(reply: string, graph: WorkflowGraph): ReadProposal {
+  const match = FENCE_RE.exec(reply);
+  if (!match) return { prose: reply };
+
+  const prose = (reply.slice(0, match.index) + reply.slice(match.index + match[0].length)).trim();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(match[1]);
+  } catch {
+    return { prose, problem: { reason: "The proposed change wasn't valid JSON." } };
+  }
+
+  const result = validateProposal(parsed, graph);
+  if ("reason" in result) return { prose, problem: result };
+  return { prose, proposal: { ...result, basedOnVersion: graph.version } };
+}
+
+/** The known node fields an `updateNode` may set. */
+const UPDATABLE: readonly (keyof WorkflowNode)[] = [
+  "kind",
+  "name",
+  "summary",
+  "agent",
+  "schedule",
+  "config",
+  "onError",
+  "retry",
+  "requiresApproval",
+  "destination",
+];
+
+/**
+ * Shape-checks a parsed block against the graph, returning either the proposal
+ * or the one sentence the operator is shown instead.
+ *
+ * Exported for the tests, which are the reason each refusal names what was
+ * wrong rather than reporting "invalid proposal": a copilot that says "I
+ * proposed something but it was invalid" is a dead end, and the reason is what
+ * lets the operator ask again usefully.
+ */
+export function validateProposal(
+  parsed: unknown,
+  graph: WorkflowGraph,
+): Omit<WorkflowProposal, "basedOnVersion"> | ProposalProblem {
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { reason: "The proposed change wasn't an object." };
+  }
+  const body = parsed as { summary?: unknown; ops?: unknown };
+  const summary = typeof body.summary === "string" ? body.summary.trim() : "";
+  if (!summary) return { reason: "The proposed change didn't say what it does." };
+  if (!Array.isArray(body.ops) || body.ops.length === 0) {
+    return { reason: "The proposed change listed no edits." };
+  }
+
+  // Tracked as the ops are read, so an edge may reference a node the same
+  // proposal adds, and may not reference one the same proposal removes.
+  const ids = new Set(graph.nodes.map((n) => n.id));
+  const edges = new Set(graph.edges.map(edgeKey));
+  const ops: ProposalOp[] = [];
+
+  for (const raw of body.ops) {
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+      return { reason: "One of the proposed edits wasn't an object." };
+    }
+    const op = raw as Record<string, unknown>;
+    switch (op.op) {
+      case "addNode": {
+        const node = op.node;
+        if (!node || typeof node !== "object" || Array.isArray(node)) {
+          return { reason: "A proposed new step carried no node." };
+        }
+        const candidate = node as Record<string, unknown>;
+        const id = typeof candidate.id === "string" ? candidate.id.trim() : "";
+        const kind = typeof candidate.kind === "string" ? candidate.kind.trim() : "";
+        const name = typeof candidate.name === "string" ? candidate.name.trim() : "";
+        if (!id || !kind || !name) {
+          return { reason: "A proposed new step is missing its id, kind or name." };
+        }
+        if (ids.has(id)) {
+          return { reason: `A proposed new step reuses the existing id \`${id}\`.` };
+        }
+        ids.add(id);
+        ops.push({ op: "addNode", node: { ...(candidate as unknown as WorkflowNode), id, kind, name } });
+        break;
+      }
+      case "updateNode": {
+        const id = typeof op.id === "string" ? op.id.trim() : "";
+        if (!ids.has(id)) {
+          return { reason: `A proposed change targets \`${id || "?"}\`, which isn't in this workflow.` };
+        }
+        const set = op.set;
+        if (!set || typeof set !== "object" || Array.isArray(set)) {
+          return { reason: `The proposed change to \`${id}\` set no fields.` };
+        }
+        const fields = Object.keys(set as object);
+        if (fields.length === 0) {
+          return { reason: `The proposed change to \`${id}\` set no fields.` };
+        }
+        // `id` is deliberately not updatable: an id keys the node's edges, so a
+        // rename through the side door would silently orphan them. Renaming is
+        // an add plus a remove, which the diff then shows as what it is.
+        const unknown = fields.find((f) => !UPDATABLE.includes(f as keyof WorkflowNode));
+        if (unknown) {
+          return { reason: `The proposed change to \`${id}\` sets \`${unknown}\`, which isn't a step field.` };
+        }
+        ops.push({ op: "updateNode", id, set: set as Partial<WorkflowNode> });
+        break;
+      }
+      case "removeNode": {
+        const id = typeof op.id === "string" ? op.id.trim() : "";
+        if (!ids.has(id)) {
+          return { reason: `A proposed removal targets \`${id || "?"}\`, which isn't in this workflow.` };
+        }
+        ids.delete(id);
+        ops.push({ op: "removeNode", id });
+        break;
+      }
+      case "addEdge": {
+        const from = typeof op.from === "string" ? op.from.trim() : "";
+        const to = typeof op.to === "string" ? op.to.trim() : "";
+        if (!ids.has(from) || !ids.has(to)) {
+          return {
+            reason: `A proposed connection joins \`${from || "?"}\` to \`${to || "?"}\`, and one of those steps isn't there.`,
+          };
+        }
+        const label = typeof op.label === "string" && op.label.trim() ? op.label.trim() : undefined;
+        edges.add(edgeKey({ from, to }));
+        ops.push({ op: "addEdge", from, to, label });
+        break;
+      }
+      case "removeEdge": {
+        const from = typeof op.from === "string" ? op.from.trim() : "";
+        const to = typeof op.to === "string" ? op.to.trim() : "";
+        if (!edges.has(edgeKey({ from, to }))) {
+          return {
+            reason: `A proposed disconnection names \`${from || "?"}\` to \`${to || "?"}\`, which isn't a connection in this workflow.`,
+          };
+        }
+        edges.delete(edgeKey({ from, to }));
+        ops.push({ op: "removeEdge", from, to });
+        break;
+      }
+      default:
+        return { reason: `The proposal used an edit this console doesn't know: \`${String(op.op)}\`.` };
+    }
+  }
+
+  return { summary, ops };
+}
+
+/**
+ * The graph a proposal would produce.
+ *
+ * **Pure.** It never touches the graph it was given, which is what makes the
+ * preview safe: the operator is looking at a candidate, and rejecting one
+ * changes nothing because there was nothing to change back.
+ */
+export function applyProposal(graph: WorkflowGraph, proposal: WorkflowProposal): WorkflowGraph {
+  let nodes = graph.nodes.map((n) => ({ ...n }));
+  let edges = graph.edges.map((e) => ({ ...e }));
+
+  for (const op of proposal.ops) {
+    switch (op.op) {
+      case "addNode":
+        nodes = [...nodes, { ...op.node }];
+        break;
+      case "updateNode":
+        nodes = nodes.map((n) => (n.id === op.id ? { ...n, ...op.set } : n));
+        break;
+      case "removeNode":
+        nodes = nodes.filter((n) => n.id !== op.id);
+        // A removed step takes its connections with it. Leaving them would
+        // produce a graph naming a node that is gone, which the host would
+        // refuse — and the operator would be told the proposal was invalid
+        // rather than that it removed a step.
+        edges = edges.filter((e) => e.from !== op.id && e.to !== op.id);
+        break;
+      case "addEdge":
+        edges = [...edges, { from: op.from, to: op.to, label: op.label }];
+        break;
+      case "removeEdge":
+        edges = edges.filter((e) => !(e.from === op.from && e.to === op.to));
+        break;
+    }
+  }
+
+  return { ...graph, nodes, edges };
+}
+
+/** One step's place in the diff. */
+export interface NodeChange {
+  id: string;
+  name: string;
+  change: "added" | "removed" | "changed";
+  /** For a `changed` step: the fields that moved, `before` → `after`. */
+  fields: { field: string; before: string; after: string }[];
+}
+
+/** One connection's place in the diff. */
+export interface EdgeChange {
+  from: string;
+  to: string;
+  change: "added" | "removed";
+}
+
+/** What the operator is shown before applying. */
+export interface GraphDiff {
+  nodes: NodeChange[];
+  edges: EdgeChange[];
+}
+
+/**
+ * The change between the saved graph and a candidate, as the review card renders
+ * it.
+ *
+ * Computed from the two graphs rather than from the op list on purpose: the ops
+ * say what was *asked for*, and this says what would actually happen. An op that
+ * sets a field to the value it already holds shows up as no change, which is the
+ * honest answer and stops a proposal from looking bigger than it is.
+ */
+export function diffGraphs(current: WorkflowGraph, candidate: WorkflowGraph): GraphDiff {
+  const before = new Map(current.nodes.map((n) => [n.id, n]));
+  const after = new Map(candidate.nodes.map((n) => [n.id, n]));
+  const nodes: NodeChange[] = [];
+
+  for (const [id, node] of after) {
+    const was = before.get(id);
+    if (!was) {
+      nodes.push({ id, name: node.name, change: "added", fields: [] });
+      continue;
+    }
+    const fields = changedFields(was, node);
+    if (fields.length > 0) {
+      nodes.push({ id, name: node.name, change: "changed", fields });
+    }
+  }
+  for (const [id, node] of before) {
+    if (!after.has(id)) nodes.push({ id, name: node.name, change: "removed", fields: [] });
+  }
+
+  const beforeEdges = new Set(current.edges.map(edgeKey));
+  const afterEdges = new Set(candidate.edges.map(edgeKey));
+  const edges: EdgeChange[] = [];
+  for (const edge of candidate.edges) {
+    if (!beforeEdges.has(edgeKey(edge))) {
+      edges.push({ from: edge.from, to: edge.to, change: "added" });
+    }
+  }
+  for (const edge of current.edges) {
+    if (!afterEdges.has(edgeKey(edge))) {
+      edges.push({ from: edge.from, to: edge.to, change: "removed" });
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/** Whether a diff would change anything at all. */
+export function isEmptyDiff(diff: GraphDiff): boolean {
+  return diff.nodes.length === 0 && diff.edges.length === 0;
+}
+
+/**
+ * Whether a proposal may still be applied to `graph`.
+ *
+ * `stale` covers both halves of the issue's "must be refused or rebased, never
+ * silently applied": a graph that moved under a live proposal, and a proposal
+ * replayed from the journal on a later visit, whose `basedOnVersion` was never
+ * ours to know.
+ */
+export function proposalIsStale(proposal: WorkflowProposal, graph: WorkflowGraph): boolean {
+  if (graph.version === undefined) return false;
+  return proposal.basedOnVersion !== graph.version;
+}
+
+function edgeKey(edge: Pick<WorkflowEdge, "from" | "to">): string {
+  return `${edge.from} ${edge.to}`;
+}
+
+/** The fields that differ between two versions of one step, rendered for review. */
+function changedFields(
+  before: WorkflowNode,
+  after: WorkflowNode,
+): { field: string; before: string; after: string }[] {
+  const out: { field: string; before: string; after: string }[] = [];
+  for (const field of UPDATABLE) {
+    const was = render(before[field]);
+    const now = render(after[field]);
+    if (was !== now) out.push({ field, before: was, after: now });
+  }
+  return out;
+}
+
+/** A field value as one short reviewable string. */
+function render(value: unknown): string {
+  if (value === undefined || value === null) return "not set";
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}

--- a/frontend/src/api/workflow-proposal.ts
+++ b/frontend/src/api/workflow-proposal.ts
@@ -179,8 +179,25 @@ export function validateProposal(
         if (ids.has(id)) {
           return { reason: `A proposed new step reuses the existing id \`${id}\`.` };
         }
+        // Refused rather than dropped. A key this console does not know is a
+        // key the review card cannot render — an added step's diff line shows
+        // its id and name — so silently keeping it would put something in the
+        // candidate graph the operator never saw, and silently discarding it
+        // would apply a step that is not the one the copilot described. Both
+        // break the same guarantee: the diff is what would happen.
+        const stray = Object.keys(candidate).find(
+          (field) => !["id", "kind", "name"].includes(field) && !isNodeField(field),
+        );
+        if (stray) {
+          return {
+            reason: `A proposed new step sets \`${stray}\`, which isn't a step field.`,
+          };
+        }
         ids.add(id);
-        ops.push({ op: "addNode", node: { ...(candidate as unknown as WorkflowNode), id, kind, name } });
+        ops.push({
+          op: "addNode",
+          node: { ...(candidate as unknown as WorkflowNode), id, kind, name },
+        });
         break;
       }
       case "updateNode": {
@@ -221,6 +238,17 @@ export function validateProposal(
         if (!ids.has(from) || !ids.has(to)) {
           return {
             reason: `A proposed connection joins \`${from || "?"}\` to \`${to || "?"}\`, and one of those steps isn't there.`,
+          };
+        }
+        // A connection that already exists would be appended a second time and
+        // then diff to NOTHING — the diff compares sets keyed by `from`/`to` —
+        // so the operator would apply a duplicated edge the review never
+        // showed. Refused for the same reason `removeEdge` refuses a
+        // connection that is not there: the graph, not the request, decides
+        // whether an op means anything.
+        if (edges.has(edgeKey({ from, to }))) {
+          return {
+            reason: `A proposed connection joins \`${from}\` to \`${to}\`, which is already connected.`,
           };
         }
         const label = typeof op.label === "string" && op.label.trim() ? op.label.trim() : undefined;
@@ -374,7 +402,12 @@ export function proposalIsStale(proposal: WorkflowProposal, graph: WorkflowGraph
 }
 
 function edgeKey(edge: Pick<WorkflowEdge, "from" | "to">): string {
-  return `${edge.from} ${edge.to}`;
+  return `${edge.from} ${edge.to}`;
+}
+
+/** Whether `field` is a step field this console can render in a diff. */
+function isNodeField(field: string): boolean {
+  return (UPDATABLE as readonly string[]).includes(field);
 }
 
 /** The fields that differ between two versions of one step, rendered for review. */

--- a/frontend/src/api/workflow-proposal.ts
+++ b/frontend/src/api/workflow-proposal.ts
@@ -354,7 +354,14 @@ export function diffGraphs(current: WorkflowGraph, candidate: WorkflowGraph): Gr
   for (const [id, node] of after) {
     const was = before.get(id);
     if (!was) {
-      nodes.push({ id, name: node.name, change: "added", fields: [] });
+      // Every field the new step carries, not just its id and name. A proposed
+      // step arrives with a `kind`, and often a `config`, a `schedule` or a
+      // `requiresApproval` — all of which change what the workflow DOES. An
+      // added row that showed only a name would let an operator apply a
+      // scheduled, auto-approving node believing they had reviewed it, which is
+      // the same guarantee this module makes about changed steps and had not
+      // been keeping about new ones.
+      nodes.push({ id, name: node.name, change: "added", fields: addedFields(node) });
       continue;
     }
     const fields = changedFields(was, node);
@@ -402,12 +409,35 @@ export function proposalIsStale(proposal: WorkflowProposal, graph: WorkflowGraph
 }
 
 function edgeKey(edge: Pick<WorkflowEdge, "from" | "to">): string {
-  return `${edge.from} ${edge.to}`;
+  // JSON, not `${from} ${to}`: a space delimiter collides — `("a b", "c")` and
+  // `("a", "b c")` both key as `a b c`. The host does not forbid a space in a
+  // node id, and the cost of the collision is not cosmetic: two different edges
+  // would compare equal, so validation could refuse a genuinely new connection
+  // and `diffGraphs` could hide a real one from the review.
+  return JSON.stringify([edge.from, edge.to]);
 }
 
 /** Whether `field` is a step field this console can render in a diff. */
 function isNodeField(field: string): boolean {
   return (UPDATABLE as readonly string[]).includes(field);
+}
+
+/**
+ * Everything a NEW step carries, rendered as diff lines against "not set".
+ *
+ * `name` is omitted because the row's own header already shows it; every other
+ * persisted field is listed, so what the operator reviews is the whole node the
+ * apply would write.
+ */
+function addedFields(node: WorkflowNode): { field: string; before: string; after: string }[] {
+  const out: { field: string; before: string; after: string }[] = [];
+  for (const field of UPDATABLE) {
+    if (field === "name") continue;
+    const value = node[field];
+    if (value === undefined || value === null) continue;
+    out.push({ field, before: "not set", after: render(value) });
+  }
+  return out;
 }
 
 /** The fields that differ between two versions of one step, rendered for review. */

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1417,6 +1417,12 @@ export function WorkflowsView({
                 // The graph on screen and the history in `runs` must be the
                 // same workflow's before anything is grounded on the pair.
                 runsReady={runsFor === graph.id}
+                // Issue #415: an applied proposal lands through the SAME
+                // handler the edit dialog's save does. One place decides what
+                // "the graph is now this" means, so a copilot edit and a canvas
+                // edit cannot leave the view in two different states.
+                onApplied={handleSaved}
+                onConflict={setConflict}
                 onClose={() => setCopilotOpen(false)}
               />
             ) : (

--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -33,16 +33,27 @@ import { Bot, Loader2, Send } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { getInferenceStatus, type CognitionPath } from "@/api/inference";
-import type { WorkflowGraph, WorkflowRunOutcome } from "@/api/workflows";
+import { ApiError } from "@/api/types";
+import { updateWorkflow, type WorkflowGraph, type WorkflowRunOutcome } from "@/api/workflows";
 import {
   askCopilot,
   loadCopilotHistory,
   type CopilotMessage,
 } from "@/api/workflow-copilot";
+import {
+  applyProposal,
+  diffGraphs,
+  isEmptyDiff,
+  proposalIsStale,
+  readProposal,
+  type GraphDiff,
+  type WorkflowProposal,
+} from "@/api/workflow-proposal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Markdown } from "@/components/markdown";
 import { Textarea } from "@/components/ui/textarea";
+import { ProposalCard, type ProposalState } from "@/views/workflows/ProposalCard";
 
 /** A local id for a message this session created (the journal supplies ids for
  * replayed ones). */
@@ -52,6 +63,20 @@ function localId(): string {
   return `local-${localSeq}`;
 }
 
+/** One company reply, split into what the operator reads and what they review. */
+interface Review {
+  /** The reply with the proposal block stripped out. */
+  prose: string;
+  proposal?: WorkflowProposal;
+  /** The candidate graph and its diff, computed once alongside the proposal. */
+  diff?: GraphDiff;
+  /** A malformed proposal block, said out loud rather than dropped. */
+  problem?: string;
+  state: ProposalState;
+  /** The host's refusal of an apply, when one came back. */
+  error?: string;
+}
+
 export function CopilotPanel({
   client,
   company,
@@ -59,6 +84,8 @@ export function CopilotPanel({
   runs,
   runsKnown,
   runsReady,
+  onApplied,
+  onConflict,
   onClose,
 }: {
   client: OpenCompanyClient;
@@ -81,6 +108,17 @@ export function CopilotPanel({
    * so the panel refuses to send until the two agree.
    */
   runsReady: boolean;
+  /**
+   * A proposal was applied and the host stored the result (issue #415).
+   *
+   * The saved graph carries a fresh version token, so this is the same hand-off
+   * the edit dialog makes on save: the view takes the stored graph as current,
+   * the canvas re-renders, and every proposal still on screen becomes stale
+   * against it — which is the behaviour we want, not a bug to work around.
+   */
+  onApplied: (saved: WorkflowGraph) => void;
+  /** A `409` from an apply, for the view's persistent reload banner. */
+  onConflict?: (message: string) => void;
   onClose: () => void;
 }) {
   const [messages, setMessages] = useState<CopilotMessage[]>([]);
@@ -98,6 +136,19 @@ export function CopilotPanel({
   // and a fast question gets exactly the parroted reply the gate exists to
   // prevent.
   const [inferenceChecked, setInferenceChecked] = useState(false);
+  // Issue #415. One entry per company message that carried a proposal block,
+  // parsed EXACTLY ONCE, when the message first appears.
+  //
+  // Once, because the parse is what stamps the graph version the proposal was
+  // reasoned about. Re-parsing on a later render — after the operator edited
+  // the canvas, or after another proposal was applied — would re-stamp it
+  // against a graph it never saw, which is precisely the silent rebase the
+  // issue rules out.
+  const [reviews, setReviews] = useState<Record<string, Review>>({});
+  // Message ids this session produced. A replayed proposal is never applyable:
+  // the graph it was reasoned about is not knowable from the journal, and
+  // "apply this to whatever is there now" is the failure mode, not the feature.
+  const [thisSession, setThisSession] = useState<ReadonlySet<string>>(() => new Set());
   const scrollRef = useRef<HTMLDivElement>(null);
   // Bumped whenever the conversation this panel is holding changes identity.
   // An in-flight request captures it and drops its result if it no longer
@@ -155,11 +206,117 @@ export function CopilotPanel({
     };
   }, [client, company]);
 
+  // Read each new company reply once: prose out, proposal (or the reason there
+  // isn't a usable one) in. `graph` is a dependency because a reply arriving
+  // after a canvas edit must be read against the graph on screen — but an
+  // already-read message is skipped, so an existing proposal keeps the version
+  // it was reasoned about.
+  useEffect(() => {
+    setReviews((prev) => {
+      let next = prev;
+      for (const message of messages) {
+        if (message.role !== "company" || next[message.id]) continue;
+        const read = readProposal(message.text, graph);
+        const review: Review = {
+          prose: read.prose,
+          proposal: read.proposal,
+          diff: read.proposal
+            ? diffGraphs(graph, applyProposal(graph, read.proposal))
+            : undefined,
+          problem: read.problem?.reason,
+          state: "pending",
+        };
+        if (next === prev) next = { ...prev };
+        next[message.id] = review;
+      }
+      return next;
+    });
+  }, [messages, graph]);
+
   // Keep the newest turn in view.
   useEffect(() => {
     const el = scrollRef.current;
     if (el) el.scrollTop = el.scrollHeight;
   }, [messages, sending]);
+
+  /**
+   * Applies one proposal through the SAME write the canvas editor performs:
+   * `updateWorkflow` with the version this panel is holding. So a proposal
+   * cannot produce a graph the editor could not have produced, and cannot
+   * overwrite a graph that moved while the operator was reading the diff — the
+   * host refuses that with a 409, and this refuses it one step earlier with a
+   * sentence naming what happened.
+   */
+  const apply = useCallback(
+    async (messageId: string, proposal: WorkflowProposal) => {
+      setReviews((prev) => ({
+        ...prev,
+        [messageId]: { ...prev[messageId], state: "applying", error: undefined },
+      }));
+      try {
+        const saved = await updateWorkflow(
+          client,
+          company,
+          graph.id,
+          applyProposal(graph, proposal),
+          graph.version,
+        );
+        setReviews((prev) => ({
+          ...prev,
+          [messageId]: { ...prev[messageId], state: "applied", error: undefined },
+        }));
+        onApplied(saved);
+      } catch (e) {
+        const conflict = e instanceof ApiError && e.status === 409;
+        const message = conflict
+          ? `${e.message} Reload the workflow and ask the copilot again.`
+          : e instanceof Error
+            ? e.message
+            : "The change could not be applied.";
+        // Back to `pending`, not to a dead end: the diff stays on screen and the
+        // operator can dismiss it or retry after reloading.
+        setReviews((prev) => ({
+          ...prev,
+          [messageId]: { ...prev[messageId], state: "pending", error: message },
+        }));
+        if (conflict && e instanceof ApiError) onConflict?.(e.message);
+      }
+    },
+    [client, company, graph, onApplied, onConflict],
+  );
+
+  /** Turning a proposal down writes nothing; the card stays, greyed. */
+  const dismiss = useCallback((messageId: string) => {
+    setReviews((prev) => ({
+      ...prev,
+      [messageId]: { ...prev[messageId], state: "dismissed", error: undefined },
+    }));
+  }, []);
+
+  /**
+   * Why this proposal cannot be applied, or `undefined` when it can.
+   *
+   * Every arm here is a refusal the issue asks for by name: a graph that moved
+   * under the proposal, a proposal replayed from a session whose graph we
+   * cannot know, a workflow the host will not let the console write at all, and
+   * a proposal that turns out to change nothing.
+   */
+  function blockedReason(messageId: string, review: Review): string | undefined {
+    if (!review.proposal || !review.diff) return undefined;
+    if (sourceDefined) {
+      return "This workflow is defined by a file in the company source tree, so a change has to be made in the repository.";
+    }
+    if (!thisSession.has(messageId)) {
+      return "This was proposed in an earlier session, so it can't be applied to the workflow as it stands now. Ask again for a fresh proposal.";
+    }
+    if (proposalIsStale(review.proposal, graph)) {
+      return "The workflow changed after this was proposed, so it no longer describes the graph on screen. Ask again for a fresh proposal.";
+    }
+    if (isEmptyDiff(review.diff)) {
+      return "This proposal would change nothing, so there is nothing to apply.";
+    }
+    return undefined;
+  }
 
   const echoing = cognition === "echo";
   // Nothing may be asked until BOTH the echo check has settled and the run
@@ -198,13 +355,12 @@ export function CopilotPanel({
         question,
       );
       if (!mine()) return;
-      setMessages((prev) => [
-        ...prev,
-        // An empty `responses` array is a real answer shape, not a crash: the
-        // cycle ran and produced no channel reply. Say that rather than
-        // dropping the turn silently, which would look like the message was
-        // never sent.
-        ...(replies.length === 0
+      // An empty `responses` array is a real answer shape, not a crash: the
+      // cycle ran and produced no channel reply. Say that rather than
+      // dropping the turn silently, which would look like the message was
+      // never sent.
+      const answered: CopilotMessage[] =
+        replies.length === 0
           ? [
               {
                 id: localId(),
@@ -218,8 +374,15 @@ export function CopilotPanel({
               role: "company" as const,
               text,
               atMillis: Date.now(),
-            }))),
-      ]);
+            }));
+      // Recorded before the messages land, so the review effect never sees a
+      // reply from this session and reads it as replayed (issue #415).
+      setThisSession((prev) => {
+        const next = new Set(prev);
+        for (const message of answered) next.add(message.id);
+        return next;
+      });
+      setMessages((prev) => [...prev, ...answered]);
     } catch (e) {
       if (!mine()) return;
       setError(e instanceof Error ? e.message : "the copilot could not answer");
@@ -287,12 +450,24 @@ export function CopilotPanel({
             workflow&apos;s copilot can&apos;t see it.
           </p>
           <p className="mt-1.5">
-            It can explain and suggest, but{" "}
-            <span className="font-medium text-foreground">it can&apos;t change the workflow</span>
-            .
-            {sourceDefined
-              ? " This one is defined by a file in the company source tree, so changes belong in the company repository."
-              : " Apply a change yourself with Edit, the path that checks the graph and refuses a stale write."}
+            {sourceDefined ? (
+              <>
+                It can explain and suggest, but{" "}
+                <span className="font-medium text-foreground">
+                  it can&apos;t change the workflow
+                </span>
+                . This one is defined by a file in the company source tree, so changes belong in
+                the company repository.
+              </>
+            ) : (
+              <>
+                Ask for a change and it{" "}
+                <span className="font-medium text-foreground">proposes one you review</span>: you
+                see the diff and decide. Nothing is written until you press Apply, and it goes
+                through the same save the editor uses, which refuses a workflow that moved while
+                you were reading.
+              </>
+            )}
           </p>
         </div>
 
@@ -333,8 +508,36 @@ export function CopilotPanel({
             ) : (
               // The same renderer every other markdown surface uses, so a
               // copilot answer reads like a chat reply rather than its own
-              // dialect.
-              <Markdown className="prose-sm">{m.text}</Markdown>
+              // dialect. The proposal block is stripped out of the prose and
+              // rendered as the review card below, so the operator never reads
+              // raw JSON (issue #415).
+              <Markdown className="prose-sm">{reviews[m.id]?.prose ?? m.text}</Markdown>
+            )}
+            {m.role === "company" &&
+              reviews[m.id]?.proposal &&
+              reviews[m.id]?.diff && (
+                <div className="mt-2">
+                  <ProposalCard
+                    summary={reviews[m.id].proposal!.summary}
+                    diff={reviews[m.id].diff!}
+                    state={reviews[m.id].state}
+                    blocked={blockedReason(m.id, reviews[m.id])}
+                    error={reviews[m.id].error}
+                    onApply={() => void apply(m.id, reviews[m.id].proposal!)}
+                    onDismiss={() => dismiss(m.id)}
+                  />
+                </div>
+              )}
+            {/* A block that arrived malformed is said out loud. Dropping it
+                would leave the operator reading prose that describes a change
+                with no way to apply it and no hint that one was attempted. */}
+            {m.role === "company" && reviews[m.id]?.problem && (
+              <Alert className="mt-2 py-1.5">
+                <AlertDescription className="text-[11px] leading-snug">
+                  The copilot tried to propose a change this console couldn&apos;t read.{" "}
+                  {reviews[m.id].problem} Ask again, or make the change in the editor.
+                </AlertDescription>
+              </Alert>
             )}
           </div>
         ))}

--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -168,6 +168,16 @@ export function CopilotPanel({
     let live = true;
     conversation.current += 1;
     setMessages([]);
+    // The proposal state goes with the transcript it belongs to (issue #415).
+    // Usually the panel is remounted — the parent keys it on the workflow id —
+    // but not when a company switch lands on a workflow of the SAME id, which
+    // is the case `send` already guards its in-flight reply against. Left
+    // behind, `reviews` would hold entries keyed by the previous company's
+    // journal ids, and `thisSession` would vouch for a proposal made against
+    // another company's graph. `proposalIsStale` catches most of that through
+    // the version token, and a host predating the token has no such catch.
+    setReviews({});
+    setThisSession(new Set());
     setError(null);
     setSending(false);
     (async () => {

--- a/frontend/src/views/workflows/ProposalCard.tsx
+++ b/frontend/src/views/workflows/ProposalCard.tsx
@@ -1,0 +1,190 @@
+// Issue #415: what the operator reads before a copilot's change is applied.
+//
+// The card is the review, so it shows the DIFF and not the proposal: what would
+// change about the graph on screen, step by step and connection by connection,
+// computed from the candidate graph rather than from the model's op list. A
+// change nobody proposed cannot appear in it, and an op that changes nothing
+// shows as nothing.
+//
+// Nothing here mutates anything. Apply is the only path that writes, it goes
+// through the same versioned `updateWorkflow` the editor uses, and Dismiss
+// writes nothing at all: the card greys out and stays in the transcript so a
+// later question can refer to what was turned down.
+
+import { AlertTriangle, ArrowRight, Check, Loader2, Minus, Plus, X } from "lucide-react";
+
+import type { GraphDiff, NodeChange } from "@/api/workflow-proposal";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+/** Where a proposal has got to. Only `pending` can write anything. */
+export type ProposalState = "pending" | "applying" | "applied" | "dismissed";
+
+interface Props {
+  summary: string;
+  diff: GraphDiff;
+  state: ProposalState;
+  /**
+   * Why this proposal cannot be applied, when it cannot: the graph moved under
+   * it, it was replayed from an earlier session, or it would change nothing.
+   * Present means the Apply button is not offered at all rather than offered
+   * and refused.
+   */
+  blocked?: string;
+  /** The host's refusal, when an Apply was attempted and came back rejected. */
+  error?: string;
+  onApply: () => void;
+  onDismiss: () => void;
+}
+
+export function ProposalCard({
+  summary,
+  diff,
+  state,
+  blocked,
+  error,
+  onApply,
+  onDismiss,
+}: Props) {
+  const settled = state === "applied" || state === "dismissed";
+  return (
+    <div
+      data-testid="workflow-proposal"
+      data-state={state}
+      className={cn(
+        "rounded-lg border bg-background p-2 text-[11px] leading-snug",
+        settled && "opacity-60",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <p className="font-medium text-foreground">{summary}</p>
+        {state === "applied" && (
+          <span className="inline-flex shrink-0 items-center gap-1 text-emerald-600 dark:text-emerald-400">
+            <Check className="size-3" /> Applied
+          </span>
+        )}
+        {state === "dismissed" && <span className="shrink-0 text-muted-foreground">Dismissed</span>}
+      </div>
+
+      <ul className="mt-2 space-y-1">
+        {diff.nodes.map((node) => (
+          <li key={`n-${node.id}`}>
+            <NodeLine node={node} />
+          </li>
+        ))}
+        {diff.edges.map((edge) => (
+          <li
+            key={`e-${edge.change}-${edge.from}-${edge.to}`}
+            className="flex items-center gap-1 text-muted-foreground"
+          >
+            {edge.change === "added" ? (
+              <Plus className="size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+            ) : (
+              <Minus className="size-3 shrink-0 text-destructive" />
+            )}
+            <span className="font-mono">{edge.from}</span>
+            <ArrowRight className="size-3 shrink-0" aria-hidden />
+            <span className="font-mono">{edge.to}</span>
+          </li>
+        ))}
+        {diff.nodes.length === 0 && diff.edges.length === 0 && (
+          <li className="text-muted-foreground">
+            This would change nothing about the workflow as it stands.
+          </li>
+        )}
+      </ul>
+
+      {blocked && !settled && (
+        <Alert className="mt-2 py-1.5">
+          <AlertTriangle className="size-3" />
+          <AlertDescription className="text-[11px] leading-snug">{blocked}</AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive" className="mt-2 py-1.5">
+          <AlertTriangle className="size-3" />
+          <AlertDescription className="text-[11px] leading-snug">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {!settled && (
+        <div className="mt-2 flex items-center gap-2">
+          <Button
+            size="sm"
+            className="h-7 px-2 text-[11px]"
+            disabled={state === "applying" || Boolean(blocked)}
+            onClick={onApply}
+            data-testid="workflow-proposal-apply"
+          >
+            {state === "applying" ? (
+              <Loader2 className="mr-1 size-3 animate-spin" />
+            ) : (
+              <Check className="mr-1 size-3" />
+            )}
+            Apply
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            className="h-7 px-2 text-[11px]"
+            disabled={state === "applying"}
+            onClick={onDismiss}
+            data-testid="workflow-proposal-dismiss"
+          >
+            <X className="mr-1 size-3" />
+            Dismiss
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** One step's line: added, removed, or changed with the fields that moved. */
+function NodeLine({ node }: { node: NodeChange }) {
+  if (node.change === "added") {
+    return (
+      <span className="flex items-start gap-1 text-muted-foreground">
+        <Plus className="mt-px size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+        <span>
+          new step <span className="font-mono">{node.id}</span>{" "}
+          <span className="text-foreground">{node.name}</span>
+        </span>
+      </span>
+    );
+  }
+  if (node.change === "removed") {
+    return (
+      <span className="flex items-start gap-1 text-muted-foreground">
+        <Minus className="mt-px size-3 shrink-0 text-destructive" />
+        <span>
+          remove <span className="font-mono">{node.id}</span>{" "}
+          <span className="text-foreground">{node.name}</span>
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className="block text-muted-foreground">
+      <span className="flex items-start gap-1">
+        <ArrowRight className="mt-px size-3 shrink-0" aria-hidden />
+        <span>
+          <span className="font-mono">{node.id}</span>{" "}
+          <span className="text-foreground">{node.name}</span>
+        </span>
+      </span>
+      <span className="mt-0.5 ml-4 block space-y-0.5">
+        {node.fields.map((field) => (
+          <span key={field.field} className="block">
+            <span className="font-medium text-foreground">{field.field}</span>:{" "}
+            <span className="line-through">{field.before}</span>{" "}
+            <ArrowRight className="inline size-3 align-[-2px]" aria-hidden />{" "}
+            <span className="text-foreground">{field.after}</span>
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/frontend/src/views/workflows/ProposalCard.tsx
+++ b/frontend/src/views/workflows/ProposalCard.tsx
@@ -146,11 +146,25 @@ export function ProposalCard({
 function NodeLine({ node }: { node: NodeChange }) {
   if (node.change === "added") {
     return (
-      <span className="flex items-start gap-1 text-muted-foreground">
-        <Plus className="mt-px size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
-        <span>
-          new step <span className="font-mono">{node.id}</span>{" "}
-          <span className="text-foreground">{node.name}</span>
+      <span className="block text-muted-foreground">
+        <span className="flex items-start gap-1">
+          <Plus className="mt-px size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <span>
+            new step <span className="font-mono">{node.id}</span>{" "}
+            <span className="text-foreground">{node.name}</span>
+          </span>
+        </span>
+        {/* A new step's whole payload, not just its name: its kind, and any
+            schedule, config or approval flag it arrives with, each of which
+            changes what the workflow does. Reviewing a name and applying a
+            scheduled auto-approving node is the gap this closes. */}
+        <span className="mt-0.5 ml-4 block space-y-0.5">
+          {node.fields.map((field) => (
+            <span key={field.field} className="block">
+              <span className="font-medium text-foreground">{field.field}</span>:{" "}
+              <span className="text-foreground">{field.after}</span>
+            </span>
+          ))}
         </span>
       </span>
     );

--- a/frontend/test/unit/workflow-copilot.test.ts
+++ b/frontend/test/unit/workflow-copilot.test.ts
@@ -71,9 +71,36 @@ describe("composeCopilotMessage", () => {
     expect(message).toMatch(/do not claim to have looked anything up/i);
   });
 
-  it("still refuses to claim it can edit the workflow", () => {
+  /**
+   * #415 replaced "you cannot edit" with the sharper pair: it cannot APPLY,
+   * and it may PROPOSE. Both halves matter — a model told only the first goes
+   * back to prose the operator has to retype, and one told only the second
+   * will claim to have made the change.
+   */
+  it("may propose a change and may not apply one", () => {
     const message = composeCopilotMessage(context, "add a retry");
-    expect(message).toMatch(/CANNOT edit the workflow/);
+    expect(message).toMatch(/CANNOT apply a change yourself/);
+    expect(message).toMatch(/PROPOSE/);
+    expect(message).toContain("## Proposing a change");
+    expect(message).toContain("```workflow-proposal");
+    // The ops the console can actually read back.
+    for (const op of ["addNode", "updateNode", "removeNode", "addEdge", "removeEdge"]) {
+      expect(message).toContain(op);
+    }
+  });
+
+  /**
+   * A source-defined workflow is refused every write by the host, so proposing
+   * one could only ever produce a diff whose Apply is refused. The protocol is
+   * withheld entirely rather than offered and then blocked.
+   */
+  it("does not offer the protocol for a workflow the console cannot write", () => {
+    const message = composeCopilotMessage(
+      { ...context, graph: { ...graph, editable: false } },
+      "add a retry",
+    );
+    expect(message).not.toContain("## Proposing a change");
+    expect(message).toMatch(/must not propose an edit/);
   });
 
   /**

--- a/frontend/test/unit/workflow-proposal.test.ts
+++ b/frontend/test/unit/workflow-proposal.test.ts
@@ -266,6 +266,43 @@ describe("diffGraphs", () => {
    * sets a field to what it already holds shows up as nothing. A proposal is
    * never allowed to look bigger than what it would do.
    */
+  /**
+   * A new step's whole payload reaches the review. `kind` decides what the step
+   * IS, and a `schedule` or `requiresApproval` decides what the workflow does
+   * without anybody pressing anything — applying those off a row that showed
+   * only a name is the reviewed-one-thing-applied-another failure this module
+   * exists to prevent.
+   */
+  it("shows every field a new step carries, not just its name", () => {
+    const current = graph();
+    const candidate = applyProposal(current, {
+      summary: "s",
+      ops: [
+        {
+          op: "addNode",
+          node: {
+            id: "digest",
+            kind: "trigger",
+            name: "Digest",
+            schedule: "0 9 * * *",
+            requiresApproval: true,
+          },
+        },
+      ],
+    });
+    const added = diffGraphs(current, candidate).nodes.find((n) => n.id === "digest");
+    expect(added?.change).toBe("added");
+    const shown = Object.fromEntries(added!.fields.map((f) => [f.field, f.after]));
+    expect(shown).toMatchObject({
+      kind: "trigger",
+      schedule: "0 9 * * *",
+      requiresApproval: "true",
+    });
+    // The header already carries the name; repeating it as a field line would
+    // be noise in the one place noise costs attention.
+    expect(shown).not.toHaveProperty("name");
+  });
+
   it("shows nothing for an edit that changes nothing", () => {
     const current = graph();
     const candidate = applyProposal(current, {
@@ -273,6 +310,46 @@ describe("diffGraphs", () => {
       ops: [{ op: "updateNode", id: "collect", set: { name: "Collect" } }],
     });
     expect(isEmptyDiff(diffGraphs(current, candidate))).toBe(true);
+  });
+});
+
+describe("edge identity", () => {
+  /**
+   * A space-delimited key collides: `("a b", "c")` and `("a", "b c")` both read
+   * as `a b c`. Two different connections comparing equal would let validation
+   * refuse a genuinely new edge, and would let `diffGraphs` hide a real one from
+   * the review — the two failures this module is most careful about, reached
+   * through a node id nobody thought to forbid.
+   */
+  it("tells apart two edges a space-joined key would confuse", () => {
+    const spaced: WorkflowGraph = {
+      ...graph(),
+      nodes: [
+        { id: "a b", kind: "agent", name: "A B" },
+        { id: "c", kind: "output", name: "C" },
+        { id: "a", kind: "agent", name: "A" },
+        { id: "b c", kind: "output", name: "B C" },
+      ],
+      edges: [{ from: "a b", to: "c" }],
+    };
+
+    // `("a", "b c")` is NOT the existing `("a b", "c")`, so it is a real new
+    // connection rather than a duplicate to refuse.
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "addEdge", from: "a", to: "b c" }] },
+      spaced,
+    );
+    expect(out).not.toHaveProperty("reason");
+
+    // …and it shows up in the diff as an addition rather than vanishing into
+    // the edge that was already there.
+    const candidate = applyProposal(spaced, {
+      summary: "s",
+      ops: [{ op: "addEdge", from: "a", to: "b c" }],
+    });
+    expect(diffGraphs(spaced, candidate).edges).toEqual([
+      { from: "a", to: "b c", change: "added" },
+    ]);
   });
 });
 

--- a/frontend/test/unit/workflow-proposal.test.ts
+++ b/frontend/test/unit/workflow-proposal.test.ts
@@ -125,6 +125,41 @@ describe("validateProposal", () => {
     expect(out).toMatchObject({ reason: expect.stringContaining("id") });
   });
 
+  /**
+   * A key this console does not know cannot be rendered — an added step's diff
+   * line carries its id and name — so keeping it would put something in the
+   * candidate graph the operator never saw, and dropping it would apply a step
+   * that is not the one described. Refused, like `updateNode`'s unknown field.
+   */
+  it("refuses a new step carrying a field that isn't a step field", () => {
+    const out = validateProposal(
+      {
+        summary: "s",
+        ops: [
+          {
+            op: "addNode",
+            node: { id: "notify", kind: "output", name: "Notify", sudo: true },
+          },
+        ],
+      },
+      g,
+    );
+    expect(out).toMatchObject({ reason: expect.stringContaining("sudo") });
+  });
+
+  /**
+   * A duplicate edge would append a second identical entry and diff to nothing
+   * — the diff compares sets keyed by `from`/`to` — so the operator would apply
+   * a change the review never showed.
+   */
+  it("refuses a connection that already exists", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "addEdge", from: "collect", to: "send" }] },
+      g,
+    );
+    expect(out).toMatchObject({ reason: expect.stringContaining("already connected") });
+  });
+
   it("refuses a connection to a step the proposal never adds", () => {
     const out = validateProposal(
       { summary: "s", ops: [{ op: "addEdge", from: "collect", to: "ghost" }] },

--- a/frontend/test/unit/workflow-proposal.test.ts
+++ b/frontend/test/unit/workflow-proposal.test.ts
@@ -1,0 +1,273 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  applyProposal,
+  diffGraphs,
+  isEmptyDiff,
+  PROPOSAL_FENCE,
+  proposalIsStale,
+  readProposal,
+  validateProposal,
+  type WorkflowProposal,
+} from "@/api/workflow-proposal";
+import type { WorkflowGraph } from "@/api/workflows";
+
+/**
+ * Issue #415. The copilot proposes an edit; the operator reviews a diff and
+ * applies it. Everything below is the part of that round trip that is decidable
+ * without a host: what a reply is allowed to contain, what the candidate graph
+ * would be, what the operator is shown, and when a proposal must be refused.
+ *
+ * The refusals get as much attention as the happy path on purpose. A proposal
+ * that applies something the operator did not review — because it was parsed
+ * loosely, because the graph moved underneath it, or because it silently
+ * dropped a node it never mentioned — is the failure mode this issue exists to
+ * prevent, and each of those has a test here.
+ */
+
+function graph(): WorkflowGraph {
+  return {
+    id: "weekly_report",
+    name: "Weekly report",
+    version: "v1",
+    editable: true,
+    nodes: [
+      { id: "collect", kind: "agent", name: "Collect", agent: "analyst" },
+      { id: "send", kind: "output", name: "Send", destination: { kind: "owner" } },
+    ],
+    edges: [{ from: "collect", to: "send" }],
+  };
+}
+
+function block(body: unknown): string {
+  return "Here is what I'd change.\n\n```" + PROPOSAL_FENCE + "\n" + JSON.stringify(body) + "\n```";
+}
+
+describe("readProposal", () => {
+  it("leaves an ordinary answer alone", () => {
+    const read = readProposal("It collects, then sends.", graph());
+    expect(read.prose).toBe("It collects, then sends.");
+    expect(read.proposal).toBeUndefined();
+    expect(read.problem).toBeUndefined();
+  });
+
+  it("splits the proposal out of the prose so no raw JSON is rendered", () => {
+    const read = readProposal(
+      block({
+        summary: "Retry the collect step",
+        ops: [{ op: "updateNode", id: "collect", set: { retry: { maxAttempts: 3 } } }],
+      }),
+      graph(),
+    );
+    expect(read.prose).toBe("Here is what I'd change.");
+    expect(read.proposal?.summary).toBe("Retry the collect step");
+    expect(read.proposal?.ops).toHaveLength(1);
+  });
+
+  /**
+   * The version is stamped by the console from the graph it parsed against,
+   * never read from the model. A model that could assert which graph it was
+   * looking at could assert a stale proposal was fresh.
+   */
+  it("stamps the version of the graph it was read against", () => {
+    const read = readProposal(
+      block({ summary: "s", ops: [{ op: "removeNode", id: "send" }] }),
+      graph(),
+    );
+    expect(read.proposal?.basedOnVersion).toBe("v1");
+  });
+
+  it("reports a block that isn't JSON instead of dropping it", () => {
+    const read = readProposal("prose\n\n```" + PROPOSAL_FENCE + "\nnot json\n```", graph());
+    expect(read.proposal).toBeUndefined();
+    expect(read.problem?.reason).toMatch(/valid JSON/);
+  });
+});
+
+describe("validateProposal", () => {
+  const g = graph();
+
+  it("refuses a proposal that says nothing about what it does", () => {
+    const out = validateProposal({ ops: [{ op: "removeNode", id: "send" }] }, g);
+    expect(out).toHaveProperty("reason");
+  });
+
+  it("refuses an empty edit list", () => {
+    expect(validateProposal({ summary: "s", ops: [] }, g)).toHaveProperty("reason");
+  });
+
+  it("refuses an edit aimed at a step that isn't there", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "updateNode", id: "ghost", set: { name: "x" } }] },
+      g,
+    );
+    expect(out).toMatchObject({ reason: expect.stringContaining("ghost") });
+  });
+
+  it("refuses a new step that reuses an existing id", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "addNode", node: { id: "collect", kind: "agent", name: "X" } }] },
+      g,
+    );
+    expect(out).toMatchObject({ reason: expect.stringContaining("collect") });
+  });
+
+  /**
+   * An id keys a node's edges, so renaming through `set` would orphan them
+   * silently. A rename has to be an add plus a remove, which the diff then
+   * shows as what it is.
+   */
+  it("refuses to rename a step through an update", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "updateNode", id: "collect", set: { id: "gather" } }] },
+      g,
+    );
+    expect(out).toMatchObject({ reason: expect.stringContaining("id") });
+  });
+
+  it("refuses a connection to a step the proposal never adds", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "addEdge", from: "collect", to: "ghost" }] },
+      g,
+    );
+    expect(out).toHaveProperty("reason");
+  });
+
+  /** …but accepts one to a step the same proposal adds, in order. */
+  it("accepts a connection to a step the same proposal adds", () => {
+    const out = validateProposal(
+      {
+        summary: "s",
+        ops: [
+          { op: "addNode", node: { id: "notify", kind: "output", name: "Notify" } },
+          { op: "addEdge", from: "collect", to: "notify" },
+        ],
+      },
+      g,
+    );
+    expect(out).not.toHaveProperty("reason");
+  });
+
+  it("refuses to disconnect two steps that were never connected", () => {
+    const out = validateProposal(
+      { summary: "s", ops: [{ op: "removeEdge", from: "send", to: "collect" }] },
+      g,
+    );
+    expect(out).toHaveProperty("reason");
+  });
+
+  it("refuses an edit kind this console cannot render", () => {
+    const out = validateProposal({ summary: "s", ops: [{ op: "replaceGraph", graph: {} }] }, g);
+    expect(out).toMatchObject({ reason: expect.stringContaining("replaceGraph") });
+  });
+});
+
+describe("applyProposal", () => {
+  it("never mutates the graph it was given, so a rejected proposal changes nothing", () => {
+    const before = graph();
+    const snapshot = JSON.stringify(before);
+    applyProposal(before, {
+      summary: "s",
+      ops: [{ op: "removeNode", id: "send" }],
+    });
+    expect(JSON.stringify(before)).toBe(snapshot);
+  });
+
+  it("takes a removed step's connections with it", () => {
+    const candidate = applyProposal(graph(), {
+      summary: "s",
+      ops: [{ op: "removeNode", id: "send" }],
+    });
+    expect(candidate.nodes.map((n) => n.id)).toEqual(["collect"]);
+    expect(candidate.edges).toEqual([]);
+  });
+
+  it("applies field-level updates without touching the rest of the step", () => {
+    const candidate = applyProposal(graph(), {
+      summary: "s",
+      ops: [{ op: "updateNode", id: "collect", set: { retry: { maxAttempts: 3 } } }],
+    });
+    const collect = candidate.nodes.find((n) => n.id === "collect");
+    expect(collect?.retry).toEqual({ maxAttempts: 3 });
+    expect(collect?.agent).toBe("analyst");
+    expect(candidate.id).toBe("weekly_report");
+  });
+});
+
+describe("diffGraphs", () => {
+  it("reports added, removed and changed steps and the fields that moved", () => {
+    const current = graph();
+    const candidate = applyProposal(current, {
+      summary: "s",
+      ops: [
+        { op: "updateNode", id: "collect", set: { name: "Collect numbers" } },
+        { op: "addNode", node: { id: "notify", kind: "output", name: "Notify" } },
+        { op: "addEdge", from: "send", to: "notify" },
+        { op: "removeEdge", from: "collect", to: "send" },
+      ],
+    });
+    const diff = diffGraphs(current, candidate);
+
+    expect(diff.nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "collect",
+          change: "changed",
+          fields: [{ field: "name", before: "Collect", after: "Collect numbers" }],
+        }),
+        expect.objectContaining({ id: "notify", change: "added" }),
+      ]),
+    );
+    expect(diff.edges).toEqual(
+      expect.arrayContaining([
+        { from: "send", to: "notify", change: "added" },
+        { from: "collect", to: "send", change: "removed" },
+      ]),
+    );
+  });
+
+  /**
+   * The diff is computed from the graphs, not from the op list, so an edit that
+   * sets a field to what it already holds shows up as nothing. A proposal is
+   * never allowed to look bigger than what it would do.
+   */
+  it("shows nothing for an edit that changes nothing", () => {
+    const current = graph();
+    const candidate = applyProposal(current, {
+      summary: "s",
+      ops: [{ op: "updateNode", id: "collect", set: { name: "Collect" } }],
+    });
+    expect(isEmptyDiff(diffGraphs(current, candidate))).toBe(true);
+  });
+});
+
+describe("proposalIsStale", () => {
+  const proposal: WorkflowProposal = {
+    summary: "s",
+    ops: [{ op: "removeNode", id: "send" }],
+    basedOnVersion: "v1",
+  };
+
+  it("is fresh against the graph it was proposed on", () => {
+    expect(proposalIsStale(proposal, graph())).toBe(false);
+  });
+
+  it("is stale once the graph moves, so it is refused rather than rebased", () => {
+    expect(proposalIsStale(proposal, { ...graph(), version: "v2" })).toBe(true);
+  });
+
+  it("is stale when the version it was based on is unknown", () => {
+    expect(proposalIsStale({ ...proposal, basedOnVersion: undefined }, graph())).toBe(true);
+  });
+
+  /**
+   * A host predating the version token (#259) has no concurrency protection at
+   * all, for the canvas editor as much as for a proposal. Refusing every
+   * proposal there would invent a protection that does not exist rather than
+   * report one.
+   */
+  it("does not invent staleness on a host that has no versions", () => {
+    const versionless = { ...graph(), version: undefined };
+    expect(proposalIsStale({ ...proposal, basedOnVersion: undefined }, versionless)).toBe(false);
+  });
+});

--- a/src/harness/confine.rs
+++ b/src/harness/confine.rs
@@ -217,8 +217,11 @@ pub fn confined_persona(company_name: &str, confinement: &Confinement) -> String
              which part you cannot answer and that it has to be asked in the company chat, then \
              answer whatever the rest of the question allows. Do not guess at company context, \
              and do not claim to have looked anything up.\n\n\
-             You cannot change the workflow. Describe a change precisely enough for a person to \
-             make it in the workflow editor, and never claim to have made it."
+             You cannot change the workflow yourself, and you have no way to try: this turn \
+             calls nothing. What you can do is PROPOSE a change in the format the message asks \
+             for (issue #415) — the operator reads it as a diff against their graph and applies \
+             it, or throws it away. A proposal is text in your reply, not an action, so never \
+             say you have made a change, and never propose one that was not asked for."
         ),
     }
 }
@@ -367,6 +370,26 @@ mod tests {
         assert!(persona.contains("no tools"), "{persona}");
         assert!(persona.contains("company chat"), "{persona}");
         assert!(persona.contains("cannot change the workflow"), "{persona}");
+    }
+
+    /// Issue #415. The turn may PROPOSE, and the persona has to be exact about
+    /// what that is: text in a reply that the operator applies, not something
+    /// the agent did. A model that reads "propose" as "do" would report changes
+    /// that never landed, which is worse than a copilot that cannot propose at
+    /// all. The confinement is untouched by this — proposing calls nothing, and
+    /// the tool policy still refuses everything.
+    #[test]
+    fn the_persona_allows_proposing_and_forbids_claiming_to_have_applied() {
+        let persona = confined_persona("Acme", &workflow());
+        assert!(persona.contains("PROPOSE"), "{persona}");
+        assert!(
+            persona.contains("the operator reads it as a diff"),
+            "{persona}"
+        );
+        assert!(
+            persona.contains("never say you have made a change"),
+            "{persona}"
+        );
     }
 
     /// The confined context is a hole: nothing written to it can be read back,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3704,6 +3704,88 @@ description = "Sets direction."
         assert_eq!(before, after, "a refused turn stores nothing in memory");
     }
 
+    /// Issue #416, the reason [`HarnessPool::total_ceiling_refusal`] was
+    /// extracted rather than copied: a confined turn reaches nothing, but it
+    /// still spends model tokens, so the tenant's ceiling refuses it exactly as
+    /// it refuses a roster dispatch. Without this test the gate could be dropped
+    /// from `run_confined` and every other test would stay green — the copilot
+    /// would simply keep spending past the cap.
+    #[tokio::test]
+    async fn a_confined_turn_is_refused_once_the_total_ceiling_is_crossed() {
+        let dir = tempfile::tempdir().unwrap();
+        let context = Arc::new(MockContext::default());
+        let meter = Arc::new(RecordingMeter::default());
+        let plan = crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: std::collections::BTreeMap::new(),
+            total_budget: Some(100),
+        };
+        let deps = deps_with_plan(
+            dir.path(),
+            context.clone(),
+            Some(meter.clone() as Arc<dyn UsageMeter>),
+            Some(plan),
+        );
+        let pool = HarnessPool::new();
+        let rec = record();
+        pool.ensure(&rec, &deps).await.expect("ensure");
+
+        let confinement = confine::Confinement::workflow("weekly_report");
+        let thread = Some("workflow-copilot:weekly_report");
+
+        // Under the ceiling the copilot answers, so the refusal below is the
+        // ceiling talking and not the confined path failing to run at all.
+        let ok = pool
+            .run_confined(&rec.id, "Acme", "hello-marker", &deps, thread, &confinement)
+            .await
+            .expect("under-ceiling confined turn runs")
+            .reply;
+        assert!(
+            ok.contains("hello-marker"),
+            "under the ceiling the model runs: {ok:?}"
+        );
+
+        // Push total period spend past the 100-token ceiling.
+        meter
+            .record(
+                &rec.id,
+                &UsageSample {
+                    at_millis: crate::ports::now_millis(),
+                    agent: "ceo".into(),
+                    provider: "managed".into(),
+                    input_tokens: 100,
+                    output_tokens: 50,
+                    cached_input_tokens: 0,
+                    cost_usd: 0.0,
+                    kind: crate::ports::SampleKind::Inference,
+                    run_id: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let refused = pool
+            .run_confined(
+                &rec.id,
+                "Acme",
+                "should-not-echo",
+                &deps,
+                thread,
+                &confinement,
+            )
+            .await
+            .expect("a refusal is a benign outcome, not a hard error")
+            .reply;
+        assert_eq!(
+            refused, TOTAL_BUDGET_EXHAUSTED_NOTICE,
+            "the copilot must not keep spending past the tenant ceiling"
+        );
+        assert!(
+            !refused.contains("should-not-echo"),
+            "the model was never called, so the prompt is not echoed: {refused:?}"
+        );
+    }
+
     /// Fail-closed tradeoff (issue #188): with a total ceiling configured but no
     /// meter to read spend from, the hard refusal does NOT fire — a transient
     /// unreadable-spend condition must not brick every turn. The turn runs (the

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1039,10 +1039,22 @@ async fn run_chat(
     parent: Option<EventSeq>,
 ) -> Result<(CycleReport, Option<String>), ApiError> {
     runtime.ensure_running().await?;
+    // Whether this is a workflow copilot thread (issue #416): a conversation
+    // ABOUT one graph, not a request to the company. Read once, because both
+    // of the deterministic side effects below have to be suppressed for it.
+    let confined = crate::company::copilot::is_copilot_thread(message.chat.as_deref());
     // Operator-chat feedback intent: a complaint phrase ("that was wrong — flag
     // it") captures a feedback item alongside the normal cycle. Neutral chat
     // carries no intent, so ordinary messages are untouched.
-    let feedback_note = if let Some(category) = crate::feedback::detect_chat_intent(&message.text) {
+    //
+    // Suppressed on a copilot thread for the same reason the card below is: "no,
+    // that's wrong, this node keeps failing" is the operator correcting a
+    // conversation about their graph, and filing it as company feedback would
+    // record a complaint they did not make about work they were not discussing.
+    let feedback_note = if let Some(category) = (!confined)
+        .then(|| crate::feedback::detect_chat_intent(&message.text))
+        .flatten()
+    {
         runtime
             .capture_feedback(crate::feedback::FeedbackInput {
                 category,
@@ -1072,7 +1084,6 @@ async fn run_chat(
     // the harness stops the turn from acting; this stops the route from acting
     // on its behalf, and it holds in every build because it is here rather than
     // behind the `openhuman` feature.
-    let confined = crate::company::copilot::is_copilot_thread(message.chat.as_deref());
     if let Some(title) = (!confined)
         .then(|| crate::company::task_intent::detect_task_intent(&message.text))
         .flatten()

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2155,9 +2155,36 @@ async fn a_copilot_thread_question_opens_no_board_card() {
 
     let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
     assert_eq!(status, StatusCode::OK);
+    // Strict on the shape, like the control half below: `is_none_or` would pass
+    // on a body that is not a list at all, so a route that started answering an
+    // error object would go green here and panic there — reported as a failure
+    // of the control rather than of the thing under test.
+    let cards = board.as_array().expect("the board lists cards");
     assert!(
-        board.as_array().is_none_or(|cards| cards.is_empty()),
+        cards.is_empty(),
         "a copilot question left work on the board: {board}"
+    );
+
+    // The same rule reaches the other deterministic side effect a chat turn
+    // has: a complaint phrase on a copilot thread is the operator correcting a
+    // conversation about their graph, not feedback about the company's work.
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/chat",
+        Some(json!({
+            "message": "no, that is wrong, this node keeps failing",
+            "chat": "workflow-copilot:weekly_report",
+        })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, filed) = send(&state, "GET", "/api/v1/company/feedback", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let items = filed.as_array().expect("the feedback list is an array");
+    assert!(
+        items.is_empty(),
+        "a copilot correction filed company feedback: {filed}"
     );
 
     // Control: the same sentence on the ordinary thread still opens a card, so


### PR DESCRIPTION
## Summary

Fixes #415 — acceptance criterion 4 of #303, deferred so the read-only copilot could ship and be verified alone. The copilot could describe a change; the operator had to translate it into canvas edits by hand.

> **Stacks on #487 (issue #416) and must not merge before it.** The base of this branch is `fix/416-copilot-responder-scoping`, and the diff below is only this issue's commit. #416 is what makes propose-then-apply safe: the turn that proposes is confined to its workflow, with no tools, no company memory and no delegation. A copilot that could propose applyable edits while unconfined would be strictly worse than an unconfined one that only answers. Once #487 merges, this retargets to `main` cleanly.

A copilot reply may now carry a **proposal**: a fenced `workflow-proposal` block holding a short list of node and edge operations. The console turns it into a candidate graph, shows the operator a diff, and applies it through the same write the canvas editor performs.

### What the operator sees before anything is applied

A review card under the reply, containing:

- the model's one-line summary of what the change does;
- **a diff of the graph**, not the proposal: each step that would be added, removed, or changed — and for a changed step, the fields that move, `before → after` (`retry: not set → {"maxAttempts":3,"backoffMs":2000}`); each connection that would be added or removed;
- **Apply** and **Dismiss**.

The prose stays prose: the block is stripped out of the rendered reply, so the operator never reads raw JSON. The diff is computed between the current graph and the candidate, **not** from the op list, so an op that sets a field to the value it already holds shows as no change, and a change nobody proposed cannot appear in the card.

### What happens on reject, and on every other refusal

**Dismiss writes nothing.** `applyProposal` is pure and produces a candidate; the saved graph is untouched until Apply, so there is nothing to undo. The card greys out and stays in the transcript with its summary and diff readable, which is the issue's third design question answered: kept, not discarded, so a later question can refer to what was turned down.

A proposal is **refused, never rebased**, and each refusal says which one it is:

| Situation | What the operator sees |
|---|---|
| The graph moved after the proposal (another proposal applied, a canvas edit) | Apply is not offered: "The workflow changed after this was proposed… Ask again for a fresh proposal." |
| Replayed from an earlier session | Apply is not offered: the graph it was reasoned about is not knowable from the journal. |
| Source-defined workflow (`editable: false`) | Apply is not offered, and the protocol is never offered to the model in the first place. |
| The proposal would change nothing | Apply is not offered: "This proposal would change nothing." |
| The host refuses the write (`409`, `400`) | The host's own message, plus "Reload the workflow and ask the copilot again." The card returns to pending so it can be dismissed or retried; a `409` also raises the view's existing reload banner. |
| The block is malformed | An inline note naming what was wrong ("A proposed change targets `ghost`, which isn't in this workflow.") instead of a silently dropped proposal. |

### Design questions, settled

- **Unit of a proposal:** an **operation list** (`addNode`, `updateNode` with field-level `set`, `removeNode`, `addEdge`, `removeEdge`), not a replacement graph. A whole graph is simple to apply and hostile to review, and lets a model drop a node it never mentioned. Ids may not be renamed through `set` — that would orphan the node's edges silently, so a rename is an add plus a remove, which the diff then shows as what it is.
- **Where validation lives:** the **host is the authority**. Apply calls `updateWorkflow(client, company, id, candidate, version)` — the identical call `WorkflowCreateDialog` makes on save — so a proposal cannot produce a graph the editor could not have produced. The console's own checks are shape-only (the JSON parses, the ops are known, the ids exist), so an obviously malformed proposal is refused with a stated reason rather than sent to the host to fail.
- **Rejected proposals:** kept in the conversation, greyed and non-applyable.

### Why this adds no capability

The proposal is **data in a reply**. The confined agent (#416) still has no tools and calls nothing; it emits text. The write is performed by the operator's console, on the operator's session, through the same authenticated, versioned route the canvas uses, after a human pressed Apply. The host needs no notion of a proposal at all, which is why there is no new route and no schema change.

## API Or Behavior Changes

- No host route, request, or response changes. Applying is `PUT …/workflows/{wid}` with `expectedVersion`, unchanged.
- Console: a copilot reply containing a `workflow-proposal` block renders a review card. Replies without one behave exactly as before.
- The composed copilot message now describes the proposal protocol — and deliberately does **not** for a source-defined workflow.
- `harness::confine`'s persona changes from "you cannot change the workflow" to "you cannot apply a change; you may propose one", with an explicit "never say you have made a change".
- New console modules: `api/workflow-proposal.ts` (parse / validate / apply / diff / staleness) and `views/workflows/ProposalCard.tsx`.

## Tests

- `frontend/test/unit/workflow-proposal.test.ts` — 22 tests over the whole decidable half: prose is left alone; the block splits out; the version is stamped by the console (never read from the model); malformed JSON is reported; and every refusal — no summary, empty op list, an edit aimed at a step that isn't there, a new step reusing an id, a rename through `set`, an edge to a step nobody adds, disconnecting an edge that doesn't exist, an unknown op kind. Plus: `applyProposal` never mutates its input (which is what makes Dismiss free), a removed step takes its edges with it, field-level updates leave the rest of the step alone, the diff reports added/removed/changed with the fields that moved, an edit that changes nothing diffs to nothing, and the four staleness cases including "don't invent staleness on a host with no version tokens".
- `frontend/test/unit/workflow-copilot.test.ts` — the composed message offers the protocol and both halves of the rule (may propose, may not apply), and withholds the protocol entirely for a source-defined workflow.
- `src/harness/confine.rs` — the persona allows proposing and forbids claiming to have applied. The confinement tests from #416 are unchanged and still pass: proposing calls nothing, and every tool is still denied.

Console gates run locally: `npm run typecheck`, `npm run typecheck:unit` clean; the two suites above pass (28 tests). `rustfmt --edition 2024 --check` clean on `src/harness/confine.rs`.

**Browser walk** — real Chromium, against a stub host serving the console's documented shapes (building the Rust host is prohibited on this machine), driving `#/workflows` → Copilot:

1. **The failure this issue describes, reproduced first.** With the host answering prose only — the pre-#415 behaviour — the reply explains the change and **no proposal card appears**: the operator's only path is retyping it into the editor.
2. **Propose → review → apply.** With a proposal in the reply: the card renders `retry: not set → {"maxAttempts":3,"backoffMs":2000}`, `new step notify Notify`, and the added `send → notify` connection. Apply → the card reads **Applied**, and the host's stored graph is exactly the reviewed change: version `v2`, nodes `collect, send, notify`, edges `collect→send, send→notify`, `collect.retry = {maxAttempts:3, backoffMs:2000}`. The `PUT` carried `expectedVersion=v1`.
3. **Dismiss writes nothing.** Card reads **Dismissed** and stays readable; the host's stored graph is still version `v1` with `collect, send`.
4. **A refused apply changes nothing.** With the host answering `409`: the card shows "the workflow changed since you loaded it Reload the workflow and ask the copilot again.", returns to pending, and the stored graph is still `v1`.
5. **Staleness is refused before the write.** Two pending proposals against `v1`; applying the first moves the graph to `v2`, and the second card immediately shows "The workflow changed after this was proposed…" with its Apply button **disabled** (asserted, not eyeballed).

No uncaught page errors in any of the five walks.

**What was not run here, stated plainly.** The walk drives a stub, not a live `--features openhuman` host, because the local build matrix is prohibited on this machine; and no real model produced the proposal — the stub emits the block the composed message asks for, so what is verified is the console's contract, the review, the write and every refusal, not a model's willingness to follow the format. No Playwright spec is added: the panel deliberately refuses to send on the echo-brained host the e2e lane builds, so a spec would have to bypass the panel and would then be asserting what the unit tests already assert.

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

## Documentation

`docs/spec/runtime/api.md` — the `/chat` copilot section records that a reply may carry a proposal, that the console (not the host) turns it into a `PUT …/workflows/{wid}` with `expectedVersion`, and that this adds no route and no capability because the confined turn still calls nothing. The adjacent "a chat turn opens a board card" note is corrected for the copilot thread exception #416 introduced.

Module docs are in the code: `api/workflow-proposal.ts` opens with why the unit is an op list, why validation here is a courtesy and the host is the authority, and why staleness is refused rather than rebased.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added workflow copilot support for reviewing proposed workflow changes.
  * Operators can view node and connection differences, then Apply or Dismiss proposals.
  * Applied changes use version checks to prevent stale updates and report conflicts.
* **Safety & Behavior**
  * Copilot conversations run without tools, company-wide context, delegation, or persistent memory.
  * Copilot messages no longer create board tasks.
  * Source-defined workflows cannot receive direct edit proposals.
* **Bug Fixes**
  * Added handling for malformed, empty, replayed, and outdated proposals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->