### PR TITLE
fix(connections): stop the software-company template pinning Composio to three providers (#550)

### DIFF
--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -16,20 +16,21 @@ human_role = "Product direction"
 # bearer, media backend, per-server MCP config).
 allow = ["*", "media", "composio"]
 
-# The Composio toolkits this company may reach. Two effects, and the second is
-# the reason this is set rather than left empty:
+# There is deliberately no `[tools.composio].toolkits` here. Absent means "open
+# mode": defer to the backend's own server-enforced allowlist, which is every
+# toolkit it permits — roughly a hundred — rather than a list this file has to
+# keep in step by hand.
 #
-#  1. Runtime narrowing — a toolkit outside this list is rejected client-side,
-#     before any network call. Empty would defer to the backend's own
-#     server-enforced allowlist ("open mode"), which is not unsafe, just wider.
-#  2. The console's per-provider "Sign in" list renders from THIS list. With it
-#     empty the Connections tab shows no provider rows at all, so an operator has
-#     no way to start an OAuth handoff from the UI.
+# A non-empty list would be authoritative and offered verbatim: the backend
+# catalog is not consulted and nothing may widen it, because a fetch must never
+# hand a company providers it decided against. So setting it caps both the agent
+# belt and the Connections tab at whatever is typed here.
 #
-# Keep it to the toolkits a company is actually expected to use; adding one here
-# is what makes it appear in the Connections tab.
-[tools.composio]
-toolkits = ["gmail", "slack", "github"]
+# It briefly was set, as a workaround for the console rendering zero provider
+# rows on an empty list (#397). That root cause is fixed — the host now answers
+# open mode with the live catalog — so re-adding a list here to make providers
+# appear would restore the cap it was meant to relieve. Narrow it only to
+# genuinely narrow this company.
 
 [[agent]]
 id = "product_manager"

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -169,6 +169,40 @@ mod tests {
         assert!(PRESETS.iter().all(|preset| !preset.manifest.is_empty()));
     }
 
+    /// No shipped template narrows Composio to a hand-written toolkit list.
+    ///
+    /// Absent means open mode: the host answers with the backend's live catalog,
+    /// which is every toolkit it permits. A non-empty list is authoritative and
+    /// offered verbatim — the catalog is not consulted and nothing may widen it —
+    /// so declaring one here caps both the agent belt and the Connections tab at
+    /// whatever was typed, for every operator who starts from that template.
+    ///
+    /// `agentic_software_company` briefly carried such a list, added to work
+    /// around a console that rendered zero provider rows for an empty one
+    /// (#397). That root cause is fixed, so a list added here now buys nothing
+    /// and silently restores the cap. Narrowing a template is a legitimate
+    /// choice — it is just one that has to be made deliberately, which is what
+    /// this test forces (#550).
+    #[test]
+    fn no_shipped_template_caps_the_composio_toolkit_list() {
+        for preset in PRESETS {
+            let manifest: toml::Value = toml::from_str(preset.manifest)
+                .unwrap_or_else(|e| panic!("{} manifest does not parse: {e}", preset.id));
+            let declared = manifest
+                .get("tools")
+                .and_then(|tools| tools.get("composio"))
+                .and_then(|composio| composio.get("toolkits"));
+            assert!(
+                declared.is_none(),
+                "{} declares [tools.composio].toolkits = {:?}, which pins its \
+                 Connections tab to that list instead of the backend's catalog. \
+                 Remove it, or narrow this template on purpose and say why here.",
+                preset.id,
+                declared.unwrap(),
+            );
+        }
+    }
+
     #[tokio::test]
     async fn starts_a_loopback_runtime_from_the_default_preset() {
         let directory = tempfile::tempdir().unwrap();


### PR DESCRIPTION
## Summary

The Connections page offered **three** Composio providers on a company started from `agentic_software_company`, where the backend permits roughly a hundred. The cap was a toolkit list in the shipped manifest. Removed, plus a guard covering all 19 templates.

Confirmed live against the staging tenant `smoke1` before and after diagnosis — its status route reported `catalogSource: "manifest"`, `openMode: false`, `count: 3`.

## Problem

`companies/agentic_software_company/company.toml` declared `toolkits = ["gmail", "slack", "github"]`.

A non-empty manifest list is authoritative and offered **verbatim**: the backend catalog is deliberately not consulted and nothing may widen it, because a fetch must never hand a company providers it decided against. That boundary is correct — the list was the problem.

It was added in #234 solely to work around the pre-#397 console, which rendered zero provider rows for an empty list. #397 fixed that root cause, which turned the workaround into the thing capping the tab. The manifest's own comment still described the old behaviour, so it read as load-bearing.

**Why nobody noticed.** `catalogWarning()` returns `null` for `catalogSource: "manifest"`, and rightly so — a company that narrowed itself is seeing exactly what it chose, and calling that "incomplete" would be false. But this template narrowed itself by accident, so the honest silence read as "this is all there is". Manifest mode also hides the search box, the "Show all N providers" control and the "Connect by slug" field, since those are gated on open mode — so the affordances that would reveal a wider catalog were exactly the ones suppressed.

All 18 other shipped templates were already in open mode. This one was the sole outlier.

## Solution

1. **Remove the block.** Absent means open mode, so the host answers with the backend's live catalog. The `[tools]` `allow` grant is untouched — this narrows nothing and widens no agent capability that `allow` did not already carry. The replacement comment states why the list is absent and why re-adding one to make providers appear would restore the cap.

2. **Guard all 19 presets** (`desktop.rs`), not just the one that regressed. `PRESETS` already compiles every shipped manifest in via `include_str!`, so the test is a parse and an assertion. Narrowing a template stays legitimate — it just has to be deliberate, and the failure message says so.

## API Or Behavior Changes

Consoles on this template now offer the backend's live Composio catalog instead of three fixed providers. No Rust behaviour change: agent-side admission is `toolkit_allowed`, which already treated an empty list as "allow every toolkit", so the agent belt is unchanged. Host and console code are untouched.

Companies already created from this template keep whatever their stored manifest holds; this changes the shipped template.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (with `--no-deps`, per the vendored-crate lint gate)
- [x] `cargo build --all-targets` (covered by the clippy/test builds)
- [x] `cargo test` — `--lib` **1750 passed / 0 failed / 1 ignored**

Also:

- **The guard was verified to bite**, not just to pass: re-adding a one-entry `[tools.composio]` block failed with the offending template named, then the manifest was restored.
- Manifest parses with `[tools.composio]` absent and `allow` still `["*", "media", "composio"]`.
- Live read of the deployed tenant's `GET …/composio` confirmed the diagnosis (`catalogSource: "manifest"`, `count: 3`) and that it already holds a working credential (`credentialSource: "static"`), so the catalog fetch succeeds there and this change is observable immediately rather than waiting on platform attestation.

## Documentation

The manifest comment is rewritten in place — it previously documented console behaviour the host no longer has, which is what made the list look required. No module doc changes: nothing about the host or console contract moved.

## Notes for review

The commit that removes the list and the commit that adds the guard are separate, so the guard can be evaluated on its own merits.

Two things deliberately **not** done here:

- **Nothing surfaces manifest mode in the console.** A template that narrows itself on purpose still tells the operator nothing about why the list is short. Arguably it should say "narrowed to N by this company's manifest" — but that is a console affordance decision, not part of un-capping this template, and `catalogWarning`'s current silence is correct for a deliberate choice.
- **`PREVIEW_COUNT = 12`** means the console shows twelve rows before a "Show all N providers" button. Unrelated to this bug (three rows never reach it), but worth knowing when reading a short list.

## Related

Closes #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated the default Composio setup to use the backend-managed toolkit catalog.
  * Removed the preset’s explicit Gmail, Slack, and GitHub toolkit restrictions.
  * Custom non-empty toolkit lists remain supported as an authoritative limit.

* **Tests**
  * Added validation to ensure bundled desktop presets do not declare explicit Composio toolkit lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->