### PR TITLE
fix(e2e): make the MCP registration test-owned, and name the working directory

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -205,7 +205,8 @@ statement about that host rather than a debt. Against a gated one they run:
 To run them:
 
 ```sh
-cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany
+cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany  # repo root
+cd frontend
 npm run e2e:live                         # PW_LIVE_BRAIN=1 npm run e2e
 ```
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -205,9 +205,8 @@ statement about that host rather than a debt. Against a gated one they run:
 To run them:
 
 ```sh
-cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany  # repo root
-cd frontend
-npm run e2e:live                         # PW_LIVE_BRAIN=1 npm run e2e
+cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany
+npm --prefix frontend run e2e:live       # PW_LIVE_BRAIN=1 npm run e2e
 ```
 
 `PW_LIVE_BRAIN=1` is a **declaration**, not a probe — nothing in a host's

--- a/frontend/test/e2e/mcp-agent.spec.ts
+++ b/frontend/test/e2e/mcp-agent.spec.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { expect, test, type Page } from "@playwright/test";
 
 import { LIVE_BRAIN, LIVE_BRAIN_REASON, MCP_SERVER } from "./capabilities";

--- a/frontend/test/e2e/mcp-agent.spec.ts
+++ b/frontend/test/e2e/mcp-agent.spec.ts
@@ -41,9 +41,6 @@ test.skip(
 );
 test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
 
-/** The name the server is registered under, and the name the agent addresses. */
-const SERVER = "pw-agent-mcp";
-
 /**
  * Opens the conversation view on the company thread.
  *
@@ -86,24 +83,32 @@ function transcriptRow(page: Page, text: string) {
 test("an agent calls a tool on a registered MCP server and shows the result", async ({
   page,
 }) => {
+  // Unique per run, and a 409 is a FAILURE rather than a shrug. The host keeps
+  // runtime servers in its secret store, so a fixed name plus a tolerated
+  // "already exists" would let this spec adopt a leftover registration from an
+  // earlier run — pointing anywhere at all — pass against it, and then delete a
+  // server it never created.
+  const server = `pw-agent-mcp-${Date.now()}`;
+
   // Registered through the API rather than the console: the console's add form
   // is `mcp.spec.ts`'s subject, and repeating it here would make this spec fail
   // for that page's reasons rather than its own.
   const added = await page.request.post("/api/v1/company/mcp/servers", {
-    data: { name: SERVER, endpoint: MCP_SERVER!, description: "e2e fixture" },
+    data: { name: server, endpoint: MCP_SERVER!, description: "e2e fixture" },
   });
   expect(
-    added.ok() || added.status() === 409,
-    `registering ${SERVER} failed: ${added.status()} ${await added.text()}`,
+    added.ok(),
+    `registering ${server} failed: ${added.status()} ${await added.text()}`,
   ).toBeTruthy();
 
+  let bodyPassed = false;
   try {
     await openThread(page);
 
     const marker = `agent-mcp-${Date.now()}`;
     const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
       name: "mcp_call_tool",
-      arguments: { server: SERVER, tool: "echo", arguments: { text: marker } },
+      arguments: { server, tool: "echo", arguments: { text: marker } },
     })}`;
 
     // The POST is awaited EXPLICITLY, and the reload below is why. A turn runs
@@ -140,10 +145,20 @@ test("an agent calls a tool on a registered MCP server and shows the result", as
     const reply = transcriptRow(page, `echo: ${marker}`);
     await expect(reply).toBeVisible({ timeout: 30_000 });
     await expect(reply).toContainText("MOCK_LLM");
+    bodyPassed = true;
   } finally {
     // The host persists runtime servers in its secret store, so a spec that
     // failed half way would otherwise leave this one registered for every later
-    // run against the same data root. A 404 here is the harmless case.
-    await page.request.delete(`/api/v1/company/mcp/servers/${SERVER}`);
+    // run against the same data root.
+    const removed = await page.request.delete(`/api/v1/company/mcp/servers/${server}`);
+    // Checked, but only when the body got that far: an assertion that throws
+    // out of a `finally` replaces the real failure with a complaint about
+    // cleanup, which is the harder one to debug of the two.
+    if (bodyPassed) {
+      expect(
+        removed.ok(),
+        `removing ${server} failed: ${removed.status()} ${await removed.text()}`,
+      ).toBeTruthy();
+    }
   }
 });

--- a/frontend/test/e2e/mcp-agent.spec.ts
+++ b/frontend/test/e2e/mcp-agent.spec.ts
@@ -150,14 +150,26 @@ test("an agent calls a tool on a registered MCP server and shows the result", as
     // The host persists runtime servers in its secret store, so a spec that
     // failed half way would otherwise leave this one registered for every later
     // run against the same data root.
-    const removed = await page.request.delete(`/api/v1/company/mcp/servers/${server}`);
-    // Checked, but only when the body got that far: an assertion that throws
-    // out of a `finally` replaces the real failure with a complaint about
-    // cleanup, which is the harder one to debug of the two.
+    //
+    // NOTHING here may throw past a failing body. An exception raised in a
+    // `finally` replaces the error already travelling out of the `try`, so a
+    // cleanup complaint would erase the real failure — the harder of the two to
+    // debug, and the one worth keeping. That covers both ways this can go
+    // wrong: `page.request.delete` REJECTS on a transport failure (it does not
+    // return a response to inspect), and the status check is an assertion.
+    // Both are therefore reported only when the body itself passed.
+    let removed: Awaited<ReturnType<typeof page.request.delete>> | undefined;
+    let transportError: unknown;
+    try {
+      removed = await page.request.delete(`/api/v1/company/mcp/servers/${server}`);
+    } catch (error) {
+      transportError = error;
+    }
     if (bodyPassed) {
+      if (transportError) throw transportError;
       expect(
-        removed.ok(),
-        `removing ${server} failed: ${removed.status()} ${await removed.text()}`,
+        removed!.ok(),
+        `removing ${server} failed: ${removed!.status()} ${await removed!.text()}`,
       ).toBeTruthy();
     }
   }

--- a/frontend/test/e2e/mcp-agent.spec.ts
+++ b/frontend/test/e2e/mcp-agent.spec.ts
@@ -107,7 +107,7 @@ test("an agent calls a tool on a registered MCP server and shows the result", as
   try {
     await openThread(page);
 
-    const marker = `agent-mcp-${Date.now()}`;
+    const marker = `agent-mcp-${randomUUID()}`;
     const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
       name: "mcp_call_tool",
       arguments: { server, tool: "echo", arguments: { text: marker } },

--- a/frontend/test/e2e/mcp-agent.spec.ts
+++ b/frontend/test/e2e/mcp-agent.spec.ts
@@ -90,7 +90,7 @@ test("an agent calls a tool on a registered MCP server and shows the result", as
   // "already exists" would let this spec adopt a leftover registration from an
   // earlier run — pointing anywhere at all — pass against it, and then delete a
   // server it never created.
-  const server = `pw-agent-mcp-${Date.now()}`;
+  const server = `pw-agent-mcp-${randomUUID()}`;
 
   // Registered through the API rather than the console: the console's add form
   // is `mcp.spec.ts`'s subject, and repeating it here would make this spec fail


### PR DESCRIPTION
## Summary

Follow-up to #484 (issue #467), which merged at 83bd8ba while these two fixes
were still in flight. Both come from CodeRabbit's review of that PR, and both
are real; neither reached `main`.

**The MCP registration in `mcp-agent.spec.ts` was not test-owned** (CodeRabbit,
Major). The server name was fixed and a `409 already exists` was accepted as
successful setup, so a leftover registration from an earlier run — pointing at
any endpoint at all — would be adopted, passed against, and then deleted by a
test that never created it. The spec would go green having validated nothing
about `MCP_SERVER`. The name is unique per run now and a `409` is a setup
failure.

Cleanup is checked as well, but **only when the body got that far**: an
assertion thrown out of a `finally` replaces the real failure with a complaint
about cleanup, which is the harder of the two to debug. That is a deliberate
narrowing of the suggested fix, and the reason is in the comment.

**The README's live-lane recipe did not say where to stand** (CodeRabbit,
Minor). It runs `cargo build` from the repository root and `npm run e2e:live`
from `frontend/`; only CI knew that, through `working-directory: frontend`.

## API Or Behavior Changes

None. Test-fixture ownership and one documentation line.

## Tests

- [x] `cargo fmt --all -- --check` — N/A - full local build matrix is prohibited on this machine; verified in CI. (No Rust in this diff.)
- [x] `cargo clippy --all-targets -- -D warnings` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo build --all-targets` — N/A - full local build matrix is prohibited on this machine; verified in CI.
- [x] `cargo test` — N/A - full local build matrix is prohibited on this machine; verified in CI.

`npm run typecheck:e2e` clean. The spec itself runs in `Console E2E (live
brain)`, which this PR's own CI run exercises — that lane is where the change
is observable, and it is green on `main` as of #484.

No new test accompanies this: the change *is* a test's correctness, and the
property it fixes (a stale registration cannot be adopted) is asserted by the
spec's own `expect(added.ok())` on every run.

## Documentation

`frontend/README.md` — the live-lane recipe now names the working directory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated live end-to-end test setup instructions to include changing into the frontend directory before running tests.

- **Tests**
  - Improved MCP agent test isolation by generating unique server names for each run.
  - Strengthened registration and cleanup checks to better detect failures.
  - Ensured mock tool calls use the server created during the current test.
  - Improved cleanup handling when test execution encounters transport failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->