### PR TITLE
feat(tasks): a discussion message can be withdrawn, and stops shipping in the bundle

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -43,7 +43,7 @@ why this is not a read/write split: [authority.md](authority.md).
 
 | Surface (`ops::*`) | Routes |
 |---|---|
-| `tasks` | `POST …/tasks`, `GET …/tasks`, `GET …/tasks/{id}` (the Task Detail read, #185), `PATCH`/`DELETE …/tasks/{id}`, `GET …/tasks/inflight`, `POST …/tasks/{id}/steer` (#111), `POST …/tasks/{id}/discussion` (#335) |
+| `tasks` | `POST …/tasks`, `GET …/tasks`, `GET …/tasks/{id}` (the Task Detail read, #185), `PATCH`/`DELETE …/tasks/{id}`, `GET …/tasks/inflight`, `POST …/tasks/{id}/steer` (#111), `POST …/tasks/{id}/discussion` (#335), `DELETE …/tasks/{id}/discussion/{seq}` (#358) |
 | `task_export` | `GET …/tasks/{id}/export` (the task's record as a document, #352) |
 | `memory` | `POST …/memory`, `DELETE …/memory/{id}` (journals `MemoryFactDeleted`) |
 | `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` (the two `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177) |
@@ -192,14 +192,69 @@ That deferral was cleaner when this branch was cut than it is now — #342 lande
 record on `main` and the question is answerable rather than blocked. Still
 deferred, but on scope, not on missing prior art.
 
-**Ordering, editing, deletion, references.** Oldest-first by journal sequence,
-which is also the console's render key. The journal is append-only, so v1 has no
-edit and no delete — what was said stays said; a retraction would need a
-tombstone event and is not one. That is a real gap: the log is what export/import
-ships, and a discussion is exactly where somebody pastes the API key they are
-blocked on. Tracked as **#358**, a redaction path for journaled human prose. A
-message is plain text: it cannot yet reference an artifact or an approval, left
-until there is a link target more durable than a row's position.
+**Ordering, editing, references.** Oldest-first by journal sequence, which is
+also the console's render key. There is still no *edit*: what was said stays
+said, and a message that could be rewritten after the fact would make the thread
+unciteable. A message is plain text: it cannot yet reference an artifact or an
+approval, left until there is a link target more durable than a row's position.
+
+### Withdrawing a discussion message (issue #358)
+
+The gap #335 shipped with: a discussion is exactly where somebody pastes the API
+key they are blocked on, the log is append-only, and the log is what
+export/import ships — so a pasted secret was not merely permanent, it was
+**portable**. Four decisions close it, and each of them is a decision rather
+than a default.
+
+**A tombstone, not a delete.** `CompanyEvent::TaskDiscussionRedacted { task_id,
+seq, by }` *supersedes* the post at `seq`; the post itself is never rewritten or
+removed. The append-only property is load-bearing beyond this tab — no control
+alters a past event, sequence numbers are stable ids other events name, and
+import replays a bundle from zero to reproduce them — and a delete would break
+all three to serve one screen.
+
+**What a reader sees.** The row keeps its place, its `seq`, its author and its
+time; its text is replaced by `REDACTED_DISCUSSION_TEXT` ("This message was
+removed.") and the row carries `redacted: true` plus `redactedBy`, the label of
+whoever withdrew it. Not a silent disappearance: a message that vanishes without
+trace lets one member quietly rewrite what a thread said, which is a different
+product from "anyone may take back a mistake in the open". The substitution
+happens in the fold, so the console thread and the task-detail export document
+(#352, which renders the same assembled value) cannot disagree.
+
+**Export and import.** `store::export::scrub_redacted_discussion` applies the
+same substitution to `events.jsonl` — on the way **out**, so a bundle never
+carries a withdrawn message, and on the way **in**, so a bundle written by a
+host that predates this cannot smuggle one back through import. The tombstone
+travels with it, so the imported thread says the same thing the exporting one
+did, with the same attribution. This is the half that actually closes the issue:
+a redaction that stopped at the console would move the exposure somewhere nobody
+is looking.
+
+**Who may.** `DELETE …/tasks/{taskId}/discussion/{seq}`, under the same
+`ScopedCompany` guard as every other task write — any member of the company, not
+admin-only. That matches the surrounding surface rather than inventing a rule:
+the same member may `DELETE` the whole card, thread and all, so holding one
+message to a higher bar than the card containing it would be incoherent. The
+withdrawal is attributed instead. An unknown card, or a `seq` that is not a
+discussion post *on this card*, is a `404`; withdrawing an already-withdrawn
+message is a no-op success, so a retry is not an error.
+
+**What it does not claim.** This is not erasure at rest on the instance that
+already holds the bytes — that is exactly what append-only forbids, and
+pretending otherwise would be worse than the gap. A leaked credential still has
+to be rotated. What the withdrawal guarantees is that the text stops being
+served by any read surface and stops leaving the building. Posts journaled
+before this shipped are fully covered, since the tombstone names a `seq` and
+nothing about the post has to change; bundles already exported are not, and
+cannot be.
+
+**Scope: the discussion, not the journal.** The mechanism is deliberately
+discussion-only. `OperatorMessage` has the same shape of problem, and generalizing
+before there is a second caller would fix its shape around one. The next human-prose
+writer that needs this should read this section and decide whether to widen the
+event or add its own — the pattern to inherit is the pair (tombstone in the log,
+substitution in every fold *and* in the bundle), not the variant.
 
 **Attribution.** A post carries the signed-in user as `by`, resolved to a roster
 label on read (a display name, or an email's local part). A user no longer on

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -391,8 +391,27 @@ export interface DiscussionMessage {
    * with a machine credential. The host never sends a user id or an email here.
    */
   author: string;
-  /** The message text, exactly as posted. */
+  /**
+   * The message text, exactly as posted — or the host's fixed "This message was
+   * removed." once withdrawn (#358). The original text is never sent again on
+   * any surface, so a console that ignores {@link redacted} still cannot render
+   * it.
+   */
   text: string;
+  /**
+   * Whether this message was withdrawn (#358).
+   *
+   * Sent only when true, so an ordinary row keeps exactly the shape it had
+   * before. The substitution is server-side; this only lets the thread style a
+   * withdrawn row as what it is instead of as something a person typed.
+   */
+  redacted?: boolean;
+  /**
+   * Who withdrew it, as the same kind of label as {@link author}. Present only
+   * on a withdrawn row — a removal with nobody's name on it is one that can be
+   * made quietly from a thread other people were reading.
+   */
+  redactedBy?: string;
 }
 
 /** A neighbouring card in the lineage, trimmed to what a link needs (#185). */
@@ -553,6 +572,30 @@ export function postTaskDiscussion(
   return client.post<DiscussionMessage>(
     `${client.scopeFor(company)}/tasks/${encodeURIComponent(id)}/discussion`,
     { text },
+  );
+}
+
+/**
+ * Withdraw a posted discussion message (#358).
+ *
+ * Answers `200` with the row as every reader now sees it: same `seq`, same
+ * author, same time, `redacted: true`, and the host's placeholder where the
+ * text was. The message is not deleted — the journal is append-only, so this
+ * appends a tombstone the read fold and the bundle writer both honour, which is
+ * what stops the text being served *and* stops it shipping in an export.
+ *
+ * Any member of the company may: the same authority that can delete the whole
+ * card, and the withdrawal is attributed. A `seq` that is not a discussion post
+ * on this card is a `404`; withdrawing twice is a no-op success.
+ */
+export function redactTaskDiscussion(
+  client: OpenCompanyClient,
+  company: string | null,
+  id: string,
+  seq: number,
+): Promise<DiscussionMessage> {
+  return client.del<DiscussionMessage>(
+    `${client.scopeFor(company)}/tasks/${encodeURIComponent(id)}/discussion/${encodeURIComponent(seq)}`,
   );
 }
 

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -39,6 +39,7 @@ import {
   ShieldCheck,
   Square,
   StickyNote,
+  Trash2,
   UserCog,
   Wrench,
 } from "lucide-react";
@@ -49,6 +50,7 @@ import {
   listInflight,
   patchTask,
   postTaskDiscussion,
+  redactTaskDiscussion,
   steerTask,
   type DiscussionMessage,
   type InflightRun,
@@ -1963,8 +1965,15 @@ function ExportButton({
  *
  * Operator-only in v1. Posting deliberately runs no agent turn — nothing here
  * dispatches work or spends money, which stays behind the board's column drag.
- * There is no edit and no delete either: the thread is journal-backed and
- * append-only, so what was said stays said.
+ * There is no edit: the thread is journal-backed and append-only, so what was
+ * said stays said.
+ *
+ * A message can be **withdrawn** (#358), which is not the same as deleted. The
+ * row keeps its place, its author and its time, and its text is replaced by the
+ * host — on this screen, on the exported record, and in the company bundle, so
+ * a pasted credential stops being readable and stops travelling. Withdrawing is
+ * the one thing on this tab that needs a confirmation, because it is the one
+ * thing that cannot be undone.
  *
  * The poll carries only the newest page of the thread (the host caps it so a
  * long discussion is not re-sent every 4s). Older messages are pulled on demand
@@ -2015,7 +2024,20 @@ function DiscussionTab({
       );
       let added = false;
       for (const m of rows) {
-        if (!bySeq.has(m.seq)) {
+        const held = bySeq.get(m.seq);
+        if (!held) {
+          bySeq.set(m.seq, m);
+          added = true;
+          continue;
+        }
+        // A message this thread already holds is normally identical to the copy
+        // the poll brought, and re-setting it would churn the render for
+        // nothing. A WITHDRAWAL is the exception (#358): the row arrives again
+        // with its text replaced, and it is the one update that must land —
+        // ignoring it would leave the original text on screen for as long as
+        // this tab stays open, which is precisely the reader the withdrawal was
+        // for.
+        if (m.redacted && !held.redacted) {
           bySeq.set(m.seq, m);
           added = true;
         }
@@ -2046,6 +2068,27 @@ function DiscussionTab({
       );
     } finally {
       setLoadingEarlier(false);
+    }
+  }
+
+  /**
+   * Withdraws one message (#358).
+   *
+   * The `200` carries the row as every reader now sees it — placeholder text,
+   * `redacted`, and who removed it — and `absorb` collapses it onto the copy on
+   * screen by `seq`, so the thread updates in place rather than waiting out the
+   * 4s poll. `onPosted` then re-reads the card for the same reason posting
+   * does: the parent holds the authoritative page.
+   */
+  async function redact(seq: number) {
+    try {
+      const row = await redactTaskDiscussion(client, company, taskId, seq);
+      absorb([row]);
+      await onPosted();
+    } catch (e) {
+      toast.error(
+        e instanceof Error ? e.message : "could not remove the message",
+      );
     }
   }
 
@@ -2099,7 +2142,15 @@ function DiscussionTab({
             </li>
           ) : null}
           {thread.map((m) => (
-            <li key={m.seq} className="rounded-lg border bg-card px-3 py-2">
+            <li
+              key={m.seq}
+              data-testid="discussion-message"
+              data-redacted={m.redacted ? "true" : undefined}
+              className={cn(
+                "rounded-lg border px-3 py-2",
+                m.redacted ? "border-dashed bg-muted/40" : "bg-card",
+              )}
+            >
               <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
                 <MessagesSquare className="size-3.5 shrink-0" aria-hidden />
                 <span className="min-w-0 flex-1 truncate font-medium text-foreground">
@@ -2111,10 +2162,41 @@ function DiscussionTab({
                 >
                   {timeOf(m.atMillis)}
                 </span>
+                {/* Issue #358. Offered only on a message that still has text to
+                    withdraw: a second removal changes nothing, so a button for
+                    it would be a control that does nothing. */}
+                {!m.redacted && (
+                  <ConfirmButton
+                    trigger={
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        className="-mr-1 size-6 shrink-0 text-muted-foreground hover:text-destructive"
+                        aria-label={`Remove the message from ${m.author}`}
+                        data-testid="discussion-redact"
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    }
+                    title="Remove this message?"
+                    description="The message stops being readable here, on the exported record, and in this company's bundle. Its place in the thread stays, showing that you removed it. This cannot be undone, and if the message contained a credential you still need to rotate it."
+                    confirmLabel="Remove it"
+                    cancelLabel="Keep it"
+                    destructive
+                    onConfirm={() => void redact(m.seq)}
+                  />
+                )}
               </div>
-              <p className="mt-1 whitespace-pre-wrap break-words text-xs">
-                {m.text}
-              </p>
+              {m.redacted ? (
+                <p className="mt-1 text-xs italic text-muted-foreground">
+                  {m.text}
+                  {m.redactedBy ? ` Removed by ${m.redactedBy}.` : null}
+                </p>
+              ) : (
+                <p className="mt-1 whitespace-pre-wrap break-words text-xs">
+                  {m.text}
+                </p>
+              )}
             </li>
           ))}
         </ol>

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -249,6 +249,16 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Posted to the discussion on task {task_id}"),
             "task.discussion_posted",
         ),
+        // Card-only for the same reason, and one stronger: a withdrawal (#358)
+        // is the operator saying that text should stop being readable, so the
+        // one thing this arm must never do is quote it. It carries no text to
+        // quote either — the event holds a pointer, not a payload.
+        CompanyEvent::TaskDiscussionRedacted { task_id, .. } => (
+            Role::System,
+            "operator".to_string(),
+            format!("Removed a discussion message on task {task_id}"),
+            "task.discussion_redacted",
+        ),
         // Action-only body: the operator's redirect instruction is never wired.
         CompanyEvent::TaskSteered {
             task_id, action, ..

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -856,6 +856,13 @@ fn summarize_event(event: &CompanyEvent) -> String {
         CompanyEvent::TaskDiscussionPosted { task_id, .. } => {
             format!("discussion post on task {task_id}")
         }
+        // Issue #358. Structural, like its neighbour and for a sharper reason:
+        // the operator has just said that message should stop being readable,
+        // so an insight line quoting anything about it would undo the act it
+        // reports. The event carries no text to quote in any case.
+        CompanyEvent::TaskDiscussionRedacted { task_id, .. } => {
+            format!("discussion message removed on task {task_id}")
+        }
         // A finished workflow run (#228). Counts only — never a delivery row's
         // `target` (a recipient's email address) or its `detail`, which can
         // quote one. This string is a non-sensitive one-liner for the insight

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -257,6 +257,23 @@ pub fn cap_discussion(text: &str) -> String {
     text.chars().take(MAX_DISCUSSION_CHARS).collect()
 }
 
+/// What stands where a withdrawn discussion message's text was (issue #358).
+///
+/// One constant, two very different readers, and they must not drift:
+///
+/// * the **read fold** (`server::ops::tasks`) substitutes it so every surface
+///   that serves a thread — the console, the task-detail export document —
+///   shows the same thing;
+/// * the **bundle writer** ([`store::export`](crate::store::export)) substitutes
+///   it into `events.jsonl`, so the withdrawn text is not in the bundle at all
+///   and an import cannot resurrect it.
+///
+/// Deliberately a sentence rather than an empty string. A blank row reads as a
+/// rendering bug; this says a thing happened, which is the honest report — the
+/// row keeps its position, its author and its time, and the console names who
+/// withdrew it beside this text.
+pub const REDACTED_DISCUSSION_TEXT: &str = "This message was removed.";
+
 // ---------------------------------------------------------------------------
 // The plan brief (issue #337, epic #183 §4)
 // ---------------------------------------------------------------------------

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -723,8 +723,11 @@ pub enum CompanyEvent {
     /// projections here reflect it: the text is deliberately never forwarded to
     /// the inference sidecar or the SSE stream.
     ///
-    /// Append-only, like every other variant: there is no edit and no delete in
-    /// v1, so a posted message is a fact about what was said and when.
+    /// Append-only, like every other variant: this event is never edited and
+    /// never removed. What #358 added is not a mutation of it but a *successor*
+    /// — see [`TaskDiscussionRedacted`](Self::TaskDiscussionRedacted) — so the
+    /// fact that something was said, by whom and when, stays in the record even
+    /// once its text stops being readable.
     ///
     /// Additive: old logs never carry it, and its presence doesn't change how
     /// any existing variant serializes.
@@ -740,6 +743,67 @@ pub enum CompanyEvent {
         /// reads back as "operator" — the same fallback
         /// [`OperatorMessage`](Self::OperatorMessage)'s `by` takes, and the same
         /// additive `skip_serializing_if` contract.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
+    /// A discussion post's text was withdrawn (issue #358).
+    ///
+    /// ## Why this exists
+    ///
+    /// A task discussion is the one surface where a person types free prose
+    /// about work that is *blocked*, and the next thing pasted into a thread
+    /// like that is often the thing that unblocks it — a key, a token, a
+    /// customer record. #348's own fixture reads "blocked on the API key". Until
+    /// this event there was no way to take it back: no edit, no delete, no
+    /// tombstone, and because the journal is what export/import ships, the
+    /// message was not merely permanent but **portable**.
+    ///
+    /// ## Why a successor rather than a mutation
+    ///
+    /// The log is append-only and that property is load-bearing well beyond
+    /// this tab: no control alters a past event, sequence numbers are stable
+    /// ids that threads and reactions name, and import replays a bundle from
+    /// zero to reproduce them. Rewriting or dropping the post in place would
+    /// break all three. So the post stays exactly as journaled and this event
+    /// **supersedes** it: every reader folds the pair and shows the post's
+    /// existence, author and time with its text replaced.
+    ///
+    /// ## What it does NOT claim
+    ///
+    /// This is not an at-rest erasure of the original bytes on the instance
+    /// that holds them, and it must not be read as one — the append-only
+    /// property is precisely what forbids that. What it guarantees is that the
+    /// text stops being served by any read surface and stops leaving the
+    /// building: [`export`](crate::store::export) replaces the superseded text
+    /// before the bundle is written, so a round trip cannot resurrect it. A
+    /// leaked credential still has to be rotated; this stops the record of it
+    /// being readable by every member of the company and travelling with the
+    /// bundle.
+    ///
+    /// Scoped deliberately to the discussion. `OperatorMessage` has the same
+    /// shape of problem and is **not** covered here; see
+    /// `docs/modules/server/README.md` for why that is a separate decision
+    /// rather than an oversight.
+    ///
+    /// Additive: old logs never carry it, and its presence doesn't change how
+    /// any existing variant serializes.
+    TaskDiscussionRedacted {
+        /// The card the superseded post belongs to. Carried so a fold that is
+        /// already filtering one task's journal can skip a tombstone for
+        /// another without resolving the post it names.
+        task_id: String,
+        /// The sequence position of the
+        /// [`TaskDiscussionPosted`](Self::TaskDiscussionPosted) this supersedes.
+        ///
+        /// Stable across export→import: a bundle replays from zero, so the
+        /// referenced position survives the round trip that carries both events.
+        seq: u64,
+        /// Who withdrew it, when a signed-in human is behind the request.
+        ///
+        /// Present for the same reason the post's `by` is: a message that
+        /// disappears with nobody's name on it is one a member can quietly
+        /// remove from a thread others were reading. `None` for a machine
+        /// credential, which reads back as "operator".
         #[serde(default, skip_serializing_if = "Option::is_none")]
         by: Option<Actor>,
     },
@@ -3034,6 +3098,35 @@ mod test {
         let attributed = CompanyEvent::TaskDiscussionPosted {
             task_id: "t1".into(),
             text: "unblocked".into(),
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "u-7".into(),
+            }),
+        };
+        assert_eq!(round_trip(&attributed), attributed);
+    }
+
+    /// Issue #358: the tombstone's wire shape, pinned because it is written
+    /// into `events.jsonl` and read back by a *different* instance on import.
+    /// The pair (post, tombstone) is what stops a withdrawn message being
+    /// resurrected, so a tombstone that failed to round-trip would silently
+    /// restore the text it was appended to remove.
+    #[test]
+    fn task_discussion_redacted_round_trips_and_omits_an_absent_actor() {
+        let anonymous = CompanyEvent::TaskDiscussionRedacted {
+            task_id: "t1".into(),
+            seq: 42,
+            by: None,
+        };
+        assert_eq!(round_trip(&anonymous), anonymous);
+        assert_eq!(
+            serde_json::to_string(&anonymous).unwrap(),
+            r#"{"kind":"TaskDiscussionRedacted","task_id":"t1","seq":42}"#
+        );
+
+        let attributed = CompanyEvent::TaskDiscussionRedacted {
+            task_id: "t1".into(),
+            seq: 42,
             by: Some(Actor {
                 kind: ActorKind::User,
                 id: "u-7".into(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1284,6 +1284,10 @@ fn cycle_task_id(
             | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
+            // A withdrawal (#358) is a record about a record: it starts no
+            // work, names no card to compete for, and its whole content is a
+            // pointer to an earlier post.
+            | CompanyEvent::TaskDiscussionRedacted { .. }
             // Issue #464: a board write announcing itself. Emphatically a
             // record — it is appended by the store *after* the write it
             // describes, so treating it as a trigger would let a card start
@@ -1394,6 +1398,10 @@ fn cycle_thread_id(
             | CompanyEvent::WorkflowNodeFinished { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
+            // A withdrawal (#358) is a record about a record: it starts no
+            // work, names no card to compete for, and its whole content is a
+            // pointer to an earlier post.
+            | CompanyEvent::TaskDiscussionRedacted { .. }
             // Issue #464: a board write announcing itself. Emphatically a
             // record — it is appended by the store *after* the write it
             // describes, so treating it as a trigger would let a card start

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -1683,6 +1683,9 @@ async fn post_discussion(
         at_millis,
         text,
         by,
+        // A message cannot be withdrawn before it exists: the tombstone (#358)
+        // names this `seq`, and this is the request that mints it.
+        redacted_by: None,
     }
     .into_message(&authors);
     Ok((StatusCode::CREATED, Json(message)))

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -15,7 +15,7 @@
 
 use axum::extract::{Path, Query};
 use axum::http::StatusCode;
-use axum::routing::{get, post};
+use axum::routing::{delete, get, post};
 use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
@@ -54,6 +54,13 @@ pub fn router() -> Router<AppState> {
         ))
         .merge(scoped("/tasks/{task_id}/steer", post(steer_task)))
         .merge(scoped("/tasks/{task_id}/discussion", post(post_discussion)))
+        // Issue #358. `DELETE` on one message, under the same `ScopedCompany`
+        // guard as every other task write — see `redact_discussion` for why
+        // that is the right authority rather than an admin-only one.
+        .merge(scoped(
+            "/tasks/{task_id}/discussion/{seq}",
+            delete(redact_discussion),
+        ))
 }
 
 /// A task card as the console renders it.
@@ -177,6 +184,14 @@ struct PatchTask {
 #[derive(Debug, Deserialize)]
 struct TaskPath {
     task_id: String,
+}
+
+/// The sub-resource path for one discussion message (issue #358): the card and
+/// the journal sequence the post was written at.
+#[derive(Debug, Deserialize)]
+struct DiscussionPath {
+    task_id: String,
+    seq: u64,
 }
 
 /// `GET …/tasks` — the whole board, newest-updated first. The console reads
@@ -742,8 +757,29 @@ pub(crate) struct DiscussionMessage {
     /// an email address and never a user id — a thread is read by every member
     /// of the company.
     author: String,
-    /// The message text, exactly as posted (codepoint-capped on write).
+    /// The message text, exactly as posted (codepoint-capped on write) — or
+    /// [`REDACTED_DISCUSSION_TEXT`](crate::ports::tasks::REDACTED_DISCUSSION_TEXT)
+    /// once withdrawn (issue #358). The original text is never served after a
+    /// withdrawal, on this route or any other.
     text: String,
+    /// Whether this message was withdrawn (issue #358).
+    ///
+    /// Sent only when true, so every row a pre-#358 console ever rendered keeps
+    /// exactly the shape it had. A console that does not know the field still
+    /// shows the placeholder text rather than the withdrawn message, because
+    /// the substitution happens server-side — the flag only lets a console that
+    /// *does* know style the row as withdrawn instead of as something a person
+    /// typed.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    redacted: bool,
+    /// Who withdrew it, as the same kind of label as `author`. Present only on
+    /// a withdrawn row.
+    ///
+    /// A removal nobody's name is on is one a member can make quietly from a
+    /// thread other people were reading, which is a different product than
+    /// "anyone may tidy up a mistake in the open".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    redacted_by: Option<String>,
 }
 
 /// The post-a-message body (`{text}`).
@@ -1114,6 +1150,15 @@ struct DiscussionRow {
     at_millis: u64,
     text: String,
     by: Option<crate::ports::types::Actor>,
+    /// Set when a later [`CompanyEvent::TaskDiscussionRedacted`] supersedes this
+    /// post (issue #358): the withdrawer, or `None` for a machine credential.
+    ///
+    /// `Option<Option<Actor>>` reads awkwardly and means exactly what it says:
+    /// the outer layer is "was it withdrawn", the inner is "by a named person".
+    /// Collapsing them would make an anonymous withdrawal indistinguishable
+    /// from no withdrawal at all, which is the one confusion this row cannot
+    /// afford.
+    redacted_by: Option<Option<crate::ports::types::Actor>>,
 }
 
 impl DiscussionRow {
@@ -1136,12 +1181,45 @@ impl DiscussionRow {
             // transcript takes for an unattributed operator message.
             _ => "operator".to_string(),
         };
+        // Issue #358. The substitution happens HERE, on the way out, rather
+        // than being left to the caller: this is the one place a journalled
+        // post becomes a wire row, so a withdrawn message cannot reach a reader
+        // through a surface that forgot to check the flag.
+        let (text, redacted, redacted_by) = match self.redacted_by {
+            Some(by) => (
+                crate::ports::tasks::REDACTED_DISCUSSION_TEXT.to_string(),
+                true,
+                Some(label_for(&by, authors)),
+            ),
+            None => (self.text, false, None),
+        };
         DiscussionMessage {
             seq: self.seq,
             at_millis: self.at_millis,
             author,
-            text: self.text,
+            text,
+            redacted,
+            redacted_by,
         }
+    }
+}
+
+/// An [`Actor`](crate::ports::types::Actor) as a label a reader recognizes.
+///
+/// The same three-way resolution the author label above uses — a roster display
+/// name, `someone` for a user no longer on the roster, `operator` for a machine
+/// credential — factored out because #358 gave the row a second person to name.
+fn label_for(
+    actor: &Option<crate::ports::types::Actor>,
+    authors: &std::collections::HashMap<String, String>,
+) -> String {
+    use crate::ports::types::ActorKind;
+    match actor {
+        Some(actor) if actor.kind == ActorKind::User => authors
+            .get(&actor.id)
+            .cloned()
+            .unwrap_or_else(|| "someone".to_string()),
+        _ => "operator".to_string(),
     }
 }
 
@@ -1358,6 +1436,10 @@ fn fold_page(
                 at_millis: ev.at_millis,
                 text: text.clone(),
                 by: by.clone(),
+                // Filled in below if a later tombstone names this seq. The log
+                // is walked forward, so the post is always seen before the
+                // event that withdraws it.
+                redacted_by: None,
             });
             // Keep the newest `first`, dropping from the front as the traversal
             // moves forward. The thread is still read oldest-first (the window
@@ -1367,6 +1449,27 @@ fn fold_page(
                 fold.discussion.remove(0);
                 fold.discussion_has_more = true;
             }
+            continue;
+        }
+        // Issue #358: a withdrawal supersedes a post this fold may already be
+        // holding. Deliberately NOT subject to the `before_seq` cursor above:
+        // the cursor pages backwards through the thread, so a tombstone written
+        // after the cursor is exactly the one that withdraws a message the
+        // caller is about to read — skipping it would serve the original text
+        // to anybody who scrolled far enough back.
+        if let CompanyEvent::TaskDiscussionRedacted {
+            task_id: id,
+            seq,
+            by,
+        } = &ev.event
+            && id == task_id
+        {
+            if let Some(row) = fold.discussion.iter_mut().find(|row| row.seq == *seq) {
+                row.redacted_by = Some(by.clone());
+            }
+            // A tombstone naming a post already dropped from the window needs
+            // nothing done: the row it withdraws is not in this page, and the
+            // page that does hold it folds this same event on its own pass.
             continue;
         }
         let entry = match &ev.event {
@@ -1583,6 +1686,168 @@ async fn post_discussion(
     }
     .into_message(&authors);
     Ok((StatusCode::CREATED, Json(message)))
+}
+
+/// `DELETE …/tasks/{task_id}/discussion/{seq}` — withdraw a posted message
+/// (issue #358).
+///
+/// ## What it does, and what it deliberately does not
+///
+/// It appends [`CompanyEvent::TaskDiscussionRedacted`], which supersedes the
+/// post at `seq`. It does **not** rewrite or remove the original event: the log
+/// is append-only, sequence numbers are stable ids other events name, and
+/// import replays a bundle from zero to reproduce them — three properties a
+/// mutation here would break for the sake of one tab.
+///
+/// What the withdrawal buys is the two things that actually matter to somebody
+/// who has just pasted a credential into a card:
+///
+/// * **every read surface stops serving the text.** The substitution is in the
+///   fold, so the console thread and the task-detail export document (#352,
+///   which renders the same assembled value) change together and cannot drift;
+/// * **the bundle stops carrying it.** [`store::export`](crate::store::export)
+///   applies the same substitution to `events.jsonl`, so a round trip cannot
+///   resurrect the message — the half that turns a permanent record into a
+///   portable one.
+///
+/// It is not an at-rest erasure on the instance that already holds the bytes,
+/// and the route does not pretend to be: rotating a leaked secret is still the
+/// remedy. See `docs/modules/server/README.md`.
+///
+/// ## Who may
+///
+/// [`ScopedCompany`] — any member of the company, the same authority every
+/// other task write on this router carries. Not admin-only, and that is a
+/// deliberate match rather than an oversight: `DELETE …/tasks/{task_id}` lets
+/// the same member remove the entire card, thread and all, so gating one
+/// message above the card that contains it would be an incoherent boundary. The
+/// withdrawal is attributed instead — `by` names whoever did it, and the thread
+/// says so beside the row.
+///
+/// ## Answers
+///
+/// `200` with the withdrawn row as every reader now sees it. `404` when the
+/// card is unknown, or when `seq` names anything other than a discussion post
+/// on *this* card — a tombstone that pointed at another task's post, or at a
+/// dispatch, would be a way to write nonsense into the journal. Withdrawing an
+/// already-withdrawn message is a no-op success: a removal asked for twice has
+/// still happened, and a `409` there would only make a retry look like a
+/// failure.
+async fn redact_discussion(
+    company: ScopedCompany,
+    Path(DiscussionPath { task_id, seq }): Path<DiscussionPath>,
+) -> Result<Json<DiscussionMessage>, ApiError> {
+    use crate::ports::types::EventSeq;
+
+    let target = EventSeq::new(seq);
+    let stored = company
+        .runtime
+        .events()
+        .read_from(company.id(), target, 1)
+        .await?
+        .into_iter()
+        .next()
+        .filter(|stored| stored.seq == target)
+        .ok_or_else(|| {
+            ApiError(OpenCompanyError::NotFound(format!(
+                "no discussion message {seq} on task {task_id}"
+            )))
+        })?;
+
+    // The event at that position must be a post on THIS card. Anything else —
+    // another task's post, a dispatch, a chat reply — is a 404 rather than a
+    // silently written tombstone nothing will ever fold.
+    let (posted_at, text, posted_by) = match &stored.event {
+        CompanyEvent::TaskDiscussionPosted {
+            task_id: id,
+            text,
+            by,
+        } if *id == task_id => (stored.at_millis, text.clone(), by.clone()),
+        _ => {
+            return Err(ApiError(OpenCompanyError::NotFound(format!(
+                "no discussion message {seq} on task {task_id}"
+            ))));
+        }
+    };
+
+    // Already withdrawn: answer the row as it stands rather than appending a
+    // second tombstone. Two tombstones for one post would fold identically, so
+    // this is about not growing the journal on a retry.
+    let existing = find_redaction(&company, &task_id, seq).await?;
+    let redacted_by = match existing {
+        Some(by) => by,
+        None => {
+            let by = company.actor.clone();
+            company
+                .runtime
+                .events()
+                .append(
+                    company.id(),
+                    CompanyEvent::TaskDiscussionRedacted {
+                        task_id: task_id.clone(),
+                        seq,
+                        by: by.clone(),
+                    },
+                )
+                .await?;
+            by
+        }
+    };
+
+    let authors = crate::server::chat_history::author_labels(&company.runtime).await?;
+    let message = DiscussionRow {
+        seq,
+        at_millis: posted_at,
+        // Carried and then dropped by `into_message`, which substitutes the
+        // placeholder for a withdrawn row. Never sent.
+        text,
+        by: posted_by,
+        redacted_by: Some(redacted_by),
+    }
+    .into_message(&authors);
+    Ok(Json(message))
+}
+
+/// The existing withdrawal of `seq` on `task_id`, if the thread already carries
+/// one.
+///
+/// Walks the journal rather than the folded page because the fold is windowed:
+/// a post far enough back to have been dropped from the page is exactly the one
+/// a retry is most likely to name.
+async fn find_redaction(
+    company: &ScopedCompany,
+    task_id: &str,
+    seq: u64,
+) -> Result<Option<Option<crate::ports::types::Actor>>, ApiError> {
+    use crate::ports::types::EventSeq;
+
+    let mut next = seq + 1;
+    loop {
+        let page = company
+            .runtime
+            .events()
+            .read_from(company.id(), EventSeq::new(next), TIMELINE_PAGE)
+            .await?;
+        if page.is_empty() {
+            return Ok(None);
+        }
+        for stored in &page {
+            if let CompanyEvent::TaskDiscussionRedacted {
+                task_id: id,
+                seq: target,
+                by,
+            } = &stored.event
+                && id == task_id
+                && *target == seq
+            {
+                return Ok(Some(by.clone()));
+            }
+        }
+        next = page
+            .last()
+            .map(|stored| stored.seq.value() + 1)
+            .unwrap_or(next);
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3512,6 +3512,266 @@ fn discussion_card(id: &str, title: &str) -> TaskRecord {
     }
 }
 
+/// #358: a posted message can be withdrawn, and the text stops being served.
+///
+/// The shape the issue asks for, asserted end to end over the real HTTP stack:
+/// the row survives (position, author, time), the text does not, the withdrawal
+/// is attributed, the journal keeps both events, and nothing about a message
+/// nobody withdrew changes.
+#[tokio::test]
+async fn a_withdrawn_discussion_message_stops_being_served() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+    runtime
+        .tasks()
+        .upsert(&company, &discussion_card("t-1", "Ship it"))
+        .await
+        .unwrap();
+
+    const SECRET: &str = "sk-live-0000-DO-NOT-KEEP";
+    let (status, posted) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks/t-1/discussion",
+        Some(json!({ "text": format!("blocked on the API key: {SECRET}") })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let seq = posted["seq"].as_u64().expect("the post carries its seq");
+
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks/t-1/discussion",
+        Some(json!({ "text": "rotated it, we are unblocked" })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+
+    let (status, withdrawn) = send(
+        &state,
+        "DELETE",
+        &format!("/api/v1/company/tasks/t-1/discussion/{seq}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(withdrawn["redacted"], true);
+    assert_eq!(
+        withdrawn["redactedBy"], "harness-admin",
+        "a withdrawal nobody's name is on is a message that can vanish quietly"
+    );
+    assert_eq!(
+        withdrawn["seq"], seq,
+        "the row keeps its place in the thread"
+    );
+
+    // The reload: what every reader of this card now gets.
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let thread = body["discussion"].as_array().expect("discussion array");
+    assert_eq!(thread.len(), 2, "the row is withdrawn, not deleted: {body}");
+    assert_eq!(thread[0]["seq"], seq);
+    assert_eq!(thread[0]["redacted"], true);
+    assert_eq!(thread[0]["redactedBy"], "harness-admin");
+    assert_eq!(
+        thread[0]["author"], "harness-admin",
+        "the poster is still named"
+    );
+    assert_eq!(
+        thread[1]["text"], "rotated it, we are unblocked",
+        "withdrawing one message must not touch another"
+    );
+    assert!(
+        thread[1].get("redacted").is_none(),
+        "an ordinary row must keep the shape a pre-#358 console renders: {thread:?}"
+    );
+    assert!(
+        !serde_json::to_string(&body).unwrap().contains(SECRET),
+        "the withdrawn text is still being served on the detail read: {body}"
+    );
+
+    // The journal keeps both events: the post's existence is a fact, and the
+    // withdrawal is a second fact about it.
+    let events = runtime
+        .events()
+        .read_from(&company, crate::ports::types::EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert!(
+        events.iter().any(|e| matches!(
+            &e.event,
+            CompanyEvent::TaskDiscussionRedacted { task_id, seq: s, .. }
+                if task_id == "t-1" && *s == seq
+        )),
+        "the withdrawal was not journaled"
+    );
+
+    // Idempotent: asking twice is not an error, and does not grow the journal.
+    let before = events.len();
+    let (status, again) = send(
+        &state,
+        "DELETE",
+        &format!("/api/v1/company/tasks/t-1/discussion/{seq}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(again["redacted"], true);
+    let after = runtime
+        .events()
+        .read_from(&company, crate::ports::types::EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap()
+        .len();
+    assert_eq!(
+        before, after,
+        "a repeated withdrawal appended a second tombstone"
+    );
+}
+
+/// #358: a `seq` that is not a discussion post on *this* card is a `404`, not a
+/// tombstone written into the journal against something else.
+#[tokio::test]
+async fn withdrawing_something_that_is_not_this_cards_post_is_refused() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+    for card in [
+        discussion_card("t-1", "Ship it"),
+        discussion_card("t-other", "Unrelated"),
+    ] {
+        runtime.tasks().upsert(&company, &card).await.unwrap();
+    }
+
+    let (_, posted) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks/t-other/discussion",
+        Some(json!({ "text": "another card's message" })),
+    )
+    .await;
+    let seq = posted["seq"].as_u64().unwrap();
+
+    // Another card's post, addressed through this card.
+    let (status, _) = send(
+        &state,
+        "DELETE",
+        &format!("/api/v1/company/tasks/t-1/discussion/{seq}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // A sequence position that holds no event at all.
+    let (status, _) = send(
+        &state,
+        "DELETE",
+        "/api/v1/company/tasks/t-1/discussion/99999",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+
+    // The other card's thread is untouched by either attempt.
+    let (_, other) = send(&state, "GET", "/api/v1/company/tasks/t-other", None).await;
+    let thread = other["discussion"].as_array().unwrap();
+    assert_eq!(thread.len(), 1);
+    assert_eq!(thread[0]["text"], "another card's message");
+    assert!(thread[0].get("redacted").is_none());
+}
+
+/// #358 + #335's paging: a withdrawal is applied even when the tombstone sits
+/// *newer* than the cursor the caller is paging back through.
+///
+/// The trap this pins: the discussion arm skips events at or after
+/// `discussionBefore`, and a tombstone is always newer than the post it
+/// withdraws. Applying the cursor to tombstones too would serve the original
+/// text to anybody who scrolled far enough back — the one reader most likely to
+/// be looking for it.
+#[tokio::test]
+async fn a_withdrawal_survives_paging_back_past_it() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+    runtime
+        .tasks()
+        .upsert(&company, &discussion_card("t-1", "Ship it"))
+        .await
+        .unwrap();
+
+    const SECRET: &str = "sk-live-PAGED-BACK";
+    let (_, posted) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks/t-1/discussion",
+        Some(json!({ "text": SECRET })),
+    )
+    .await;
+    let seq = posted["seq"].as_u64().unwrap();
+
+    // Enough newer posts that the first one falls off the first page.
+    for n in 0..60 {
+        runtime
+            .events()
+            .append(
+                &company,
+                CompanyEvent::TaskDiscussionPosted {
+                    task_id: "t-1".into(),
+                    text: format!("message {n}"),
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let (status, _) = send(
+        &state,
+        "DELETE",
+        &format!("/api/v1/company/tasks/t-1/discussion/{seq}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Page back to the start of the thread, past the tombstone's own position.
+    let (_, first) = send(&state, "GET", "/api/v1/company/tasks/t-1", None).await;
+    let oldest_on_page = first["discussion"].as_array().unwrap()[0]["seq"]
+        .as_u64()
+        .unwrap();
+    let (status, older) = send(
+        &state,
+        "GET",
+        &format!("/api/v1/company/tasks/t-1?discussionBefore={oldest_on_page}"),
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        !serde_json::to_string(&older).unwrap().contains(SECRET),
+        "paging back served the withdrawn text: {older}"
+    );
+    let row = older["discussion"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|m| m["seq"] == seq)
+        .expect("the withdrawn row is on the older page");
+    assert_eq!(row["redacted"], true);
+}
+
 /// #335: the per-task Discussion tab's whole contract — a post persists, reads
 /// back on the card's own detail, and belongs to exactly one card.
 ///

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -31,9 +31,9 @@ use crate::ports::events::EventLog;
 use crate::ports::memory::MemoryStore;
 use crate::ports::store::CompanyStore;
 use crate::ports::types::{
-    BudgetOverride, CompanyId, CompanyRecord, CompressedTrace, ContextChunk, EventSeq, LedgerEntry,
-    OverlayAgent, OverlayDesk, OverlayDeskMember, OverlayDeskOrder, OverlayWorkflow, StoredEvent,
-    TemplateProvenance,
+    BudgetOverride, CompanyEvent, CompanyId, CompanyRecord, CompressedTrace, ContextChunk,
+    EventSeq, LedgerEntry, OverlayAgent, OverlayDesk, OverlayDeskMember, OverlayDeskOrder,
+    OverlayWorkflow, StoredEvent, TemplateProvenance,
 };
 
 /// Canonical bundle file and directory names, matching the fs
@@ -191,7 +191,13 @@ impl BundleContents {
             .await?
             .ok_or_else(|| OpenCompanyError::CompanyNotFound(id.to_string()))?;
 
-        let events = events.read_from(id, EventSeq::new(0), usize::MAX).await?;
+        // Issue #358: the withdrawn half of a discussion never reaches the
+        // bundle. This is the load-bearing half of that issue — hiding a
+        // message on the console while the bundle keeps carrying it makes the
+        // record *portable* instead of merely permanent, which is the worse
+        // failure of the two.
+        let events =
+            scrub_redacted_discussion(events.read_from(id, EventSeq::new(0), usize::MAX).await?);
         let traces = memory.recent_traces(id, usize::MAX).await?;
 
         let metas = context.list(id, "").await?;
@@ -360,7 +366,14 @@ impl BundleContents {
         }
 
         let ledger = read_jsonl::<LedgerEntry>(&src.join(LEDGER_JSONL)).await?;
-        let events = read_jsonl::<StoredEvent>(&src.join(EVENTS_JSONL)).await?;
+        // Scrubbed on the way IN as well as on the way out (issue #358), which
+        // is not belt-and-braces: a bundle written by a host that predates this
+        // carries the withdrawn text beside its tombstone, and importing it
+        // as-is would write that text into a fresh journal — the resurrection
+        // the issue names, arriving through the one door the exporter cannot
+        // guard.
+        let events =
+            scrub_redacted_discussion(read_jsonl::<StoredEvent>(&src.join(EVENTS_JSONL)).await?);
         let traces =
             read_jsonl::<CompressedTrace>(&src.join(MEMORY_DIR).join(TRACES_JSONL)).await?;
 
@@ -394,6 +407,64 @@ impl BundleContents {
             overlay_budgets: meta.overlay_budgets,
         })
     }
+}
+
+/// Replaces the text of every discussion post a later tombstone withdrew
+/// (issue #358).
+///
+/// ## Why the bundle is where this matters most
+///
+/// A withdrawal that only affected the console would leave the message in
+/// `events.jsonl`, and the bundle is the copy that *leaves the instance* — it
+/// is handed to support, restored onto a laptop, committed to a repository. So
+/// a redaction that stops at the read fold does not make a pasted credential
+/// less exposed; it makes it exposed somewhere nobody is looking.
+///
+/// ## What it does
+///
+/// Walks the log once, collecting the `(task_id, seq)` pairs named by
+/// [`CompanyEvent::TaskDiscussionRedacted`], then rewrites the `text` of each
+/// post they name to
+/// [`REDACTED_DISCUSSION_TEXT`](crate::ports::tasks::REDACTED_DISCUSSION_TEXT).
+/// Two passes rather than one because a tombstone always follows its post, so a
+/// single forward pass would have already written the post out.
+///
+/// **The tombstone itself is kept.** Dropping it would leave the imported
+/// company with a post whose text is a placeholder and no record of why, and
+/// the fold would show it as an ordinary message reading "This message was
+/// removed." — a sentence nobody wrote. Carried through, the imported thread
+/// says the same thing the exporting one did, with the same attribution.
+///
+/// Every other event passes through untouched, including posts with no
+/// tombstone: this is a substitution, not a filter, so the log's shape,
+/// ordering and sequence numbering are exactly what they were.
+fn scrub_redacted_discussion(events: Vec<StoredEvent>) -> Vec<StoredEvent> {
+    use std::collections::HashSet;
+
+    let withdrawn: HashSet<(String, u64)> = events
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            CompanyEvent::TaskDiscussionRedacted { task_id, seq, .. } => {
+                Some((task_id.clone(), *seq))
+            }
+            _ => None,
+        })
+        .collect();
+    if withdrawn.is_empty() {
+        return events;
+    }
+
+    events
+        .into_iter()
+        .map(|mut stored| {
+            if let CompanyEvent::TaskDiscussionPosted { task_id, text, .. } = &mut stored.event
+                && withdrawn.contains(&(task_id.clone(), stored.seq.value()))
+            {
+                *text = crate::ports::tasks::REDACTED_DISCUSSION_TEXT.to_string();
+            }
+            stored
+        })
+        .collect()
 }
 
 /// Exports `id`'s complete state through the ports into an unpacked bundle
@@ -893,6 +964,223 @@ mod test {
             events[0].event,
             CompanyEvent::LifecycleChanged { .. }
         ));
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// Issue #358, the half that actually closes it: a withdrawn discussion
+    /// message is not in the bundle, and an import cannot bring it back.
+    ///
+    /// Asserted three ways, because each is a different way to leak it:
+    ///
+    /// 1. the **bundle file** (`events.jsonl`) does not contain the secret —
+    ///    this is the copy that leaves the instance, so grepping the bytes is
+    ///    the assertion that matters most;
+    /// 2. the **imported journal** carries the placeholder, not the text;
+    /// 3. the **tombstone travels**, so the imported thread still reports that
+    ///    a message was withdrawn rather than showing a bare placeholder that
+    ///    reads like something a person typed.
+    ///
+    /// A post with no tombstone is untouched in the same bundle, so this is a
+    /// substitution rather than a filter that eats discussion history.
+    #[tokio::test]
+    async fn a_withdrawn_discussion_message_does_not_survive_export_import() {
+        let home1 = tmp_root("redact-src");
+        let home2 = tmp_root("redact-dst");
+        let dest = tmp_root("redact-bundle");
+        let id = CompanyId::new("redact-co");
+        const SECRET: &str = "sk-live-DO-NOT-SHIP-THIS";
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".into(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+
+        let leaked = e1
+            .append(
+                &id,
+                CompanyEvent::TaskDiscussionPosted {
+                    task_id: "t1".into(),
+                    text: format!("blocked on the API key: {SECRET}"),
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+        // A second post nobody withdrew, to prove the scrub is targeted.
+        e1.append(
+            &id,
+            CompanyEvent::TaskDiscussionPosted {
+                task_id: "t1".into(),
+                text: "rotated it, we are unblocked".into(),
+                by: None,
+            },
+        )
+        .await
+        .unwrap();
+        e1.append(
+            &id,
+            CompanyEvent::TaskDiscussionRedacted {
+                task_id: "t1".into(),
+                seq: leaked.value(),
+                by: Some(Actor {
+                    kind: ActorKind::Operator,
+                    id: "owner".into(),
+                }),
+            },
+        )
+        .await
+        .unwrap();
+
+        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+            .await
+            .unwrap();
+
+        // 1. The bytes that leave the building.
+        let shipped = tokio::fs::read_to_string(dest.join(EVENTS_JSONL))
+            .await
+            .unwrap();
+        assert!(
+            !shipped.contains(SECRET),
+            "the withdrawn message shipped in the bundle: {shipped}"
+        );
+        assert!(
+            shipped.contains(crate::ports::tasks::REDACTED_DISCUSSION_TEXT),
+            "the withdrawn post is missing its placeholder: {shipped}"
+        );
+        assert!(
+            shipped.contains("rotated it, we are unblocked"),
+            "the scrub ate a post nobody withdrew: {shipped}"
+        );
+
+        // 2 and 3. What the importing instance ends up holding.
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        import_bundle(&dest, s2, e2.clone(), m2, c2).await.unwrap();
+        let events = e2
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+
+        let posted: Vec<&str> = events
+            .iter()
+            .filter_map(|stored| match &stored.event {
+                CompanyEvent::TaskDiscussionPosted { text, .. } => Some(text.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            posted,
+            vec![
+                crate::ports::tasks::REDACTED_DISCUSSION_TEXT,
+                "rotated it, we are unblocked"
+            ],
+            "the imported journal must carry the placeholder, not the secret"
+        );
+        assert!(
+            events.iter().any(|stored| matches!(
+                &stored.event,
+                CompanyEvent::TaskDiscussionRedacted { task_id, seq, .. }
+                    if task_id == "t1" && *seq == leaked.value()
+            )),
+            "the tombstone did not survive the round trip, so the imported thread \
+             cannot say the message was withdrawn"
+        );
+
+        for dir in [home1, home2, dest] {
+            tokio::fs::remove_dir_all(&dir).await.ok();
+        }
+    }
+
+    /// The same guard on the way IN: a bundle written by a host that predates
+    /// #358 carries the withdrawn text beside its tombstone, and importing it
+    /// must not write that text into the fresh journal.
+    ///
+    /// Built by hand-editing the exported `events.jsonl` back to the
+    /// pre-redaction bytes, which is exactly the shape such a bundle has.
+    #[tokio::test]
+    async fn an_old_bundle_cannot_smuggle_a_withdrawn_message_back_in() {
+        let home1 = tmp_root("smuggle-src");
+        let home2 = tmp_root("smuggle-dst");
+        let dest = tmp_root("smuggle-bundle");
+        let id = CompanyId::new("smuggle-co");
+        const SECRET: &str = "sk-live-SMUGGLED";
+
+        let (s1, e1, m1, c1) = fs_ports(&home1);
+        s1.save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest(),
+            ledger: Vec::new(),
+            lifecycle: "running".into(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+        let leaked = e1
+            .append(
+                &id,
+                CompanyEvent::TaskDiscussionPosted {
+                    task_id: "t1".into(),
+                    text: SECRET.into(),
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+        e1.append(
+            &id,
+            CompanyEvent::TaskDiscussionRedacted {
+                task_id: "t1".into(),
+                seq: leaked.value(),
+                by: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        export_bundle(&id, &dest, s1, e1, m1, c1, ExportOpts::default())
+            .await
+            .unwrap();
+
+        // Put the secret back, as an older exporter would have written it.
+        let path = dest.join(EVENTS_JSONL);
+        let scrubbed = tokio::fs::read_to_string(&path).await.unwrap();
+        let old_shape = scrubbed.replace(crate::ports::tasks::REDACTED_DISCUSSION_TEXT, SECRET);
+        assert!(old_shape.contains(SECRET), "the fixture did not rewrite");
+        tokio::fs::write(&path, old_shape).await.unwrap();
+
+        let (s2, e2, m2, c2) = fs_ports(&home2);
+        import_bundle(&dest, s2, e2.clone(), m2, c2).await.unwrap();
+        let events = e2
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap();
+        assert!(
+            !events.iter().any(|stored| matches!(
+                &stored.event,
+                CompanyEvent::TaskDiscussionPosted { text, .. } if text.contains(SECRET)
+            )),
+            "an old bundle smuggled a withdrawn message into the new journal"
+        );
 
         for dir in [home1, home2, dest] {
             tokio::fs::remove_dir_all(&dir).await.ok();


### PR DESCRIPTION
## Summary

Fixes #358. A task discussion is the one surface where a person types free prose about work that is *blocked*, and the next thing pasted into a thread like that is often the thing that unblocks it — #348's own test fixture reads *"blocked on the API key"*. That post was append-only with no edit, no delete and no tombstone, and because the journal is what export/import ships, the message was not merely permanent: it was **portable**. It left the instance with the bundle.

`DELETE …/tasks/{taskId}/discussion/{seq}` withdraws one message. Below are the four decisions the issue asked to have settled, each with the argument rather than the assertion.

### 1. A tombstone, not a hard delete

`CompanyEvent::TaskDiscussionRedacted { task_id, seq, by }` **supersedes** the post at `seq`. The post event is never rewritten and never removed.

Three properties made this the only coherent shape, and a delete breaks all three for the sake of one tab:

- the log is append-only — *no control alters a past event* (epic #184);
- sequence numbers are stable ids other events name (a thread reply, a reaction), so removing an event shifts identities that are already referenced;
- import replays a bundle from zero to reproduce the original numbering, which a hole in the sequence would silently change.

**What a reader sees where the text was.** The row keeps its place in the thread, its `seq`, its author and its time. The text is replaced by `REDACTED_DISCUSSION_TEXT` ("This message was removed.") and the row carries `redacted: true` plus `redactedBy` — the label of whoever withdrew it. Deliberately not a silent disappearance: a message that vanishes without trace lets one member quietly rewrite what a thread said, which is a different product from "anyone may take back a mistake in the open". The substitution happens in the read fold, so the console thread and the task-detail export document (#352, which renders the *same* assembled value) cannot drift apart.

### 2. What export/import does with it — the half that actually closes the issue

`store::export::scrub_redacted_discussion` applies the same substitution to `events.jsonl`:

- **on the way out**, so a bundle never carries a withdrawn message;
- **on the way in**, so a bundle written by a host that predates this cannot smuggle one back through import — the resurrection the issue names, arriving through the one door the exporter cannot guard.

The **tombstone travels with the post**. Dropping it would leave the importing company with a post whose text is a placeholder and no record of why, and the fold would render it as an ordinary message reading "This message was removed." — a sentence nobody wrote. Carried through, the imported thread says exactly what the exporting one said, with the same attribution.

A redaction that stopped at the console would not make a pasted credential less exposed; it would move the exposure somewhere nobody is looking.

### 3. Who may redact

`ScopedCompany` — **any member of the company**, the same guard every other task write on this router carries. Not admin-only, and that is a match rather than an oversight: `DELETE …/tasks/{taskId}` already lets the same member remove the entire card, thread and all, so holding one message to a higher bar than the card that contains it would be an incoherent boundary. The withdrawal is attributed instead — `by` names whoever did it and the thread says so beside the row.

`404` when the card is unknown, or when `seq` names anything other than a discussion post **on this card** (another task's post, a dispatch, a chat reply) — a tombstone pointing at something else would be a way to write nonsense into the journal. Withdrawing an already-withdrawn message is a **no-op success**: the removal has still happened, and a `409` there would make a retry look like a failure.

### 4. Retrospective reach

- **Posts already journaled are fully covered.** The tombstone names a `seq`; nothing about the post has to change, so a message posted long before this shipped can be withdrawn today.
- **Bundles already exported are not**, and cannot be — they are copies in other people's hands.
- **This is not erasure at rest** on the instance that already holds the bytes, and the code says so rather than implying otherwise: that is precisely what the append-only property forbids. A leaked credential still has to be rotated. What the withdrawal guarantees is that the text stops being served by any read surface and stops leaving the building.

### Scope

Discussion-only, deliberately. `OperatorMessage` has the same shape of problem and is **not** covered here; generalizing before there is a second caller would fix the mechanism's shape around one use. `docs/modules/server/README.md` records the pattern the next human-prose writer should inherit — the pair (tombstone in the log, substitution in every fold *and* in the bundle), not the variant.

## API Or Behavior Changes

- **New route:** `DELETE …/tasks/{taskId}/discussion/{seq}` under both scope forms. `200` with the withdrawn row, `404` as above.
- **New journal variant:** `CompanyEvent::TaskDiscussionRedacted`. Additive — old logs never carry it and no existing variant's serialization changes. Its wire shape is pinned by a round-trip test because it is written into bundles and read back by a *different* instance.
- **`DiscussionMessage` gains `redacted` and `redactedBy`**, both `skip_serializing_if`, so an ordinary row keeps byte-for-byte the shape it had. A console that ignores the fields still cannot render a withdrawn message: the substitution is server-side.
- Agent-facing surfaces are unchanged and quote nothing: the sidecar wire event and the orchestrator insight line are card-only (`"Removed a discussion message on task t-1"`), which matters more here than for a post — the operator has just said that text should stop being readable.
- Console: the Discussion tab grows a per-message Remove control behind a confirmation, and renders a withdrawn row as withdrawn.

## Tests

**The export/import half, pinned hardest** — it is the part a reviewer should doubt:

- `a_withdrawn_discussion_message_does_not_survive_export_import` — asserts three separate leaks are closed: the **bundle bytes** (`events.jsonl` read back and grepped for the secret), the **imported journal** (carries the placeholder, not the text), and the **tombstone surviving** (so the imported thread can still report the withdrawal). A post nobody withdrew is asserted intact in the same bundle, so this is a substitution and not a filter that eats discussion history.
- `an_old_bundle_cannot_smuggle_a_withdrawn_message_back_in` — hand-edits an exported bundle back to its pre-#358 bytes (exactly the shape an older host writes) and proves import refuses to write the text into the fresh journal.

**The route and the fold:**

- `a_withdrawn_discussion_message_stops_being_served` — over the real HTTP stack: the row survives with its author and position, `redacted`/`redactedBy` are set, the secret is absent from the whole detail response, the other message is untouched, an ordinary row keeps its pre-#358 shape, both events are in the journal, and a second withdrawal is a no-op that appends nothing.
- `withdrawing_something_that_is_not_this_cards_post_is_refused` — another card's post and an empty sequence position are both `404`, and the other card's thread is untouched by either attempt.
- `a_withdrawal_survives_paging_back_past_it` — the trap this fold has: a tombstone is always *newer* than the post it withdraws, and the discussion arm skips events at or after `discussionBefore`. Applying the cursor to tombstones too would serve the original text to whoever scrolled far enough back — the one reader most likely to be looking for it.
- `task_discussion_redacted_round_trips_and_omits_an_absent_actor` — the tombstone's wire shape.

Local gates: `npm run typecheck` clean; `rustfmt --edition 2024 --check` clean on all eight Rust files touched.

**Browser walk** — real Chromium, against a stub serving the host's documented shapes (building the Rust host is prohibited on this machine):

- **The failure first, on `upstream/main`:** the Discussion tab renders `blocked on the API key: sk-live-7f3d-DO-NOT-SHIP` and there is **no remove control of any kind** — 0 by test-id, 0 by accessible name. That is the issue: no way to act on your own mistake, for anybody.
- **On this branch:** the control appears; the confirmation says what withdrawal actually does ("stops being readable here, on the exported record, and in this company's bundle", "cannot be undone", "you still need to rotate it"); after confirming, the row reads **"This message was removed. Removed by operator."**, carries `data-redacted="true"`, the secret is gone from the page, and the neighbouring message is untouched.
- **The host's copy** is the substituted row, and a **full page reload** still shows no secret — so it is the host's answer, not local state.
- No uncaught page errors in either walk.

One console-side trap worth naming, found during the walk: the tab's `absorb` deduped by `seq` and **ignored** any row it already held, so a withdrawal arriving on the poll would have left the original text on screen for as long as the tab stayed open. It now replaces a held row when the incoming one is withdrawn, and keeps the no-churn guard for every other case.

**Not run here:** the Rust half was not compiled or executed locally (the build matrix is prohibited on this machine), so CI is the first compiler to see it; and no Playwright spec is added, because the e2e lane's host is the default build and this behaviour is already asserted over the real HTTP stack in `write_test.rs`.

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI

## Documentation

`docs/modules/server/README.md` gains **"Withdrawing a discussion message (issue #358)"**: the four decisions above with their reasoning, what a reader sees, what export/import does, who may, what it does not claim, and the explicit journal-wide-vs-discussion-only statement the issue's acceptance list asks for. The stale paragraph promising "no edit and no delete" is corrected rather than left to contradict the code, and the route table lists the new route.

## Acceptance

- [x] An operator can remove a posted discussion message from every read surface — the substitution is in the fold shared by the console read and the export document
- [x] A redacted message does not come back through export → import — asserted on the bundle bytes and on the imported journal, in both directions of the pipe
- [x] Whether a redaction is itself visible (and to whom) is decided and written down in `docs/modules/server/README.md` — visible to every reader of the thread, with the withdrawer named
- [x] The chosen mechanism is stated as journal-wide or discussion-only — discussion-only, with the pattern to inherit recorded for the next human-prose writer
