### PR TITLE
ci: add a lane that executes tinyplace-gated tests (#477)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,59 @@ jobs:
       - name: Test tool-belt contract (openhuman, mcp, telegram)
         run: cargo test --locked --features openhuman,mcp,telegram --lib harness::build::tests
 
+      # Issue #477. Before this step, `tinyplace` was COMPILED by CI and
+      # EXECUTED by nothing. `Check (--all-features)` above builds every
+      # `tinyplace`-gated line and deliberately runs none of them, and no other
+      # `cargo test` line in this file names the feature — so the whole gate was
+      # covered for compilation and not at all for behaviour, and a logic defect
+      # behind it shipped green. Those are different claims, and only the second
+      # one is what a test suite is for: `src/economy/outbox.rs` carries a
+      # passing round-trip test for `Outbox::drain()` whose only caller in the
+      # entire tree is that test's own module (#454). Nothing ever ran the
+      # assertion, so nothing pointed out that the production drain it describes
+      # does not exist.
+      #
+      # FULL `--lib`, not a module filter — and this is the substance of the
+      # step, not a detail of it. `tinyplace` gates code across the tree, not
+      # just the economy adapter and its crypto primitives: company config, the
+      # runtime builder's economy wiring (in BOTH the `cfg` and the `cfg(not)`
+      # arm), the A2A server surface and the route that mounts it, and the
+      # platform-split key paths under `src/store/`. Narrowing to `economy::`
+      # would leave every one of those compiled and never run, which is the
+      # precise condition this step exists to end.
+      #
+      # The narrow shape of the belt-contract step above does NOT transfer here.
+      # That one is scoped because `mcp` changes what a tool belt *contains* and
+      # a single module pins that contract, so the rest of the run would be
+      # re-proving what an earlier lane already proved. `tinyplace` is the
+      # `openhuman,tinycortex` shape instead — a feature that changes behaviour
+      # at every site it gates — and that lane runs its whole suite for the same
+      # reason. The compile is what this costs; the compile is identical either
+      # way, so a filter would only discard results already paid for.
+      #
+      # `--lib` rather than `--tests` because no integration target under
+      # `tests/` carries a crate-level `cfg` on `tinyplace`; `--tests` would
+      # link an extra binary this feature set leaves empty. That does not
+      # reopen #475's hole. If such a target is ever added, `Assert every
+      # integration target actually runs` above fails it with `0 tests`, because
+      # that assertion sweeps EVERY target in the manifest whatever gates it —
+      # which is also why that script is not repeated here: on a lane without
+      # `openhuman` it would have to fail by design.
+      #
+      # A STEP on this job, not a fifth job: the vendored-submodule init and the
+      # system build dependencies this job already installs are exactly what
+      # this compile needs, and a separate job would repeat both plus a cold
+      # Rust cache to run a suite that finishes in seconds. Placed last so the
+      # cheaper cached steps still fail first. Split it out if this job's wall
+      # clock ever becomes the constraint — that is a pure CI-shape change with
+      # no argument riding on it.
+      #
+      # `--locked` per issue #251's rule for every graph-resolving invocation:
+      # this is a fifth distinct feature resolution, and without it this lane
+      # would be the one place CI silently re-resolves the dependency graph.
+      - name: Test (tinyplace)
+        run: cargo test --locked --features tinyplace --lib
+
   # Issue #281. Both jobs above are Rust-only, so before this job existed NOTHING
   # in CI installed Node: `frontend/` was invisible to the entire build, and a
   # TypeScript error there passed every required check and merged. The first


### PR DESCRIPTION
## Summary

Closes #477.

No CI job ever *ran* a test with the `tinyplace` feature enabled. `Check
(--all-features)` compiles every `tinyplace`-gated line and is check-only by
design, and of the five `cargo test` / `cargo clippy` invocations in
`ci.yml`, none named the feature. So the gate had full coverage of
*compilation* and zero coverage of *behaviour* — and those are different
claims. Any logic defect behind `#[cfg(feature = "tinyplace")]` merged green.

Not hypothetical. `src/economy/outbox.rs` carries a passing round-trip test
for `Outbox::drain()` whose only caller in the entire tree is that same
`#[cfg(test)]` module: there is no production drain at all (#454). Nothing
executed the assertion, so nothing pointed out that the thing it describes
does not exist. A feature CI never runs is exactly where a test asserts
something true about a function nothing reaches.

This adds one step to the existing `Rust (openhuman, tinycortex)` job:

```yaml
- name: Test (tinyplace)
  run: cargo test --locked --features tinyplace --lib
```

**Full `--lib`, not a module filter**, and that is the substance of the change
rather than a detail. `tinyplace` gates code well outside `src/economy/` —
company config, the runtime builder's economy wiring (both the `cfg` and the
`cfg(not)` arm), the A2A server surface and the route that mounts it, and the
platform-split key paths under `src/store/`. The numbers below show a module
filter would have left 10 real tests compiled and unrun. The narrow shape of
the `mcp` belt-contract step does not transfer: that one is scoped because
`mcp` changes what a tool belt *contains* and one module pins that contract.
`tinyplace` is the `openhuman,tinycortex` shape — behaviour changes at every
site it gates — and that lane runs its whole suite for the same reason. The
compile is the cost, and it is identical either way.

**A step, not a new job**: it reuses this job's vendored-submodule init and
system build dependencies, which a separate job would repeat along with a cold
Rust cache to run a suite that finishes in under three seconds. Placed last so
the cheaper cached steps still fail first. It can be split out later as a pure
CI-shape change if the job's wall clock becomes the constraint.

Both pinned constraints are untouched: `--tests` stays on the gated test step,
and `--all-features` stays `cargo check` and never becomes `cargo test`. The
diff is purely additive — 53 insertions, 0 deletions, no existing `run:`
modified.

### On `scripts/ci/assert-integration-targets-run.sh`

Not run on this lane, deliberately. No integration target under `tests/` has a
crate-level `cfg` needing `tinyplace` — the only target in the tree,
`one_card_per_message.rs`, is gated on `openhuman`. On a lane without
`openhuman` the script would have to fail by design, which is correct
behaviour and not a useful check.

This does not reopen #475's hole. If a `tinyplace`-gated integration target is
ever added, the existing `Assert every integration target actually runs` step
fails it with `0 tests`, because that assertion sweeps *every* target in the
manifest regardless of which feature gates it, and its message says to add the
lane rather than loosen the `cfg`. The guard is already in place; it just
fires from the other step. `--lib` here is what avoids linking an extra empty
binary for a target this feature set cannot satisfy.

## API Or Behavior Changes

None. CI configuration only — no Rust source changed, so `cargo fmt --all --
--check` is unaffected.

Worth naming without fixing here: **every lane in this file is advisory.**
`main` currently has no branch protection and no required checks, so a red
`Rust (openhuman, tinycortex)` does not block a merge. This step makes the
`tinyplace` failure *visible*; pinning required checks is the open follow-up
on #295, and it is what makes any of this file enforcing.

## Tests

`tinyplace` had never been resolved alone in CI — only inside `--all-features`,
which can mask a missing-feature break. Verified first that it stands up solo:

```
cargo check --locked --features tinyplace --all-targets   # clean, 32.92s
```

It does, so the step uses `--features tinyplace` and needs no
`openhuman,tinycortex,tinyplace` fallback.

**Before / after — counts from the actual command each lane runs.** All
measured on this branch, in a worktree off `upstream/main` @ `68b39a86`:

| Command | Result | Tests |
|---|---|---|
| `cargo test --locked --lib` (default, today's lanes) | ok | **1583** passed, 1 ignored |
| `cargo test --locked --features tinyplace --lib` (this step) | ok | **1640** passed, 1 ignored |

**57 tests move from "compiled, never executed" to "executed", and the count
is visible in the run log.**

The scoped numbers, which are why the step is not `--lib economy::`:

| Command | Tests |
|---|---|
| `cargo test --locked --lib economy::` (default) | 4 passed |
| `cargo test --locked --features tinyplace --lib economy::` | 51 passed |

47 of the 57 newly-executing tests are under `economy::`. **The other 10 are
not** — they live in the runtime builder, company config, the server routes
and the store paths. Filtering to `economy::`, as #477's own example sketches,
would have left those 10 in exactly the state this PR exists to end, for no
saving: the compile is the cost and it is the same compile.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked --features tinyplace --all-targets`
- [x] `cargo test --locked --lib` — 1583 passed
- [x] `cargo test --locked --features tinyplace --lib` — 1640 passed
- [x] YAML parses; `rust-gated` step list verified in order
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust source
      changed, and the gated lane's clippy step is untouched
- [ ] `cargo build --all-targets` — N/A: covered by the `--all-targets` check
      above and by the job's existing build step

CI on this branch is the link the issue asks for: the `Test (tinyplace)` step
prints its own `test result: ok. N passed` line into the run log.

## Documentation

None needed. The step carries its reasoning in-line, in the register the
surrounding steps use — stating the *property* that justifies the target
selection rather than a fact about the tree, since #475 showed a comment
justified by "there is no `tests/` directory" expires silently the day someone
adds one. The `CLAUDE.md` testing rule added by #481 already covers the
`tests/`-target case and needs no amendment: this change adds a lane for
`--lib` coverage and leaves that rule's assertion path exactly as written.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated coverage for the `tinyplace` feature.
  * The full library test suite now runs with locked dependencies to verify feature-specific behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->