### PR TITLE
feat(ports): a retention policy for the company event journal

### DIFF
--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -16,7 +16,7 @@ Append-only, replayable, **single-writer**, and company-scoped. Boot replays the
 tail to rebuild in-flight state. Every variant is serialized internally-tagged
 under `kind`, so each JSONL line is self-describing.
 
-Two properties are load-bearing everywhere below:
+Three properties are load-bearing everywhere below:
 
 * **Additive-only.** A new variant, or a new field carrying
   `#[serde(default, skip_serializing_if = …)]`, cannot change how an
@@ -30,6 +30,12 @@ Two properties are load-bearing everywhere below:
   interleave a record and its newline onto one line and brick the next replay).
   Several boot-time sweeps rest on this; see
   [Interrupted runs](#interrupted-runs-issue-371).
+* **A sequence is a stable id, and retention keeps it that way** (issue #275).
+  Only the three workflow-run kinds and `McpCallFailed` may ever be pruned;
+  everything else is permanent, because it is either the audit trail or the
+  referent of a stored `EventSeq` (a thread `parent`, a `ReactionToggled`
+  target, a `TaskDiscussionRedacted` tombstone). Pruning renumbers nothing and
+  leaves gaps. See [Retention](ports-state.md#retention-issue-275).
 
 ## Variants
 

--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -73,8 +73,47 @@ pub trait EventLog: Send + Sync {
     async fn read_from(&self, id: &CompanyId, seq: EventSeq, limit: usize)
         -> Result<Vec<StoredEvent>>;
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent>;
+    async fn prune(&self, id: &CompanyId, policy: &RetentionPolicy)
+        -> Result<PruneReport>;
 }
 ```
+
+### Retention (issue #275)
+
+`prune` is the only operation that removes a journal entry. Nothing calls it on
+the append path — retention is an operator action, not a side effect of writing
+— and it is built so that the irreversible direction is the hard one to reach:
+
+| Guard | Effect |
+| --- | --- |
+| `RetentionPolicy::default()` | removes nothing; both bounds are `None` |
+| `CompanyEvent::retention_class()` | exhaustive match, no `_` arm — a new variant fails the build until classified, and `Permanent` is the answer for anything ambiguous |
+| `plan_prune` | one pure function all three backends route through, so fs / sqlite / mongodb cannot disagree about what a policy means |
+| the sequence watermark | the highest-sequence entry is never removed, whatever the policy |
+| default trait body | `Err(Unimplemented)` — a backend without retention refuses, rather than reporting a pass that removed nothing |
+
+Only four kinds are `Prunable`: `WorkflowRunStarted`, `WorkflowRunFinished`,
+`WorkflowNodeFinished` and `McpCallFailed`. Everything else is `Permanent`,
+either because it is the audit trail (approvals, lifecycle, payments) or
+because another entry addresses it *by sequence* — thread parents, reaction
+targets, and the `TaskDiscussionRedacted` tombstone from issue #358 all name a
+message by its `EventSeq`, so pruning a referent would dangle a pointer no fold
+can repair.
+
+**Sequences are never renumbered.** Pruning leaves gaps, which `read_from`'s
+`seq >=` scan already tolerates: a cursor or SSE subscriber parked on a removed
+sequence resumes at the next survivor. The watermark rule exists because
+`FsEventLog` and `SqliteStore` both derive the next sequence from the highest
+one present, so an emptied log would hand the next append a number a retained
+cross-reference still holds.
+
+The age bound is measured back from the newest entry in the log, not from
+wall-clock now — the same anchoring
+[`UsageMeter`](ports-console.md#usagemeter) uses, which keeps a pass
+deterministic, testable without a clock, and unable to empty a dormant
+company's journal just because time passed. Unlike `UsageMeter`, which evicts
+on write against a fixed 90-day window, the journal never evicts implicitly:
+it is what export/import ships and what boot replays.
 
 **The `CompanyEvent` vocabulary lives in
 [`events.md`](events.md)** — every variant, the additive-serialization contract

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -1,10 +1,214 @@
 //! The [`EventLog`] port: append-only, replayable event history.
+//!
+//! # Retention
+//!
+//! The journal is append-only and grows for the life of a company (issue #275).
+//! [`EventLog::prune`] is the only operation that removes an entry, and it is
+//! deliberately awkward to invoke by accident:
+//!
+//! - It is **never** called on the append path. The [`UsageMeter`] precedent
+//!   evicts on write against a hard-coded window; a journal must not, because
+//!   the journal is what export/import ships and what boot replays. Retention
+//!   here is something an operator asks for, not something a write does.
+//! - It takes an explicit [`RetentionPolicy`], and the [`Default`] policy
+//!   removes nothing. A caller that forgets to configure a bound gets a no-op,
+//!   not a silent deletion.
+//! - It refuses to touch an event whose kind is
+//!   [`RetentionClass::Permanent`], and classification is an exhaustive match
+//!   (see [`CompanyEvent::retention_class`]) so a newly added event variant
+//!   fails the build until somebody decides. Unclassifiable means permanent.
+//! - The backend does not decide *what* goes. [`plan_prune`] is a pure
+//!   function shared by all three production backends, so fs, sqlite and
+//!   mongodb cannot drift apart on the one operation that cannot be undone.
+//!
+//! Sequence numbers are **not** renumbered. Pruning leaves gaps, which
+//! `read_from`'s `>= seq` scan already tolerates: a cursor or SSE subscriber
+//! parked on a pruned sequence resumes at the next surviving one. Renumbering
+//! would instead invalidate every stored cross-reference — thread parents,
+//! reaction targets, and the `TaskDiscussionRedacted` tombstone from #358 all
+//! address a message by its sequence.
+//!
+//! [`UsageMeter`]: crate::ports::usage::UsageMeter
+
+use std::collections::HashMap;
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 
-use crate::Result;
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, StoredEvent};
+use crate::{OpenCompanyError, Result};
+
+/// Whether a journal entry may ever be discarded by a retention pass.
+///
+/// The split is not "important vs unimportant" — it is "reconstructible
+/// operational exhaust vs a record something else depends on". Two things make
+/// an entry [`Permanent`](Self::Permanent):
+///
+/// 1. **It is the audit trail.** An approval verdict, a lifecycle transition, a
+///    payment, a tool-access grant. Deleting these is the failure mode the
+///    issue's first question guards against.
+/// 2. **Another entry addresses it by sequence.** A thread reply points at its
+///    parent, a reaction points at a message, and `TaskDiscussionRedacted`
+///    points at the post it supersedes. Pruning a referent leaves a dangling
+///    pointer that no fold can repair, so every referent kind is permanent.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RetentionClass {
+    /// Operational exhaust: safe to discard once a bound says so.
+    Prunable,
+    /// Audit-bearing, or addressed by sequence from another entry. Never
+    /// removed, whatever the policy says.
+    Permanent,
+}
+
+/// An explicit bound on how much of the journal is kept.
+///
+/// Both bounds are `None` by default, and a policy with no bound set removes
+/// nothing — retention is opt-in per caller, never an ambient default. When
+/// both are set an entry goes if *either* bound selects it.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RetentionPolicy {
+    /// Discard prunable entries older than this, measured back from the newest
+    /// entry in the log rather than from wall-clock now. `None` disables the
+    /// age bound.
+    ///
+    /// Anchoring to the newest *observed* entry is the same rule
+    /// [`retention_cutoff`](crate::ports::usage::retention_cutoff) uses for
+    /// usage samples: it makes a pass deterministic and testable with no clock,
+    /// and it never empties a dormant company's journal just because time
+    /// passed with nothing happening.
+    pub max_age_millis: Option<u64>,
+    /// Keep at most this many prunable entries *of each kind*, discarding the
+    /// oldest beyond it. `None` disables the count bound.
+    ///
+    /// Per-kind rather than per-log, mirroring OpenHuman's
+    /// `MAX_FLOW_RUNS_PER_FLOW`: a burst of webhook traffic should not evict
+    /// the run outcomes the issue set out to bound.
+    pub max_entries_per_kind: Option<usize>,
+}
+
+impl RetentionPolicy {
+    /// The policy that removes nothing. Identical to [`Default`], named for
+    /// call sites that want to say so out loud.
+    pub fn keep_everything() -> Self {
+        Self::default()
+    }
+
+    /// A policy bounding prunable entries by age.
+    pub fn with_max_age_millis(millis: u64) -> Self {
+        Self {
+            max_age_millis: Some(millis),
+            ..Self::default()
+        }
+    }
+
+    /// A policy bounding prunable entries by per-kind count.
+    pub fn with_max_entries_per_kind(entries: usize) -> Self {
+        Self {
+            max_entries_per_kind: Some(entries),
+            ..Self::default()
+        }
+    }
+
+    /// Whether this policy can remove anything at all.
+    ///
+    /// Backends short-circuit on this, so a default-constructed policy costs
+    /// one branch rather than a full scan.
+    pub fn is_noop(&self) -> bool {
+        self.max_age_millis.is_none() && self.max_entries_per_kind.is_none()
+    }
+
+    /// The oldest `at_millis` this policy keeps, given the newest entry the log
+    /// holds. Entries strictly older than the cutoff are discarded; an entry
+    /// exactly `max_age_millis` old is inside the window and kept.
+    ///
+    /// `None` when no age bound is set.
+    pub fn cutoff_millis(&self, newest_at_millis: u64) -> Option<u64> {
+        self.max_age_millis
+            .map(|age| newest_at_millis.saturating_sub(age))
+    }
+}
+
+/// What one [`EventLog::prune`] pass did.
+///
+/// Returned rather than logged so a caller can assert on it, surface it, or
+/// refuse to proceed — a deletion that reports nothing is indistinguishable
+/// from a deletion that went wrong.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct PruneReport {
+    /// How many entries the pass considered.
+    pub scanned: usize,
+    /// How many entries it removed.
+    pub removed: usize,
+    /// The lowest sequence still present afterwards, or `None` if the log is
+    /// empty. Gaps below it are expected and permanent.
+    pub oldest_retained: Option<EventSeq>,
+}
+
+/// Decides which entries a retention pass removes.
+///
+/// Pure and total: no clock, no I/O, no backend knowledge. Every production
+/// backend routes its `prune` through this, which is what makes "fs, sqlite and
+/// mongodb agree" a property of the code rather than of three parallel test
+/// suites.
+///
+/// `events` may arrive in any order; the returned sequences are sorted
+/// ascending and contain no duplicates.
+///
+/// Three rules, applied in order:
+///
+/// 1. A no-op policy removes nothing.
+/// 2. A [`RetentionClass::Permanent`] entry is never removed.
+/// 3. The highest-sequence entry is never removed, whatever its class.
+///
+/// Rule 3 is not cosmetic. `FsEventLog` and `SqliteStore` both allocate the
+/// next sequence from the highest one present, so a pass that emptied the log
+/// would hand the next append a sequence already used by a *retained*
+/// cross-reference — silently re-pointing a redaction tombstone or a thread
+/// parent at an unrelated message. Keeping the watermark entry makes sequence
+/// reuse unreachable without asking either backend to persist a counter it
+/// does not have today.
+pub fn plan_prune(events: &[StoredEvent], policy: &RetentionPolicy) -> Vec<EventSeq> {
+    if policy.is_noop() || events.is_empty() {
+        return Vec::new();
+    }
+
+    let watermark = events.iter().map(|e| e.seq).max();
+    let newest_at = events.iter().map(|e| e.at_millis).max().unwrap_or_default();
+    let cutoff = policy.cutoff_millis(newest_at);
+
+    // Candidates are prunable and not the sequence watermark. Ordered newest
+    // first so the per-kind count bound keeps the most recent entries.
+    let mut candidates: Vec<&StoredEvent> = events
+        .iter()
+        .filter(|e| e.event.retention_class() == RetentionClass::Prunable)
+        .filter(|e| Some(e.seq) != watermark)
+        .collect();
+    candidates.sort_by_key(|e| std::cmp::Reverse(e.seq));
+
+    let mut doomed = Vec::new();
+    let mut seen_per_kind: HashMap<&'static str, usize> = HashMap::new();
+
+    for event in candidates {
+        let too_old = cutoff.is_some_and(|c| event.at_millis < c);
+
+        let kept_of_kind = seen_per_kind.entry(event.event.kind()).or_insert(0);
+        let over_count = policy
+            .max_entries_per_kind
+            .is_some_and(|max| *kept_of_kind >= max);
+
+        if too_old || over_count {
+            doomed.push(event.seq);
+        } else {
+            // Only surviving entries count against the per-kind budget;
+            // otherwise an age-evicted entry would consume a slot that a
+            // younger entry of the same kind should have had.
+            *kept_of_kind += 1;
+        }
+    }
+
+    doomed.sort();
+    doomed
+}
 
 /// Append-only, replayable event log. Boot replays the tail to rebuild
 /// in-flight state.
@@ -21,4 +225,269 @@ pub trait EventLog: Send + Sync {
     ) -> Result<Vec<StoredEvent>>;
     /// Subscribes to events appended after the call.
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent>;
+
+    /// Applies `policy`, removing the entries [`plan_prune`] selects, and
+    /// reports what went.
+    ///
+    /// The default refuses. A backend that has not implemented retention
+    /// answers "port not implemented" rather than reporting a successful pass
+    /// that removed nothing — the two are indistinguishable to a caller, and
+    /// only one of them is true. Implement it, or let it fail loudly.
+    ///
+    /// Removal is permanent and leaves sequence gaps by design; see the module
+    /// docs.
+    async fn prune(&self, id: &CompanyId, policy: &RetentionPolicy) -> Result<PruneReport> {
+        let _ = (id, policy);
+        Err(OpenCompanyError::Unimplemented("EventLog::prune"))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{Actor, ActorKind, WorkflowNodeStatus};
+
+    /// A fixed base far from epoch 0 so cutoff arithmetic stays positive.
+    const BASE: u64 = 1_000_000_000_000;
+    const DAY: u64 = 86_400_000;
+
+    fn run_started(n: u64) -> CompanyEvent {
+        CompanyEvent::WorkflowRunStarted {
+            workflow_id: "wf".into(),
+            run_id: format!("run-{n}"),
+            scheduled: false,
+        }
+    }
+
+    fn node_finished(n: u64) -> CompanyEvent {
+        CompanyEvent::WorkflowNodeFinished {
+            workflow_id: "wf".into(),
+            run_id: format!("run-{n}"),
+            node_id: format!("node-{n}"),
+            status: WorkflowNodeStatus::Ok,
+            elapsed_ms: 1,
+        }
+    }
+
+    fn lifecycle(n: u64) -> CompanyEvent {
+        CompanyEvent::LifecycleChanged {
+            from: "running".into(),
+            to: format!("paused-{n}"),
+            by: Actor {
+                kind: ActorKind::Operator,
+                id: "operator".into(),
+            },
+        }
+    }
+
+    /// Builds a log from `(seq, at_millis, event)` triples.
+    fn log(entries: Vec<(u64, u64, CompanyEvent)>) -> Vec<StoredEvent> {
+        entries
+            .into_iter()
+            .map(|(seq, at_millis, event)| StoredEvent {
+                seq: EventSeq::new(seq),
+                company: CompanyId::new("acme"),
+                event,
+                at_millis,
+            })
+            .collect()
+    }
+
+    fn seqs(raw: &[u64]) -> Vec<EventSeq> {
+        raw.iter().copied().map(EventSeq::new).collect()
+    }
+
+    #[test]
+    fn default_policy_is_a_no_op() {
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE + DAY, run_started(1)),
+            (2, BASE + 2 * DAY, run_started(2)),
+        ]);
+        assert!(RetentionPolicy::default().is_noop());
+        assert_eq!(plan_prune(&events, &RetentionPolicy::default()), vec![]);
+    }
+
+    #[test]
+    fn empty_log_prunes_nothing() {
+        assert_eq!(
+            plan_prune(&[], &RetentionPolicy::with_max_entries_per_kind(0)),
+            vec![]
+        );
+    }
+
+    #[test]
+    fn age_bound_is_anchored_to_the_newest_entry_not_a_clock() {
+        // Newest is 10 days after BASE; a 5-day window keeps everything from
+        // BASE+5d onward. No wall clock is consulted, so this test is stable
+        // whenever it runs.
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE + 4 * DAY, run_started(1)),
+            (2, BASE + 5 * DAY, run_started(2)),
+            (3, BASE + 10 * DAY, run_started(3)),
+        ]);
+        let policy = RetentionPolicy::with_max_age_millis(5 * DAY);
+        assert_eq!(plan_prune(&events, &policy), seqs(&[0, 1]));
+    }
+
+    #[test]
+    fn an_entry_exactly_at_the_window_edge_is_kept() {
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE + 5 * DAY, run_started(1)),
+        ]);
+        // Newest is BASE+5d, so the cutoff is exactly BASE. Seq 0 sits on it
+        // and is inside the window.
+        let policy = RetentionPolicy::with_max_age_millis(5 * DAY);
+        assert_eq!(plan_prune(&events, &policy), vec![]);
+    }
+
+    #[test]
+    fn permanent_kinds_survive_any_policy() {
+        let events = log(vec![
+            (0, BASE, lifecycle(0)),
+            (1, BASE, lifecycle(1)),
+            (2, BASE, lifecycle(2)),
+            (3, BASE + 1000 * DAY, run_started(0)),
+        ]);
+        let policy = RetentionPolicy {
+            max_age_millis: Some(1),
+            max_entries_per_kind: Some(0),
+        };
+        // Only the watermark is prunable-by-kind, and rule 3 protects it.
+        assert_eq!(plan_prune(&events, &policy), vec![]);
+    }
+
+    #[test]
+    fn count_bound_keeps_the_newest_per_kind() {
+        // Two prunable kinds interleaved: each gets its own budget of 1, so a
+        // burst of one kind cannot evict the other.
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE, node_finished(0)),
+            (2, BASE, run_started(1)),
+            (3, BASE, node_finished(1)),
+            (4, BASE, run_started(2)),
+            (5, BASE, lifecycle(0)),
+        ]);
+        let policy = RetentionPolicy::with_max_entries_per_kind(1);
+        // Kept: seq 4 (newest run-start), seq 3 (newest node-finish), seq 5
+        // (permanent, and the watermark).
+        assert_eq!(plan_prune(&events, &policy), seqs(&[0, 1, 2]));
+    }
+
+    #[test]
+    fn the_sequence_watermark_is_never_removed() {
+        // Every entry is prunable and every entry is over both bounds; the
+        // highest sequence still survives, because fs and sqlite allocate the
+        // next sequence from it.
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE, run_started(1)),
+            (2, BASE, run_started(2)),
+        ]);
+        let policy = RetentionPolicy {
+            max_age_millis: Some(0),
+            max_entries_per_kind: Some(0),
+        };
+        assert_eq!(plan_prune(&events, &policy), seqs(&[0, 1]));
+    }
+
+    #[test]
+    fn either_bound_alone_can_select_an_entry() {
+        let events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE + 100 * DAY, run_started(1)),
+            (2, BASE + 100 * DAY, run_started(2)),
+        ]);
+        // Age alone would take seq 0; count alone (keep 2) would also take
+        // seq 0. Together they still take exactly seq 0 — the rule is a union,
+        // not a double count.
+        let policy = RetentionPolicy {
+            max_age_millis: Some(DAY),
+            max_entries_per_kind: Some(2),
+        };
+        assert_eq!(plan_prune(&events, &policy), seqs(&[0]));
+    }
+
+    #[test]
+    fn an_age_evicted_entry_does_not_consume_a_count_slot() {
+        // Sequence order and timestamp order disagree here — seq 1 is the old
+        // one — which is the only arrangement that can tell the two counting
+        // rules apart. Backfill and clock skew both produce it.
+        //
+        // seq 1 is evicted by age. If it *also* consumed one of the two
+        // per-kind slots, seq 0 would be evicted for being over the count.
+        // It must not be: the budget is for what is kept.
+        let events = log(vec![
+            (0, BASE + 100 * DAY, run_started(0)),
+            (1, BASE, run_started(1)),
+            (2, BASE + 100 * DAY, run_started(2)),
+            (3, BASE + 100 * DAY, lifecycle(0)),
+        ]);
+        let policy = RetentionPolicy {
+            max_age_millis: Some(DAY),
+            max_entries_per_kind: Some(2),
+        };
+        assert_eq!(plan_prune(&events, &policy), seqs(&[1]));
+    }
+
+    #[test]
+    fn input_order_does_not_change_the_outcome() {
+        let mut events = log(vec![
+            (0, BASE, run_started(0)),
+            (1, BASE, run_started(1)),
+            (2, BASE, run_started(2)),
+            (3, BASE, lifecycle(0)),
+        ]);
+        let policy = RetentionPolicy::with_max_entries_per_kind(1);
+        let forward = plan_prune(&events, &policy);
+        events.reverse();
+        assert_eq!(forward, plan_prune(&events, &policy));
+        assert_eq!(forward, seqs(&[0, 1]));
+    }
+
+    #[test]
+    fn chat_kinds_addressed_by_sequence_are_permanent() {
+        // The referents of a thread parent, a reaction, and #358's redaction
+        // tombstone. Pruning any of them dangles a stored pointer.
+        for event in [
+            CompanyEvent::OperatorMessage {
+                text: "hi".into(),
+                by: None,
+                chat: None,
+                parent: None,
+            },
+            CompanyEvent::AgentReply {
+                chat_id: "desk".into(),
+                agent_id: "ceo".into(),
+                text: "hello".into(),
+                steps: vec![],
+                task_id: None,
+                parent: None,
+            },
+        ] {
+            assert_eq!(
+                event.retention_class(),
+                RetentionClass::Permanent,
+                "{} must stay permanent: other entries address it by sequence",
+                event.kind()
+            );
+        }
+    }
+
+    #[test]
+    fn kind_matches_the_serialized_tag() {
+        // `kind()` is hand-written, so pin it against what serde actually
+        // emits; a rename that misses one of the two would otherwise be silent.
+        for event in [run_started(0), node_finished(0), lifecycle(0)] {
+            let json = serde_json::to_value(&event).expect("serialize");
+            assert_eq!(
+                json.get("kind").and_then(|k| k.as_str()),
+                Some(event.kind()),
+                "kind() disagrees with the serde tag"
+            );
+        }
+    }
 }

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -41,7 +41,7 @@ pub use brain::{Brain, Cognition, CycleHost, UsageMetering};
 pub use channel::ChannelAdapter;
 pub use context::ContextStore;
 pub use economy::AgentEconomy;
-pub use events::EventLog;
+pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_prune};
 pub use facts::{FactKind, FactRecord, FactStore};
 pub use ids::{generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -949,6 +949,101 @@ pub enum CompanyEvent {
     },
 }
 
+impl CompanyEvent {
+    /// The variant's serialized discriminant — the same string that appears
+    /// under the internally-tagged `kind` field of a journal line.
+    ///
+    /// Written out rather than derived so the value is available without
+    /// serializing, and so a rename of the wire tag has to be made here too
+    /// instead of drifting silently.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::OperatorMessage { .. } => "OperatorMessage",
+            Self::WebhookReceived { .. } => "WebhookReceived",
+            Self::ScheduleFired { .. } => "ScheduleFired",
+            Self::A2aTaskReceived { .. } => "A2aTaskReceived",
+            Self::ApprovalParked { .. } => "ApprovalParked",
+            Self::ApprovalResolved { .. } => "ApprovalResolved",
+            Self::FeedbackFiled { .. } => "FeedbackFiled",
+            Self::PaymentReceived { .. } => "PaymentReceived",
+            Self::LifecycleChanged { .. } => "LifecycleChanged",
+            Self::AgentReply { .. } => "AgentReply",
+            Self::ReactionToggled { .. } => "ReactionToggled",
+            Self::MemoryFactDeleted { .. } => "MemoryFactDeleted",
+            Self::ToolAccessChanged { .. } => "ToolAccessChanged",
+            Self::TaskDispatched { .. } => "TaskDispatched",
+            Self::McpCallFailed { .. } => "McpCallFailed",
+            Self::WorkflowCreated { .. } => "WorkflowCreated",
+            Self::WorkflowUpdated { .. } => "WorkflowUpdated",
+            Self::WorkflowDeleted { .. } => "WorkflowDeleted",
+            Self::TaskSteered { .. } => "TaskSteered",
+            Self::TaskCardChanged { .. } => "TaskCardChanged",
+            Self::DeskTaskCompleted { .. } => "DeskTaskCompleted",
+            Self::TaskDiscussionPosted { .. } => "TaskDiscussionPosted",
+            Self::TaskDiscussionRedacted { .. } => "TaskDiscussionRedacted",
+            Self::WorkflowRunFinished { .. } => "WorkflowRunFinished",
+            Self::WorkflowRunStarted { .. } => "WorkflowRunStarted",
+            Self::WorkflowNodeFinished { .. } => "WorkflowNodeFinished",
+        }
+    }
+
+    /// Whether a retention pass may ever discard this entry (issue #275).
+    ///
+    /// **Exhaustive on purpose — do not add a `_` arm.** A new event variant
+    /// must fail this match and make somebody choose, because the safe default
+    /// for an unclassified entry is to keep it forever, and a wildcard would
+    /// silently pick the other one.
+    ///
+    /// Only four kinds are prunable, and each is high-volume machine exhaust
+    /// that no other entry addresses:
+    ///
+    /// - the three workflow-run kinds — the growth the issue was filed for,
+    ///   left behind when #259 deletes a workflow, and
+    /// - `McpCallFailed`, a per-attempt tool failure whose durable meaning is
+    ///   already carried by the run outcome it belongs to.
+    ///
+    /// Everything else is permanent. `WebhookReceived` and `ScheduleFired` are
+    /// tempting — both are voluminous and machine-generated — but a webhook
+    /// body is the only record of what a counterparty actually sent, and a
+    /// schedule tick is the only evidence a cron fired at all. Both are
+    /// evidence, so both stay. Chat kinds stay for a second, harder reason:
+    /// `OperatorMessage`, `AgentReply` and `TaskDiscussionPosted` are addressed
+    /// by sequence from thread parents, reactions, and #358's redaction
+    /// tombstone, so pruning one dangles a pointer nothing can repair.
+    pub fn retention_class(&self) -> crate::ports::events::RetentionClass {
+        use crate::ports::events::RetentionClass::{Permanent, Prunable};
+        match self {
+            Self::WorkflowRunStarted { .. }
+            | Self::WorkflowRunFinished { .. }
+            | Self::WorkflowNodeFinished { .. }
+            | Self::McpCallFailed { .. } => Prunable,
+
+            Self::OperatorMessage { .. }
+            | Self::WebhookReceived { .. }
+            | Self::ScheduleFired { .. }
+            | Self::A2aTaskReceived { .. }
+            | Self::ApprovalParked { .. }
+            | Self::ApprovalResolved { .. }
+            | Self::FeedbackFiled { .. }
+            | Self::PaymentReceived { .. }
+            | Self::LifecycleChanged { .. }
+            | Self::AgentReply { .. }
+            | Self::ReactionToggled { .. }
+            | Self::MemoryFactDeleted { .. }
+            | Self::ToolAccessChanged { .. }
+            | Self::TaskDispatched { .. }
+            | Self::WorkflowCreated { .. }
+            | Self::WorkflowUpdated { .. }
+            | Self::WorkflowDeleted { .. }
+            | Self::TaskSteered { .. }
+            | Self::TaskCardChanged { .. }
+            | Self::DeskTaskCompleted { .. }
+            | Self::TaskDiscussionPosted { .. }
+            | Self::TaskDiscussionRedacted { .. } => Permanent,
+        }
+    }
+}
+
 /// How one workflow node's execution came out (issue #371).
 ///
 /// A closed two-value set on purpose: it is the entire payload of

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -406,6 +406,146 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
     assert_eq!(tail[0].seq, EventSeq::new(3));
 }
 
+/// Asserts the [`EventLog`] retention contract (issue #275): the default
+/// policy is inert, permanent kinds survive any policy, sequences are never
+/// renumbered or reused, and a pruned log still reads and appends correctly.
+///
+/// Deliberately says nothing about the age bound. `append` stamps `at_millis`
+/// from the wall clock, so a backend test cannot place an event in the past
+/// without a clock seam none of the three backends has. Age selection is a
+/// property of [`plan_prune`](crate::ports::events::plan_prune), which is pure
+/// and unit-tested against synthetic timestamps in `ports::events`; what a
+/// *backend* has to prove is that it removes exactly the entries that function
+/// names, which is what this covers.
+pub async fn assert_event_retention(events: Arc<dyn EventLog>) {
+    use crate::ports::events::RetentionPolicy;
+
+    let acme = CompanyId::new("acme");
+
+    let run_started = |n: u64| CompanyEvent::WorkflowRunStarted {
+        workflow_id: "wf".to_string(),
+        run_id: format!("run-{n}"),
+        scheduled: false,
+    };
+    let audit = |n: u64| CompanyEvent::LifecycleChanged {
+        from: "running".to_string(),
+        to: format!("paused-{n}"),
+        by: crate::ports::types::Actor {
+            kind: crate::ports::types::ActorKind::Operator,
+            id: "operator".to_string(),
+        },
+    };
+
+    // Interleave prunable run outcomes with permanent audit entries so the
+    // pass has to discriminate rather than truncate a prefix.
+    for n in 0..5u64 {
+        events.append(&acme, run_started(n)).await.unwrap();
+        events.append(&acme, audit(n)).await.unwrap();
+    }
+    let before = events
+        .read_from(&acme, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(before.len(), 10, "fixture seeded 10 events");
+
+    // 1. The default policy is a no-op. Retention is opt-in.
+    let report = events
+        .prune(&acme, &RetentionPolicy::default())
+        .await
+        .unwrap();
+    assert_eq!(report.removed, 0, "default policy removed something");
+    assert_eq!(report.scanned, 10);
+    let after_noop = events
+        .read_from(&acme, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    assert_eq!(after_noop, before, "no-op prune changed the log");
+
+    // 2. A count bound removes only prunable kinds, keeping the newest.
+    let report = events
+        .prune(&acme, &RetentionPolicy::with_max_entries_per_kind(2))
+        .await
+        .unwrap();
+    // 5 run-starts at seqs 0,2,4,6,8; the bound keeps the newest 2 (seqs 8, 6)
+    // and discards the other 3. The permanent audit rows are never candidates,
+    // and the seq watermark (9) is an audit row anyway.
+    assert_eq!(
+        report.removed, 3,
+        "count bound should discard the 3 oldest of 5 run-starts"
+    );
+
+    let kept = events
+        .read_from(&acme, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    let lifecycles = kept
+        .iter()
+        .filter(|e| e.event.kind() == "LifecycleChanged")
+        .count();
+    assert_eq!(lifecycles, 5, "a permanent kind was pruned");
+    let runs: Vec<String> = kept
+        .iter()
+        .filter_map(|e| match &e.event {
+            CompanyEvent::WorkflowRunStarted { run_id, .. } => Some(run_id.clone()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        runs,
+        vec!["run-3".to_string(), "run-4".to_string()],
+        "count bound did not keep the newest run outcomes"
+    );
+
+    // 3. Sequences are not renumbered: every surviving entry keeps the number
+    //    it was assigned, so a stored cross-reference still resolves.
+    for ev in &kept {
+        let original = before
+            .iter()
+            .find(|b| b.seq == ev.seq)
+            .expect("surviving seq was never issued");
+        assert_eq!(&original.event, &ev.event, "seq {:?} renumbered", ev.seq);
+    }
+    assert_eq!(
+        report.oldest_retained,
+        kept.first().map(|e| e.seq),
+        "report disagrees with the log about the oldest survivor"
+    );
+
+    // 4. `read_from` tolerates the gaps a prune leaves: a cursor parked on a
+    //    removed sequence resumes at the next survivor rather than erroring.
+    let removed_seq = before
+        .iter()
+        .map(|e| e.seq)
+        .find(|seq| !kept.iter().any(|k| k.seq == *seq))
+        .expect("something was removed");
+    let resumed = events
+        .read_from(&acme, removed_seq, usize::MAX)
+        .await
+        .unwrap();
+    assert!(
+        resumed.first().is_some_and(|e| e.seq > removed_seq),
+        "read_from did not resume past a pruned sequence"
+    );
+
+    // 5. The next append must not reuse a sequence a survivor still holds.
+    //    This is the invariant that makes pruning safe for the fs and sqlite
+    //    backends, which derive the next sequence from the highest present.
+    let highest_before = kept.iter().map(|e| e.seq).max().unwrap();
+    let next = events.append(&acme, audit(99)).await.unwrap();
+    assert!(
+        next > highest_before,
+        "append reused sequence {next:?} after a prune (highest surviving was {highest_before:?})"
+    );
+    let reread = events
+        .read_from(&acme, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    let mut seqs: Vec<EventSeq> = reread.iter().map(|e| e.seq).collect();
+    let unique = seqs.len();
+    seqs.dedup();
+    assert_eq!(unique, seqs.len(), "duplicate sequences after prune+append");
+}
+
 /// Everything written through the ports reads back through the ports,
 /// byte-identically — the totality precondition an export relies on.
 pub async fn assert_export_totality(

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -19,7 +19,7 @@ use tokio::sync::{Mutex as TokioMutex, broadcast};
 use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::context::ContextStore;
-use crate::ports::events::EventLog;
+use crate::ports::events::{EventLog, PruneReport, RetentionPolicy, plan_prune};
 use crate::ports::inbox::{EmailRecord, InboxMeta, InboxStore};
 use crate::ports::memory::MemoryStore;
 use crate::ports::secrets::SecretStore;
@@ -552,10 +552,24 @@ impl EventLog for FsEventLog {
         let lock = path_lock(&path);
         let _guard = lock.lock().await;
 
-        // The next sequence is the current line count; held under the lock so
-        // concurrent appends never collide on a seq.
+        // The next sequence is one past the highest already present; held under
+        // the lock so concurrent appends never collide on a seq.
+        //
+        // Reading the *maximum* rather than the line count is what makes
+        // `prune` safe (issue #275): a count-derived sequence silently reuses
+        // the numbers of any removed lines, and sequences are stable ids —
+        // thread parents, reaction targets and #358's redaction tombstone all
+        // address a message by one. For a log that has never been pruned the
+        // two agree exactly (n lines numbered 0..n-1 both yield n), so this
+        // changes no existing behaviour.
         let existing = read_optional(&path).await?;
-        let seq = existing.lines().filter(|l| !l.trim().is_empty()).count() as u64;
+        let seq = existing
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .filter_map(|l| serde_json::from_str::<StoredEvent>(l).ok())
+            .map(|ev| ev.seq.value() + 1)
+            .max()
+            .unwrap_or(0);
 
         let stored = StoredEvent {
             seq: EventSeq::new(seq),
@@ -597,6 +611,43 @@ impl EventLog for FsEventLog {
             }
         });
         Box::pin(stream)
+    }
+
+    async fn prune(&self, id: &CompanyId, policy: &RetentionPolicy) -> Result<PruneReport> {
+        let path = self.bundle(id).events_jsonl();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+
+        // Strict parsing on purpose: `read_jsonl` fails the whole pass on a
+        // line it cannot read, where `read_jsonl_lenient` would skip it and
+        // then the rewrite below would drop it for good. A file we cannot
+        // fully understand is a file we must not rewrite.
+        let all = read_jsonl::<StoredEvent>(&path).await?;
+        let doomed = plan_prune(&all, policy);
+
+        let mut report = PruneReport {
+            scanned: all.len(),
+            removed: 0,
+            oldest_retained: all.iter().map(|e| e.seq).min(),
+        };
+        if doomed.is_empty() {
+            return Ok(report);
+        }
+
+        let kept: Vec<StoredEvent> = all
+            .into_iter()
+            .filter(|ev| doomed.binary_search(&ev.seq).is_err())
+            .collect();
+        report.removed = doomed.len();
+        report.oldest_retained = kept.iter().map(|e| e.seq).min();
+
+        let mut body = String::new();
+        for record in &kept {
+            body.push_str(&serde_json::to_string(record)?);
+            body.push('\n');
+        }
+        write_atomic(&path, &body).await?;
+        Ok(report)
     }
 }
 
@@ -1066,6 +1117,13 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_monotonic_event_seq(Arc::new(FsEventLog::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_event_retention() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_event_retention(Arc::new(FsEventLog::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -45,7 +45,7 @@ use crate::Result;
 use crate::company::CompanyManifest;
 use crate::error::OpenCompanyError;
 use crate::ports::context::ContextStore;
-use crate::ports::events::EventLog;
+use crate::ports::events::{EventLog, PruneReport, RetentionPolicy, plan_prune};
 use crate::ports::login_codes::LoginCodeRecord;
 use crate::ports::memory::MemoryStore;
 use crate::ports::now_millis;
@@ -444,6 +444,40 @@ impl EventLog for MongoStore {
             }
         });
         Box::pin(stream)
+    }
+
+    async fn prune(&self, id: &CompanyId, policy: &RetentionPolicy) -> Result<PruneReport> {
+        // Same whole-log read as the sqlite backend, and for the same reason:
+        // the decision belongs to `plan_prune` so the three backends cannot
+        // disagree about what a policy means.
+        let all = self.read_from(id, EventSeq::new(0), usize::MAX).await?;
+        let doomed = plan_prune(&all, policy);
+
+        let mut report = PruneReport {
+            scanned: all.len(),
+            removed: 0,
+            oldest_retained: all.iter().map(|e| e.seq).min(),
+        };
+        if doomed.is_empty() {
+            return Ok(report);
+        }
+
+        let seqs: Vec<i64> = doomed.iter().map(|s| s.value() as i64).collect();
+        self.collection("events")
+            .delete_many(doc! {
+                "company_id": id.as_ref(),
+                "seq": {"$in": seqs},
+            })
+            .await
+            .map_err(mongo_err)?;
+
+        report.removed = doomed.len();
+        report.oldest_retained = all
+            .iter()
+            .map(|e| e.seq)
+            .filter(|seq| doomed.binary_search(seq).is_err())
+            .min();
+        Ok(report)
     }
 }
 
@@ -2029,6 +2063,13 @@ mod test {
     async fn conformance_monotonic_event_seq() {
         let Some(s) = store().await else { return };
         conformance::assert_monotonic_event_seq(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_event_retention() {
+        let Some(s) = store().await else { return };
+        conformance::assert_event_retention(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -36,7 +36,7 @@ use crate::Result;
 use crate::company::CompanyManifest;
 use crate::error::OpenCompanyError;
 use crate::ports::context::ContextStore;
-use crate::ports::events::EventLog;
+use crate::ports::events::{EventLog, PruneReport, RetentionPolicy, plan_prune};
 use crate::ports::login_codes::LoginCodeRecord;
 use crate::ports::memory::MemoryStore;
 use crate::ports::now_millis;
@@ -533,6 +533,48 @@ impl EventLog for SqliteStore {
             }
         });
         Box::pin(stream)
+    }
+
+    async fn prune(&self, id: &CompanyId, policy: &RetentionPolicy) -> Result<PruneReport> {
+        // Whole-log read rather than a `DELETE … WHERE at_ms < ?`: the policy's
+        // per-kind bound is a property of the decoded event, and routing every
+        // backend through `plan_prune` is what keeps fs, sqlite and mongodb
+        // from drifting on the one operation that cannot be undone. Journals
+        // are bounded by this very feature, so the read is affordable.
+        let all = self.read_from(id, EventSeq::new(0), usize::MAX).await?;
+        let doomed = plan_prune(&all, policy);
+
+        let mut report = PruneReport {
+            scanned: all.len(),
+            removed: 0,
+            oldest_retained: all.iter().map(|e| e.seq).min(),
+        };
+        if doomed.is_empty() {
+            return Ok(report);
+        }
+
+        {
+            let mut conn = self.conn();
+            let tx = conn.transaction().map_err(sql_err)?;
+            {
+                let mut stmt = tx
+                    .prepare("DELETE FROM events WHERE company_id = ?1 AND seq = ?2")
+                    .map_err(sql_err)?;
+                for seq in &doomed {
+                    stmt.execute(params![id.as_ref(), seq.value() as i64])
+                        .map_err(sql_err)?;
+                }
+            }
+            tx.commit().map_err(sql_err)?;
+        }
+
+        report.removed = doomed.len();
+        report.oldest_retained = all
+            .iter()
+            .map(|e| e.seq)
+            .filter(|seq| doomed.binary_search(seq).is_err())
+            .min();
+        Ok(report)
     }
 }
 
@@ -2150,6 +2192,12 @@ mod test {
     async fn conformance_monotonic_event_seq() {
         let s = store();
         conformance::assert_monotonic_event_seq(s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_event_retention() {
+        let s = store();
+        conformance::assert_event_retention(s).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #275.

### Read this part first: a latent correctness bug that had to land with the feature

`FsEventLog::append` derived the next sequence number from the **line count** of `events.jsonl`:

```rust
let seq = existing.lines().filter(|l| !l.trim().is_empty()).count() as u64;
```

Remove any line and every subsequent append reuses a sequence number that a *surviving* row still holds. Sequences are stable ids: `parent` on `OperatorMessage`/`AgentReply`, `ReactionToggled`'s target, and #358's `TaskDiscussionRedacted` tombstone all address a message **by its sequence**. A reused sequence therefore silently re-points a withdrawal tombstone — or a thread parent — at an unrelated message. Nothing errors; the log just quietly means something different.

Retention is the first feature that removes a line, so on the default backend it would have been unsound the day it shipped. That is why the fix is in this PR rather than a follow-up: the feature is not safe without it.

The fix is `max(seq) + 1`. **For a log that has never been pruned the two expressions are identical** — n lines numbered `0..n-1` both yield `n` — so no existing behaviour changes and no stored log needs migrating.

Full audit of the three backends, since the same question applies to each:

| Backend | Allocates from | Safe under pruning? |
| --- | --- | --- |
| `FsEventLog` | line count → **now** one-past-the-highest | **was unsafe**, fixed here |
| `SqliteStore` | `COALESCE(MAX(seq) + 1, 0)` | safe while anything survives |
| `MongoStore` | a persistent `counters` document | always safe |

The shared invariant that makes all three safe: **a pass never removes the highest-sequence entry**, whatever the policy says.

### The feature

Nothing in OpenCompany ever removed a journal entry, so the log grew for the life of a company. `EventLog` gains one method — `prune(id, &RetentionPolicy) -> Result<PruneReport>` — built so the irreversible direction is the hard one to reach:

| Guard | Effect |
| --- | --- |
| `RetentionPolicy::default()` | both bounds `None`, removes nothing — retention is opt-in per caller |
| `CompanyEvent::retention_class()` | exhaustive match with **no `_` arm**, so a new event variant fails the build until somebody classifies it, and `Permanent` is the answer for anything ambiguous |
| `plan_prune()` | one **pure** function all three backends route through, so fs / sqlite / mongodb cannot drift on the one operation that cannot be undone |
| watermark rule | the highest sequence is never removed, so sequence reuse is unreachable |
| default trait body | `Err(Unimplemented("EventLog::prune"))` — a backend without retention says so, rather than reporting a pass that removed nothing. The two are indistinguishable to a caller and only one is true. |

**Which of the three questions in the issue this answers, and how.**

*Is the journal an audit log — append-only, never pruned?* Mostly yes, and #504 (issue #358) already set the posture: withdrawing a discussion post appends a tombstone that supersedes the row rather than rewriting it. So only **4 of 26** kinds are prunable — `WorkflowRunStarted`, `WorkflowRunFinished`, `WorkflowNodeFinished`, `McpCallFailed`. Everything else is permanent, either because it is the audit trail (approvals, lifecycle, payments, tool-access) or because another entry addresses it by sequence.

`WebhookReceived` and `ScheduleFired` are deliberately **not** prunable despite being the highest-volume kinds: a webhook body is the only record of what a counterparty actually sent, and a schedule tick the only evidence a cron fired at all. Both are evidence.

*By age, by count, or by kind?* Kind first — it gates everything — then either bound may select within the prunable set. The count bound is **per kind** (mirroring OpenHuman's `MAX_FLOW_RUNS_PER_FLOW`) so a burst of one kind cannot evict the run outcomes this issue was filed about.

*Does pruning renumber `EventSeq`, and what does that do to cursors and SSE?* It does not renumber. Pruning leaves gaps, which `read_from`'s `seq >=` scan already tolerates — a cursor or SSE subscriber parked on a removed sequence resumes at the next survivor. Renumbering would instead invalidate every stored cross-reference listed above.

**No clock.** The age bound is measured back from the newest entry *in the log*, not from wall-clock now — the same anchoring `ports::usage::retention_cutoff` already uses for usage samples. It makes every case testable without a clock seam and cannot empty a dormant company's journal just because time passed. The journal does diverge from that precedent in one way, deliberately: `UsageMeter` evicts on write against a fixed 90-day window, and the journal never evicts implicitly, because it is what export/import ships and what boot replays.

### Scope, stated so it is not mistaken for unfinished work

**Nothing calls `prune`.** No scheduler, no boot hook, no `company.toml` key. That is the decision, not an omission: the requirement is an explicit policy rather than an implicit default that silently deletes history, and the strongest form of that is retention happening only when something asks for it. Wiring a caller or a config surface is a deliberate follow-up and should be its own reviewable decision.

**#450 is not folded in.** It is the embedded writer's unbounded, undeduped per-item append-failure logging — a log-amplification problem in a different code path, about the OpenHuman runtime journal rather than the `CompanyEvent` log. The two share no surface. It remains open and unassigned.

**No collision:** the journal-adjacent branch `fix/fs-append-atomic-newline` is 0 commits ahead of `main` and 524 behind — stale. Recorded here to save the next person the same check.

## API Or Behavior Changes

**Additive to the `EventLog` trait.** `prune` has a default body returning `Unimplemented`, so the five test-only `EventLog` doubles in `src/` compile unchanged. The three production backends implement it.

New public items, all re-exported from `crate::ports`: `RetentionPolicy`, `RetentionClass`, `PruneReport`, `plan_prune`. New inherent methods on `CompanyEvent`: `kind()` and `retention_class()`.

**One behaviour change:** `FsEventLog::append` now allocates from one-past-the-highest sequence instead of the line count. As above, the two agree exactly for any log that has never been pruned, so this is observable only after a prune. No wire format changes, no serialization changes, no stored log requires migration, and the `session_db` equivalents here — the `events` table/collection and `events.jsonl` — keep their existing shape.

**Nothing is deleted unless a caller asks.** No default policy prunes anything.

## Tests

- [x] `cargo fmt --all -- --check` — run, clean.
- [x] `cargo clippy --all-targets -- -D warnings` — **run as `cargo clippy --lib --tests -- -D warnings`, under both `--features sqlite` and `--features mongodb`; clean on both.** Not run with `--all-targets` (examples/benches) — disk is a shared constraint on this machine and the change touches no example or bench target. CI covers the full invocation.
- [x] `cargo build --all-targets` — **N/A — not run locally, deliberately.** No full build matrix on this machine (shared disk). Compilation of every changed path is covered by the `cargo test --lib` and `cargo check --lib --tests --features mongodb` runs below, both of which built the crate. CI is the gate for the full matrix.
- [x] `cargo test` — **run as `cargo test --lib --features sqlite`: 1680 passed, 1 failed.** The single failure is pre-existing and unrelated — see below. Integration targets under `tests/` were not run locally; this change adds none and touches none.

What was actually exercised:

- **12 unit tests on `plan_prune`** (`src/ports/events.rs`), against synthetic timestamps with no clock: default-is-a-no-op, empty log, newest-anchored cutoff, an entry exactly on the window edge being kept, permanent-survives-any-policy, per-kind budgeting, the watermark rule, the two bounds behaving as a union rather than a double count, input-order independence, and `kind()` pinned against the tag `serde` actually emits.
  - `an_age_evicted_entry_does_not_consume_a_count_slot` deliberately puts sequence order and timestamp order in **disagreement** (what backfill and clock skew produce), because that is the only arrangement that can distinguish the two plausible counting rules. With sequence and time correlated, both implementations agree and the test would prove nothing.
- **`assert_event_retention`**, a new backend-agnostic conformance assertion wired into all three backends: the default policy is inert, permanent kinds survive, surviving sequences are unrenumbered, `read_from` resumes past a gap, and a later append does not reuse a survivor's sequence.
- `cargo check --lib --tests --features mongodb` — clean.

Three things a reviewer should know rather than assume:

1. **The mongodb conformance test compiled but did not execute.** The suite self-skips without a live server (`let Some(s) = store().await else { return }`), so this is **not** a green run for that backend. Its `prune` is the same `plan_prune` + delete-by-exact-sequence shape as sqlite's, and both route through the same pure planner, but that is an argument from construction, not from execution.
2. **`openhuman::launcher::tests::tauri_cli_is_fresh_when_binary_is_newer_than_sources` fails, and is not introduced or addressed here.** It is a filesystem-mtime freshness check with no relation to this change; I confirmed it fails identically on a stashed, clean tree at the same base commit.
3. **The age bound is deliberately absent from the conformance suite.** `append` stamps `at_millis` from the wall clock, so a backend test cannot place an event in the past without a clock seam none of the three backends has. Age selection is a property of `plan_prune`, which is pure and pinned against synthetic timestamps instead; what a *backend* must prove is that it removes exactly the entries that function names, which is what the conformance assertion covers.

## Documentation

- `docs/spec/runtime/ports-state.md` — the `EventLog` contract gains a **Retention (issue #275)** section: the guard table, the classification and why only four kinds are prunable, the no-renumbering rule with the cursor/SSE consequence, and the newest-anchored age bound with its deliberate divergence from `UsageMeter`.
- `docs/spec/runtime/events.md` — the "properties that are load-bearing" list goes from two to three, adding that a sequence is a stable id and retention keeps it that way, with a pointer to the section above.

**On the 500-line convention:** `events.md` was **already 509 lines** before this PR, over the repo's cap; this change adds 6, taking it to 515. **This PR does not introduce the violation.** The 6 lines are kept because the per-variant retention rule genuinely belongs in the event-vocabulary doc, which is where a reader looks for what happens to old entries. Splitting that file is worth doing but is unrelated to retention and would bury this diff — offered as a follow-up rather than done here. (There is no CI lint for the cap; I checked.)

Rustdoc carries the operational detail that does not belong in the spec: the module docs on `src/ports/events.rs` explain why `prune` is off the append path and why sequences are not renumbered, and `retention_class`'s docs record the reasoning for each side of the split — including why `WebhookReceived` and `ScheduleFired` stay permanent despite being tempting targets.
