### PR TITLE
fix(ports): repair the build — cover WorkflowReportDelivered in the CompanyEvent matches

### DIFF
--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1048,6 +1048,7 @@ impl CompanyEvent {
             Self::WorkflowRunFinished { .. } => "WorkflowRunFinished",
             Self::WorkflowRunStarted { .. } => "WorkflowRunStarted",
             Self::WorkflowNodeFinished { .. } => "WorkflowNodeFinished",
+            Self::WorkflowReportDelivered { .. } => "WorkflowReportDelivered",
         }
     }
 
@@ -1074,6 +1075,13 @@ impl CompanyEvent {
     /// `OperatorMessage`, `AgentReply` and `TaskDiscussionPosted` are addressed
     /// by sequence from thread parents, reactions, and #358's redaction
     /// tombstone, so pruning one dangles a pointer nothing can repair.
+    ///
+    /// And a third reason, sharper than either: **something still reads it.**
+    /// `WorkflowReportDelivered` is folded at boot by
+    /// `runtime::delivered_by_unsettled_runs` to learn what a crashed run
+    /// already sent. Pruning it re-delivers already-sent reports to real
+    /// people. When classifying a new variant, ask not only "is this evidence"
+    /// and "does anything point at it", but "does anything read it back".
     pub fn retention_class(&self) -> crate::ports::events::RetentionClass {
         use crate::ports::events::RetentionClass::{Permanent, Prunable};
         match self {
@@ -1104,6 +1112,19 @@ impl CompanyEvent {
             | Self::DeskTaskCompleted { .. }
             | Self::TaskDiscussionPosted { .. }
             | Self::TaskDiscussionRedacted { .. } => Permanent,
+
+            // Permanent for the third reason, and the sharpest one: something
+            // still *reads* this at boot.
+            // `runtime::delivered_by_unsettled_runs` folds these lines from
+            // sequence 0 to learn what a crashed run already sent, so a re-run
+            // can skip it. The event is written write-behind at dispatch
+            // precisely because the mail has already left the process.
+            //
+            // Pruning it would not lose evidence — it would re-deliver
+            // already-sent reports to real people, which is the exact failure
+            // issue #529 added it to prevent. It looks like machine exhaust and
+            // sits beside the three prunable workflow-run kinds; it is not.
+            Self::WorkflowReportDelivered { .. } => Permanent,
         }
     }
 }


### PR DESCRIPTION
## Summary

**`main` @ `50bd79e` does not compile.** This restores it. One file, two match arms.

```
error[E0004]: non-exhaustive patterns: `&CompanyEvent::WorkflowReportDelivered { .. }` not covered
  --> src/ports/types.rs  (CompanyEvent::kind)
error[E0004]: non-exhaustive patterns: `&CompanyEvent::WorkflowReportDelivered { .. }` not covered
  --> src/ports/types.rs  (CompanyEvent::retention_class)
error: could not compile `opencompany` (lib) due to 2 previous errors
```

### Why no lane caught it

A semantic merge conflict between two already-merged PRs:

- **#534** added the `CompanyEvent::WorkflowReportDelivered` variant.
- **#537** added two *new* exhaustive matches over `CompanyEvent` — `kind()` and `retention_class()` — on a branch cut before #534 existed.

Neither PR touched a line the other touched, so git reported no conflict and both merged cleanly. Each was green against its own base, because on each base the tree really did compile. The breakage exists only in the merged result, which is the one tree neither PR's CI ever built.

This is not a review miss and no reviewer of either PR could reasonably have caught it. The structural fix is requiring branches to be up to date with `main` before merge, so the merge result is what gets built — noted for follow-up, deliberately not attempted here.

### The classification, which is the one judgement call

`WorkflowReportDelivered` is **`Permanent`**, and load-bearing rather than conventional.

It looks like machine exhaust and it sits directly beside the three workflow-run kinds that *are* prunable, so the tempting answer is `Prunable`. That would be a real bug. `runtime::delivered_by_unsettled_runs` (`src/runtime/workflow_outcome.rs:286`) reads the journal **from sequence 0** and folds these lines to learn what a crashed run already sent, so a re-run can skip them. The event is written write-behind at dispatch precisely because the mail has already left the process.

Pruning it would not lose *evidence* — it would **re-deliver already-sent reports to real people**, which is the exact failure #529 added the event to prevent.

That is a third reason for `Permanent`, distinct from the two `retention_class` already documented (it is the audit trail / another entry addresses it by sequence). The new one is sharper: **something still reads it back**. I extended the doc comment by one paragraph to name that third test, because leaving a doc that enumerates two reasons while adding an arm that holds for a third is exactly the drift that produces the next bug. That paragraph plus the arm's own comment is the only content in this PR beyond the two arms themselves.

**@oxoxDev / #529's author — please confirm the `Permanent` classification.** I am confident in it from reading the variant's docs and its boot-time reader, but you own the delivery-ledger invariant and should have the final word. Nothing prunes today (see below), so there is no live risk either way while this is confirmed.

### Scope

Two match arms, one doc paragraph, one arm comment. No behaviour change: `retention_class` is only consulted by `plan_prune`, and nothing in the tree calls `EventLog::prune` — #537 deliberately shipped the policy without a caller. So this PR's only runtime effect is that the crate compiles again.

Coordination: `tinyhuman-82` has the identical fix on its #539 branch. Once this merges, that rebases and the duplicate drops out.

## API Or Behavior Changes

None. `CompanyEvent::kind()` returns `"WorkflowReportDelivered"` for the new variant, matching the tag `serde` already emits for it (`#[serde(tag = "kind")]`, verified against the existing round-trip tests at `src/ports/types.rs:4123`+). No wire format, serialization, or stored-log change.

## Tests

- [x] `cargo fmt --all -- --check` — run, clean.
- [x] `cargo clippy --all-targets -- -D warnings` — **run as `cargo clippy --lib --tests -- -D warnings`; clean.** Not run with `--all-targets` (examples/benches); this change touches no example or bench target. CI covers the full invocation.
- [x] `cargo build --all-targets` — **N/A — not run locally.** Shared-disk constraint on this machine; the `openhuman,tinycortex` feature lane measures ~15 GB. `cargo check --lib` and `cargo test --lib` both built the crate and are the direct evidence the E0004s are gone. CI is the gate for the full matrix.
- [x] `cargo test` — **run as `cargo test --lib`: 1670 passed, 1 failed.**

Evidence, in the order it was gathered:

1. `cargo check --lib` on unmodified `upstream/main` — reproduced **exactly 2** errors, both E0004, both on the functions above. This also confirms the other four exhaustive `CompanyEvent` matches were correctly updated by #534; only the two #537 introduced were stale.
2. `cargo check --lib` after the fix — clean.
3. `cargo test --lib` — 1670 passed, 1 failed. The single failure is `openhuman::launcher::tests::tauri_cli_is_fresh_when_binary_is_newer_than_sources`, a pre-existing filesystem-mtime check unrelated to this change and independently known to the fleet; not introduced here, not addressed here.
4. The 12 `plan_prune` unit tests and the `assert_event_retention` conformance test still pass.

Not run locally: the `--features openhuman,tinycortex` lane (~15 GB) and the integration targets under `tests/`. This change adds and touches neither.

**One gap worth stating plainly:** #537's `kind_matches_the_serialized_tag` test iterates three hand-picked variants, so it would not have caught a missing arm even had it existed at merge time — and it cannot, since a missing arm is a compile error, not a test failure. The compiler is the right detector here and it worked; what failed was that no CI run ever compiled the merged tree.

## Documentation

No spec change — the port contract and the retention rules in `docs/spec/runtime/ports-state.md` are unaffected, since this adds a variant to an existing classification rather than changing the classification's rules.

Rustdoc only, both in `src/ports/types.rs`: the third `Permanent` test named on `retention_class`'s doc comment, and the reasoning recorded at the arm itself so the next person to read that match sees why the one variant that looks like exhaust is not.
