### PR TITLE
fix(chat): a live reply and its rehydrated twin are one message (#483)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -46,7 +46,13 @@ import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hook
 import { useHashView } from "@/hooks/use-hash-view";
 import { toast } from "sonner";
 
-import { type ChatMessage, fromHistory, hostMessageId, makeMessage } from "@/lib/chat";
+import {
+  type ChatMessage,
+  fromHistory,
+  hostMessageId,
+  liveReplyIdentity,
+  makeMessage,
+} from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { defaultDesks, type Desk } from "@/lib/desks";
 import { writeLastChannel } from "@/lib/last-channel";
@@ -615,6 +621,8 @@ export function AppShell({
               makeMessage("company", event.text, {
                 channel: event.agentId,
                 taskId: event.taskId,
+                // Issue #483 — see `liveReplyIdentity`.
+                ...liveReplyIdentity(event),
               }),
             ],
           };
@@ -634,11 +642,18 @@ export function AppShell({
       if (!channelId) return;
       setTranscripts((t) => {
         const existing = t[channelId] ?? [];
-        // The same recent-tail content dedupe the thread store uses, and for
-        // the same reason: local ids are ephemeral counters and rehydrated ones
-        // are `h`-prefixed, so neither side of the race can be matched by id.
-        // The cost is that two genuinely identical company lines inside eight
-        // messages collapse into one — a price the thread store already pays.
+        // The same recent-tail content dedupe the thread store uses. It still
+        // earns its place: the operator's own turn is rendered locally by the
+        // awaited POST under an ephemeral `m<seq>` id, so a late echo of that
+        // reply can only be matched by content.
+        //
+        // It is no longer the ONLY guard, and issue #483 is why. This line now
+        // carries the host's id (below), so `hydrateChannel`'s id dedupe can
+        // recognise it — which the content check could never do from the other
+        // side, because hydration prepends history rather than appending to the
+        // recent tail this scans. Live-then-hydrate was the one route neither
+        // guard covered, and it doubled every reply that arrived while its
+        // channel was closed.
         const dup = existing
           .slice(-8)
           .some((m) => m.from === "company" && m.text === event.text);
@@ -650,6 +665,10 @@ export function AppShell({
             makeMessage("company", event.text, {
               channel: event.agentId,
               taskId: event.taskId,
+              // Issue #483: same identity as the thread store above. This is
+              // the store `hydrateChannel` writes into, so this is where the
+              // duplicate was visible.
+              ...liveReplyIdentity(event),
               // Issue #364: a reply to a thread joins that thread live, instead
               // of appearing in the channel and moving on the next reload. The
               // host names the parent by its own id, so it takes the same

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -190,6 +190,16 @@ export interface AgentReplyEvent {
   chatId: string;
   agentId: string;
   text: string;
+  /**
+   * The **host-side** id of this message (issue #483) — the stream envelope's
+   * `seq`. `chat/history` projects its own `id` from the same `StoredEvent`
+   * sequence, so a live line stamped with this carries the identity a later
+   * rehydration will mint for it, and the two can be recognised as one message
+   * instead of both being rendered.
+   *
+   * Namespaced into a console id by the injector, same as {@link parentId}.
+   */
+  seq: number;
   /** The board card this reply opened (issue #246), when it opened one. */
   taskId?: string;
   /**
@@ -425,6 +435,9 @@ function handleEvent(
         chatId: event.chatId,
         agentId: event.agentId,
         text: event.text,
+        // Issue #483: the host's own id for this message. Carried so the
+        // injected line and its later rehydrated twin share an identity.
+        seq: event.seq,
         // Issue #246: a reply injected from the stream — one this console did
         // not POST for, e.g. an inbound Telegram turn — carries its "card
         // opened" chip too, rather than only the locally-awaited copy.

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -88,6 +88,28 @@ let seq = 0;
 const nextId = () => `m${seq++}`;
 
 /**
+ * The identity a live-streamed company reply must be built with (issue #483).
+ *
+ * A reply arriving over the stream and the same reply coming back from
+ * `chat/history` are one message, and the console has to be able to tell. Both
+ * sides carry the host's `StoredEvent` sequence — the stream frame as `seq`,
+ * the history entry as `id` — so stamping the live line with it makes the two
+ * resolve to the same console id, and `hydrateChannel`'s id dedupe recognises
+ * the line it already has.
+ *
+ * Without this the live line was born under an ephemeral `m<counter>` id that
+ * hydration could never match, so a reply that arrived while its channel was
+ * closed was rendered twice on opening it.
+ *
+ * This exists as its own function so the identity decision has somewhere a test
+ * can reach. Inlined at the two call sites, nothing could assert it was still
+ * being made.
+ */
+export function liveReplyIdentity(event: { seq: number }): { messageId: string } {
+  return { messageId: String(event.seq) };
+}
+
+/**
  * Build a stamped message. `at` is injected so callers stay pure/testable.
  *
  * `messageId` is the host's own id for the line, when the caller already has

--- a/frontend/test/unit/chat-live-hydrate-identity.test.ts
+++ b/frontend/test/unit/chat-live-hydrate-identity.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import { fromHistory, liveReplyIdentity, makeMessage } from "@/lib/chat";
+import type { ChatHistoryMessageDto } from "@/api/types";
+
+/**
+ * Issue #483 — a reply that arrived live was rendered a second time when its
+ * channel was later hydrated from `chat/history`.
+ *
+ * The cause was an identity gap, not a race. Two writers put a company reply
+ * into a transcript, and they deduped on different keys that could never agree:
+ *
+ * - the live stream injection deduped on **content**, against the recent tail;
+ * - `hydrateChannel` deduped on **id**.
+ *
+ * A live line used to be built with an ephemeral `m<seq>` counter, so hydration
+ * — which prepends `h`-prefixed ids — never recognised it, called it fresh, and
+ * inserted the same reply twice. The content check could not cover it from the
+ * other side either, because hydration prepends rather than appending to the
+ * tail that check scans.
+ *
+ * The fix is that the live line now carries the host's own id. This file pins
+ * the property that makes that work: the stream frame's `seq` and the history
+ * entry's `id` are the same host identifier — both projected from one
+ * `StoredEvent.seq` — so stamping the live line with it yields *the same
+ * console id* the rehydrated twin will get.
+ *
+ * These are string-level assertions on purpose. If the namespacing of either
+ * side ever changes independently, the duplicate returns silently, and the only
+ * symptom is a reply appearing twice in a channel the operator had closed.
+ */
+
+function historyEntry(over: Partial<ChatHistoryMessageDto> = {}): ChatHistoryMessageDto {
+  return {
+    id: "4211",
+    channel: "engineering",
+    author: "engineering",
+    text: "You said: quarterly numbers",
+    atMillis: 1_700_000_000_000,
+    mine: false,
+    ...over,
+  };
+}
+
+describe("a live reply and its rehydrated twin", () => {
+  it("resolve to one console id, so hydration can recognise the line it already has", () => {
+    const seq = 4211;
+
+    // Built exactly the way the stream injection builds it — through
+    // `liveReplyIdentity`, not by re-deriving the id here. Asserting against a
+    // hand-written `messageId` would pass even if the injection stopped
+    // stamping one, which is the failure this test exists to prevent.
+    const live = makeMessage("company", "You said: quarterly numbers", {
+      channel: "engineering",
+      ...liveReplyIdentity({ seq }),
+    });
+
+    // What `chat/history` yields for the same message.
+    const [rehydrated] = fromHistory([historyEntry({ id: String(seq) })]);
+
+    expect(live.id).toBe(rehydrated.id);
+  });
+
+  it("is deduped by the id check hydration actually runs", () => {
+    const seq = 4211;
+    const live = makeMessage("company", "You said: quarterly numbers", {
+      channel: "engineering",
+      ...liveReplyIdentity({ seq }),
+    });
+    const hydrated = fromHistory([historyEntry({ id: String(seq) })]);
+
+    // `hydrateChannel`'s filter, verbatim in shape: anything already known by
+    // id is not fresh. Before the fix `live.id` was `m<counter>` and this set
+    // never contained the hydrated id, so the reply was inserted a second time.
+    const known = new Set([live].map((m) => m.id));
+    const fresh = hydrated.filter((m) => !known.has(m.id));
+
+    expect(fresh).toHaveLength(0);
+  });
+
+  it("still separates two genuinely different messages", () => {
+    const first = makeMessage("company", "same words", { messageId: "1" });
+    const second = makeMessage("company", "same words", { messageId: "2" });
+
+    // Identical text, different host messages. Collapsing these would be the
+    // opposite defect — a real reply silently swallowed — so the id must
+    // distinguish them even though a content check could not.
+    expect(first.id).not.toBe(second.id);
+
+    const known = new Set([first.id]);
+    expect(fromHistory([historyEntry({ id: "2", text: "same words" })]).filter(
+      (m) => !known.has(m.id),
+    )).toHaveLength(1);
+  });
+
+  it("leaves a line with no host id in the browser-local namespace", () => {
+    // The operator's own optimistic send has no host id yet. It must NOT
+    // collide with a host id, or reconciliation would swap the wrong line.
+    const optimistic = makeMessage("you", "quarterly numbers", {});
+    const hosted = makeMessage("company", "…", { messageId: "1" });
+
+    expect(optimistic.id).not.toBe(hosted.id);
+    expect(hosted.id.startsWith("h")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #483.

A company reply that arrived while its channel was **closed** was rendered twice when the operator opened that channel. Live and visible, not just a test problem.

The cause is an identity gap, not a race. Two writers put a reply into a transcript and deduped on keys that could never agree:

- the live stream injection deduped on **content**, against the recent tail;
- `hydrateChannel` deduped on **id**.

A live line was born under an ephemeral `m<counter>` id, so hydration — which prepends `h`-prefixed ids — never recognised it, called it fresh, and inserted the same reply again. The content check could not cover it from the other side either, because hydration *prepends* history rather than appending to the tail that check scans. Live-then-hydrate was the one route neither guard covered.

**The host already sends what was needed.** The stream envelope emits `"seq": stored.seq.value()`; `chat/history` projects its `id` from the same `StoredEvent.seq`. So the frame has always carried the exact identifier the rehydrated twin will be given — the console just wasn't using it. The live line is now stamped with it, and the existing id dedupe recognises the line it already has.

This is why it presented as a flake: it needs a live frame *and* a later hydration for one channel, and load widens the window in which both happen. It failed 5-of-5 concurrent CI runs and 0-of-3 solo runs, and has blocked PRs that touch no frontend code at all — including a documentation-only one and a Rust storage one.

## API Or Behavior Changes

`AgentReplyEvent` gains a required `seq`. It is the host id the hook already received and discarded, so nothing new crosses the wire.

The content-based dedupe stays and still earns its place: the operator's own turn is rendered locally by the awaited POST under an ephemeral id, so a late echo of that reply can only be matched by content. It is simply no longer the only guard.

## Tests

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npx vitest run` — 54 passed across 7 files

No lint script exists in this repo; none was run and none is claimed.

**The first version of this test was decorative and I replaced it.** It asserted that `makeMessage` and `fromHistory` agree on an id — true before this change, so it passed with the fix removed. Verified by deleting the fix and watching it still pass.

So the identity decision was extracted into `liveReplyIdentity`, which both injection sites now call, giving the test something real to reach. Breaking that helper now fails 2 of the 4 tests — verified the same way, by breaking it and watching them go red.

The tests also pin the opposite failure: two genuinely different messages with identical text must stay separate, since collapsing those would silently swallow a real reply.

**The wiring guard is the e2e spec**, `chat-live-events.spec.ts:130`, which walks exactly this route in a browser and reproduces the duplicate today. A unit test cannot prove the component calls the helper; that spec can, and it should go from failing-under-concurrency to passing.

## Documentation

The comment claiming "neither side of the race can be matched by id" was the reasoning that made this invisible — it was true when written and is now the thing that changed. Rewritten at both sites, with `liveReplyIdentity` carrying the explanation.
