### PR TITLE
feat(connections): offer the toolkits the backend actually permits, not a hardcoded eight (#397)

### DIFF
--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -49,11 +49,28 @@ export interface ComposioStatus {
   openMode: boolean;
   /**
    * The toolkits to render as provider rows — the manifest list when non-empty,
-   * else a curated starting set. In open mode this is a suggestion, not a
-   * limit: any slug the backend permits can still be authorized, which is what
-   * the "other provider" field is for.
+   * else the backend's live catalog. In open mode this is still not a hard
+   * limit: any slug the backend permits can be authorized, which is what the
+   * "other provider" field is for.
    */
   effectiveToolkits: string[];
+  /**
+   * Where {@link effectiveToolkits} came from (issue #397).
+   *
+   * - `manifest` — the company's own allowlist, offered verbatim. Not a
+   *   degradation: the company chose this list.
+   * - `backend` — Composio's live catalog. Authoritative.
+   * - `fallback` — the catalog could not be fetched, so this is a built-in
+   *   starter list that may be incomplete. Always paired with
+   *   {@link catalogNotice}.
+   *
+   * Rendering a `fallback` the same way as a `backend` list would waste the
+   * distinction: eight providers would look like the whole set, which is the
+   * shape of the bug this issue was reopened for.
+   */
+  catalogSource: "manifest" | "backend" | "fallback";
+  /** Why the list is a fallback, for the operator. `null` unless degraded. */
+  catalogNotice: string | null;
 }
 
 /** A mutating response: the resulting status plus a plain-language note. */

--- a/frontend/src/lib/composio-catalog.ts
+++ b/frontend/src/lib/composio-catalog.ts
@@ -1,0 +1,198 @@
+// Turning the host's Composio status into the provider rows the console renders
+// (issue #397).
+//
+// The host now answers open mode with the backend's live catalog — roughly a
+// hundred toolkits — rather than a hardcoded eight. A hundred rows is its own
+// usability problem, and dumping them unsorted and unfiltered would trade one
+// broken page for another. These helpers own the two decisions that fixes:
+//
+//  1. **Order**, so the answer to "where is Gmail" is "at the top", not "row
+//     thirty-one". Connected providers first (an operator scanning this panel is
+//     usually checking what is live), then the handful everyone reaches for,
+//     then the long tail alphabetically.
+//  2. **Reach**, so the tail is discoverable. The list collapses to a preview
+//     with an explicit "show all N" and a search box that matches on both slug
+//     and display name. Before this, reaching a provider outside the eight meant
+//     knowing its Composio slug and typing it into a free-text field — which is
+//     a fine escape hatch and a terrible discovery mechanism.
+//
+// Pure functions on purpose: `vitest.config.ts` scopes the unit runner to
+// helpers with no document and no host, and this is exactly that. What the
+// component does with the rows belongs in `test/e2e`.
+
+import type { ComposioStatus } from "@/api/composio";
+
+/** Friendly display labels for the common toolkits; slug-cased fallback otherwise. */
+const TOOLKIT_LABELS: Record<string, string> = {
+  gmail: "Gmail",
+  slack: "Slack",
+  github: "GitHub",
+  googlecalendar: "Google Calendar",
+  googledrive: "Google Drive",
+  googlesheets: "Google Sheets",
+  googledocs: "Google Docs",
+  notion: "Notion",
+  linear: "Linear",
+  discord: "Discord",
+  hubspot: "HubSpot",
+  jira: "Jira",
+  asana: "Asana",
+  trello: "Trello",
+  zendesk: "Zendesk",
+  salesforce: "Salesforce",
+  dropbox: "Dropbox",
+  airtable: "Airtable",
+  calendly: "Calendly",
+  stripe: "Stripe",
+  shopify: "Shopify",
+  twitter: "X (Twitter)",
+  linkedin: "LinkedIn",
+  youtube: "YouTube",
+  outlook: "Outlook",
+  onedrive: "OneDrive",
+  sharepoint: "SharePoint",
+  supabase: "Supabase",
+  gitlab: "GitLab",
+  bitbucket: "Bitbucket",
+};
+
+/**
+ * A display label for a toolkit slug.
+ *
+ * The table is a nicety, not a catalog — it exists so `googlecalendar` reads as
+ * "Google Calendar" rather than "Googlecalendar". A slug missing from it is
+ * title-cased and still renders; nothing here can hide a provider the host sent.
+ * That is the distinction #397 turns on: the *list* comes from the backend, and
+ * only its *typography* is local.
+ */
+export function toolkitLabel(slug: string): string {
+  const key = slug.trim().toLowerCase();
+  return TOOLKIT_LABELS[key] ?? (key ? key.charAt(0).toUpperCase() + key.slice(1) : slug);
+}
+
+/**
+ * The providers a company reaches for first, in the order they are surfaced.
+ *
+ * Purely an ordering hint for the rendered list — it never adds a row, never
+ * removes one, and is not what the host offers. A curated slug absent from the
+ * host's list is simply absent.
+ */
+export const CURATED_TOOLKITS: readonly string[] = [
+  "gmail",
+  "googlecalendar",
+  "googledrive",
+  "github",
+  "slack",
+  "notion",
+  "linear",
+  "discord",
+];
+
+/** How many rows show before the operator asks for the rest. */
+export const PREVIEW_COUNT = 12;
+
+/** One provider row as the section renders it. */
+export interface ProviderRow {
+  /** The Composio toolkit slug — the key every host call is made with. */
+  slug: string;
+  /** What the operator reads. */
+  label: string;
+  /** Whether the company has at least one active connection for it. */
+  connected: boolean;
+  /** Whether it is one of the {@link CURATED_TOOLKITS}. */
+  curated: boolean;
+}
+
+/**
+ * Build the ordered provider rows.
+ *
+ * `effective` is the host's answer (manifest list, backend catalog, or flagged
+ * fallback — this function does not care which, and must not: re-deciding here
+ * what the host already decided is how the two drifted apart in the first
+ * place). `extra` carries slugs the operator connected through the free-text
+ * field this session, so they keep a row instead of vanishing. `connected` maps
+ * lowercased slug to connected state.
+ *
+ * Order: connected, then curated, then the rest alphabetically. Duplicates
+ * collapse; blank slugs are dropped.
+ */
+export function buildProviderRows(
+  effective: readonly string[],
+  extra: readonly string[],
+  connected: Readonly<Record<string, boolean>>,
+): ProviderRow[] {
+  const seen = new Set<string>();
+  const rows: ProviderRow[] = [];
+  for (const raw of [...effective, ...extra]) {
+    const slug = raw.trim().toLowerCase();
+    if (!slug || seen.has(slug)) continue;
+    seen.add(slug);
+    rows.push({
+      slug,
+      label: toolkitLabel(slug),
+      connected: connected[slug] === true,
+      curated: CURATED_TOOLKITS.includes(slug),
+    });
+  }
+  const rank = (row: ProviderRow) => (row.connected ? 0 : row.curated ? 1 : 2);
+  return rows.sort((a, b) => {
+    if (rank(a) !== rank(b)) return rank(a) - rank(b);
+    if (rank(a) === 1) return CURATED_TOOLKITS.indexOf(a.slug) - CURATED_TOOLKITS.indexOf(b.slug);
+    return a.label.localeCompare(b.label);
+  });
+}
+
+/**
+ * Narrow rows to a search query, matched case-insensitively against both the
+ * slug and the display label.
+ *
+ * Both halves matter: an operator who knows the product types "google calendar"
+ * and an operator who knows Composio types `googlecalendar`, and neither should
+ * come up empty.
+ */
+export function filterProviderRows(rows: readonly ProviderRow[], query: string): ProviderRow[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...rows];
+  return rows.filter((row) => row.slug.includes(q) || row.label.toLowerCase().includes(q));
+}
+
+/**
+ * The rows to actually render, and whether anything is being held back.
+ *
+ * A search shows every match — someone who typed a query wants the answer, not
+ * the first twelve answers. Without one, a long list collapses to
+ * {@link PREVIEW_COUNT} unless the operator has expanded it.
+ */
+export function visibleProviderRows(
+  rows: readonly ProviderRow[],
+  query: string,
+  expanded: boolean,
+): { visible: ProviderRow[]; hidden: number } {
+  const matched = filterProviderRows(rows, query);
+  if (query.trim() || expanded || matched.length <= PREVIEW_COUNT) {
+    return { visible: matched, hidden: 0 };
+  }
+  return { visible: matched.slice(0, PREVIEW_COUNT), hidden: matched.length - PREVIEW_COUNT };
+}
+
+/**
+ * The warning to show the operator when the list they are looking at is not the
+ * backend's real catalog, or `null` when it is trustworthy.
+ *
+ * This is the console half of the host's honesty contract. The host marks a
+ * fallback as `catalogSource: "fallback"` and says why; if the console then
+ * rendered it identically to a fetched catalog, the marking would have bought
+ * nothing — the operator would still be looking at eight providers with no way
+ * to know the other ninety exist.
+ *
+ * `manifest` is not a degradation: a company that narrowed its own allowlist is
+ * seeing exactly what it chose, and telling it the list "may be incomplete"
+ * would be false.
+ */
+export function catalogWarning(status: Pick<ComposioStatus, "catalogSource" | "catalogNotice">): string | null {
+  if (status.catalogSource !== "fallback") return null;
+  return (
+    status.catalogNotice ??
+    "Composio's provider catalog could not be fetched, so this is a built-in starter list and may be incomplete."
+  );
+}

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,5 +1,17 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { Check, KeyRound, Loader2, LogIn, Plug, Save, ShieldCheck, Trash2 } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertTriangle,
+  Check,
+  ChevronDown,
+  KeyRound,
+  Loader2,
+  LogIn,
+  Plug,
+  Save,
+  Search,
+  ShieldCheck,
+  Trash2,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
@@ -17,6 +29,12 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  buildProviderRows,
+  catalogWarning,
+  toolkitLabel,
+  visibleProviderRows,
+} from "@/lib/composio-catalog";
 
 interface Props {
   client: OpenCompanyClient;
@@ -32,20 +50,6 @@ interface Props {
    * operator has already pasted a live credential into it.
    */
   canManage: boolean;
-}
-
-/** Friendly display labels for the common toolkits; slug-cased fallback otherwise. */
-const TOOLKIT_LABELS: Record<string, string> = {
-  gmail: "Gmail",
-  slack: "Slack",
-  github: "GitHub",
-  googlecalendar: "Google Calendar",
-  notion: "Notion",
-  linear: "Linear",
-};
-
-function toolkitLabel(slug: string): string {
-  return TOOLKIT_LABELS[slug.toLowerCase()] ?? slug.charAt(0).toUpperCase() + slug.slice(1);
 }
 
 /**
@@ -81,13 +85,21 @@ export function ComposioSection({ client, company, canManage }: Props) {
   // Only meaningful in the attested state, where the paste card is an override
   // rather than the way in.
   const [showOverride, setShowOverride] = useState(false);
-  // Open mode only: a slug typed into the "another provider" field. Open mode
-  // permits every toolkit the backend allows, and the curated rows are a
-  // starting point rather than the whole set (issue #397).
+  // Open mode only: a slug typed into the "connect by slug" field. It is now an
+  // escape hatch rather than the way to reach the tail — the rows above are the
+  // backend's real catalog — but it still earns its place: it is the only way to
+  // connect a provider when the catalog could not be fetched, and the only way
+  // to reach one the catalog happens to omit (issue #397).
   const [otherToolkit, setOtherToolkit] = useState("");
   // Slugs connected through that field this session, so they get a row of their
   // own instead of vanishing after a successful sign-in.
   const [extraToolkits, setExtraToolkits] = useState<string[]>([]);
+  // Provider search. In open mode the host now hands over the backend's real
+  // catalog — roughly a hundred toolkits — so finding one by scrolling stopped
+  // being reasonable (issue #397).
+  const [query, setQuery] = useState("");
+  // Whether the operator asked to see past the preview.
+  const [expanded, setExpanded] = useState(false);
 
   const requestGeneration = useRef(0);
   const pollTimers = useRef<Record<string, number>>({});
@@ -143,6 +155,8 @@ export function ComposioSection({ client, company, canManage }: Props) {
     setShowOverride(false);
     setOtherToolkit("");
     setExtraToolkits([]);
+    setQuery("");
+    setExpanded(false);
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -222,6 +236,17 @@ export function ComposioSection({ client, company, canManage }: Props) {
     }
   }
 
+  // Ordered once per status/connection change: connected first, then the
+  // handful everyone reaches for, then the tail alphabetically. Ordering and
+  // filtering live in `@/lib/composio-catalog` so they are testable without a
+  // document — see `vitest.config.ts` on where the line sits.
+  const rows = useMemo(
+    () => buildProviderRows(status?.effectiveToolkits ?? [], extraToolkits, connected),
+    [status?.effectiveToolkits, extraToolkits, connected],
+  );
+  const { visible, hidden } = visibleProviderRows(rows, query, expanded);
+  const degraded = status ? catalogWarning(status) : null;
+
   if (load === "unavailable") return null;
 
   const attested = status?.credentialSource === "attested";
@@ -299,24 +324,42 @@ export function ComposioSection({ client, company, canManage }: Props) {
                     authorize against. Paste a token below first.
                   </p>
                 )}
-                {openMode && (
-                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    This company allows <span className="font-medium">any</span> provider Composio
-                    offers — these are the common ones. Connect a different provider by its slug
-                    below.
+                {degraded ? (
+                  // The host could not read Composio's catalog. Say so — a
+                  // built-in list rendered like a fetched one is a claim we
+                  // cannot back (issue #397).
+                  <p className="flex items-start gap-2 rounded-md bg-amber-500/10 p-2 text-xs text-amber-700 dark:text-amber-400">
+                    <AlertTriangle className="mt-px size-3 shrink-0" />
+                    <span>{degraded}</span>
                   </p>
+                ) : (
+                  openMode && (
+                    <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                      This company allows <span className="font-medium">any</span> provider Composio
+                      offers — {rows.length} in total, most-used first. Search to narrow them.
+                    </p>
+                  )
+                )}
+                {rows.length > 8 && (
+                  <div className="relative">
+                    <Search className="absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+                    <Input
+                      aria-label="Search providers"
+                      autoComplete="off"
+                      className="pl-7"
+                      placeholder={`Search ${rows.length} providers…`}
+                      value={query}
+                      onChange={(e) => setQuery(e.target.value)}
+                    />
+                  </div>
                 )}
                 <ul className="divide-y divide-border">
-                  {[
-                    ...status.effectiveToolkits,
-                    ...extraToolkits.filter((t) => !status.effectiveToolkits.includes(t)),
-                  ].map((toolkit) => {
-                    const isConnected = connected[toolkit.toLowerCase()] === true;
-                    const isSigningIn = signingIn === toolkit;
+                  {visible.map((row) => {
+                    const isSigningIn = signingIn === row.slug;
                     return (
-                      <li key={toolkit} className="flex items-center justify-between py-2">
-                        <span className="text-sm">{toolkitLabel(toolkit)}</span>
-                        {isConnected ? (
+                      <li key={row.slug} className="flex items-center justify-between py-2">
+                        <span className="text-sm">{row.label}</span>
+                        {row.connected ? (
                           <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
                             <Check className="size-3" /> connected
                           </span>
@@ -327,7 +370,7 @@ export function ComposioSection({ client, company, canManage }: Props) {
                             size="sm"
                             variant="outline"
                             disabled={signingIn !== null || noCredential}
-                            onClick={() => void signIn(toolkit)}
+                            onClick={() => void signIn(row.slug)}
                           >
                             {isSigningIn ? (
                               <Loader2 className="size-4 animate-spin" />
@@ -341,11 +384,23 @@ export function ComposioSection({ client, company, canManage }: Props) {
                     );
                   })}
                 </ul>
+                {visible.length === 0 && query.trim() !== "" && (
+                  <p className="py-2 text-xs text-muted-foreground">
+                    No provider matches “{query.trim()}”. Composio&apos;s slug may differ from the
+                    product name — try connecting it by slug below.
+                  </p>
+                )}
+                {hidden > 0 && (
+                  <Button size="sm" variant="ghost" onClick={() => setExpanded(true)}>
+                    <ChevronDown className="size-4" />
+                    Show all {rows.length} providers
+                  </Button>
+                )}
                 {openMode && canManage && (
                   <div className="flex items-end gap-2 border-t border-border pt-3">
                     <div className="flex-1 space-y-1">
                       <Label htmlFor="composio-other-toolkit" className="text-xs">
-                        Another provider
+                        Connect by slug
                       </Label>
                       <Input
                         id="composio-other-toolkit"

--- a/frontend/test/unit/composio-catalog.test.ts
+++ b/frontend/test/unit/composio-catalog.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  CURATED_TOOLKITS,
+  PREVIEW_COUNT,
+  buildProviderRows,
+  catalogWarning,
+  filterProviderRows,
+  toolkitLabel,
+  visibleProviderRows,
+} from "@/lib/composio-catalog";
+
+/** A hundred-slug catalog — the shape the backend actually returns. */
+function hundredSlugs(): string[] {
+  return Array.from({ length: 100 }, (_, i) => `provider${String(i).padStart(3, "0")}`);
+}
+
+describe("toolkitLabel", () => {
+  it("reads a known slug as its product name", () => {
+    expect(toolkitLabel("googlecalendar")).toBe("Google Calendar");
+    expect(toolkitLabel("github")).toBe("GitHub");
+  });
+
+  it("still renders a slug it has never seen", () => {
+    // The list is the backend's; only its typography is ours. A slug missing
+    // from the label table must never be dropped or blanked — that would put a
+    // local table back in charge of what the operator can reach, which is the
+    // bug #397 is about.
+    expect(toolkitLabel("obscureprovider")).toBe("Obscureprovider");
+    expect(toolkitLabel("  MixedCase  ")).toBe("Mixedcase");
+  });
+});
+
+describe("buildProviderRows", () => {
+  it("renders every slug the host sent, whatever it is", () => {
+    const rows = buildProviderRows(hundredSlugs(), [], {});
+    expect(rows).toHaveLength(100);
+  });
+
+  it("puts connected first, then the common ones, then the tail alphabetically", () => {
+    const rows = buildProviderRows(
+      ["zendesk", "gmail", "airtable", "github", "notion"],
+      [],
+      { notion: true },
+    );
+    expect(rows.map((r) => r.slug)).toEqual([
+      // connected first — an operator scanning the panel is checking what is live
+      "notion",
+      // then curated, in curated order
+      "gmail",
+      "github",
+      // then the tail, alphabetically by label
+      "airtable",
+      "zendesk",
+    ]);
+  });
+
+  it("keeps session-connected extras and collapses duplicates and blanks", () => {
+    const rows = buildProviderRows(["gmail", "GMAIL", "", "  "], ["hubspot", "gmail"], {});
+    expect(rows.map((r) => r.slug)).toEqual(["gmail", "hubspot"]);
+  });
+
+  it("marks connection state case-insensitively", () => {
+    const rows = buildProviderRows(["Gmail"], [], { gmail: true });
+    expect(rows[0]).toMatchObject({ slug: "gmail", connected: true, curated: true });
+  });
+});
+
+describe("filterProviderRows", () => {
+  const rows = buildProviderRows(["googlecalendar", "gmail", "hubspot", "zendesk"], [], {});
+
+  it("matches on the product name an operator would type", () => {
+    expect(filterProviderRows(rows, "google cal").map((r) => r.slug)).toEqual(["googlecalendar"]);
+  });
+
+  it("matches on the Composio slug too", () => {
+    // Both halves matter: one operator knows the product, the other knows
+    // Composio, and neither should come up empty.
+    expect(filterProviderRows(rows, "hubspot").map((r) => r.slug)).toEqual(["hubspot"]);
+  });
+
+  it("is case-insensitive and returns nothing for a genuine miss", () => {
+    expect(filterProviderRows(rows, "ZENDESK").map((r) => r.slug)).toEqual(["zendesk"]);
+    expect(filterProviderRows(rows, "nothing-like-this")).toEqual([]);
+  });
+
+  it("an empty query narrows nothing", () => {
+    expect(filterProviderRows(rows, "   ")).toHaveLength(rows.length);
+  });
+});
+
+describe("visibleProviderRows", () => {
+  const rows = buildProviderRows(hundredSlugs(), [], {});
+
+  it("collapses a hundred rows to a preview and reports what is held back", () => {
+    // The reason this exists: the host now serves the real catalog, and
+    // rendering a hundred unfiltered rows would trade one broken page for
+    // another.
+    const { visible, hidden } = visibleProviderRows(rows, "", false);
+    expect(visible).toHaveLength(PREVIEW_COUNT);
+    expect(hidden).toBe(100 - PREVIEW_COUNT);
+  });
+
+  it("shows everything once the operator expands", () => {
+    const { visible, hidden } = visibleProviderRows(rows, "", true);
+    expect(visible).toHaveLength(100);
+    expect(hidden).toBe(0);
+  });
+
+  it("a search reaches past the preview — the tail must be discoverable", () => {
+    // provider0NN — 10 matches, all beyond the twelve-row preview for most of
+    // them. A search that only looked at the preview would make the long tail
+    // unreachable by name, leaving the slug field as the only route to it.
+    const { visible, hidden } = visibleProviderRows(rows, "provider09", false);
+    expect(visible.map((r) => r.slug)).toEqual([
+      "provider090",
+      "provider091",
+      "provider092",
+      "provider093",
+      "provider094",
+      "provider095",
+      "provider096",
+      "provider097",
+      "provider098",
+      "provider099",
+    ]);
+    expect(hidden).toBe(0);
+  });
+
+  it("a short list is never collapsed", () => {
+    const short = buildProviderRows(CURATED_TOOLKITS, [], {});
+    const { visible, hidden } = visibleProviderRows(short, "", false);
+    expect(visible).toHaveLength(short.length);
+    expect(hidden).toBe(0);
+  });
+});
+
+describe("catalogWarning", () => {
+  it("warns the operator when the list is a fallback, and says why", () => {
+    // The console half of the host's honesty contract. A fallback rendered
+    // identically to a fetched catalog would make the host's marking worthless:
+    // eight providers would look like the whole set.
+    const warning = catalogWarning({
+      catalogSource: "fallback",
+      catalogNotice: "Composio's provider catalog could not be fetched (connection refused).",
+    });
+    expect(warning).toContain("connection refused");
+  });
+
+  it("still warns when the host sent no reason", () => {
+    const warning = catalogWarning({ catalogSource: "fallback", catalogNotice: null });
+    expect(warning).toContain("may be incomplete");
+  });
+
+  it("stays silent for a real catalog", () => {
+    expect(catalogWarning({ catalogSource: "backend", catalogNotice: null })).toBeNull();
+  });
+
+  it("stays silent for a company's own allowlist", () => {
+    // `manifest` is not a degradation — the company chose that list, and telling
+    // it the list "may be incomplete" would be false.
+    expect(catalogWarning({ catalogSource: "manifest", catalogNotice: null })).toBeNull();
+  });
+});

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -215,7 +215,10 @@ fn slug_toolkit(slug: &str) -> String {
 }
 
 #[cfg(feature = "composio")]
-pub use live::{ComposioMetering, authorize_connect_url, composio_tools, list_connection_states};
+pub use live::{
+    ComposioMetering, authorize_connect_url, composio_tools, list_catalog_toolkits,
+    list_connection_states,
+};
 
 #[cfg(feature = "composio")]
 mod live {
@@ -426,6 +429,55 @@ mod live {
                 .or_insert(active);
         }
         Ok(states.into_iter().collect())
+    }
+
+    /// The backend's live Composio toolkit catalog — every slug it will let
+    /// this tenant connect. Backs the console's open-mode provider list
+    /// (issue #397).
+    ///
+    /// This is the same `GET /agent-integrations/composio/toolkits` call the
+    /// `composio_list_toolkits` agent tool makes and the same one OpenHuman's
+    /// Skills grid drives off, so the console offers what the backend actually
+    /// permits instead of a list maintained by hand here.
+    ///
+    /// Deliberately **not** filtered by the tenant allowlist, unlike
+    /// [`list_connection_states`]: the only caller is the open-mode path, where
+    /// the allowlist is empty by definition. A company with a non-empty
+    /// allowlist is offered its own list verbatim and never reaches this
+    /// function — the catalog must not be able to widen a manifest that
+    /// deliberately narrowed.
+    ///
+    /// Entries are the catalog's **connectable** slugs — `enabled == true`,
+    /// mirroring the vendored runtime's own `connectable_toolkit_slugs`, since
+    /// advertising a provider the backend gate will refuse only invites a failed
+    /// sign-in. Backends predating the dynamic catalog send no `catalog[]` at
+    /// all; their plain slug allowlist is used instead. Slugs are trimmed,
+    /// lowercased, de-duplicated and sorted for a stable render order. Any
+    /// upstream error is scrubbed of the tenant bearer before it bubbles.
+    pub async fn list_catalog_toolkits(config: &TenantComposio) -> Result<Vec<String>> {
+        tracing::debug!("[composio] ops list_catalog_toolkits");
+        let (client, secrets) = live_call(config).await?;
+        let resp = match client.list_toolkits().await {
+            Ok(resp) => resp,
+            Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+        };
+        let normalize = |slug: &str| slug.trim().to_ascii_lowercase();
+        let mut slugs: std::collections::BTreeSet<String> = resp
+            .catalog
+            .iter()
+            .filter(|entry| entry.enabled.unwrap_or(false))
+            .map(|entry| normalize(&entry.slug))
+            .filter(|slug| !slug.is_empty())
+            .collect();
+        if slugs.is_empty() {
+            slugs = resp
+                .toolkits
+                .iter()
+                .map(|slug| normalize(slug))
+                .filter(|slug| !slug.is_empty())
+                .collect();
+        }
+        Ok(slugs.into_iter().collect())
     }
 
     // ── composio_list_toolkits ──────────────────────────────────────────
@@ -1232,7 +1284,40 @@ mod ops_helper_tests {
         }))
     }
 
+    /// Mock `GET /agent-integrations/composio/toolkits` — the dynamic catalog
+    /// shape (backend #1012): a `toolkits` allowlist plus a `catalog[]` whose
+    /// entries carry an `enabled` gate. `zendesk` is present but not connectable
+    /// and must not be advertised; the casing and whitespace on `HubSpot` must
+    /// normalise.
+    async fn toolkits_handler() -> axum::Json<Value> {
+        axum::Json(json!({
+            "success": true,
+            "data": {
+                "toolkits": ["gmail", "slack"],
+                "catalog": [
+                    { "slug": " HubSpot ", "name": "HubSpot", "enabled": true },
+                    { "slug": "gmail", "name": "Gmail", "enabled": true },
+                    { "slug": "zendesk", "name": "Zendesk", "enabled": false },
+                    { "slug": "gmail", "name": "Gmail (dup)", "enabled": true }
+                ]
+            }
+        }))
+    }
+
+    /// Mock toolkits route for a backend predating the dynamic catalog: the
+    /// plain slug allowlist and no `catalog[]` at all.
+    async fn legacy_toolkits_handler() -> axum::Json<Value> {
+        axum::Json(json!({
+            "success": true,
+            "data": { "toolkits": ["Notion", "gmail", ""] }
+        }))
+    }
+
     async fn spawn_backend() -> String {
+        spawn_backend_with(get(toolkits_handler)).await
+    }
+
+    async fn spawn_backend_with(toolkits: axum::routing::MethodRouter) -> String {
         let app = Router::new()
             .route(
                 "/agent-integrations/composio/authorize",
@@ -1241,7 +1326,8 @@ mod ops_helper_tests {
             .route(
                 "/agent-integrations/composio/connections",
                 get(connections_handler),
-            );
+            )
+            .route("/agent-integrations/composio/toolkits", toolkits);
         let listener = tokio::net::TcpListener::bind(SocketAddr::from(([127, 0, 0, 1], 0)))
             .await
             .unwrap();
@@ -1291,6 +1377,43 @@ mod ops_helper_tests {
             vec![("gmail".to_string(), true), ("slack".to_string(), false)],
             "gmail active (one ACTIVE row), slack pending only, notion filtered out"
         );
+    }
+
+    /// The console's open-mode source (issue #397): the backend's real catalog,
+    /// normalised. Connectable entries only, trimmed + lowercased, de-duplicated,
+    /// sorted.
+    #[tokio::test]
+    async fn list_catalog_toolkits_returns_the_backends_connectable_catalog() {
+        let url = spawn_backend().await;
+        let catalog = list_catalog_toolkits(&config(&url, Vec::new()))
+            .await
+            .expect("catalog fetch");
+        assert_eq!(
+            catalog,
+            vec!["gmail".to_string(), "hubspot".to_string()],
+            "connectable entries only, normalised, de-duplicated and sorted"
+        );
+    }
+
+    /// A backend predating the dynamic catalog sends no `catalog[]`. Its plain
+    /// slug allowlist is used rather than reporting an empty catalog — which the
+    /// console would (correctly) render as a degraded fallback.
+    #[tokio::test]
+    async fn list_catalog_toolkits_falls_back_to_the_plain_allowlist() {
+        let url = spawn_backend_with(get(legacy_toolkits_handler)).await;
+        let catalog = list_catalog_toolkits(&config(&url, Vec::new()))
+            .await
+            .expect("catalog fetch");
+        assert_eq!(catalog, vec!["gmail".to_string(), "notion".to_string()]);
+    }
+
+    /// An unreachable backend is an error, never a quietly-empty catalog — the
+    /// caller has to be able to tell "nothing is permitted" from "I could not
+    /// ask".
+    #[tokio::test]
+    async fn list_catalog_toolkits_surfaces_a_fetch_failure() {
+        let out = list_catalog_toolkits(&config("http://127.0.0.1:1", Vec::new())).await;
+        out.expect_err("an unreachable backend must not read as an empty catalog");
     }
 
     #[tokio::test]

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -71,66 +71,116 @@ use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyEvent;
 use crate::server::error::ApiError;
+use crate::server::ops::composio_toolkits::{self, CatalogSource, OpenModeToolkits};
 use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The reminder attached to every mutating response.
 const SWITCH_NOTE: &str =
     "Agents pick up the new Composio token on their next turn — no restart needed.";
 
-/// The providers the console offers when a company is in **open mode** (issue
-/// #397).
+/// The toolkits the console should offer for a company, whether that answer
+/// came from open mode, and where the list came from.
 ///
-/// An empty `[tools.composio].toolkits` means "defer to the backend's
-/// server-enforced allowlist" — i.e. *every* toolkit is permitted, roughly a
-/// hundred slugs. The console previously read that same empty list as "offer
-/// nothing", so the one value meaning *allow everything* rendered zero provider
-/// rows on 19 of 20 shipped templates.
+/// A non-empty manifest allowlist is authoritative and is offered **verbatim**:
+/// a company that deliberately narrowed its belt sees exactly what it chose, the
+/// backend catalog is not consulted, and nothing can widen it. That is not a
+/// performance shortcut — it is the boundary. Widening a restrictive manifest
+/// from a catalog fetch would silently hand a company providers it decided
+/// against.
 ///
-/// Two things are wrong with simply listing all hundred: the console does not
-/// know the backend's allowlist without a network round-trip on a page-load
-/// path, and a hundred rows is its own usability problem. So open mode offers
-/// this curated set — the toolkits a company actually reaches for first, each of
-/// which is in the backend's default allowlist — and the console pairs it with a
-/// free-text field that can authorize **any** slug the backend permits. The
-/// curated list is a starting point, never a ceiling: nothing here narrows what
-/// the backend or the agent-side allowlist admits.
+/// Empty means **open mode**, where the manifest is deferring to the backend's
+/// own server-enforced allowlist. The honest answer there is the backend's live
+/// catalog ([`composio_toolkits`]), fetched once per
+/// [`CATALOG_TTL`](composio_toolkits::CATALOG_TTL) and marked
+/// [`CatalogSource::Fallback`] with a reason if it cannot be had.
+///
+/// Returning the triple (rather than letting the console infer any of it) is the
+/// whole point of the fix: the console must never have to guess which of two
+/// opposite meanings an empty list carries, nor whether the list it is rendering
+/// is the real catalog.
 ///
 /// This is a **console affordance only**. Agent-side toolkit admission is
 /// [`toolkit_allowed`](crate::harness::composio), which still treats an empty
-/// manifest list as "allow every toolkit" — unchanged by this constant.
-pub(crate) const OPEN_MODE_TOOLKITS: &[&str] = &[
-    "gmail",
-    "googlecalendar",
-    "googledrive",
-    "github",
-    "slack",
-    "notion",
-    "linear",
-    "discord",
-];
-
-/// The toolkits the console should offer for a company, and whether that answer
-/// came from open mode.
-///
-/// A non-empty manifest allowlist is authoritative and is offered verbatim — a
-/// company that deliberately narrowed its belt sees exactly what it chose.
-/// Empty means open mode, which offers [`OPEN_MODE_TOOLKITS`].
-///
-/// Returning the pair (rather than letting the console infer open mode from an
-/// empty list) is the whole point of the fix: the console must never again have
-/// to guess which of the two opposite meanings an empty list carries.
-fn effective_toolkits(manifest: &[String]) -> (bool, Vec<String>) {
+/// manifest list as "allow every toolkit" — unchanged by any of this.
+async fn effective_toolkits(
+    runtime: &CompanyRuntime,
+    manifest: &[String],
+) -> (bool, OpenModeToolkits) {
     if manifest.is_empty() {
-        (
-            true,
-            OPEN_MODE_TOOLKITS
-                .iter()
-                .map(|s| (*s).to_string())
-                .collect(),
-        )
+        (true, open_mode_toolkits(runtime).await)
     } else {
-        (false, manifest.to_vec())
+        (
+            false,
+            OpenModeToolkits {
+                toolkits: manifest.to_vec(),
+                source: CatalogSource::Manifest,
+                notice: None,
+            },
+        )
     }
+}
+
+/// Open mode's provider list: the backend's live catalog, cached, or an
+/// honestly-marked fallback.
+///
+/// The cache is consulted before the (cfg-split) fetch and records the outcome
+/// either way, so a status poll during an outage costs a map lookup rather than
+/// another fetch timeout of waiting.
+async fn open_mode_toolkits(runtime: &CompanyRuntime) -> OpenModeToolkits {
+    let key = catalog_cache_key(runtime);
+    if let Some(cached) = composio_toolkits::cache().lookup(&key, std::time::Instant::now()) {
+        return OpenModeToolkits::from_outcome(cached);
+    }
+    let outcome = fetch_catalog(runtime).await;
+    composio_toolkits::cache().store(&key, outcome.clone(), std::time::Instant::now());
+    OpenModeToolkits::from_outcome(outcome)
+}
+
+/// This company's catalog cache key. The backend URL is resolved the same way
+/// the status DTO resolves it, so a company repointed at a different backend
+/// does not read the old backend's catalog.
+fn catalog_cache_key(runtime: &CompanyRuntime) -> String {
+    use crate::app::config::EnvSource;
+    let env = crate::app::config::ProcessEnv;
+    let backend_url = backend_url_or_default(
+        env.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV),
+        env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
+    );
+    composio_toolkits::cache_key(runtime.id(), &backend_url)
+}
+
+/// Fetch the backend's toolkit catalog for this company, bounded by
+/// `composio_toolkits::FETCH_TIMEOUT`.
+///
+/// `Err` is a plain-language reason the console can show — never a bare
+/// fall-through to a short list that would look authoritative.
+#[cfg(feature = "composio")]
+async fn fetch_catalog(runtime: &CompanyRuntime) -> Result<Vec<String>, String> {
+    // No credential of any tier means there is nothing to dial the backend
+    // with. Say that, rather than spending the timeout to discover it.
+    let config = resolve_tenant(runtime).await.map_err(|_| {
+        "this company has no Composio credential yet, so the catalog cannot be read".to_string()
+    })?;
+    let fetch = crate::harness::composio::list_catalog_toolkits(&config);
+    match tokio::time::timeout(composio_toolkits::FETCH_TIMEOUT, fetch).await {
+        Err(_) => Err(format!(
+            "the Composio backend did not answer within {}s",
+            composio_toolkits::FETCH_TIMEOUT.as_secs()
+        )),
+        Ok(Err(err)) => Err(err.to_string()),
+        Ok(Ok(toolkits)) if toolkits.is_empty() => {
+            Err("the Composio backend returned an empty catalog".to_string())
+        }
+        Ok(Ok(toolkits)) => Ok(toolkits),
+    }
+}
+
+/// Without the `composio` feature there is no client to fetch a catalog with.
+/// The status route still answers (reporting `inBuild:false`), and it says so
+/// rather than presenting the fallback as the backend's list.
+#[cfg(not(feature = "composio"))]
+async fn fetch_catalog(_runtime: &CompanyRuntime) -> Result<Vec<String>, String> {
+    Err("Composio is not compiled into this build".to_string())
 }
 
 /// Builds the Composio management route fragment.
@@ -185,10 +235,23 @@ struct ComposioStatusDto {
     /// empty list reads as.
     open_mode: bool,
     /// The toolkits the console offers as provider rows — the manifest list when
-    /// it is non-empty, else the curated [`OPEN_MODE_TOOLKITS`] starting set. In
-    /// open mode this is a suggestion, not a limit: any slug the backend permits
-    /// can still be authorized.
+    /// it is non-empty, else the backend's live catalog (or, when that cannot be
+    /// fetched, a built-in fallback flagged by [`Self::catalog_source`]). In open
+    /// mode this is still not a hard limit: any slug the backend permits can be
+    /// authorized by typing it.
     effective_toolkits: Vec<String>,
+    /// Where [`Self::effective_toolkits`] came from — `manifest`, `backend`, or
+    /// `fallback` (issue #397).
+    ///
+    /// The console must be able to distinguish "these are the hundred providers
+    /// the backend permits" from "the catalog could not be read, here are eight
+    /// we know of". Both render as a list of slugs; only one of them is
+    /// authoritative, and a console that could not tell them apart would present
+    /// the second as though it were the first.
+    catalog_source: CatalogSource,
+    /// Why the list is a fallback, in plain language for the operator. `None`
+    /// unless [`Self::catalog_source`] is `fallback`.
+    catalog_notice: Option<String>,
 }
 
 /// A mutating response: the resulting status plus the switch reminder.
@@ -278,7 +341,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         )
     };
     let credential_source = credential_source_for(stored, &env);
-    let (open_mode, effective) = effective_toolkits(&toolkits);
+    let (open_mode, effective) = effective_toolkits(runtime, &toolkits).await;
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
         granted,
@@ -286,7 +349,9 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         backend_url: backend_url_or_default(env_url, api_url),
         toolkits,
         open_mode,
-        effective_toolkits: effective,
+        effective_toolkits: effective.toolkits,
+        catalog_source: effective.source,
+        catalog_notice: effective.notice,
     })
 }
 
@@ -312,6 +377,12 @@ async fn set_token(
     store_token(runtime.id(), runtime.secrets().as_ref(), &body.token)
         .await
         .map_err(ApiError)?;
+    // The credential decides which Composio entity the backend resolves, so a
+    // set / rotate / clear can change which catalog this company gets. Drop the
+    // cached one rather than serving the previous account's answer for up to
+    // `CATALOG_TTL` — the response below re-reads the status, so the operator
+    // sees the new list immediately.
+    composio_toolkits::cache().evict(&catalog_cache_key(runtime));
     // After the store, so the journal records a completed change. An empty
     // value is a clear, not a set — the two are worth telling apart in an
     // audit trail, since one grants access and the other withdraws it.
@@ -495,7 +566,8 @@ async fn connections_impl(_runtime: &CompanyRuntime) -> Result<Json<Vec<Connecti
 
 #[cfg(test)]
 mod tests {
-    use super::{ComposioStatusDto, CredentialSource, credential_source_for};
+    use super::{CatalogSource, ComposioStatusDto, CredentialSource, credential_source_for};
+    use crate::server::ops::composio_toolkits;
 
     use axum::body::{Body, to_bytes};
     use axum::http::{Request, StatusCode};
@@ -519,10 +591,23 @@ mod tests {
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {
+        state_with_manifest_id(home, "acme", manifest_toml).await
+    }
+
+    /// The same, under an explicit company id.
+    ///
+    /// The catalog cache is process-wide and keyed by company, so the tests that
+    /// seed it need ids of their own — two tests sharing `acme` would share an
+    /// entry and race.
+    async fn state_with_manifest_id(
+        home: &std::path::Path,
+        company: &str,
+        manifest_toml: &str,
+    ) -> AppState {
         use crate::ports::CompanyStore;
         let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
         let store = FsCompanyStore::new(home.to_path_buf());
-        let id = CompanyId::new("acme");
+        let id = CompanyId::new(company);
         store
             .save(&CompanyRecord {
                 id: id.clone(),
@@ -546,7 +631,7 @@ mod tests {
             .unwrap();
         let state = AppState::new(AppConfig::default());
         state.registry().insert(id, std::sync::Arc::new(runtime));
-        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        crate::server::test_support::seed_fixed_admin(&state, company).await;
         state
     }
 
@@ -556,12 +641,23 @@ mod tests {
         uri: &str,
         body: Option<Value>,
     ) -> (StatusCode, Value, String) {
+        send_for(state, "acme", method, uri, body).await
+    }
+
+    /// [`send`] against a named company's session.
+    async fn send_for(
+        state: &AppState,
+        company: &str,
+        method: &str,
+        uri: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value, String) {
         send_as(
             state,
             method,
             uri,
             body,
-            Auth::Cookie(crate::server::test_support::fixed_cookie("acme")),
+            Auth::Cookie(crate::server::test_support::fixed_cookie(company)),
         )
         .await
     }
@@ -634,7 +730,198 @@ mod tests {
         );
         assert!(
             offered.iter().any(|t| t == "github"),
-            "the curated set covers the common providers: {offered:?}"
+            "the fallback set covers the common providers: {offered:?}"
+        );
+        // No credential and (in the default build) no client, so the catalog
+        // cannot be read. The list is still offered — but it says so.
+        assert_eq!(
+            dto["catalogSource"], "fallback",
+            "an unfetchable catalog must never be reported as the backend's: {dto}"
+        );
+        assert!(
+            dto["catalogNotice"]
+                .as_str()
+                .is_some_and(|n| n.contains("incomplete")),
+            "a fallback tells the operator it may be incomplete: {dto}"
+        );
+    }
+
+    /// The company registered under `company` in `state`.
+    fn runtime_of(state: &AppState, company: &str) -> std::sync::Arc<super::CompanyRuntime> {
+        state
+            .registry()
+            .get(&CompanyId::new(company))
+            .expect("company is registered")
+    }
+
+    /// A hundred-slug catalog, the shape the backend actually returns.
+    fn hundred_slugs() -> Vec<String> {
+        (0..100).map(|i| format!("provider{i:03}")).collect()
+    }
+
+    /// The heart of the reopened issue: in open mode the console is offered the
+    /// **backend's** catalog, not a list maintained by hand in this repo.
+    ///
+    /// The cache is seeded rather than a backend stood up, because what is under
+    /// test is the decision — "open mode serves the fetched catalog" — and not
+    /// the HTTP call, which has its own test beside
+    /// `list_catalog_toolkits`. Seeding proves the thing that regressed: that a
+    /// fetched answer actually reaches the response instead of being discarded
+    /// in favour of the constant.
+    #[tokio::test]
+    async fn open_mode_serves_the_fetched_catalog_rather_than_a_hardcoded_list() {
+        let home_dir = home();
+        let state = state_with_manifest_id(
+            home_dir.path(),
+            "catalogco",
+            "[company]\nname = \"Catalog Co\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
+        )
+        .await;
+        let catalog = hundred_slugs();
+        composio_toolkits::cache().store(
+            &super::catalog_cache_key(runtime_of(&state, "catalogco").as_ref()),
+            Ok(catalog.clone()),
+            std::time::Instant::now(),
+        );
+
+        let (status, dto, raw) =
+            send_for(&state, "catalogco", "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(dto["openMode"], true);
+        assert_eq!(
+            dto["catalogSource"], "backend",
+            "a real catalog is reported as the backend's answer: {dto}"
+        );
+        assert_eq!(
+            dto["catalogNotice"],
+            Value::Null,
+            "nothing to apologise for"
+        );
+        assert_eq!(
+            dto["effectiveToolkits"],
+            json!(catalog),
+            "open mode must serve what the backend permits, verbatim"
+        );
+        assert!(
+            dto["effectiveToolkits"].as_array().unwrap().len()
+                > composio_toolkits::FALLBACK_TOOLKITS.len(),
+            "the fetched catalog is far longer than the built-in list — serving the \
+             constant here is the exact regression this test exists to catch: {dto}"
+        );
+    }
+
+    /// The important one. A company that deliberately narrowed its belt must
+    /// **not** be silently widened by the catalog.
+    ///
+    /// The same hundred-slug catalog is in the cache; this company asked for
+    /// `gmail` and gets `gmail`. Anything that unioned, defaulted-to, or fell
+    /// back to the catalog for an explicit manifest would hand the company
+    /// ninety-nine providers it decided against.
+    #[tokio::test]
+    async fn an_explicit_allowlist_is_never_widened_by_the_catalog() {
+        let home_dir = home();
+        let state = state_with_manifest_id(
+            home_dir.path(),
+            "narrowco",
+            "[company]\nname = \"Narrow Co\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        )
+        .await;
+        composio_toolkits::cache().store(
+            &super::catalog_cache_key(runtime_of(&state, "narrowco").as_ref()),
+            Ok(hundred_slugs()),
+            std::time::Instant::now(),
+        );
+
+        let (status, dto, raw) =
+            send_for(&state, "narrowco", "GET", "/api/v1/company/composio", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(dto["openMode"], false);
+        assert_eq!(dto["effectiveToolkits"], json!(["gmail"]));
+        assert_eq!(dto["toolkits"], json!(["gmail"]));
+        assert_eq!(
+            dto["catalogSource"], "manifest",
+            "the company's own list is the source, and the catalog is not consulted: {dto}"
+        );
+    }
+
+    /// A catalog that cannot be fetched degrades to the built-in list — and the
+    /// response says so, both in `catalogSource` and in words the console can
+    /// show the operator. Silently serving eight slugs that look like the whole
+    /// catalog is the failure this pins shut.
+    #[tokio::test]
+    async fn an_unfetchable_catalog_is_marked_degraded_not_passed_off_as_real() {
+        let home_dir = home();
+        let state = state_with_manifest_id(
+            home_dir.path(),
+            "degradedco",
+            "[company]\nname = \"Degraded Co\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
+        )
+        .await;
+        composio_toolkits::cache().store(
+            &super::catalog_cache_key(runtime_of(&state, "degradedco").as_ref()),
+            Err("connection refused".to_string()),
+            std::time::Instant::now(),
+        );
+
+        let (status, dto, raw) = send_for(
+            &state,
+            "degradedco",
+            "GET",
+            "/api/v1/company/composio",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_eq!(dto["openMode"], true);
+        assert_eq!(
+            dto["catalogSource"], "fallback",
+            "the built-in list must never claim to be the backend's: {dto}"
+        );
+        let notice = dto["catalogNotice"]
+            .as_str()
+            .expect("a degraded list must explain itself");
+        assert!(notice.contains("connection refused"), "{notice}");
+        assert!(notice.contains("may be incomplete"), "{notice}");
+        // Still usable: the operator gets something to click, just not a claim.
+        assert_eq!(
+            dto["effectiveToolkits"],
+            json!(composio_toolkits::FALLBACK_TOOLKITS)
+        );
+    }
+
+    /// A credential change drops the cached catalog: a rotated BYO token can
+    /// resolve to a different Composio account, and serving the previous
+    /// account's list for the rest of the TTL is the stale-by-construction
+    /// answer this issue is about.
+    ///
+    /// Driven through a *clear* rather than a set so the status re-read at the
+    /// end of the write has no credential to dial with — the assertion is about
+    /// the eviction, and a test that reached the network to make it would be a
+    /// different test.
+    #[tokio::test]
+    async fn a_credential_change_evicts_the_cached_catalog() {
+        let home_dir = home();
+        let state = state_with_manifest_id(
+            home_dir.path(),
+            "rotateco",
+            "[company]\nname = \"Rotate Co\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n",
+        )
+        .await;
+        let key = super::catalog_cache_key(runtime_of(&state, "rotateco").as_ref());
+        composio_toolkits::cache().store(&key, Ok(hundred_slugs()), std::time::Instant::now());
+
+        let (status, resp, raw) = send_for(
+            &state,
+            "rotateco",
+            "PUT",
+            "/api/v1/company/composio/token",
+            Some(json!({ "token": "" })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+        assert_ne!(
+            resp["status"]["catalogSource"], "backend",
+            "the pre-change catalog must not survive the change: {resp}"
         );
     }
 
@@ -775,9 +1062,12 @@ mod tests {
             toolkits: vec!["gmail".to_string()],
             open_mode: false,
             effective_toolkits: vec!["gmail".to_string()],
+            catalog_source: CatalogSource::Manifest,
+            catalog_notice: None,
         };
         let json = serde_json::to_value(&dto).unwrap();
         assert_eq!(json["credentialSource"], "attested");
+        assert_eq!(json["catalogSource"], "manifest");
         let keys: Vec<&String> = json.as_object().unwrap().keys().collect();
         assert_eq!(
             keys,
@@ -788,7 +1078,9 @@ mod tests {
                 "backendUrl",
                 "toolkits",
                 "openMode",
-                "effectiveToolkits"
+                "effectiveToolkits",
+                "catalogSource",
+                "catalogNotice"
             ],
             "the read shape must stay exactly this: {keys:?}"
         );

--- a/src/server/ops/composio_toolkits.rs
+++ b/src/server/ops/composio_toolkits.rs
@@ -1,0 +1,393 @@
+//! The toolkit catalog behind Composio **open mode** (issue #397).
+//!
+//! An empty `[tools.composio].toolkits` means "defer to the backend's
+//! server-enforced allowlist" — every toolkit the backend permits, which today
+//! is roughly a hundred slugs. Until this module existed the console was handed
+//! a hardcoded eight instead and the backend's own catalog
+//! (`GET /agent-integrations/composio/toolkits`) was never consulted, so the
+//! list drifted the moment the backend added an integration.
+//!
+//! ## What this module owns
+//!
+//! * the answer for open mode — the fetched catalog, or an honestly-marked
+//!   fallback;
+//! * the process-level cache that keeps a page-load path off the network; and
+//! * [`FALLBACK_TOOLKITS`], the last-resort list, which is **never** presented
+//!   as if it were the real catalog.
+//!
+//! ## Why a fallback still exists
+//!
+//! The fetch needs a credential and a reachable backend, and a build that
+//! compiled the `composio` feature in. A company missing any of those still has
+//! to see something it can click — a console that renders nothing is the exact
+//! failure #397 was filed about. So the fallback stays, but
+//! [`CatalogSource::Fallback`] and a plain-language notice ride along with it so
+//! the console can tell the operator the list may be incomplete. A fallback
+//! served as though it were the catalog would be worse than no fallback: it
+//! looks authoritative and is silently eight items long.
+//!
+//! ## This is a console affordance, not a capability change
+//!
+//! Nothing here widens or narrows what an agent may reach. Agent-side admission
+//! is [`toolkit_allowed`](crate::harness::composio), which is untouched: an
+//! empty manifest allowlist still admits every toolkit, a non-empty one still
+//! admits only its members. Equally, a **non-empty** manifest allowlist never
+//! consults this module at all — a company that deliberately narrowed its belt
+//! is offered exactly what it chose, and the catalog cannot widen it.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+
+/// The last-resort provider list, used only when the real catalog cannot be
+/// fetched — and always accompanied by [`CatalogSource::Fallback`] plus a
+/// notice, so it is never mistaken for the backend's answer.
+///
+/// These are the toolkits a company reaches for first and are all in the
+/// backend's default allowlist, which makes them a defensible thing to show
+/// when the alternative is an empty page. They are **not** a ceiling: the
+/// console's free-text slug field still authorizes anything the backend
+/// permits, and agent-side admission never consulted this list.
+pub(crate) const FALLBACK_TOOLKITS: &[&str] = &[
+    "gmail",
+    "googlecalendar",
+    "googledrive",
+    "github",
+    "slack",
+    "notion",
+    "linear",
+    "discord",
+];
+
+/// How long a successfully fetched catalog is served before it is re-fetched.
+///
+/// Fifteen minutes. The catalog changes when Composio adds an integration or
+/// the backend widens its allowlist — churn measured in days, not seconds. The
+/// cost of staleness is that a brand-new provider is missing from a picker for
+/// at most a quarter of an hour; the cost of no cache is a backend round-trip
+/// on *every* console status poll, on a page-load path, for a list that will be
+/// byte-identical. Fifteen minutes puts the ceiling at four fetches an hour per
+/// company however hard the console polls.
+pub(crate) const CATALOG_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// How long a *failed* fetch is remembered before another is attempted.
+///
+/// One minute — deliberately much shorter than [`CATALOG_TTL`]. A failure is
+/// cached at all because a backend that is down would otherwise be dialled once
+/// per status poll, adding a whole `FETCH_TIMEOUT` to every console page-load for as
+/// long as the outage lasts. It is cached only briefly because the operator
+/// staring at a degraded notice wants it to clear as soon as the backend
+/// recovers, and a minute is short enough that a refresh feels like it worked.
+pub(crate) const FAILURE_TTL: Duration = Duration::from_secs(60);
+
+/// How long the status route waits on the catalog before degrading.
+///
+/// The shared integration client's own timeout is 60s, which is a sane budget
+/// for an agent tool and a catastrophe here: this call sits on `GET …/composio`,
+/// which the console fetches on page load and after every mutation. Five
+/// seconds is long enough for a healthy backend and short enough that a sick one
+/// costs the operator a visible notice rather than a hung panel.
+///
+/// Gated with its only caller: a build without the `composio` feature has no
+/// client to time out.
+#[cfg(feature = "composio")]
+pub(crate) const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Where the toolkit list the console renders actually came from.
+///
+/// The console needs this told to it rather than inferred — the whole shape of
+/// #397 is that an inferred answer was wrong in the one case that mattered.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) enum CatalogSource {
+    /// The company's own `[tools.composio].toolkits`, offered verbatim. The
+    /// catalog is not consulted and cannot widen it.
+    Manifest,
+    /// The backend's live toolkit catalog. This is the answer open mode is
+    /// supposed to give.
+    Backend,
+    /// [`FALLBACK_TOOLKITS`] — the catalog could not be fetched. Always paired
+    /// with a notice saying so.
+    Fallback,
+}
+
+/// The toolkits open mode offers, and how honest the answer is.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct OpenModeToolkits {
+    /// The slugs to offer as provider rows.
+    pub toolkits: Vec<String>,
+    /// Where they came from.
+    pub source: CatalogSource,
+    /// Plain-language reason the list is a fallback, for the console to show the
+    /// operator. `None` exactly when [`Self::source`] is not
+    /// [`CatalogSource::Fallback`].
+    pub notice: Option<String>,
+}
+
+impl OpenModeToolkits {
+    /// The good case: the backend answered.
+    pub(crate) fn from_backend(toolkits: Vec<String>) -> Self {
+        Self {
+            toolkits,
+            source: CatalogSource::Backend,
+            notice: None,
+        }
+    }
+
+    /// The honest degradation: the built-in list, marked as such, with the
+    /// reason attached.
+    pub(crate) fn degraded(reason: &str) -> Self {
+        Self {
+            toolkits: FALLBACK_TOOLKITS.iter().map(|s| (*s).to_string()).collect(),
+            source: CatalogSource::Fallback,
+            notice: Some(format!(
+                "Composio's provider catalog could not be fetched ({}), so this is a built-in \
+                 starter list and may be incomplete. Any other provider the backend permits can \
+                 still be connected by its slug.",
+                bound_reason(reason)
+            )),
+        }
+    }
+
+    /// Turn a cached-or-fresh fetch outcome into the rendered answer.
+    pub(crate) fn from_outcome(outcome: Result<Vec<String>, String>) -> Self {
+        match outcome {
+            Ok(toolkits) => Self::from_backend(toolkits),
+            Err(reason) => Self::degraded(&reason),
+        }
+    }
+}
+
+/// Keep an upstream reason to one readable clause.
+///
+/// The upstream text has already had the tenant bearer stripped out of it by
+/// the harness before it reaches here; this is a legibility bound, not a
+/// security one. A backend that answers with a wall of HTML should not push a
+/// wall of HTML into a status response.
+fn bound_reason(reason: &str) -> String {
+    const MAX: usize = 160;
+    let reason = reason.trim().replace(['\n', '\r'], " ");
+    if reason.is_empty() {
+        return "no reason given".to_string();
+    }
+    match reason.char_indices().nth(MAX) {
+        None => reason,
+        Some((cut, _)) => format!("{}…", &reason[..cut]),
+    }
+}
+
+/// One cached fetch outcome and when it was recorded.
+struct CacheEntry {
+    at: Instant,
+    outcome: Result<Vec<String>, String>,
+}
+
+impl CacheEntry {
+    /// Successes live for [`CATALOG_TTL`], failures for [`FAILURE_TTL`].
+    fn ttl(&self) -> Duration {
+        if self.outcome.is_ok() {
+            CATALOG_TTL
+        } else {
+            FAILURE_TTL
+        }
+    }
+}
+
+/// A process-level, per-company cache of the fetched catalog.
+///
+/// Keyed per company rather than per backend URL even though the catalog is
+/// mostly a property of the backend: a company's own BYO token can resolve to a
+/// different Composio account with a different answer, and sharing one entry
+/// across tenants would let one company's outage mark another company's panel
+/// degraded. Entries are small (a hundred short strings) and bounded by the
+/// number of companies an instance hosts.
+#[derive(Default)]
+pub(crate) struct CatalogCache {
+    entries: Mutex<HashMap<String, CacheEntry>>,
+}
+
+impl CatalogCache {
+    /// The cached outcome for `key`, if one was recorded within its TTL of
+    /// `now`. An expired entry reads as a miss and is left for the next
+    /// [`Self::store`] to overwrite.
+    pub(crate) fn lookup(&self, key: &str, now: Instant) -> Option<Result<Vec<String>, String>> {
+        let entries = self.entries.lock().ok()?;
+        let entry = entries.get(key)?;
+        (now.saturating_duration_since(entry.at) < entry.ttl()).then(|| entry.outcome.clone())
+    }
+
+    /// Record an outcome as observed at `at`.
+    pub(crate) fn store(&self, key: &str, outcome: Result<Vec<String>, String>, at: Instant) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.insert(key.to_string(), CacheEntry { at, outcome });
+        }
+    }
+
+    /// Drop `key`'s entry so the next read re-fetches.
+    ///
+    /// Called when the company's credential changes: a rotated BYO token can
+    /// resolve to a different Composio account, and continuing to serve the old
+    /// account's catalog for up to [`CATALOG_TTL`] would be exactly the kind of
+    /// stale-by-construction answer this issue is about.
+    pub(crate) fn evict(&self, key: &str) {
+        if let Ok(mut entries) = self.entries.lock() {
+            entries.remove(key);
+        }
+    }
+}
+
+/// The process-wide catalog cache.
+pub(crate) fn cache() -> &'static CatalogCache {
+    static CACHE: OnceLock<CatalogCache> = OnceLock::new();
+    CACHE.get_or_init(CatalogCache::default)
+}
+
+/// The cache key for a company on a backend. Both halves matter: the same
+/// company reconfigured onto a different backend must not read the old
+/// backend's catalog.
+pub(crate) fn cache_key(company: &crate::ports::types::CompanyId, backend_url: &str) -> String {
+    format!("{company}|{backend_url}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn slugs(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    /// A fetched catalog is served as the backend's answer, with nothing
+    /// apologising for it.
+    #[test]
+    fn a_fetched_catalog_is_reported_as_the_backend_answer() {
+        let resolved = OpenModeToolkits::from_outcome(Ok(slugs(&["gmail", "hubspot", "zendesk"])));
+        assert_eq!(resolved.source, CatalogSource::Backend);
+        assert_eq!(resolved.toolkits, slugs(&["gmail", "hubspot", "zendesk"]));
+        assert_eq!(resolved.notice, None, "a real catalog needs no caveat");
+    }
+
+    /// The honesty requirement: a failed fetch still yields a usable list, but
+    /// it is marked as a fallback AND says why, so the console can tell the
+    /// operator the list may be incomplete. A fallback that reported
+    /// `CatalogSource::Backend`, or carried no notice, would look exactly like
+    /// the real catalog — which is the failure mode this test exists to stop.
+    #[test]
+    fn a_failed_fetch_degrades_visibly_and_says_why() {
+        let resolved = OpenModeToolkits::from_outcome(Err("backend unreachable".to_string()));
+        assert_eq!(resolved.source, CatalogSource::Fallback);
+        assert_eq!(resolved.toolkits, slugs(FALLBACK_TOOLKITS));
+        let notice = resolved.notice.expect("a fallback must explain itself");
+        assert!(
+            notice.contains("backend unreachable"),
+            "the operator is told the actual reason: {notice}"
+        );
+        assert!(
+            notice.contains("may be incomplete"),
+            "the operator is told the list is not authoritative: {notice}"
+        );
+    }
+
+    /// An upstream error that arrives as a wall of text is bounded before it
+    /// reaches a status response.
+    #[test]
+    fn an_enormous_upstream_reason_is_bounded() {
+        let resolved = OpenModeToolkits::from_outcome(Err("x".repeat(5_000)));
+        let notice = resolved.notice.expect("fallback notice");
+        assert!(
+            notice.len() < 500,
+            "unbounded reason: {} bytes",
+            notice.len()
+        );
+        assert!(notice.contains('…'), "the cut is visible: {notice}");
+    }
+
+    /// Bounding is UTF-8 safe — a multi-byte reason must not panic on a byte
+    /// slice through a codepoint.
+    #[test]
+    fn bounding_a_multibyte_reason_does_not_panic() {
+        let bounded = bound_reason(&"é".repeat(500));
+        assert!(bounded.ends_with('…'));
+    }
+
+    /// A newline-laden reason collapses to one clause, and an empty one still
+    /// produces a sentence rather than an awkward gap.
+    #[test]
+    fn a_reason_is_normalised() {
+        assert_eq!(bound_reason("  a\nb  "), "a b");
+        assert_eq!(bound_reason("   "), "no reason given");
+    }
+
+    /// A stored success is served for `CATALOG_TTL` and not a moment longer.
+    #[test]
+    fn a_cached_catalog_expires_at_the_ttl() {
+        let cache = CatalogCache::default();
+        let at = Instant::now();
+        cache.store("k", Ok(slugs(&["gmail"])), at);
+
+        assert_eq!(
+            cache.lookup("k", at + CATALOG_TTL - Duration::from_secs(1)),
+            Some(Ok(slugs(&["gmail"]))),
+            "inside the TTL the cache answers without a fetch"
+        );
+        assert_eq!(
+            cache.lookup("k", at + CATALOG_TTL + Duration::from_secs(1)),
+            None,
+            "past the TTL the caller must re-fetch"
+        );
+    }
+
+    /// A failure is remembered — so an outage does not cost a timeout per poll
+    /// — but for a fraction of the success TTL, so recovery is visible quickly.
+    #[test]
+    fn a_cached_failure_expires_far_sooner_than_a_success() {
+        let cache = CatalogCache::default();
+        let at = Instant::now();
+        cache.store("k", Err("boom".to_string()), at);
+
+        assert!(
+            FAILURE_TTL < CATALOG_TTL,
+            "a remembered failure must not outlive a remembered success"
+        );
+        assert_eq!(
+            cache.lookup("k", at + FAILURE_TTL - Duration::from_secs(1)),
+            Some(Err("boom".to_string())),
+            "a repeat poll during an outage is served from cache, not the network"
+        );
+        assert_eq!(
+            cache.lookup("k", at + FAILURE_TTL + Duration::from_secs(1)),
+            None,
+            "a recovered backend is re-probed within the minute"
+        );
+    }
+
+    /// An eviction forces the next read to re-fetch — the credential-rotation
+    /// path.
+    #[test]
+    fn eviction_forces_a_refetch() {
+        let cache = CatalogCache::default();
+        let at = Instant::now();
+        cache.store("k", Ok(slugs(&["gmail"])), at);
+        cache.evict("k");
+        assert_eq!(cache.lookup("k", at), None);
+    }
+
+    /// Companies do not share an entry: one tenant's outage cannot mark another
+    /// tenant's panel degraded, and a BYO token pointing at a different Composio
+    /// account cannot leak its catalog sideways.
+    #[test]
+    fn companies_do_not_share_a_cache_entry() {
+        use crate::ports::types::CompanyId;
+        let url = "https://api.example.test";
+        assert_ne!(
+            cache_key(&CompanyId::new("acme"), url),
+            cache_key(&CompanyId::new("globex"), url)
+        );
+        assert_ne!(
+            cache_key(&CompanyId::new("acme"), url),
+            cache_key(&CompanyId::new("acme"), "https://other.example.test")
+        );
+    }
+}

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -19,6 +19,7 @@ pub mod artifacts;
 pub mod capabilities;
 pub mod channels;
 pub mod composio;
+pub mod composio_toolkits;
 pub mod connections_read;
 pub mod domain;
 pub mod finances;


### PR DESCRIPTION
## Summary

Closes #397.

In open mode the console offered a **hardcoded list of eight** toolkits. The
backend's own catalog runs to roughly a hundred, and
`/agent-integrations/composio/toolkits` was called nowhere in this repo — so an
operator could only connect providers someone had remembered to add to a constant.

Open mode now serves the catalog the backend actually permits, fetched over the
existing platform-attested per-tenant credential. OpenHuman's Skills page has
always worked this way; this brings the console in line.

#402 fixed the sharper half of this issue — the console no longer has to infer
open mode from an empty manifest list — and all of that is preserved. This is the
half that was deferred, which the constant's own doc comment acknowledged: *"a
curated list is a starting point, never a ceiling."*

## API Or Behavior Changes

`GET …/composio` gains `catalogSource` (`manifest` / `backend` / `fallback`) and
`catalogNotice`.

- **Open mode** serves the fetched catalog's connectable slugs (`enabled == true`).
- **An explicit manifest allowlist is unchanged** — served verbatim, on a separate
  branch that never consults the catalog. A company that deliberately narrowed its
  belt is never silently widened.
- **A failed fetch degrades visibly.** The former eight-item list survives as a
  last-resort fallback, but is tagged `fallback` and rendered under a notice saying
  the list may be incomplete.

That last point is a deliberate divergence from OpenHuman, which falls back to a
known-list silently. On a desktop app an operator can open a dev console and see
what happened; a hosted operator cannot, so a silent fallback would be
indistinguishable from a real catalog.

Agent-side toolkit admission (`toolkit_allowed`) is **untouched** — this is a
console affordance, not a capability change.

Catalog cache: 15 minutes on success (catalog churn is measured in days; caps at
four fetches per hour per company however hard the console polls), 60 seconds on
failure so recovery surfaces within a minute, and a 5-second fetch timeout because
the shared client's own 60-second default would hang a page load.

Console: connected providers first, then the commonly-reached-for set, then the
tail alphabetically; collapsed to a 12-row preview with "Show all N providers". A
search box appears past 8 rows and matches slug **or** product name, so both
`googlecalendar` and "google calendar" find the same row. The default view stays
the size it is today — nothing regresses for the common case — while the tail
becomes discoverable by name instead of by guessing a slug. The connect-by-slug
field stays, since it is the only route when the catalog cannot be fetched.

No new client: the vendored `ComposioClient::list_toolkits` already existed and is
reused.

## Tests

Negative controls, all executed:

| Control | Result |
|---|---|
| open mode reverted to the constant | 4 tests failed |
| catalog allowed to override an explicit manifest | `an_explicit_allowlist_is_never_widened_by_the_catalog` failed, alone |
| failure falls back silently | 3 failed, incl. the degraded-marking test |
| `toolkit_allowed` inverted | 2 failed — proves admission is genuinely untouched |
| frontend: local label table filters the host's list | 8 failed |
| frontend: search only looks inside the preview | 3 failed |
| frontend: fallback rendered with no warning | 2 failed |

Verified in a real browser against a mock 100-toolkit backend: `catalogSource:
backend`, 100 slugs with the `enabled:false` entry correctly excluded, a connected
provider sorted first, search reaching a slug past the preview, and "Show all 100"
rendering the full set. Pointed at a dead port: `catalogSource: fallback`, eight
rows under the incomplete-list notice.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test` — `server::ops::composio` 26 passed; full suite 1602; gated `--tests` 2420
- [x] `cargo check --all-features`
- [x] frontend — `npx vitest run` 147 passed, all three typechecks, `npm run build`

`cargo build --all-targets`: N/A — covered by the clippy lanes above.

## Documentation

Module docs updated in place alongside the changed code. No spec file needed a
change; the toolkit-source behaviour is described where it is implemented.

## Related — found while verifying, not fixed here

The console's other hardcoded catalog, `CONNECTION_PROVIDERS`, has 11 native-OAuth
tiles of which only `slack`, `gmail` and `github` have a backend key. Two are worse
than missing: `provider_config_from` builds env keys as
`OPENCOMPANY_OAUTH_{ID}_ID`, so a hyphenated id yields
`OPENCOMPANY_OAUTH_GOOGLE-CALENDAR_ID` — a name no shell can export, making those
tiles structurally unreachable.

Deliberately not fixed here. The obvious retarget would make two tiles share an id
that is both the React key and the connection-state key, and that id is a
documented end-to-end contract with the manifest's `[[connection]] provider`. The
mechanism to fix it properly already exists — `connections_read::connect_route`
answers "can a Connect succeed here?" per provider — but `project_connections` only
iterates declared manifest connections, so undeclared catalog tiles get no host
answer and keep a live-looking button. Filing separately.

These should not be merged into the Composio catalog: a toolkit appearing in
Composio's catalog says nothing about whether this host holds an OAuth app for it.
