### PR TITLE
fix(events): main is red under full-feature build — cover WorkflowReportDelivered in two matches

### DIFF
--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1048,6 +1048,7 @@ impl CompanyEvent {
             Self::WorkflowRunFinished { .. } => "WorkflowRunFinished",
             Self::WorkflowRunStarted { .. } => "WorkflowRunStarted",
             Self::WorkflowNodeFinished { .. } => "WorkflowNodeFinished",
+            Self::WorkflowReportDelivered { .. } => "WorkflowReportDelivered",
         }
     }
 
@@ -1103,7 +1104,11 @@ impl CompanyEvent {
             | Self::TaskCardChanged { .. }
             | Self::DeskTaskCompleted { .. }
             | Self::TaskDiscussionPosted { .. }
-            | Self::TaskDiscussionRedacted { .. } => Permanent,
+            | Self::TaskDiscussionRedacted { .. }
+            // The write-behind delivery ledger (#529): its whole purpose is to
+            // stop a re-run from re-sending a report, so pruning it would
+            // reintroduce the duplicate it exists to prevent. Permanent.
+            | Self::WorkflowReportDelivered { .. } => Permanent,
         }
     }
 }


### PR DESCRIPTION
## Summary

**Main is red under the full-feature (tenant) build** — the staging deploy fails to compile. Two stacked PRs each merged green against their own base, but the merged tree is non-exhaustive:

- #534 (#529) added the `CompanyEvent::WorkflowReportDelivered` variant (unconditional) and updated `kind()`.
- #537 (#275) added a **new** exhaustive `retention_class()` match, branched before #534, so it has no arm for the new variant.

Together, `src/ports/types.rs` has two non-exhaustive matches:

```
error[E0004]: non-exhaustive patterns: `CompanyEvent::WorkflowReportDelivered { .. }` not covered
  --> src/ports/types.rs:1024  (fn kind)
  --> src/ports/types.rs:1079  (fn retention_class)
```

This fix adds the missing arm to both:
- `kind()` → returns the variant tag `"WorkflowReportDelivered"`.
- `retention_class()` → **Permanent**. The delivery ledger's whole purpose (#529) is to stop a re-run from re-sending a report; pruning it would reintroduce the duplicate it exists to prevent.

Surfaced by the `deploy-staging` run for `16a5d4f4` (build-and-push-to-ECR step); no tenant rolled — smoke1/marketing still on the prior image.

## API Or Behavior Changes

None. Exhaustiveness-only fix; no wire-format or behavior change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --lib` — clean (the error is feature-independent; the deploy log listed these two E0004s as the only errors)

## Documentation

None needed — no public surface changed. Follow-up worth filing: the full tenant feature combo (`mongodb,…,mcp,media,composio,imap,telegram,medulla,tinycortex,sidecar`) is only built at deploy time, so exhaustiveness regressions like this pass PR CI and first fail in the deploy — a CI lane building that combo would catch it pre-merge (full-feature CI gap).
