### PR TITLE
feat(console): show a workflow run's output, and an actionable no-inference banner (#528)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -308,10 +308,21 @@ export function getWorkflow(
 /**
  * Runs a workflow.
  *
- * With `detach` the host answers as soon as the run has an id (`202`), instead
- * of holding the request open for the whole run — which is what stops a proxy's
- * idle timeout from severing a healthy multi-minute run. The outcome then
- * arrives over the event stream and in {@link listWorkflowRuns}.
+ * **The console omits `detach` on purpose (issue #528).** A run's full `output`
+ * is carried ONLY by the settled `200` body: the journal, the SSE frames, and
+ * {@link listWorkflowRuns} are all structural (per-node status and timing, no
+ * agent text), and there is no run-detail route to fetch the output back later.
+ * The one surface that renders what a run produced mounts on that body, so the
+ * console must hold the request open to receive it. This is affordable because
+ * since #383 the host runs even the synchronous path on a spawned server task —
+ * the run itself survives a dropped connection; only the answer rides the wire.
+ *
+ * With `detach` the host instead answers as soon as the run has an id (`202`),
+ * without holding the request open — which stops a proxy's idle timeout from
+ * severing a healthy multi-minute run, at the cost of the console never seeing
+ * the output. The option is kept for callers that only need the run to start
+ * (e.g. a fire-and-forget trigger) and will read the outcome from the stream or
+ * the history.
  *
  * **Always check {@link isDetached} on the result**, whatever you asked for: a
  * host predating #383 ignores the flag and answers with the settled run, and

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -16,6 +16,7 @@ import {
   Loader2,
   Pencil,
   Play,
+  Plug,
   Plus,
   RotateCw,
   Square,
@@ -52,7 +53,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
   Select,
@@ -64,6 +65,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { WorkflowNode } from "@/components/workflow-node";
 import { WorkflowCreateDialog } from "@/views/WorkflowCreateDialog";
+import { cn } from "@/lib/utils";
 import type { NodeRunState } from "@/lib/workflow-sample";
 // Issue #303: the canvas arithmetic, the run-state folds and the three drawers
 // moved out when this file passed 1800 lines and was about to grow an index and
@@ -79,6 +81,7 @@ import {
 import { LastRunChip, RunHistoryPanel } from "@/views/workflows/RunHistoryPanel";
 import { WorkflowIndex, type IndexMode } from "@/views/workflows/WorkflowIndex";
 import { CopilotPanel } from "@/views/workflows/CopilotPanel";
+import { classifyRunError } from "@/views/workflows/run-error";
 import { RunResultPanel } from "@/views/workflows/RunResultPanel";
 import { NodeDetailPanel } from "@/views/workflows/NodeDetailPanel";
 
@@ -282,6 +285,17 @@ export function WorkflowsView({
   // button must be disabled during the request too, and a rejected request
   // never produces a run id.
   const [starting, setStarting] = useState(false);
+  // Issue #528 / #514: a run the host REFUSED for a reason the operator can act
+  // on — no inference source configured, or a saved one a restart owes. Like a
+  // version conflict, this is not a toast: the fix is a few clicks away in
+  // Settings, so it earns a persistent banner keyed on the structured `code`.
+  const [runRefusal, setRunRefusal] = useState<{ code: string; message: string } | null>(null);
+  // Issue #528: whether a NON-scheduled `workflow_run_started` frame for the
+  // workflow on screen has arrived since the last dispatch — i.e. our own run
+  // reached the engine before the connection could drop. A ref, not state,
+  // because the `run()` catch reads it synchronously and it must not itself
+  // trigger a render. Reset at the top of every `run()`.
+  const sawOwnRunStartRef = useRef(false);
   // The run whose cancel came back 404, if any.
   //
   // Deliberately a run id rather than a boolean. A 404 is ambiguous — either
@@ -695,6 +709,10 @@ export function WorkflowsView({
   const run = useCallback(async () => {
     if (!selectedId) return;
     setStarting(true);
+    // Clear the last refusal and the own-run-start watch before this attempt, so
+    // neither leaks into the new run's triage (issue #528).
+    setRunRefusal(null);
+    sawOwnRunStartRef.current = false;
     // Issue #371: clear the previous run's marks and paint the opening frontier
     // immediately, so the canvas responds to the click rather than waiting on
     // the first frame. The `workflow_run_started` frame re-sets the same thing
@@ -705,20 +723,25 @@ export function WorkflowsView({
     // can never disagree.
     const asked = request.trim();
     try {
-      // Issue #383: ask to detach. The host answers as soon as the run has an
-      // id, so the console stops holding a request open for the whole run — the
-      // thing a proxy's idle timeout severs.
+      // Issue #528: run SYNCHRONOUSLY — no `detach`. The run's full `output` is
+      // carried ONLY by this settled 200 body; the journal, SSE, and runs list
+      // are structural (per-node status, no agent text), and there is no
+      // run-detail route to fetch it back. So `RunResultPanel` — the only surface
+      // that renders what a run produced — can mount only when this body reaches
+      // the `setResult` branch below. The cost of asking synchronously is just
+      // that the body must arrive: since #383 the host runs the sync path on a
+      // spawned server task, so the run itself survives a dropped connection —
+      // the connection carries the answer, it does not carry the run.
       const res = await runWorkflow(
         client,
         company,
         selectedId,
         asked ? { request: asked } : {},
-        { detach: true },
       );
       setRanWith(asked);
-      // Discriminate on the SHAPE, never on what we asked for. A host predating
-      // #383 ignores `detach` and answers with the settled run — a perfectly
-      // good answer, just a different one.
+      // The `isDetached` branch is kept verbatim as a compatibility seam: a host
+      // that answers with an acceptance for any reason still reads correctly —
+      // discriminate on the SHAPE, never on what we asked for.
       if (isDetached(res)) {
         setActiveRunId(res.runId);
         setAwaitingRunId(res.runId);
@@ -732,16 +755,37 @@ export function WorkflowsView({
       // chip and the panel reflect it immediately.
       setRunsTick((n) => n + 1);
     } catch (e) {
-      toast.error(e instanceof Error ? e.message : "could not run the workflow");
-      // A run that failed is journaled too (#228), and is the outcome most
-      // worth finding again later — so refresh the history on this path as well.
-      setRunsTick((n) => n + 1);
-      // Drop the optimistic frontier so a failed run does not leave a node
-      // pulsing "running" forever. The fold owns anything actually reported.
-      setOptimistic(null);
-      // Nothing was accepted, so nothing is in flight to guard against or to
-      // offer a Cancel for.
-      setActiveRunId(null);
+      // Issue #528 / #514: triage on the STRUCTURED shape, not the message.
+      const kind = classifyRunError(e, sawOwnRunStartRef.current);
+      if (kind === "refusal-inference" && e instanceof ApiError) {
+        // The host refused the run for a reason the operator clears from
+        // Settings. Raise the persistent banner keyed on the code and swallow the
+        // toast — a vanishing raw-string toast is a dead end for a fixable state.
+        // Nothing ran, so drop the optimistic frontier and the in-flight guard.
+        setRunRefusal({ code: e.code, message: e.message });
+        setOptimistic(null);
+        setActiveRunId(null);
+      } else if (kind === "connection-lost") {
+        // The request's connection dropped, but we saw the run start, and the
+        // host's spawned task (#383) keeps walking the graph. Keep the optimistic
+        // canvas and the Stop button (adopted from the live fold), tell the
+        // operator where the outcome will surface, and lean on the history poll.
+        toast.info(
+          "The run continues on the host — watch the canvas; the outcome lands in History.",
+        );
+        setRunsTick((n) => n + 1);
+      } else {
+        toast.error(e instanceof Error ? e.message : "could not run the workflow");
+        // A run that failed is journaled too (#228), and is the outcome most
+        // worth finding again later — so refresh the history on this path as well.
+        setRunsTick((n) => n + 1);
+        // Drop the optimistic frontier so a failed run does not leave a node
+        // pulsing "running" forever. The fold owns anything actually reported.
+        setOptimistic(null);
+        // Nothing was accepted, so nothing is in flight to guard against or to
+        // offer a Cancel for.
+        setActiveRunId(null);
+      }
     } finally {
       setStarting(false);
     }
@@ -882,6 +926,23 @@ export function WorkflowsView({
     setOptimistic(null);
   }, [liveRun]);
 
+  // Issue #528: adopt the live run's id while the synchronous POST is still in
+  // flight.
+  //
+  // The always-detach path (#383) used to seed `activeRunId` straight from the
+  // acceptance body, which is what put the mid-run Stop button on screen. Running
+  // synchronously (so the settled body can carry the output) removed that seed,
+  // so restore it from the live fold: while the request is open and the fold has
+  // adopted OUR own — non-scheduled — run, take its id. A concurrent cron fire is
+  // `scheduled` and must never be adopted here. Recording that we saw our own
+  // start frame is also what lets the run() catch tell a survivable dropped
+  // connection ("the run continues on the host") from a run that never began.
+  useEffect(() => {
+    if (!starting || !liveRun || !liveRun.active || liveRun.scheduled) return;
+    sawOwnRunStartRef.current = true;
+    if (activeRunId === null) setActiveRunId(liveRun.runId);
+  }, [starting, liveRun, activeRunId]);
+
   // Issue #383: release the Run guard when the run we started actually settles,
   // as reported by the live frames. This is the fast path.
   useEffect(() => {
@@ -925,10 +986,19 @@ export function WorkflowsView({
   // journals, but this view is no longer the place watching it, and leaving a
   // Cancel button pointed at another workflow's run would be worse than losing
   // the affordance.
+  //
+  // Issue #528: it must also drop the run RESULT and any run refusal. Now that a
+  // synchronous run populates `result` on every modern host, a stale run-output
+  // drawer (or a "no inference" banner) would otherwise outlive the switch and
+  // read as belonging to the newly-selected workflow. The graph fetch clears
+  // `result` too, but making it explicit here keeps both switch axes honest even
+  // if the graph load is skipped or in flight.
   useEffect(() => {
     setOptimistic(null);
     setOverlayRun(null);
     setActiveRunId(null);
+    setResult(null);
+    setRunRefusal(null);
   }, [selectedId, company]);
 
   // Issue #339: `?run=<runId>` — open the canvas showing that past run.
@@ -1296,6 +1366,34 @@ export function WorkflowsView({
                 <RotateCw className="mr-1.5 size-4" />
                 Reload
               </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+      )}
+
+      {/* Issue #528 / #514: the host refused the run for a reason the operator
+          can clear from Settings. Persistent (not a toast) and mirroring the
+          conflict banner's layout, with the fix one click away. Keyed on the
+          structured `code`, never the prose. */}
+      {runRefusal && (
+        <div className="px-4 pt-3">
+          <Alert variant="destructive" data-testid="workflow-run-inference-alert">
+            <AlertDescription className="flex flex-wrap items-center justify-between gap-2">
+              <span>
+                {runRefusal.code === "inference_required"
+                  ? "This company has no inference provider configured, so workflows can't run. Set a provider under Settings → Connections → Inference, then run again."
+                  : runRefusal.message}
+              </span>
+              {runRefusal.code === "inference_required" && (
+                <a
+                  href="#/settings/connections"
+                  className={cn(buttonVariants({ variant: "outline", size: "sm" }))}
+                  data-testid="workflow-run-inference-cta"
+                >
+                  <Plug className="mr-1.5 size-4" />
+                  Set up inference
+                </a>
+              )}
             </AlertDescription>
           </Alert>
         </div>

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -58,7 +58,7 @@ export function RunResultPanel({
   ).length;
 
   return (
-    <div className="border-t bg-card/60">
+    <div className="border-t bg-card/60" data-testid="workflow-run-result">
       <div className="flex items-center justify-between px-4 py-2">
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run result</span>

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -25,6 +25,16 @@ export interface LiveRun {
   elapsed: Record<string, number>;
   /** False once the run has settled — its ok/error marks stay, its running ones go. */
   active: boolean;
+  /**
+   * Whether a cron started this run rather than an operator (issue #528).
+   *
+   * Read verbatim off the winning `workflow_run_started` frame. It lets the
+   * console tell its OWN manual run apart from a concurrent scheduled fire while
+   * the run POST is still open: the synchronous run path (#528) re-seeds the
+   * mid-run Stop button and the connection-lost triage from the live fold, and a
+   * cron run — which nobody clicked Run for — must never feed either.
+   */
+  scheduled: boolean;
 }
 
 /** Folds the run-progress frame window (issue #371) into the canvas state for
@@ -60,6 +70,7 @@ export function foldLiveRun(
   if (started.type !== "workflow_run_started") return null;
 
   const runId = started.runId;
+  const scheduled = started.scheduled;
   // The trigger fired by definition, and the engine reports no step for it, so
   // nothing else would ever mark it. Its successors are where execution is now.
   const states = initialRunState(graph);
@@ -101,7 +112,7 @@ export function foldLiveRun(
     }
   }
 
-  return { runId, states, elapsed, active };
+  return { runId, states, elapsed, active, scheduled };
 }
 
 /** A node's display name, falling back to its id when the graph is not loaded

--- a/frontend/src/views/workflows/run-error.ts
+++ b/frontend/src/views/workflows/run-error.ts
@@ -1,0 +1,65 @@
+// How the Workflows console reads a failed run POST (issues #528, #514).
+//
+// Pure and React-free so the triage can be unit-tested on its own: the
+// `run()` catch in `WorkflowsView` is otherwise the only place this logic
+// lives, and it is exactly the part where a wrong branch turns a fixable
+// refusal into a vanishing toast, or a survivable dropped connection into a
+// "the run failed" lie.
+
+import { ApiError } from "@/api/types";
+
+/**
+ * The host refusal codes that mean "the run never started, and the operator can
+ * fix it" (issue #514).
+ *
+ * `inference_required` — the company has never configured an inference source,
+ * so there is no brain to run the workflow. `restart_required` — a saved
+ * inference config is stranded behind a boot decision and a restart would pick
+ * it up. Both are `409`s from the host's own `{error, code}` envelope.
+ *
+ * `not_wired` is DELIBERATELY absent. On a genuinely inference-less build the
+ * host answers that as a `404`, and treating it as a run-refusal would tell the
+ * operator to configure a provider the deployment cannot use — issue #514
+ * exists precisely to split those two, so re-merging them here would undo it.
+ * The set is keyed on the structured `code` ONLY; never string-match the prose.
+ */
+export const INFERENCE_RUN_CODES: ReadonlySet<string> = new Set([
+  "inference_required",
+  "restart_required",
+]);
+
+/**
+ * What a rejected run POST actually was:
+ *
+ * * `refusal-inference` — the host considered the run and refused it for a
+ *   reason the operator clears from Settings (no inference / restart owed). Gets
+ *   a persistent banner, not a toast.
+ * * `connection-lost` — nothing was refused; the connection dropped, but the run
+ *   is still walking its graph on the host (issue #383's spawned server task
+ *   survives a severed request). Only claimed when this view actually saw its
+ *   own run's start frame, so it is honest about "still going".
+ * * `other` — a real failure to report as-is.
+ */
+export type RunErrorClass = "refusal-inference" | "connection-lost" | "other";
+
+/**
+ * Classifies a rejected `runWorkflow` POST.
+ *
+ * `sawOwnRunStart` is whether a NON-scheduled `workflow_run_started` frame for
+ * the workflow on screen has arrived since this run was dispatched — i.e. the
+ * run reached the engine before the connection died. Without it a status-0 or
+ * upstream-5xx failure is just a failure: we cannot promise "it continues on the
+ * host" for a run we never saw begin.
+ */
+export function classifyRunError(e: unknown, sawOwnRunStart: boolean): RunErrorClass {
+  if (!(e instanceof ApiError)) return "other";
+  // Refusal first: it is the one branch keyed on a host envelope (`fromHost`)
+  // AND a specific code, so it can never be shadowed by the transport checks.
+  if (e.fromHost && INFERENCE_RUN_CODES.has(e.code)) return "refusal-inference";
+  // A status-0 ApiError is a transport failure the client synthesised; a
+  // `fromHost:false` non-zero status is a proxy/upstream that gave up (an HTML
+  // 502/504 with no host envelope). Either way the host may still be running the
+  // job — but only say so if we watched it start.
+  if ((e.status === 0 || !e.fromHost) && sawOwnRunStart) return "connection-lost";
+  return "other";
+}

--- a/frontend/test/e2e/workflow-run-inference.spec.ts
+++ b/frontend/test/e2e/workflow-run-inference.spec.ts
@@ -1,0 +1,81 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issue #528 / #514: a run the host refuses because the company has no inference
+ * provider surfaces as a PERSISTENT, actionable banner — not a vanishing
+ * raw-string toast.
+ *
+ * #514 gives the host a `409 { code: "inference_required" }` for this exact
+ * state (a company that never configured an inference source). The console keys
+ * on that structured `code` — never the localisable prose — raises a banner that
+ * says what is wrong in plain words, and links the operator straight to the
+ * inference settings so the dead-end toast becomes a way forward.
+ *
+ * Needs no brain: the refusal is injected with `page.route`, so this runs in
+ * BOTH the default `Console E2E` lane and the live-brain lane.
+ */
+
+/** Dismisses the first-run tour if it is up; tolerates its absence. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** The workflow picker's trigger. */
+function picker(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+/** Selects a workflow by name and waits for the selection to settle. */
+async function selectWorkflow(page: Page, name: string) {
+  await picker(page).click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(picker(page)).toContainText(name);
+}
+
+/** The run POST, and only it — not `…/workflows/runs`, not `…/cron/preview`. */
+const RUN_POST = /\/workflows\/[^/]+\/run(\?|$)/;
+
+test("a run refused for a missing inference provider shows a persistent, linked banner", async ({
+  page,
+}) => {
+  // Injecting the host's #514 refusal means this needs no inference backend, and
+  // pins the console's reading to the structured code rather than the prose.
+  await page.route(RUN_POST, async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    await route.fulfill({
+      status: 409,
+      contentType: "application/json",
+      body: JSON.stringify({
+        error:
+          "workflow execution needs an inference source, and none is configured " +
+          "for this company. Set a provider in Settings → Inference, then run again.",
+        code: "inference_required",
+      }),
+    });
+  });
+
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+
+  await selectWorkflow(page, "Committed flow");
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+
+  // The banner is persistent (an Alert, not a toast) and explains the state in
+  // plain words.
+  const alert = page.getByTestId("workflow-run-inference-alert");
+  await expect(alert).toBeVisible();
+  await expect(alert).toContainText(/no inference provider configured/i);
+
+  // …and it links the operator to where they fix it.
+  const cta = page.getByTestId("workflow-run-inference-cta");
+  await expect(cta).toBeVisible();
+  await expect(cta).toHaveAttribute("href", "#/settings/connections");
+});

--- a/frontend/test/e2e/workflow-run-result.spec.ts
+++ b/frontend/test/e2e/workflow-run-result.spec.ts
@@ -1,0 +1,74 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
+/**
+ * Issue #528: the Workflows console runs SYNCHRONOUSLY, so the settled run body
+ * reaches `RunResultPanel` and the operator can actually read what a run
+ * produced.
+ *
+ * Before this, the Run button always asked the host to `detach`: on a modern
+ * host `isDetached` was true, `setResult` never fired, and the run-output drawer
+ * — the ONLY surface that renders a run's per-node agent text — never mounted.
+ * The full `output` is carried by that 200 body alone (the journal, the SSE
+ * frames, and the runs list are all structural), so a detached run left the
+ * operator with a green toast and nothing to read.
+ *
+ * This spec needs a real run, and a run needs a brain: the committed workflow's
+ * agent node produces its text through inference. With the feature off the run
+ * journals nothing and the drawer would have nothing to show, so it gates on
+ * `LIVE_BRAIN` — the `Console E2E (live brain)` lane runs it (issue #467).
+ */
+
+/**
+ * Dismisses the first-run tour if it is up; tolerates its absence. Its overlay
+ * swallows pointer events, so without this the spec fails on an unrelated modal.
+ */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** The workflow picker's trigger. */
+function picker(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+/** Selects a workflow by name and waits for the selection to settle. */
+async function selectWorkflow(page: Page, name: string) {
+  await picker(page).click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(picker(page)).toContainText(name);
+}
+
+test("running a workflow shows its per-node output in the result drawer", async ({
+  page,
+}) => {
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+
+  // The source-defined fixture — its agent node ("Draft the note") is what the
+  // drawer must render text for. Its ids and names are pinned by the harness.
+  await selectWorkflow(page, "Committed flow");
+
+  await page.getByRole("button", { name: "Run", exact: true }).click();
+
+  // The whole fix: the synchronous body reaches `setResult`, so the drawer
+  // mounts. A detached run would leave this hidden forever.
+  const drawer = page.getByTestId("workflow-run-result");
+  await expect(drawer).toBeVisible({ timeout: 60_000 });
+
+  // And it renders the run's per-node result, not just a heading — the node card
+  // for the agent step carries its graph name, which only the parsed
+  // (non-fallback) render path produces.
+  await expect(drawer.getByText("Draft the note")).toBeVisible();
+});

--- a/frontend/test/unit/workflow-run-error.test.ts
+++ b/frontend/test/unit/workflow-run-error.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowGraph } from "@/api/workflows";
+import { ApiError } from "@/api/types";
+import type { CompanyStreamEvent } from "@/hooks/use-events";
+import { foldLiveRun } from "@/views/workflows/graph";
+import { classifyRunError } from "@/views/workflows/run-error";
+
+/**
+ * How the Workflows console reads a failed run POST (issues #528, #514).
+ *
+ * The `run()` catch has three genuinely different jobs, and picking the wrong
+ * one is a user-visible failure every time:
+ *
+ * - a host refusal it can FIX (no inference configured) must raise a persistent
+ *   banner, never a vanishing toast — and it must key on the structured `code`,
+ *   because the prose is localisable and drifts;
+ * - `not_wired` is deliberately NOT such a refusal: on a genuinely offline build
+ *   pointing the operator at an inference setting would lie (issue #514 exists to
+ *   split those), so it must fall through to a plain error;
+ * - a dropped connection on a run we SAW start is survivable — the host keeps
+ *   walking the graph (#383) — so it must reassure rather than cry failure, but
+ *   only when we actually saw the run begin.
+ */
+describe("classifyRunError", () => {
+  it("treats an inference_required host refusal as a fixable refusal", () => {
+    const e = new ApiError(409, "inference_required", "needs an inference source", true);
+    expect(classifyRunError(e, false)).toBe("refusal-inference");
+  });
+
+  it("treats a restart_required host refusal as a fixable refusal", () => {
+    const e = new ApiError(409, "restart_required", "a restart is owed", true);
+    expect(classifyRunError(e, false)).toBe("refusal-inference");
+  });
+
+  it("does NOT treat not_wired as an inference refusal — that stays a plain error", () => {
+    // A genuinely inference-less build answers 404 not_wired; #514 keeps it out
+    // of the refusal set so the console never tells the operator to configure a
+    // provider the deployment cannot use.
+    const e = new ApiError(404, "not_wired", "this build has no execution", true);
+    expect(classifyRunError(e, false)).toBe("other");
+    expect(classifyRunError(e, true)).toBe("other");
+  });
+
+  it("reads a status-0 transport failure as connection-lost when the run was seen to start", () => {
+    const e = new ApiError(0, "network_error", "cannot reach the company host", false);
+    expect(classifyRunError(e, true)).toBe("connection-lost");
+  });
+
+  it("reads a status-0 transport failure as a plain error when the run never started", () => {
+    const e = new ApiError(0, "network_error", "cannot reach the company host", false);
+    expect(classifyRunError(e, false)).toBe("other");
+  });
+
+  it("reads a proxy 504 (no host envelope) as connection-lost when the run was seen to start", () => {
+    const e = new ApiError(504, "http_504", "HTTP 504", false);
+    expect(classifyRunError(e, true)).toBe("connection-lost");
+  });
+
+  it("reads a proxy 504 as a plain error when the run never started", () => {
+    const e = new ApiError(504, "http_504", "HTTP 504", false);
+    expect(classifyRunError(e, false)).toBe("other");
+  });
+
+  it("treats a non-ApiError rejection as a plain error", () => {
+    expect(classifyRunError(new Error("boom"), true)).toBe("other");
+    expect(classifyRunError("boom", true)).toBe("other");
+    expect(classifyRunError(undefined, true)).toBe("other");
+  });
+});
+
+/**
+ * The fold carries the run's `scheduled` flag straight off its start frame
+ * (issue #528), so the console can tell its own manual run apart from a
+ * concurrent cron fire while the run POST is still open.
+ */
+describe("foldLiveRun scheduled", () => {
+  const GRAPH: WorkflowGraph = {
+    id: "wf1",
+    name: "Nightly digest",
+    nodes: [
+      { id: "t", kind: "trigger", name: "Trigger" },
+      { id: "a", kind: "agent", name: "Agent" },
+    ],
+    edges: [{ from: "t", to: "a" }],
+  };
+
+  function startFrame(scheduled: boolean): CompanyStreamEvent {
+    return {
+      type: "workflow_run_started",
+      seq: 1,
+      atMillis: 1_000,
+      workflowId: "wf1",
+      runId: "run-1",
+      scheduled,
+    };
+  }
+
+  it("is false for an operator-started run", () => {
+    const live = foldLiveRun([startFrame(false)], "wf1", GRAPH);
+    expect(live).not.toBeNull();
+    expect(live?.scheduled).toBe(false);
+    expect(live?.runId).toBe("run-1");
+    expect(live?.active).toBe(true);
+  });
+
+  it("is true for a cron-started run", () => {
+    const live = foldLiveRun([startFrame(true)], "wf1", GRAPH);
+    expect(live?.scheduled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Two console fixes so an operator can actually see what a run does.

1. **Output was unreadable.** On any modern host every run is detached, and the only panel that renders a run's per-node output text mounts solely on the legacy synchronous path — so you could run a workflow and never read what it produced. The full output exists **only** in the synchronous response body; the journal, SSE frames, and runs-list carry no output text, and there is no run-detail route.
2. **The no-inference error was a dead end.** A run refused for missing inference showed a vanishing raw-string toast ("not wired in this deployment").

Closes #528. Consumes #514's `inference_required` contract.

## API Or Behavior Changes

- The console runs workflows **synchronously by default** so the settled body reaches the result drawer. Since #383 the server's sync path runs on a spawned task and survives a dropped connection, so the only cost of sync is that the body must arrive; the `detach` option is retained for other callers. The `isDetached` branch stays as a compatibility seam, and the mid-run Stop button is preserved by adopting the live run id.
- A run refused with `code: "inference_required"` or `"restart_required"` now renders a **persistent, actionable "Set up inference" banner** (`href="#/settings/connections"`), keyed on the structured `code` only — never the prose. `not_wired` is deliberately excluded (on a genuinely execution-less build the link would lie).
- A connection loss mid-run shows an informational toast and keeps the live view instead of a hard error.

## Tests

- [x] `npm run typecheck` · `typecheck:unit` · `typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` — 169/169 (10 new in `workflow-run-error.test.ts`)
- [ ] `cargo *` — N/A: frontend-only change.

New e2e: `workflow-run-result.spec.ts` (live-brain lane — asserts the drawer shows node text), `workflow-run-inference.spec.ts` (both console lanes — 409 injected via `page.route`). Manual live-host verification of both surfaces is pending (see checklist below).

## Documentation

`runWorkflow` API doc notes the sync-by-default rationale. A durable backend run-output store + run-detail read route is a tracked follow-up (out of scope here).