### PR TITLE
fix(workflows): make the default marketing preset runnable, and wire web_search into tool_call nodes (#530)

### DIFF
--- a/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
+++ b/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
@@ -36,6 +36,21 @@ id = "research"
 kind = "tool_call"
 name = "Web research"
 summary = "Pulls sources and competitor takes."
+# `on_error` is a first-class node field, NOT a `config` key — the validator
+# rejects reserved keys inside `[node.config]`. `continue` means a search that
+# fails (e.g. no managed search credential on this install) becomes an error
+# item on the default port and the run proceeds to `copy`, instead of halting
+# the whole pipeline. web_search degrades gracefully with no credential.
+on_error = "continue"
+[node.config]
+# The metered discovery tool wired by the workflow tool belt (issue #238); the
+# `web` namespace can only read a URL the agent already has, never find one.
+slug = "web_search"
+[node.config.args]
+# Bind the strategist's reply as the query: `=`-expressions resolve against the
+# input item, and an agent node returns `{ text, agent_ref }` (see caps::mod).
+query = "=item.text"
+max_results = 5
 
 [[node]]
 id = "copy"
@@ -52,10 +67,14 @@ summary = "Generates the hero image."
 agent = "creative_director"
 
 [[node]]
+# No CMS exists to POST to, and the human sign-off is `[company].human_role`, so
+# this is an agent assembly step, not an HTTP call. Reusing `copywriter` across
+# two nodes is legal — the id stays `publish` so the edges are untouched.
 id = "publish"
-kind = "http_request"
-name = "Publish to CMS"
-summary = "POST the approved draft."
+kind = "agent"
+name = "Assemble final post"
+summary = "Assemble the publish-ready post and hero-image reference, then hand off for operator sign-off."
+agent = "copywriter"
 
 [[node]]
 id = "done"

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -250,3 +250,117 @@ fn the_repo_skill_registry_parses() {
         );
     }
 }
+
+/// Every bundled workflow must be *runnable*, not merely parseable (issue #530).
+/// `every_workflow_graph_parses` only proves the TOML deserializes; it never
+/// checks that a `tool_call` names a wired tool or that an `agent` names a real
+/// teammate — which is exactly how the marketing agency preset shipped pointing
+/// `research` at an unwired slug (halt) and `publish` at a nonexistent HTTP node.
+///
+/// This translates each graph the way the engine will and asserts the two facts
+/// that decide whether a run halts: every `tool_call` slug resolves to a real
+/// toolbelt namespace ([`namespace_of`]), and every `agent` ref is on that
+/// company's roster.
+///
+/// Gated on `openhuman` because `translate` and `namespace_of` live behind that
+/// feature; the `Rust (openhuman, tinycortex)` CI lane runs it.
+#[cfg(feature = "openhuman")]
+#[test]
+fn every_bundled_workflow_is_runnable_against_its_roster() {
+    use std::collections::BTreeSet;
+
+    use tinyflows::model::NodeKind;
+
+    use crate::harness::toolbelt::namespace_of;
+    use crate::workflows::translate;
+
+    for company in subdirs(&repo_root().join("companies")) {
+        let manifest = CompanyManifest::from_path(&company)
+            .unwrap_or_else(|err| panic!("{}: {err}", company.display()));
+        let roster: BTreeSet<&str> = manifest.agents.iter().map(|a| a.id.as_str()).collect();
+
+        for file in toml_files(&company.join("workflows")) {
+            let text = std::fs::read_to_string(&file)
+                .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
+            let workflow =
+                parse_workflow(&text).unwrap_or_else(|err| panic!("{}: {err}", file.display()));
+            let graph = translate(&workflow);
+
+            for node in &graph.nodes {
+                match node.kind {
+                    NodeKind::ToolCall => {
+                        let slug = node
+                            .config
+                            .get("slug")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "{} node `{}`: a tool_call with no slug",
+                                    file.display(),
+                                    node.id
+                                )
+                            });
+                        assert!(
+                            namespace_of(slug).is_some(),
+                            "{} node `{}`: tool_call slug `{slug}` maps to no toolbelt namespace, so \
+                             the run halts on it — every tool_call must name a wired tool (shell / \
+                             code / web / search / …).",
+                            file.display(),
+                            node.id
+                        );
+                    }
+                    NodeKind::Agent => {
+                        let agent_ref = node
+                            .config
+                            .get("agent_ref")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_else(|| {
+                                panic!(
+                                    "{} node `{}`: an agent node with no agent_ref",
+                                    file.display(),
+                                    node.id
+                                )
+                            });
+                        assert!(
+                            roster.contains(agent_ref),
+                            "{} node `{}`: agent_ref `{agent_ref}` is not on the roster ({roster:?}) \
+                             — the step would route to a teammate that does not exist.",
+                            file.display(),
+                            node.id
+                        );
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+/// The marketing agency's default desktop preset specifically — the three
+/// defects issue #530 fixed, pinned so a future edit cannot silently reintroduce
+/// them: `research` calls the metered `web_search` and continues past a search
+/// failure rather than halting, and `publish` is the copywriter assembly step
+/// (there is no CMS to POST to).
+#[cfg(feature = "openhuman")]
+#[test]
+fn the_marketing_campaign_preset_is_runnable() {
+    use crate::workflows::translate;
+
+    let path =
+        repo_root().join("companies/agentic_marketing_agency/workflows/campaign_pipeline.toml");
+    let text = std::fs::read_to_string(&path).unwrap();
+    let graph = translate(&parse_workflow(&text).expect("campaign parses"));
+    let node = |id: &str| {
+        graph
+            .nodes
+            .iter()
+            .find(|n| n.id == id)
+            .unwrap_or_else(|| panic!("no node `{id}`"))
+    };
+
+    let research = node("research");
+    assert_eq!(research.config["slug"], "web_search");
+    assert_eq!(research.config["on_error"], "continue");
+
+    assert_eq!(node("publish").config["agent_ref"], "copywriter");
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -12,8 +12,9 @@
 //!   [`OcMemory`](crate::harness::memory), approval policy, and cost metering.
 //! * **tool_call** ([`WorkflowToolInvoker`](tools::WorkflowToolInvoker)) — a
 //!   `tool_call` node executes a real Cell A toolbelt tool (`shell` / `code` /
-//!   `web`) scoped to a dedicated per-company workflow workspace, fail-closed on
-//!   the company's `[tools].allow` grants.
+//!   `web`, plus the metered `search` family behind an explicit `search` grant)
+//!   scoped to a dedicated per-company workflow workspace, fail-closed on the
+//!   company's `[tools].allow` grants.
 //! * **http_request** ([`GuardedHttpClient`](http::GuardedHttpClient)) — an
 //!   `http_request` node routes through OpenHuman's `HttpRequestTool` so every
 //!   request (and redirect) passes the upstream `url_guard` SSRF check.
@@ -112,12 +113,24 @@ pub async fn build_capabilities(
     let web_allowed_domains = record.manifest.tools.web_allowed_domains.clone();
     let grants = record.manifest.tools.allow.clone();
 
+    // The metered `search` family is threaded through the invoker the same way
+    // `build_agent` wires it onto a roster agent — explicit `search` grant +
+    // managed backend, fail-closed. Read `deps.search` / `deps.meter` here,
+    // before `deps` moves into `HarnessAgentRunner` below. The agent label names
+    // the run so a search sample is attributed to the workflow, not a chat turn.
+    let search_metering = crate::harness::search::SearchMetering {
+        company: company.clone(),
+        agent: format!("workflow:{workflow_id}"),
+        meter: deps.meter.clone(),
+    };
     let tools = WorkflowToolInvoker::new(
         exec_security.clone(),
         &workflow_ws,
         web_allowed_domains.clone(),
         grants,
         &deps.capabilities,
+        deps.search.as_ref(),
+        search_metering,
     );
     let http = GuardedHttpClient::new(exec_security, web_allowed_domains);
 
@@ -159,8 +172,8 @@ pub async fn build_capabilities(
         state,
         resolver,
         // `deps` moves in last — the borrows above (`deps.capabilities`,
-        // `deps.secrets`, `deps.workspace_root`, `deps.workflow_source_dir`) are
-        // all done by here.
+        // `deps.search`, `deps.meter`, `deps.secrets`, `deps.workspace_root`,
+        // `deps.workflow_source_dir`) are all done by here.
         agent: Some(Arc::new(HarnessAgentRunner::new(
             pool,
             deps,

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -12,7 +12,11 @@
 //! Every invocation is **fail-closed**: the slug's grant namespace (via
 //! [`toolbelt::namespace_of`]) must be covered by the company's `[tools].allow`
 //! globs — reusing the exact grant-intersection rule an agent's exec tools use
-//! ([`crate::harness::build::grants_cover`]) — before the tool is even looked up.
+//! ([`crate::harness::build::grants_cover`]) — before the tool is even looked
+//! up. The one exception is the priced `search` namespace, which requires an
+//! **explicit** `search` grant (`grants_search_explicit`) rather than glob
+//! coverage, so `*` never buys a managed search call and the invoke-time gate
+//! matches construction.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -93,19 +97,25 @@ impl ToolInvoker for WorkflowToolInvoker {
     /// real connection is a documented follow-on.
     async fn invoke(&self, slug: &str, args: Value, _conn: Option<&str>) -> TfResult<Value> {
         // FAIL-CLOSED grant check FIRST, before any lookup or execution.
-        match toolbelt::namespace_of(slug) {
-            Some(namespace) if crate::harness::build::grants_cover(&self.grants, namespace) => {}
-            Some(namespace) => {
-                return Err(EngineError::Capability(format!(
-                    "tool_call '{slug}' (namespace '{namespace}') is not granted by this company's \
-                     [tools].allow"
-                )));
-            }
-            None => {
-                return Err(EngineError::Capability(format!(
-                    "tool_call '{slug}' is not a wired workflow tool"
-                )));
-            }
+        let Some(namespace) = toolbelt::namespace_of(slug) else {
+            return Err(EngineError::Capability(format!(
+                "tool_call '{slug}' is not a wired workflow tool"
+            )));
+        };
+        // The priced `search` namespace needs an EXPLICIT `search` grant — the
+        // catch-all `*` must never confer a managed search call — so this gate
+        // matches the construction gate in `new` (and `build::build_agent`).
+        // Every other namespace uses the ordinary grant-glob intersection.
+        let granted = if namespace == "search" {
+            crate::company::grants_search_explicit(&self.grants)
+        } else {
+            crate::harness::build::grants_cover(&self.grants, namespace)
+        };
+        if !granted {
+            return Err(EngineError::Capability(format!(
+                "tool_call '{slug}' (namespace '{namespace}') is not granted by this company's \
+                 [tools].allow"
+            )));
         }
 
         let tool = self.tools.get(slug).ok_or_else(|| {
@@ -188,6 +198,33 @@ mod tests {
         assert!(
             matches!(unwired, Err(EngineError::Capability(ref m)) if m.contains("not a wired")),
             "{unwired:?}"
+        );
+    }
+
+    #[test]
+    fn the_search_namespace_requires_an_explicit_grant_not_a_wildcard() {
+        use tinyflows::caps::ToolInvoker;
+        // `*` covers ordinary namespaces but must NOT confer the priced `search`
+        // family — the invoke-time gate mirrors construction (build.rs).
+        let wildcard = WorkflowToolInvoker {
+            tools: HashMap::new(),
+            grants: vec!["*".to_string()],
+        };
+        let denied = tokio_test_block_on(wildcard.invoke("web_search", json!({}), None));
+        assert!(
+            matches!(denied, Err(EngineError::Capability(ref m)) if m.contains("not granted")),
+            "{denied:?}"
+        );
+        // An explicit `search` grant passes the gate; the empty tool map then
+        // fails the lookup with a different, later error.
+        let granted = WorkflowToolInvoker {
+            tools: HashMap::new(),
+            grants: vec!["search".to_string()],
+        };
+        let looked_up = tokio_test_block_on(granted.invoke("web_search", json!({}), None));
+        assert!(
+            matches!(looked_up, Err(EngineError::Capability(ref m)) if m.contains("not available")),
+            "{looked_up:?}"
         );
     }
 

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -9,6 +9,15 @@
 //! [`name()`](openhuman_core::openhuman::tools::Tool::name). A `tool_call` node's
 //! `slug` selects one by name.
 //!
+//! It also wires the metered `search` family (`web_search`) — the discovery tool
+//! the `web` namespace never had (`web_fetch` / `http_request` / `curl` only read
+//! a URL the agent already has) — on the same two gates the agent builder uses
+//! ([`crate::harness::build::build_agent`]): an **explicit** `search` grant
+//! (`grants_search_explicit`; the catch-all `*` never confers it, because each
+//! call is a priced managed request) AND a managed search backend on the deps.
+//! Granted-but-uncredentialed wires nothing and warns, so `web_search` degrades
+//! gracefully when no managed credential is configured (fail-closed).
+//!
 //! Every invocation is **fail-closed**: the slug's grant namespace (via
 //! [`toolbelt::namespace_of`]) must be covered by the company's `[tools].allow`
 //! globs — reusing the exact grant-intersection rule an agent's exec tools use
@@ -31,10 +40,12 @@ use oh::security::SecurityPolicy;
 use oh::tools::{Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
+use crate::harness::search::{SearchBackend, SearchMetering};
 use crate::harness::toolbelt::{self, CapabilityFilter};
 
-/// A [`ToolInvoker`] over the Cell A toolbelt, scoped to a per-company workflow
-/// workspace and gated by the company's `[tools].allow` grants.
+/// A [`ToolInvoker`] over the Cell A toolbelt (plus the metered `search` family),
+/// scoped to a per-company workflow workspace and gated by the company's
+/// `[tools].allow` grants.
 pub struct WorkflowToolInvoker {
     /// The wired toolbelt tools, indexed by runtime `name()` (== the node slug).
     tools: HashMap<String, Arc<dyn Tool>>,
@@ -52,6 +63,8 @@ impl WorkflowToolInvoker {
         web_allowed_domains: Vec<String>,
         grants: Vec<String>,
         filter: &CapabilityFilter,
+        search: Option<&SearchBackend>,
+        search_metering: SearchMetering,
     ) -> Self {
         // Mirror `build_agent`: do not initialize a tool family (or its audit
         // state) unless the company's grants can invoke that namespace.
@@ -73,6 +86,26 @@ impl WorkflowToolInvoker {
                 web_allowed_domains,
                 workspace,
             ));
+        }
+        // Metered web search (issue #238) — mirror `build_agent`'s two-gate
+        // wiring exactly: an EXPLICIT `search` grant (`grants_search_explicit`;
+        // the catch-all `*` never confers it, because each call is a priced
+        // managed request) AND a managed search backend on the deps. Granted-but-
+        // uncredentialed wires nothing and warns, so `web_search` degrades
+        // gracefully when no managed credential is configured (fail-closed).
+        if crate::company::grants_search_explicit(&grants) {
+            match search {
+                Some(backend) => {
+                    tools.extend(crate::harness::search::search_tools(
+                        backend,
+                        search_metering,
+                    ));
+                }
+                None => tracing::warn!(
+                    "[workflow] company explicitly grants `search` but no managed search backend \
+                     is configured; web_search NOT wired (fail-closed)"
+                ),
+            }
         }
         // Apply the capability-tier filter (identity in production) just as the
         // agent builder does, so the workflow surface never exceeds the agent one.
@@ -242,6 +275,8 @@ mod tests {
             Vec::new(),
             Vec::new(),
             &CapabilityFilter::AllowAll,
+            None,
+            test_metering(),
         );
         assert!(none.tools.is_empty());
 
@@ -251,11 +286,73 @@ mod tests {
             Vec::new(),
             vec!["code.*".to_string()],
             &CapabilityFilter::AllowAll,
+            None,
+            test_metering(),
         );
         assert!(code.tools.contains_key("apply_patch"));
         assert!(code.tools.contains_key("csv_export"));
         assert!(!code.tools.contains_key("shell"));
         assert!(!code.tools.contains_key("web_fetch"));
+    }
+
+    #[test]
+    fn search_wires_only_with_an_explicit_grant_and_a_backend() {
+        let dir = tempfile::tempdir().unwrap();
+        let security = Arc::new(toolbelt::exec_security(
+            dir.path(),
+            crate::harness::policy::PolicyMode::Supervised,
+        ));
+        let backend = SearchBackend::new(
+            "https://api.example.test".to_string(),
+            crate::company::credentials::Credential::from_value("managed"),
+            5,
+        );
+
+        // Explicit `search` grant + a backend → the metered `web_search` is wired.
+        let wired = WorkflowToolInvoker::new(
+            security.clone(),
+            dir.path(),
+            Vec::new(),
+            vec!["search".to_string()],
+            &CapabilityFilter::AllowAll,
+            Some(&backend),
+            test_metering(),
+        );
+        assert!(wired.tools.contains_key("web_search"));
+
+        // The catch-all `*` must NOT confer the priced search family.
+        let wildcard = WorkflowToolInvoker::new(
+            security.clone(),
+            dir.path(),
+            Vec::new(),
+            vec!["*".to_string()],
+            &CapabilityFilter::AllowAll,
+            Some(&backend),
+            test_metering(),
+        );
+        assert!(!wildcard.tools.contains_key("web_search"));
+
+        // Granted but uncredentialed wires nothing (fail-closed) rather than panicking.
+        let uncredentialed = WorkflowToolInvoker::new(
+            security,
+            dir.path(),
+            Vec::new(),
+            vec!["search".to_string()],
+            &CapabilityFilter::AllowAll,
+            None,
+            test_metering(),
+        );
+        assert!(!uncredentialed.tools.contains_key("web_search"));
+    }
+
+    /// A throwaway [`SearchMetering`] for the construction tests — the tool is
+    /// never executed here, so the company/agent/meter values are inert.
+    fn test_metering() -> SearchMetering {
+        SearchMetering {
+            company: crate::ports::types::CompanyId::new("test"),
+            agent: "workflow:test".to_string(),
+            meter: None,
+        }
     }
 
     /// Minimal blocking bridge so the fail-closed checks (which never touch the

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -308,7 +308,8 @@ mod tests {
         assert_eq!(kind("strategist"), Some(NodeKind::Agent));
         assert_eq!(kind("gate"), Some(NodeKind::Condition));
         assert_eq!(kind("research"), Some(NodeKind::ToolCall));
-        assert_eq!(kind("publish"), Some(NodeKind::HttpRequest));
+        // `publish` is an agent assembly step (#530) — there is no CMS to POST to.
+        assert_eq!(kind("publish"), Some(NodeKind::Agent));
         // `output` lowers to a pass-through `transform`.
         assert_eq!(kind("done"), Some(NodeKind::Transform));
     }
@@ -368,11 +369,13 @@ mod tests {
 
     // --- P1: config overlay + error/retry/approval + error routing ---------
 
-    /// A snapshot pinning that the shipped campaign pipeline (which uses none of
-    /// the P1 fields) translates byte-identically to the pre-P1 output: every
-    /// node's config equals exactly what the old kind-only mapping produced.
+    /// A snapshot pinning the shipped campaign pipeline's translated config. Most
+    /// nodes carry only kind-derived config; the `research` `tool_call` binds the
+    /// metered `web_search` slug + args and an `on_error = "continue"` policy
+    /// (#530), and `publish` is an `agent` assembly step (there is no CMS to POST
+    /// to), so each carries exactly the config those choices imply.
     #[test]
-    fn campaign_translation_is_byte_identical_to_legacy() {
+    fn campaign_translation_lowers_to_the_expected_engine_config() {
         let file = parse_workflow(CAMPAIGN).expect("campaign parses");
         let graph = translate(&file);
         let config = |id: &str| {
@@ -389,8 +392,21 @@ mod tests {
             json!({ "agent_ref": "brand_strategist", "prompt": "Turns the brief into an angle + outline." })
         );
         assert_eq!(config("gate"), json!({}));
-        assert_eq!(config("research"), json!({ "slug": "research" }));
-        assert_eq!(config("publish"), json!({}));
+        assert_eq!(
+            config("research"),
+            json!({
+                "slug": "web_search",
+                "args": { "query": "=item.text", "max_results": 5 },
+                "on_error": "continue"
+            })
+        );
+        assert_eq!(
+            config("publish"),
+            json!({
+                "agent_ref": "copywriter",
+                "prompt": "Assemble the publish-ready post and hero-image reference, then hand off for operator sign-off."
+            })
+        );
         assert_eq!(config("done"), json!({}));
     }
 


### PR DESCRIPTION
## Summary

The default marketing preset's `campaign_pipeline` halted on the first Run — the most-likely first workflow a new operator ever runs. `research` (a `tool_call` with no config) fell back to the node id as its slug and resolved to no tool; `publish` (an `http_request`) pointed at a nonexistent CMS; and the real root cause: the workflow tool belt never wired the metered `search` family, so even a correct `web_search` slug failed "not available" despite the company granting `search`. This wires search into the workflow belt (mirroring the agent builder), makes the preset runnable end to end, and pins the whole class with a regression test.

Closes #530.

## API Or Behavior Changes

- `WorkflowToolInvoker` now wires the `web_search` tool for a `tool_call` node when the company **explicitly** grants `search` (never via `*`) **and** a managed search backend is present — fail-closed with a warn otherwise, mirroring `build_agent` (`build.rs:415-431`). This enables `web_search` in every company's workflow `tool_call` nodes under the same gates as agents.
- The invoke-time gate for the `search` namespace now requires an explicit grant (`grants_search_explicit`, was `grants_cover`), so the run-time gate matches construction.
- Preset graph: `research` → `tool_call` slug `web_search` (`on_error = continue`, degrades gracefully with no credential); `publish` → `agent` bound to `copywriter` (assemble the publish-ready post; sign-off stays the human's job).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — 0 warnings
- [x] `cargo test --features openhuman,tinycortex` — `workflows::` 189, `company::content_test` 9
- [x] `cargo check --features openhuman,mcp,telegram` · `cargo check --all-features`

New regression sweep: every bundled workflow's `tool_call` slugs resolve via `namespace_of` and every `agent` ref is on that company's roster — so an unrunnable preset cannot ship again. Manual end-to-end run of the preset is pending (see checklist).

## Documentation

Module/struct docs enumerating the wired tool families updated (were shell/code/web only).