### PR TITLE
fix(console): count the legacy import per kind instead of calling folders notes (#500)

### DIFF
--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -77,6 +77,30 @@ const AUTOSAVE_DELAY_MS = 800;
 /** The folder created to hold notes rescued from the retired local scratchpad. */
 const IMPORT_FOLDER_NAME = "Imported from this browser";
 
+/**
+ * The body of the import receipt, for a scratchpad of `files` notes and
+ * `folders` folders (issue #500).
+ *
+ * Names *both* categories rather than reporting one number, because the
+ * scratchpad is a flat list of two kinds and no single label is honest for
+ * every mix of them: calling the whole list "notes" over-reports a mixed
+ * import, and counting only files makes a folder-only import announce
+ * "0 notes" — a success that reads as a failure and still never mentions the
+ * folders that did arrive. The common files-only scratchpad renders exactly
+ * as it always did. The `IMPORT_FOLDER_NAME` root is packaging, not imported
+ * content, and is deliberately outside this tally.
+ */
+export function importSummary(files: number, folders: number): string {
+  const parts: string[] = [];
+  if (files > 0) parts.push(`${files} note${files === 1 ? "" : "s"}`);
+  if (folders > 0) parts.push(`${folders} folder${folders === 1 ? "" : "s"}`);
+  // Unreachable from the banner, which only renders for a non-empty
+  // scratchpad — but a receipt claiming an unqualified "Imported" would be the
+  // worst possible reading of an import that moved nothing.
+  if (parts.length === 0) return "nothing";
+  return parts.join(" and ");
+}
+
 /** What the editor's status line is currently reporting. */
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -328,6 +352,10 @@ export function WorkspaceView({ client, company }: Props) {
 
   async function importLegacy() {
     setImporting(true);
+    // Partitioned once, so the loops below and the receipt that reports them
+    // can never disagree about what was imported (#500).
+    const folders = legacy.filter((n) => n.kind === "folder");
+    const files = legacy.filter((n) => n.kind === "file");
     try {
       const root = await createNode(client, company, {
         name: IMPORT_FOLDER_NAME,
@@ -338,7 +366,7 @@ export function WorkspaceView({ client, company }: Props) {
       const remap = new Map<string, string>();
       const parentFor = (node: FsNode) =>
         node.parentId ? (remap.get(node.parentId) ?? root.id) : root.id;
-      for (const folder of legacy.filter((n) => n.kind === "folder")) {
+      for (const folder of folders) {
         const created = await createNode(client, company, {
           name: folder.name,
           kind: "folder",
@@ -346,7 +374,7 @@ export function WorkspaceView({ client, company }: Props) {
         });
         remap.set(folder.id, created.id);
       }
-      for (const file of legacy.filter((n) => n.kind === "file")) {
+      for (const file of files) {
         await createNode(client, company, {
           name: ensureMdExt(file.name),
           kind: "file",
@@ -356,7 +384,7 @@ export function WorkspaceView({ client, company }: Props) {
       }
       clearLegacyLocal(company);
       setLegacy([]);
-      toast.success(`Imported ${legacy.length} note${legacy.length === 1 ? "" : "s"}.`);
+      toast.success(`Imported ${importSummary(files.length, folders.length)}.`);
       await loadTree({ silent: true });
     } catch (e) {
       // The key is left intact on failure, so the banner comes back and nothing

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -174,14 +174,23 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
 }) => {
   const stamp = Date.now().toString(36);
   const rescued = `local-note-${stamp}`;
+  const filed = `filed-note-${stamp}`;
+  const rescuedFolder = `local-folder-${stamp}`;
   const legacyKey = await legacyKeyFor(request);
 
-  // Plant a legacy key holding one user-authored note (`fs-…`) alongside a
-  // bundled seed node (`seed-…`), exactly as the retired store would have.
+  // Plant a legacy key holding user-authored nodes (`fs-…`) alongside a bundled
+  // seed node (`seed-…`), exactly as the retired store would have.
+  //
+  // The user's nodes are deliberately of BOTH kinds, one of them a note nested
+  // inside the folder (#500). An all-files fixture makes the list's length and
+  // its file count the same number, so a receipt counting the wrong one of the
+  // two still passes — which is exactly how "N notes" survived counting
+  // folders. The nesting also puts a real parent-child pair through the
+  // import's `parentFor` remap, which a flat fixture never exercised.
   await page.goto("/#/workspace");
   await dismissOnboarding(page);
   await page.evaluate(
-    ([key, name]) => {
+    ([key, name, folderName, nestedName]) => {
       localStorage.setItem(
         key,
         JSON.stringify([
@@ -201,20 +210,44 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
             updatedAt: Date.now(),
             content: "Something the operator actually typed.",
           },
+          {
+            id: "fs-user-folder",
+            name: folderName,
+            kind: "folder",
+            parentId: null,
+            updatedAt: Date.now(),
+          },
+          {
+            id: "fs-user-2",
+            name: `${nestedName}.md`,
+            kind: "file",
+            parentId: "fs-user-folder",
+            updatedAt: Date.now(),
+            content: "Filed inside a folder the operator made.",
+          },
         ]),
       );
     },
-    [legacyKey, rescued] as const,
+    [legacyKey, rescued, rescuedFolder, filed] as const,
   );
 
   await openWorkspace(page);
 
-  // The banner offers only the user's note — the seed is not counted.
+  // The banner offers only the user's nodes — the seed is not counted.
   const banner = page.getByTestId("workspace-migration-banner");
   await expect(banner).toBeVisible({ timeout: 30_000 });
-  await expect(banner).toContainText("1 note");
+  await expect(banner).toContainText("3 notes");
 
   await page.getByTestId("workspace-migration-import").click();
+
+  // The receipt names what was actually imported, per kind (#500). Two notes
+  // and one folder — not the flat list's length, and not the import folder the
+  // console creates to hold them, which is packaging rather than content.
+  await expect(page.locator("[data-sonner-toast] [data-title]").first()).toHaveText(
+    "Imported 2 notes and 1 folder.",
+    { timeout: 30_000 },
+  );
+
   await expect(banner).toBeHidden({ timeout: 30_000 });
 
   // The rescued note is on the host, under the import folder.
@@ -229,6 +262,15 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
   const note = nodes.find((n) => n.name === `${rescued}.md`);
   expect(note, "the user's note must be imported").toBeTruthy();
   expect(note!.parentId).toBe(folder!.id);
+
+  // The user's own folder came across too, and the note filed inside it is
+  // still inside it — the remap resolved the child's old local parent id.
+  const nested = nodes.find((n) => n.kind === "folder" && n.name === rescuedFolder);
+  expect(nested, "the user's folder must be imported").toBeTruthy();
+  expect(nested!.parentId).toBe(folder!.id);
+  const filedNote = nodes.find((n) => n.name === `${filed}.md`);
+  expect(filedNote, "the nested note must be imported").toBeTruthy();
+  expect(filedNote!.parentId).toBe(nested!.id);
 
   // The seed's invented note was never imported.
   expect(nodes.some((n) => n.name.includes("Spring launch"))).toBe(false);

--- a/frontend/test/unit/workspace-import-summary.test.ts
+++ b/frontend/test/unit/workspace-import-summary.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { importSummary } from "@/views/WorkspaceView";
+
+/**
+ * The legacy-import receipt (issue #500).
+ *
+ * The retired scratchpad is a flat list of two kinds, and the toast used to
+ * report its whole length as "notes" — so a mixed import over-reported, and a
+ * folder-only import claimed notes it never created. Every branch below is a
+ * shape a real scratchpad can have, which is the point: the string has to be
+ * true for all of them, not just the files-only one the fixture happened to
+ * cover.
+ */
+
+describe("importSummary", () => {
+  it("names a single note in the singular", () => {
+    expect(importSummary(1, 0)).toBe("1 note");
+  });
+
+  it("names several notes in the plural", () => {
+    expect(importSummary(3, 0)).toBe("3 notes");
+  });
+
+  it("names a single folder in the singular", () => {
+    expect(importSummary(0, 1)).toBe("1 folder");
+  });
+
+  it("names several folders in the plural", () => {
+    expect(importSummary(0, 4)).toBe("4 folders");
+  });
+
+  it("never mentions notes for a folder-only scratchpad", () => {
+    // The old expression said "Imported 1 note." here, having imported none.
+    expect(importSummary(0, 1)).not.toContain("note");
+  });
+
+  it("never mentions folders for a files-only scratchpad", () => {
+    expect(importSummary(2, 0)).not.toContain("folder");
+  });
+
+  it("names both categories for a mixed scratchpad", () => {
+    // The issue's own example: the old expression called this "4 notes".
+    expect(importSummary(3, 1)).toBe("3 notes and 1 folder");
+    expect(importSummary(2, 3)).toBe("2 notes and 3 folders");
+  });
+
+  it("stays total for an empty import the banner can never offer", () => {
+    expect(importSummary(0, 0)).toBe("nothing");
+  });
+});


### PR DESCRIPTION
## Summary

The Workspace's legacy-import toast reported `legacy.length` — the whole flat
scratchpad list — as "N notes", but the import loops partition that list by
kind. A scratchpad of 1 folder and 3 files toasted "Imported 4 notes" having
imported three; a folder-only scratchpad of one folder toasted "Imported 1
note" having imported none, singular/plural included.

The list is now partitioned once, at the top of `importLegacy`, and the loops
iterate those locals — so the counts and the work can no longer drift apart.
A small pure helper (`importSummary`) builds the receipt and **names both
categories**, because no single label is honest for every mix: calling the
whole list "notes" over-reports a mixed import, and counting only files makes
a successful folder-only import announce "Imported 0 notes." — a success that
reads as a failure and still never mentions the folders that arrived. The
`Imported from this browser` root the import creates is packaging rather than
content, and stays outside the tally as it always did.

Observed on a running console (real host, real browser), before → after:

| Scratchpad | Before | After |
|---|---|---|
| 3 notes | `Imported 3 notes.` | `Imported 3 notes.` |
| 1 folder | `Imported 1 note.` | `Imported 1 folder.` |
| 2 notes + 1 folder | `Imported 3 notes.` | `Imported 2 notes and 1 folder.` |

The common files-only case renders byte-identical to today's output — which is
the case where today's output was right.

Nothing caught this because the E2E fixture planted two entries, both
`kind: "file"`. With no folders, the list's length and the file count are the
same number, so an assertion on the wrong expression passes; and nothing
asserted the toast's number at all. The fixture now carries a folder plus a
note nested inside it, which also puts a real parent-child pair through the
import's `parentFor` remap for the first time, and the spec asserts the exact
rendered toast string.

## API Or Behavior Changes

User-visible copy only: the workspace legacy-import success toast now names
notes and folders separately. No API, route, or storage change. The failure
path (which deliberately leaves the legacy key intact), the seed sweep,
discard, and import ordering are untouched.

Adjacent and deliberately **not** fixed here: the migration *banner* still
labels the pending flat list "N notes" for the same reason the toast did — a
folder-only scratchpad is announced as "1 note … is not in the company
workspace yet". Out of scope for this issue; worth its own change.

## Tests

Console-side change; the Rust checklist below is not applicable.

Run locally from `frontend/`:

- `npx vitest run` — 72 passed (10 files), including the new
  `test/unit/workspace-import-summary.test.ts` (8 cases: files-only singular
  and plural, folders-only singular and plural, mixed, and the issue's own
  3 notes + 1 folder shape).
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean.
- `npm run build` — clean.
- `npx playwright test test/e2e/workspace.spec.ts` — 2 passed, against a live
  host (`cargo build --locked --bin opencompany`, default features), including
  the exact-toast assertion and the nested-note placement.
- Manual: drove the running console for the files-only, folders-only, mixed and
  single-note shapes and read the toast each time — the table above is what was
  observed, not what was predicted.

- [x] N/A: `cargo fmt --all -- --check` — no Rust changed.
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- [x] N/A: `cargo build --all-targets` — no Rust changed.
- [x] N/A: `cargo test` — no Rust changed.

## Documentation

None needed — no public API, route, or architecture change; the reasoning for
the wording lives beside the helper it governs.

Closes #500
