### PR TITLE
fix(workspace): a read the harness would cut can no longer invite a full-body overwrite (#417)

### DIFF
--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -268,10 +268,15 @@ prompt = "Weekly review and operator digest"
     `expected_updated_at` revision token taken from a prior read, so a note
     edited in the console since the agent read it is refused rather than
     clobbered; creating, renaming and deleting notes stay operator-only. Both
-    sides are capped at 64 KiB, which makes a larger note agent-read-only: the
-    agent sees a truncated body, and a write against it is refused rather than
-    discarding the part it could not see, so only an operator can edit it in the
-    console. Under
+    sides are capped at the agent harness's own per-tool-result byte budget
+    minus the framing a read wraps a body in (issue #417) — 12 KiB today,
+    derived rather than chosen so a full read always survives the harness cut
+    and the write gate is measured against the bytes the model actually
+    received. A larger note is agent-read-only: the agent sees a truncated body,
+    and a write against it is refused rather than discarding the part it could
+    not see, so only an operator can edit it in the console. **Operator edits
+    are not capped by this** — the console and the REST handlers write through
+    the `WorkspaceStore` port directly and never enter the agent tool path. Under
     `[policy].mode = "supervised"` (the default) a write additionally parks for
     approval, and under `readonly` it is denied — reads stay available in every
     mode. The namespace is **not** gateable by `[plan].token_budgets`: reads

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -89,6 +89,37 @@ use crate::ports::skills_state::SkillState;
 use crate::ports::types::CompanyId;
 use crate::runtime::tools::extends_on_boundary;
 
+/// The per-tool-result byte budget every OpenCompany agent runs under.
+///
+/// The harness cuts **every** tool result to this many bytes on its way into
+/// the model's context — `ToolOutputMiddleware`, fed from
+/// `ContextManager::tool_result_budget_bytes`, which [`build_agent`] threads in
+/// below via [`AgentBuilder::context_config`]. It is the real ceiling on what a
+/// model ever sees from a tool, and it is *smaller* than the caps individual
+/// tools tend to write for themselves.
+///
+/// It is stated here rather than inherited on purpose (issue #417). Before this
+/// constant existed `build_agent` never called `context_config`, so the builder
+/// fell back to `ContextConfig::default()` and the 16 KiB became OpenCompany's
+/// effective bound by accident — invisible from this crate, and out of step
+/// with a tool that had capped itself at 64 KiB. `workspace_read` consequently
+/// told the model "nothing was dropped, you may write the complete body back"
+/// about a note the model had only seen the first 16 KiB of, and the resulting
+/// `workspace_write` silently destroyed the rest.
+///
+/// So any tool whose result carries a *contract* — "this is the whole thing",
+/// "act on the trailer below" — must size itself against this number, not
+/// against a cap of its own choosing. [`workspace_tools`] derives its read and
+/// write caps from it directly.
+///
+/// The value still tracks the vendored default: keeping the number identical
+/// makes adopting it a no-op today, so the behaviour change belongs to the
+/// consumers that now respect it, not to this line.
+///
+/// [`workspace_tools`]: crate::harness::workspace_tools
+pub(crate) const TOOL_RESULT_BUDGET_BYTES: usize =
+    oh::agent::context::DEFAULT_TOOL_RESULT_BUDGET_BYTES;
+
 /// Map a manifest cognition-tier hint to a hosted model/tier name.
 ///
 /// The manifest tier "never selects a model" (that is the TinyHumans backend's
@@ -591,6 +622,16 @@ pub fn build_agent(
         .tool_dispatcher(tool_dispatcher)
         .tool_policy(Arc::new(policy))
         .prompt_builder(prompt_builder)
+        // Stated, not inherited (issue #417). Omitting this call leaves the
+        // builder on `ContextConfig::default()`, which lands on the same number
+        // — so this is behaviour-identical today. What changes is that the
+        // number is now *chosen here*, where tools that must size their results
+        // against it can read it as [`TOOL_RESULT_BUDGET_BYTES`], instead of
+        // being a vendored default no OpenCompany source mentioned.
+        .context_config(oh::config::ContextConfig {
+            tool_result_budget_bytes: TOOL_RESULT_BUDGET_BYTES,
+            ..Default::default()
+        })
         .model_name(model)
         .workspace_dir(workspace)
         .agent_definition_name(manifest_agent.id.clone())

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -82,6 +82,33 @@
 //!   [`MAX_CONTENT_BYTES`]: if the note is bigger than a read can return, the
 //!   agent cannot have seen all of it, so it must not overwrite it. Stateless,
 //!   and it closes the silent-truncation data-loss path.
+//!
+//! # Why the caps are derived, not chosen (issue #417)
+//!
+//! That last invariant was stated against the wrong number for as long as this
+//! module existed. The harness cuts **every** tool result to
+//! [`TOOL_RESULT_BUDGET_BYTES`] on its way into the model's context;
+//! `MAX_CONTENT_BYTES` was a flat 64 KiB, four times larger. Between the two a
+//! read reported `dropped == 0`, took the write-eligible branch, and told the
+//! model to send back "the complete new body" — of a note the model had only
+//! been handed the first ~16 KiB of. The write gate agreed (64 KiB), the write
+//! landed, and the remainder of an operator's note was gone with nothing in the
+//! loop reporting a loss.
+//!
+//! The fix is not a smaller literal. It is that the module no longer picks a
+//! bound at all: [`MAX_CONTENT_BYTES`] is [`TOOL_RESULT_BUDGET_BYTES`] minus the
+//! framing this module wraps a body in, so a full read *always* fits and the
+//! outer cut never fires on these tools. The module's gate and the model's view
+//! are then the same gate by construction, and a const assertion fails the
+//! build if a later edit separates them again.
+//!
+//! One consequence worth stating plainly: a note larger than
+//! [`MAX_CONTENT_BYTES`] is agent-read-only — the existing
+//! `current_len > MAX_CONTENT_BYTES` refusal, now reached by far more notes than
+//! before. That window is precisely the window in which the old code destroyed
+//! data. Operator edits are untouched: the console and the REST handlers in
+//! [`server::ops::workspace`](crate::server::ops::workspace) call the
+//! [`WorkspaceStore`] port directly and never enter this module.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -92,6 +119,7 @@ use serde_json::{Value, json};
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
+use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
 
@@ -108,11 +136,40 @@ pub const WORKSPACE_WRITE_TOOL: &str = "workspace_write";
 /// should narrow with `prefix` rather than read the whole index.
 const MAX_LIST_ENTRIES: usize = 300;
 
+/// Bytes a [`WORKSPACE_READ_TOOL`] result reserves for everything that is not
+/// the note body: the header, the write-eligibility line, the untrusted-content
+/// preamble, both fence markers with their nonce, and the truncation notice.
+///
+/// Generous on purpose. The cost of over-reserving is a slightly smaller
+/// readable note; the cost of under-reserving is the whole bug this module was
+/// re-cut for — the outer budget shaving the closing fence off the end.
+const READ_OVERHEAD_BYTES: usize = 4096;
+
 /// Max body bytes one [`WORKSPACE_READ_TOOL`] call returns.
 ///
 /// Also the write eligibility threshold — see the module docs on why a note
 /// larger than this is read-only from an agent's point of view.
-const MAX_CONTENT_BYTES: usize = 64 * 1024;
+///
+/// Derived from [`TOOL_RESULT_BUDGET_BYTES`] rather than picked (issue #417).
+/// It used to be a flat 64 KiB, four times the budget the harness then applied
+/// to the finished result, so between the two numbers the module believed it
+/// had returned a whole note while the model received a fraction of one — and
+/// the write-eligible branch invited an overwrite from that fraction. Sizing
+/// the read so a *full* result fits under the harness budget is what makes the
+/// module's gate and the model's view the same gate.
+const MAX_CONTENT_BYTES: usize = TOOL_RESULT_BUDGET_BYTES - READ_OVERHEAD_BYTES;
+
+/// The invariant the two constants above exist to hold: a read returning the
+/// largest body it will ever return, plus every byte of framing around it,
+/// still fits under the harness's per-tool-result budget.
+///
+/// Written as a const assertion because it is the load-bearing property. If a
+/// later edit raises [`MAX_CONTENT_BYTES`], shrinks
+/// [`TOOL_RESULT_BUDGET_BYTES`], or grows the framing past
+/// [`READ_OVERHEAD_BYTES`]'s reservation, the outer cut starts firing on this
+/// tool again — silently, and with data loss at the end of it. This fails the
+/// build instead.
+const _: () = assert!(MAX_CONTENT_BYTES + READ_OVERHEAD_BYTES <= TOOL_RESULT_BUDGET_BYTES);
 
 /// Max bytes of new content [`WORKSPACE_WRITE_TOOL`] accepts in one call.
 ///
@@ -120,6 +177,16 @@ const MAX_CONTENT_BYTES: usize = 64 * 1024;
 /// must stay a note the agent can read back in full, or the next write would be
 /// refused as oversized.
 const MAX_WRITE_BYTES: usize = MAX_CONTENT_BYTES;
+
+/// Max bytes of a caller- or operator-supplied name echoed back inside a
+/// header this module promises to keep small.
+///
+/// The `prefix` argument is agent-supplied and otherwise unbounded, so echoing
+/// it verbatim would let one tool call blow past
+/// [`LIST_OVERHEAD_BYTES`]'s reservation and push the very guidance the header
+/// exists to protect back out of reach. Node paths are operator-supplied and no
+/// backend caps a node name, so the read header takes the same bound.
+const MAX_ECHOED_PATH_BYTES: usize = 512;
 
 /// Depth guard when walking a node's ancestor chain to render its path.
 ///
@@ -413,6 +480,22 @@ fn clamp_body(body: &str, max_bytes: usize) -> (&str, usize) {
     (kept, body.len() - kept.len())
 }
 
+/// A path or prefix, bounded for echoing back inside a header.
+///
+/// Headers in this module carry the instructions the model has to act on, and
+/// they are sized against a fixed reservation. A path is either agent-supplied
+/// (`prefix`) or operator-supplied (a node name, which no backend length-caps),
+/// so neither can be pasted in unbounded without putting the rest of the header
+/// past the reservation — and past the harness budget, which cuts from the end.
+fn echo_path(path: &str) -> String {
+    let (kept, dropped) = clamp_body(path, MAX_ECHOED_PATH_BYTES);
+    if dropped == 0 {
+        kept.to_string()
+    } else {
+        format!("{kept}… (+{dropped} bytes)")
+    }
+}
+
 /// A fresh random token for one read's content fence.
 ///
 /// The fence delimits operator/agent-authored prose that the model must treat
@@ -538,7 +621,8 @@ impl Tool for WorkspaceListTool {
             let message = match &prefix {
                 Some(prefix) => format!(
                     "No workspace notes exist under `{prefix}`. Call `{WORKSPACE_LIST_TOOL}` with \
-                     no prefix to see the whole tree."
+                     no prefix to see the whole tree.",
+                    prefix = echo_path(prefix)
                 ),
                 None => "This company's workspace is empty — no folders or notes have been \
                          created yet. There is no company documentation to consult; say so \
@@ -552,7 +636,10 @@ impl Tool for WorkspaceListTool {
         let shown = total.min(MAX_LIST_ENTRIES);
         let mut out = String::new();
         match &prefix {
-            Some(prefix) => out.push_str(&format!("Company workspace under `{prefix}`")),
+            Some(prefix) => out.push_str(&format!(
+                "Company workspace under `{prefix}`",
+                prefix = echo_path(prefix)
+            )),
             None => out.push_str("Company workspace"),
         }
         out.push_str(&format!(
@@ -692,12 +779,24 @@ impl Tool for WorkspaceReadTool {
         let (kept, dropped) = clamp_body(&body, MAX_CONTENT_BYTES);
         let nonce = fence_nonce();
 
+        // The size line states what was *returned* as well as what exists, so a
+        // partial read is legible from the first line rather than only from a
+        // marker at the very end — which is exactly the position an outer cut
+        // takes away first.
+        let sizes = if dropped == 0 {
+            format!("{} bytes", body.len())
+        } else {
+            format!(
+                "returned {kept_len} of {total} bytes",
+                kept_len = kept.len(),
+                total = body.len(),
+            )
+        };
         let mut out = format!(
-            "Workspace note `{path}` (id={id}, rev={rev}, {bytes} bytes).\n",
-            path = entry.path,
+            "Workspace note `{path}` (id={id}, rev={rev}, {sizes}).\n",
+            path = echo_path(&entry.path),
             id = entry.node.id,
             rev = entry.node.updated_at_millis,
-            bytes = body.len(),
         );
         if dropped == 0 {
             out.push_str(&format!(
@@ -1604,6 +1703,204 @@ mod tests {
 
         let (_, body) = store.read(&id, "n-big").await.unwrap().unwrap();
         assert_eq!(body.len(), big.len(), "the oversized note was clobbered");
+    }
+
+    /// The nonce off a read's BEGIN fence, so a test can demand the *matching*
+    /// END fence rather than any occurrence of the words.
+    fn fence_of(out: &str) -> String {
+        let at = out
+            .find("--- BEGIN WORKSPACE NOTE ")
+            .expect("the read is fenced");
+        out[at + "--- BEGIN WORKSPACE NOTE ".len()..]
+            .split_whitespace()
+            .next()
+            .expect("the fence carries a nonce")
+            .to_string()
+    }
+
+    /// Issue #417, the data-loss window itself.
+    ///
+    /// A 20 KiB note sat between the module's old 64 KiB read cap and the
+    /// harness's 16 KiB budget. The module saw `dropped == 0`, emitted the
+    /// write-eligible branch — "call `workspace_write` … with the complete new
+    /// body" — and the harness then handed the model ~16 KiB of the note. An
+    /// agent doing exactly as instructed wrote back what it had seen, the
+    /// 64 KiB write gate accepted it, and the rest of the operator's note was
+    /// destroyed with nothing reporting a loss.
+    ///
+    /// Two things have to hold for that to be closed, and neither implies the
+    /// other: the invitation must be absent (so a compliant agent is never told
+    /// to send a whole body it does not have), and the result must fit under
+    /// the harness budget (so the module's view and the model's view are the
+    /// same bytes, closing fence included).
+    #[tokio::test]
+    async fn a_note_the_harness_would_have_cut_is_read_only_and_never_invites_a_rewrite() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        let id = CompanyId::new("acme");
+        let body = "x".repeat(20 * 1024);
+        store
+            .create(&id, &file("n-big", "big.md", None), Some(&body))
+            .await
+            .unwrap();
+
+        let read = WorkspaceReadTool::new(CompanyWorkspace::new(store, id));
+        let out = text(&read.execute(json!({"path": "big.md"})).await.unwrap());
+
+        // The agent is told it may not write, and is never handed the sentence
+        // that caused the overwrite.
+        assert!(out.contains("CANNOT be overwritten"), "{out}");
+        assert!(
+            !out.contains("complete new body"),
+            "a partial read still invited a full-body overwrite: {out}"
+        );
+
+        // The whole result survives the harness, so the model sees the same
+        // bytes this module believes it returned — terminator included.
+        assert!(
+            out.len() <= TOOL_RESULT_BUDGET_BYTES,
+            "a read of a {} byte note rendered {} bytes, over the {TOOL_RESULT_BUDGET_BYTES}-byte \
+             harness budget — the outer cut would fire and take the end with it",
+            body.len(),
+            out.len(),
+        );
+        let nonce = fence_of(&out);
+        assert!(
+            out.trim_end()
+                .ends_with(&format!("--- END WORKSPACE NOTE {nonce} ---")),
+            "the closing fence is not the last thing in the result: {out}"
+        );
+
+        // And the first line says how much of it arrived, rather than leaving
+        // that to a marker at the very end.
+        assert!(
+            out.contains(&format!(
+                "returned {MAX_CONTENT_BYTES} of {} bytes",
+                body.len()
+            )),
+            "the header does not state what was returned: {out}"
+        );
+    }
+
+    /// The worst case the reservation has to cover: a body at exactly the cap,
+    /// so nothing is dropped and the *whole* framing is emitted — write-
+    /// eligibility line, fence preamble, both markers — around a path long
+    /// enough to need clamping.
+    ///
+    /// This is the case [`READ_OVERHEAD_BYTES`] exists for. If the reservation
+    /// were removed (or the cap raised to the budget), a full read would land
+    /// over the budget and the harness would shave the closing fence off the
+    /// end of the very reads the module says nothing was dropped from.
+    #[tokio::test]
+    async fn a_full_read_at_the_cap_still_fits_under_the_harness_budget() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        let id = CompanyId::new("acme");
+        // A path far longer than anything the console produces, to prove the
+        // reservation covers the header and not just the body.
+        let outer = "L".repeat(200);
+        let inner = "M".repeat(200);
+        let leaf = format!("{}.md", "N".repeat(200));
+        store
+            .create(&id, &folder("f-outer", &outer, None), None)
+            .await
+            .unwrap();
+        store
+            .create(&id, &folder("f-inner", &inner, Some("f-outer")), None)
+            .await
+            .unwrap();
+        let body = "z".repeat(MAX_CONTENT_BYTES);
+        store
+            .create(&id, &file("n-max", &leaf, Some("f-inner")), Some(&body))
+            .await
+            .unwrap();
+
+        let read = WorkspaceReadTool::new(CompanyWorkspace::new(store, id));
+        let out = text(&read.execute(json!({"id": "n-max"})).await.unwrap());
+
+        // Nothing was dropped, so this is the write-eligible branch — the one
+        // whose promise has to be true.
+        assert!(out.contains("complete new body"), "{out}");
+        assert!(
+            out.contains(&format!("{MAX_CONTENT_BYTES} bytes")),
+            "the header should report the note's full size: {out}"
+        );
+        assert!(
+            out.len() <= TOOL_RESULT_BUDGET_BYTES,
+            "a full read at the cap rendered {} bytes, over the \
+             {TOOL_RESULT_BUDGET_BYTES}-byte harness budget: the framing needs more than the \
+             {READ_OVERHEAD_BYTES} bytes reserved for it",
+            out.len(),
+        );
+        let nonce = fence_of(&out);
+        assert!(
+            out.trim_end()
+                .ends_with(&format!("--- END WORKSPACE NOTE {nonce} ---")),
+            "the closing fence is not the last thing in the result: {out}"
+        );
+    }
+
+    /// The write gate at its boundary: one byte over the read cap is refused.
+    ///
+    /// The existing oversized test uses cap + 4 KiB, which passes even if the
+    /// gate is off by kilobytes. This pins the gate to the same number the read
+    /// clamps at, which is the whole point of deriving both from one constant.
+    #[tokio::test]
+    async fn a_write_is_refused_on_a_note_one_byte_over_the_read_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        let id = CompanyId::new("acme");
+        let body = "x".repeat(MAX_CONTENT_BYTES + 1);
+        store
+            .create(&id, &file("n-edge", "edge.md", None), Some(&body))
+            .await
+            .unwrap();
+        let rev = store
+            .read(&id, "n-edge")
+            .await
+            .unwrap()
+            .unwrap()
+            .0
+            .updated_at_millis;
+
+        let write = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let result = write
+            .execute(json!({
+                "path": "edge.md",
+                "content": "what the agent saw",
+                "expected_updated_at": rev,
+            }))
+            .await
+            .unwrap();
+        assert!(result.is_error, "{}", text(&result));
+        assert!(text(&result).contains("larger than"), "{}", text(&result));
+
+        let (_, after) = store.read(&id, "n-edge").await.unwrap().unwrap();
+        assert_eq!(after.len(), body.len(), "the note was clobbered");
+
+        // Not vacuous in the other direction: at exactly the cap the same write
+        // is allowed, so the refusal above is the boundary and not a blanket.
+        let ok_body = "x".repeat(MAX_CONTENT_BYTES);
+        store
+            .create(&id, &file("n-ok", "ok.md", None), Some(&ok_body))
+            .await
+            .unwrap();
+        let rev = store
+            .read(&id, "n-ok")
+            .await
+            .unwrap()
+            .unwrap()
+            .0
+            .updated_at_millis;
+        let result = write
+            .execute(json!({
+                "path": "ok.md",
+                "content": "a complete rewrite",
+                "expected_updated_at": rev,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text(&result));
     }
 
     #[tokio::test]

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -669,10 +669,17 @@ impl Tool for WorkspaceListTool {
         let mut rendered = String::new();
         let mut shown = 0usize;
         for entry in entries.into_iter().take(MAX_LIST_ENTRIES) {
+            // Bound the echoed path for the same reason the header does: a node
+            // name is operator-supplied and no backend length-caps it, so one
+            // deep path could otherwise render a line larger than the whole
+            // byte budget and `break` the loop on its first iteration — hiding
+            // every subsequent entry behind a single pathological name. The
+            // clamp announces its own drop, and `id=` (never truncated) stays
+            // the addressable handle, so a bounded entry is still usable.
             let line = format!(
                 "{kind}\t{path}\tid={id}\trev={rev}\n",
                 kind = kind_label(entry.node.kind),
-                path = entry.path,
+                path = echo_path(&entry.path),
                 id = entry.node.id,
                 rev = entry.node.updated_at_millis,
             );
@@ -1818,6 +1825,62 @@ mod tests {
     ///
     /// So the listing must stop on bytes, and both trailers must move above the
     /// entries where no cut can reach them.
+    /// One pathological name must not hide the entries behind it.
+    ///
+    /// A node name is operator-supplied and no backend length-caps it, so a
+    /// single deep path can render a line larger than the whole byte budget.
+    /// Unbounded, that line fails the budget check on the loop's first
+    /// iteration and `break`s — reporting `0 of N` for a workspace that is
+    /// almost entirely listable. Bounding the echoed path keeps every line
+    /// small enough that only the genuine tail is ever lost.
+    #[tokio::test]
+    async fn one_oversized_path_does_not_hide_the_entries_behind_it() {
+        let deep = "d".repeat(MAX_ECHOED_PATH_BYTES * 4);
+        let mut nodes = vec![file("n-deep", &deep, None)];
+        for n in 0..12 {
+            nodes.push(file(
+                &format!("n-after-{n:02}"),
+                &format!("after-{n:02}.md"),
+                None,
+            ));
+        }
+
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
+        let list = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let out = text(&list.execute(json!({})).await.unwrap());
+
+        // Every entry survives — the oversized one is clamped, not fatal.
+        let shown: usize = out.matches("\tid=").count();
+        assert_eq!(
+            shown,
+            13,
+            "one long name truncated the listing to {shown} of 13 entries: {}",
+            &out[..out.len().min(400)]
+        );
+
+        // The clamp announces itself rather than presenting a shortened path
+        // as if it were the whole thing.
+        assert!(
+            out.contains("… (+"),
+            "the oversized path was shortened without saying so: {}",
+            &out[..out.len().min(400)]
+        );
+
+        // The id is the addressable handle and is never clamped, so a bounded
+        // entry is still usable.
+        assert!(
+            out.contains("id=n-deep"),
+            "the clamped entry lost its id, so nothing can address it: {}",
+            &out[..out.len().min(400)]
+        );
+
+        assert!(
+            out.len() <= TOOL_RESULT_BUDGET_BYTES,
+            "the listing rendered {} bytes, over the {TOOL_RESULT_BUDGET_BYTES}-byte budget",
+            out.len(),
+        );
+    }
+
     #[tokio::test]
     async fn a_long_listing_fits_the_budget_and_carries_its_guidance_in_the_header() {
         let mut nodes = vec![folder("f-standards", "Standards", None)];

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -102,13 +102,22 @@
 //! are then the same gate by construction, and a const assertion fails the
 //! build if a later edit separates them again.
 //!
-//! One consequence worth stating plainly: a note larger than
-//! [`MAX_CONTENT_BYTES`] is agent-read-only — the existing
-//! `current_len > MAX_CONTENT_BYTES` refusal, now reached by far more notes than
-//! before. That window is precisely the window in which the old code destroyed
-//! data. Operator edits are untouched: the console and the REST handlers in
-//! [`server::ops::workspace`](crate::server::ops::workspace) call the
-//! [`WorkspaceStore`] port directly and never enter this module.
+//! Two consequences worth stating plainly:
+//!
+//! * A note larger than [`MAX_CONTENT_BYTES`] is agent-read-only — the existing
+//!   `current_len > MAX_CONTENT_BYTES` refusal, now reached by far more notes
+//!   than before. That window is precisely the window in which the old code
+//!   destroyed data. Operator edits are untouched: the console and the REST
+//!   handlers in [`server::ops::workspace`](crate::server::ops::workspace) call
+//!   the [`WorkspaceStore`] port directly and never enter this module.
+//! * Anything the model must *act* on goes in the header, not a trailer. An
+//!   outer cut removes the end of a result first, so guidance parked at the
+//!   bottom disappears exactly when the condition it describes is true.
+//!   [`WorkspaceListTool`] had the same bug in its milder form: its "narrow the
+//!   listing with `prefix`" marker and its `unaddressable` notice both sat below
+//!   up to 300 entries, and the budget bit at roughly 176 — so the advice was
+//!   cut away on precisely the listings long enough to need it. Both now sit
+//!   above the entries, and the entries stop on bytes rather than on a count.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -130,11 +139,28 @@ pub const WORKSPACE_READ_TOOL: &str = "workspace_read";
 /// Tool name: overwrite one workspace note.
 pub const WORKSPACE_WRITE_TOOL: &str = "workspace_write";
 
-/// Max entries one [`WORKSPACE_LIST_TOOL`] call renders before truncating.
+/// Absolute cap on entries one [`WORKSPACE_LIST_TOOL`] call renders.
 ///
 /// A tree this size is already several thousand tokens; past it the agent
-/// should narrow with `prefix` rather than read the whole index.
+/// should narrow with `prefix` rather than read the whole index. This is the
+/// *upper* bound only — the listing usually stops earlier, when the rendered
+/// entries reach [`MAX_LIST_BYTES`]. It was the only bound until issue #417,
+/// and on its own it is the wrong shape: 300 entries at ~90-105 bytes each is
+/// roughly twice what the harness will pass through, so the count never bit
+/// before the byte budget did.
 const MAX_LIST_ENTRIES: usize = 300;
+
+/// Bytes a [`WORKSPACE_LIST_TOOL`] result reserves for everything that is not
+/// an entry line: the header (including the narrowing guidance) and the
+/// `unaddressable` notice.
+const LIST_OVERHEAD_BYTES: usize = 2048;
+
+/// Max bytes of entry lines one [`WORKSPACE_LIST_TOOL`] call renders.
+const MAX_LIST_BYTES: usize = TOOL_RESULT_BUDGET_BYTES - LIST_OVERHEAD_BYTES;
+
+/// The listing's counterpart to the read invariant: a full listing, plus the
+/// header and notice reserved around it, fits under the harness budget.
+const _: () = assert!(MAX_LIST_BYTES + LIST_OVERHEAD_BYTES <= TOOL_RESULT_BUDGET_BYTES);
 
 /// Bytes a [`WORKSPACE_READ_TOOL`] result reserves for everything that is not
 /// the note body: the header, the write-eligibility line, the untrusted-content
@@ -633,7 +659,36 @@ impl Tool for WorkspaceListTool {
         }
 
         let total = entries.len();
-        let shown = total.min(MAX_LIST_ENTRIES);
+
+        // Render entries first, stopping on whichever bound bites: the entry
+        // count, or the byte budget. Counting bytes is the load-bearing half —
+        // an entry line is only ~90-105 bytes, so 300 of them run well past
+        // what the harness will pass through, and the overflow used to be taken
+        // off the end silently (issue #417). Rendering here rather than into
+        // `out` is what lets the header below state a truthful `shown`.
+        let mut rendered = String::new();
+        let mut shown = 0usize;
+        for entry in entries.into_iter().take(MAX_LIST_ENTRIES) {
+            let line = format!(
+                "{kind}\t{path}\tid={id}\trev={rev}\n",
+                kind = kind_label(entry.node.kind),
+                path = entry.path,
+                id = entry.node.id,
+                rev = entry.node.updated_at_millis,
+            );
+            if rendered.len() + line.len() > MAX_LIST_BYTES {
+                break;
+            }
+            rendered.push_str(&line);
+            shown += 1;
+        }
+
+        // Header, then the `unaddressable` notice, then the entries. The first
+        // two are things the model has to act on; the entries are the part it
+        // is safe to lose the tail of, so they go last. The reverse order (the
+        // original) put the "narrow with `prefix`" advice *after* the entries,
+        // where an outer cut removed it precisely when a listing was long
+        // enough to need it.
         let mut out = String::new();
         match &prefix {
             Some(prefix) => out.push_str(&format!(
@@ -646,18 +701,11 @@ impl Tool for WorkspaceListTool {
             " — {shown} of {total} entries. Read one with `{WORKSPACE_READ_TOOL}` using its path \
              or id.\n"
         ));
-        for entry in entries.into_iter().take(shown) {
-            out.push_str(&format!(
-                "{kind}\t{path}\tid={id}\trev={rev}\n",
-                kind = kind_label(entry.node.kind),
-                path = entry.path,
-                id = entry.node.id,
-                rev = entry.node.updated_at_millis,
-            ));
-        }
         if total > shown {
             out.push_str(&format!(
-                "[… {} more entries not shown. Narrow the listing with the `prefix` parameter.]\n",
+                "The other {} entries are NOT listed below — this result is size-capped. Narrow \
+                 the listing with the `prefix` parameter to reach them; re-running this same call \
+                 returns the same entries.\n",
                 total - shown
             ));
         }
@@ -669,6 +717,7 @@ impl Tool for WorkspaceListTool {
                 index.unaddressable
             ));
         }
+        out.push_str(&rendered);
         Ok(ToolResult::success(out))
     }
 }
@@ -1703,6 +1752,128 @@ mod tests {
 
         let (_, body) = store.read(&id, "n-big").await.unwrap().unwrap();
         assert_eq!(body.len(), big.len(), "the oversized note was clobbered");
+    }
+
+    /// A store that answers `tree()` from a fixed node list and nothing else.
+    ///
+    /// The listing bounds have to be exercised against a tree big enough to hit
+    /// them and containing nodes no real backend will create for us — a
+    /// dangling parent, to raise `unaddressable`. `FsOps` refuses both, so the
+    /// only way to reach that rendering is to hand the index the tree directly.
+    struct FixedTree(Vec<WorkspaceNode>);
+
+    #[async_trait]
+    impl WorkspaceStore for FixedTree {
+        async fn tree(&self, _company: &CompanyId) -> crate::Result<Vec<WorkspaceNode>> {
+            Ok(self.0.clone())
+        }
+        async fn read(
+            &self,
+            _company: &CompanyId,
+            _id: &str,
+        ) -> crate::Result<Option<(WorkspaceNode, String)>> {
+            unreachable!("the listing never reads a body")
+        }
+        async fn write(
+            &self,
+            _company: &CompanyId,
+            _id: &str,
+            _content: &str,
+        ) -> crate::Result<WorkspaceNode> {
+            unreachable!("the listing never writes")
+        }
+        async fn create(
+            &self,
+            _company: &CompanyId,
+            _node: &WorkspaceNode,
+            _content: Option<&str>,
+        ) -> crate::Result<()> {
+            unreachable!("the listing never creates")
+        }
+        async fn rename_move(
+            &self,
+            _company: &CompanyId,
+            _id: &str,
+            _name: Option<&str>,
+            _parent_id: Option<Option<&str>>,
+        ) -> crate::Result<WorkspaceNode> {
+            unreachable!("the listing never renames")
+        }
+        async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+            unreachable!("the listing never deletes")
+        }
+        async fn is_empty(&self, _company: &CompanyId) -> crate::Result<bool> {
+            Ok(self.0.is_empty())
+        }
+    }
+
+    /// Issue #417's second head: the listing's own guidance was unreachable.
+    ///
+    /// `MAX_LIST_ENTRIES` is 300 but an entry renders at ~90-105 bytes, so the
+    /// harness budget bit at roughly 176 — below the count bound, which means
+    /// the "… more entries not shown, narrow with `prefix`" marker was never
+    /// even generated, and the `unaddressable` notice below it was cut away
+    /// too. Both sat at the end of the body, which is the end an outer cut
+    /// takes first.
+    ///
+    /// So the listing must stop on bytes, and both trailers must move above the
+    /// entries where no cut can reach them.
+    #[tokio::test]
+    async fn a_long_listing_fits_the_budget_and_carries_its_guidance_in_the_header() {
+        let mut nodes = vec![folder("f-standards", "Standards", None)];
+        for n in 0..MAX_LIST_ENTRIES {
+            nodes.push(file(
+                &format!("node-{n:04}-0000000000"),
+                &format!("Engineering standards v{n:03}.md"),
+                Some("f-standards"),
+            ));
+        }
+        // Two nodes whose ancestor chain dangles, so `unaddressable` is set.
+        nodes.push(file("n-orphan-a", "orphan-a.md", Some("gone")));
+        nodes.push(file("n-orphan-b", "orphan-b.md", Some("gone")));
+
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
+        let list = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let out = text(&list.execute(json!({})).await.unwrap());
+
+        // The whole listing reaches the model, so nothing below is cut off.
+        assert!(
+            out.len() <= TOOL_RESULT_BUDGET_BYTES,
+            "the listing rendered {} bytes, over the {TOOL_RESULT_BUDGET_BYTES}-byte harness \
+             budget — the outer cut would fire and take the last entries with it",
+            out.len(),
+        );
+
+        // The byte bound is what stopped it, not the count bound: this tree has
+        // 301 addressable entries and fewer are shown. If only the count bound
+        // existed the marker below would never be generated at all.
+        let shown: usize = out.matches("\tid=").count();
+        assert!(
+            shown > 0 && shown < MAX_LIST_ENTRIES,
+            "expected a partial listing, got {shown} of {MAX_LIST_ENTRIES}"
+        );
+        assert!(
+            out.contains(&format!("{shown} of {} entries", MAX_LIST_ENTRIES + 1)),
+            "the header must count honestly: {}",
+            &out[..out.len().min(400)]
+        );
+
+        // Everything the model has to act on precedes the first entry line, so
+        // truncating the tail can never remove it.
+        let first_entry = out.find("\tid=").expect("entries were rendered");
+        let head = &out[..first_entry];
+        assert!(
+            head.contains("Narrow the listing with the `prefix` parameter"),
+            "the narrowing guidance is not in the header: {head}"
+        );
+        assert!(
+            head.contains("node(s) have no valid path and were omitted entirely"),
+            "the unaddressable notice is not in the header: {head}"
+        );
+        assert!(
+            head.contains("2 node(s)"),
+            "the unaddressable count is wrong: {head}"
+        );
     }
 
     /// The nonce off a read's BEGIN fence, so a test can demand the *matching*

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -604,6 +604,112 @@ async fn an_edit_between_turns_changes_what_the_next_turn_reads() {
     );
 }
 
+/// Issue #417, through the one path that can actually prove it: the harness's
+/// own tool-result budget, applied by the real middleware.
+///
+/// The unit tests in [`workspace_tools`](crate::harness::workspace_tools) can
+/// only assert that a read *renders* under some number. They cannot see the
+/// second bound — `ToolOutputMiddleware`, fed from
+/// [`TOOL_RESULT_BUDGET_BYTES`](crate::harness::build::TOOL_RESULT_BUDGET_BYTES)
+/// via `AgentBuilder::context_config` — which cuts every tool result on its way
+/// into the model's context. That bound is what made the old 64 KiB read cap a
+/// data-loss bug: the module reported nothing dropped, and the model got the
+/// first ~16 KiB and an anonymous byte marker.
+///
+/// So this reads a 20 KiB note through the whole pipeline and asserts on the
+/// bytes the *model* received. Two properties, and the second is the one no
+/// unit test can reach:
+///
+/// 1. The read never invites a rewrite of a note it only partly returned.
+/// 2. The result arrives whole — closing fence last, and no
+///    `tool_result_budget` marker, meaning the outer cut never fired at all.
+///
+/// (2) failing is the exact shape of the original bug: an unterminated fence
+/// means the untrusted-content region was left open, and it means the module's
+/// idea of what it returned and the model's idea of what it received have come
+/// apart again.
+#[tokio::test]
+async fn an_oversized_note_reaches_the_model_whole_and_read_only() {
+    let (base_url, script) = spawn_script(vec![
+        Turn::Call {
+            tool: "workspace_read",
+            args: json!({ "path": "Standards/Big standard.md" }),
+        },
+        Turn::Say("I read what I could of it."),
+    ])
+    .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (pool, deps, record, store) = harness(base_url, "\"workspace\"", dir.path()).await;
+
+    // Larger than the read cap, smaller than the old 64 KiB one — the window
+    // in which a note used to be silently shortened and then overwritten.
+    let body = "The operator wrote this and expects to keep it. ".repeat(440);
+    assert!(
+        body.len() > 16 * 1024 && body.len() < 64 * 1024,
+        "{}",
+        body.len()
+    );
+    store
+        .create(
+            &record.id,
+            &note("n-big", "Big standard.md", "f-std"),
+            Some(&body),
+        )
+        .await
+        .unwrap();
+
+    pool.run(
+        &record.id,
+        "ceo",
+        "What does the big standard say?",
+        &deps,
+        None,
+    )
+    .await
+    .expect("turn runs");
+
+    let results = tool_results(&script);
+    let read = results
+        .iter()
+        .find(|r| r.contains("BEGIN WORKSPACE NOTE"))
+        .unwrap_or_else(|| panic!("the read result never reached the model: {results:?}"));
+
+    // (1) The model is told it may not write, and is never handed the sentence
+    // that drove the overwrite.
+    assert!(read.contains("CANNOT be overwritten"), "{read}");
+    assert!(
+        !read.contains("complete new body"),
+        "the model was invited to rewrite a note it only partly received: {read}"
+    );
+
+    // (2) The result the model got is the result the module rendered.
+    assert!(
+        !read.contains("truncated by tool_result_budget"),
+        "the harness cut the read result — the two bounds still disagree: {read}"
+    );
+    let at = read
+        .find("--- BEGIN WORKSPACE NOTE ")
+        .expect("the read is fenced");
+    let nonce = read[at + "--- BEGIN WORKSPACE NOTE ".len()..]
+        .split_whitespace()
+        .next()
+        .expect("the fence carries a nonce");
+    assert!(
+        read.trim_end()
+            .ends_with(&format!("--- END WORKSPACE NOTE {nonce} ---")),
+        "the model never received the closing fence, so the untrusted-content region it was \
+         warned about was left open: {read}"
+    );
+
+    // Not vacuous: the body really did travel, and really was shortened.
+    assert!(read.contains("The operator wrote this and expects to keep it."));
+    assert!(
+        read.contains(&format!("of {} bytes", body.len())),
+        "the header should say how much of the note exists: {read}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // The approval boundary, driven by a model (issues #443, #444)
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #417.

`workspace_read` capped a note at `MAX_CONTENT_BYTES` (64 KiB) and emitted its
**write-eligible** branch whenever its own `dropped == 0` — telling the agent to
call `workspace_write` with "the complete new body". But the harness applies a
second, smaller bound to every tool result (`DEFAULT_TOOL_RESULT_BUDGET_BYTES`,
16 KiB), and `build_agent` never called `context_config`, so that default was
inherited silently.

For a note between the two numbers the module believed nothing was dropped, the
model saw roughly the first 16 KiB, and it complied — writing back the fragment
it had seen. `MAX_WRITE_BYTES` accepted it. **The rest of the note was destroyed
and nothing in the loop reported a loss.**

This restores the invariant the module documents for itself — *a truncated read
can never become a write* — by making the module's own bound the effective one,
so its gate and the model's actual view agree.

The same shape was fixed in `workspace_list`: its "narrow with `prefix`" guidance
sat at the end of the body, so it was cut away precisely when the listing was
long enough to need it. Trailers the model must act on now live in the header,
where an outer cut cannot remove them.

## API Or Behavior Changes

**Notes between 12 KiB and 64 KiB become agent-readable but not agent-writable.**
That window is the data-loss window itself, so the change is intended, but it is
user-visible: an agent that could previously revise such a note now receives
`Refused: … larger than the 12288-byte read limit`.

Operator edits are unaffected — the console and REST write path
(`server::ops::workspace::write_file`) does not go through `workspace_tools.rs`.
Verified directly rather than assumed: that module has no reference to either cap,
both are private consts with no re-export, and the frontend applies no size check.

`workspace_read`'s header now reports `returned X of Y bytes` when truncated.
`workspace_list` renders size-aware, keeping 300 as an absolute cap, with the
narrowing guidance and the `unaddressable` notice above the entries.

The tool-result budget is now stated explicitly in `build_agent` rather than
inherited. Behaviour is identical today; the point is that the number is chosen
here instead of by accident.

## Tests

49 tests in scope, up from 44, including a turn-level test through the real
middleware rather than a mock.

Every negative control was executed — break the fix, run, observe, restore:

| Control | Result |
|---|---|
| `MAX_CONTENT_BYTES` → 64 KiB | **build fails** on the const-assert |
| …assert neutralised so tests run | both read tests fail — one reports `rendered 66505 bytes, over the 16384-byte harness budget`, the other `a partial read still invited a full-body overwrite` |
| `READ_OVERHEAD_BYTES` → 0 | both read tests fail (17353 and 17038 bytes vs the 16384 budget) |
| delete the `current_len` write gate | write-refusal test fails |
| remove the size-aware list stop | list test fails: `rendered 23806 bytes, over the 16384-byte budget` |
| trailers moved back below entries | list test fails: guidance absent from the header at 184 of 301 entries |
| turn test under the old 64 KiB cap | fails — the model received a `[tool_result_preview]` envelope carrying the write-eligible instruction, an unterminated `--- BEGIN WORKSPACE NOTE`, and `[… 573 bytes truncated by tool_result_budget …]` with **no closing fence** |

That last one is the defect reproduced verbatim in the real pipeline.

Worth recording: the pre-existing test for this area passed with the bug present.
It exercised cap + 4 KiB, so it was structurally blind to the 16–64 KiB window.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex --lib harness::workspace` — 49 passed

Adjacent scopes re-run green: `harness::build` 19, `policy::` 92,
`runtime::builder` 23, `harness::toolbelt` 15.

`cargo build --all-targets`: N/A — the two clippy lanes above build all targets in
both feature configurations.

## Documentation

`docs/spec/runtime/manifest.md` — the 64 KiB figure was stale; the caps are now
documented as derived from the harness budget.

## Open question for review

`READ_OVERHEAD_BYTES` is 4096, but measured framing is ~969 bytes — about 4x
headroom, and every byte of it comes out of what an agent may write. Tightening to
2048 would still double the measured worst case and would raise the writable
ceiling from 12 KiB to 14 KiB. Kept at 4096 here; happy to change it if reviewers
prefer the tighter number.

Separately, and out of scope: the operator write path has **no** size limit of its
own — no handler validation, no body-limit layer, no store cap. The only backstop
is axum's implicit 2 MiB JSON extractor limit. Pre-existing, worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace tool output limits now adapt to the available response budget.
  * Large workspace listings and notes are clearly marked when truncated, including returned and total sizes.
  * Path information is safely shortened to preserve useful content within the limit.

* **Bug Fixes**
  * Prevented writes to content that was only partially read, avoiding accidental data loss.
  * Improved boundary handling so outputs remain within the configured tool-result budget.

* **Documentation**
  * Updated workspace tool documentation to describe dynamic limits, truncation behavior, and write restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->