### PR TITLE
fix(console): name the migration banner's pending nodes per kind (#507)

### DIFF
--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ChevronDown,
   ChevronRight,
@@ -101,6 +101,29 @@ export function importSummary(files: number, folders: number): string {
   return parts.join(" and ");
 }
 
+/**
+ * The migration banner's sentence, for a pending scratchpad of `files` notes
+ * and `folders` folders (issue #507).
+ *
+ * Shares [`importSummary`] with the post-import receipt rather than counting
+ * again, because the banner and the receipt describe the *same* nodes one
+ * moment apart: when they counted separately they drifted, and the banner
+ * offered "3 notes" that the receipt then reported as "2 notes and 1 folder"
+ * — the pre-import prompt left over-reporting after #500 fixed the receipt.
+ *
+ * The verb agrees with the **total node count**, not with the leading number
+ * of the summary. "1 note and 1 folder" is two things and takes "are"; the
+ * summary's own first word is "1". Passing `files + folders` is what keeps
+ * that right for a mixed scratchpad.
+ */
+export function migrationBannerText(files: number, folders: number): string {
+  const total = files + folders;
+  return (
+    `${importSummary(files, folders)} from this browser's old scratchpad ` +
+    `${total === 1 ? "is" : "are"} not in the company workspace yet.`
+  );
+}
+
 /** What the editor's status line is currently reporting. */
 type SaveState = "idle" | "saving" | "saved" | "error";
 
@@ -165,6 +188,13 @@ export function WorkspaceView({ client, company }: Props) {
   const [showExplorer, setShowExplorer] = useState(true);
   const [legacy, setLegacy] = useState<FsNode[]>([]);
   const [importing, setImporting] = useState(false);
+  // The pending scratchpad partitioned by kind, once, for every surface that
+  // describes or imports it: the banner's sentence, the import loops, and the
+  // receipt. #500 partitioned inside `importLegacy` so the loops and the
+  // receipt could not disagree; the banner counted the flat list separately
+  // and drifted anyway (#507). One partition is what makes them agree.
+  const legacyFolders = useMemo(() => legacy.filter((n) => n.kind === "folder"), [legacy]);
+  const legacyFiles = useMemo(() => legacy.filter((n) => n.kind === "file"), [legacy]);
   const uploadRef = useRef<HTMLInputElement>(null);
 
   // Generation tokens so a response from a previous company scope (or from a
@@ -352,10 +382,6 @@ export function WorkspaceView({ client, company }: Props) {
 
   async function importLegacy() {
     setImporting(true);
-    // Partitioned once, so the loops below and the receipt that reports them
-    // can never disagree about what was imported (#500).
-    const folders = legacy.filter((n) => n.kind === "folder");
-    const files = legacy.filter((n) => n.kind === "file");
     try {
       const root = await createNode(client, company, {
         name: IMPORT_FOLDER_NAME,
@@ -366,7 +392,7 @@ export function WorkspaceView({ client, company }: Props) {
       const remap = new Map<string, string>();
       const parentFor = (node: FsNode) =>
         node.parentId ? (remap.get(node.parentId) ?? root.id) : root.id;
-      for (const folder of folders) {
+      for (const folder of legacyFolders) {
         const created = await createNode(client, company, {
           name: folder.name,
           kind: "folder",
@@ -374,7 +400,7 @@ export function WorkspaceView({ client, company }: Props) {
         });
         remap.set(folder.id, created.id);
       }
-      for (const file of files) {
+      for (const file of legacyFiles) {
         await createNode(client, company, {
           name: ensureMdExt(file.name),
           kind: "file",
@@ -384,7 +410,7 @@ export function WorkspaceView({ client, company }: Props) {
       }
       clearLegacyLocal(company);
       setLegacy([]);
-      toast.success(`Imported ${importSummary(files.length, folders.length)}.`);
+      toast.success(`Imported ${importSummary(legacyFiles.length, legacyFolders.length)}.`);
       await loadTree({ silent: true });
     } catch (e) {
       // The key is left intact on failure, so the banner comes back and nothing
@@ -643,8 +669,7 @@ export function WorkspaceView({ client, company }: Props) {
           <Alert className="m-3 mb-0 w-auto" data-testid="workspace-migration-banner">
             <AlertDescription className="flex flex-wrap items-center gap-3">
               <span className="flex-1">
-                {legacy.length} note{legacy.length === 1 ? "" : "s"} from this browser's old
-                scratchpad {legacy.length === 1 ? "is" : "are"} not in the company workspace yet.
+                {migrationBannerText(legacyFiles.length, legacyFolders.length)}
               </span>
               <Button
                 size="sm"

--- a/frontend/test/e2e/workspace.spec.ts
+++ b/frontend/test/e2e/workspace.spec.ts
@@ -233,10 +233,15 @@ test("the retired local scratchpad is offered for import, its seed discarded", a
 
   await openWorkspace(page);
 
-  // The banner offers only the user's nodes — the seed is not counted.
+  // The banner offers only the user's nodes — the seed is not counted — and
+  // names them per kind (#507). It used to say "3 notes" for this very
+  // fixture, then import them and toast "Imported 2 notes and 1 folder": the
+  // prompt and the receipt disagreed about the same three nodes. Asserting
+  // both strings in one test is what holds them together.
   const banner = page.getByTestId("workspace-migration-banner");
   await expect(banner).toBeVisible({ timeout: 30_000 });
-  await expect(banner).toContainText("3 notes");
+  await expect(banner).toContainText("2 notes and 1 folder");
+  await expect(banner).toContainText("are not in the company workspace yet");
 
   await page.getByTestId("workspace-migration-import").click();
 

--- a/frontend/test/unit/workspace-migration-banner.test.ts
+++ b/frontend/test/unit/workspace-migration-banner.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import { importSummary, migrationBannerText } from "@/views/WorkspaceView";
+
+/**
+ * The migration banner's sentence (issue #507).
+ *
+ * The banner counted the flat scratchpad list and called every entry a "note",
+ * exactly as the receipt did before #500 — so a folder-only scratchpad was
+ * offered as "1 note … is not in the company workspace yet" when it held no
+ * notes at all. The two surfaces describe the same nodes one click apart, so
+ * the cases below check both that each sentence is true on its own and that
+ * the pair agrees.
+ */
+
+describe("migrationBannerText", () => {
+  it("names a files-only scratchpad, unchanged from the wording that was right", () => {
+    expect(migrationBannerText(3, 0)).toBe(
+      "3 notes from this browser's old scratchpad are not in the company workspace yet.",
+    );
+  });
+
+  it("names a folders-only scratchpad without inventing notes", () => {
+    // The reported defect: this said "1 note … is" for zero notes.
+    expect(migrationBannerText(0, 1)).toBe(
+      "1 folder from this browser's old scratchpad is not in the company workspace yet.",
+    );
+    expect(migrationBannerText(0, 1)).not.toContain("note");
+  });
+
+  it("names both categories for a mixed scratchpad", () => {
+    // The issue's own example: 1 folder + 2 files was offered as "3 notes".
+    expect(migrationBannerText(2, 1)).toBe(
+      "2 notes and 1 folder from this browser's old scratchpad are not in the company workspace yet.",
+    );
+  });
+
+  it("agrees with the singular for a lone note", () => {
+    expect(migrationBannerText(1, 0)).toBe(
+      "1 note from this browser's old scratchpad is not in the company workspace yet.",
+    );
+  });
+
+  it("takes the plural verb when each kind is singular but there are two nodes", () => {
+    // The trap in keying the verb off the summary's leading number: it reads
+    // "1", but "1 note and 1 folder" is two things.
+    expect(migrationBannerText(1, 1)).toContain("are not in the company workspace yet");
+    expect(migrationBannerText(1, 1)).not.toContain(" is not in");
+  });
+
+  it("takes the singular verb only for a genuinely single node", () => {
+    expect(migrationBannerText(1, 0)).toContain(" is not in");
+    expect(migrationBannerText(0, 1)).toContain(" is not in");
+    expect(migrationBannerText(2, 0)).toContain(" are not in");
+    expect(migrationBannerText(0, 2)).toContain(" are not in");
+  });
+
+  it("describes the same nodes the receipt will report", () => {
+    // The banner and the toast are one click apart on one scratchpad. Before
+    // #507 they disagreed: "3 notes" offered, "2 notes and 1 folder" imported.
+    for (const [files, folders] of [
+      [3, 0],
+      [0, 1],
+      [2, 1],
+      [1, 1],
+      [0, 4],
+    ] as const) {
+      expect(migrationBannerText(files, folders)).toContain(importSummary(files, folders));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #507.

The Workspace migration banner counted the flat legacy node list and called
every entry a "note". A scratchpad holding one folder announced **"1 note from
this browser's old scratchpad is not in the company workspace yet"** with no
notes in it at all; a mixed scratchpad of 1 folder and 2 files said "3 notes".
`legacy` is a flat `FsNode[]` of both kinds — the import loops below it already
partition by `n.kind`.

This is the same defect #500 fixed in the post-import **receipt**. PR #503
deliberately scoped itself there and said so, leaving the pre-import **prompt**
over-reporting.

### The real defect was two surfaces counting independently

Worth stating plainly, because the issue is written as a wrong-count bug and the
narrow reading of it produces a weaker fix. The banner and the receipt describe
the *same nodes*, one click apart, and they had **two separate counting
expressions**. That is why they disagreed out loud: the banner offered "3 notes"
and importing them toasted "Imported 2 notes and 1 folder."

So the banner does not re-derive the phrase with corrected arithmetic — it calls
the very `importSummary` helper the receipt uses:

```tsx
export function migrationBannerText(files: number, folders: number): string {
  const total = files + folders;
  return (
    `${importSummary(files, folders)} from this browser's old scratchpad ` +
    `${total === 1 ? "is" : "are"} not in the company workspace yet.`
  );
}
```

There is now no second expression that *can* drift. A future edit to the noun
phrase moves both surfaces together or neither.

The partition moves with it. #503 partitioned once inside `importLegacy`, which
kept the loops and the receipt honest but left the banner counting the flat list
on its own — which is precisely how this survived. The list is now partitioned
once at the component level and the banner, both import loops, and the receipt
all read those same locals.

### The verb trap — please read before editing this line

The old verb agreement was **already correct**, and the obvious fix regresses it.

`legacy.length` is the *total node count*, so `is`/`are` was right; only the noun
was wrong. Anyone who "fixes" this by switching the whole expression to the file
count breaks a case that used to work. The verb therefore keys off
`files + folders`, never off the summary's leading number:

```
migrationBannerText(1, 1) === "1 note and 1 folder … are not in the company workspace yet."
```

The string starts with "1" and takes **`are`**, because it names two things.
`workspace-migration-banner.test.ts` pins this case specifically so a later
editor cannot quietly get it wrong.

### Before → after

| Scratchpad | Before | After |
| --- | --- | --- |
| 3 notes | `3 notes … are` | `3 notes … are` (unchanged — this case was right) |
| 1 folder | `1 note … is` | `1 folder … is` |
| 2 notes + 1 folder | `3 notes … are` | `2 notes and 1 folder … are` |
| 1 note + 1 folder | `2 notes … are` | `1 note and 1 folder … are` |

The common files-only scratchpad renders byte-identical to today's output — the
case where today's output was already honest.

Deliberately untouched, as in #500: the failure path (which leaves the legacy key
intact), the seed sweep, discard, import ordering, and the `IMPORT_FOLDER_NAME`
root, which is packaging rather than content and correctly stays outside every
tally.

## API Or Behavior Changes

User-visible copy only: the Workspace migration banner now names notes and
folders separately, and agrees with the receipt that follows it. No API, route,
storage, or schema change. `importSummary` is unchanged; `migrationBannerText` is
a new export in the same module, consumed only by the banner.

## Tests

Console-side change. The Rust checklist below does not apply and is annotated
per box.

Run locally from `frontend/`, against CI's exact dependency tree (`npm ci` from
`package-lock.json`, matching the `Console` job — not a pnpm install, which
resolves a different `jsdom`):

- `npm run typecheck` — clean
- `npm run typecheck:e2e` — clean (covers the edited Playwright spec)
- `npm run typecheck:unit` — clean
- `npx vitest run test/unit/workspace-migration-banner.test.ts test/unit/workspace-import-summary.test.ts` — **15 passed**

**New** `frontend/test/unit/workspace-migration-banner.test.ts` (7 cases):
files-only, folders-only, mixed, the lone note, the `1 + 1` verb trap, a
singular-vs-plural sweep, and a **cross-surface agreement** case asserting that
`migrationBannerText` contains `importSummary(files, folders)` for five shapes —
that last one is what pins the issue's "banner and receipt agree" acceptance
criterion rather than leaving it to prose.

**Updated** `frontend/test/e2e/workspace.spec.ts`: the fixture plants 2 files +
1 folder and asserted the banner's **current, wrong** `"3 notes"`. That is a
pinned bug, so it is updated rather than deleted, and the spec now asserts the
banner string *and* the receipt string in one test — the two can no longer be
changed apart without a test failing.

These assertions are load-bearing, not decorative: reverting `migrationBannerText`
to the old flat-count expression turns 3 of the 7 new cases red (folders-only,
mixed, agreement) while files-only and lone-note stay green — correct, since
those are the two cases the old code got right.

**Pre-existing, unrelated, and not addressed here:** `test/unit/tour-resume.test.ts`
fails 10/10 locally with `window.localStorage.clear is not a function`. It is not
introduced by this PR — it reproduces on clean `main` with these changes stashed,
and CI is green on this branch's base commit `d7c4ff2d`. The cause is local
Node v25 versus CI's Node 22, which breaks `jsdom` 27's `localStorage`. Flagged
so nobody re-investigates it during review; no change made.

- [x] `cargo fmt --all -- --check` — N/A: no Rust files changed (frontend-only diff).
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust files changed.
- [x] `cargo build --all-targets` — N/A: no Rust files changed.
- [x] `cargo test` — N/A: no Rust files changed; the console suites run above are the relevant coverage.

## Documentation

No docs change needed. This is user-visible copy inside one component, not a
route, public API, launcher behavior, or `tiny*` integration surface, so nothing
in `README.md`, `docs/spec/README.md`, or `docs/modules/` describes the string.
The reasoning that a reader needs — why the banner shares the receipt's helper
instead of counting again, and why the verb follows the total rather than the
summary's leading number — is documented on `migrationBannerText` itself and in
the comment above the hoisted partition, next to the code it constrains.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the scratchpad migration banner to clearly summarize imported content by type, including notes and folders.
  * Improved singular and plural wording for accurate messaging across different import sizes.
  * Clarified that imported items are not yet available in the company workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->