### PR TITLE
fix(workflows): approving a paused run does not re-send what it already delivered (#438, #440)

### DIFF
--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -77,9 +77,10 @@ pub enum DeliveryStatus {
     /// then look at Approvals for what became of it.
     Pending,
     /// Deliberately not attempted — a policy precondition was unmet (no mailbox
-    /// configured, or a cold recipient on a runtime that cannot park). Not an
-    /// error; the report simply was not owed to that address under the current
-    /// rules.
+    /// configured, or a cold recipient on a runtime that cannot park), or a run
+    /// earlier in this lineage already delivered this node's report and the
+    /// continuation must not send it twice (issue #438). Not an error; the
+    /// report simply was not owed to that address under the current rules.
     Skipped,
     /// Refused by policy: the company does not grant what the destination needs.
     Denied,
@@ -146,6 +147,21 @@ pub enum DeliveryReason {
     /// The recipient is not an established thread and the send could not be
     /// parked for approval either.
     ParkingUnavailable,
+    /// A run earlier in this lineage already delivered this node's report, so
+    /// the continuation did not send it again (issue #438).
+    ///
+    /// Resuming an approved gate is a **re-run** — the engine settles when it
+    /// pauses, so continuing means walking the graph again from the trigger.
+    /// Every `output` node upstream of the gate is therefore reached a second
+    /// time, and without this the operator's approval would mail the same
+    /// report to the same person twice. The ledger of what a lineage has
+    /// already sent rides the continuation's trigger input; see
+    /// [`crate::runtime::workflow_resume`].
+    ///
+    /// A **parked** report counts as delivered too: the card is durable and
+    /// approving it sends, so re-parking would stack a second identical card
+    /// and approving both would send twice.
+    AlreadyDelivered,
     /// A `channel` report was posted to the wired adapter.
     ChannelPosted,
     /// The destination names a channel this deployment never wired. **Which
@@ -197,6 +213,10 @@ impl std::fmt::Display for DeliveryReason {
             Self::ParkingUnavailable => {
                 "the recipient has never written to the company, and the report could not be \
                  queued for approval either"
+            }
+            Self::AlreadyDelivered => {
+                "an earlier run in this workflow's approval lineage already delivered this report, \
+                 so it was not sent again"
             }
             Self::ChannelPosted => "posted to the channel",
             Self::ChannelNotWired => "the destination channel is not wired on this runtime",

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -49,12 +49,40 @@
 //!
 //! **Upstream nodes re-execute.** That is the engine's documented semantic for
 //! resume, not something added here, but it is real: agent nodes re-spend
-//! tokens, and a reached `output` node **re-delivers** — a warm-recipient email
-//! will send a second time, because the established-thread check is state-based
-//! rather than run-based. This is acceptable for v1 because a gate normally
-//! sits *before* the side-effecting node it is gating, which is the entire
-//! reason to author one. It is not acceptable silently, which is why it is
-//! written here, in the PR, and nowhere hidden.
+//! tokens on every continuation. A gate normally sits *before* the
+//! side-effecting node it is gating — which is the entire reason to author one
+//! — so for most graphs the cost is tokens and wall-clock. It is not acceptable
+//! silently, which is why it is written here, in the parked card's own `note`
+//! payload, and nowhere hidden.
+//!
+//! # The one cost that was not acceptable: re-delivery (issue #438)
+//!
+//! A reached `output` node used to **deliver again** on every continuation. The
+//! established-recipient check is state-based rather than run-based, so a warm
+//! recipient was simply mailed the same report a second time the moment an
+//! operator approved a *later* gate — a side effect that left the process and
+//! reached a real person, caused by clicking Approve.
+//!
+//! The fix is a **delivery ledger** carried in the parked card and threaded into
+//! the continuation's trigger input under [`CONTINUATION_DELIVERED_KEY`]:
+//! `{node, kind}` for every report this lineage has already sent (`Sent`) or
+//! parked (`Pending` — the card is durable, and approving it sends, so it counts
+//! as delivered). Delivery skips a listed node with
+//! [`DeliveryReason::AlreadyDelivered`](crate::ports::DeliveryReason::AlreadyDelivered)
+//! and dispatches nothing. The ledger is
+//! *unioned* with whatever the incoming input already carried, so a graph with
+//! two gates accumulates across both resumes rather than forgetting the first.
+//!
+//! Carrying it on the card rather than in a side table is the same choice the
+//! input itself makes: the card stays self-contained, so the guard survives a
+//! restart exactly like the resume does.
+//!
+//! **The honest limit.** The ledger is per `output` node, not per recipient. An
+//! `owner` destination that fanned out to three admins and failed on the third
+//! is recorded as delivered, and the continuation will not retry that third
+//! address. Re-mailing two people to reach one is the worse outcome, so this is
+//! deliberate rather than an oversight — a partial fan-out is repaired from the
+//! run history, not by a resume.
 //!
 //! # At-most-once, deny, and expiry
 //!
@@ -65,6 +93,7 @@
 //! paused run is already settled, "nothing runs" is the complete outcome — no
 //! task to cancel, no connection to close.
 
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
 use crate::Result;
@@ -72,6 +101,7 @@ use crate::company::load_workflow_union;
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
 use crate::ports::types::Effect;
+use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::workflow_spawn::WorkflowSpawn;
 
 /// The effect kind a paused `requires_approval` node parks as (issue #395).
@@ -89,6 +119,103 @@ pub const PAYLOAD_WORKFLOW_ID: &str = "workflow_id";
 pub const PAYLOAD_NODE_ID: &str = "node_id";
 /// The payload key holding the trigger input the paused run was started with.
 pub const PAYLOAD_INPUT: &str = "input";
+/// The payload key holding this lineage's delivery ledger (issue #438) — the
+/// reports a continuation must NOT send again.
+pub const PAYLOAD_DELIVERED: &str = "delivered";
+/// The payload key holding the plain-prose statement of what approving costs.
+pub const PAYLOAD_NOTE: &str = "note";
+
+/// The reserved trigger-input key the delivery ledger rides into a continuation
+/// run under (issue #438).
+///
+/// Reserved, and shaped so nobody authors it by accident: it is threaded by the
+/// host, read by `deliver_outputs`, and never by the engine or a graph author.
+/// It is stripped before two parked gates are compared — see `is_same_gate` — because a continuation's input differs from the paused
+/// run's by exactly this key, and letting that difference count would make
+/// every continuation gate a "new" decision and stack a duplicate card.
+pub const CONTINUATION_DELIVERED_KEY: &str = "__opencompany_delivered";
+
+/// What approving a workflow gate actually does, in the operator's own terms.
+///
+/// This rides the card as [`PAYLOAD_NOTE`] rather than living only in a design
+/// doc, because the person deciding is the one who pays the cost: approving is
+/// not "let the run continue from here", it re-runs the graph from the trigger.
+/// Prose, not a code reference — the reader is an operator looking at an
+/// Approvals card.
+pub const CONTINUATION_NOTE: &str = "Approving this re-runs the whole workflow from the start — every step before this gate runs \
+     again, and any agent steps spend tokens again. Reports this run already delivered will not be \
+     sent a second time.";
+
+/// One `output` node whose report a run in this lineage has already delivered.
+///
+/// `kind` rides along beside `node` so the record says *what* was sent where —
+/// a card an operator reads, and a run history a reviewer reads, both want
+/// "the owner summary already went out", not a bare node id. Matching is on
+/// `node`: an output node has exactly one destination, so the id is the
+/// identity and the kind is the description.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliveredReport {
+    /// The `output` node whose report was delivered.
+    pub node: String,
+    /// The destination kind it was delivered to (`owner` / `email` / `channel`).
+    pub kind: String,
+}
+
+/// The reports this lineage has already delivered, read off a trigger input.
+///
+/// Tolerant by construction — a missing key, a non-array, or a malformed row
+/// yields "nothing known to be delivered", which is the pre-#438 behaviour
+/// (deliver it). Failing loudly here would turn a garbled continuation into a
+/// run that delivers nothing at all, which is the worse error.
+pub fn delivered_in_input(input: &Value) -> Vec<DeliveredReport> {
+    input
+        .get(CONTINUATION_DELIVERED_KEY)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| serde_json::from_value(row.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The ledger a gate parked on this run should carry: what the run just
+/// delivered, unioned with what its own trigger input already listed.
+///
+/// The union is what makes a **two-gate** graph correct. Approving the first
+/// gate starts a continuation that skips the already-delivered report — and
+/// then pauses at the second gate. If that second card carried only what the
+/// continuation itself delivered (nothing, since it skipped), approving it
+/// would deliver the report for real. The ledger has to accumulate down the
+/// lineage, not restart at each hop.
+///
+/// `Sent` and `Pending` both count. `Pending` is a parked cold-recipient card:
+/// journal-backed, survives a restart, and approving it sends. Treating it as
+/// undelivered would re-park an identical card on every continuation and
+/// approving both would send twice — `park_cold_recipient` has no dedupe of its
+/// own. `Skipped` / `Denied` / `Failed` deliberately do not count: nothing left
+/// the process, so a continuation is free to try again.
+fn delivery_ledger(input: &Value, deliveries: &[DeliveryReport]) -> Vec<DeliveredReport> {
+    let mut ledger = delivered_in_input(input);
+    for report in deliveries {
+        if !matches!(
+            report.status,
+            DeliveryStatus::Sent | DeliveryStatus::Pending
+        ) {
+            continue;
+        }
+        let entry = DeliveredReport {
+            node: report.node.clone(),
+            kind: report.kind.clone(),
+        };
+        // An `owner` destination fans out to one row per admin, so the same
+        // node appears several times; the ledger holds it once.
+        if !ledger.contains(&entry) {
+            ledger.push(entry);
+        }
+    }
+    ledger
+}
 
 /// Builds the effect a paused gate parks as.
 ///
@@ -105,7 +232,18 @@ pub const PAYLOAD_INPUT: &str = "input";
 /// [`ApprovalSummary::broadly_grantable`](crate::runtime::ApprovalSummary) requires an agent,
 /// the console never offers "let it do this for a period" on a card where that
 /// would mean nothing.
-pub fn gate_effect(workflow_id: &str, node_id: &str, input: &Value, run_id: &str) -> Effect {
+///
+/// `deliveries` is what the run that paused actually delivered (issue #438).
+/// It is folded into the card's ledger rather than looked up later for the same
+/// reason the input is copied in: a card that needs a side table is a card that
+/// stops working after a restart.
+pub fn gate_effect(
+    workflow_id: &str,
+    node_id: &str,
+    input: &Value,
+    run_id: &str,
+    deliveries: &[DeliveryReport],
+) -> Effect {
     Effect {
         kind: WORKFLOW_APPROVE_KIND.to_string(),
         group: crate::ports::types::EffectGroup::Other,
@@ -119,6 +257,10 @@ pub fn gate_effect(workflow_id: &str, node_id: &str, input: &Value, run_id: &str
             // a resume needs nothing but the journal. This is what makes
             // approve-after-restart work.
             PAYLOAD_INPUT: input.clone(),
+            // What must NOT be sent again when this card is approved.
+            PAYLOAD_DELIVERED: delivery_ledger(input, deliveries),
+            // What approving costs, in the operator's own terms.
+            PAYLOAD_NOTE: CONTINUATION_NOTE,
         }),
         // Native, not a teammate's tool call — see the doc above.
         agent: None,
@@ -140,13 +282,39 @@ pub fn gate_effect(workflow_id: &str, node_id: &str, input: &Value, run_id: &str
 /// rubber-stamp.
 ///
 /// `run_id` is deliberately **not** part of it: it differs by construction on
-/// every re-run, so including it would make the dedupe a no-op.
+/// every re-run, so including it would make the dedupe a no-op. Neither is the
+/// [`PAYLOAD_DELIVERED`] ledger, nor the [`CONTINUATION_DELIVERED_KEY`] the
+/// input carries it under (issue #438) — both differ by construction between a
+/// paused run and the continuation it started, and both describe what has
+/// *already happened* rather than what is being decided. Counting either would
+/// make every continuation gate read as a new decision, which is precisely the
+/// duplicate-card failure this function exists to prevent.
 fn is_same_gate(a: &Effect, b: &Effect) -> bool {
     a.kind == b.kind
         && a.kind == WORKFLOW_APPROVE_KIND
-        && [PAYLOAD_WORKFLOW_ID, PAYLOAD_NODE_ID, PAYLOAD_INPUT]
+        && [PAYLOAD_WORKFLOW_ID, PAYLOAD_NODE_ID]
             .iter()
             .all(|key| a.payload.get(*key) == b.payload.get(*key))
+        && decided_input(a) == decided_input(b)
+}
+
+/// The part of a parked gate's trigger input that identifies the *decision*:
+/// everything except the host-threaded delivery ledger.
+fn decided_input(effect: &Effect) -> Option<Value> {
+    effect
+        .payload
+        .get(PAYLOAD_INPUT)
+        .cloned()
+        .map(without_ledger)
+}
+
+/// `input` with the reserved delivery-ledger key removed. A non-object input is
+/// returned as-is — there is nothing to strip.
+fn without_ledger(mut input: Value) -> Value {
+    if let Value::Object(map) = &mut input {
+        map.remove(CONTINUATION_DELIVERED_KEY);
+    }
+    input
 }
 
 /// True when `effect` names a gate the journal is already holding a card for.
@@ -181,11 +349,6 @@ pub fn already_parked(journal: &crate::runtime::journal::RuntimeJournal, effect:
 pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Result<()> {
     let workflow_id = required_str(effect, PAYLOAD_WORKFLOW_ID)?;
     let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
-    let input = effect
-        .payload
-        .get(PAYLOAD_INPUT)
-        .cloned()
-        .unwrap_or(Value::Null);
 
     // Through the runtime's own accessor so a build without workflow execution
     // gives an honest error instead of a compile-time edge — this module is in
@@ -213,7 +376,7 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
             ))
         })?;
 
-    let input = with_approval(input, node_id);
+    let input = continuation_input(effect)?;
     // The handle is dropped on purpose. The task holds its own guard, journals
     // its own outcome and deregisters itself; awaiting it here would hold the
     // approvals request open for the length of a whole workflow run, which is
@@ -227,6 +390,64 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
         "workflow: an approved gate started a continuation run; upstream nodes re-execute"
     );
     Ok(())
+}
+
+/// The trigger input a continuation run starts with: the paused run's own
+/// input, plus the approved gate, plus this lineage's delivery ledger.
+///
+/// One function rather than three call-site steps because the three have to
+/// travel together — an input that carries the approval but not the ledger
+/// resumes *and re-delivers*, which is issue #438 with extra steps. It is
+/// `pub(crate)` so the run-level regression test can build a continuation
+/// exactly the way the approvals path does, rather than reconstructing it and
+/// proving only that the reconstruction works.
+pub(crate) fn continuation_input(effect: &Effect) -> Result<Value> {
+    let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
+    let input = effect
+        .payload
+        .get(PAYLOAD_INPUT)
+        .cloned()
+        .unwrap_or(Value::Null);
+    let delivered: Vec<DeliveredReport> = effect
+        .payload
+        .get(PAYLOAD_DELIVERED)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| serde_json::from_value(row.clone()).ok())
+                .collect()
+        })
+        .unwrap_or_default();
+    Ok(with_delivered(with_approval(input, node_id), &delivered))
+}
+
+/// Writes `delivered` onto the trigger input under
+/// [`CONTINUATION_DELIVERED_KEY`], replacing whatever was there.
+///
+/// Replace, not merge: the card's ledger was *built* by unioning the input's
+/// own list with what the run delivered (see [`delivery_ledger`]), so it is
+/// already the superset. Merging again here would be a second, redundant place
+/// for that rule to drift.
+///
+/// An empty ledger writes nothing at all, which keeps a first run's input shape
+/// untouched — the reserved key appears only once there is something to
+/// suppress.
+fn with_delivered(input: Value, delivered: &[DeliveredReport]) -> Value {
+    if delivered.is_empty() {
+        return input;
+    }
+    match input {
+        Value::Object(mut map) => {
+            map.insert(
+                CONTINUATION_DELIVERED_KEY.to_string(),
+                serde_json::json!(delivered),
+            );
+            Value::Object(map)
+        }
+        // `with_approval` always yields an object, so this is unreachable
+        // through `continuation_input`. Kept total rather than panicking.
+        other => other,
+    }
 }
 
 /// Unions `node_id` into the trigger input's `approvals` array.
@@ -289,7 +510,24 @@ mod tests {
     use super::*;
 
     fn effect(workflow: &str, node: &str, input: Value) -> Effect {
-        gate_effect(workflow, node, &input, "run-1")
+        gate_effect(workflow, node, &input, "run-1", &[])
+    }
+
+    /// A delivery row with `status`, as `deliver_outputs` would have returned it.
+    fn delivery(node: &str, kind: &str, status: DeliveryStatus) -> DeliveryReport {
+        DeliveryReport {
+            node: node.to_string(),
+            kind: kind.to_string(),
+            target: None,
+            status,
+            detail: String::new(),
+            reason: crate::ports::DeliveryReason::Unspecified,
+        }
+    }
+
+    /// The ledger rows a parked card carries.
+    fn ledger(effect: &Effect) -> Vec<DeliveredReport> {
+        serde_json::from_value(effect.payload[PAYLOAD_DELIVERED].clone()).expect("ledger parses")
     }
 
     #[test]
@@ -385,6 +623,208 @@ mod tests {
     fn non_string_entries_in_a_prior_approvals_array_are_dropped() {
         let out = with_approval(serde_json::json!({ "approvals": ["a", 7, null] }), "b");
         assert_eq!(out["approvals"], serde_json::json!(["a", "b"]));
+    }
+
+    // --- issue #438: the delivery ledger -------------------------------------
+
+    /// What the run delivered rides the card, so approving it can suppress a
+    /// second send. `Sent` and `Pending` are both "already delivered": a parked
+    /// cold-send card is durable and approving it sends, so re-parking would
+    /// stack a duplicate and approving both would mail twice.
+    #[test]
+    fn a_gate_card_carries_what_the_run_already_delivered() {
+        let e = gate_effect(
+            "digest",
+            "gate",
+            &serde_json::json!({ "request": "x" }),
+            "run-1",
+            &[
+                delivery("owner_summary", "owner", DeliveryStatus::Sent),
+                delivery("cold_note", "email", DeliveryStatus::Pending),
+            ],
+        );
+        assert_eq!(
+            ledger(&e),
+            vec![
+                DeliveredReport {
+                    node: "owner_summary".into(),
+                    kind: "owner".into()
+                },
+                DeliveredReport {
+                    node: "cold_note".into(),
+                    kind: "email".into()
+                },
+            ]
+        );
+    }
+
+    /// A row that never left the process is NOT on the ledger — nothing was
+    /// sent, so a continuation is free to try again. Suppressing these would
+    /// silently retire a report on the strength of a failure.
+    #[test]
+    fn a_report_that_did_not_go_out_stays_deliverable() {
+        for status in [
+            DeliveryStatus::Skipped,
+            DeliveryStatus::Denied,
+            DeliveryStatus::Failed,
+        ] {
+            let e = gate_effect(
+                "digest",
+                "gate",
+                &Value::Null,
+                "run-1",
+                &[delivery("summary", "owner", status)],
+            );
+            assert!(
+                ledger(&e).is_empty(),
+                "{status:?} sent nothing, so it must stay deliverable"
+            );
+        }
+    }
+
+    /// An `owner` destination fans out to one row per admin. The ledger is per
+    /// node, so it holds that node once rather than once per recipient.
+    #[test]
+    fn a_fanned_out_destination_is_one_ledger_row() {
+        let e = gate_effect(
+            "digest",
+            "gate",
+            &Value::Null,
+            "run-1",
+            &[
+                delivery("summary", "owner", DeliveryStatus::Sent),
+                delivery("summary", "owner", DeliveryStatus::Sent),
+            ],
+        );
+        assert_eq!(ledger(&e).len(), 1);
+    }
+
+    /// The ledger rides the continuation's trigger input — this is the whole
+    /// mechanism, since `deliver_outputs` reads it from there and nowhere else.
+    #[test]
+    fn the_ledger_rides_the_continuation_input() {
+        let card = gate_effect(
+            "digest",
+            "gate",
+            &serde_json::json!({ "request": "x" }),
+            "run-1",
+            &[delivery("summary", "owner", DeliveryStatus::Sent)],
+        );
+
+        let input = continuation_input(&card).expect("a well-formed card continues");
+
+        assert_eq!(input["approvals"], serde_json::json!(["gate"]));
+        assert_eq!(
+            input["request"], "x",
+            "the original topic still rides along"
+        );
+        assert_eq!(
+            delivered_in_input(&input),
+            vec![DeliveredReport {
+                node: "summary".into(),
+                kind: "owner".into()
+            }]
+        );
+    }
+
+    /// **The two-gate case.** Approving the first gate starts a continuation
+    /// that skips the already-sent report and then pauses at the second gate.
+    /// That second card must carry the FIRST run's deliveries too — it delivered
+    /// nothing itself, so a ledger built only from its own rows would be empty
+    /// and approving it would send the report for real.
+    #[test]
+    fn the_ledger_accumulates_across_two_gates() {
+        // Run 1 delivers the summary and pauses on gate-a.
+        let first = gate_effect(
+            "digest",
+            "gate-a",
+            &serde_json::json!({ "request": "x" }),
+            "run-1",
+            &[delivery("summary", "owner", DeliveryStatus::Sent)],
+        );
+        let continuation = continuation_input(&first).expect("continues");
+
+        // Run 2 skips the summary (delivering nothing) and pauses on gate-b.
+        let second = gate_effect("digest", "gate-b", &continuation, "run-2", &[]);
+        assert_eq!(
+            ledger(&second),
+            vec![DeliveredReport {
+                node: "summary".into(),
+                kind: "owner".into()
+            }],
+            "the second card must remember what the first run sent"
+        );
+
+        // And approving THAT still suppresses it, with both gates approved.
+        let next = continuation_input(&second).expect("continues");
+        assert_eq!(next["approvals"], serde_json::json!(["gate-a", "gate-b"]));
+        assert_eq!(delivered_in_input(&next).len(), 1);
+    }
+
+    /// A run that delivered nothing writes no reserved key at all, so an
+    /// ordinary continuation's input keeps exactly the shape it always had.
+    #[test]
+    fn a_lineage_that_delivered_nothing_threads_no_reserved_key() {
+        let card = effect("digest", "gate", serde_json::json!({ "request": "x" }));
+        let input = continuation_input(&card).expect("continues");
+        assert!(input.get(CONTINUATION_DELIVERED_KEY).is_none(), "{input}");
+        assert!(delivered_in_input(&input).is_empty());
+    }
+
+    /// The ledger must not make a continuation's gate look like a *different*
+    /// decision — that would stack a second card for one gate on every resume,
+    /// which is the dedupe failure #395 closed.
+    #[test]
+    fn the_ledger_does_not_split_one_decision_into_two_cards() {
+        let paused = gate_effect(
+            "digest",
+            "gate",
+            &serde_json::json!({ "request": "x" }),
+            "run-1",
+            &[delivery("summary", "owner", DeliveryStatus::Sent)],
+        );
+        // The same gate, re-reached by the continuation the card started: same
+        // input plus the approval… minus the approval, which the gate node
+        // consumed. What differs is the ledger key alone.
+        let mut continuation = continuation_input(&paused).expect("continues");
+        continuation
+            .as_object_mut()
+            .expect("object")
+            .remove("approvals");
+        let re_reached = gate_effect("digest", "gate", &continuation, "run-2", &[]);
+
+        assert!(
+            is_same_gate(&paused, &re_reached),
+            "the ledger is not part of the decision:\n{:?}\n{:?}",
+            paused.payload,
+            re_reached.payload
+        );
+    }
+
+    /// The card says, in plain words, what approving actually does. The operator
+    /// deciding is the one who pays for the re-run.
+    #[test]
+    fn the_card_states_what_approving_costs() {
+        let e = effect("digest", "gate", Value::Null);
+        let note = e.payload[PAYLOAD_NOTE].as_str().expect("a note");
+        assert!(note.contains("re-runs"), "{note}");
+        assert!(note.contains("tokens"), "{note}");
+        assert!(note.contains("not be sent"), "{note}");
+    }
+
+    /// A garbled ledger degrades to "nothing known to be delivered" rather than
+    /// refusing the resume. Failing here would turn one malformed row into a
+    /// continuation that delivers nothing at all — the worse error.
+    #[test]
+    fn a_malformed_ledger_is_ignored_rather_than_fatal() {
+        for garbage in [
+            serde_json::json!("not an array"),
+            serde_json::json!([{ "node": 7 }]),
+            serde_json::json!([null]),
+        ] {
+            let input = serde_json::json!({ CONTINUATION_DELIVERED_KEY: garbage });
+            assert!(delivered_in_input(&input).is_empty());
+        }
     }
 
     #[test]
@@ -553,7 +993,16 @@ mode = "full"
         rt: &Arc<crate::company::runtime::CompanyRuntime>,
         input: Value,
     ) -> ApprovalId {
-        let effect = gate_effect("gated", "gate", &input, "run-that-paused");
+        park_gate_after(rt, input, &[]).await
+    }
+
+    /// [`park_gate`], for a run that delivered `deliveries` before it paused.
+    async fn park_gate_after(
+        rt: &Arc<crate::company::runtime::CompanyRuntime>,
+        input: Value,
+        deliveries: &[DeliveryReport],
+    ) -> ApprovalId {
+        let effect = gate_effect("gated", "gate", &input, "run-that-paused", deliveries);
         let id = rt
             .approvals
             .park(rt.id(), effect.clone())
@@ -611,6 +1060,48 @@ mode = "full"
         // A new causal root, not the paused run's id.
         assert_ne!(started[0].run_id, "run-that-paused");
         assert!(rt.pending_approvals().is_empty(), "the card is decided");
+    }
+
+    /// Issue #438, over the real decide path: the run an approval starts is
+    /// handed the ledger of what its ancestor already delivered.
+    ///
+    /// The unit tests above pin the ledger's arithmetic; this one pins that it
+    /// actually reaches a run — through the gate, the journal, `perform_effect`
+    /// and the spawn — because that is the hop where a threading mistake would
+    /// leave every other test green and still mail the report twice.
+    #[tokio::test]
+    async fn a_continuation_run_is_told_what_was_already_delivered() {
+        let home = seed_home();
+        let (rt, runner) = runtime(home.path(), true).await;
+        let id = park_gate_after(
+            &rt,
+            json!({ "request": "quarterly numbers" }),
+            &[DeliveryReport {
+                node: "summary".into(),
+                kind: "owner".into(),
+                target: Some("ada@acme.test".into()),
+                status: DeliveryStatus::Sent,
+                detail: "emailed the company's admin".into(),
+                reason: crate::ports::DeliveryReason::OwnerEmailed,
+            }],
+        )
+        .await;
+
+        rt.resolve_approval(&id, Verdict::Approve, operator())
+            .await
+            .expect("resolves");
+
+        let started = wait_for_runs(&runner, 1).await;
+        assert_eq!(started.len(), 1);
+        assert_eq!(
+            delivered_in_input(&started[0].input),
+            vec![DeliveredReport {
+                node: "summary".into(),
+                kind: "owner".into()
+            }],
+            "the continuation must know the summary already went out: {:?}",
+            started[0].input
+        );
     }
 
     /// Denying starts nothing. The paused run was already settled, so "nothing

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -47,7 +47,8 @@
 //! Issue #228 closes that gap without inventing a subsystem: every finished run
 //! — this scheduler's and the console's Run button alike — is journaled as a
 //! [`CompanyEvent::WorkflowRunFinished`](crate::ports::types::CompanyEvent)
-//! through [`record_run_finished`], projected live onto the operator SSE stream,
+//! through [`record_run_finished`](crate::runtime::record_run_finished), projected
+//! live onto the operator SSE stream,
 //! and read back durably from `GET …/workflows/runs`. The log lines below stay
 //! exactly as they were: they remain the platform team's diagnostic, and the
 //! event is the operator's surface. The two answer to different readers, so
@@ -86,7 +87,6 @@ use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::CompanyRegistry;
 use crate::runtime::cron::{CivilTime, CronExpr};
 use crate::runtime::scheduler::{Clock, MINUTE_MS, millis_to_next_minute};
-use crate::runtime::workflow_outcome::record_run_finished;
 
 /// Identifies one schedulable workflow: which company, which graph.
 type WorkflowKey = (CompanyId, String);
@@ -274,6 +274,18 @@ impl WorkflowScheduler {
                 }
             };
 
+            // Issue #440: the shared way to start a supervised run. Built once
+            // per company (it holds cloned handles, so a per-fire clone is
+            // cheap) and cloned into each fire's task below.
+            //
+            // This scheduler used to mint its own run id through the supervisor
+            // and journal its own `WorkflowRunFinished` on both arms — a second
+            // copy of the two rules `WorkflowSpawn` exists to own. The copies
+            // agreed, which is exactly what made the duplication dangerous: a
+            // fix to one would not have reached the other, and nothing would
+            // have failed to say so.
+            let spawn = crate::runtime::WorkflowSpawn::new(&runtime, runner);
+
             for (file, cron, expr) in scheduled {
                 if !expr.matches(&civil) {
                     continue;
@@ -308,22 +320,16 @@ impl WorkflowScheduler {
                     "firedAtMs": now,
                 });
 
-                let runner = runner.clone();
                 let workflow = file;
                 // Cloned BEFORE the spawn: the task outlives this loop
-                // iteration (and this borrow of `runtime`), so the handle has to
-                // be moved in rather than reached for from inside. Issue #228 —
-                // this is what turns a scheduled run's outcome from a host-stdout
-                // line into something the tenant's own console can read back.
-                let events = runtime.events().clone();
-                // Issue #383: cloned for the same reason as `events` — the task
-                // outlives this borrow of `runtime`. A cron fire is exactly the
-                // run an operator most needs to be able to stop: nobody chose
-                // its timing, and a wedged nightly run holds its overlap claim
-                // (above) until it ends, suppressing every later fire of that
-                // schedule. Registering it here is what puts a Cancel button on
-                // it in the console.
-                let supervisor = runtime.run_supervisor().clone();
+                // iteration (and this borrow of `runtime`), so everything it
+                // needs has to be moved in rather than reached for from inside.
+                // The clone carries the company id, the event log (issue #228 —
+                // what turns a scheduled run's outcome from a host-stdout line
+                // into something the tenant's own console reads back), the run
+                // supervisor (issue #383 — what puts a Cancel button on a cron
+                // fire nobody chose the timing of) and the runner.
+                let spawn = spawn.clone();
                 // A FRESH TASK PER FIRE IS CORRECT HERE, and is not a hole in
                 // the `WORKFLOW_DEPTH` re-entry guard
                 // (`crate::workflows::runner`). That guard is a task-local
@@ -347,19 +353,23 @@ impl WorkflowScheduler {
                     // schedule for the life of the process with no log line.
                     let _claim = claim;
                     let (company, workflow_id) = key;
-                    // Issue #371: minted here so this run's progress events and
-                    // its outcome share one id — including on the `Err` arm
-                    // below, where the runner hands back nothing that could
-                    // carry one. `scheduled: true` rides the run's
-                    // `WorkflowRunStarted`, so the console can mark a cron fire
-                    // as such *while it runs*, not only once it settles.
+                    // Issue #440: through the shared primitive, which owns both
+                    // halves this used to copy — the supervisor-minted run id
+                    // (issue #383: it is the address the console's Cancel button
+                    // sends to, and #371: the id the run's progress events and
+                    // its outcome share, including on the error arm where the
+                    // runner hands back nothing that could carry one) and the
+                    // `record_run_finished` on BOTH arms (issue #228), with the
+                    // run guard held across the journal write.
                     //
-                    // Issue #383: minted through the supervisor rather than
-                    // directly, which registers the run's stop signal. Held for
-                    // the whole run, including the outcome journalling below.
-                    let (ctx, _run_guard) = supervisor.begin(&workflow_id, true);
-                    match runner.run(&company, &workflow, input, &ctx).await {
-                        Ok(run) => {
+                    // The handle is **awaited**, not dropped. The claim above is
+                    // this scheduler's own overlap guard and has to outlive the
+                    // run, and the delivery-log sweep below needs the outcome.
+                    // Both remain the scheduler's job; what is shared is only
+                    // how a run is started and recorded.
+                    let (_run_id, handle) = spawn.spawn(workflow, input, true);
+                    match handle.await {
+                        Ok(Ok(run)) => {
                             // A manual run hands `deliveries` back in the HTTP
                             // response and the console renders it. A scheduled
                             // run has no response and nobody watching, so
@@ -439,41 +449,36 @@ impl WorkflowScheduler {
                                 undelivered = counts.undelivered(),
                                 "workflow scheduler: scheduled run finished"
                             );
-                            // Issue #228: the operator-facing half. The log
-                            // lines above stay exactly as they are — they are
-                            // the platform team's diagnostic on host stdout,
-                            // which on a hosted tenant is emphatically not the
-                            // operator. This is the record the tenant's own
-                            // console reads back, after the fact, on reload.
-                            record_run_finished(
-                                &events,
-                                &company,
-                                &workflow_id,
-                                true,
-                                &ctx.run_id,
-                                Ok(&run),
-                            )
-                            .await;
+                            // The operator-facing half — the journaled
+                            // `WorkflowRunFinished` the tenant's own console
+                            // reads back — was written by `spawn` before this
+                            // handle resolved (issue #228). The log lines above
+                            // stay exactly as they are: they are the platform
+                            // team's diagnostic on host stdout, which on a
+                            // hosted tenant is emphatically not the operator.
                         }
-                        Err(err) => {
+                        Ok(Err(err)) => {
                             tracing::warn!(
                                 %company,
                                 workflow = %workflow_id,
                                 %err,
                                 "workflow scheduler: scheduled run failed"
                             );
-                            // The worst outcome was until now the quietest: a
-                            // run that died outright produced one host-stdout
-                            // warning and nothing an operator could ever find.
-                            record_run_finished(
-                                &events,
-                                &company,
-                                &workflow_id,
-                                true,
-                                &ctx.run_id,
-                                Err(err.to_string().as_str()),
-                            )
-                            .await;
+                        }
+                        // The run task itself came apart — a panic inside the
+                        // runner, which unwinds in the spawned task rather than
+                        // here. Nothing was journaled for it (the outcome write
+                        // lives in that task), so this line is the only trace
+                        // there is, and it must not be silent. The claim still
+                        // releases: it is held by this task's guard.
+                        Err(err) => {
+                            tracing::error!(
+                                %company,
+                                workflow = %workflow_id,
+                                %err,
+                                "workflow scheduler: a scheduled run's task did not complete; its \
+                                 outcome was never recorded"
+                            );
                         }
                     }
                 });
@@ -1500,6 +1505,24 @@ to = "done"
     // ── Issue #228: the run outcome reaches the journal, not just stdout ─────
 
     /// Every `WorkflowRunFinished` journaled for `company`.
+    /// Yields until the journal holds `want` finished-run records, then returns
+    /// them. The append happens after the run completes, so a test that reads
+    /// once races it.
+    async fn wait_for_outcomes(
+        registry: &CompanyRegistry,
+        company: &str,
+        want: usize,
+    ) -> Vec<CompanyEvent> {
+        for _ in 0..10_000 {
+            let outcomes = run_outcomes(registry, company).await;
+            if outcomes.len() >= want {
+                return outcomes;
+            }
+            tokio::task::yield_now().await;
+        }
+        panic!("only ever saw fewer than {want} finished-run records");
+    }
+
     async fn run_outcomes(registry: &CompanyRegistry, company: &str) -> Vec<CompanyEvent> {
         let id = CompanyId::new(company);
         let runtime = registry.get(&id).expect("registered");
@@ -1583,6 +1606,108 @@ to = "done"
         // target rides it. This is the same field the manual run's HTTP response
         // already ships to the console today.
         assert_eq!(skipped.target.as_deref(), Some(RECIPIENT));
+    }
+
+    /// **Issue #440: the cron path and the shared path record the same thing.**
+    ///
+    /// The scheduler used to keep its own copy of "mint the id through the
+    /// supervisor, journal the outcome on both arms" — the two rules
+    /// [`WorkflowSpawn`](crate::runtime::WorkflowSpawn) owns. The copies agreed,
+    /// which is what made the duplication dangerous rather than harmless: a fix
+    /// to one would silently miss the other and no test would notice.
+    ///
+    /// So this runs the same graph through both entry points over one company
+    /// (one event log, one runner, one supervisor) and asserts the journaled
+    /// records differ in exactly two places: the `scheduled` flag, which is the
+    /// one thing the two paths genuinely mean differently, and the run id, which
+    /// is fresh per run by construction. Everything else — the workflow id, the
+    /// delivery rows, the pending approvals, the error and the cancelled flag —
+    /// must match, and a divergence introduced on either side fails here.
+    #[tokio::test]
+    async fn a_cron_fire_and_a_direct_spawn_journal_the_same_record() {
+        use crate::company::parse_workflow;
+
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let company = "spawn-parity-co";
+        // Non-empty delivery rows, so the comparison covers the part of the
+        // record most likely to be dropped by one path and not the other.
+        let (runner, completed) = RecordingRunner::with_deliveries(vec![
+            report(
+                "owner_summary",
+                DeliveryStatus::Skipped,
+                "this recipient has never written to the company",
+            ),
+            report("also_sent", DeliveryStatus::Sent, "emailed the recipient"),
+        ]);
+        let registry = company_with_overlays(
+            &home,
+            company,
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        // --- path 1: the cron fire.
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| completed.load(Ordering::SeqCst) == 1).await;
+        wait_for_outcomes(&registry, company, 1).await;
+
+        // --- path 2: the shared primitive, driven directly over the SAME
+        // runtime — same event log, same runner, same supervisor.
+        let runtime = registry
+            .get(&CompanyId::new(company))
+            .expect("the company is registered");
+        let runner = runtime
+            .workflow_runner()
+            .cloned()
+            .expect("the same runner the scheduler used");
+        let workflow = parse_workflow(&body("digest", Some("* * * * *"))).expect("parses");
+        let (_run_id, handle) =
+            crate::runtime::WorkflowSpawn::new(&runtime, runner).spawn(workflow, json!({}), false);
+        handle.await.expect("the run task completes").expect("runs");
+        let outcomes = wait_for_outcomes(&registry, company, 2).await;
+
+        let [cron, direct] = [&outcomes[0], &outcomes[1]].map(|event| {
+            let CompanyEvent::WorkflowRunFinished {
+                workflow_id,
+                scheduled,
+                run_id,
+                deliveries,
+                pending_approvals,
+                error,
+                cancelled,
+            } = event
+            else {
+                unreachable!("filtered above")
+            };
+            (
+                workflow_id,
+                scheduled,
+                run_id,
+                deliveries,
+                pending_approvals,
+                error,
+                cancelled,
+            )
+        });
+
+        // The two legitimate differences.
+        assert!(*cron.1, "a cron fire is scheduled");
+        assert!(!*direct.1, "a directly spawned run is not");
+        assert!(cron.2.is_some() && direct.2.is_some(), "both carry an id");
+        assert_ne!(cron.2, direct.2, "each run is its own causal root");
+
+        // Everything else is the same record, written by the same code.
+        assert_eq!(cron.0, direct.0, "workflow id");
+        assert_eq!(cron.3, direct.3, "delivery rows");
+        assert_eq!(cron.4, direct.4, "pending approvals");
+        assert_eq!(cron.5, direct.5, "error");
+        assert_eq!(cron.6, direct.6, "cancelled");
+        assert_eq!(cron.3.len(), 2, "the fixture's rows really did survive");
     }
 
     /// The arm that was quietest of all: a scheduled run that failed outright
@@ -1807,12 +1932,16 @@ to = "done"
     ///
     /// This is the claim the scheduler's comment makes and nothing pinned. It
     /// is worth pinning because the two things that make it true are both easy
-    /// to undo without breaking anything else: the context has to be minted
-    /// through the supervisor **inside** the spawned task, and the guard has to
+    /// to undo without breaking anything else: the run id has to be minted
+    /// through the supervisor **inside** the spawned task, and its guard has to
     /// be held across `record_run_finished` rather than dropped after the run.
-    /// Moving `begin` out of the task, or binding the guard to `_`, would still
+    /// Starting the run unregistered, or binding the guard to `_`, would still
     /// pass every other test in this module — the run would fire, complete and
     /// journal exactly as before, and simply stop being stoppable.
+    ///
+    /// Since issue #440 both are `WorkflowSpawn`'s to keep rather than this
+    /// module's, which is the point of routing through it — but the claim is
+    /// the scheduler's to make, so the test stays here.
     ///
     /// The cron case matters more than the manual one: nobody chose the timing,
     /// and a wedged nightly run holds its overlap claim, suppressing every later

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -15,16 +15,27 @@
 //! `spawn_workflow_run`. Issue #395 added a second entry point — resuming a
 //! `requires_approval` node the operator signed off, which is a **new run** and
 //! therefore owes the same two things — and a second copy of a rule this
-//! specific is a rule that drifts. So it moves here, and both callers construct
+//! specific is a rule that drifts. So it moves here, and every caller constructs
 //! a [`WorkflowSpawn`] instead.
 //!
-//! # What this deliberately does not own
+//! # The cron scheduler too (issue #440)
 //!
-//! The cron [`WorkflowScheduler`](super::WorkflowScheduler) keeps its own spawn
-//! body. It wraps the same two steps in a schedule *claim* and a per-delivery
-//! log sweep that only make sense for a fire nobody is watching, and folding
-//! those in here would make this helper a union of two jobs rather than the
-//! shared floor of one. It is a candidate for a later pass, not this one.
+//! The cron [`WorkflowScheduler`](super::WorkflowScheduler) used to keep its own
+//! spawn body, on the argument that its schedule *claim* and its per-delivery
+//! log sweep would make this helper a union of two jobs. That argument was
+//! wrong about where the seam is. The claim and the sweep are the scheduler's
+//! and stay there — it takes the claim before starting, holds it across an
+//! **awaited** [`spawn`](Self::spawn) handle, and folds the returned outcome
+//! into its host-stdout summary. What it no longer keeps is a second copy of
+//! the two rules above.
+//!
+//! The copies agreed at the time, and that is precisely what made them
+//! dangerous: two identical implementations of a discipline mean a fix to
+//! either one silently misses the other, with nothing failing to say so.
+//!
+//! Awaiting the handle is what makes that sharing work for a scheduled fire:
+//! the outcome is journaled inside the task, so by the time the handle resolves
+//! the record exists and the claim can be released.
 //!
 //! # Owned parts, not the runtime
 //!
@@ -84,10 +95,12 @@ impl WorkflowSpawn {
     /// was.
     ///
     /// The returned [`JoinHandle`] may be awaited (the console's synchronous
-    /// mode) or dropped (its detached mode, and the resume arm). Dropping it
-    /// abandons the *waiting*, never the work: the task holds its own guard,
-    /// journals its own outcome, and deregisters itself on every exit path
-    /// including an unwind.
+    /// mode, and the cron scheduler, which has to hold its overlap claim for
+    /// the length of the run) or dropped (the console's detached mode, and the
+    /// resume arm). Dropping it abandons the *waiting*, never the work: the
+    /// task holds its own guard, journals its own outcome, and deregisters
+    /// itself on every exit path including an unwind. Awaiting it therefore
+    /// resolves only once the outcome is already durable.
     pub fn spawn(
         self,
         workflow: WorkflowFile,

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -74,6 +74,26 @@
 //! workflow mail on most companies and turn the established-thread gate into a
 //! suggestion. See `park_cold_recipient` below.
 //!
+//! # A report is delivered once per approval lineage (issue #438)
+//!
+//! Resuming a workflow gate is a **re-run**: the engine settles when it pauses,
+//! so continuing walks the graph again from the trigger and every `output` node
+//! upstream of the gate is reached a second time. Delivery is state-based — an
+//! established recipient stays established — so approving a gate used to mail
+//! the same report to the same person again, as a direct result of clicking
+//! Approve.
+//!
+//! [`deliver_outputs`] therefore takes a **delivery ledger**: the `{node, kind}`
+//! rows this lineage has already sent or parked, threaded onto the
+//! continuation's trigger input by the approval that started it (see
+//! [`crate::runtime::workflow_resume`]). A reached node on that list is skipped
+//! with [`DeliveryReason::AlreadyDelivered`] and nothing is dispatched.
+//!
+//! A `Pending` row counts as delivered, which closes a second hole in the same
+//! place: [`park_cold_recipient`] has no dedupe of its own, so a continuation
+//! used to stack a second identical cold-send card — and approving both would
+//! send the mail twice.
+//!
 //! # Failure is reported, never fatal
 //!
 //! A delivery failure must not fail a run that already did its work. Every
@@ -127,6 +147,7 @@ use crate::ports::{
 };
 use crate::runtime::cycle::EMAIL_SEND_KIND;
 use crate::runtime::journal::RuntimeJournal;
+use crate::runtime::workflow_resume::DeliveredReport;
 use crate::server::ops::mailer::{MailCredentials, OutboundEmail};
 use crate::server::ops::smtp::local_part;
 
@@ -215,11 +236,20 @@ impl std::fmt::Debug for WorkflowDeliveryDeps {
 /// Never returns an error: a delivery problem is data on the run result, not a
 /// failed run (see the module docs). Nodes with no `destination`, and nodes the
 /// run never reached, produce no rows at all.
+///
+/// `already_delivered` is this lineage's delivery ledger (issue #438): the
+/// reports a run *earlier in the same approval chain* already sent or parked. A
+/// reached node listed there is skipped with
+/// [`DeliveryReason::AlreadyDelivered`] and **nothing is dispatched** — it is
+/// empty on every run nobody resumed, so an ordinary run is untouched. See
+/// [`crate::runtime::workflow_resume`] for why a continuation reaches these
+/// nodes again at all.
 pub async fn deliver_outputs(
     delivery: Option<&WorkflowDeliveryDeps>,
     record: &CompanyRecord,
     workflow: &WorkflowFile,
     output: &Value,
+    already_delivered: &[DeliveredReport],
 ) -> Vec<DeliveryReport> {
     let mut reports = Vec::new();
 
@@ -244,6 +274,36 @@ pub async fn deliver_outputs(
                 node = %node.id,
                 "workflow delivery: output node not reached; nothing to deliver"
             );
+            continue;
+        }
+
+        // Issue #438: a run earlier in this approval lineage already delivered
+        // this node's report. The continuation reached the node again because
+        // resuming re-runs the graph from the trigger, not because anything is
+        // owed — so this is a skip with a reason, and **no dispatch of any
+        // kind**. Checked before the unwired-ports arm below on purpose: a
+        // report that already went out must not be reported as one this build
+        // could not send.
+        if already_delivered.iter().any(|prior| prior.node == node.id) {
+            tracing::info!(
+                company = %record.id,
+                workflow = %workflow.id,
+                node = %node.id,
+                kind = %destination.kind,
+                "workflow delivery: an earlier run in this approval lineage already delivered this \
+                 report; not sending it again"
+            );
+            reports.push(DeliveryReport {
+                node: node.id.clone(),
+                kind: destination.kind.clone(),
+                target: destination.target.clone(),
+                status: DeliveryStatus::Skipped,
+                detail: "this report was already delivered by an earlier run of this workflow — \
+                         approving a gate re-runs the graph from the start, and a report that has \
+                         already gone out is not sent a second time"
+                    .to_string(),
+                reason: DeliveryReason::AlreadyDelivered,
+            });
             continue;
         }
 
@@ -1264,6 +1324,7 @@ allow = [{allow}]
             &record(&[]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1322,6 +1383,7 @@ allow = [{allow}]
             &record(&[]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1343,6 +1405,7 @@ allow = [{allow}]
             &record(&[]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1367,6 +1430,7 @@ allow = [{allow}]
             &record(&[]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1389,6 +1453,7 @@ allow = [{allow}]
             &record(&[]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1412,6 +1477,7 @@ allow = [{allow}]
             &record(&["email.send"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1442,6 +1508,7 @@ allow = [{allow}]
             &record(&["docs.*", "web"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1470,6 +1537,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1504,6 +1572,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1549,6 +1618,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1608,6 +1678,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1657,6 +1728,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1684,6 +1756,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1710,6 +1783,7 @@ allow = [{allow}]
             &record(&["docs.*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1734,6 +1808,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1768,6 +1843,7 @@ allow = [{allow}]
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1816,6 +1892,7 @@ mode = "full"
             &rec,
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1857,6 +1934,7 @@ mode = "full"
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1877,6 +1955,7 @@ mode = "full"
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1902,6 +1981,7 @@ mode = "full"
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1956,6 +2036,7 @@ mode = "full"
             &record(&["*"]),
             &graph("email", Some(ADDRESS)),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -1992,6 +2073,7 @@ mode = "full"
             &record(&[]),
             &graph("channel", Some(OPERATOR_CHANNEL)),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -2015,6 +2097,7 @@ mode = "full"
             &record(&["*"]),
             &graph("channel", Some("telegram")),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -2057,6 +2140,7 @@ mode = "full"
             &record(&["*"]),
             &graph("owner", None),
             &output,
+            &[],
         )
         .await;
 
@@ -2090,8 +2174,14 @@ to = "done"
         )
         .expect("parses");
 
-        let reports =
-            deliver_outputs(Some(&h.deps), &record(&["*"]), &plain, &reached_output()).await;
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &plain,
+            &reached_output(),
+            &[],
+        )
+        .await;
         assert!(reports.is_empty(), "{reports:?}");
     }
 
@@ -2105,6 +2195,7 @@ to = "done"
             &record(&["*"]),
             &graph("owner", None),
             &reached_output(),
+            &[],
         )
         .await;
 
@@ -2117,6 +2208,147 @@ to = "done"
             reports[0].detail.contains("nothing was sent"),
             "{reports:?}"
         );
+    }
+
+    // --- issue #438: one delivery per approval lineage ------------------------
+
+    /// One ledger row naming `node`, as a continuation's trigger input carries.
+    fn already(node: &str, kind: &str) -> Vec<DeliveredReport> {
+        vec![DeliveredReport {
+            node: node.to_string(),
+            kind: kind.to_string(),
+        }]
+    }
+
+    /// **The regression.** A continuation reaches the same `output` node again,
+    /// and must not mail the report a second time. The row says so, and the
+    /// transport is never touched.
+    #[tokio::test]
+    async fn a_report_this_lineage_already_sent_is_not_sent_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+            &already("done", "owner"),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped);
+        assert_eq!(reports[0].reason, DeliveryReason::AlreadyDelivered);
+        assert_eq!(reports[0].node, "done");
+        assert!(
+            h.mail.sent().is_empty(),
+            "the transport must never be reached: {:?}",
+            h.mail.sent()
+        );
+        assert!(h.channel.sent().is_empty());
+    }
+
+    /// A report the first run **parked** counts as delivered too. Otherwise
+    /// every continuation stacks a second identical cold-send card, and
+    /// approving both mails the stranger twice — `park_cold_recipient` has no
+    /// dedupe of its own.
+    #[tokio::test]
+    async fn a_report_this_lineage_already_parked_is_not_parked_again() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, false).with_parking(dir.path(), "full");
+        // Cold: the company has never heard from this address.
+        let cold = graph("email", Some("stranger@example.test"));
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["email"]),
+            &cold,
+            &reached_output(),
+            &already("done", "email"),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped);
+        assert_eq!(reports[0].reason, DeliveryReason::AlreadyDelivered);
+        assert!(
+            h.journal
+                .as_ref()
+                .expect("parking wired")
+                .pending()
+                .is_empty(),
+            "a continuation must not stack a second card for one send"
+        );
+        assert!(h.mail.sent().is_empty());
+    }
+
+    /// The ledger suppresses the node it names and nothing else. A second
+    /// output node in the same graph still delivers — otherwise one earlier
+    /// send would silence the whole graph.
+    #[tokio::test]
+    async fn a_node_the_ledger_does_not_name_still_delivers() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+            &already("some_other_node", "owner"),
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(h.mail.sent().len(), 1);
+    }
+
+    /// A run nobody resumed carries an empty ledger, and behaves exactly as it
+    /// did before #438. Every other test in this module passes `&[]`, so this
+    /// states the invariant they all rely on.
+    #[tokio::test]
+    async fn a_run_with_no_ledger_delivers_normally() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        h.add_admin("u1", "ada@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(h.mail.sent().len(), 1);
+    }
+
+    /// An unreached node on the ledger produces no row at all: "not reached"
+    /// outranks "already delivered", because there was nothing to deliver this
+    /// time either way.
+    #[tokio::test]
+    async fn an_unreached_node_on_the_ledger_still_produces_no_row() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        let unreached = serde_json::json!({ "nodes": { "start": { "items": [] } } });
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            &unreached,
+            &already("done", "owner"),
+        )
+        .await;
+
+        assert!(reports.is_empty(), "{reports:?}");
     }
 
     // --- report extraction ---------------------------------------------------

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -368,12 +368,39 @@ async fn run_workflow_inner(
         }
     };
 
+    // Route every reached `output` node's report to its configured destination.
+    // Deliberately here rather than in the HTTP handler: the orchestrator's
+    // `run_workflow` tool and the trigger scheduler drive this same path, and a
+    // scheduled run is exactly the case where nobody is watching the console's
+    // run-result drawer. Never fails the run — each attempt is reported instead.
+    //
+    // Issue #438: `already_delivered` is what a continuation must NOT send
+    // again. It is read off the trigger input, where the approval that started
+    // this run threaded it — an empty list on a run nobody resumed, so a
+    // first-run delivery is untouched.
+    let already_delivered = crate::runtime::workflow_resume::delivered_in_input(&trigger_input);
+    let deliveries = super::delivery::deliver_outputs(
+        delivery.as_ref(),
+        record,
+        workflow,
+        &outcome.output,
+        &already_delivered,
+    )
+    .await;
+
     // Issue #395: turn every gate the engine paused on into a decidable
     // approval. Deliberately here, beside the delivery call and for the same
     // reason: all three entry points — the console route, the cron scheduler,
     // and the orchestrator's `run_workflow` tool — come through this function,
     // and a scheduled run is exactly the case where nobody is watching the
     // response that used to be the only place these ids appeared.
+    //
+    // **After delivery, and that ordering is load-bearing** (issue #438). The
+    // parked card carries the ledger of what this run delivered, so it can only
+    // be built once delivery has happened. Nothing is lost by the swap: the two
+    // steps are independent — parking reads `pending_approvals` and delivery
+    // reads reached `output` nodes, and a node past a gate was never reached, so
+    // no delivery could ever depend on a gate having been parked first.
     //
     // Skipped for a cancelled run, which returns above: an operator who stopped
     // a run is not asking to be asked about the gates it never reached.
@@ -384,17 +411,9 @@ async fn run_workflow_inner(
         &run_id,
         &trigger_input,
         &outcome.pending_approvals,
+        &deliveries,
     )
     .await;
-
-    // Route every reached `output` node's report to its configured destination.
-    // Deliberately here rather than in the HTTP handler: the orchestrator's
-    // `run_workflow` tool and the trigger scheduler drive this same path, and a
-    // scheduled run is exactly the case where nobody is watching the console's
-    // run-result drawer. Never fails the run — each attempt is reported instead.
-    let deliveries =
-        super::delivery::deliver_outputs(delivery.as_ref(), record, workflow, &outcome.output)
-            .await;
 
     Ok(WorkflowRun {
         output: outcome.output,
@@ -432,6 +451,13 @@ async fn run_workflow_inner(
 /// queue fills with identical cards for one decision — which is exactly how an
 /// operator learns to rubber-stamp the queue. Identity is the gate, not the run;
 /// see [`already_parked`](crate::runtime::workflow_resume::already_parked).
+///
+/// # The delivery ledger (issue #438)
+///
+/// `deliveries` is what this run actually routed, and it rides the card so the
+/// continuation an approval starts knows what has already left the process.
+/// Without it, approving a gate re-mails every report upstream of it — the
+/// re-run semantics above applied to a side effect that reaches a real person.
 async fn park_pending_gates(
     delivery: Option<&super::delivery::WorkflowDeliveryDeps>,
     record: &CompanyRecord,
@@ -439,6 +465,7 @@ async fn park_pending_gates(
     run_id: &str,
     trigger_input: &Value,
     pending: &[String],
+    deliveries: &[crate::ports::DeliveryReport],
 ) {
     if pending.is_empty() {
         return;
@@ -464,6 +491,7 @@ async fn park_pending_gates(
             node_id,
             trigger_input,
             run_id,
+            deliveries,
         );
         if crate::runtime::workflow_resume::already_parked(&parking.journal, &effect) {
             tracing::debug!(
@@ -2049,6 +2077,195 @@ to = "done"
         .expect("run completes");
         assert!(run.pending_approvals.is_empty());
         assert!(journal.pending().is_empty());
+    }
+
+    // --- #438: a report is delivered once per approval lineage ---------------
+
+    /// A graph that **delivers before it pauses**: the report goes out, then the
+    /// gate stops the run. This is the shape that made approving a gate mail the
+    /// same person twice, and it is not exotic — "summarise, send it, then ask
+    /// me before doing the irreversible thing" is an ordinary workflow.
+    const DELIVER_THEN_GATE: &str = r#"
+id = "lineage"
+name = "Lineage"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "summary"
+kind = "output"
+name = "Owner summary"
+[node.destination]
+kind = "owner"
+[[node]]
+id = "gate"
+kind = "output"
+name = "Gate"
+requires_approval = true
+[[edge]]
+from = "start"
+to = "summary"
+[[edge]]
+from = "summary"
+to = "gate"
+"#;
+
+    /// Deps with a real approvals queue **and** a counting mail sender, plus an
+    /// active admin so an `owner` destination resolves to a real address.
+    ///
+    /// The mail sender is the instrument the whole test rests on: the claim is
+    /// not "the row says skipped", it is "the transport was called exactly
+    /// once across the entire lineage".
+    async fn deps_with_parking_and_mail(
+        dir: &std::path::Path,
+    ) -> (
+        HarnessDeps,
+        Arc<crate::runtime::journal::RuntimeJournal>,
+        crate::server::ops::mailer::RecordingMailSender,
+    ) {
+        use crate::ports::{UserRecord, UserRole, UserStatus, UserStore};
+
+        let users = Arc::new(FsOps::new(dir));
+        users
+            .upsert_user(
+                &CompanyId::new("acme"),
+                &UserRecord {
+                    id: "u1".to_string(),
+                    email: "ada@acme.test".to_string(),
+                    display_name: None,
+                    role: UserRole::Admin,
+                    status: UserStatus::Active,
+                    password_hash: None,
+                    must_change_password: false,
+                    created_at_millis: 1,
+                    last_seen_at_millis: None,
+                    updated_at_millis: 1,
+                },
+            )
+            .await
+            .expect("admin upserted");
+
+        let mail = crate::server::ops::mailer::RecordingMailSender::new();
+        let policy = toml::from_str("mode = \"full\"\n").expect("valid [policy] block");
+        let journal = Arc::new(crate::runtime::journal::RuntimeJournal::new(
+            dir.join("journal.jsonl"),
+        ));
+        let mut deps = deps(dir);
+        deps.delivery = Some(super::super::delivery::WorkflowDeliveryDeps {
+            mail: Some(crate::company::runtime::CompanyMail {
+                sender: Arc::new(mail.clone()),
+                smtp: crate::server::ops::smtp::SmtpCredentials {
+                    host: "smtp.example.test".into(),
+                    port: 587,
+                    security: crate::server::ops::smtp::SmtpSecurity::Starttls,
+                    username: "acme".into(),
+                    password: "hunter2".into(),
+                    from_name: "Acme".into(),
+                    from_email: "acme@opencompany.test".into(),
+                },
+            }),
+            inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
+            users,
+            channels: Vec::new(),
+            parking: Some(super::super::delivery::DeliveryParking {
+                approvals: Arc::new(crate::policy::ManifestApprovalGate::new(policy)),
+                journal: journal.clone(),
+            }),
+        });
+        (deps, journal, mail)
+    }
+
+    /// **The headline regression for issue #438.** Across a whole lineage — the
+    /// run that paused plus the continuation an approval starts — the report is
+    /// delivered exactly **once**.
+    ///
+    /// Counted at the transport, not at the row: a `skipped` row proves the
+    /// bookkeeping, and only the send count proves nobody's inbox was touched
+    /// twice. Before the fix this test reads `2` on the last assertion.
+    ///
+    /// The continuation is built by
+    /// [`continuation_input`](crate::runtime::workflow_resume::continuation_input)
+    /// — the same function the Approvals path calls — rather than assembled
+    /// here, so what is proven is the production path and not a lookalike. The
+    /// approvals plumbing on either side of it (the card is parked, approving
+    /// resolves it and spawns) is pinned by `workflow_resume`'s own suite.
+    #[tokio::test]
+    async fn a_report_is_delivered_once_across_a_gate_and_its_continuation() {
+        let dir = tempfile::tempdir().unwrap();
+        let (deps, journal, mail) = deps_with_parking_and_mail(dir.path()).await;
+        let file = parse_workflow(DELIVER_THEN_GATE).expect("parses");
+
+        // --- run 1: the report goes out, then the run pauses on the gate.
+        let first = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps.clone(),
+            &record(),
+            &file,
+            serde_json::json!({ "request": "quarterly numbers" }),
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("run pauses cleanly");
+
+        assert!(
+            first.pending_approvals.iter().any(|id| id == "gate"),
+            "the run must pause on the gate: {:?}",
+            first.pending_approvals
+        );
+        assert_eq!(first.deliveries.len(), 1, "{:?}", first.deliveries);
+        assert_eq!(
+            first.deliveries[0].status,
+            crate::ports::DeliveryStatus::Sent
+        );
+        assert_eq!(mail.sent().len(), 1, "run 1 sends the report once");
+
+        // --- the operator approves: the card becomes a continuation input.
+        let card = journal
+            .pending()
+            .into_iter()
+            .find(|p| p.effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND)
+            .expect("the paused gate is waiting on the operator")
+            .effect;
+        let continuation = crate::runtime::workflow_resume::continuation_input(&card)
+            .expect("a well-formed card continues");
+
+        // --- run 2: the same graph, from the trigger, with the gate approved.
+        let second = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &record(),
+            &file,
+            continuation,
+            &WorkflowRunContext::new(false),
+        )
+        .await
+        .expect("the continuation runs");
+
+        // The whole point, in one number — asserted FIRST, so a regression
+        // fails on the send count itself rather than on the bookkeeping that
+        // describes it.
+        assert_eq!(
+            mail.sent().len(),
+            1,
+            "one report, one send, across the whole lineage: {:?}",
+            mail.sent()
+        );
+
+        assert!(
+            second.pending_approvals.is_empty(),
+            "the approved gate must not pause again: {:?}",
+            second.pending_approvals
+        );
+        assert_eq!(second.deliveries.len(), 1, "{:?}", second.deliveries);
+        assert_eq!(
+            second.deliveries[0].status,
+            crate::ports::DeliveryStatus::Skipped
+        );
+        assert_eq!(
+            second.deliveries[0].reason,
+            crate::ports::DeliveryReason::AlreadyDelivered
+        );
     }
 
     // --- issue #371: the per-node progress trail -----------------------------


### PR DESCRIPTION
## Summary

Closes #438 and #440.

**#438 — approving a paused workflow could send the same email twice.**

A workflow that pauses for an approval is *settled*, not suspended: the engine finishes the run and reports which gates it stopped at. So resuming is necessarily a re-run from the top, and every node upstream of the gate executes a second time. Agent nodes re-spend tokens. An `output` node that already ran **delivers again**, because the established-recipient check is state-based rather than run-based — so a warm-recipient report is re-sent on approval.

The re-run primitive is correct and restart-durable, and it is untouched. What is added is a delivery ledger: the run records what it actually delivered, that record rides on the parked approval card itself, and a reached output node whose id is in it is skipped rather than dispatched. Keeping it on the card preserves the property the resume design is built on — the card is self-contained, so this survives a restart the same way the rest of it does.

`Pending` counts as delivered, deliberately. A parked cold-send card is durable and approving it sends, so treating it as already-delivered also closes a second hole: cold-recipient parking had no dedupe, and a continuation stacked a second identical card for the same send.

**#440 — cron started runs by its own copy of the shared path.** The scheduler kept its own supervisor registration and end-of-run journalling, duplicating what the shared spawn primitive owns. Nothing was broken — the copies agreed — but a fix landing in one would not land in the other. The fire path now goes through the shared primitive; the schedule claim and the delivery-log sweep stay the scheduler's own.

## API Or Behavior Changes

**A resumed run no longer re-delivers reports its earlier attempt already sent.** Everything else about resume is unchanged.

The approval card now carries a plain-language note that approving re-runs the workflow from the start, that earlier steps run again and re-spend tokens, and that already-delivered reports will not be re-sent — the cost is stated where the decision is made.

**An honest limit, stated rather than hidden:** a *partial* fan-out is not retried. If a report reached two of three admins before the run paused, the third will not receive it on resume. Re-sending to two people in order to reach one is the worse outcome, so this takes the other side of that trade deliberately. The full answer is checkpointed resume, which needs work in the vendored engine — its checkpointed entry point does not compose with the observer and cancellation token this runner needs. The guard here is forward-compatible with that.

`DeliveryReason` gained a variant. Its kebab-case token is additive and the console types the field as a string, so no frontend change is owed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib`
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

The decisive assertion for #438 is a counting mail sender across an approval lineage: the first run of an output-then-gate graph sends exactly one, the resumed run sends zero, and **the total across the lineage is exactly one**. That is the double-send claim itself rather than a proxy for it. Around it: sent-skipped, pending-skipped, an unlisted node still delivering, a non-continuation run untouched, and the ledger accumulating across two gates.

#440 is covered by the existing scheduler suite plus a parity test — one run driven through the scheduler and one through the shared primitive over a shared event log, asserting the journalled records differ only in the scheduled flag and the run id.

**A live-host check is owed and is not claimed here.** #438 has a user-facing surface — the Approvals card, the run drawer, and a real inbox. The sequence that proves it: author a workflow whose gate follows a warm-recipient delivery, run it, approve from the console, then confirm the recipient's mailbox holds **exactly one** message, the continuation's drawer shows the skipped already-delivered row, and the card carried the re-run cost note. A gate-before-delivery workflow must behave exactly as it does today.

## Documentation

The spawn primitive's module doc described the scheduler's copy as a deliberate omission; that is no longer true and has been rewritten.
