### PR TITLE
test(board): assert what Planning means on each lane, and drag like a browser (#501)

### DIFF
--- a/frontend/test/e2e/board-columns.spec.ts
+++ b/frontend/test/e2e/board-columns.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test, type Page } from "@playwright/test";
 
+import { LIVE_BRAIN } from "./capabilities";
+
 /**
  * Issue #301 — the board's shape, asserted against a live host.
  *
@@ -101,7 +103,39 @@ test("new work enters through one prompt box and lands in To-do", async ({ page,
   expect(created.note).toBe(long);
 });
 
+/**
+ * Issue #501. This test states a **no-planner** contract, and only a host
+ * without one keeps it.
+ *
+ * Its own comment used to say the no-dispatch assertion "lets the column ship
+ * ahead of epic #183 §4's auto-advance". §4 has since landed as the planning
+ * station (`src/harness/planning.rs`, issue #337), and a card entering Planning
+ * on a planner-attached host now edge-fires exactly one pass and is **settled**
+ * by it — never left sitting in `planning`:
+ *
+ * | pass outcome | where the card lands |
+ * |---|---|
+ * | a plan, nothing blocking, a valid assignee | `in_progress` — and the dispatch edge fires |
+ * | a plan, a hard prerequisite missing | `todo`, with the gap on the note |
+ * | the pass itself failed | `todo`, with the reason on the note |
+ *
+ * So on the live-brain lane both of this test's claims are false by design: the
+ * card does not stay in `planning`, and the first row dispatches. `plan_task`
+ * is a `#[cfg(feature = "openhuman")]` no-op without the harness, so the
+ * assertions below remain exactly right on the default lane, which is where
+ * this runs.
+ *
+ * The skip is therefore INVERTED — `skip(LIVE_BRAIN)`, not `skip(!LIVE_BRAIN)`.
+ * This test needs the absence of a brain, which is the opposite of every other
+ * capability skip in the suite. The harness contract is asserted by the test
+ * below instead, so the lane loses no coverage.
+ */
 test("dragging into Planning moves the card without dispatching it", async ({ page, request }) => {
+  test.skip(
+    LIVE_BRAIN,
+    "asserts Planning is inert, which is only true without a planner; the harness " +
+      "contract is covered by the live-brain test below. Issue #501.",
+  );
   const title = `e2e planning drag ${Date.now()}`;
   const seeded = await request.post(`${API}/tasks`, { data: { title } });
   expect(seeded.ok()).toBeTruthy();
@@ -115,10 +149,23 @@ test("dragging into Planning moves the card without dispatching it", async ({ pa
 
   // Playwright's dragTo does not drive React's HTML5 drag handlers reliably
   // here, so the drop is dispatched directly at the Planning column.
+  //
+  // One **shared `DataTransfer`** across the three events, and it is
+  // load-bearing (issue #501). A bare `dispatchEvent("dragstart")` builds a
+  // `DragEvent` whose `dataTransfer` is `null`, so the board cannot stash the
+  // card id where a real drag puts it, and the drop handler falls back to
+  // React state — `moveTo(col, dropped)` reads `dropped || dragId`. That
+  // fallback exists for browsers that mangle the payload; it is not the path a
+  // real gesture takes, and leaning on it makes the three dispatches straddle a
+  // window in which a re-render matters. Handing the same `DataTransfer` to all
+  // three makes this the gesture a browser actually performs: `setData` at
+  // `dragstart`, `getData` at `drop`, and nothing in between that a re-render
+  // can touch.
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
   const planning = page.locator("div.w-72").nth(EXPECTED_COLUMNS.indexOf("Planning"));
-  await card.dispatchEvent("dragstart");
-  await planning.dispatchEvent("dragover");
-  await planning.dispatchEvent("drop");
+  await card.dispatchEvent("dragstart", { dataTransfer });
+  await planning.dispatchEvent("dragover", { dataTransfer });
+  await planning.dispatchEvent("drop", { dataTransfer });
 
   await expect
     .poll(
@@ -141,4 +188,74 @@ test("dragging into Planning moves the card without dispatching it", async ({ pa
   expect(
     (detail.timeline ?? []).filter((entry: { kind: string }) => entry.kind === "dispatched"),
   ).toHaveLength(0);
+});
+
+/**
+ * The other half of issue #501: what Planning means **with** a planner.
+ *
+ * This is the assertion the live-brain lane was missing. It found the defect
+ * that opened #501 and had nothing to replace the inert-column claim with, so
+ * the lane reported a failure without ever stating the contract that actually
+ * holds there.
+ *
+ * The contract is settlement, not a destination. `src/harness/planning.rs`
+ * edge-fires one pass per card entering Planning and lands the card in
+ * `in_progress` (plan written, nothing blocking) or back in `todo` (a missing
+ * prerequisite, or the pass itself failed) — always with a `[system]` note
+ * saying which. The one outcome the product must never produce is a card left
+ * parked in `planning` with nothing having happened, which is exactly what a
+ * lost drop or a stalled pass would look like.
+ *
+ * So this asserts the negative that matters — the card does not stay put — and
+ * then that wherever it landed is one of the two documented landings and says
+ * why. It is deliberately agnostic about WHICH: the harness lane's brain echoes
+ * rather than plans, so today it always takes the failure row, and pinning that
+ * would make this test a description of the mock rather than of the product.
+ *
+ * The window is generous because a pass makes a real model call, bounded by
+ * `PLANNING_TIMEOUT` (120s) on the host side.
+ */
+test("a card dropped into Planning is planned and settled, never left parked", async ({
+  page,
+  request,
+}) => {
+  test.skip(
+    !LIVE_BRAIN,
+    "needs a --features openhuman,tinycortex host with a planner attached; without " +
+      "one Planning is inert and the test above is the applicable contract. Issue #501.",
+  );
+
+  const title = `e2e planning settle ${Date.now()}`;
+  const seeded = await request.post(`${API}/tasks`, { data: { title } });
+  expect(seeded.ok()).toBeTruthy();
+  const id = (await seeded.json()).id as string;
+
+  await page.goto("/#/tasks");
+  await dismissTour(page);
+
+  const card = page.locator("div[draggable=true]").filter({ hasText: title }).first();
+  await expect(card).toBeVisible({ timeout: 15_000 });
+
+  // The same faithful gesture as the test above: one DataTransfer across all
+  // three events, so the id travels where a real drag puts it.
+  const dataTransfer = await page.evaluateHandle(() => new DataTransfer());
+  const planning = page.locator("div.w-72").nth(EXPECTED_COLUMNS.indexOf("Planning"));
+  await card.dispatchEvent("dragstart", { dataTransfer });
+  await planning.dispatchEvent("dragover", { dataTransfer });
+  await planning.dispatchEvent("drop", { dataTransfer });
+
+  const read = async () => (await (await request.get(`${API}/tasks/${id}`)).json()).task;
+
+  // It reached the host and the pass settled it. A card still in `planning`
+  // when this expires is the real failure this test exists to catch: either the
+  // drop never landed, or a pass started and never finished.
+  await expect
+    .poll(async () => (await read()).column, { timeout: 150_000 })
+    .not.toBe("planning");
+
+  const settled = await read();
+  expect(["todo", "in_progress"]).toContain(settled.column);
+  // And it says why it moved, rather than moving silently. `[system]` is the
+  // attribution every planning outcome writes onto the note.
+  expect(settled.note ?? "").toContain("[system]");
 });


### PR DESCRIPTION
## Summary

Closes #501.

**The issue describes a bug that does not exist.** Its own failure artifact falsifies it, and the correction matters more than the fix: left as written, the next person reads the title and goes hunting for a drag that HTML5 loses on re-render. There is no such defect here.

### What the artifact says

`playwright-live-brain-failures` from run [31098118431], the page snapshot at the moment of failure. The card is in To-do, carrying this:

```
button "e2e planning drag 1786017364745 medium [system] planning could not read the model's
answer as a plan, so nothing was written — try again, or drag the card straight to In Progress
to run it unplanned"
```

That string is `src/harness/planning.rs:948`. **Only the host writes it.** So the drop reached the host, the console `PATCH`ed the card into `planning`, and the host put it back. The drag was never lost. The issue's central claim — "the drop did not reach the host at all" — is the one thing the evidence rules out.

### What actually happens

1. The drop lands; the console `PATCH`es `column: "planning"`; the host accepts it.
2. On a **planner-attached** host, entering Planning edge-fires one pass: `CompanyRuntime::plan_task` → `harness::planning::run_planning_pass`, a real model call. On a default-feature host `plan_task` is a `#[cfg(feature = "openhuman")]` no-op — "keeping the column inert", as its doc says.
3. The live-brain lane's brain echoes rather than plans, so `parse_draft` returns `None` → `PassFailure`.
4. `settle_failed` (`planning.rs:562`) appends that note **and sets `card.column = COLUMN_TODO`**.
5. The spec polls 15s and reads `"todo"`.

### Why the spec was wrong rather than the product

The spec's own comment scoped its no-dispatch assertion: it "lets the column ship **ahead of epic #183 §4's auto-advance**". §4 has since landed as the planning station (issue #337), whose module header states the contract:

| pass outcome | where the card lands |
|---|---|
| a plan, nothing blocking, a valid assignee | `in_progress` — **and the dispatch edge fires** |
| a plan, a hard prerequisite missing | `todo`, with the gap on the note |
| the pass itself failed | `todo`, with the reason on the note |

So on a planner-attached host a card **never stays in `planning`**, and the first row **does dispatch**. Both of the test's claims are false there by design, and both remain exactly right on the default lane. This is an assertion that outlived its own stated scope — the same shape as #475, one directory over.

## What changed, and why none of it is a relaxation

This is the part worth checking hardest, so it is itemised.

**1. The inert-Planning test is scoped to the lane where its contract holds.** It now carries `test.skip(LIVE_BRAIN, …)` — **inverted** from every other capability skip in the suite, because this test needs the *absence* of a brain. Every assertion inside it is byte-for-byte unchanged: still `toBe("planning")`, still zero `dispatched` timeline entries, still running on every push in the default lane. Nothing was loosened; a claim that is only true without a planner is now only made without a planner.

**2. The live-brain lane gains an assertion it never had.** This is the opposite of a relaxation and it is the substance of the change. That lane previously stated *no* contract for Planning — which is why it could report a failure and offer nothing to replace the claim with. The new test asserts what does hold there:

* the card **must not stay parked in `planning`** — the one outcome the product must never produce, and precisely what a genuinely lost drop or a stalled pass would look like;
* wherever it landed is one of the two documented columns (`todo` or `in_progress`);
* it carries a `[system]` note, so it says why it moved rather than moving silently.

It is deliberately agnostic about *which* landing. The lane's brain echoes, so today it always takes the failure row; pinning that would make the test a description of the mock rather than of the product.

**3. The drag is now the gesture a browser actually performs.** The three dispatches carried no `DataTransfer`, so `dragstart` could not `setData` the card id and `drop` could not `getData` it — the handler fell through to its React-state fallback (`moveTo` reads `dropped || dragId`). One shared `DataTransfer` handle across `dragstart`/`dragover`/`drop` puts the id where a real drag puts it. This is strictly *more* faithful than before: it exercises the production path instead of a fallback, and it is what makes the three round trips immune to anything that re-renders between them. It also closes the issue's own second suggested remedy properly rather than by hoping.

Net: no assertion weakened, one assertion added, one gesture made real.

## Is the drag itself safe? Yes, and here is why

The issue worries that "the dragged-card id lives in React state between them". In the product it does not. The column's `onDrop` reads the id from `e.dataTransfer`, which is browser-owned and survives any React re-render:

```ts
onDrop={(e) => { … void moveTo(col.id, e.dataTransfer?.getData(CARD_MIME) ?? null); }}
```

`dragId` state drives the drag affordance and serves as a fallback for browsers that mangle the payload. The only way to reach that fallback is a synthetic event with no `DataTransfer` — which is what the spec was doing and no browser does. So there is no operator-facing lost-drag defect to fix, and this PR does not pretend to fix one.

## Does the real failure deserve its own issue?

**No.** The real failure is this spec asserting a pre-auto-advance contract against a post-auto-advance host, and it is fully fixed here — the claim is scoped to the lane where it is true, and the lane where it is false now asserts what is. There is no residual product defect behind it, so a follow-up issue would have nothing to close.

**One product observation, which I have deliberately NOT fixed here.** The board header still reads *"Drag a card to move it; drop into 'In progress' to hand it to its assignee."* On a planner-attached host that is no longer the only way work gets handed over: a successful plan promotes the card to `in_progress` and the dispatch edge fires, so dropping into **Planning** can also spend an agent turn. The string is correct on the default build and misleading on a harness build. That is a one-line UI honesty question, not a test fix, and it belongs in its own issue rather than in this diff.

## API Or Behavior Changes

None. Test-only: one spec file. No product code is touched.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI.

No Rust file is touched by this change.

Verified locally: `npm run typecheck:e2e` clean (the spec suite is type-checked by `tsconfig.e2e.json`, which `tsc -b` does not reach).

The behavioural verification is the two CI lanes themselves, which is the only place a live host exists:

* `Console E2E` (default features) runs the existing test with its assertions unchanged, and now with a faithful `DataTransfer` drag. A pass there is the evidence that change 3 did not break the path that was working.
* `Console E2E (live brain)` skips that test and runs the new one. A pass there is the evidence that the drop reaches the host and the pass settles the card — the thing #501 believed was not happening.

Both are on this PR's run.

## Documentation

None needed: no product behaviour or API changed. The contract this spec now mirrors is already documented where it is implemented, in `src/harness/planning.rs`'s module header and on `COLUMN_PLANNING` in `src/ports/tasks.rs`; this change makes the spec agree with it rather than restating it.
