### PR TITLE
fix(workflows): stop a crashed run's re-run from re-delivering already-sent reports (#529)

### DIFF
--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -339,6 +339,23 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Workflow {workflow_id} finished node {node_id}"),
             "workflow.node",
         ),
+        // Issue #529: a report left the process. Structural, like the per-node
+        // arm above — node id and destination kind, never the target address:
+        // the sidecar reads company activity for insight, and "the owner summary
+        // went out" is the insight; *whom* it reached is operator-only, the same
+        // boundary `DeliveryReport::detail` draws. The run's own
+        // `WorkflowRunFinished` arm already folds the delivery counts.
+        CompanyEvent::WorkflowReportDelivered {
+            workflow_id,
+            node,
+            kind,
+            ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!("Workflow {workflow_id} delivered its {kind} report from node {node}"),
+            "workflow.report_delivered",
+        ),
     };
     WireEvent {
         seq,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -914,6 +914,16 @@ fn summarize_event(event: &CompanyEvent) -> String {
             node_id,
             ..
         } => format!("workflow {workflow_id} finished node {node_id}"),
+        // Issue #529: a delivered-report record. Same no-payload rule as its
+        // neighbours — the node and the destination kind, never the target
+        // address, which is operator-only. The run's own finished line already
+        // folds the delivery counts, so this is summarized, not surfaced.
+        CompanyEvent::WorkflowReportDelivered {
+            workflow_id,
+            node,
+            kind,
+            ..
+        } => format!("workflow {workflow_id} delivered {kind} report from node {node}"),
     }
 }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -947,6 +947,70 @@ pub enum CompanyEvent {
         /// Wall-clock duration of the node's execution, in milliseconds.
         elapsed_ms: u64,
     },
+    /// One `output` node's report actually left the process (issue #529) — the
+    /// durable record of a dispatch that the run's own
+    /// [`WorkflowRunFinished`](Self::WorkflowRunFinished) does not carry across a
+    /// crash.
+    ///
+    /// # The hole this closes
+    ///
+    /// A run's delivery rows live only on
+    /// [`WorkflowRunFinished::deliveries`](Self::WorkflowRunFinished), which is
+    /// journaled **after** the run returns. A crash, panic, or mid-graph failure
+    /// therefore orphans the side effect: the mail left the process, but the
+    /// boot sweep settles the run `FAILED` with no delivery record, and the
+    /// operator's re-run re-delivers every already-sent report to real people
+    /// (issue #438's ledger rides one approval lineage's trigger input and is not
+    /// persisted, so an independently re-run workflow re-delivers). This event is
+    /// written **write-behind, at dispatch** — immediately after each `Sent` send
+    /// and each `Pending` park — so a durable ledger of what already went out
+    /// survives a crash and a re-run can skip it. See
+    /// [`delivered_by_unsettled_runs`](crate::runtime::delivered_by_unsettled_runs).
+    ///
+    /// Write-behind, not write-ahead: a crash *between* the journal and the send
+    /// would silently suppress a report, which is worse than one duplicate. So
+    /// the record can only ever lag the send, never precede it.
+    ///
+    /// # Dedupe identity is `node`
+    ///
+    /// The fold keys on [`node`](Self::WorkflowReportDelivered::node) so it
+    /// unions cleanly with #438's
+    /// [`DeliveredReport`](crate::runtime::workflow_resume::DeliveredReport),
+    /// whose identity is also the node. An `owner` destination that fanned out to
+    /// several admins writes one line per recipient, so `target` differs across
+    /// lines for one node; per-recipient dedupe is a documented deferred limit,
+    /// exactly as #438's ledger is per node rather than per recipient.
+    ///
+    /// Additive: an entirely new `kind`, so no journal written before it existed
+    /// carries it, and its presence changes how no existing variant serializes.
+    WorkflowReportDelivered {
+        /// The workflow graph that delivered (its `workflows/<id>.toml` stem).
+        workflow_id: String,
+        /// The run that dispatched this report — the same id its
+        /// [`WorkflowRunStarted`](Self::WorkflowRunStarted) carries.
+        run_id: String,
+        /// The `output` node whose report left the process. This is the dedupe
+        /// identity the fold and #438's ledger both key on.
+        node: String,
+        /// The destination kind as authored (`owner` / `email` / `channel`) — the
+        /// description beside the identity, so a reader sees *what* went where.
+        ///
+        /// Renamed to `destination_kind` on the wire: this enum is
+        /// internally-tagged under `kind`, so a field literally named `kind`
+        /// would collide with the tag and emit a duplicate key. The Rust name
+        /// stays `kind` to read the same as its
+        /// [`DeliveryReport`](crate::ports::DeliveryReport) and
+        /// [`DeliveredReport`](crate::runtime::workflow_resume::DeliveredReport)
+        /// siblings.
+        #[serde(rename = "destination_kind")]
+        kind: String,
+        /// The address or channel actually dispatched to. `None` only when a
+        /// destination named none; for `owner` this is the server-resolved
+        /// recipient, not something the graph named. Optional on the wire so a
+        /// line stays minimal when there is nothing to record.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        target: Option<String>,
+    },
 }
 
 /// How one workflow node's execution came out (issue #371).
@@ -3952,6 +4016,66 @@ mod test {
                 pending_approvals: vec!["review".to_string()],
                 error: None,
                 cancelled: false,
+            }
+        );
+    }
+
+    /// Issue #529: the delivered-report event survives the JSONL round trip the
+    /// journal puts every event through, `target` and all — the whole reason it
+    /// exists is to be read back after a crash.
+    #[test]
+    fn workflow_report_delivered_round_trips() {
+        let event = CompanyEvent::WorkflowReportDelivered {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            node: "owner_summary".to_string(),
+            kind: "owner".to_string(),
+            target: Some("ada@example.com".to_string()),
+        };
+        assert_eq!(round_trip(&event), event);
+    }
+
+    /// Issue #529: the wire shape is pinned, and `target` is omitted entirely
+    /// when a destination named none — the same `skip_serializing_if` economy
+    /// every optional field on this enum keeps, so a channel line stays minimal.
+    #[test]
+    fn workflow_report_delivered_pins_its_wire_shape_and_omits_absent_target() {
+        let with_target = serde_json::to_string(&CompanyEvent::WorkflowReportDelivered {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            node: "owner_summary".to_string(),
+            kind: "owner".to_string(),
+            target: Some("ada@example.com".to_string()),
+        })
+        .expect("serialize");
+        assert_eq!(
+            with_target,
+            r#"{"kind":"WorkflowReportDelivered","workflow_id":"digest","run_id":"run-1","node":"owner_summary","destination_kind":"owner","target":"ada@example.com"}"#
+        );
+
+        let no_target = serde_json::to_string(&CompanyEvent::WorkflowReportDelivered {
+            workflow_id: "digest".to_string(),
+            run_id: "run-1".to_string(),
+            node: "notice".to_string(),
+            kind: "channel".to_string(),
+            target: None,
+        })
+        .expect("serialize");
+        assert_eq!(
+            no_target,
+            r#"{"kind":"WorkflowReportDelivered","workflow_id":"digest","run_id":"run-1","node":"notice","destination_kind":"channel"}"#,
+            "an absent target must not ride the line as a null"
+        );
+        // …and a line with no `target` loads back as `None` rather than failing.
+        let decoded: CompanyEvent = serde_json::from_str(&no_target).expect("minimal line loads");
+        assert_eq!(
+            decoded,
+            CompanyEvent::WorkflowReportDelivered {
+                workflow_id: "digest".to_string(),
+                run_id: "run-1".to_string(),
+                node: "notice".to_string(),
+                kind: "channel".to_string(),
+                target: None,
             }
         );
     }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1565,6 +1565,13 @@ impl RuntimeBuilder {
                                         approvals: gate.clone(),
                                         journal: journal.clone(),
                                     }),
+                                    // Issue #529: the same journal the runner
+                                    // writes its start/per-node trail to, so a
+                                    // dispatch's write-behind delivery record
+                                    // lands in the one log the boot-time fold
+                                    // reads back. One company owns one journal;
+                                    // this is that handle.
+                                    events: events.clone(),
                                 }),
                                 // Issue #237: the SAME workspace handle the
                                 // console's REST/GraphQL surface writes through

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1282,6 +1282,11 @@ fn cycle_task_id(
             // like the run outcome they bracket.
             | CompanyEvent::WorkflowRunStarted { .. }
             | CompanyEvent::WorkflowNodeFinished { .. }
+            // Issue #529: a report that left the process is a record of a
+            // dispatch a workflow already made, journaled write-behind so a
+            // re-run can skip it. Like the run outcome it precedes, it starts no
+            // cycle and rivals no card.
+            | CompanyEvent::WorkflowReportDelivered { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
             // A withdrawal (#358) is a record about a record: it starts no
@@ -1396,6 +1401,9 @@ fn cycle_thread_id(
             | CompanyEvent::WorkflowRunFinished { .. }
             | CompanyEvent::WorkflowRunStarted { .. }
             | CompanyEvent::WorkflowNodeFinished { .. }
+            // Issue #529: a record of a report already dispatched — names no
+            // thread and rivals none, exactly like the run events it sits among.
+            | CompanyEvent::WorkflowReportDelivered { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
             // A withdrawal (#358) is a record about a record: it starts no

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -110,7 +110,9 @@ pub use run_supervisor::{RunGuard, RunSupervisor};
 pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
-pub use workflow_outcome::{record_run_finished, sweep_interrupted_runs};
+pub use workflow_outcome::{
+    delivered_by_unsettled_runs, record_run_finished, sweep_interrupted_runs,
+};
 pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
 pub use workflow_spawn::WorkflowSpawn;

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -45,6 +45,7 @@ use std::sync::Arc;
 use crate::ports::EventLog;
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
 use crate::ports::workflow_runner::{DeliveryReport, WorkflowRun};
+use crate::runtime::workflow_resume::DeliveredReport;
 
 /// The error stamped on a run the host never got to finish (issue #371).
 ///
@@ -231,6 +232,113 @@ pub async fn sweep_interrupted_runs(events: &Arc<dyn EventLog>, company: &Compan
         )
         .await;
     }
+}
+
+/// What the trailing suffix of **unclean** runs of one workflow already
+/// delivered, folded from the journal (issue #529).
+///
+/// # The hole this closes
+///
+/// A run's deliveries live only on
+/// [`WorkflowRunFinished::deliveries`](CompanyEvent::WorkflowRunFinished), which
+/// is journaled *after* the run returns. A crash, a mid-graph failure, or a
+/// panic therefore orphans the side effect: the report left the process, but the
+/// boot sweep settles the run `FAILED` (or the run simply has no finish at all),
+/// so no delivery record exists — and an operator's re-run re-mails every
+/// already-sent report to real people. Issue #438's ledger does not cover this:
+/// it rides one approval lineage's trigger input and is never persisted, so an
+/// *independently* re-run or re-triggered workflow re-delivers.
+///
+/// This fold is the durable half. It replays the journal and returns the reports
+/// dispatched by the **uncleanly-finished trailing runs** — the ones that owe
+/// the next run nothing, because their work is stranded.
+///
+/// # Semantics: a clean finish absorbs and clears
+///
+/// One pass in journal order, holding a set of delivered nodes for `workflow_id`:
+///
+/// * a [`WorkflowReportDelivered`](CompanyEvent::WorkflowReportDelivered) for
+///   this workflow **inserts** its node (write-behind at dispatch, so a
+///   crashed run's sends are here even though its finish is not);
+/// * a [`WorkflowRunFinished`](CompanyEvent::WorkflowRunFinished) for this
+///   workflow with **no error clears** the set.
+///
+/// The clear is what keeps a daily scheduled digest delivering every day: a run
+/// that finishes cleanly (a normal completion, or a
+/// [`cancelled`](CompanyEvent::WorkflowRunFinished) one — which returns *before*
+/// `deliver_outputs` and so dispatched nothing here, and carries no error)
+/// absorbs everything delivered up to it, so the next run starts owed nothing.
+/// Only deliveries by the *unclean* trailing suffix — a crash whose boot-sweep
+/// finish carries the synthetic `error: Some(..)`, a mid-graph failure, or a
+/// panic that never journaled a finish at all — survive the fold, and those are
+/// exactly the ones a re-run must not repeat.
+///
+/// Identity is the **node**, so this unions cleanly with issue #438's
+/// [`DeliveredReport`](crate::runtime::workflow_resume::DeliveredReport): the
+/// caller concatenates the two and dedupes. An `owner` fan-out that wrote one
+/// line per admin collapses to a single node entry here.
+///
+/// Best-effort read, the same posture as
+/// [`sweep_interrupted_runs`] (which is left untouched): a journal read failure
+/// yields an empty ledger and a warn, because a delivery guard that cannot read
+/// the journal must fail *open* to the pre-#529 behaviour (deliver) rather than
+/// silently suppress a report.
+pub async fn delivered_by_unsettled_runs(
+    events: &Arc<dyn EventLog>,
+    company: &CompanyId,
+    workflow_id: &str,
+) -> Vec<DeliveredReport> {
+    let stored = match events
+        .read_from(company, EventSeq::new(0), usize::MAX)
+        .await
+    {
+        Ok(stored) => stored,
+        Err(err) => {
+            tracing::warn!(
+                %company,
+                workflow = %workflow_id,
+                %err,
+                "could not read the journal to fold this workflow's stranded deliveries; a re-run \
+                 will not know what a crashed run already sent"
+            );
+            return Vec::new();
+        }
+    };
+
+    // Insertion order preserved, deduped by node — an output node has exactly one
+    // destination, so its id is the identity and the first-seen kind describes
+    // it. A `Vec` rather than a set keeps the returned order deterministic for
+    // the caller's union.
+    let mut delivered: Vec<DeliveredReport> = Vec::new();
+    for stored in stored {
+        match stored.event {
+            // The dedupe (`not already present`) rides the guard: a repeat of a
+            // node already in the ledger simply does not match, and falls through
+            // to the no-op arm below — an `owner` fan-out's one-line-per-admin
+            // collapses to a single entry this way.
+            CompanyEvent::WorkflowReportDelivered {
+                workflow_id: wid,
+                node,
+                kind,
+                ..
+            } if wid == workflow_id && !delivered.iter().any(|prior| prior.node == node) => {
+                delivered.push(DeliveredReport { node, kind });
+            }
+            // A clean finish (no error) absorbs everything delivered up to it and
+            // resets the ledger — the cadence guarantee. A failed / interrupted
+            // finish carries an error and does NOT clear, so its run's stranded
+            // deliveries stay owed-nothing to the next run.
+            CompanyEvent::WorkflowRunFinished {
+                workflow_id: wid,
+                error,
+                ..
+            } if wid == workflow_id && error.is_none() => {
+                delivered.clear();
+            }
+            _ => {}
+        }
+    }
+    delivered
 }
 
 #[cfg(test)]
@@ -604,5 +712,317 @@ mod test {
             settled,
             vec![("run-a".to_string(), true), ("run-b".to_string(), false)]
         );
+    }
+
+    // --- issue #529: the durable delivery fold --------------------------------
+
+    /// Appends a `WorkflowReportDelivered` — the write-behind record a dispatch
+    /// leaves at run time.
+    async fn deliver(
+        events: &Arc<dyn EventLog>,
+        company: &CompanyId,
+        workflow_id: &str,
+        run_id: &str,
+        node: &str,
+        kind: &str,
+    ) {
+        events
+            .append(
+                company,
+                CompanyEvent::WorkflowReportDelivered {
+                    workflow_id: workflow_id.to_string(),
+                    run_id: run_id.to_string(),
+                    node: node.to_string(),
+                    kind: kind.to_string(),
+                    target: Some("ada@example.com".to_string()),
+                },
+            )
+            .await
+            .expect("append");
+    }
+
+    /// The nodes the fold returns for `workflow_id`, in order.
+    async fn stranded(
+        events: &Arc<dyn EventLog>,
+        company: &CompanyId,
+        workflow_id: &str,
+    ) -> Vec<String> {
+        delivered_by_unsettled_runs(events, company, workflow_id)
+            .await
+            .into_iter()
+            .map(|d| d.node)
+            .collect()
+    }
+
+    /// A report delivered by a run that never journaled a finish (a crash) is
+    /// owed-nothing to the next run — it is in the ledger.
+    #[tokio::test]
+    async fn a_delivery_without_a_finish_is_stranded() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+
+        let ledger = delivered_by_unsettled_runs(&events, &company, "digest").await;
+        assert_eq!(
+            ledger,
+            vec![DeliveredReport {
+                node: "owner_summary".to_string(),
+                kind: "owner".to_string(),
+            }],
+            "a crashed run's delivery must be owed-nothing to the next run"
+        );
+    }
+
+    /// The cadence guarantee: a run that delivered AND finished cleanly clears
+    /// the ledger, so the next scheduled run of the same workflow delivers
+    /// again rather than being suppressed forever.
+    #[tokio::test]
+    async fn a_clean_finish_clears_the_ledger() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            "run-1",
+            Ok(&run_with(Vec::new(), Vec::new())),
+        )
+        .await;
+
+        assert!(
+            stranded(&events, &company, "digest").await.is_empty(),
+            "a clean finish absorbs what the run delivered"
+        );
+    }
+
+    /// A failed finish carries an error and does NOT clear — its run's stranded
+    /// delivery stays owed-nothing to the next run.
+    #[tokio::test]
+    async fn a_failed_finish_keeps_the_ledger() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+        record_run_finished(&events, &company, "digest", true, "run-1", Err("it broke")).await;
+
+        assert_eq!(
+            stranded(&events, &company, "digest").await,
+            vec!["owner_summary".to_string()],
+            "a finish that failed must not clear the delivered ledger"
+        );
+    }
+
+    /// The boot sweep's synthetic INTERRUPTED finish is a failed finish
+    /// (`error: Some`), so it likewise keeps the ledger — a host that died
+    /// mid-run still owes the next run nothing for what it managed to send.
+    #[tokio::test]
+    async fn a_swept_interrupted_finish_keeps_the_ledger() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+        // The host went away before finishing; boot settles it synthetically.
+        sweep_interrupted_runs(&events, &company).await;
+
+        assert_eq!(
+            stranded(&events, &company, "digest").await,
+            vec!["owner_summary".to_string()],
+            "the sweep's synthetic error must not read as a clean finish"
+        );
+    }
+
+    /// A cancelled run carries `error: None`, so it clears the ledger — and that
+    /// is correct: a cancelled run returns before `deliver_outputs`, so it
+    /// dispatched nothing here, and clearing simply resets to owed-nothing.
+    #[tokio::test]
+    async fn a_cancelled_finish_clears_the_ledger() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        // A prior crashed run stranded a delivery…
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+        // …then a later run of the same workflow was stopped by an operator.
+        let mut cancelled = run_with(Vec::new(), Vec::new());
+        cancelled.cancelled = true;
+        record_run_finished(&events, &company, "digest", true, "run-2", Ok(&cancelled)).await;
+
+        assert!(
+            stranded(&events, &company, "digest").await.is_empty(),
+            "a cancelled run has no error, so it clears like any clean finish"
+        );
+    }
+
+    /// The multi-crash union: run 1 sends A then crashes, run 2 skips A, sends B,
+    /// then crashes. The ledger accumulates {A, B} across both unclean runs.
+    #[tokio::test]
+    async fn deliveries_union_across_multiple_crashes() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(&events, &company, "digest", "run-1", "a", "owner").await;
+        record_run_finished(&events, &company, "digest", true, "run-1", Err("crash 1")).await;
+
+        start(&events, &company, "run-2", true).await;
+        // run 2 skipped A (its own already_delivered saw it) and sent B.
+        deliver(&events, &company, "digest", "run-2", "b", "owner").await;
+        record_run_finished(&events, &company, "digest", true, "run-2", Err("crash 2")).await;
+
+        assert_eq!(
+            stranded(&events, &company, "digest").await,
+            vec!["a".to_string(), "b".to_string()],
+            "two unclean runs accumulate rather than the second forgetting the first"
+        );
+    }
+
+    /// The same node delivered twice (an `owner` fan-out writes one line per
+    /// admin) collapses to a single ledger entry, keyed on the node.
+    #[tokio::test]
+    async fn a_fanned_out_node_collapses_to_one_entry() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+
+        assert_eq!(
+            stranded(&events, &company, "digest").await,
+            vec!["owner_summary".to_string()],
+            "per-recipient lines dedupe to one node in the ledger"
+        );
+    }
+
+    /// The fold is per-workflow: a crash in workflow A does not strand a
+    /// delivery against workflow B, and a clean finish of A does not clear B.
+    #[tokio::test]
+    async fn the_fold_is_isolated_per_workflow() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        deliver(&events, &company, "digest", "run-1", "a", "owner").await;
+        deliver(&events, &company, "weekly", "run-2", "b", "owner").await;
+        // A clean finish of `digest` clears only `digest`.
+        record_run_finished(
+            &events,
+            &company,
+            "digest",
+            true,
+            "run-1",
+            Ok(&run_with(Vec::new(), Vec::new())),
+        )
+        .await;
+
+        assert!(
+            stranded(&events, &company, "digest").await.is_empty(),
+            "digest's own clean finish cleared it"
+        );
+        assert_eq!(
+            stranded(&events, &company, "weekly").await,
+            vec!["b".to_string()],
+            "weekly's stranded delivery is untouched by digest's finish"
+        );
+    }
+
+    /// Events the fold does not care about — starts, node finishes, unrelated
+    /// records — are ignored rather than disturbing the ledger.
+    #[tokio::test]
+    async fn unrelated_events_are_ignored() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        start(&events, &company, "run-1", true).await;
+        events
+            .append(
+                &company,
+                CompanyEvent::WorkflowNodeFinished {
+                    workflow_id: "digest".to_string(),
+                    run_id: "run-1".to_string(),
+                    node_id: "ceo".to_string(),
+                    status: crate::ports::types::WorkflowNodeStatus::Ok,
+                    elapsed_ms: 3,
+                },
+            )
+            .await
+            .expect("append");
+        deliver(
+            &events,
+            &company,
+            "digest",
+            "run-1",
+            "owner_summary",
+            "owner",
+        )
+        .await;
+
+        assert_eq!(
+            stranded(&events, &company, "digest").await,
+            vec!["owner_summary".to_string()],
+            "only delivered/finished events for this workflow move the ledger"
+        );
+    }
+
+    /// An empty or delivery-free journal folds to nothing rather than erroring.
+    #[tokio::test]
+    async fn an_empty_journal_folds_to_nothing() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        assert!(stranded(&events, &company, "digest").await.is_empty());
     }
 }

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -77,12 +77,29 @@
 //! input itself makes: the card stays self-contained, so the guard survives a
 //! restart exactly like the resume does.
 //!
+//! # The durable ledger behind the card (issue #529)
+//!
+//! The card ledger above guards **one approval lineage**: it rides the trigger
+//! input, so it only reaches a continuation an approval starts. It does nothing
+//! for a run that *crashed* — its deliveries never made it onto any card,
+//! because the run never paused — nor for a workflow re-run or re-triggered
+//! *independently* of the paused lineage. Issue #529 backs the card ledger with
+//! a durable one: every dispatch that leaves the process journals a
+//! [`WorkflowReportDelivered`](crate::ports::types::CompanyEvent::WorkflowReportDelivered)
+//! write-behind, and the runner folds those stranded deliveries
+//! ([`delivered_by_unsettled_runs`](crate::runtime::delivered_by_unsettled_runs))
+//! into the same `already_delivered` list this lineage ledger feeds — unioned,
+//! deduped by node. The two share [`DeliveredReport`] as their identity, so a
+//! crash-then-re-run skips what a crashed run already sent for the same reason a
+//! resume skips what the paused run sent.
+//!
 //! **The honest limit.** The ledger is per `output` node, not per recipient. An
 //! `owner` destination that fanned out to three admins and failed on the third
 //! is recorded as delivered, and the continuation will not retry that third
 //! address. Re-mailing two people to reach one is the worse outcome, so this is
 //! deliberate rather than an oversight — a partial fan-out is repaired from the
-//! run history, not by a resume.
+//! run history, not by a resume. The durable #529 ledger keeps the same per-node
+//! identity, so this limit is unchanged across a crash.
 //!
 //! # At-most-once, deny, and expiry
 //!

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -138,12 +138,12 @@ use crate::company::WorkflowFile;
 use crate::company::runtime::CompanyMail;
 use crate::company::{WorkflowDestinationDef, WorkflowNodeKind};
 use crate::ports::types::{
-    Actor, ActorKind, ApprovalId, CompanyId, CompanyRecord, Effect, EffectGroup, OutboundMessage,
-    Verdict,
+    Actor, ActorKind, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, Effect, EffectGroup,
+    OutboundMessage, Verdict,
 };
 use crate::ports::{
     ApprovalGate, ChannelAdapter, DeliveryReason, DeliveryReport, DeliveryStatus, EmailRecord,
-    InboxStore, UserRole, UserStatus, UserStore, generate_id, now_millis,
+    EventLog, InboxStore, UserRole, UserStatus, UserStore, generate_id, now_millis,
 };
 use crate::runtime::cycle::EMAIL_SEND_KIND;
 use crate::runtime::journal::RuntimeJournal;
@@ -189,6 +189,21 @@ pub struct WorkflowDeliveryDeps {
     /// closed to the pre-#227 behaviour: the report is `skipped`, never a
     /// `pending` row no queue is backing.
     pub parking: Option<DeliveryParking>,
+    /// The company's event journal, for the write-behind delivery record
+    /// (issue #529). Every dispatch that actually leaves the process — a `Sent`
+    /// send, or a `Pending` park whose card sends on approval — appends one
+    /// [`CompanyEvent::WorkflowReportDelivered`], so a run that crashes before
+    /// its [`WorkflowRunFinished`](CompanyEvent::WorkflowRunFinished) is written
+    /// still leaves a durable ledger a re-run can consult and skip.
+    ///
+    /// Non-optional and the same handle the runner reads for its progress trail,
+    /// unlike [`parking`](Self::parking): the write-behind is the whole point of
+    /// this field, and the only construction site is the production builder,
+    /// where the journal always exists. The append is best-effort — a failure
+    /// warns and is swallowed, never failing a delivery whose work already
+    /// happened, the same stance as
+    /// [`record_run_finished`](crate::runtime::record_run_finished).
+    pub events: Arc<dyn EventLog>,
 }
 
 /// The approval queue's two halves, bundled so a delivery can only ever hold
@@ -243,11 +258,21 @@ impl std::fmt::Debug for WorkflowDeliveryDeps {
 /// [`DeliveryReason::AlreadyDelivered`] and **nothing is dispatched** — it is
 /// empty on every run nobody resumed, so an ordinary run is untouched. See
 /// [`crate::runtime::workflow_resume`] for why a continuation reaches these
-/// nodes again at all.
+/// nodes again at all. Issue #529 widens the same guard across a *crash*: the
+/// caller unions this per-lineage ledger with a durable one folded from the
+/// journal, so an independently re-run workflow skips what a crashed run already
+/// sent.
+///
+/// `run_id` is the run this dispatch belongs to — it rides every
+/// [`CompanyEvent::WorkflowReportDelivered`] this call appends (issue #529), so
+/// the durable delivery record correlates with the run's start and per-node
+/// trail exactly as [`WorkflowRunFinished`](CompanyEvent::WorkflowRunFinished)
+/// does.
 pub async fn deliver_outputs(
     delivery: Option<&WorkflowDeliveryDeps>,
     record: &CompanyRecord,
     workflow: &WorkflowFile,
+    run_id: &str,
     output: &Value,
     already_delivered: &[DeliveredReport],
 ) -> Vec<DeliveryReport> {
@@ -334,6 +359,14 @@ pub async fn deliver_outputs(
             continue;
         };
 
+        // Issue #529: journal WRITE-BEHIND — after `deliver_one` has dispatched,
+        // not before. Every row it just pushed for this node whose outcome
+        // actually left the process (`Sent`, or a `Pending` park whose durable
+        // card sends on approval) gets one `WorkflowReportDelivered` line, so a
+        // crash before the run's finish still leaves a ledger a re-run can skip.
+        // The skip/failed rows above never reach here, and none of them left the
+        // process anyway.
+        let before = reports.len();
         deliver_one(
             delivery,
             record,
@@ -344,9 +377,63 @@ pub async fn deliver_outputs(
             &mut reports,
         )
         .await;
+        for report in &reports[before..] {
+            journal_delivered(&delivery.events, &record.id, &workflow.id, run_id, report).await;
+        }
     }
 
     reports
+}
+
+/// Appends one [`CompanyEvent::WorkflowReportDelivered`] for a delivery row that
+/// left the process (issue #529).
+///
+/// Only `Sent` and `Pending` are journaled, and the reasoning is the crash story
+/// the whole event exists for. A `Sent` row's mail is out of the process; a
+/// `Pending` row is a durable, journal-backed approval card that sends on
+/// approval — both count as delivered, exactly as issue #438's ledger counts
+/// them (see [`crate::runtime::workflow_resume`]). `Skipped` / `Denied` /
+/// `Failed` journal nothing: nothing left the process, so a re-run is free to
+/// retry them.
+///
+/// Best-effort, like every write on this path: a failure is logged loud and
+/// swallowed. Losing the record risks one duplicate on a later re-run — the
+/// accepted cost of write-behind — and is never worth failing a delivery whose
+/// send already happened.
+async fn journal_delivered(
+    events: &Arc<dyn EventLog>,
+    company: &CompanyId,
+    workflow_id: &str,
+    run_id: &str,
+    report: &DeliveryReport,
+) {
+    if !matches!(
+        report.status,
+        DeliveryStatus::Sent | DeliveryStatus::Pending
+    ) {
+        return;
+    }
+    let event = CompanyEvent::WorkflowReportDelivered {
+        workflow_id: workflow_id.to_string(),
+        run_id: run_id.to_string(),
+        node: report.node.clone(),
+        kind: report.kind.clone(),
+        target: report.target.clone(),
+    };
+    if let Err(err) = events.append(company, event).await {
+        // Swallowed on purpose: the report already went out. Losing this record
+        // means a re-run might send it a second time, which is the write-behind
+        // trade-off — a loud line, never a failed delivery.
+        tracing::warn!(
+            %company,
+            workflow = %workflow_id,
+            %run_id,
+            node = %report.node,
+            %err,
+            "workflow delivery: the delivered-report record could not be journaled; the report \
+             itself was sent, but a later re-run may not know it already went out"
+        );
+    }
 }
 
 /// Dispatches one node's destination, appending every attempt's row to
@@ -1175,6 +1262,10 @@ allow = [{allow}]
         /// queue an agent's does.
         gate: Option<Arc<ManifestApprovalGate>>,
         journal: Option<Arc<RuntimeJournal>>,
+        /// The real on-disk event journal the write-behind delivery record
+        /// (issue #529) lands in — held so a test can read back the
+        /// [`CompanyEvent::WorkflowReportDelivered`] lines a dispatch appended.
+        events: Arc<dyn EventLog>,
     }
 
     impl Harness {
@@ -1188,8 +1279,13 @@ allow = [{allow}]
             } else {
                 Vec::new()
             };
+            // A real filesystem journal, like the outcome tests use: the write
+            // side must actually land on disk and read back, so the delivered
+            // ledger is exercised end to end rather than against a double.
+            let events: Arc<dyn EventLog> = Arc::new(crate::store::FsEventLog::new(dir));
             Self {
                 deps: WorkflowDeliveryDeps {
+                    events: events.clone(),
                     mail: with_mail.then(|| CompanyMail {
                         sender: Arc::new(mail.clone()),
                         smtp: smtp_creds(),
@@ -1206,6 +1302,7 @@ allow = [{allow}]
                 company: CompanyId::new("acme"),
                 gate: None,
                 journal: None,
+                events,
             }
         }
 
@@ -1306,6 +1403,64 @@ allow = [{allow}]
                 .await
                 .expect("inbox readable")
         }
+
+        /// Every `WorkflowReportDelivered` the write-behind path journaled
+        /// (issue #529) — what a re-run's fold would later read back.
+        async fn journaled_deliveries(&self) -> Vec<CompanyEvent> {
+            self.events
+                .read_from(
+                    &self.company,
+                    crate::ports::types::EventSeq::new(0),
+                    usize::MAX,
+                )
+                .await
+                .expect("journal readable")
+                .into_iter()
+                .map(|s| s.event)
+                .filter(|e| matches!(e, CompanyEvent::WorkflowReportDelivered { .. }))
+                .collect()
+        }
+
+        /// Swaps the delivery bundle's event journal for one whose every append
+        /// **fails**, for the "a journal failure does not fail delivery" case.
+        fn with_failing_events(mut self) -> Self {
+            self.deps.events = Arc::new(FailingEventLog);
+            self
+        }
+    }
+
+    /// An [`EventLog`] whose `append` always errors — the write-behind delivery
+    /// record's failure path (issue #529). Reads yield nothing; the point is the
+    /// append, and that a delivery survives it.
+    struct FailingEventLog;
+
+    #[async_trait]
+    impl EventLog for FailingEventLog {
+        async fn append(
+            &self,
+            _company: &CompanyId,
+            _event: CompanyEvent,
+        ) -> crate::Result<crate::ports::types::EventSeq> {
+            Err(OpenCompanyError::Config(
+                "event journal is unwritable".into(),
+            ))
+        }
+
+        async fn read_from(
+            &self,
+            _company: &CompanyId,
+            _seq: crate::ports::types::EventSeq,
+            _limit: usize,
+        ) -> crate::Result<Vec<crate::ports::types::StoredEvent>> {
+            Ok(Vec::new())
+        }
+
+        fn subscribe(
+            &self,
+            _company: &CompanyId,
+        ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
     }
 
     // --- owner ---------------------------------------------------------------
@@ -1323,6 +1478,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1382,6 +1538,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1404,6 +1561,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1429,6 +1587,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1452,6 +1611,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1476,6 +1636,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["email.send"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1507,6 +1668,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["docs.*", "web"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1536,6 +1698,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1571,6 +1734,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1617,6 +1781,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1677,6 +1842,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1727,6 +1893,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1755,6 +1922,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1782,6 +1950,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["docs.*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1807,6 +1976,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1842,6 +2012,7 @@ allow = [{allow}]
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1891,6 +2062,7 @@ mode = "full"
             Some(&h.deps),
             &rec,
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1933,6 +2105,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("stranger@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1954,6 +2127,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -1980,6 +2154,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some("ada@example.com")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2035,6 +2210,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("email", Some(ADDRESS)),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2072,6 +2248,7 @@ mode = "full"
             Some(&h.deps),
             &record(&[]),
             &graph("channel", Some(OPERATOR_CHANNEL)),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2096,6 +2273,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("channel", Some("telegram")),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2139,6 +2317,7 @@ mode = "full"
             Some(&h.deps),
             &record(&["*"]),
             &graph("owner", None),
+            "run-1",
             &output,
             &[],
         )
@@ -2178,6 +2357,7 @@ to = "done"
             Some(&h.deps),
             &record(&["*"]),
             &plain,
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2194,6 +2374,7 @@ to = "done"
             None,
             &record(&["*"]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2233,6 +2414,7 @@ to = "done"
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &already("done", "owner"),
         )
@@ -2265,6 +2447,7 @@ to = "done"
             Some(&h.deps),
             &record(&["email"]),
             &cold,
+            "run-1",
             &reached_output(),
             &already("done", "email"),
         )
@@ -2297,6 +2480,7 @@ to = "done"
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &already("some_other_node", "owner"),
         )
@@ -2320,6 +2504,7 @@ to = "done"
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &reached_output(),
             &[],
         )
@@ -2343,6 +2528,7 @@ to = "done"
             Some(&h.deps),
             &record(&[]),
             &graph("owner", None),
+            "run-1",
             &unreached,
             &already("done", "owner"),
         )
@@ -2393,5 +2579,163 @@ to = "done"
         assert!(cut.ends_with(TRUNCATION_MARKER));
         // Untouched when it fits.
         assert_eq!(truncate_chars("short", 10), "short");
+    }
+
+    // --- issue #529: the write-behind delivery record ------------------------
+
+    /// A `Sent` dispatch journals exactly one `WorkflowReportDelivered`, shaped
+    /// from the row — the durable record a crashed run leaves so a re-run can
+    /// skip it.
+    #[tokio::test]
+    async fn a_sent_delivery_journals_one_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("channel", Some("operator")),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+
+        let journaled = h.journaled_deliveries().await;
+        assert_eq!(
+            journaled.len(),
+            1,
+            "exactly one record per dispatch: {journaled:?}"
+        );
+        let CompanyEvent::WorkflowReportDelivered {
+            workflow_id,
+            run_id,
+            node,
+            kind,
+            target,
+        } = &journaled[0]
+        else {
+            panic!("expected a WorkflowReportDelivered, got {:?}", journaled[0]);
+        };
+        assert_eq!(workflow_id, "report_flow");
+        assert_eq!(run_id, "run-1");
+        assert_eq!(node, "done");
+        assert_eq!(kind, "channel");
+        assert_eq!(target.as_deref(), Some("operator"));
+    }
+
+    /// A `Pending` park journals a record too: the card is durable and approving
+    /// it sends, so a re-run must treat the report as already delivered —
+    /// exactly as issue #438's in-lineage ledger counts a `Pending` row.
+    #[tokio::test]
+    async fn a_pending_park_journals_a_record() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_parking(dir.path(), "full");
+        h.receive_from("someone-else@example.com").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&["*"]),
+            &graph("email", Some("stranger@example.com")),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+        assert_eq!(reports[0].status, DeliveryStatus::Pending, "{reports:?}");
+
+        let journaled = h.journaled_deliveries().await;
+        assert_eq!(
+            journaled.len(),
+            1,
+            "a park is a delivery for the ledger: {journaled:?}"
+        );
+        let CompanyEvent::WorkflowReportDelivered { node, kind, .. } = &journaled[0] else {
+            panic!("expected a WorkflowReportDelivered");
+        };
+        assert_eq!(node, "done");
+        assert_eq!(kind, "email");
+    }
+
+    /// A row that did NOT leave the process journals nothing. A `Failed` channel
+    /// (unwired target) leaves no record, so a re-run is free to retry it.
+    #[tokio::test]
+    async fn a_failed_delivery_journals_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        // No channel wired, so a `channel` destination fails.
+        let h = Harness::new(dir.path(), false, false);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("channel", Some("operator")),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+        assert_eq!(reports[0].status, DeliveryStatus::Failed, "{reports:?}");
+        assert!(
+            h.journaled_deliveries().await.is_empty(),
+            "a failed dispatch left the process nothing to record"
+        );
+    }
+
+    /// An `AlreadyDelivered` skip journals nothing — the report is on the ledger
+    /// precisely because it already went out, so recording it again would double
+    /// the very thing the ledger exists to prevent.
+    #[tokio::test]
+    async fn an_already_delivered_skip_journals_nothing() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("channel", Some("operator")),
+            "run-1",
+            &reached_output(),
+            &[DeliveredReport {
+                node: "done".to_string(),
+                kind: "channel".to_string(),
+            }],
+        )
+        .await;
+        assert_eq!(reports[0].status, DeliveryStatus::Skipped, "{reports:?}");
+        assert_eq!(reports[0].reason, DeliveryReason::AlreadyDelivered);
+        assert!(
+            h.journaled_deliveries().await.is_empty(),
+            "a report skipped because it already went out is not re-recorded"
+        );
+    }
+
+    /// A journal that cannot be written does not fail the delivery: the report
+    /// still sends and its row is still `Sent`. Losing the record risks one
+    /// duplicate on a later re-run — the accepted write-behind cost, never a
+    /// failed send.
+    #[tokio::test]
+    async fn a_journal_failure_does_not_fail_a_delivery() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), false, true).with_failing_events();
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("channel", Some("operator")),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Sent,
+            "an unwritable journal must not fail a send that succeeded: {reports:?}"
+        );
+        // And the report really did reach the transport.
+        assert_eq!(h.channel.sent().len(), 1);
     }
 }

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -229,6 +229,7 @@ pub(super) fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc
                 approvals: gate,
                 journal: journal.clone(),
             }),
+            events: Arc::new(crate::store::FsEventLog::new(dir)),
         }),
         workspace: None,
         search: None,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -374,15 +374,40 @@ async fn run_workflow_inner(
     // scheduled run is exactly the case where nobody is watching the console's
     // run-result drawer. Never fails the run — each attempt is reported instead.
     //
-    // Issue #438: `already_delivered` is what a continuation must NOT send
-    // again. It is read off the trigger input, where the approval that started
-    // this run threaded it — an empty list on a run nobody resumed, so a
-    // first-run delivery is untouched.
-    let already_delivered = crate::runtime::workflow_resume::delivered_in_input(&trigger_input);
+    // Issue #438: the per-lineage half of the guard. `delivered_in_input` is
+    // what a *continuation* must NOT send again — read off the trigger input,
+    // where the approval that started this run threaded it. Empty on a run nobody
+    // resumed.
+    //
+    // Issue #529: unioned with the durable half. A crashed run journals its
+    // sends write-behind but never its finish, so its deliveries are stranded in
+    // the journal with nothing on any trigger input to carry them. An
+    // *independent* re-run (the operator pressing Run again, or a schedule
+    // firing) has an empty per-lineage ledger and would re-mail every already-
+    // sent report. `delivered_by_unsettled_runs` folds those stranded deliveries
+    // back so the re-run skips them. Consulted only when the journal is wired
+    // (`events` is `Some`) — the default build and every unwired test degrade to
+    // the pre-#529 per-lineage behaviour, delivering as before.
+    let mut already_delivered = crate::runtime::workflow_resume::delivered_in_input(&trigger_input);
+    if let Some(events) = events.as_ref() {
+        for entry in
+            crate::runtime::delivered_by_unsettled_runs(events, &record.id, &workflow.id).await
+        {
+            // Deduped by node — the two ledgers may name the same report, and a
+            // reached node is skipped on the first match regardless.
+            if !already_delivered
+                .iter()
+                .any(|prior| prior.node == entry.node)
+            {
+                already_delivered.push(entry);
+            }
+        }
+    }
     let deliveries = super::delivery::deliver_outputs(
         delivery.as_ref(),
         record,
         workflow,
+        &run_id,
         &outcome.output,
         &already_delivered,
     )
@@ -860,6 +885,7 @@ to = "done"
             channels: vec![Arc::new(channel.clone())],
             // This case delivers to a channel, which never parks.
             parking: None,
+            events: Arc::new(crate::store::FsEventLog::new(dir.path())),
         });
 
         let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
@@ -1881,6 +1907,7 @@ to = "done"
                 approvals: gate,
                 journal: journal.clone(),
             }),
+            events: Arc::new(crate::store::FsEventLog::new(dir)),
         });
         (deps, journal)
     }
@@ -2172,6 +2199,7 @@ to = "gate"
                 approvals: Arc::new(crate::policy::ManifestApprovalGate::new(policy)),
                 journal: journal.clone(),
             }),
+            events: Arc::new(crate::store::FsEventLog::new(dir)),
         });
         (deps, journal, mail)
     }
@@ -2265,6 +2293,233 @@ to = "gate"
         assert_eq!(
             second.deliveries[0].reason,
             crate::ports::DeliveryReason::AlreadyDelivered
+        );
+    }
+
+    // --- issue #529: the durable delivery ledger across a crash --------------
+
+    /// Deps that deliver a report to the operator channel, sharing an event log
+    /// and a channel across runs — so a run 1's write-behind record and the
+    /// count of sends are both visible to run 2.
+    fn deps_delivering_to_channel(
+        dir: &std::path::Path,
+        events: Arc<dyn crate::ports::EventLog>,
+        channel: crate::runtime::channel::OperatorChannel,
+        consult_journal: bool,
+    ) -> HarnessDeps {
+        let mut deps = deps(dir);
+        // `consult_journal` toggles ONLY whether the runner reads the durable
+        // ledger — the delivery bundle always journals write-behind to the same
+        // log, so the journal state is identical between the two. This is what
+        // makes the negative control a true control: same journal, guard off.
+        deps.events = consult_journal.then(|| events.clone());
+        deps.delivery = Some(crate::workflows::WorkflowDeliveryDeps {
+            mail: None,
+            inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
+            users: Arc::new(FsOps::new(dir)),
+            channels: vec![Arc::new(channel)],
+            parking: None,
+            events,
+        });
+        deps
+    }
+
+    /// **The headline regression for issue #529.** A run delivers a report and
+    /// then crashes — `run_workflow` returns, but the caller never journals the
+    /// finish (exactly what a host kill leaves). The boot sweep settles it with
+    /// the synthetic interrupted finish, and an operator re-runs the workflow.
+    /// The report must NOT go out a second time: the transport count stays at 1
+    /// and the re-run's row reads `Skipped` / `AlreadyDelivered`.
+    ///
+    /// Breaking the union/fold (the durable consult in `run_workflow_inner`)
+    /// turns this into the negative control below — the count becomes 2 and this
+    /// assertion fails, which is what makes the guard provably load-bearing.
+    #[tokio::test]
+    async fn a_crashed_runs_delivery_is_not_repeated_on_an_independent_re_run() {
+        use crate::runtime::channel::OperatorChannel;
+
+        let dir = tempfile::tempdir().unwrap();
+        let events: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path()));
+        let channel = OperatorChannel::new();
+        let rec = record();
+        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+
+        // Run 1 delivers, then "crashes": run_workflow returns, but nothing
+        // journals a WorkflowRunFinished for it.
+        let deps1 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
+        let ctx1 = WorkflowRunContext::new(false);
+        let run1 = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps1,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx1,
+        )
+        .await
+        .expect("run 1 runs");
+        assert_eq!(
+            run1.deliveries[0].status,
+            crate::ports::DeliveryStatus::Sent
+        );
+        assert_eq!(channel.sent().len(), 1, "run 1 delivered exactly once");
+
+        // The boot sweep settles the crashed run with the synthetic interrupted
+        // finish — an error, which must NOT clear the durable ledger.
+        crate::runtime::sweep_interrupted_runs(&events, &rec.id).await;
+
+        // Run 2 is an independent re-run of the same workflow.
+        let deps2 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
+        let ctx2 = WorkflowRunContext::new(false);
+        let run2 = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps2,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx2,
+        )
+        .await
+        .expect("run 2 runs");
+
+        assert_eq!(
+            channel.sent().len(),
+            1,
+            "the durable ledger stopped the crashed run's report from being re-delivered"
+        );
+        assert_eq!(run2.deliveries.len(), 1, "{:?}", run2.deliveries);
+        assert_eq!(
+            run2.deliveries[0].status,
+            crate::ports::DeliveryStatus::Skipped
+        );
+        assert_eq!(
+            run2.deliveries[0].reason,
+            crate::ports::DeliveryReason::AlreadyDelivered
+        );
+    }
+
+    /// **The committed negative control.** The identical journal state as the
+    /// test above — run 1 delivered and crashed — but run 2 runs with the
+    /// durable consult bypassed (`deps.events` unwired, so the fold never runs).
+    /// The report goes out a second time: the count reaches 2. This proves the
+    /// guard is load-bearing rather than incidental — without the consult, the
+    /// re-delivery the whole issue is about happens.
+    #[tokio::test]
+    async fn without_the_durable_consult_a_crashed_runs_report_is_re_delivered() {
+        use crate::runtime::channel::OperatorChannel;
+
+        let dir = tempfile::tempdir().unwrap();
+        let events: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path()));
+        let channel = OperatorChannel::new();
+        let rec = record();
+        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+
+        let deps1 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
+        let ctx1 = WorkflowRunContext::new(false);
+        run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps1,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx1,
+        )
+        .await
+        .expect("run 1 runs");
+        assert_eq!(channel.sent().len(), 1);
+        crate::runtime::sweep_interrupted_runs(&events, &rec.id).await;
+
+        // Run 2: SAME journal, but the guard is off (`consult_journal = false`).
+        let deps2 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), false);
+        let ctx2 = WorkflowRunContext::new(false);
+        let run2 = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps2,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx2,
+        )
+        .await
+        .expect("run 2 runs");
+
+        assert_eq!(
+            channel.sent().len(),
+            2,
+            "without consulting the durable ledger, the crashed run's report goes out again"
+        );
+        assert_eq!(
+            run2.deliveries[0].status,
+            crate::ports::DeliveryStatus::Sent,
+            "the unguarded re-run delivers rather than skips"
+        );
+    }
+
+    /// The cadence guarantee: a run that delivers AND finishes cleanly must not
+    /// suppress the next scheduled run. Run 1 delivers and its clean finish is
+    /// journaled; run 2 delivers again — a daily digest keeps going out every
+    /// day, because a clean finish clears the durable ledger.
+    #[tokio::test]
+    async fn a_clean_finish_lets_the_next_run_deliver_again() {
+        use crate::runtime::channel::OperatorChannel;
+
+        let dir = tempfile::tempdir().unwrap();
+        let events: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path()));
+        let channel = OperatorChannel::new();
+        let rec = record();
+        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+
+        // Run 1 delivers…
+        let deps1 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
+        let ctx1 = WorkflowRunContext::new(false);
+        let run1 = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps1,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx1,
+        )
+        .await
+        .expect("run 1 runs");
+        assert_eq!(channel.sent().len(), 1);
+        // …and the caller journals its clean finish, the way a real entry point
+        // does once the run returns.
+        crate::runtime::record_run_finished(
+            &events,
+            &rec.id,
+            &file.id,
+            true,
+            &ctx1.run_id,
+            Ok(&run1),
+        )
+        .await;
+
+        // Run 2 (the next day's fire) delivers again — never suppressed.
+        let deps2 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
+        let ctx2 = WorkflowRunContext::new(false);
+        let run2 = run_workflow(
+            Arc::new(HarnessPool::new()),
+            deps2,
+            &rec,
+            &file,
+            serde_json::json!({ "brief": "quarterly numbers" }),
+            &ctx2,
+        )
+        .await
+        .expect("run 2 runs");
+
+        assert_eq!(
+            channel.sent().len(),
+            2,
+            "a clean finish must not suppress the next legitimate delivery"
+        );
+        assert_eq!(
+            run2.deliveries[0].status,
+            crate::ports::DeliveryStatus::Sent
         );
     }
 


### PR DESCRIPTION
## Summary

A workflow run interrupted mid-graph (host crash, panic, or a mid-graph failure) was settled Failed with no durable record of what it had already delivered — so the operator's natural recovery, a re-run, **re-delivered every already-sent report to real people**. Delivery's only durable record was written *after* the run returned, and the #438 idempotency ledger spans one approval lineage and is never persisted. This adds a durable per-dispatch journal event and makes any re-run idempotent against prior deliveries.

Closes #529. Extends #496 across crashes and independent re-runs.

## API Or Behavior Changes

- New journal event `WorkflowReportDelivered { workflow_id, run_id, destination_kind, node, target }`, appended **write-behind** immediately after each `Sent` dispatch and each `Pending` park. `Failed` / `Skipped` / `AlreadyDelivered` journal nothing — a re-run should retry those.
- On run start the runner folds the journal (`delivered_by_unsettled_runs`) and unions it with the #438 per-lineage ledger: deliveries by the trailing suffix of **unclean** runs are skipped; the first **clean or cancelled** finish clears the set, so periodic / scheduled delivery still fires every cadence.
- Runs remain non-resumable (still settled Failed). This closes the data-loss half; true checkpoint-resume is deferred (F1, tracked).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --features openhuman,tinycortex` — delivery 40, runner 39, workflow_outcome 20, workflow_resume 26, ports::types 67; incl. crash-then-re-run integration (transport count == 1) + committed negative control (guard off → 2) + cadence guard
- [x] `cargo check --features openhuman,mcp,telegram` · `cargo check --all-features --all-targets`

## Documentation

`workflow_resume` doc notes the durable ledger now backs the #438 card ledger across crashes. Deferred follow-ups F1 (checkpoint-resume), F2 (per-recipient ledger), F3 (detached-panic finish label), F4 (fold-at-boot cache) to be filed.