### PR TITLE
fix(delegation): nothing stages on the delegation queue unless a drain has claimed it (#453)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -223,6 +223,22 @@ impl HarnessBrain {
         let control = guard.control().clone();
 
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
+        // Issue #453: the same argument as the publish claim below, one queue
+        // over. This is a full agent turn with the whole toolbelt, so it can
+        // reach `review_task` / `assign_task` / `spawn_task` — and nothing here
+        // drained them. A `review_task` from a re-issued call was staged, the
+        // tool said the card had moved, and the next turn's `clear()` destroyed
+        // it.
+        //
+        // It **drains** rather than refusing, deliberately. `review_task` is a
+        // gateable Write effect, so an operator can be asked to approve one; if
+        // this path refused, approving it would make the approval unspendable —
+        // approve, refuse, re-park, forever. The claim is taken **per
+        // re-dispatch turn**, not per continuation cycle: one cycle may run
+        // several of these (issue #476 batches resolutions), and each turn owns
+        // its own drain window so one re-dispatch's queue can never leak into
+        // the next one's.
+        let delegation_claim = self.deps.delegations.claim();
         // Issue #445: this is a full agent turn with the whole toolbelt, so it
         // can publish — and before this nothing drained it, exactly as on the
         // chat path. It is a conversation continuation (it answers into the
@@ -262,6 +278,39 @@ impl HarnessBrain {
         }
         drop(publish_claim);
 
+        // Then the delegations (issue #453), in that order: publishes first so a
+        // file the turn offered is recorded before a card write can fail, and
+        // delegations before the bubble is built so the bubble can carry the id
+        // of a card this drain opened.
+        //
+        // Never propagated with `?`. The turn has already run and the operator is
+        // owed its answer; unwinding here would swallow the reply over a board
+        // write. A hand-off drained from here runs the delegate and settles their
+        // card, but has nowhere to relay their reply to — there is no relay turn
+        // on this path. That is a strict improvement on dropping it unrun, and it
+        // is recorded on the card the hand-off opens.
+        let drained = match self
+            .delegation_runner(&run_turn)
+            .drain_and_execute(
+                grant.origin_thread.as_deref(),
+                false,
+                delegation::HandOffs::Run,
+            )
+            .await
+        {
+            Ok(drained) => drained,
+            Err(err) => {
+                tracing::error!(
+                    approval_id = %approval_id,
+                    agent = %grant.agent,
+                    error = %err,
+                    "[delegation] the re-issued call queued board work that could not be executed"
+                );
+                delegation::Drained::default()
+            }
+        };
+        drop(delegation_claim);
+
         let text = match outcome {
             Ok(outcome) => outcome.reply,
             Err(err) => {
@@ -298,7 +347,11 @@ impl HarnessBrain {
         // agent's answer into the conversation twice.
         Ok(Some(OutboundMessage {
             message_id: None,
-            task_id: None,
+            // The card this turn's board work opened, when it opened one (issue
+            // #453) — the same first-wins id an operator turn's bubble carries,
+            // so a continuation that spawned or handed off work links to it
+            // instead of pointing at nothing.
+            task_id: drained.spawned_task,
             channel: grant.agent.clone(),
             text,
             steps: Vec::new(),
@@ -415,6 +468,18 @@ impl HarnessBrain {
                 .pending_publishes
                 .claim(publish::PublishDestination::Task)
         });
+        // Issue #453: and the delegation queue, for the same span. A dispatched
+        // card's responder is the orchestrator, which carries the delegation
+        // tools, and `handle_task_delegations` below is the drain — so this path
+        // has always been entitled to delegate and now says so. Unconditional:
+        // the drain runs whatever else is wired (a card with no task store
+        // simply executes to no effect, which every task path on this seam does).
+        //
+        // Spans the whole steer loop through the drain, not one iteration of it.
+        // The per-iteration `clear()` inside the loop stays — it abandons a
+        // redirected turn's work, which is a different decision from who is
+        // entitled to queue.
+        let _delegation_claim = self.deps.delegations.claim();
         // Issue #339, same argument for staged workflow references: an operator
         // chat turn earlier in this cycle may have run a workflow through the
         // orchestrator's tool, and that run belongs to the conversation, not to
@@ -5210,6 +5275,287 @@ members = ["eng1", "eng2"]
                 .is_empty(),
             "nothing is journaled for a deny"
         );
+    }
+
+    // --- Issue #453: a re-dispatch drains what its turn queued ---------------
+
+    /// What the scripted model does on each successive `/chat/completions` call.
+    #[derive(Clone, Debug)]
+    enum ScriptTurn {
+        /// Emit a native tool call.
+        Call {
+            tool: &'static str,
+            args: serde_json::Value,
+        },
+        /// Finish with plain assistant text.
+        Say(&'static str),
+    }
+
+    /// Serves a scripted OpenAI-compatible endpoint on loopback and returns its
+    /// base URL.
+    ///
+    /// `MockProvider` cannot express a tool call, and a tool call is the whole
+    /// point here: the defect is that a `review_task` made by a re-issued turn
+    /// was staged and never drained. Same shape `workspace_turn_test` and
+    /// `gated_tool_turn_test` established — stub exactly one boundary, the
+    /// model's choices, and run everything else for real.
+    async fn spawn_model_script(turns: Vec<ScriptTurn>) -> String {
+        use axum::Json;
+        use axum::routing::post;
+
+        let script = Arc::new(std::sync::Mutex::new(turns));
+        let app = axum::Router::new().route(
+            "/chat/completions",
+            post(move |Json(_body): Json<serde_json::Value>| {
+                let script = Arc::clone(&script);
+                async move {
+                    let next = {
+                        let mut turns = script.lock().unwrap();
+                        if turns.is_empty() {
+                            None
+                        } else {
+                            Some(turns.remove(0))
+                        }
+                    };
+                    // Running off the end means the loop went round more times
+                    // than expected; end the turn rather than hang.
+                    let message = match next.unwrap_or(ScriptTurn::Say("done")) {
+                        ScriptTurn::Say(text) => {
+                            serde_json::json!({ "role": "assistant", "content": text })
+                        }
+                        ScriptTurn::Call { tool, args } => serde_json::json!({
+                            "role": "assistant",
+                            "content": null,
+                            "tool_calls": [{
+                                "id": format!("call-{tool}"),
+                                "type": "function",
+                                "function": { "name": tool, "arguments": args.to_string() }
+                            }]
+                        }),
+                    };
+                    Json(serde_json::json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    }))
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        format!("http://{addr}")
+    }
+
+    /// A brain over the scripted model with a **real task store**, so a
+    /// `review_task` the re-dispatched turn makes can actually move a card.
+    fn brain_over_script(
+        dir: &std::path::Path,
+        requests: crate::harness::policy::ApprovalRequestQueue,
+        base_url: String,
+    ) -> HarnessBrain {
+        use crate::company::credentials::Credential;
+        use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+
+        let deps = HarnessDeps {
+            provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+                base_url,
+                credential: Credential::from_value("stub-key"),
+                extra_headers: Vec::new(),
+            })),
+            provider_slug: "managed".to_string(),
+            context: Arc::new(FsContextStore::new(dir)),
+            store: Arc::new(FsCompanyStore::new(dir)),
+            meter: None,
+            workspace_root: dir.to_path_buf(),
+            model_override: Some("stub-model".to_string()),
+            tasks: Some(Arc::new(FsOps::new(dir))),
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: std::sync::Arc::from([]),
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: orchestrator::DelegationQueue::default(),
+            workflow_runner: orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+            approval_requests: requests,
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+            run_supervisor: crate::runtime::RunSupervisor::default(),
+            delivery: None,
+            search: None,
+            workspace: None,
+        };
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record())
+    }
+
+    /// A card sitting in review, waiting on the verdict the operator approved.
+    fn card_in_review(id: &str) -> TaskRecord {
+        TaskRecord {
+            id: id.to_string(),
+            title: format!("Work item {id}"),
+            note: None,
+            column: COLUMN_IN_REVIEW.to_string(),
+            priority: "medium".to_string(),
+            assignee: "ceo".to_string(),
+            updated_at_millis: now_millis(),
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+        }
+    }
+
+    fn granted(approval: &str, tool: &str) -> crate::runtime::grants::GrantedCall {
+        crate::runtime::grants::GrantedCall {
+            approval_id: ApprovalId::new(approval),
+            agent: "ceo".into(),
+            tool: tool.into(),
+            args: serde_json::json!({}),
+            at_millis: now_millis(),
+            origin_thread: None,
+        }
+    }
+
+    /// **The reachability assertion.** A test that the drain works when called
+    /// is not coverage that the drain is reached — and on this path it was not.
+    ///
+    /// `redispatch_granted_call` runs a full toolbelt turn and claimed publishes
+    /// only, so a `review_task` the re-issued call made was staged, answered
+    /// with "the card has moved to done", and destroyed by the next turn's
+    /// `clear()`. It **drains** rather than refusing, deliberately: `review_task`
+    /// is a gateable Write effect, so refusing here would make an operator's own
+    /// approval unspendable — approve, refuse, re-park.
+    #[tokio::test]
+    async fn a_granted_redispatch_drains_the_board_work_its_turn_queued() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        requests.grants().grant(granted("appr-1", "review_task"));
+        let base_url = spawn_model_script(vec![
+            ScriptTurn::Call {
+                tool: "review_task",
+                args: serde_json::json!({ "task_id": "card-1", "decision": "approve" }),
+            },
+            ScriptTurn::Say("Approved."),
+        ])
+        .await;
+        let brain = brain_over_script(dir.path(), requests, base_url);
+        let tasks = brain.deps.tasks.clone().expect("task store");
+        tasks
+            .upsert(&CompanyId::new("acme"), &card_in_review("card-1"))
+            .await
+            .expect("seed the card");
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+        assert_eq!(result.channel_responses.len(), 1);
+
+        let cards = tasks.list(&CompanyId::new("acme")).await.expect("list");
+        assert_eq!(
+            cards[0].column,
+            crate::ports::tasks::COLUMN_DONE,
+            "the approved card must actually move — staging it and returning was the defect"
+        );
+        assert_eq!(
+            brain.deps.delegations.queued(),
+            0,
+            "and nothing may be left for a later turn's clear() to destroy"
+        );
+        assert!(
+            !brain.deps.delegations.drain_committed(),
+            "the claim releases with the re-dispatch turn"
+        );
+    }
+
+    /// The #476 nuance: one continuation cycle can run **several** re-dispatch
+    /// turns, one per batched resolution. The claim is therefore per turn, not
+    /// per cycle — each re-dispatch owns its own drain window.
+    ///
+    /// A per-cycle claim would pass a single-approval test and fail here in the
+    /// worst way: the second turn's staged verdict would ride on the first
+    /// turn's already-spent window, or the second acquire would clear work the
+    /// first had not drained yet.
+    #[tokio::test]
+    async fn batched_resolutions_each_get_their_own_drain_window() {
+        let dir = tempfile::tempdir().unwrap();
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        requests.grants().grant(granted("appr-1", "review_task"));
+        requests.grants().grant(granted("appr-2", "review_task"));
+        let base_url = spawn_model_script(vec![
+            ScriptTurn::Call {
+                tool: "review_task",
+                args: serde_json::json!({ "task_id": "card-1", "decision": "approve" }),
+            },
+            ScriptTurn::Say("Approved card-1."),
+            ScriptTurn::Call {
+                tool: "review_task",
+                args: serde_json::json!({ "task_id": "card-2", "decision": "revise" }),
+            },
+            ScriptTurn::Say("Sent card-2 back."),
+        ])
+        .await;
+        let brain = brain_over_script(dir.path(), requests, base_url);
+        let tasks = brain.deps.tasks.clone().expect("task store");
+        let company = CompanyId::new("acme");
+        for id in ["card-1", "card-2"] {
+            tasks
+                .upsert(&company, &card_in_review(id))
+                .await
+                .expect("seed the card");
+        }
+
+        let result = brain
+            .run_cycle(
+                cycle_over(vec![
+                    approval_resolved("appr-1", Verdict::Approve),
+                    approval_resolved("appr-2", Verdict::Approve),
+                ]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+        assert_eq!(
+            result.channel_responses.len(),
+            2,
+            "both resolutions re-dispatch"
+        );
+
+        let cards = tasks.list(&company).await.expect("list");
+        let column = |id: &str| {
+            cards
+                .iter()
+                .find(|c| c.id == id)
+                .map(|c| c.column.clone())
+                .unwrap_or_else(|| panic!("{id} is on the board"))
+        };
+        assert_eq!(
+            column("card-1"),
+            crate::ports::tasks::COLUMN_DONE,
+            "the first re-dispatch's verdict must survive the second re-dispatch's claim"
+        );
+        assert_eq!(
+            column("card-2"),
+            crate::ports::tasks::COLUMN_TODO,
+            "and the second's own verdict lands too"
+        );
+        assert_eq!(brain.deps.delegations.queued(), 0);
+        assert!(!brain.deps.delegations.drain_committed());
     }
 
     /// An approved resolution with NO grant behind it is a silent no-op.

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -17,7 +17,10 @@
 //!   [`Delegation`] onto a shared [`DelegationQueue`]. They perform no work
 //!   themselves; the [`HarnessBrain`](crate::harness::HarnessBrain) drains the
 //!   queue after the orchestrator's turn (v1: synchronous, in-cycle, capped at
-//!   [`MAX_DELEGATIONS_PER_TURN`], no sub-agent re-delegation).
+//!   [`MAX_DELEGATIONS_PER_TURN`], no sub-agent re-delegation). Since issue #453
+//!   they push only when a drain site has [claimed](DelegationQueue::claim) the
+//!   queue; a turn run from a path that drains nothing gets an in-turn refusal
+//!   instead of a receipt for work that will never happen.
 //! * [`RunWorkflowTool`] — executes one of the company's saved workflow graphs
 //!   by id via the [`WorkflowRunner`] port (issue #67). It loads the graph from
 //!   the company source directory (the same loader the REST run route uses) and
@@ -238,9 +241,37 @@ pub enum Delegation {
 /// queue is seen by the tools captured into the orchestrator agent and by the
 /// brain that drains it, because [`HarnessDeps`](crate::harness::HarnessDeps)
 /// clones share this handle.
+///
+/// # Why staging must be *claimed* (issue #453)
+///
+/// Staging has one failure mode and it is the worst kind: a caller for whom
+/// **nothing drains**. `review_task` returned *"Approved card X; it is complete
+/// and has moved to done"* the instant it pushed, and two production paths ran
+/// a full toolbelt turn and never drained — the approval re-dispatch and the
+/// workflow agent node. On those the sentence was false every time, and the
+/// next turn's [`clear`](Self::clear) destroyed the work the operator had just
+/// been told was done. A tool that cannot fail launders the failure through the
+/// agent into a confident falsehood.
+///
+/// So the queue carries a **drain commitment** alongside the staged items, and
+/// a drain site [`claim`](Self::claim)s it for the span in which it promises to
+/// drain. The default is *uncommitted*, and that direction is the whole
+/// guarantee: a turn run from a path that has not claimed — including one
+/// written later, by someone who never read this — gets an honest in-turn
+/// refusal instead of a receipt nothing will honour. Enforced by construction
+/// rather than by remembering: *no claim, no delegation*.
+///
+/// This is [`PendingPublishQueue`](crate::harness::publish::PendingPublishQueue)'s
+/// #445 shape, deliberately. The one difference is that there is nothing to name:
+/// every drain site executes the same delegations the same way, so the
+/// commitment is a boolean rather than a destination.
 #[derive(Clone, Default)]
 pub struct DelegationQueue {
     inner: Arc<Mutex<Vec<Delegation>>>,
+    /// Whether some drain site has promised to drain what is staged here
+    /// (issue #453). `false` — nothing drains — is the default and the
+    /// fail-safe direction.
+    committed: Arc<Mutex<bool>>,
     /// Desk keys a `delegate_to_desk` call named that the company does not have
     /// (issue #272).
     ///
@@ -259,8 +290,11 @@ impl DelegationQueue {
     ///
     /// Production callers want [`push_within_cap`](Self::push_within_cap)
     /// instead: this one can queue work the drain will later throw away, which
-    /// is exactly the failure issue #419 is about. Kept for the tests that
-    /// deliberately over-fill the queue to prove the cap holds.
+    /// is exactly the failure issue #419 is about. It bypasses the #453 drain
+    /// commitment for the same reason it bypasses the cap — it is the escape
+    /// hatch the tests that stand in for a turn use, and it is not reachable
+    /// from any tool. Kept for the tests that deliberately over-fill the queue
+    /// to prove the cap holds.
     pub fn push(&self, delegation: Delegation) {
         self.inner
             .lock()
@@ -268,8 +302,32 @@ impl DelegationQueue {
             .push(delegation);
     }
 
-    /// Enqueues a delegation unless `cap` are already queued for this turn.
-    /// Returns whether it was queued (issue #419).
+    /// Whether a drain site has committed to draining this queue (issue #453).
+    pub fn drain_committed(&self) -> bool {
+        *self.committed.lock().expect("delegation commitment")
+    }
+
+    /// Claims this queue for a drain site that promises to drain it, for as long
+    /// as the returned [`DelegationClaim`] lives (issue #453).
+    ///
+    /// Clears on the way in for the reason the drain sites already cleared by
+    /// hand — a prior turn's staged delegation must never be executed for this
+    /// caller — and, via [`DelegationClaim`]'s `Drop`, on the way out too. The
+    /// exit half is the one that is new and load-bearing: an early return, a
+    /// `?`, or a panic mid-turn used to leave items staged for the next caller
+    /// to clear, so correctness depended on every future path remembering. Now
+    /// the claim's scope *is* the window in which delegating works.
+    #[must_use = "the claim releases on drop; dropping it immediately un-claims the queue"]
+    pub fn claim(&self) -> DelegationClaim {
+        self.clear();
+        *self.committed.lock().expect("delegation commitment") = true;
+        DelegationClaim {
+            queue: self.clone(),
+        }
+    }
+
+    /// Enqueues a delegation unless nothing will drain it, or `cap` are already
+    /// queued for this turn (issues #419 and #453).
     ///
     /// # Why the cap is enforced *here*
     ///
@@ -289,14 +347,24 @@ impl DelegationQueue {
     /// queue is [`clear`](Self::clear)ed before every turn precisely so a stale
     /// delegation cannot leak into one — including into a CEO-relay turn, which
     /// is forbidden to delegate at all.
+    ///
+    /// # Why the commitment is checked *first*
+    ///
+    /// When nothing will drain, that is the only fact that matters: reporting
+    /// the cap instead would tell the model to try again next turn, and the next
+    /// turn on that path drains no better than this one. The two refusals are
+    /// therefore distinct [`Staged`] variants and never collapsed.
     #[must_use = "a refused delegation must be reported to the model, not dropped"]
-    pub fn push_within_cap(&self, delegation: Delegation, cap: usize) -> bool {
+    pub fn push_within_cap(&self, delegation: Delegation, cap: usize) -> Staged {
+        if !self.drain_committed() {
+            return Staged::NoDrain;
+        }
         let mut guard = self.inner.lock().expect("delegation queue");
         if guard.len() >= cap {
-            return false;
+            return Staged::OverCap;
         }
         guard.push(delegation);
-        true
+        Staged::Queued
     }
 
     /// Records that a hand-off named `desk`, which the company cannot hand work
@@ -364,6 +432,49 @@ impl DelegationQueue {
     #[cfg(test)]
     pub fn queued(&self) -> usize {
         self.inner.lock().expect("delegation queue").len()
+    }
+}
+
+/// What happened when a tool offered a delegation to the queue (issues #419,
+/// #453).
+///
+/// Three outcomes rather than a `bool`, because the two refusals need different
+/// sentences: one says *this turn is full, raise it next turn*, and the other
+/// says *this context cannot do board work at all, do not retry*. A model told
+/// the wrong one either burns its next turn on a call that will fail identically
+/// or gives up on work it could still have queued.
+#[must_use = "a delegation that was not queued must be reported to the model, not dropped"]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Staged {
+    /// Queued; some drain site will execute it as this turn completes.
+    Queued,
+    /// Nothing has claimed the queue, so nothing would ever execute it.
+    NoDrain,
+    /// This turn has already queued [`MAX_DELEGATIONS_PER_TURN`].
+    OverCap,
+}
+
+/// The live claim on a [`DelegationQueue`] — proof that some drain site is
+/// listening (issue #453).
+///
+/// Held for the span in which a caller promises to drain; on `Drop` the queue is
+/// emptied and returns to uncommitted, so delegating is off again the moment
+/// that promise ends. Mirrors
+/// [`PublishClaim`](crate::harness::publish::PublishClaim), and the in-flight
+/// steer guard before it, for the same reason: the cleanup has to happen on
+/// **every** exit path, including the ones nobody wrote by hand.
+///
+/// Deliberately not [`Clone`] — two live claims would mean two owners of one
+/// promise, and the second to drop would un-claim the queue underneath the
+/// first.
+pub struct DelegationClaim {
+    queue: DelegationQueue,
+}
+
+impl Drop for DelegationClaim {
+    fn drop(&mut self) {
+        *self.queue.committed.lock().expect("delegation commitment") = false;
+        self.queue.clear();
     }
 }
 
@@ -845,7 +956,8 @@ impl Tool for SpawnTaskTool {
             .filter(|a| !a.is_empty())
             .map(str::to_string);
 
-        if !self.queue.push_within_cap(
+        let effect = format!("the card \"{title}\" was NOT opened");
+        match self.queue.push_within_cap(
             Delegation::SpawnTask {
                 title: title.clone(),
                 note,
@@ -853,9 +965,9 @@ impl Tool for SpawnTaskTool {
             },
             MAX_DELEGATIONS_PER_TURN,
         ) {
-            return Ok(ToolResult::error(over_cap(&format!(
-                "the card \"{title}\" was NOT opened"
-            ))));
+            Staged::Queued => {}
+            Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
+            Staged::NoDrain => return Ok(ToolResult::error(no_drain(SPAWN_TASK_TOOL, &effect))),
         }
         Ok(ToolResult::success(format!(
             "Queued a task card: \"{title}\". It will be opened on the board this turn."
@@ -970,16 +1082,19 @@ impl Tool for DelegateToDeskTool {
             return Ok(ToolResult::error(refusal));
         }
 
-        if !self.queue.push_within_cap(
+        let effect = format!("nothing was handed to the {desk} desk");
+        match self.queue.push_within_cap(
             Delegation::DelegateToDesk {
                 desk: desk.clone(),
                 instruction,
             },
             MAX_DELEGATIONS_PER_TURN,
         ) {
-            return Ok(ToolResult::error(over_cap(&format!(
-                "nothing was handed to the {desk} desk"
-            ))));
+            Staged::Queued => {}
+            Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
+            Staged::NoDrain => {
+                return Ok(ToolResult::error(no_drain(DELEGATE_TO_DESK_TOOL, &effect)));
+            }
         }
         Ok(ToolResult::success(format!(
             "Delegated to the {desk} desk. Its lead will answer this turn."
@@ -1048,7 +1163,8 @@ impl Tool for AssignTaskTool {
         let assignee = required_str(&args, "assignee")?;
         let note = optional_str(&args, "note");
 
-        if !self.queue.push_within_cap(
+        let effect = format!("card {task_id} was NOT assigned");
+        match self.queue.push_within_cap(
             Delegation::AssignTask {
                 task_id: task_id.clone(),
                 assignee: assignee.clone(),
@@ -1056,12 +1172,15 @@ impl Tool for AssignTaskTool {
             },
             MAX_DELEGATIONS_PER_TURN,
         ) {
-            return Ok(ToolResult::error(over_cap(&format!(
-                "card {task_id} was NOT assigned"
-            ))));
+            Staged::Queued => {}
+            Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
+            Staged::NoDrain => return Ok(ToolResult::error(no_drain(ASSIGN_TASK_TOOL, &effect))),
         }
+        // Staged truth, not the past tense (issue #453). Nothing has been
+        // written yet; the drain this turn's claim promises is what writes it.
         Ok(ToolResult::success(format!(
-            "Assigned card {task_id} to {assignee}."
+            "Recorded the assignment of card {task_id} to {assignee}; it takes effect as this turn \
+             completes."
         )))
     }
 }
@@ -1129,7 +1248,8 @@ impl Tool for ReviewTaskTool {
         })?;
         let note = optional_str(&args, "note");
 
-        if !self.queue.push_within_cap(
+        let effect = format!("card {task_id} was NOT reviewed");
+        match self.queue.push_within_cap(
             Delegation::ReviewTask {
                 task_id: task_id.clone(),
                 decision,
@@ -1137,16 +1257,23 @@ impl Tool for ReviewTaskTool {
             },
             MAX_DELEGATIONS_PER_TURN,
         ) {
-            return Ok(ToolResult::error(over_cap(&format!(
-                "card {task_id} was NOT reviewed"
-            ))));
+            Staged::Queued => {}
+            Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
+            Staged::NoDrain => return Ok(ToolResult::error(no_drain(REVIEW_TASK_TOOL, &effect))),
         }
+        // Issue #453: the card has NOT moved yet. It moves when the drain runs,
+        // and the drain runs because this turn is claimed — which is what makes
+        // "as this turn completes" a commitment rather than a hope. The old
+        // wording ("it is complete and has moved to done") was the past tense
+        // for something that had not happened, and on an unclaimed path it never
+        // would.
         Ok(match decision {
             ReviewDecision::Approve => ToolResult::success(format!(
-                "Approved card {task_id}; it is complete and has moved to done."
+                "Recorded your approval of card {task_id}; it moves to done as this turn completes."
             )),
             ReviewDecision::Revise => ToolResult::success(format!(
-                "Sent card {task_id} back to To-do for another pass."
+                "Recorded your revision request; card {task_id} returns to To-do as this turn \
+                 completes."
             )),
         })
     }
@@ -1165,6 +1292,29 @@ fn over_cap(effect: &str) -> String {
         "Refused: this turn has already used all {MAX_DELEGATIONS_PER_TURN} of its delegations, so \
 {effect}. Nothing was queued and nothing will happen. Do not report this as done — tell the \
 operator which items you got to and which you did not, and raise the rest in your next turn."
+    )
+}
+
+/// The refusal a delegation tool returns when **nothing will drain** what it
+/// would queue (issue #453) — modelled on
+/// [`cannot_publish_here`](crate::harness::publish) one module over.
+///
+/// It has to do two jobs, and they are not the two [`over_cap`] does. It must
+/// not read as a transient condition worth retrying — every turn on an unclaimed
+/// path fails identically — and it must tell the agent what to say next, because
+/// the failure this replaces was one the agent could not detect: it was told the
+/// card had moved, so it told the operator the card had moved, and the next
+/// turn's `clear()` threw the delegation away.
+fn no_drain(tool: &str, effect: &str) -> String {
+    tracing::warn!(
+        tool = %tool,
+        "[delegation] a delegation tool was called from a turn with no claimed drain; refusing \
+         rather than queuing into a queue nothing will drain"
+    );
+    format!(
+        "Refused: nothing here can carry out board work, so {effect}. Board actions are \
+         unavailable in this context. Do not retry — it will fail the same way — and do NOT report \
+         the action as done or describe the card as moved. Say plainly that you could not do it."
     )
 }
 
@@ -2241,25 +2391,159 @@ mod tests {
     #[test]
     fn push_within_cap_refuses_once_the_turn_is_full() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         for i in 0..MAX_DELEGATIONS_PER_TURN {
-            assert!(queue.push_within_cap(
+            assert_eq!(
+                queue.push_within_cap(
+                    Delegation::SpawnTask {
+                        title: format!("t{i}"),
+                        note: None,
+                        assignee: None,
+                    },
+                    MAX_DELEGATIONS_PER_TURN,
+                ),
+                Staged::Queued
+            );
+        }
+        assert_eq!(
+            queue.push_within_cap(
                 Delegation::SpawnTask {
-                    title: format!("t{i}"),
+                    title: "one too many".to_string(),
                     note: None,
                     assignee: None,
                 },
                 MAX_DELEGATIONS_PER_TURN,
-            ));
-        }
-        assert!(!queue.push_within_cap(
-            Delegation::SpawnTask {
-                title: "one too many".to_string(),
-                note: None,
-                assignee: None,
-            },
-            MAX_DELEGATIONS_PER_TURN,
-        ));
+            ),
+            Staged::OverCap
+        );
         assert_eq!(queue.queued(), MAX_DELEGATIONS_PER_TURN);
+    }
+
+    // ── Issue #453: no claim, no delegation ────────────────────────────────
+
+    /// The commitment is checked before the cap, and it is the answer an
+    /// unclaimed queue gives however empty it is. A model told "this turn is
+    /// full" would try again next turn; on an unclaimed path the next turn fails
+    /// identically, so the two refusals must stay distinguishable.
+    #[test]
+    fn an_unclaimed_queue_refuses_before_the_cap_is_even_consulted() {
+        let queue = DelegationQueue::default();
+        assert!(!queue.drain_committed(), "uncommitted is the default");
+        assert_eq!(
+            queue.push_within_cap(
+                Delegation::SpawnTask {
+                    title: "first and only".to_string(),
+                    note: None,
+                    assignee: None,
+                },
+                MAX_DELEGATIONS_PER_TURN,
+            ),
+            Staged::NoDrain,
+            "an EMPTY unclaimed queue is still a queue nothing drains"
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// The RAII half, which is the one that was missing everywhere before #453:
+    /// an early exit — a `?`, a panic, a `return` from the middle of a turn —
+    /// must leave the queue empty and uncommitted, so the *next* caller inherits
+    /// a refusal rather than this one's abandoned work.
+    #[test]
+    fn a_claim_that_exits_early_un_commits_and_clears() {
+        let queue = DelegationQueue::default();
+
+        // A turn that queues work and then bails before draining.
+        fn bail(queue: &DelegationQueue) -> Result<(), &'static str> {
+            let _claim = queue.claim();
+            assert_eq!(
+                queue.push_within_cap(
+                    Delegation::ReviewTask {
+                        task_id: "t1".to_string(),
+                        decision: ReviewDecision::Approve,
+                        note: None,
+                    },
+                    MAX_DELEGATIONS_PER_TURN,
+                ),
+                Staged::Queued
+            );
+            assert_eq!(queue.queued(), 1, "staged while the claim is live");
+            Err("the turn failed after queuing")
+        }
+
+        assert!(bail(&queue).is_err());
+        assert_eq!(
+            queue.queued(),
+            0,
+            "the abandoned delegation must not survive the claim that staged it"
+        );
+        assert!(
+            !queue.drain_committed(),
+            "and the next caller must inherit a refusal, not this one's promise"
+        );
+
+        // Acquiring also clears, so a prior turn's leftovers can never be
+        // executed for the caller that comes next.
+        queue.push(Delegation::SpawnTask {
+            title: "left behind".to_string(),
+            note: None,
+            assignee: None,
+        });
+        let _claim = queue.claim();
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// The headline refusal, per tool, with the sentence each one owes the
+    /// model. The effect clause is the tool's own — a generic "refused" would
+    /// leave the model guessing which of its calls did not happen.
+    #[tokio::test]
+    async fn every_delegation_tool_refuses_when_nothing_will_drain() {
+        let queue = DelegationQueue::default();
+        let store = Arc::new(MemStore::seeded(desks_record(&CompanyId::new("acme"))))
+            as Arc<dyn CompanyStore>;
+
+        let cases: Vec<(Box<dyn Tool>, Value, &str)> = vec![
+            (
+                Box::new(SpawnTaskTool::new(queue.clone())),
+                json!({ "title": "Ship it" }),
+                "the card \"Ship it\" was NOT opened",
+            ),
+            (
+                Box::new(DelegateToDeskTool::new(
+                    queue.clone(),
+                    CompanyId::new("acme"),
+                    store,
+                )),
+                json!({ "desk": "strategy", "instruction": "draft a plan" }),
+                "nothing was handed to the strategy desk",
+            ),
+            (
+                Box::new(AssignTaskTool::new(queue.clone())),
+                json!({ "task_id": "t1", "assignee": "writer" }),
+                "card t1 was NOT assigned",
+            ),
+            (
+                Box::new(ReviewTaskTool::new(queue.clone())),
+                json!({ "task_id": "t1", "decision": "approve" }),
+                "card t1 was NOT reviewed",
+            ),
+        ];
+
+        for (tool, args, effect) in cases {
+            let name = tool.name().to_string();
+            let result = tool.execute(args).await.expect("execute");
+            assert!(result.is_error, "{name} must refuse: {}", result.text());
+            let text = result.text();
+            assert!(text.contains(effect), "{name}: {text}");
+            // Not retryable — the next turn on this path drains no better.
+            assert!(text.contains("Do not retry"), "{name}: {text}");
+            // And the model must not narrate it as done, which is the whole
+            // failure this replaces.
+            assert!(text.contains("report the action as done"), "{name}: {text}");
+            // Deliberately NOT the cap sentence: this is a different problem
+            // with a different remedy.
+            assert!(!text.contains("delegations"), "{name}: {text}");
+        }
+        assert_eq!(queue.queued(), 0, "nothing may be staged by a refusal");
     }
 
     /// The defect #419 names: the tool told the model "it will be opened on the
@@ -2269,6 +2553,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_task_refuses_past_the_cap_instead_of_promising_a_discarded_card() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let tool = SpawnTaskTool::new(queue.clone());
         for i in 0..MAX_DELEGATIONS_PER_TURN {
             let ok = tool
@@ -2301,6 +2586,7 @@ mod tests {
     #[tokio::test]
     async fn delegate_to_desk_refuses_past_the_cap() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         // An empty store loads no record, so desk grounding fails open and the
         // hand-off is queued exactly as it was before #272 — which isolates this
         // test to the cap.
@@ -2332,6 +2618,7 @@ mod tests {
     #[tokio::test]
     async fn the_lifecycle_tools_refuse_past_the_cap_too() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let assign = AssignTaskTool::new(queue.clone());
         let review = ReviewTaskTool::new(queue.clone());
         for i in 0..MAX_DELEGATIONS_PER_TURN {
@@ -2366,6 +2653,7 @@ mod tests {
     #[tokio::test]
     async fn spawn_task_tool_enqueues_a_task() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let tool = SpawnTaskTool::new(queue.clone());
         tool.execute(json!({ "title": "Ship it", "note": "soon", "assignee": "eng" }))
             .await
@@ -2394,6 +2682,7 @@ mod tests {
     #[tokio::test]
     async fn assign_task_tool_enqueues_an_assignment() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let tool = AssignTaskTool::new(queue.clone());
         tool.execute(json!({ "task_id": "t1", "assignee": "eng", "note": "closer to it" }))
             .await
@@ -2426,13 +2715,30 @@ mod tests {
     #[tokio::test]
     async fn review_task_tool_enqueues_both_verdicts() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let tool = ReviewTaskTool::new(queue.clone());
-        tool.execute(json!({ "task_id": "t1", "decision": "approve", "note": "good" }))
+        let approved = tool
+            .execute(json!({ "task_id": "t1", "decision": "approve", "note": "good" }))
             .await
             .expect("approve");
-        tool.execute(json!({ "task_id": "t2", "decision": "revise" }))
+        let revised = tool
+            .execute(json!({ "task_id": "t2", "decision": "revise" }))
             .await
             .expect("revise");
+
+        // Issue #453: staged truth, not the past tense. The card has not moved
+        // when this sentence is written — the drain the claim promises is what
+        // moves it — and saying otherwise is what made an undrained turn a lie
+        // told through the agent.
+        assert!(!approved.is_error);
+        let text = approved.text();
+        assert!(text.contains("Recorded your approval of card t1"), "{text}");
+        assert!(text.contains("as this turn completes"), "{text}");
+        assert!(!text.contains("has moved"), "nothing has moved yet: {text}");
+        let text = revised.text();
+        assert!(text.contains("card t2 returns to To-do"), "{text}");
+        assert!(text.contains("as this turn completes"), "{text}");
+
         assert_eq!(
             queue.drain(MAX_DELEGATIONS_PER_TURN),
             vec![
@@ -2540,6 +2846,7 @@ members = ["nobody"]
     #[tokio::test]
     async fn delegate_to_desk_tool_enqueues_a_hand_off() {
         let queue = DelegationQueue::default();
+        let _claim = queue.claim();
         let tool = desk_tool(desks_record(&CompanyId::new("acme")), &queue);
         let result = tool
             .execute(json!({ "desk": "strategy", "instruction": "draft a plan" }))
@@ -2616,6 +2923,10 @@ members = ["nobody"]
     #[tokio::test]
     async fn delegate_to_desk_tool_queues_ungrounded_when_no_record_is_readable() {
         let queue = DelegationQueue::default();
+        // Claimed (issue #453): "fail open" is about the *desk grounding*, and
+        // this pins that an unreadable record still queues. Whether anything
+        // drains is a separate question with its own refusal.
+        let _claim = queue.claim();
         let tool = DelegateToDeskTool::new(
             queue.clone(),
             CompanyId::new("acme"),

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -162,6 +162,38 @@ pub(crate) struct DeskReply {
     pub(crate) steps: Vec<TurnStep>,
 }
 
+/// Whether a drain may run the hand-offs it finds, or must drop them.
+///
+/// The CEO-relay turn is the one caller that must drop: a second hand-off from
+/// there is the re-delegation loop the drain exists to stop. Board writes are
+/// still executed — a card the relay turn opened is not a re-delegation (issue
+/// #442).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HandOffs {
+    /// Run them, and report what came back.
+    Run,
+    /// Drop them, with a log line; execute everything else.
+    Drop,
+}
+
+/// What one drain of the delegation queue produced (issue #453).
+///
+/// Extracted so every path that runs a turn can reuse the *exact* execution
+/// semantics rather than re-deriving them. Before this, only the two callers
+/// that happened to contain the loop had them, and the approval re-dispatch —
+/// which runs a full toolbelt turn — silently had none at all.
+#[derive(Default)]
+pub(crate) struct Drained {
+    /// Standalone chat bubbles to surface as-is.
+    pub(crate) bubbles: Vec<OutboundMessage>,
+    /// Synchronous desk answers, in the order they came back. Empty when
+    /// [`HandOffs::Drop`] was asked for.
+    pub(crate) desk_replies: Vec<DeskReply>,
+    /// The **first** board card this drain opened, matching
+    /// [`OperatorTurn::spawned_task`]'s first-wins rule.
+    pub(crate) spawned_task: Option<String>,
+}
+
 /// The operator-facing result of one operator message after delegation: the
 /// bubble's reply and folded step timeline, plus any standalone delegation
 /// bubbles to append as sibling channel responses. None of the current
@@ -304,10 +336,12 @@ impl<'a> DelegationRunner<'a> {
         self
     }
 
-    /// Handles one operator message end-to-end: clear stale delegations, run the
-    /// responder's turn, drain whatever it queued (capped, discarded past the
-    /// cap), and — when a synchronous desk delegation answered — run exactly one
-    /// CEO-relay hand-back turn whose reply replaces the operator-facing text.
+    /// Handles one operator message end-to-end: claim the delegation queue for
+    /// this turn (issue #453 — the acquire also clears, so nothing stale leaks
+    /// in), run the responder's turn, drain whatever it queued (capped,
+    /// discarded past the cap), and — when a synchronous desk delegation
+    /// answered — run exactly one CEO-relay hand-back turn whose reply replaces
+    /// the operator-facing text.
     ///
     /// The relay turn must not re-delegate: its prompt is relay-only, and as a
     /// safety net the delegation queue is cleared before it and drained-and-
@@ -320,10 +354,20 @@ impl<'a> DelegationRunner<'a> {
         message: &str,
         chat_id: Option<&str>,
     ) -> Result<OperatorTurn> {
-        // Clear stale delegations so nothing leaks from a prior turn, run the
-        // responder's turn (metered behind the `RunTurn` impl), then drain
-        // whatever it queued.
-        self.queue.clear();
+        // Claim the delegation queue for this turn and its drain (issue #453).
+        //
+        // The acquire-clear subsumes the bare `clear()` this used to open with —
+        // same guarantee, that nothing a prior turn staged leaks into this one —
+        // and adds the half that was missing: for the span of this claim, and
+        // only for it, the delegation tools are allowed to queue at all. On every
+        // exit path, including the `?`s below, `Drop` un-commits and empties, so
+        // a turn that dies mid-drain cannot leave work staged for whoever runs
+        // next.
+        //
+        // Additive beside the `approvals` handle #474 wired: they do not
+        // interact — one reads a count either side of a turn, this one owns the
+        // queue's write window.
+        let _claim = self.queue.claim();
         // Issue #463: did the REST chat handler already card this message?
         //
         // Evaluated ONCE, here, and for one reason: this is the only place the
@@ -403,22 +447,18 @@ impl<'a> DelegationRunner<'a> {
         // why the operator bubble linked to nothing on a recognised imperative
         // even though the board carried a card for it.
         let mut spawned_task: Option<String> = handler_card.or(direct_card_id);
-        for delegation in self.queue.drain(self.max_delegations) {
-            let out = self
-                .run_delegation(delegation, chat_id, carded_by_handler)
-                .await?;
-            if let Some(id) = out.spawned_task {
-                spawned_task.get_or_insert(id);
-            }
-            if let Some(bubble) = out.bubble {
-                bubbles.push(bubble);
-            }
-            if let Some(desk) = out.desk_reply {
-                // Fold the teammate's activity onto the operator timeline, then
-                // remember the answer to relay.
-                operator_steps.extend(desk.steps);
-                desk_replies.push((desk.member, desk.reply));
-            }
+        let drained = self
+            .drain_and_execute(chat_id, carded_by_handler, HandOffs::Run)
+            .await?;
+        if let Some(id) = drained.spawned_task {
+            spawned_task.get_or_insert(id);
+        }
+        bubbles.extend(drained.bubbles);
+        for desk in drained.desk_replies {
+            // Fold the teammate's activity onto the operator timeline, then
+            // remember the answer to relay.
+            operator_steps.extend(desk.steps);
+            desk_replies.push((desk.member, desk.reply));
         }
         // CEO-relay hand-back: when a synchronous desk delegation answered, run
         // exactly ONE more responder turn whose prompt is the original message
@@ -442,26 +482,13 @@ impl<'a> DelegationRunner<'a> {
             // the turn that wanted it happened to be a relay, which is invisible
             // from the operator's side. Board writes are executed; hand-offs are
             // still dropped, so the bound stays exactly one extra turn.
-            for delegation in self.queue.drain(self.max_delegations) {
-                if let Delegation::DelegateToDesk { desk, .. } = &delegation {
-                    tracing::debug!(
-                        company = %self.company,
-                        desk = %desk,
-                        "[delegation] dropped a hand-off queued by the relay turn: a relay may only \
-                         relay"
-                    );
-                    continue;
-                }
-                let out = self
-                    .run_delegation(delegation, chat_id, carded_by_handler)
-                    .await?;
-                if let Some(id) = out.spawned_task {
-                    spawned_task.get_or_insert(id);
-                }
-                if let Some(bubble) = out.bubble {
-                    bubbles.push(bubble);
-                }
+            let drained = self
+                .drain_and_execute(chat_id, carded_by_handler, HandOffs::Drop)
+                .await?;
+            if let Some(id) = drained.spawned_task {
+                spawned_task.get_or_insert(id);
             }
+            bubbles.extend(drained.bubbles);
             // A hand-off the relay turn's tool refused is dropped with the
             // hand-offs themselves — there is no card in scope to record it on,
             // and the drain would otherwise leak it into the next turn.
@@ -489,6 +516,65 @@ impl<'a> DelegationRunner<'a> {
             bubbles,
             spawned_task,
         })
+    }
+
+    /// Drains the queue (capped, discarded past the cap) and executes every
+    /// delegation on it, reporting what came back (issue #453).
+    ///
+    /// # Why this is a function
+    ///
+    /// It used to be a loop written out twice inside
+    /// [`handle_operator_message`](Self::handle_operator_message), which meant a
+    /// path that ran a turn without copying that loop drained nothing — and two
+    /// production paths did exactly that. The approval re-dispatch runs a full
+    /// toolbelt turn and claimed only publishes, so a `review_task` made from a
+    /// re-issued call was staged, never executed, and destroyed by the next
+    /// turn's clear. Extracting the loop is what lets that path reuse the *exact*
+    /// execution semantics — the cap, the first-wins card id, the refusal
+    /// handling — instead of a near-copy that drifts.
+    ///
+    /// **This is not the guarantee.** The guarantee is
+    /// [`DelegationQueue::claim`]: a caller that forgets to drain gets an
+    /// in-turn refusal at the tool rather than a receipt for work that will not
+    /// happen. This is the convenience that makes doing it right the short path.
+    ///
+    /// Refused desk keys are deliberately NOT drained here — they are recorded
+    /// on the card by [`handle_task_delegations`](Self::handle_task_delegations)
+    /// and logged by the relay path, and those are two different treatments of
+    /// one fact rather than something a shared drain can decide.
+    pub(crate) async fn drain_and_execute(
+        &self,
+        chat_id: Option<&str>,
+        carded_by_handler: bool,
+        hand_offs: HandOffs,
+    ) -> Result<Drained> {
+        let mut drained = Drained::default();
+        for delegation in self.queue.drain(self.max_delegations) {
+            if hand_offs == HandOffs::Drop
+                && let Delegation::DelegateToDesk { desk, .. } = &delegation
+            {
+                tracing::debug!(
+                    company = %self.company,
+                    desk = %desk,
+                    "[delegation] dropped a hand-off queued by the relay turn: a relay may only \
+                     relay"
+                );
+                continue;
+            }
+            let out = self
+                .run_delegation(delegation, chat_id, carded_by_handler)
+                .await?;
+            if let Some(id) = out.spawned_task {
+                drained.spawned_task.get_or_insert(id);
+            }
+            if let Some(bubble) = out.bubble {
+                drained.bubbles.push(bubble);
+            }
+            if let Some(desk) = out.desk_reply {
+                drained.desk_replies.push(desk);
+            }
+        }
+        Ok(drained)
     }
 
     /// Drains and executes whatever a **dispatched card's** turn queued (issue
@@ -1116,6 +1202,20 @@ impl<'a> DelegationRunner<'a> {
                 note,
             } => {
                 let Some((tasks, mut card)) = self.load_card(&task_id).await? else {
+                    // Issue #453: the residual case. The tool told the model the
+                    // assignment takes effect as the turn completes, the drain
+                    // ran, and there was no card to write to — so the receipt
+                    // promised something no store hiccup or missing wiring
+                    // explains. Silent no-op is right for the *card* (there is
+                    // nothing to do), and wrong for the operator, who is the
+                    // only one who can tell a mistyped id from a deleted card.
+                    tracing::warn!(
+                        company = %self.company,
+                        task_id = %task_id,
+                        "[delegation] assign_task named a card that is not on the board (or no \
+                         task store is wired); nothing was assigned, and the turn was told it \
+                         would be"
+                    );
                     return Ok(DelegationOutcome::default());
                 };
                 // Issue #205: the orchestrator writes this `assignee` out of an
@@ -1175,6 +1275,20 @@ impl<'a> DelegationRunner<'a> {
                 note,
             } => {
                 let Some((tasks, mut card)) = self.load_card(&task_id).await? else {
+                    // Issue #453, the same residual case one arm up and the more
+                    // consequential of the two: the model has just been told the
+                    // card "moves to done as this turn completes", and this is
+                    // the drain completing with nothing to move. The claim
+                    // guarantees the drain ran; it cannot guarantee the id names
+                    // a real card.
+                    tracing::warn!(
+                        company = %self.company,
+                        task_id = %task_id,
+                        ?decision,
+                        "[delegation] review_task named a card that is not on the board (or no \
+                         task store is wired); the verdict was recorded nowhere, and the turn was \
+                         told the card had moved"
+                    );
                     return Ok(DelegationOutcome::default());
                 };
                 card.note = Some(append_note(
@@ -1475,7 +1589,9 @@ mod tests {
     use std::sync::Mutex;
 
     use crate::ports::TaskStore;
-    use crate::ports::tasks::{COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO};
+    use crate::ports::tasks::{
+        COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO,
+    };
     use crate::ports::types::LedgerEntry;
     use crate::store::FsOps;
 
@@ -1673,6 +1789,12 @@ investor update for the quarter\n]"
         /// The board as it looked at the START of each turn, so a test can prove
         /// a card existed *while* an agent worked rather than only afterwards.
         board_at_turn: Mutex<Vec<Vec<(String, String)>>>,
+        /// Whether the delegation queue was **claimed** while each turn ran
+        /// (issue #453). This is what a real tool reads to decide between
+        /// staging and refusing, so recording it here is how a test proves the
+        /// turn was entitled to delegate at all — rather than only that the
+        /// drain happened to run afterwards.
+        committed_at_turn: Mutex<Vec<bool>>,
         tasks: Arc<dyn TaskStore>,
         company: CompanyId,
     }
@@ -1685,6 +1807,7 @@ investor update for the quarter\n]"
                 script: Mutex::new(turns.into()),
                 calls: Mutex::new(Vec::new()),
                 board_at_turn: Mutex::new(Vec::new()),
+                committed_at_turn: Mutex::new(Vec::new()),
                 tasks: fx.tasks.clone(),
                 company: fx.record.id.clone(),
             }
@@ -1699,6 +1822,12 @@ investor update for the quarter\n]"
         /// started.
         fn board_at_turn(&self, n: usize) -> Vec<(String, String)> {
             self.board_at_turn.lock().expect("board")[n].clone()
+        }
+
+        /// Whether the delegation queue was claimed while turn `n` ran (issue
+        /// #453).
+        fn committed_at_turn(&self, n: usize) -> bool {
+            self.committed_at_turn.lock().expect("committed")[n]
         }
 
         async fn next(
@@ -1720,6 +1849,10 @@ investor update for the quarter\n]"
                 .map(|c| (c.assignee, c.column))
                 .collect();
             self.board_at_turn.lock().expect("board").push(board);
+            self.committed_at_turn
+                .lock()
+                .expect("committed")
+                .push(self.queue.drain_committed());
             let turn = self
                 .script
                 .lock()
@@ -1875,6 +2008,81 @@ members = ["engineer"]
         async fn cards(&self) -> Vec<TaskRecord> {
             self.tasks.list(&self.record.id).await.expect("list cards")
         }
+    }
+
+    // ── Issue #453: the receipt and the board agree ─────────────────────────
+
+    /// The plain claim `review_task`'s receipt makes: an operator turn that
+    /// approves a card actually moves it.
+    ///
+    /// Both halves matter and they are different facts. `committed_at_turn`
+    /// proves the turn ran **under a claim**, which is what entitled the tool to
+    /// stage rather than refuse; the card's column proves the drain that claim
+    /// promised really executed. A test with only the second half would pass on
+    /// a path that drains but never claims — which is not the invariant, because
+    /// the next such path written would inherit nothing.
+    #[tokio::test]
+    async fn an_operator_turn_approval_actually_lands_the_card() {
+        let fx = Fixture::new();
+        let card = TaskRecord {
+            id: "card-1".to_string(),
+            title: "Draft the launch plan".to_string(),
+            note: Some("[engineer] drafted".to_string()),
+            column: COLUMN_IN_REVIEW.to_string(),
+            priority: "medium".to_string(),
+            assignee: "engineer".to_string(),
+            updated_at_millis: now_millis(),
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+        };
+        fx.tasks
+            .upsert(&fx.record.id, &card)
+            .await
+            .expect("seed the card under review");
+
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::queueing(
+                "approved — it's done",
+                vec![Delegation::ReviewTask {
+                    task_id: "card-1".to_string(),
+                    decision: lifecycle::ReviewDecision::Approve,
+                    note: Some("looks good".to_string()),
+                }],
+            )],
+        );
+
+        fx.runner(&turns)
+            .handle_operator_message("chief", "approve the launch plan card", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            turns.committed_at_turn(0),
+            "the turn must run under a claim, or the tool would have refused instead of staging"
+        );
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(
+            cards[0].column, COLUMN_DONE,
+            "the card the operator was told had moved must actually have moved"
+        );
+        assert!(
+            cards[0]
+                .note
+                .as_deref()
+                .unwrap_or_default()
+                .contains("looks good"),
+            "the verdict is on the card: {:?}",
+            cards[0].note
+        );
+        assert_eq!(fx.queue.queued(), 0, "the drain emptied the queue");
+        assert!(
+            !fx.queue.drain_committed(),
+            "and the claim released with the turn, so the next caller inherits a refusal"
+        );
     }
 
     fn handoff(instruction: &str) -> Delegation {

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -197,6 +197,29 @@ fn hex_segment(value: &str) -> String {
 /// teammate id. This extracts the turn message from the request and runs it
 /// through [`HarnessPool::run`], which meters the turn's cost through `deps` — so
 /// a workflow step and a chat turn account identically.
+///
+/// # It claims neither the publish queue nor the delegation queue — on purpose
+///
+/// A node's turn carries the whole toolbelt, so an orchestrator-tier `agent_ref`
+/// can reach `review_task`, `assign_task`, `spawn_task` and `delegate_to_desk`,
+/// and a granted one can reach `publish_artifact`. Nothing here drains either
+/// queue: a workflow run has no board card behind it and no conversation to
+/// surface a delegation's answer into — the same absence that makes
+/// [`park_gated_calls`](HarnessAgentRunner::park_gated_calls) record approvals
+/// explicitly unlinked.
+///
+/// So this path takes **no claim**, and that is the decision rather than an
+/// omission. What the agent gets is an honest in-turn refusal it can report —
+/// *"the card was NOT reviewed"* — instead of what it got before #453: a
+/// success receipt saying the card had moved to done, followed by the next
+/// turn's `clear()` destroying the delegation. Silent destruction replaced by a
+/// visible refusal.
+///
+/// Wiring a drain here would be a real feature (a workflow node that can move
+/// the board), and it is deliberately not this issue: it needs a decision about
+/// which card a node's `spawn_task` parents to and where a hand-off's reply
+/// goes. Until then, refusing is the truthful answer. Mirrors how this path
+/// already takes no [`PublishClaim`](crate::harness::publish::PublishClaim).
 pub struct HarnessAgentRunner {
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -85,18 +85,26 @@ enum Turn {
 /// A scripted OpenAI-compatible `/chat/completions` endpoint.
 struct Script {
     turns: Mutex<Vec<Turn>>,
+    /// Every request body the model was sent, in order (issue #453). The tool
+    /// results of a turn come back to the model inside the *next* request, so
+    /// this is where a test reads what a refused tool actually told it.
+    seen: Mutex<Vec<Value>>,
 }
 
-/// Serve the script on loopback and return its base URL.
-async fn spawn_script(turns: Vec<Turn>) -> String {
+/// Serve the script on loopback and return its base URL, handing back the
+/// shared script so a test can read what the model was sent.
+async fn spawn_script_recording(turns: Vec<Turn>) -> (String, Arc<Script>) {
     let script = Arc::new(Script {
         turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
     });
+    let handle = Arc::clone(&script);
     let app = axum::Router::new().route(
         "/chat/completions",
-        post(move |Json(_body): Json<Value>| {
+        post(move |Json(body): Json<Value>| {
             let script = Arc::clone(&script);
             async move {
+                script.seen.lock().unwrap().push(body);
                 let next = {
                     let mut turns = script.turns.lock().unwrap();
                     if turns.is_empty() {
@@ -131,7 +139,12 @@ async fn spawn_script(turns: Vec<Turn>) -> String {
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
-    format!("http://{addr}")
+    (format!("http://{addr}"), handle)
+}
+
+/// Serve the script on loopback and return its base URL.
+async fn spawn_script(turns: Vec<Turn>) -> String {
+    spawn_script_recording(turns).await.0
 }
 
 /// A one-agent company that gates `shell`.
@@ -331,6 +344,85 @@ async fn the_parked_request_survives_a_later_chat_cycle() {
         deps.approval_requests.queued(),
         0,
         "and nothing is left on the queue for a later cycle to park a second time"
+    );
+}
+
+// ── Issue #453: a workflow node's board action is refused, not destroyed ────
+
+/// The second reachability hole of exactly the #395 shape, one queue over.
+///
+/// A workflow `agent` node runs a full toolbelt turn, and an orchestrator-tier
+/// `agent_ref` carries `review_task`. Nothing on this path drains the delegation
+/// queue — there is no card behind a run and no conversation to answer into — so
+/// before this the tool staged the verdict, answered *"Approved card X; it is
+/// complete and has moved to done"*, and the next chat cycle's `clear()` threw
+/// it away. Green tests, moved card in the transcript, unmoved card on the
+/// board.
+///
+/// This drives the **real** path — real graph, real `run_workflow`, real
+/// `HarnessAgentRunner`, real pool, real orchestrator tools — and asserts the
+/// two things a unit test over the tool cannot: that the refusal is what a
+/// workflow node actually receives, and that the queue is empty afterwards.
+///
+/// The refusal is read out of the *next* request the model was sent, because
+/// that is where a tool result lands. Asserting on the tool's return value in
+/// isolation would prove the string, not the reachability.
+#[tokio::test]
+async fn a_workflow_node_is_refused_in_turn_instead_of_having_its_verdict_destroyed() {
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, script) = spawn_script_recording(vec![
+        Turn::Call {
+            tool: "review_task",
+            args: json!({ "task_id": "card-1", "decision": "approve" }),
+        },
+        Turn::Say("I could not approve that card."),
+    ])
+    .await;
+    let (deps, _journal) = deps(base_url, dir.path());
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    super::runner::run_workflow(
+        pool,
+        deps.clone(),
+        &record,
+        &file,
+        json!({ "request": "approve the launch card" }),
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect(
+        "the run completes — a refused board action refuses the call, it does not fail the node",
+    );
+
+    // The model was told, in its own turn, that the card did NOT move.
+    let seen = script.seen.lock().unwrap().clone();
+    let transcript = serde_json::to_string(&seen).expect("serialize the requests");
+    assert!(
+        transcript.contains("card card-1 was NOT reviewed"),
+        "the node's turn must carry the refusal: {transcript}"
+    );
+    assert!(
+        transcript.contains("Do not retry"),
+        "a workflow node drains no better next turn: {transcript}"
+    );
+    assert!(
+        !transcript.contains("has moved to done"),
+        "the receipt that made this a lie must be gone: {transcript}"
+    );
+
+    // …and nothing was staged for a later chat cycle to clear — the silent
+    // destruction this replaces.
+    assert_eq!(
+        deps.delegations.queued(),
+        0,
+        "a workflow node must leave nothing on the shared delegation queue"
+    );
+    assert!(
+        !deps.delegations.drain_committed(),
+        "this path deliberately claims nothing; see `HarnessAgentRunner`'s doc"
     );
 }
 


### PR DESCRIPTION
## Summary

Closes #453.

`review_task` told the agent *"Approved card {id}; it is complete and has moved to done."* Nothing had moved. The tool pushed an intent onto the delegation queue and returned in the past tense; the card moves only if that queue is later drained.

**Two production paths run an orchestrator turn and never drain it** — the approval re-dispatch, and the workflow agent node. On both, the sentence was false every time and the next turn's `clear()` destroyed the work. `assign_task` had the identical shape.

This is the defect class that keeps recurring here: stage the work, return an unqualified success naming a completed outcome, depend on a drain that may never run. Four of the five known instances tell an **agent** something false, which it then repeats to the operator with complete confidence — which is how someone ends up looking for a document that was never written.

Fixed by construction rather than by call site, following the merged template from #452: the queue carries a drain commitment whose default is *uncommitted*, and the tools refuse before staging anything. A turn-running path added next year inherits an honest refusal instead of a silent drop.

- **The re-dispatch path drains** rather than refusing. `review_task` is a gateable write, so refusing there would make an operator's approval unspendable — approve, refuse, re-park, forever. The claim is taken per re-dispatch turn, since one continuation can run several.
- **The workflow node refuses**, deliberately, and the decision is recorded in a doc comment rather than left as an omission. It previously returned success and had the work destroyed.
- **Receipts now state what actually happened:** *"Recorded your approval of card {id}; it moves to done as this turn completes."* Backed by the claim, "as this turn completes" is a commitment rather than a hope.

## API Or Behavior Changes

**Board work queued by an approval re-dispatch now actually executes.** It previously vanished. That is the fix working, but it is a real behaviour change: a granted `delegate_to_desk` now runs a desk turn that formerly disappeared, with the cost and side effects that implies. The continuation bubble also carries the card id when the drain opened one.

**A workflow agent node's board action now returns a visible refusal** where it previously returned success and was silently destroyed.

`push_within_cap` changed from `bool` to a three-way result; commitment is checked *before* the cap, because a model told "this turn is full" retries next turn, and an unclaimed path would fail identically but for a different reason.

One residual, stated: a hand-off drained on the re-dispatch path runs the delegate and settles their card, but has nowhere to relay their reply — there is no relay turn there. Documented at the call site as strictly better than not running it at all.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --lib` — 2334 passed, 0 failed, 2 ignored
- [x] `cargo check --locked --all-features --all-targets`

`Cargo.lock` unchanged.

**A test that the drain works when called is not coverage that the drain is reached** — that is exactly how this survived. So the assertions are about reachability, and both named paths are covered:

- a granted re-dispatch drains the board work its turn queued — card reaches `done`, queue empty, claim released;
- **batched resolutions each get their own drain window** — two approvals, two re-dispatch turns, both cards land;
- a workflow node's `review_task` is refused in turn, the refusal is read out of the next request the model was sent, and `has moved to done` is gone.

The two brain tests drive the real path through a scripted OpenAI-compatible endpoint, because the existing mock provider cannot emit a tool call — and a tool call is the entire point.

**A live check is owed and not claimed:** approving a card in chat should read as staged *and* land the card in Done in the same turn, and the same via an Approvals-page sign-off, which is the re-dispatch path.

## Documentation

The workflow node's no-claim decision is documented where that path runs, so the refusal reads as a choice rather than a gap.

**Merge note:** `src/harness/brain.rs` is also touched by #492, which adds a single `scope: None` line to a test fixture. Disjoint regions and a clean merge is likely, but the pair wants building together before the second lands — per-PR CI never builds the union of two open branches.
