### PR TITLE
feat(workspace): agents can create in the shared tree, and every node records its author (#551, #326)

### DIFF
--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -129,9 +129,21 @@ The workspace store seeds a new company from its `companies/<name>/workspace/**`
 template on first use (`WorkspaceStore::is_empty` gates the seed); skills read
 the company's `skills/<id>/SKILL.md` plus the repo-level shared registry.
 
+Boot also provisions the reserved `Agents/<agent-id>/` folders (issue #551) via
+`company::workspace_agents::ensure_agent_folders`. That call is gated on "this
+is not a rebuild" and on **nothing else** — deliberately not on `seed_dir`,
+since a provisioned tenant and the desktop build have no company bundle to seed
+from and their agents need folders regardless, and deliberately not on
+`is_empty`, since that gate exists to make operator deletions stick against
+re-seeding and a roster that gained a teammate last week still needs a folder
+for them. It is idempotent, so it costs one tree read per boot. The second
+provisioning seam is `HarnessPool::ensure`, which covers every roster change
+after boot.
+
 The builder threads that same `WorkspaceStore` handle onto `HarnessDeps`
-(`workspace`), so agents read the operator's note tree through the tools in
-`harness::workspace_tools` (issue #237) rather than being blind to it. One
-handle, three writers — console REST, GraphQL, and a granted agent — so an
-operator edit is what the next turn reads, with no rebuild. `None` fails
-closed: no workspace tools are wired.
+(`workspace`), so agents read and write the shared note tree through the tools
+in `harness::workspace_tools` (issues #237, #551) rather than being blind to it.
+One handle, three writers — console REST, GraphQL, and a granted agent — so an
+operator edit is what the next turn reads, with no rebuild, and an agent's note
+is in the tab the operator is already looking at. Each write records its author
+(issue #326). `None` fails closed: no workspace tools are wired.

--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -46,7 +46,7 @@ why this is not a read/write split: [authority.md](authority.md).
 | `tasks` | `POST …/tasks`, `GET …/tasks`, `GET …/tasks/{id}` (the Task Detail read, #185), `PATCH`/`DELETE …/tasks/{id}`, `GET …/tasks/inflight`, `POST …/tasks/{id}/steer` (#111), `POST …/tasks/{id}/discussion` (#335), `DELETE …/tasks/{id}/discussion/{seq}` (#358) |
 | `task_export` | `GET …/tasks/{id}/export` (the task's record as a document, #352) |
 | `memory` | `POST …/memory`, `DELETE …/memory/{id}` (journals `MemoryFactDeleted`) |
-| `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` (the two `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177) |
+| `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` (the two `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177). Node bodies carry `createdBy`/`updatedBy` (#326) |
 | `skills` | `POST …/skills`, `GET …/skills/registry`, `POST …/skills/{slug}/install\|uninstall`, `PUT …/skills/{slug}` |
 | `team` | `POST …/team`, `DELETE …/team/{id}`, `PUT …/team/{id}/inbox` (overlay; roster-only in v1) |
 | `mail` | `POST …/inboxes/{key}/read` |

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -217,8 +217,9 @@ So the two questions are now separate answers from one declaration
 - **may an operator hand it over for a stretch of time?** — refused for anything
   that can execute arbitrary code (`shell`), reach an arbitrary address
   (`http_request`, `curl`, `web_fetch`, `git_operations`), act through a
-  third-party server (`mcp_call_tool`), overwrite operator-owned guidance
-  (`workspace_write`), or run a saved workflow; refused for every named
+  third-party server (`mcp_call_tool`), change the company's shared note tree
+  (`workspace_write`, `workspace_create`), or run a saved workflow; refused for
+  every named
   consequence — Spend, Send, Sign, Publish, Hire, Identity; and refused for any
   tool nobody has declared.
 

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -168,6 +168,20 @@ only — bodies are fetched per file, so a navigation read does not grow with th
 size of the workspace. Reading a folder id as a file is a `404`, never an empty
 note.
 
+Both workspace `GET`s — and the `POST` / `PATCH` node bodies — carry
+`createdBy` and `updatedBy` (#326), each `{"kind":"seed"|"operator"|"agent",
+"id"?}` with `id` present exactly when `kind` is `agent`. `createdBy` is fixed
+at creation; `updatedBy` follows content writes only, so an operator rename does
+not repaint an agent's authorship. The console renders the creator as a badge
+and the last writer only when the two differ. Both fields are always serialized,
+and a node predating the field reads back as `operator`. The `PUT` write route
+stamps `operator`; agent writes stamp `agent{id}` from the agent's roster id,
+which is fixed at agent-build time and never taken from tool arguments. Agents
+reach the same tree through `workspace_list` / `workspace_read` /
+`workspace_create` / `workspace_write`, and a created note has its default home
+in the reserved `Agents/<agent-id>/` folder (#551) — a convention the persona
+brief steers toward, not a boundary the routes enforce.
+
 Team writes are an **operator overlay** persisted through the store, merged
 into the manifest roster at read time — the version-controlled `company.toml`
 is never rewritten. Overlay teammates are addressable: since issue #71 the

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -256,18 +256,33 @@ prompt = "Weekly review and operator digest"
     The Usage view surfaces a `Web searches` KPI plus a search status row
     (active / paused at cap 0 / awaiting credential / not granted / not in this
     build).
-  - **`workspace`** (issue #237) grants the company's shared note tree — the
-    operator-owned `Standards/` / `Playbooks/` / `Product/` documents seeded
-    from `companies/<name>/workspace/**`. It is **split**, unlike every other
-    namespace: *reads* (`workspace_list`, `workspace_read`) follow the ordinary
-    rule, so a catch-all `*` confers them; *writes* (`workspace_write`) need an
-    **explicit** `workspace` or `workspace.write` entry in `[tools].allow`,
-    because a write mutates guidance every other agent then treats as the
-    company's source of truth. `workspace.read` is therefore a genuinely
-    read-only grant. Writes overwrite one **existing** note only and require an
+  - **`workspace`** (issues #237, #551) grants the company's shared note tree —
+    the `Standards/` / `Playbooks/` / `Product/` documents seeded from
+    `companies/<name>/workspace/**`, plus whatever the operator and the agents
+    have written since. It is **split**, unlike every other namespace: *reads*
+    (`workspace_list`, `workspace_read`) follow the ordinary rule, so a
+    catch-all `*` confers them; *mutations* (`workspace_write`,
+    `workspace_create`) need an **explicit** `workspace` or `workspace.write`
+    entry in `[tools].allow`, because they change a tree every other agent then
+    treats as the company's source of truth. `workspace.read` is therefore a
+    genuinely read-only grant. Create and write ride the one flag on purpose:
+    overwriting an existing standard is strictly more destructive than adding a
+    note beside it, so a grant permitting the first has already permitted the
+    second. `workspace_write` overwrites one **existing** note and requires an
     `expected_updated_at` revision token taken from a prior read, so a note
     edited in the console since the agent read it is refused rather than
-    clobbered; creating, renaming and deleting notes stay operator-only. Both
+    clobbered. `workspace_create` adds one folder or note at a path that is
+    **free** and whose parent folder already exists — never an overwrite, never
+    a `mkdir -p`. Renaming and deleting stay operator-only.
+
+    Agent writes are **unconfined**: an agent may create or edit anywhere in its
+    company's tree. Confining creation while leaving overwrite free would
+    protect nothing. What keeps the tree navigable instead is steering plus
+    attribution — the persona brief names the agent's own reserved folder
+    `Agents/<agent-id>/` (provisioned per roster agent at boot and on every
+    roster change) as the default home for what it produces and marks shared
+    guidance as something to edit only on purpose, and every node records who
+    created it and who last wrote it (issue #326), which the console shows. Both
     sides are capped at the agent harness's own per-tool-result byte budget
     minus the framing a read wraps a body in (issue #417) — 12 KiB today,
     derived rather than chosen so a full read always survives the harness cut

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -126,15 +126,17 @@ destroying the diff.
 ### WorkspaceStore
 
 The Obsidian-style note tree (`src/ports/workspace.rs`), seeded from the
-company's `workspace/**` on first use.
+company's `workspace/**` on first use and thereafter written by both the
+operator (console/REST) and the company's agents (`workspace_create` /
+`workspace_write`).
 
 ```rust
 pub trait WorkspaceStore: Send + Sync {
     async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>>;
     async fn read(&self, company: &CompanyId, id: &str)
         -> Result<Option<(WorkspaceNode, String)>>;
-    async fn write(&self, company: &CompanyId, id: &str, content: &str)
-        -> Result<WorkspaceNode>;
+    async fn write(&self, company: &CompanyId, id: &str, content: &str,
+                   author: WorkspaceOrigin) -> Result<WorkspaceNode>;
     async fn create(&self, /* parent, name, kind, content */) -> Result<WorkspaceNode>;
     async fn rename_move(&self, /* id, new_name, new_parent */) -> Result<WorkspaceNode>;
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;
@@ -144,6 +146,26 @@ pub trait WorkspaceStore: Send + Sync {
 
 Nodes are folders or files (`NodeKind`); `[[wikilink]]` backlinks are derived
 at read time by the GraphQL layer.
+
+**Authorship (#326).** Every `WorkspaceNode` carries `created_by` and
+`updated_by`, both a `WorkspaceOrigin` ∈ `seed | operator | agent{id}`. `write`
+takes the author and stamps `updated_by`; `create` receives a fully-formed node
+whose caller sets both. `rename_move` deliberately touches **neither**, so an
+operator reorganising the tree cannot mask who wrote the body that is stored.
+Backends persist the node as opaque JSON and both fields are
+`#[serde(default)]`, so a node written before the fields existed loads as
+`operator` — no column, no migration. `assert_workspace_store` pins the
+round-trip, the write stamp, and the rename non-stamp across all three
+backends.
+
+**`Agents/<agent-id>/` (#551).** `company::workspace_agents::ensure_agent_folders`
+adopt-or-creates a reserved `Agents` root plus one folder per roster agent, from
+two seams: `RuntimeBuilder::build` (boot) and `HarnessPool::ensure` (every
+roster rebuild, so console `add_member` and orchestrator `add_agent` are
+covered). It is idempotent and fail-closed — any name collision warns and skips
+rather than creating a duplicate that would make the path ambiguous. The folder
+is an organizational and attribution unit only; agents may create and write
+**anywhere** in their company's tree.
 
 ### FactStore
 

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -5,14 +5,48 @@
 // agents finally look at one tree instead of two.
 //
 // Agents reach the same store through the `workspace_list` / `workspace_read` /
-// `workspace_write` tools (issue #237), which means a note written by an agent
-// shows up here and a note the operator writes here is readable by an agent on
-// its next turn.
+// `workspace_create` / `workspace_write` tools (issues #237, #551), which means
+// a note an agent wrote or created shows up here and a note the operator writes
+// here is readable by an agent on its next turn. Every node carries who created
+// it and who last wrote it (issue #326) so the two are told apart on sight.
 
 import type { OpenCompanyClient } from "./client";
 
 /** Whether a node is a folder or a file. */
 export type NodeKind = "folder" | "file";
+
+/**
+ * Who authored a node — the host's `WorkspaceOrigin` (issue #326).
+ *
+ * `seed` is neither: it shipped with the company bundle and was typed by
+ * nobody. `agentId` is present exactly when `kind` is `"agent"`.
+ */
+export type WorkspaceOrigin =
+  | { kind: "seed" }
+  | { kind: "operator" }
+  | { kind: "agent"; id: string };
+
+/** The origin every node falls back to — what the host defaults a legacy node to. */
+export const OPERATOR_ORIGIN: WorkspaceOrigin = { kind: "operator" };
+
+/**
+ * A short human label for an origin, or `null` for a plain operator note.
+ *
+ * Mirrors `ORIGIN_LABELS` in `api/memory.ts`, but returns `null` rather than
+ * "Operator" for the operator case: in the Brain every row has an interesting
+ * origin, whereas here the operator is the unremarkable default and badging it
+ * would put a chip on nearly every note while saying nothing.
+ */
+export function originLabel(origin: WorkspaceOrigin | undefined): string | null {
+  switch (origin?.kind) {
+    case "agent":
+      return `Agent · ${origin.id}`;
+    case "seed":
+      return "Seeded";
+    default:
+      return null;
+  }
+}
 
 /**
  * One node in the workspace tree, as the host returns it.
@@ -31,6 +65,10 @@ export interface FsNode {
   content?: string;
   /** Epoch-millis of the last update. */
   updatedAt: number;
+  /** Who created this node. Never changes. */
+  createdBy: WorkspaceOrigin;
+  /** Who last wrote this node's body. A rename or move does not change it. */
+  updatedBy: WorkspaceOrigin;
 }
 
 /** One file's body plus the notes that link to it, from `GET …/workspace/file/{id}`. */
@@ -39,23 +77,40 @@ export interface WorkspaceFile {
   name: string;
   content: string;
   updatedAt: number;
+  createdBy: WorkspaceOrigin;
+  updatedBy: WorkspaceOrigin;
   /** Other files whose content links to this one via `[[name]]` — computed by the host. */
   backlinks: FsNode[];
 }
 
-/** The wire shape: `parentId` is omitted at the root rather than sent as null. */
-interface FsNodeWire extends Omit<FsNode, "parentId"> {
+/**
+ * The wire shape: `parentId` is omitted at the root rather than sent as null,
+ * and the two origins are optional purely for rollout skew — a console served
+ * by a host that predates issue #326 gets neither field, and defaulting is
+ * cheaper than a blank badge.
+ */
+interface FsNodeWire extends Omit<FsNode, "parentId" | "createdBy" | "updatedBy"> {
   parentId?: string | null;
+  createdBy?: WorkspaceOrigin;
+  updatedBy?: WorkspaceOrigin;
 }
 
 /**
  * Normalizes a node off the wire. The host omits `parentId` at the workspace
  * root (`skip_serializing_if = "Option::is_none"`), and every tree query in the
  * view keys off `parentId === null`, so an absent field becomes an explicit
- * null exactly once — here — rather than at each call site.
+ * null exactly once — here — rather than at each call site. The origins get the
+ * same treatment against an older host: absent means operator, which is the
+ * same default the Rust port applies to a node written before the field
+ * existed.
  */
 function normalize(node: FsNodeWire): FsNode {
-  return { ...node, parentId: node.parentId ?? null };
+  return {
+    ...node,
+    parentId: node.parentId ?? null,
+    createdBy: node.createdBy ?? OPERATOR_ORIGIN,
+    updatedBy: node.updatedBy ?? OPERATOR_ORIGIN,
+  };
 }
 
 /** Every node in the company's workspace (metadata only; no bodies). */
@@ -73,10 +128,19 @@ export async function fetchFile(
   company: string | null,
   id: string,
 ): Promise<WorkspaceFile> {
-  const file = await client.get<Omit<WorkspaceFile, "backlinks"> & { backlinks: FsNodeWire[] }>(
-    `${client.scopeFor(company)}/workspace/file/${encodeURIComponent(id)}`,
-  );
-  return { ...file, backlinks: file.backlinks.map(normalize) };
+  const file = await client.get<
+    Omit<WorkspaceFile, "backlinks" | "createdBy" | "updatedBy"> & {
+      backlinks: FsNodeWire[];
+      createdBy?: WorkspaceOrigin;
+      updatedBy?: WorkspaceOrigin;
+    }
+  >(`${client.scopeFor(company)}/workspace/file/${encodeURIComponent(id)}`);
+  return {
+    ...file,
+    createdBy: file.createdBy ?? OPERATOR_ORIGIN,
+    updatedBy: file.updatedBy ?? OPERATOR_ORIGIN,
+    backlinks: file.backlinks.map(normalize),
+  };
 }
 
 /** Create a folder or file. The host mints the id and the timestamp. */

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -25,11 +25,15 @@ import {
   deleteNode as deleteNodeApi,
   fetchFile,
   fetchTree,
+  originLabel,
   renameMoveNode,
   writeFile,
+  OPERATOR_ORIGIN,
   type WorkspaceFile,
+  type WorkspaceOrigin,
 } from "@/api/workspace";
 import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -300,12 +304,19 @@ export function WorkspaceView({ client, company }: Props) {
       const ack = await writeFile(client, company, job.id, job.content);
       setSaveState("saved");
       // Patch the authoritative stamp onto both the open file and the tree row,
-      // so "last updated" is the host's answer and not a guess.
+      // so "last updated" is the host's answer and not a guess. `updatedBy`
+      // rides along: this route stamps the operator server-side, and leaving
+      // the stale value would keep showing "edited by <agent>" on a note the
+      // operator has just rewritten, until the next refetch.
       setOpenFile((f) =>
-        f && f.id === job.id ? { ...f, content: job.content, updatedAt: ack.updatedAt } : f,
+        f && f.id === job.id
+          ? { ...f, content: job.content, updatedAt: ack.updatedAt, updatedBy: OPERATOR_ORIGIN }
+          : f,
       );
       setNodes((all) =>
-        all.map((n) => (n.id === job.id ? { ...n, updatedAt: ack.updatedAt } : n)),
+        all.map((n) =>
+          n.id === job.id ? { ...n, updatedAt: ack.updatedAt, updatedBy: OPERATOR_ORIGIN } : n,
+        ),
       );
     } catch (e) {
       // Keep the buffer: the operator's text is never dropped because a save
@@ -488,6 +499,11 @@ export function WorkspaceView({ client, company }: Props) {
         name: created.name,
         content: content ?? "",
         updatedAt: created.updatedAt,
+        // Straight off the create response rather than assumed: the host mints
+        // the origins, and this route is the operator's, so they will say
+        // `operator` — but reading them keeps this in step if that ever moves.
+        createdBy: created.createdBy,
+        updatedBy: created.updatedBy,
         backlinks: [],
       });
       setFileError(null);
@@ -695,8 +711,10 @@ export function WorkspaceView({ client, company }: Props) {
                 <PanelLeft className="size-4" />
               </IconBtn>
               <span className="truncate text-sm font-medium">{titleOf(openNode)}</span>
-              {/* No authorship on a node (#326), so "when" is the only signal an
-                  agent has been in here — worth showing plainly. */}
+              <Authorship
+                createdBy={openFile?.createdBy ?? openNode.createdBy}
+                updatedBy={openFile?.updatedBy ?? openNode.updatedBy}
+              />
               <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
                 {formatUpdated(openFile?.updatedAt ?? openNode.updatedAt)}
               </span>
@@ -839,6 +857,53 @@ function Tree(props: TreeProps) {
   );
 }
 
+/** Badge styling per origin, mirroring `ORIGIN_STYLES` in `api/memory.ts`. */
+const ORIGIN_STYLES: Record<WorkspaceOrigin["kind"], string> = {
+  agent: "border-teal-500/30 bg-teal-500/10 text-teal-600 dark:text-teal-400",
+  seed: "border-border bg-muted text-muted-foreground",
+  operator: "border-border bg-muted text-muted-foreground",
+};
+
+/**
+ * Who made this note, in the open-file header.
+ *
+ * Two facts, shown asymmetrically on purpose. The **creator** is the identity of
+ * the note and gets a badge — but only when it is worth saying, so a plain
+ * operator note stays unadorned rather than every note in the tree wearing a
+ * chip. The **last writer** is shown only when it differs from the creator,
+ * which is exactly the case issue #326 called out: an agent wrote this and then
+ * somebody else edited it (or the reverse). When both are the same the badge
+ * already says it.
+ */
+function Authorship({
+  createdBy,
+  updatedBy,
+}: {
+  createdBy: WorkspaceOrigin;
+  updatedBy: WorkspaceOrigin;
+}) {
+  const created = originLabel(createdBy);
+  const edited = sameOrigin(createdBy, updatedBy) ? null : originLabel(updatedBy);
+  if (!created && !edited) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-1.5" data-testid="workspace-authorship">
+      {created && (
+        <Badge variant="outline" className={cn("text-[10px]", ORIGIN_STYLES[createdBy.kind])}>
+          {created}
+        </Badge>
+      )}
+      {edited && (
+        <span className="hidden text-xs text-muted-foreground sm:inline">edited by {edited}</span>
+      )}
+    </span>
+  );
+}
+
+function sameOrigin(a: WorkspaceOrigin, b: WorkspaceOrigin): boolean {
+  if (a.kind !== b.kind) return false;
+  return a.kind !== "agent" || a.id === (b as { id: string }).id;
+}
+
 function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
   const { depth, expanded, openId, onToggle, onOpen } = props;
   const isFolder = node.kind === "folder";
@@ -867,6 +932,20 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
             <FileText className="ml-3.5 size-4 shrink-0 text-muted-foreground" />
           )}
           <span className="truncate">{isFolder ? node.name : titleOf(node)}</span>
+          {/* Agent-created nodes get a marker in the tree itself, so "what has
+              the company been writing" is answerable by scanning rather than by
+              opening each note. Only the agent case — badging the operator's
+              own notes back at them says nothing. */}
+          {node.createdBy.kind === "agent" && (
+            <Badge
+              variant="outline"
+              className={cn("shrink-0 px-1 py-0 text-[10px]", ORIGIN_STYLES.agent)}
+              title={`Created by agent ${node.createdBy.id}`}
+              data-testid="workspace-tree-agent-badge"
+            >
+              {node.createdBy.id}
+            </Badge>
+          )}
         </button>
         <DropdownMenu>
           <DropdownMenuTrigger

--- a/frontend/test/unit/workspace-origin.test.ts
+++ b/frontend/test/unit/workspace-origin.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { fetchFile, fetchTree, originLabel, type WorkspaceOrigin } from "@/api/workspace";
+
+/**
+ * Workspace authorship (issue #326), on the console side.
+ *
+ * Two properties are worth pinning here rather than leaving to the view. The
+ * label is what the operator actually reads, and getting the operator case
+ * wrong would put a chip on every note in the tree. The normalization default
+ * is the rollout-skew guard: a console served by a host that predates the field
+ * must render "operator", not a blank badge or a crash.
+ */
+
+const client = (payload: unknown) =>
+  ({
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(payload),
+  }) as never;
+
+describe("originLabel", () => {
+  it("names the agent that authored a node", () => {
+    expect(originLabel({ kind: "agent", id: "ceo" })).toBe("Agent · ceo");
+  });
+
+  it("distinguishes a seeded node from one somebody wrote", () => {
+    expect(originLabel({ kind: "seed" })).toBe("Seeded");
+  });
+
+  it("says nothing for a plain operator note", () => {
+    // Deliberately null rather than "Operator": the operator is the
+    // unremarkable default here, and badging it would decorate nearly every
+    // note in the tree while conveying nothing.
+    expect(originLabel({ kind: "operator" })).toBeNull();
+    expect(originLabel(undefined)).toBeNull();
+  });
+});
+
+describe("normalization off the wire", () => {
+  it("defaults a node with no origins to operator", async () => {
+    const [node] = await fetchTree(
+      client([{ id: "n1", name: "voice.md", kind: "file", updatedAt: 1 }]),
+      "acme",
+    );
+    expect(node.createdBy).toEqual<WorkspaceOrigin>({ kind: "operator" });
+    expect(node.updatedBy).toEqual<WorkspaceOrigin>({ kind: "operator" });
+    // The pre-existing parentId normalization still holds alongside it.
+    expect(node.parentId).toBeNull();
+  });
+
+  it("keeps the origins the host actually sent, on the node and its backlinks", async () => {
+    const node = await fetchFile(
+      client({
+        id: "n1",
+        name: "voice.md",
+        content: "# Voice",
+        updatedAt: 2,
+        createdBy: { kind: "agent", id: "cmo" },
+        updatedBy: { kind: "operator" },
+        backlinks: [
+          { id: "n2", name: "brief.md", kind: "file", updatedAt: 1, createdBy: { kind: "seed" } },
+        ],
+      }),
+      "acme",
+      "n1",
+    );
+    expect(node.createdBy).toEqual<WorkspaceOrigin>({ kind: "agent", id: "cmo" });
+    expect(node.updatedBy).toEqual<WorkspaceOrigin>({ kind: "operator" });
+    expect(node.backlinks[0].createdBy).toEqual<WorkspaceOrigin>({ kind: "seed" });
+    expect(node.backlinks[0].updatedBy).toEqual<WorkspaceOrigin>({ kind: "operator" });
+  });
+});

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -42,6 +42,10 @@ mod workflow_file;
 // `GET …/workspace/file/{id}` route the console calls. Always compiled: the
 // REST route is in the default build, and one shared scan is what keeps the two
 // read surfaces from drifting.
+// `Agents/<agent-id>/` provisioning (issue #551). Always compiled and
+// openhuman-free: it is called from the runtime builder at boot, which is in
+// the default build, and it touches nothing but the `WorkspaceStore` port.
+pub mod workspace_agents;
 pub(crate) mod workspace_links;
 pub mod workspace_seed;
 

--- a/src/company/workspace_agents.rs
+++ b/src/company/workspace_agents.rs
@@ -1,0 +1,485 @@
+//! `Agents/<agent-id>/` — the reserved workspace folder each agent calls home
+//! (issue #551).
+//!
+//! Before this module an agent had nowhere in the shared tree that was
+//! recognisably *its own*: everything it produced landed in its private
+//! per-agent sandbox or on a task artifact, neither of which the operator or
+//! another agent browses. `Agents/` gives each roster member a named place in
+//! the one tree both sides read, so "where did the CMO put the launch brief"
+//! has an answer a human can navigate to.
+//!
+//! # What this is, and what it very deliberately is not
+//!
+//! It is an **organizational and attribution unit**, identified by path. It is
+//! **not** a permission boundary. Agents write anywhere in the tree — that is
+//! the settled design (a `workspace_write` has always been able to overwrite
+//! any note, and gating *create* while *overwrite* stays free would protect
+//! nothing, since overwriting is the strictly more destructive of the two).
+//! What keeps the tree tidy is steering — the persona brief names
+//! `Agents/<your id>/` as the default home for anything an agent produces —
+//! plus the authorship stamps from issue #326, which make it visible after the
+//! fact who put what where. Containment lives one level up, in company tenancy,
+//! the explicit `workspace` write grant, the CAS token, and policy parking.
+//!
+//! # Fail-closed adoption
+//!
+//! Identity is by path, and nothing in the [`WorkspaceStore`] port enforces
+//! unique sibling names, so provisioning is check-then-act. Every ambiguous
+//! situation resolves the same way: **warn and skip**, never guess and never
+//! overwrite.
+//!
+//! * Exactly one root folder named `Agents` → adopt it as-is.
+//! * A root *file* named `Agents`, or several root nodes carrying the name →
+//!   warn and do nothing at all. Creating a rival root would make the path
+//!   permanently ambiguous, which the tool layer's resolver then refuses for
+//!   every agent (see `harness::workspace_tools`).
+//! * Same rule again, one level down, per `Agents/<agent-id>`.
+//!
+//! The whole function is idempotent, which is what lets it run on every boot
+//! and on every harness roster rebuild without accumulating anything.
+
+use std::collections::BTreeSet;
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+/// The reserved root folder holding one subfolder per agent.
+///
+/// A literal, because identity here is by path: this is the name the persona
+/// brief tells agents to look for and the name issue #552's published
+/// deliverables land under.
+pub const AGENTS_ROOT: &str = "Agents";
+
+/// Adopt-or-create `Agents/` and `Agents/<id>` for every agent in `agent_ids`.
+///
+/// One `tree()` read, then only the creates that are actually missing. Safe to
+/// call on every boot and every roster rebuild.
+///
+/// The `Agents` root is stamped [`WorkspaceOrigin::Seed`] — it is scaffolding
+/// the runtime lays down, authored by no operator and no agent — while each
+/// `Agents/<id>` folder is stamped [`WorkspaceOrigin::Agent`] for the agent it
+/// belongs to, so the console can say whose folder it is without parsing the
+/// path.
+///
+/// Errors from the tree read propagate; a failed *create* warns and moves on.
+/// Provisioning a convenience folder must not take down a boot or a turn, and
+/// the next call retries it.
+pub async fn ensure_agent_folders<I, S>(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    agent_ids: I,
+) -> Result<()>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    // Deduplicated because the callers union a manifest roster with a live
+    // overlay roster, which legitimately overlap.
+    let ids: BTreeSet<String> = agent_ids
+        .into_iter()
+        .map(|id| id.as_ref().trim().to_string())
+        .filter(|id| !id.is_empty())
+        .collect();
+    if ids.is_empty() {
+        return Ok(());
+    }
+
+    let nodes = store.tree(company).await?;
+
+    let Some(root_id) = ensure_root(store, company, &nodes).await? else {
+        return Ok(());
+    };
+
+    for id in ids {
+        // The id becomes a node name, and a name carrying a separator renders
+        // an ambiguous or traversal-shaped path. The `fs` backend refuses such
+        // names outright and the sqlite/mongodb backends do not, so the guard
+        // lives here rather than being assumed of the store.
+        if !is_legal_segment(&id) {
+            tracing::warn!(
+                company = %company,
+                agent = %id,
+                "[workspace] agent id is not a legal path segment; skipping its `{AGENTS_ROOT}/` folder"
+            );
+            continue;
+        }
+
+        let existing: Vec<&WorkspaceNode> = nodes
+            .iter()
+            .filter(|n| n.parent_id.as_deref() == Some(root_id.as_str()) && n.name == id)
+            .collect();
+        match existing.as_slice() {
+            // Already provisioned (or the operator made it by hand) — adopt.
+            [one] if one.kind == NodeKind::Folder => continue,
+            [_] => {
+                tracing::warn!(
+                    company = %company,
+                    agent = %id,
+                    "[workspace] `{AGENTS_ROOT}/{id}` already exists as a file, not a folder; leaving it alone"
+                );
+                continue;
+            }
+            [] => {}
+            many => {
+                tracing::warn!(
+                    company = %company,
+                    agent = %id,
+                    count = many.len(),
+                    "[workspace] several nodes are named `{AGENTS_ROOT}/{id}`; leaving them alone"
+                );
+                continue;
+            }
+        }
+
+        let origin = WorkspaceOrigin::Agent { id: id.clone() };
+        let node = WorkspaceNode {
+            id: crate::ports::generate_id(),
+            name: id.clone(),
+            kind: NodeKind::Folder,
+            parent_id: Some(root_id.clone()),
+            updated_at_millis: crate::ports::now_millis(),
+            created_by: origin.clone(),
+            updated_by: origin,
+        };
+        if let Err(e) = store.create(company, &node, None).await {
+            tracing::warn!(
+                company = %company,
+                agent = %id,
+                error = %e,
+                "[workspace] could not create `{AGENTS_ROOT}/{id}`; will retry on the next rebuild"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// Adopt the existing `Agents` root, or create it. `None` means "the tree is
+/// ambiguous here — do nothing", which is the fail-closed answer.
+async fn ensure_root(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    nodes: &[WorkspaceNode],
+) -> Result<Option<String>> {
+    let candidates: Vec<&WorkspaceNode> = nodes
+        .iter()
+        .filter(|n| n.parent_id.is_none() && n.name == AGENTS_ROOT)
+        .collect();
+
+    match candidates.as_slice() {
+        [one] if one.kind == NodeKind::Folder => return Ok(Some(one.id.clone())),
+        [_] => {
+            tracing::warn!(
+                company = %company,
+                "[workspace] the workspace root already holds a FILE named `{AGENTS_ROOT}`; not provisioning agent folders"
+            );
+            return Ok(None);
+        }
+        [] => {}
+        many => {
+            tracing::warn!(
+                company = %company,
+                count = many.len(),
+                "[workspace] several root nodes are named `{AGENTS_ROOT}`; not provisioning agent folders"
+            );
+            return Ok(None);
+        }
+    }
+
+    let root = WorkspaceNode {
+        id: crate::ports::generate_id(),
+        name: AGENTS_ROOT.to_string(),
+        kind: NodeKind::Folder,
+        parent_id: None,
+        updated_at_millis: crate::ports::now_millis(),
+        // Runtime scaffolding, not anybody's writing.
+        created_by: WorkspaceOrigin::Seed,
+        updated_by: WorkspaceOrigin::Seed,
+    };
+    match store.create(company, &root, None).await {
+        Ok(()) => Ok(Some(root.id)),
+        Err(e) => {
+            tracing::warn!(
+                company = %company,
+                error = %e,
+                "[workspace] could not create the `{AGENTS_ROOT}` root; will retry on the next rebuild"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Whether `name` is usable as a single workspace path segment.
+///
+/// Mirrors the `fs` backend's `reject_unsafe_name` and the agent tool layer's
+/// `is_legal_segment`. Duplicated rather than shared because this module is in
+/// the default build and the tool layer links only under the `openhuman`
+/// feature; the rule is three lines and a shared home for it would drag the
+/// whole harness into every build.
+fn is_legal_segment(name: &str) -> bool {
+    !name.is_empty()
+        && name != "."
+        && name != ".."
+        && !name.contains('/')
+        && !name.contains('\\')
+        && !name.contains('\0')
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::store::FsOps;
+
+    fn agent(id: &str) -> WorkspaceOrigin {
+        WorkspaceOrigin::Agent { id: id.to_string() }
+    }
+
+    async fn store() -> (tempfile::TempDir, Arc<dyn WorkspaceStore>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ops: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        (dir, ops)
+    }
+
+    /// A node's rendered `parent/child` path, for readable assertions.
+    fn path_of(nodes: &[WorkspaceNode], node: &WorkspaceNode) -> String {
+        match &node.parent_id {
+            None => node.name.clone(),
+            Some(parent) => match nodes.iter().find(|n| &n.id == parent) {
+                Some(p) => format!("{}/{}", path_of(nodes, p), node.name),
+                None => node.name.clone(),
+            },
+        }
+    }
+
+    fn paths(nodes: &[WorkspaceNode]) -> Vec<String> {
+        let mut out: Vec<String> = nodes.iter().map(|n| path_of(nodes, n)).collect();
+        out.sort();
+        out
+    }
+
+    #[tokio::test]
+    async fn it_provisions_a_root_and_one_folder_per_agent() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo", "cmo"])
+            .await
+            .unwrap();
+
+        let nodes = ws.tree(&company).await.unwrap();
+        assert_eq!(paths(&nodes), vec!["Agents", "Agents/ceo", "Agents/cmo"]);
+
+        // The root is runtime scaffolding; each folder belongs to its agent.
+        let root = nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap();
+        assert_eq!(root.created_by, WorkspaceOrigin::Seed);
+        assert_eq!(root.kind, NodeKind::Folder);
+        let ceo = nodes.iter().find(|n| n.name == "ceo").unwrap();
+        assert_eq!(ceo.created_by, agent("ceo"));
+        assert_eq!(ceo.kind, NodeKind::Folder);
+    }
+
+    /// The property that lets this run on every boot and every roster rebuild.
+    #[tokio::test]
+    async fn it_is_idempotent() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+
+        for _ in 0..3 {
+            ensure_agent_folders(ws.as_ref(), &company, ["ceo"])
+                .await
+                .unwrap();
+        }
+        assert_eq!(
+            paths(&ws.tree(&company).await.unwrap()),
+            ["Agents", "Agents/ceo"]
+        );
+    }
+
+    /// A roster that grows between boots gets the new folder and keeps the old
+    /// ones — the `add_member` / `add_agent` case the harness call site covers.
+    #[tokio::test]
+    async fn a_later_agent_is_added_without_disturbing_the_first() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo"])
+            .await
+            .unwrap();
+        let before = ws.tree(&company).await.unwrap();
+        let ceo_id = before.iter().find(|n| n.name == "ceo").unwrap().id.clone();
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo", "designer"])
+            .await
+            .unwrap();
+
+        let after = ws.tree(&company).await.unwrap();
+        assert_eq!(
+            paths(&after),
+            vec!["Agents", "Agents/ceo", "Agents/designer"]
+        );
+        assert_eq!(
+            after.iter().find(|n| n.name == "ceo").unwrap().id,
+            ceo_id,
+            "the existing folder must be adopted, not replaced"
+        );
+    }
+
+    /// An operator-made `Agents/` folder is adopted as-is rather than
+    /// duplicated — identity is by path, so a second root would make every
+    /// `Agents/...` path permanently ambiguous.
+    #[tokio::test]
+    async fn an_existing_agents_folder_is_adopted() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        let existing = WorkspaceNode {
+            id: "hand-made".to_string(),
+            name: AGENTS_ROOT.to_string(),
+            kind: NodeKind::Folder,
+            parent_id: None,
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
+        };
+        ws.create(&company, &existing, None).await.unwrap();
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo"])
+            .await
+            .unwrap();
+
+        let nodes = ws.tree(&company).await.unwrap();
+        assert_eq!(paths(&nodes), vec!["Agents", "Agents/ceo"]);
+        let root = nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap();
+        assert_eq!(root.id, "hand-made", "the operator's folder must be reused");
+        assert_eq!(
+            root.created_by,
+            WorkspaceOrigin::Operator,
+            "adoption must not rewrite the operator's authorship"
+        );
+    }
+
+    /// Fail-closed: a root *file* named `Agents` is a collision this module has
+    /// no honest way to resolve, so it does nothing rather than shadowing the
+    /// operator's note with a rival folder of the same name.
+    #[tokio::test]
+    async fn a_root_file_named_agents_blocks_provisioning() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ws.create(
+            &company,
+            &WorkspaceNode {
+                id: "note".to_string(),
+                name: AGENTS_ROOT.to_string(),
+                kind: NodeKind::File,
+                parent_id: None,
+                updated_at_millis: 1,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
+            },
+            Some("# not a folder"),
+        )
+        .await
+        .unwrap();
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo"])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            paths(&ws.tree(&company).await.unwrap()),
+            vec!["Agents"],
+            "nothing may be created alongside the colliding root"
+        );
+    }
+
+    /// Same rule one level down: an `Agents/ceo` *file* is left alone.
+    #[tokio::test]
+    async fn a_colliding_child_file_is_left_alone() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_agent_folders(ws.as_ref(), &company, ["cmo"])
+            .await
+            .unwrap();
+        let root_id = ws
+            .tree(&company)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.name == AGENTS_ROOT)
+            .unwrap()
+            .id;
+        ws.create(
+            &company,
+            &WorkspaceNode {
+                id: "ceo-note".to_string(),
+                name: "ceo".to_string(),
+                kind: NodeKind::File,
+                parent_id: Some(root_id),
+                updated_at_millis: 1,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
+            },
+            Some("# notes about the ceo"),
+        )
+        .await
+        .unwrap();
+
+        ensure_agent_folders(ws.as_ref(), &company, ["ceo"])
+            .await
+            .unwrap();
+
+        let nodes = ws.tree(&company).await.unwrap();
+        assert_eq!(paths(&nodes), vec!["Agents", "Agents/ceo", "Agents/cmo"]);
+        assert_eq!(
+            nodes.iter().find(|n| n.name == "ceo").unwrap().kind,
+            NodeKind::File,
+            "the operator's note must not be shadowed by a folder of the same name"
+        );
+    }
+
+    /// An id that is not a legal path segment would render an unaddressable or
+    /// traversal-shaped path, so it is skipped rather than created.
+    #[tokio::test]
+    async fn an_illegal_agent_id_is_skipped_without_blocking_the_others() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+
+        ensure_agent_folders(ws.as_ref(), &company, ["../escape", "ok", "", "."])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            paths(&ws.tree(&company).await.unwrap()),
+            vec!["Agents", "Agents/ok"]
+        );
+    }
+
+    /// No roster, no scaffolding: an empty id list must not mint a stray
+    /// `Agents/` folder in a workspace that has no agents to put in it.
+    #[tokio::test]
+    async fn an_empty_roster_creates_nothing() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_agent_folders(ws.as_ref(), &company, Vec::<String>::new())
+            .await
+            .unwrap();
+        assert!(ws.is_empty(&company).await.unwrap());
+    }
+
+    /// The tree is company-scoped: provisioning one company leaves another's
+    /// workspace untouched.
+    #[tokio::test]
+    async fn provisioning_is_per_company() {
+        let (_dir, ws) = store().await;
+        let acme = CompanyId::new("acme");
+        let other = CompanyId::new("other");
+
+        ensure_agent_folders(ws.as_ref(), &acme, ["ceo"])
+            .await
+            .unwrap();
+
+        assert!(ws.is_empty(&other).await.unwrap());
+    }
+}

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -430,23 +430,38 @@ pub fn build_agent(
         }
     }
 
-    // Company workspace (issue #237) — live read (and optionally write) tools
-    // over the operator-owned note tree, so an agent can ground an answer in
-    // the company's own `Standards/` / `Playbooks/` instead of guessing. Two
-    // independent gates, deliberately asymmetric:
+    // Company workspace (issues #237, #551) — live read (and optionally
+    // create/write) tools over the shared note tree, so an agent can ground an
+    // answer in the company's own `Standards/` / `Playbooks/` instead of
+    // guessing, and can put what it produces somewhere the operator and its
+    // teammates will actually find it. Two independent gates, deliberately
+    // asymmetric:
     //
     //  1. READS follow the ordinary namespace rule, so a catch-all `*` confers
-    //     them — the whole point of the issue is that shared guidance should be
+    //     them — the whole point of #237 is that shared guidance should be
     //     reachable by default.
-    //  2. WRITES need an **EXPLICIT** `workspace` (or `workspace.write`) grant
-    //     (`grants_workspace_write_explicit`); `*` does NOT confer them,
-    //     mirroring the media/composio precedent, because a write mutates
-    //     operator-owned guidance every other agent then trusts.
+    //  2. CREATE + WRITE need an **EXPLICIT** `workspace` (or
+    //     `workspace.write`) grant (`grants_workspace_write_explicit`); `*`
+    //     does NOT confer them, mirroring the media/composio precedent, because
+    //     they mutate a tree every other agent then trusts. Both ride the one
+    //     flag: overwriting an existing standard is strictly more destructive
+    //     than adding a note beside it, so a grant that permits the first has
+    //     already permitted the second.
     //
     // Unwired-store is fail-closed: with no `deps.workspace` no tool is built
-    // and the agent behaves exactly as it did before this cell. Create, rename
-    // and delete stay operator-only — the write tool's required
-    // `expected_updated_at` means only an existing note can be targeted.
+    // and the agent behaves exactly as it did before this cell.
+    //
+    // Note what does and does not contain a write here, now that create is
+    // agent-reachable (#551). It is NOT intra-company isolation — an agent may
+    // create and overwrite anywhere in its company's tree, by design. What
+    // holds is: company tenancy (the store is pinned to one `CompanyId` at
+    // build time, and every tool resolves inside a single company-scoped tree
+    // read); the explicit grant above; the write tool's required
+    // `expected_updated_at` CAS token; policy parking, since `workspace_write`
+    // and `workspace_create` are both `Reach::Consequence` and never grantable
+    // standing (`policy::consequence`); and authorship, since every node
+    // records who created it and who last wrote it (#326). Rename and delete
+    // remain operator-only — they are not on this surface at all.
     //
     // Not mapped in `toolbelt::namespace_of`, so these stay intrinsic to the
     // capability filter (the `file_tools` precedent): the reads are free and

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -458,6 +458,7 @@ pub fn build_agent(
             Some(crate::harness::workspace_tools::workspace_tools(
                 store.clone(),
                 company.clone(),
+                manifest_agent.id.clone(),
                 workspace_writes,
             ))
         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -982,6 +982,40 @@ impl HarnessPool {
         // so installing the live set here is what carries a console budget edit
         // into the roster the very next turn runs on.
         fresh_company.overlay_budgets = overlay_budgets;
+
+        // Issue #551: provision `Agents/<id>/` for the roster this rebuild is
+        // about to build, manifest teammates and overlay teammates alike.
+        //
+        // This is the second of the feature's two seams. The first
+        // ([`RuntimeBuilder::build`]) covers boot; this one covers everything
+        // that changes the roster afterwards — a manifest edit, the console's
+        // `add_member`, the orchestrator's `add_agent` — because all three land
+        // here as a moved overlay fingerprint, on the slow path, just before
+        // the roster is rebuilt. Putting it here rather than in each of those
+        // writers is what keeps them from having to know the workspace exists.
+        //
+        // Only when a workspace store is actually wired: with none, no agent
+        // has workspace tools either, so there is nothing for a folder to be
+        // the home of.
+        if let Some(workspace) = &fresh_deps.workspace {
+            crate::company::workspace_agents::ensure_agent_folders(
+                workspace.as_ref(),
+                &company.id,
+                fresh_company
+                    .manifest
+                    .agents
+                    .iter()
+                    .map(|agent| agent.id.as_str())
+                    .chain(
+                        fresh_company
+                            .overlay_agents
+                            .iter()
+                            .map(|agent| agent.id.as_str()),
+                    ),
+            )
+            .await?;
+        }
+
         let roster = build_roster(&fresh_company, &fresh_deps, &skill_deltas)?;
 
         let mut agents = self.agents.write().await;
@@ -2360,6 +2394,77 @@ description = "Builds the product."
         assert_eq!(
             roster[0].role, "Chief Executive",
             "the manifest role survives, not the overlay's"
+        );
+    }
+
+    /// Issue #551, the second provisioning seam.
+    ///
+    /// Everything that changes a roster after boot — a manifest edit, the
+    /// console's `add_member`, the orchestrator's `add_agent` — reaches the
+    /// harness the same way: a moved overlay fingerprint, then a roster
+    /// rebuild. Hanging provisioning off that rebuild is what covers all three
+    /// without any of those writers learning that a workspace exists.
+    #[tokio::test]
+    async fn ensure_provisions_an_agents_folder_for_a_teammate_added_at_runtime() {
+        use crate::company::workspace_agents::AGENTS_ROOT;
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ws: Arc<dyn crate::ports::WorkspaceStore> =
+            Arc::new(crate::store::FsOps::new(dir.path()));
+        let mut fx = fixture();
+        fx.deps.workspace = Some(ws.clone());
+
+        let mut rec = record();
+        let pool = HarnessPool::new();
+        pool.ensure(&rec, &fx.deps).await.expect("first ensure");
+
+        let names = |nodes: &[crate::ports::WorkspaceNode]| {
+            let mut out: Vec<String> = nodes.iter().map(|n| n.name.clone()).collect();
+            out.sort();
+            out
+        };
+        let tree = ws.tree(&rec.id).await.expect("tree");
+        assert_eq!(
+            names(&tree),
+            vec![
+                AGENTS_ROOT.to_string(),
+                "ceo".to_string(),
+                "engineer".to_string()
+            ],
+            "both manifest teammates get a folder"
+        );
+
+        // The runtime-added teammate. The overlay fingerprint moves, so this
+        // `ensure` takes the rebuild path rather than the cached fast path.
+        rec.overlay_agents.push(OverlayAgent {
+            id: "designer".into(),
+            name: "Dana".into(),
+            role: "Designer".into(),
+            description: None,
+        });
+        pool.ensure(&rec, &fx.deps).await.expect("second ensure");
+
+        let tree = ws.tree(&rec.id).await.expect("tree");
+        assert!(
+            tree.iter().any(|n| n.name == "designer"),
+            "the overlay teammate got no folder: {:?}",
+            names(&tree)
+        );
+        assert_eq!(
+            tree.iter()
+                .filter(|n| n.name == AGENTS_ROOT && n.parent_id.is_none())
+                .count(),
+            1,
+            "the rebuild minted a rival Agents root"
+        );
+        assert_eq!(
+            tree.iter()
+                .find(|n| n.name == "designer")
+                .unwrap()
+                .created_by,
+            crate::ports::WorkspaceOrigin::Agent {
+                id: "designer".to_string()
+            },
         );
     }
 

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -314,13 +314,15 @@ fn caps_are_codepoint_safe() {
 /// terminates instead of hanging the pass.
 #[test]
 fn workspace_paths_render_and_terminate() {
-    use crate::ports::workspace::{NodeKind, WorkspaceNode};
+    use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
     let node = |id: &str, name: &str, parent: Option<&str>, kind| WorkspaceNode {
         id: id.to_string(),
         name: name.to_string(),
         kind,
         parent_id: parent.map(str::to_string),
         updated_at_millis: 0,
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
     };
     let paths = workspace_paths(vec![
         node("1", "Standards", None, NodeKind::Folder),

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1274,10 +1274,11 @@ mod tests {
         );
     }
 
-    /// The company workspace (issue #237): the two read tools reach only this
-    /// company's own note tree and must be allowed in every mode, while
-    /// `workspace_write` overwrites operator-owned guidance and must park under
-    /// supervised / be denied under readonly.
+    /// The company workspace (issues #237, #551): the two read tools reach only
+    /// this company's own note tree and must be allowed in every mode, while
+    /// `workspace_write` (overwrites shared guidance) and `workspace_create`
+    /// (adds to the tree everyone reads) must park under supervised / be denied
+    /// under readonly.
     ///
     /// This is the ACTUAL gate on a workspace write. Issue #237 proposed that
     /// declaring `PermissionLevel::Write` would keep the `ApprovalPolicy` as
@@ -1299,15 +1300,17 @@ mod tests {
                 "{tool} only reads this company's own workspace and must be allowed"
             );
         }
-        assert!(
-            matches!(
-                supervised
-                    .check(&request("workspace_write", serde_json::json!({})))
-                    .await,
-                ToolPolicyDecision::RequireApproval { .. }
-            ),
-            "workspace_write must park under supervised"
-        );
+        for tool in ["workspace_write", "workspace_create"] {
+            assert!(
+                matches!(
+                    supervised
+                        .check(&request(tool, serde_json::json!({})))
+                        .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} must park under supervised"
+            );
+        }
 
         let readonly = policy("readonly", &[], None);
         for tool in ["workspace_list", "workspace_read"] {
@@ -1317,25 +1320,28 @@ mod tests {
                 "{tool} must stay available to a read-only desk"
             );
         }
-        assert!(
-            matches!(
-                readonly
-                    .check(&request("workspace_write", serde_json::json!({})))
-                    .await,
-                ToolPolicyDecision::Deny { .. }
-            ),
-            "workspace_write must be denied under readonly"
-        );
+        for tool in ["workspace_write", "workspace_create"] {
+            assert!(
+                matches!(
+                    readonly.check(&request(tool, serde_json::json!({}))).await,
+                    ToolPolicyDecision::Deny { .. }
+                ),
+                "{tool} must be denied under readonly"
+            );
+        }
 
         // Under `full` there is no per-call gate at all — which is precisely
         // why `workspace_write` carries a required `expected_updated_at`
-        // compare-and-swap token of its own.
+        // compare-and-swap token of its own, and why `workspace_create` refuses
+        // a path that already resolves rather than overwriting it.
         let full = policy("full", &[], None);
-        assert_eq!(
-            full.check(&request("workspace_write", serde_json::json!({})))
-                .await,
-            ToolPolicyDecision::Allow
-        );
+        for tool in ["workspace_write", "workspace_create"] {
+            assert_eq!(
+                full.check(&request(tool, serde_json::json!({}))).await,
+                ToolPolicyDecision::Allow,
+                "{tool} under full mode"
+            );
+        }
     }
 
     /// The operator's escape hatch: `always_approve` wins over every tier, so a
@@ -2599,6 +2605,7 @@ mod tests {
             "curl",
             "web_fetch",
             "workspace_write",
+            "workspace_create",
             // Anything a remote server chooses to advertise.
             "mcp_registry_tool_call",
             "mcp_call_tool",
@@ -2943,16 +2950,18 @@ mod tests {
         assert!(!grantable("deploy_site", &args));
     }
 
-    /// `workspace_write` keeps its `Other` label on the card — there is no
-    /// consequence word to name — while being refused a standing scope. That
-    /// separation is the point of issue #444: the label and the permission are
-    /// different questions.
+    /// The two workspace mutations keep their `Other` label on the card — there
+    /// is no consequence word to name — while being refused a standing scope.
+    /// That separation is the point of issue #444: the label and the permission
+    /// are different questions.
     #[test]
-    fn workspace_write_is_labelled_other_and_is_still_not_grantable() {
+    fn workspace_mutations_are_labelled_other_and_are_still_not_grantable() {
         let args = serde_json::json!({});
-        assert_eq!(classify_group("workspace_write", &args), EffectGroup::Other);
-        assert!(classify_group("workspace_write", &args).is_unclassified());
-        assert!(!grantable("workspace_write", &args));
-        assert!(is_external_effect("workspace_write", &args));
+        for tool in ["workspace_write", "workspace_create"] {
+            assert_eq!(classify_group(tool, &args), EffectGroup::Other, "{tool}");
+            assert!(classify_group(tool, &args).is_unclassified(), "{tool}");
+            assert!(!grantable(tool, &args), "{tool}");
+            assert!(is_external_effect(tool, &args), "{tool}");
+        }
     }
 }

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -130,7 +130,7 @@ use openhuman_core::openhuman as oh;
 
 use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::types::CompanyId;
-use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
 /// Tool name: list the company workspace's path index.
 pub const WORKSPACE_LIST_TOOL: &str = "workspace_list";
@@ -224,20 +224,37 @@ const MAX_PATH_DEPTH: usize = 64;
 // The company-scoped handle
 // ---------------------------------------------------------------------------
 
-/// A [`WorkspaceStore`] pinned to one company — the object every tool holds.
+/// A [`WorkspaceStore`] pinned to one company and one agent — the object every
+/// tool holds.
 ///
-/// The `company` is set once at agent-build time and is never derived from tool
-/// arguments, which is what makes the tenancy argument in the module docs hold.
+/// Both `company` and `agent_id` are set once at agent-build time and are never
+/// derived from tool arguments. For `company` that is what makes the tenancy
+/// argument in the module docs hold; for `agent_id` it is what makes the
+/// authorship stamp trustworthy — an agent cannot claim to be another agent,
+/// because it never gets to say who it is.
 #[derive(Clone)]
 pub struct CompanyWorkspace {
     store: Arc<dyn WorkspaceStore>,
     company: CompanyId,
+    agent_id: String,
 }
 
 impl CompanyWorkspace {
-    /// Pin `store` to `company`.
-    pub fn new(store: Arc<dyn WorkspaceStore>, company: CompanyId) -> Self {
-        Self { store, company }
+    /// Pin `store` to `company`, writing as `agent_id`.
+    pub fn new(store: Arc<dyn WorkspaceStore>, company: CompanyId, agent_id: String) -> Self {
+        Self {
+            store,
+            company,
+            agent_id,
+        }
+    }
+
+    /// This agent's origin, for stamping [`WorkspaceNode::created_by`] /
+    /// [`WorkspaceNode::updated_by`].
+    fn origin(&self) -> WorkspaceOrigin {
+        WorkspaceOrigin::Agent {
+            id: self.agent_id.clone(),
+        }
     }
 
     /// Read this company's whole tree and build the path index.
@@ -1080,7 +1097,12 @@ impl Tool for WorkspaceWriteTool {
         match self
             .workspace
             .store
-            .write(&self.workspace.company, &entry.node.id, content)
+            .write(
+                &self.workspace.company,
+                &entry.node.id,
+                content,
+                self.workspace.origin(),
+            )
             .await
         {
             Ok(node) => Ok(ToolResult::success(format!(
@@ -1112,9 +1134,10 @@ impl Tool for WorkspaceWriteTool {
 pub fn workspace_tools(
     store: Arc<dyn WorkspaceStore>,
     company: CompanyId,
+    agent_id: String,
     can_write: bool,
 ) -> Vec<Box<dyn Tool>> {
-    let workspace = CompanyWorkspace::new(store, company);
+    let workspace = CompanyWorkspace::new(store, company, agent_id);
     let mut tools: Vec<Box<dyn Tool>> = vec![
         Box::new(WorkspaceListTool::new(workspace.clone())),
         Box::new(WorkspaceReadTool::new(workspace.clone())),
@@ -1132,6 +1155,22 @@ mod tests {
 
     // -- helpers ------------------------------------------------------------
 
+    /// The agent every test writes as, so an authorship assertion has a name to
+    /// check against.
+    const TEST_AGENT: &str = "ceo";
+
+    /// A [`CompanyWorkspace`] pinned to `company`, writing as [`TEST_AGENT`].
+    fn ws(store: Arc<dyn WorkspaceStore>, company: CompanyId) -> CompanyWorkspace {
+        CompanyWorkspace::new(store, company, TEST_AGENT.to_string())
+    }
+
+    /// This agent's origin — what a create or a write must stamp.
+    fn agent_origin() -> WorkspaceOrigin {
+        WorkspaceOrigin::Agent {
+            id: TEST_AGENT.to_string(),
+        }
+    }
+
     fn folder(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
         WorkspaceNode {
             id: id.to_string(),
@@ -1139,6 +1178,8 @@ mod tests {
             kind: NodeKind::Folder,
             parent_id: parent.map(str::to_string),
             updated_at_millis: 1_000,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
         }
     }
 
@@ -1149,6 +1190,8 @@ mod tests {
             kind: NodeKind::File,
             parent_id: parent.map(str::to_string),
             updated_at_millis: 2_000,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
         }
     }
 
@@ -1330,10 +1373,7 @@ mod tests {
     #[tokio::test]
     async fn tenancy_company_b_cannot_list_company_a_notes() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceListTool::new(CompanyWorkspace::new(
-            store.clone(),
-            CompanyId::new("other"),
-        ));
+        let tool = WorkspaceListTool::new(ws(store.clone(), CompanyId::new("other")));
         let out = text(&tool.execute(json!({})).await.unwrap());
         assert!(out.contains("workspace is empty"), "{out}");
         assert!(!out.contains("Engineering standards.md"), "{out}");
@@ -1346,15 +1386,11 @@ mod tests {
     async fn tenancy_a_borrowed_node_id_does_not_resolve_for_another_company() {
         let (_dir, store) = seeded("acme").await;
         // Sanity: the id is real and readable for its owner.
-        let owner =
-            WorkspaceReadTool::new(CompanyWorkspace::new(store.clone(), CompanyId::new("acme")));
+        let owner = WorkspaceReadTool::new(ws(store.clone(), CompanyId::new("acme")));
         let owned = text(&owner.execute(json!({"id": "n-eng"})).await.unwrap());
         assert!(owned.contains("Review every PR."), "{owned}");
 
-        let intruder = WorkspaceReadTool::new(CompanyWorkspace::new(
-            store.clone(),
-            CompanyId::new("other"),
-        ));
+        let intruder = WorkspaceReadTool::new(ws(store.clone(), CompanyId::new("other")));
         let result = intruder.execute(json!({"id": "n-eng"})).await.unwrap();
         assert!(result.is_error, "a borrowed id must not read");
         let out = text(&result);
@@ -1367,10 +1403,7 @@ mod tests {
     #[tokio::test]
     async fn tenancy_a_borrowed_node_id_cannot_be_written_by_another_company() {
         let (_dir, store) = seeded("acme").await;
-        let intruder = WorkspaceWriteTool::new(CompanyWorkspace::new(
-            store.clone(),
-            CompanyId::new("other"),
-        ));
+        let intruder = WorkspaceWriteTool::new(ws(store.clone(), CompanyId::new("other")));
         let result = intruder
             .execute(json!({
                 "id": "n-eng",
@@ -1395,7 +1428,7 @@ mod tests {
     #[tokio::test]
     async fn traversal_paths_cannot_escape_the_company_tree() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceReadTool::new(ws(store, CompanyId::new("acme")));
         for path in [
             "../../../../etc/passwd",
             "Standards/../../../etc/passwd",
@@ -1414,7 +1447,7 @@ mod tests {
     #[tokio::test]
     async fn list_renders_paths_ids_and_revisions_and_prefix_narrows() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
 
         let all = text(&tool.execute(json!({})).await.unwrap());
         assert!(all.contains("folder\tStandards\tid=f-standards"), "{all}");
@@ -1432,7 +1465,7 @@ mod tests {
     #[tokio::test]
     async fn read_fences_the_body_and_hands_back_the_revision() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceReadTool::new(ws(store, CompanyId::new("acme")));
         let out = text(
             &tool
                 .execute(json!({"path": "Standards/Engineering standards.md"}))
@@ -1462,7 +1495,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store, id));
+        let tool = WorkspaceReadTool::new(ws(store, id));
         let out = text(&tool.execute(json!({"path": "evil.md"})).await.unwrap());
         // The body is returned byte-exact (so a round trip cannot corrupt it),
         // and the real terminator carries a nonce the note cannot contain.
@@ -1513,7 +1546,7 @@ mod tests {
     #[tokio::test]
     async fn reading_a_folder_points_at_the_listing_instead() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceReadTool::new(ws(store, CompanyId::new("acme")));
         let result = tool.execute(json!({"path": "Standards"})).await.unwrap();
         assert!(result.is_error);
         let out = text(&result);
@@ -1524,7 +1557,7 @@ mod tests {
     #[tokio::test]
     async fn a_missing_path_fails_soft_with_guidance() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceReadTool::new(ws(store, CompanyId::new("acme")));
         let result = tool
             .execute(json!({"path": "Nope/missing.md"}))
             .await
@@ -1537,7 +1570,7 @@ mod tests {
     async fn an_empty_workspace_reports_itself_rather_than_erroring() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
-        let tool = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
         let result = tool.execute(json!({})).await.unwrap();
         assert!(!result.is_error, "an empty workspace is not an error");
         assert!(text(&result).contains("workspace is empty"));
@@ -1549,12 +1582,17 @@ mod tests {
     async fn reads_are_live_not_cached() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceReadTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceReadTool::new(ws(store.clone(), id.clone()));
         let before = text(&tool.execute(json!({"id": "n-eng"})).await.unwrap());
         assert!(before.contains("Review every PR."));
 
         store
-            .write(&id, "n-eng", "# Engineering\nShip on Fridays.")
+            .write(
+                &id,
+                "n-eng",
+                "# Engineering\nShip on Fridays.",
+                WorkspaceOrigin::Operator,
+            )
             .await
             .unwrap();
 
@@ -1569,7 +1607,7 @@ mod tests {
     async fn a_write_with_the_current_revision_lands() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = tool
             .execute(json!({
                 "path": "Standards/Engineering standards.md",
@@ -1593,7 +1631,7 @@ mod tests {
         for revision in [json!(2_000), json!("2000"), json!(" 2000 ")] {
             let (_dir, store) = seeded("acme").await;
             let id = CompanyId::new("acme");
-            let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+            let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
             let result = tool
                 .execute(json!({
                     "id": "n-eng",
@@ -1619,7 +1657,7 @@ mod tests {
     async fn a_non_numeric_revision_string_is_still_refused() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = tool
             .execute(json!({
                 "id": "n-eng",
@@ -1639,7 +1677,7 @@ mod tests {
     async fn a_stale_revision_is_refused_and_names_the_current_one() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = tool
             .execute(json!({
                 "id": "n-eng",
@@ -1669,7 +1707,7 @@ mod tests {
     async fn a_write_without_a_revision_is_refused() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = tool
             .execute(json!({"id": "n-eng", "content": "blind"}))
             .await
@@ -1687,7 +1725,7 @@ mod tests {
     async fn a_write_cannot_create_a_note() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = tool
             .execute(json!({
                 "path": "Standards/brand new.md",
@@ -1707,7 +1745,7 @@ mod tests {
     #[tokio::test]
     async fn a_write_cannot_target_a_folder() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceWriteTool::new(ws(store, CompanyId::new("acme")));
         let result = tool
             .execute(json!({
                 "path": "Standards",
@@ -1733,7 +1771,7 @@ mod tests {
             .await
             .unwrap();
 
-        let read = WorkspaceReadTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let read = WorkspaceReadTool::new(ws(store.clone(), id.clone()));
         let out = text(&read.execute(json!({"path": "big.md"})).await.unwrap());
         assert!(out.contains("bytes truncated"), "{out}");
         assert!(out.contains("CANNOT be overwritten"), "{out}");
@@ -1745,7 +1783,7 @@ mod tests {
             .unwrap()
             .0
             .updated_at_millis;
-        let write = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let write = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = write
             .execute(json!({
                 "path": "big.md",
@@ -1786,6 +1824,7 @@ mod tests {
             _company: &CompanyId,
             _id: &str,
             _content: &str,
+            _author: WorkspaceOrigin,
         ) -> crate::Result<WorkspaceNode> {
             unreachable!("the listing never writes")
         }
@@ -1846,7 +1885,7 @@ mod tests {
         }
 
         let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
-        let list = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let list = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
         let out = text(&list.execute(json!({})).await.unwrap());
 
         // Every entry survives — the oversized one is clamped, not fatal.
@@ -1896,7 +1935,7 @@ mod tests {
         nodes.push(file("n-orphan-b", "orphan-b.md", Some("gone")));
 
         let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
-        let list = WorkspaceListTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let list = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
         let out = text(&list.execute(json!({})).await.unwrap());
 
         // The whole listing reaches the model, so nothing below is cut off.
@@ -1978,7 +2017,7 @@ mod tests {
             .await
             .unwrap();
 
-        let read = WorkspaceReadTool::new(CompanyWorkspace::new(store, id));
+        let read = WorkspaceReadTool::new(ws(store, id));
         let out = text(&read.execute(json!({"path": "big.md"})).await.unwrap());
 
         // The agent is told it may not write, and is never handed the sentence
@@ -2049,7 +2088,7 @@ mod tests {
             .await
             .unwrap();
 
-        let read = WorkspaceReadTool::new(CompanyWorkspace::new(store, id));
+        let read = WorkspaceReadTool::new(ws(store, id));
         let out = text(&read.execute(json!({"id": "n-max"})).await.unwrap());
 
         // Nothing was dropped, so this is the write-eligible branch — the one
@@ -2097,7 +2136,7 @@ mod tests {
             .0
             .updated_at_millis;
 
-        let write = WorkspaceWriteTool::new(CompanyWorkspace::new(store.clone(), id.clone()));
+        let write = WorkspaceWriteTool::new(ws(store.clone(), id.clone()));
         let result = write
             .execute(json!({
                 "path": "edge.md",
@@ -2140,7 +2179,7 @@ mod tests {
     #[tokio::test]
     async fn an_oversized_new_body_is_refused() {
         let (_dir, store) = seeded("acme").await;
-        let tool = WorkspaceWriteTool::new(CompanyWorkspace::new(store, CompanyId::new("acme")));
+        let tool = WorkspaceWriteTool::new(ws(store, CompanyId::new("acme")));
         let result = tool
             .execute(json!({
                 "id": "n-eng",

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -1,18 +1,20 @@
 //! Live read/write tools over the company [`WorkspaceStore`] (issue #237).
 //!
-//! The company workspace is the operator-owned note tree — `Playbooks/`,
-//! `Product/`, `Standards/` — seeded from `companies/<name>/workspace/**` and
-//! thereafter edited in the console. Before this module nothing under
-//! `src/harness/` touched it, so an operator could fill `Standards/` with the
-//! guidance every agent is supposed to follow and no agent would ever read a
-//! word of it.
+//! The company workspace is the shared note tree — `Playbooks/`, `Product/`,
+//! `Standards/` — seeded from `companies/<name>/workspace/**` and thereafter
+//! written by the operator in the console and by the agents through these
+//! tools. Before this module nothing under `src/harness/` touched it, so an
+//! operator could fill `Standards/` with the guidance every agent is supposed
+//! to follow and no agent would ever read a word of it.
 //!
-//! Three tools close that gap:
+//! Four tools close that gap:
 //!
 //! * [`WORKSPACE_LIST_TOOL`] — the bounded path index (path, kind, id,
 //!   revision), with an optional `prefix` for subtree listing.
 //! * [`WORKSPACE_READ_TOOL`] — one note by `path` or `id`, body capped and
 //!   fenced as untrusted reference material.
+//! * [`WORKSPACE_CREATE_TOOL`] — add one folder or note at a free path whose
+//!   parent already exists (issue #551).
 //! * [`WORKSPACE_WRITE_TOOL`] — overwrite one existing note, guarded by a
 //!   **required** `expected_updated_at` compare-and-swap token.
 //!
@@ -20,9 +22,27 @@
 //! session cache, so a note edited in the console between two turns changes
 //! what the agent quotes on the next turn with no agent rebuild.
 //!
+//! # Agents write unconfined — and why that is the right call (issue #551)
+//!
+//! There is no prefix gate here. An agent may create and overwrite anywhere in
+//! the company's tree, exactly as `workspace_write` always could. Confining
+//! *create* to `Agents/<id>/` while leaving *overwrite* free would protect
+//! nothing — overwriting an existing standard is the strictly more destructive
+//! of the two operations — so the confinement would be theatre with a
+//! maintenance cost.
+//!
+//! What replaces it is a steering-plus-attribution pair. [`workspace_brief`]
+//! and the tool descriptions name `Agents/<your agent id>/` as the default home
+//! for anything an agent produces and mark shared guidance as something to
+//! touch only on purpose; and every node records who created it and who last
+//! wrote it (issue #326), so a mess is legible and reversible rather than
+//! anonymous. Two irreversible operations, rename and delete, are still absent
+//! from this surface entirely — the operator has a console to undo them in and
+//! the agent does not.
+//!
 //! # The tenancy boundary
 //!
-//! This is a live read/write surface over operator-owned data, so the
+//! This is a live read/write surface over shared company data, so the
 //! containment argument has to be structural rather than asserted:
 //!
 //! 1. [`CompanyWorkspace::company`] is fixed at build time from `build_agent`'s
@@ -72,9 +92,12 @@
 //!   proposed it as optional. Under `[policy].mode = "full"` there is no
 //!   approval gate on writes at all, so the token is the *only* thing standing
 //!   between a hallucinated path and a clobbered standard. Requiring it makes
-//!   "read before you write" structural rather than advisory, and — because
-//!   only an existing note has a revision — also enforces the issue's
-//!   create/rename/delete-stay-operator-only rule for free.
+//!   "read before you write" structural rather than advisory. It used to carry
+//!   a second job — because only an existing note has a revision, requiring the
+//!   token also made creation impossible — and that side effect is what issue
+//!   #551 removed: agent output had nowhere to land in the shared tree, so it
+//!   stayed stranded in a private sandbox. [`WorkspaceCreateTool`] gives it a
+//!   home; the CAS token keeps doing the one job it was actually for.
 //! * **Diverges — a truncated read can never become a write.** OpenHuman
 //!   learned this as `file_state::check_partial_read` ("perform a full read
 //!   before overwriting"). Rather than track read stamps, [`WorkspaceWriteTool`]
@@ -128,6 +151,7 @@ use serde_json::{Value, json};
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
+use crate::company::workspace_agents::AGENTS_ROOT;
 use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
@@ -138,6 +162,8 @@ pub const WORKSPACE_LIST_TOOL: &str = "workspace_list";
 pub const WORKSPACE_READ_TOOL: &str = "workspace_read";
 /// Tool name: overwrite one workspace note.
 pub const WORKSPACE_WRITE_TOOL: &str = "workspace_write";
+/// Tool name: create one workspace folder or note.
+pub const WORKSPACE_CREATE_TOOL: &str = "workspace_create";
 
 /// Absolute cap on entries one [`WORKSPACE_LIST_TOOL`] call renders.
 ///
@@ -570,22 +596,43 @@ fn fence_nonce() -> String {
 /// and never embeds a tree snapshot. A snapshot baked into the system prompt at
 /// build time is stale the moment the operator edits a note, and the whole point
 /// of hitting the store per call is that there is no snapshot to go stale.
+///
+/// # Why the write half is steering, not a rule the code enforces
+///
+/// Issue #551 settled that agents write **unconfined** — anywhere in the tree,
+/// create as well as overwrite. There is no prefix gate, and adding one would
+/// be theatre while `{WORKSPACE_WRITE_TOOL}` can already overwrite any note (the
+/// strictly more destructive of the two operations). So what keeps the tree
+/// navigable is this paragraph: name the agent's own folder as the default
+/// home, name shared guidance as something to touch only on purpose, and leave
+/// the irreversible operations (rename, delete) with the operator, who is the
+/// only party with a console to undo them in. The safety net underneath is
+/// attribution — every node records who created it and who last wrote it
+/// (issue #326) — not refusal.
 pub fn workspace_brief(can_write: bool) -> String {
     let mut brief = format!(
         "\n\n## Company workspace\n\
          This company keeps a shared note tree — its single source of truth for standards, \
-         playbooks and product context, written and owned by the operator. It is NOT in your \
-         context: call `{WORKSPACE_LIST_TOOL}` to see what exists, then `{WORKSPACE_READ_TOOL}` \
-         to read a note by its path. Do this before answering anything about company standards, \
-         processes or product decisions — never guess at or invent their contents, and never \
-         assume a note you read earlier is still current."
+         playbooks and product context. Both the operator and your teammates read and write it, \
+         so it is how work becomes visible to the rest of the company. It is NOT in your context: \
+         call `{WORKSPACE_LIST_TOOL}` to see what exists, then `{WORKSPACE_READ_TOOL}` to read a \
+         note by its path. Do this before answering anything about company standards, processes \
+         or product decisions — never guess at or invent their contents, and never assume a note \
+         you read earlier is still current."
     );
     if can_write {
         brief.push_str(&format!(
-            " You may also revise an existing note with `{WORKSPACE_WRITE_TOOL}`, which requires \
-             the `expected_updated_at` revision from a `{WORKSPACE_READ_TOOL}` of that same note \
-             — so read it, apply your change to the full body you were given, and write the whole \
-             body back. Creating, renaming and deleting notes is the operator's job, not yours."
+            " `{AGENTS_ROOT}/<your agent id>/` is your own folder and the default home for anything you \
+             produce — put a deliverable, a draft or a working note there with \
+             `{WORKSPACE_CREATE_TOOL}` rather than leaving it only in your reply. You may create \
+             or edit notes anywhere in the tree, but shared guidance (`Standards/`, `Playbooks/`) \
+             belongs to everyone: edit it only when the task you were given is about it, and \
+             otherwise leave it alone. Revising an existing note is `{WORKSPACE_WRITE_TOOL}`, \
+             which requires the `expected_updated_at` revision from a `{WORKSPACE_READ_TOOL}` of \
+             that same note — so read it, apply your change to the full body you were given, and \
+             write the whole body back. Every note records who created it and who last wrote it, \
+             so your edits are attributed to you. Renaming and deleting stay the operator's job, \
+             not yours."
         ));
     }
     brief
@@ -925,11 +972,13 @@ impl Tool for WorkspaceWriteTool {
 
     fn description(&self) -> &str {
         "Overwrite one EXISTING note in the company's shared workspace with a complete new body. \
-         USE FOR revising operator-owned company documentation you have just read. You must pass \
-         `expected_updated_at` — the `rev` from a `workspace_read` of that same note — and the \
-         write is refused if the note changed since. This replaces the whole body, so include \
-         everything you want kept. NOT for creating, renaming or deleting notes (operator-only), \
-         and NOT for your own scratch files (use the `file_*` tools)."
+         USE FOR revising a note you have just read — your own work under `Agents/<your agent \
+         id>/`, or shared company documentation when the task you were given is about it. You \
+         must pass `expected_updated_at` — the `rev` from a `workspace_read` of that same note — \
+         and the write is refused if the note changed since. This replaces the whole body, so \
+         include everything you want kept. NOT for adding a new note (that is \
+         `workspace_create`), NOT for renaming or deleting (operator-only), and NOT for your own \
+         scratch files (use the `file_*` tools)."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1123,14 +1172,250 @@ impl Tool for WorkspaceWriteTool {
 }
 
 // ---------------------------------------------------------------------------
+// workspace_create
+// ---------------------------------------------------------------------------
+
+/// Creates one new folder or note in the shared tree. Wired only under an
+/// explicit `workspace` grant, alongside [`WorkspaceWriteTool`].
+pub struct WorkspaceCreateTool {
+    workspace: CompanyWorkspace,
+}
+
+impl WorkspaceCreateTool {
+    fn new(workspace: CompanyWorkspace) -> Self {
+        Self { workspace }
+    }
+}
+
+#[async_trait]
+impl Tool for WorkspaceCreateTool {
+    fn name(&self) -> &str {
+        WORKSPACE_CREATE_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Create ONE new folder or note in the company's shared workspace at `path`. USE FOR \
+         putting work you have produced somewhere the operator and your teammates can find it — \
+         your own folder `Agents/<your agent id>/` is the default home for it. The parent folder \
+         must already exist (create it first, one level at a time), and the path must be free — \
+         this never overwrites. To change a note that already exists use `workspace_write`. NOT \
+         for your own scratch files (use the `file_*` tools)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Where to create it, e.g. \"Agents/ceo/Q3 launch brief.md\". Every segment but the last must already be an existing folder. Include the file extension on a note."
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": ["folder", "file"],
+                    "description": "`folder` for a directory, `file` for a Markdown note."
+                },
+                "content": {
+                    "type": "string",
+                    "description": "The note's initial Markdown body. Only meaningful when `kind` is `file`; omit for a folder."
+                }
+            },
+            "required": ["path", "kind"],
+            "additionalProperties": false
+        })
+    }
+
+    /// Honest level for a tool that adds operator-visible content. As with
+    /// [`WorkspaceWriteTool`], this is not what gates the call — see the
+    /// `workspace_create` descriptor in
+    /// [`policy::consequence`](crate::policy::consequence).
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let Some(path) = args
+            .get("path")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|p| !p.is_empty())
+        else {
+            return Ok(ToolResult::error(
+                "Invalid arguments: `path` is required, e.g. \"Agents/ceo/Launch brief.md\"."
+                    .to_string(),
+            ));
+        };
+
+        let kind = match args.get("kind").and_then(Value::as_str).map(str::trim) {
+            Some("folder") => NodeKind::Folder,
+            Some("file") => NodeKind::File,
+            other => {
+                return Ok(ToolResult::error(format!(
+                    "Invalid arguments: `kind` must be \"folder\" or \"file\"{extra}.",
+                    extra = match other {
+                        Some(got) => format!(", not `{got}`", got = echo_path(got)),
+                        None => String::new(),
+                    }
+                )));
+            }
+        };
+
+        let content = args
+            .get("content")
+            .and_then(Value::as_str)
+            .filter(|c| !c.is_empty());
+        if kind == NodeKind::Folder && content.is_some() {
+            return Ok(ToolResult::error(
+                "Refused: a folder has no body. Create the folder first, then create the note \
+                 inside it with its `content`."
+                    .to_string(),
+            ));
+        }
+        if let Some(content) = content
+            && content.len() > MAX_WRITE_BYTES
+        {
+            return Ok(ToolResult::error(format!(
+                "Refused: the body is {} bytes, over the {MAX_WRITE_BYTES}-byte limit for a \
+                 workspace note. Create it smaller — a note larger than the read limit could not \
+                 be read back or revised afterwards.",
+                content.len()
+            )));
+        }
+
+        // Validate the path BEFORE anything resolves, the same order the other
+        // tools use — a traversal-shaped argument is refused on its shape, not
+        // on whether it happens to match something.
+        let segments = match split_logical_path(path) {
+            Ok(segments) => segments,
+            Err(why) => return Ok(ToolResult::error(format!("Invalid `path`: {why}."))),
+        };
+        let normalized = segments.join("/");
+        let (parent_segments, name) = segments.split_at(segments.len() - 1);
+        let name = name[0];
+
+        let index = match self.workspace.index().await {
+            Ok(index) => index,
+            Err(e) => {
+                return Ok(ToolResult::error(format!(
+                    "Could not read the company workspace: {e}"
+                )));
+            }
+        };
+
+        // Never overwrite, and never add a second node at an existing path. The
+        // second half matters as much as the first: a duplicate name makes the
+        // path ambiguous for **every** agent from then on, and the reserved
+        // `Agents` root is exactly the path an agent must not be able to
+        // shadow with a rival of its own.
+        if let Some(existing) = index.by_path.get(&normalized) {
+            let what = match existing.first().map(|e| e.node.kind) {
+                Some(NodeKind::Folder) => "a folder",
+                _ => "a note",
+            };
+            return Ok(ToolResult::error(format!(
+                "Refused: `{path}` already exists ({what}). Nothing was changed. To replace a \
+                 note's body, read it with `{WORKSPACE_READ_TOOL}` and overwrite it with \
+                 `{WORKSPACE_WRITE_TOOL}`; to add something new, pick a path that is free.",
+                path = echo_path(&normalized),
+            )));
+        }
+
+        // The parent must already exist. This creates exactly one node — the
+        // store's `create` contract is one node with a resolved parent, and
+        // silently making the intermediate folders would let a single typo grow
+        // a whole phantom subtree nobody asked for.
+        let parent_id = if parent_segments.is_empty() {
+            None
+        } else {
+            let parent_path = parent_segments.join("/");
+            match index.by_path.get(&parent_path).map(Vec::as_slice) {
+                Some([entry]) if entry.node.kind == NodeKind::Folder => Some(entry.node.id.clone()),
+                Some([entry]) => {
+                    return Ok(ToolResult::error(format!(
+                        "Refused: `{parent}` is a note, not a folder, so nothing can be created \
+                         inside it.",
+                        parent = echo_path(&entry.path),
+                    )));
+                }
+                Some(entries) => {
+                    return Ok(ToolResult::error(format!(
+                        "Refused: the parent path `{parent}` is ambiguous — {n} nodes share it. \
+                         Ask the operator to rename one of them in the console.",
+                        parent = echo_path(&parent_path),
+                        n = entries.len(),
+                    )));
+                }
+                None => {
+                    return Ok(ToolResult::error(format!(
+                        "Refused: the folder `{parent}` does not exist, so `{path}` has nowhere to \
+                         go. Create the folder first with `{WORKSPACE_CREATE_TOOL}` and \
+                         kind=\"folder\" (one level at a time), then retry this call.",
+                        parent = echo_path(&parent_path),
+                        path = echo_path(&normalized),
+                    )));
+                }
+            }
+        };
+
+        let origin = self.workspace.origin();
+        let node = WorkspaceNode {
+            id: crate::ports::generate_id(),
+            name: name.to_string(),
+            kind,
+            parent_id,
+            updated_at_millis: crate::ports::now_millis(),
+            created_by: origin.clone(),
+            updated_by: origin,
+        };
+        match self
+            .workspace
+            .store
+            .create(&self.workspace.company, &node, content)
+            .await
+        {
+            // The id and revision go back with the acknowledgement so an
+            // immediate follow-up `workspace_write` needs no extra round trip
+            // through list + read.
+            Ok(()) => Ok(ToolResult::success(match kind {
+                NodeKind::Folder => format!(
+                    "Created the workspace folder `{path}` (id={id}). Create notes inside it with \
+                     `{WORKSPACE_CREATE_TOOL}`.",
+                    path = echo_path(&normalized),
+                    id = node.id,
+                ),
+                NodeKind::File => format!(
+                    "Created the workspace note `{path}` (id={id}, rev={rev}, {bytes} bytes). To \
+                     revise it, call `{WORKSPACE_WRITE_TOOL}` with expected_updated_at={rev} and \
+                     the complete new body.",
+                    path = echo_path(&normalized),
+                    id = node.id,
+                    rev = node.updated_at_millis,
+                    bytes = content.map_or(0, str::len),
+                ),
+            })),
+            Err(e) => Ok(ToolResult::error(format!(
+                "Could not create `{path}`: {e}",
+                path = echo_path(&normalized),
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Wiring
 // ---------------------------------------------------------------------------
 
 /// Build the workspace tool set for one agent.
 ///
-/// `can_write` decides whether [`WORKSPACE_WRITE_TOOL`] is included; the caller
+/// `can_write` decides whether [`WORKSPACE_CREATE_TOOL`] and
+/// [`WORKSPACE_WRITE_TOOL`] are included; the caller
 /// ([`build_agent`](crate::harness::build::build_agent)) derives it from an
 /// **explicit** `workspace` grant, so a bare `*` yields the two read tools only.
+///
+/// Create and write ride the same flag on purpose. Overwriting an existing
+/// operator-owned standard is strictly more destructive than adding a new note
+/// beside it, so any grant that permits the first has already permitted the
+/// second.
 pub fn workspace_tools(
     store: Arc<dyn WorkspaceStore>,
     company: CompanyId,
@@ -1143,6 +1428,7 @@ pub fn workspace_tools(
         Box::new(WorkspaceReadTool::new(workspace.clone())),
     ];
     if can_write {
+        tools.push(Box::new(WorkspaceCreateTool::new(workspace.clone())));
         tools.push(Box::new(WorkspaceWriteTool::new(workspace)));
     }
     tools
@@ -2192,26 +2478,372 @@ mod tests {
         assert!(text(&result).contains("over the"));
     }
 
+    // -- workspace_create (issue #551) ---------------------------------------
+
+    /// The whole point of the feature, end to end: an agent creates a note that
+    /// was not there before, and it lands in the tree the operator reads.
+    #[tokio::test]
+    async fn create_lands_a_new_note_in_the_shared_tree() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        let out = tool
+            .execute(json!({
+                "path": "Standards/Deploys.md",
+                "kind": "file",
+                "content": "# Deploys\nGreen builds only.",
+            }))
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{}", text(&out));
+
+        let tree = store.tree(&id).await.unwrap();
+        let node = tree
+            .iter()
+            .find(|n| n.name == "Deploys.md")
+            .expect("the note is in the tree");
+        assert_eq!(node.kind, NodeKind::File);
+        let (_, body) = store.read(&id, &node.id).await.unwrap().unwrap();
+        assert_eq!(body, "# Deploys\nGreen builds only.");
+
+        // The acknowledgement hands back the id and the revision, so an
+        // immediate follow-up write needs no extra list + read round trip.
+        let out = text(&out);
+        assert!(out.contains(&format!("id={}", node.id)), "{out}");
+        assert!(
+            out.contains(&format!("expected_updated_at={}", node.updated_at_millis)),
+            "{out}"
+        );
+    }
+
+    /// Authorship: a created node is stamped with the creating agent on BOTH
+    /// origins, and the path it was created at has nothing to do with it.
+    ///
+    /// This test is deliberately sited under `Standards/` — shared,
+    /// operator-owned guidance, as far from the agent's own folder as the tree
+    /// goes. It is the executable form of the settled decision that agents
+    /// write **unconfined**: if someone later adds a prefix gate, this fails.
+    #[tokio::test]
+    async fn create_is_unconfined_and_stamps_the_creating_agent() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        let out = tool
+            .execute(json!({ "path": "Standards/Agent addendum.md", "kind": "file" }))
+            .await
+            .unwrap();
+        assert!(
+            !out.is_error,
+            "creating outside `Agents/` must be allowed: {}",
+            text(&out)
+        );
+
+        let node = store
+            .tree(&id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.name == "Agent addendum.md")
+            .unwrap();
+        assert_eq!(node.created_by, agent_origin());
+        assert_eq!(node.updated_by, agent_origin());
+    }
+
+    /// The steered-for case: the agent's own folder, created as a folder and
+    /// then filled.
+    #[tokio::test]
+    async fn create_makes_a_folder_then_a_note_inside_it() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        for args in [
+            json!({ "path": "Agents", "kind": "folder" }),
+            json!({ "path": "Agents/ceo", "kind": "folder" }),
+            json!({ "path": "Agents/ceo/Launch brief.md", "kind": "file", "content": "# Launch" }),
+        ] {
+            let out = tool.execute(args.clone()).await.unwrap();
+            assert!(!out.is_error, "{args}: {}", text(&out));
+        }
+
+        let tree = store.tree(&id).await.unwrap();
+        let brief = tree.iter().find(|n| n.name == "Launch brief.md").unwrap();
+        let ceo = tree.iter().find(|n| n.name == "ceo").unwrap();
+        assert_eq!(brief.parent_id.as_deref(), Some(ceo.id.as_str()));
+        assert_eq!(ceo.kind, NodeKind::Folder);
+    }
+
+    /// Create never overwrites. A path that already resolves is refused with
+    /// the note left byte-identical — the failure mode this tool must never
+    /// have, since it carries no compare-and-swap token to protect one.
+    #[tokio::test]
+    async fn create_refuses_a_path_that_already_exists_and_changes_nothing() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        let out = tool
+            .execute(json!({
+                "path": "Standards/Engineering standards.md",
+                "kind": "file",
+                "content": "# Mine now",
+            }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "{}", text(&out));
+        assert!(text(&out).contains(WORKSPACE_WRITE_TOOL), "{}", text(&out));
+
+        let (_, body) = store.read(&id, "n-eng").await.unwrap().unwrap();
+        assert_eq!(
+            body, "# Engineering\nReview every PR.",
+            "the existing note was clobbered"
+        );
+        assert_eq!(store.tree(&id).await.unwrap().len(), 3, "a node was added");
+    }
+
+    /// The reserved-root case of the rule above, called out because it is the
+    /// one that matters most: identity in `Agents/` is by path, so an agent
+    /// that could mint a rival root named `Agents` would make every
+    /// `Agents/...` path permanently ambiguous — for itself, for its teammates
+    /// and for the provisioner.
+    #[tokio::test]
+    async fn create_cannot_mint_a_rival_agents_root() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        crate::company::workspace_agents::ensure_agent_folders(store.as_ref(), &id, [TEST_AGENT])
+            .await
+            .unwrap();
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        let out = tool
+            .execute(json!({ "path": "Agents", "kind": "folder" }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "{}", text(&out));
+        assert_eq!(
+            store
+                .tree(&id)
+                .await
+                .unwrap()
+                .iter()
+                .filter(|n| n.name == "Agents" && n.parent_id.is_none())
+                .count(),
+            1,
+        );
+    }
+
+    /// One node per call: a missing parent is an actionable refusal, not a
+    /// silent `mkdir -p`. A single typo in a deep path would otherwise grow a
+    /// whole phantom subtree nobody asked for.
+    #[tokio::test]
+    async fn create_refuses_a_missing_parent_and_says_what_to_do() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), id.clone()));
+
+        let out = tool
+            .execute(json!({ "path": "Playbooks/Launch/Checklist.md", "kind": "file" }))
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        let message = text(&out);
+        assert!(message.contains("Playbooks/Launch"), "{message}");
+        assert!(message.contains(WORKSPACE_CREATE_TOOL), "{message}");
+        assert!(message.contains("folder"), "{message}");
+        assert_eq!(
+            store.tree(&id).await.unwrap().len(),
+            3,
+            "a refused create must not have made intermediate folders"
+        );
+    }
+
+    /// A note is not a folder, so nothing can be created inside one.
+    #[tokio::test]
+    async fn create_refuses_a_parent_that_is_a_note() {
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceCreateTool::new(ws(store, CompanyId::new("acme")));
+        let out = tool
+            .execute(json!({ "path": "README.md/child.md", "kind": "file" }))
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(text(&out).contains("not a folder"), "{}", text(&out));
+    }
+
+    /// The same traversal rules as every other tool, and applied on the
+    /// argument's *shape* before anything resolves.
+    #[tokio::test]
+    async fn create_refuses_traversal_shaped_paths() {
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), CompanyId::new("acme")));
+        for path in ["../escape.md", "Standards/../../etc/passwd", "./x.md", ".."] {
+            let out = tool
+                .execute(json!({ "path": path, "kind": "file" }))
+                .await
+                .unwrap();
+            assert!(out.is_error, "path {path:?} must be refused");
+        }
+        assert_eq!(
+            store.tree(&CompanyId::new("acme")).await.unwrap().len(),
+            3,
+            "a traversal-shaped path created something"
+        );
+    }
+
+    /// A body an agent could not read back in full must never be created —
+    /// the next `workspace_write` on it would be refused as oversized, leaving
+    /// a note nobody but the operator can ever touch again.
+    #[tokio::test]
+    async fn create_refuses_a_body_over_the_write_cap() {
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceCreateTool::new(ws(store.clone(), CompanyId::new("acme")));
+        let out = tool
+            .execute(json!({
+                "path": "Standards/Huge.md",
+                "kind": "file",
+                "content": "x".repeat(MAX_WRITE_BYTES + 1),
+            }))
+            .await
+            .unwrap();
+        assert!(out.is_error);
+        assert!(text(&out).contains("over the"), "{}", text(&out));
+        assert_eq!(store.tree(&CompanyId::new("acme")).await.unwrap().len(), 3);
+    }
+
+    /// Bad arguments answer with the fix, not with a stack of nulls.
+    #[tokio::test]
+    async fn create_rejects_a_missing_or_unknown_kind() {
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceCreateTool::new(ws(store, CompanyId::new("acme")));
+        for args in [
+            json!({ "path": "Standards/x.md" }),
+            json!({ "path": "Standards/x.md", "kind": "note" }),
+            json!({ "kind": "file" }),
+            json!({ "path": "Standards/x", "kind": "folder", "content": "body" }),
+        ] {
+            let out = tool.execute(args.clone()).await.unwrap();
+            assert!(out.is_error, "{args} must be refused");
+        }
+    }
+
+    /// The acceptance criterion issue #551 is actually about: one agent's
+    /// output is another agent's input. Agent A creates, agent B — a different
+    /// `CompanyWorkspace`, its own tool instances — lists and reads it.
+    #[tokio::test]
+    async fn one_agent_creates_and_another_reads_it_back() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+
+        let author = CompanyWorkspace::new(store.clone(), id.clone(), "cmo".to_string());
+        let out = WorkspaceCreateTool::new(author)
+            .execute(json!({
+                "path": "Standards/Brand voice.md",
+                "kind": "file",
+                "content": "# Brand voice\nWarm, plain, specific.",
+            }))
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{}", text(&out));
+
+        let reader = CompanyWorkspace::new(store, id, "engineer".to_string());
+        let listing = text(
+            &WorkspaceListTool::new(reader.clone())
+                .execute(json!({}))
+                .await
+                .unwrap(),
+        );
+        assert!(listing.contains("Standards/Brand voice.md"), "{listing}");
+
+        let read = text(
+            &WorkspaceReadTool::new(reader)
+                .execute(json!({ "path": "Standards/Brand voice.md" }))
+                .await
+                .unwrap(),
+        );
+        assert!(read.contains("Warm, plain, specific."), "{read}");
+    }
+
+    /// A write restamps `updated_by` with the writer and leaves `created_by`
+    /// alone, so "who made this" survives someone else editing it.
+    #[tokio::test]
+    async fn a_write_restamps_the_writer_and_preserves_the_creator() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+
+        let created = WorkspaceCreateTool::new(CompanyWorkspace::new(
+            store.clone(),
+            id.clone(),
+            "cmo".to_string(),
+        ))
+        .execute(json!({ "path": "Standards/Voice.md", "kind": "file", "content": "v1" }))
+        .await
+        .unwrap();
+        assert!(!created.is_error, "{}", text(&created));
+
+        let node = store
+            .tree(&id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.name == "Voice.md")
+            .unwrap();
+
+        let out = WorkspaceWriteTool::new(ws(store.clone(), id.clone()))
+            .execute(json!({
+                "path": "Standards/Voice.md",
+                "content": "v2",
+                "expected_updated_at": node.updated_at_millis,
+            }))
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{}", text(&out));
+
+        let after = store
+            .tree(&id)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.name == "Voice.md")
+            .unwrap();
+        assert_eq!(
+            after.created_by,
+            WorkspaceOrigin::Agent {
+                id: "cmo".to_string()
+            },
+            "the creator must survive another agent's edit"
+        );
+        assert_eq!(after.updated_by, agent_origin());
+    }
+
     // -- wiring -------------------------------------------------------------
 
     #[test]
-    fn the_write_tool_is_only_present_when_writes_are_granted() {
+    fn the_mutating_tools_are_only_present_when_writes_are_granted() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
 
-        let read_only = workspace_tools(store.clone(), CompanyId::new("acme"), false);
+        let read_only = workspace_tools(
+            store.clone(),
+            CompanyId::new("acme"),
+            TEST_AGENT.to_string(),
+            false,
+        );
         let names: Vec<&str> = read_only.iter().map(|t| t.name()).collect();
         assert_eq!(names, vec![WORKSPACE_LIST_TOOL, WORKSPACE_READ_TOOL]);
 
-        let writable = workspace_tools(store, CompanyId::new("acme"), true);
+        let writable = workspace_tools(store, CompanyId::new("acme"), TEST_AGENT.to_string(), true);
         let names: Vec<&str> = writable.iter().map(|t| t.name()).collect();
         assert_eq!(
             names,
             vec![
                 WORKSPACE_LIST_TOOL,
                 WORKSPACE_READ_TOOL,
+                WORKSPACE_CREATE_TOOL,
                 WORKSPACE_WRITE_TOOL
-            ]
+            ],
+            "create and write ride the same explicit grant"
         );
     }
 
@@ -2219,10 +2851,11 @@ mod tests {
     fn declared_permission_levels_match_what_each_tool_does() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
-        let tools = workspace_tools(store, CompanyId::new("acme"), true);
+        let tools = workspace_tools(store, CompanyId::new("acme"), TEST_AGENT.to_string(), true);
         assert_eq!(tools[0].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[1].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[2].permission_level(), PermissionLevel::Write);
+        assert_eq!(tools[3].permission_level(), PermissionLevel::Write);
     }
 
     #[test]
@@ -2230,8 +2863,37 @@ mod tests {
         let read_only = workspace_brief(false);
         assert!(read_only.contains(WORKSPACE_LIST_TOOL));
         assert!(!read_only.contains(WORKSPACE_WRITE_TOOL));
+        assert!(!read_only.contains(WORKSPACE_CREATE_TOOL));
         let writable = workspace_brief(true);
         assert!(writable.contains(WORKSPACE_WRITE_TOOL));
+        assert!(writable.contains(WORKSPACE_CREATE_TOOL));
         assert!(writable.contains("expected_updated_at"));
+    }
+
+    /// Issue #551 replaced a refusal with steering, so the steering is the
+    /// mechanism and has to be asserted like one.
+    ///
+    /// The brief must name the agent's own folder as the default home, mark
+    /// shared guidance as conditional rather than forbidden (the tree is
+    /// unconfined — saying "never" here would be a lie the tools do not back),
+    /// and keep rename/delete with the operator.
+    #[test]
+    fn the_brief_steers_toward_the_agents_own_folder() {
+        let brief = workspace_brief(true);
+        assert!(
+            brief.contains(&format!("{AGENTS_ROOT}/<your agent id>/")),
+            "the brief must name the agent's own folder: {brief}"
+        );
+        for phrase in [
+            "default home",
+            "anywhere in the tree",
+            "Standards/",
+            "Renaming and deleting",
+        ] {
+            assert!(
+                brief.contains(phrase),
+                "the brief dropped {phrase:?}: {brief}"
+            );
+        }
     }
 }

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -37,7 +37,7 @@ use crate::harness::policy::ApprovalRequestQueue;
 use crate::harness::provider::{HostedProvider, HostedProviderConfig};
 use crate::harness::{HarnessDeps, HarnessPool};
 use crate::ports::types::{CompanyId, CompanyRecord};
-use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 use crate::store::{FsCompanyStore, FsContextStore, FsOps};
 
 /// What the scripted model does on each successive call.
@@ -184,6 +184,8 @@ fn folder(id: &str, name: &str) -> WorkspaceNode {
         kind: NodeKind::Folder,
         parent_id: None,
         updated_at_millis: crate::ports::now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
     }
 }
 
@@ -194,6 +196,8 @@ fn note(id: &str, name: &str, parent: &str) -> WorkspaceNode {
         kind: NodeKind::File,
         parent_id: Some(parent.to_string()),
         updated_at_millis: crate::ports::now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
     }
 }
 
@@ -581,7 +585,12 @@ async fn an_edit_between_turns_changes_what_the_next_turn_reads() {
 
     // The operator edits the note in the console — the same store handle.
     store
-        .write(&record.id, "n-eng", "# Engineering\nDeploy on green only.")
+        .write(
+            &record.id,
+            "n-eng",
+            "# Engineering\nDeploy on green only.",
+            WorkspaceOrigin::Operator,
+        )
         .await
         .unwrap();
 

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -211,14 +211,23 @@ const DECLARED: &[Declared] = &[
     d("http_request", EffectGroup::Other, Reach::Consequence),
     d("curl", EffectGroup::Other, Reach::Consequence),
     d("web_fetch", EffectGroup::Other, Reach::Consequence),
-    // ---- The company workspace: operator-owned guidance --------------------
+    // ---- The company workspace: the shared note tree ------------------------
     // Reads are free (issue #237). `workspace_write` overwrites guidance the
     // operator wrote, which is why `is_external_effect` has always refused to
     // exempt it — and why it is now also refused a standing grant. That
     // contradiction (park every time / grant for a week) is issue #444's
     // headline, resolved in the direction the parking side already argued.
+    //
+    // `workspace_create` (issue #551) takes the identical classification, and
+    // gets it for the same reason rather than by copying: it adds a node to the
+    // tree every other agent and the operator read, unconfined by any prefix,
+    // so it reaches past this turn exactly as an overwrite does. Anything
+    // weaker would also be incoherent — a standing grant to *add* notes beside
+    // a per-call gate on *editing* them buys an agent the ability to fill the
+    // tree without ever asking.
     d("workspace_list", EffectGroup::Other, Reach::Nothing),
     d("workspace_read", EffectGroup::Other, Reach::Nothing),
+    d("workspace_create", EffectGroup::Other, Reach::Consequence),
     d("workspace_write", EffectGroup::Other, Reach::Consequence),
     // ---- Publishing --------------------------------------------------------
     // Externally visible and not reversible by the company alone.
@@ -588,6 +597,7 @@ mod tests {
             "http_request",
             "curl",
             "web_fetch",
+            "workspace_create",
             "workspace_write",
             "git_operations",
             "run_workflow",
@@ -866,7 +876,13 @@ mod tests {
     /// name of `file_write` already is the whole of what it can do.
     #[test]
     fn a_tool_whose_name_says_everything_has_no_scope() {
-        for tool in ["file_write", "memory_store", "shell", "workspace_write"] {
+        for tool in [
+            "file_write",
+            "memory_store",
+            "shell",
+            "workspace_write",
+            "workspace_create",
+        ] {
             assert_eq!(
                 standing_scope_of(tool, &json!({ "tool": "GITHUB_LIST_BRANCHES" })),
                 None,
@@ -910,6 +926,7 @@ mod tests {
             search::WEB_SEARCH_TOOL,
             workspace_tools::WORKSPACE_LIST_TOOL,
             workspace_tools::WORKSPACE_READ_TOOL,
+            workspace_tools::WORKSPACE_CREATE_TOOL,
             workspace_tools::WORKSPACE_WRITE_TOOL,
             crate::harness::composio_catalog::LIST_TOOLS_TOOL,
             crate::harness::composio_catalog::LIST_TOOLKITS_TOOL,

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -64,7 +64,7 @@ pub use workflow_runner::{
     DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowRun, WorkflowRunContext,
     WorkflowRunner,
 };
-pub use workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+pub use workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
 #[cfg(test)]
 mod test {

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -4,7 +4,19 @@
 //! operator organizes, edits, and links with `[[wiki links]]`. Node ids are
 //! stable ULIDs, **not** paths, so a rename or move never breaks a reference.
 //! The tree is seeded once from `companies/<name>/workspace/**` (WS1 walker)
-//! and thereafter owned by the operator — deletions stick.
+//! and thereafter written by both the operator and the company's agents.
+//!
+//! # Authorship (issue #326)
+//!
+//! Every node records two origins: [`WorkspaceNode::created_by`], fixed at
+//! creation, and [`WorkspaceNode::updated_by`], restamped by each content
+//! write. Both are a [`WorkspaceOrigin`]. Without them a note an agent wrote is
+//! indistinguishable from one the operator typed, which is untenable now that
+//! agents can create notes as well as overwrite them (issue #551).
+//!
+//! The split is deliberate: `rename_move` does **not** touch `updated_by`, so
+//! an operator tidying an agent's note into a different folder cannot make the
+//! body look operator-authored.
 
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -20,6 +32,53 @@ pub enum NodeKind {
     Folder,
     /// A file with Markdown content.
     File,
+}
+
+/// Who authored a workspace node.
+///
+/// Internally tagged, so one serde shape serves all three surfaces this value
+/// crosses: the opaque `node_json` blob every backend persists, the REST wire
+/// body the console reads, and the TypeScript type mirroring it. An agent
+/// origin is `{"kind":"agent","id":"ceo"}`; the other two are just
+/// `{"kind":"seed"}` / `{"kind":"operator"}`.
+///
+/// # Why this is not [`ActorKind`](crate::ports::types::ActorKind)
+///
+/// `ActorKind` is the crate's established "who did this" enum and is
+/// deliberately fieldless and `Copy`, with the id carried alongside it in
+/// [`Actor::id`](crate::ports::types::Actor). This type diverges from that
+/// convention on purpose, for two reasons:
+///
+/// * **`Seed` is not an actor.** A node walked out of
+///   `companies/<name>/workspace/**` at first boot was authored by nobody — not
+///   the operator, not an agent. Folding it into `ActorKind::System` would make
+///   "the runtime wrote this" and "this shipped with the company" the same
+///   badge in the console, erasing the distinction issue #326 exists to draw.
+/// * **The flat alternative is worse across seven surfaces.** Four independent
+///   fields (`created_by_kind` + `created_by_id` + `updated_by_kind` +
+///   `updated_by_id`) would make the store JSON, the REST body, the GraphQL
+///   type, the TypeScript type, the console, the seeder and the agent tools
+///   each re-derive the invariant "an id is present iff the kind is agent". One
+///   enum states it once and serde enforces it at every boundary.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "lowercase")]
+pub enum WorkspaceOrigin {
+    /// Walked out of the company bundle at first boot by the WS1 seeder.
+    Seed,
+    /// A human operator, through the console or the REST routes.
+    ///
+    /// The default, and therefore what every node written before authorship
+    /// existed deserializes to. That is a one-time, direction-honest
+    /// misattribution: a legacy seeded note reads as operator-authored, which
+    /// is the conservative answer (it never credits an agent for something it
+    /// did not write).
+    #[default]
+    Operator,
+    /// An agent inside this company, named by its roster id.
+    Agent {
+        /// The agent's roster id, e.g. `ceo`.
+        id: String,
+    },
 }
 
 /// One node in the workspace tree. `id` is a stable ULID; `parent_id` is `None`
@@ -38,6 +97,18 @@ pub struct WorkspaceNode {
     pub parent_id: Option<String>,
     /// Epoch-millis timestamp of the last update.
     pub updated_at_millis: u64,
+    /// Who created this node. Never restamped — the creator of a note is a
+    /// fact about its history, not about its current body.
+    #[serde(default)]
+    pub created_by: WorkspaceOrigin,
+    /// Who last wrote this node's **content**.
+    ///
+    /// Restamped by [`WorkspaceStore::write`] and by nothing else — in
+    /// particular not by [`WorkspaceStore::rename_move`], so an operator
+    /// reorganising the tree cannot mask agent authorship of the body that is
+    /// actually stored.
+    #[serde(default)]
+    pub updated_by: WorkspaceOrigin,
 }
 
 /// Durable per-company workspace tree. Company A's files MUST be invisible to
@@ -51,10 +122,23 @@ pub trait WorkspaceStore: Send + Sync {
     async fn read(&self, company: &CompanyId, id: &str) -> Result<Option<(WorkspaceNode, String)>>;
     /// Overwrites a file's content, returning the updated node. A folder id is
     /// an [`OpenCompanyError::InvalidRequest`](crate::error::OpenCompanyError).
-    async fn write(&self, company: &CompanyId, id: &str, content: &str) -> Result<WorkspaceNode>;
+    ///
+    /// `author` is stamped onto [`WorkspaceNode::updated_by`]; it is the
+    /// caller's identity, never anything derived from `content`.
+    async fn write(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        content: &str,
+        author: WorkspaceOrigin,
+    ) -> Result<WorkspaceNode>;
     /// Creates a node (folder or file). The node's `id` must be fresh; the
     /// `parent_id`, when set, must name an existing folder. `content` seeds a
     /// file body.
+    ///
+    /// No `author` argument: the node arrives fully formed, so the caller sets
+    /// [`WorkspaceNode::created_by`] and [`WorkspaceNode::updated_by`] on it
+    /// directly.
     async fn create(
         &self,
         company: &CompanyId,
@@ -63,6 +147,8 @@ pub trait WorkspaceStore: Send + Sync {
     ) -> Result<()>;
     /// Renames and/or reparents a node, returning the updated node. Moving a
     /// folder under its own descendant (a cycle) is rejected.
+    ///
+    /// Leaves both origin fields alone — see [`WorkspaceNode::updated_by`].
     ///
     /// `parent` distinguishes three intents: `None` leaves the parent
     /// unchanged, `Some(None)` moves the node to the workspace root, and
@@ -80,4 +166,83 @@ pub trait WorkspaceStore: Send + Sync {
     /// Whether the workspace has no nodes — the gate the seeder checks so a
     /// seeded-then-emptied workspace is never re-seeded.
     async fn is_empty(&self, company: &CompanyId) -> Result<bool>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every backend persists a node as opaque JSON, so a node written before
+    /// authorship existed has neither field. It must still load — and must load
+    /// as `Operator`, the conservative answer that never credits an agent for
+    /// something it did not write.
+    ///
+    /// This is the whole of the migration story: no `ALTER TABLE`, no
+    /// `add_column_if_missing`, no backfill.
+    #[test]
+    fn a_legacy_node_without_origins_loads_as_operator() {
+        let legacy = r#"{
+            "id": "n-1",
+            "name": "voice.md",
+            "kind": "file",
+            "parentId": null,
+            "updatedAtMillis": 1700000000000
+        }"#;
+        let node: WorkspaceNode = serde_json::from_str(legacy).expect("legacy node must load");
+        assert_eq!(node.created_by, WorkspaceOrigin::Operator);
+        assert_eq!(node.updated_by, WorkspaceOrigin::Operator);
+    }
+
+    /// The internally-tagged wire shape, pinned.
+    ///
+    /// The same bytes are read by three independent consumers — the stores'
+    /// `node_json`, the REST body the console parses, and the GraphQL
+    /// projection — so a stray `rename_all` or a switch to an adjacently-tagged
+    /// representation would break the console at runtime with nothing in Rust
+    /// CI noticing. This test is what turns that into a compile-suite failure.
+    #[test]
+    fn the_agent_origin_wire_shape_is_tagged_kind_plus_id() {
+        let agent = WorkspaceOrigin::Agent {
+            id: "ceo".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_value(&agent).unwrap(),
+            serde_json::json!({ "kind": "agent", "id": "ceo" })
+        );
+        assert_eq!(
+            serde_json::to_value(WorkspaceOrigin::Seed).unwrap(),
+            serde_json::json!({ "kind": "seed" })
+        );
+        assert_eq!(
+            serde_json::to_value(WorkspaceOrigin::Operator).unwrap(),
+            serde_json::json!({ "kind": "operator" })
+        );
+
+        // …and back, so the shape is a round trip rather than a one-way render.
+        let parsed: WorkspaceOrigin =
+            serde_json::from_value(serde_json::json!({ "kind": "agent", "id": "ceo" })).unwrap();
+        assert_eq!(parsed, agent);
+    }
+
+    /// A node carrying both origins round-trips through the exact `node_json`
+    /// path the backends use.
+    #[test]
+    fn a_node_round_trips_both_origins() {
+        let node = WorkspaceNode {
+            id: "n-1".to_string(),
+            name: "brief.md".to_string(),
+            kind: NodeKind::File,
+            parent_id: Some("f-1".to_string()),
+            updated_at_millis: 42,
+            created_by: WorkspaceOrigin::Agent {
+                id: "cmo".to_string(),
+            },
+            updated_by: WorkspaceOrigin::Operator,
+        };
+        let json = serde_json::to_string(&node).unwrap();
+        assert_eq!(serde_json::from_str::<WorkspaceNode>(&json).unwrap(), node);
+        // camelCase on the node, matching every other field on it.
+        assert!(json.contains("\"createdBy\""), "{json}");
+        assert!(json.contains("\"updatedBy\""), "{json}");
+    }
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -831,6 +831,30 @@ impl RuntimeBuilder {
             seed_workspace(ops.workspace.as_ref(), &id, seed_dir).await?;
         }
 
+        // Issue #551: give every manifest agent its `Agents/<id>/` folder in the
+        // shared tree, so anything it produces has a named home both the
+        // operator and the other agents can navigate to.
+        //
+        // Gated on `handover.is_none()` and nothing else, deliberately:
+        //
+        //  * NOT on `seed_dir` — a provisioned tenant and the desktop build have
+        //    no company bundle to seed from, and their agents need folders just
+        //    as much.
+        //  * NOT on `is_empty` — that gate exists so an operator's deletions
+        //    stick against re-seeding, which is a different question. A roster
+        //    grows between boots, and a workspace that already has notes in it
+        //    still needs a folder for the teammate added last week.
+        //
+        // It is idempotent, so running it on every boot costs one tree read.
+        if handover.is_none() {
+            crate::company::workspace_agents::ensure_agent_folders(
+                ops.workspace.as_ref(),
+                &id,
+                self.manifest.agents.iter().map(|agent| agent.id.as_str()),
+            )
+            .await?;
+        }
+
         let consent = self.consent;
         // Inherited on a rebuild so the in-memory filing rate limiter survives.
         // A fresh limiter would make a rebuild loop a rate-limit bypass.
@@ -2766,6 +2790,78 @@ mod test {
         assert!(!tree.iter().any(|n| n.name == "voice.md"));
         // Sanity: the record store still loads.
         assert!(runtime.store().load(&id).await.unwrap().is_some());
+    }
+
+    /// Issue #551: boot gives every manifest agent a home in the shared tree.
+    ///
+    /// Also pins the two gates the seeding block above does NOT share: this
+    /// runs with **no** `seed_dir` (the provisioned-tenant and desktop shape),
+    /// and it runs again on a workspace that is no longer empty, picking up the
+    /// teammate the manifest gained in between.
+    #[tokio::test]
+    async fn boot_provisions_an_agents_folder_per_manifest_agent() {
+        use crate::company::workspace_agents::AGENTS_ROOT;
+        use crate::ports::workspace::{NodeKind, WorkspaceOrigin};
+
+        let home_dir = tmp_home("oc-agents-");
+        let home = home_dir.path().to_path_buf();
+        let id = CompanyId::new("acme");
+        let roster = |agents: &str| {
+            parse(&format!(
+                "[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n{agents}"
+            ))
+        };
+
+        let runtime = RuntimeBuilder::new(
+            home.clone(),
+            roster("[[agent]]\nid=\"ceo\"\nrole=\"Chief Executive\"\n"),
+        )
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+        let tree = runtime.workspace().tree(&id).await.unwrap();
+        let root = tree
+            .iter()
+            .find(|n| n.name == AGENTS_ROOT && n.parent_id.is_none())
+            .expect("the Agents root is provisioned with no seed dir");
+        assert_eq!(root.kind, NodeKind::Folder);
+        assert_eq!(root.created_by, WorkspaceOrigin::Seed);
+        let ceo = tree.iter().find(|n| n.name == "ceo").expect("Agents/ceo");
+        assert_eq!(ceo.parent_id.as_deref(), Some(root.id.as_str()));
+        assert_eq!(
+            ceo.created_by,
+            WorkspaceOrigin::Agent {
+                id: "ceo".to_string()
+            }
+        );
+
+        // A manifest that gains a teammate: the workspace is no longer empty,
+        // so an `is_empty` gate would have skipped this rebuild entirely.
+        drop(runtime);
+        let runtime = RuntimeBuilder::new(
+            home,
+            roster(
+                "[[agent]]\nid=\"ceo\"\nrole=\"Chief Executive\"\n\
+                 [[agent]]\nid=\"cmo\"\nrole=\"Chief Marketing\"\n",
+            ),
+        )
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+        let tree = runtime.workspace().tree(&id).await.unwrap();
+        assert!(
+            tree.iter().any(|n| n.name == "cmo"),
+            "a teammate added between boots got no folder"
+        );
+        assert_eq!(
+            tree.iter()
+                .filter(|n| n.name == AGENTS_ROOT && n.parent_id.is_none())
+                .count(),
+            1,
+            "the second boot minted a rival Agents root"
+        );
     }
 
     /// Issue #85: the launch path's template provenance is stamped onto the

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1918,7 +1918,7 @@ async fn seed_workspace(
 
     use crate::company::workspace_seed::{NodeKind as SeedKind, walk_workspace};
     use crate::ports::now_millis;
-    use crate::ports::workspace::{NodeKind, WorkspaceNode};
+    use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
 
     let nodes = walk_workspace(&seed_dir.join("workspace"))?;
     let mut path_to_id: HashMap<PathBuf, String> = HashMap::new();
@@ -1942,6 +1942,10 @@ async fn seed_workspace(
             kind,
             parent_id,
             updated_at_millis: now_millis(),
+            // Shipped with the company bundle: authored by neither the operator
+            // nor an agent, and the console says exactly that (issue #326).
+            created_by: WorkspaceOrigin::Seed,
+            updated_by: WorkspaceOrigin::Seed,
         };
         workspace.create(id, &node, seed.content.as_deref()).await?;
         path_to_id.insert(seed.rel_path.clone(), node.id);

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -352,6 +352,14 @@ type FsNode {
 	When it was last updated, ISO-8601 UTC.
 	"""
 	updatedAt: String!
+	"""
+	Who created the node.
+	"""
+	createdBy: WorkspaceOrigin!
+	"""
+	Who last wrote the node's content (a rename or move does not change it).
+	"""
+	updatedBy: WorkspaceOrigin!
 }
 
 type Inbox {
@@ -1064,9 +1072,36 @@ type WorkspaceFile {
 	"""
 	updatedAt: String!
 	"""
+	Who created this file.
+	"""
+	createdBy: WorkspaceOrigin!
+	"""
+	Who last wrote the content above.
+	"""
+	updatedBy: WorkspaceOrigin!
+	"""
 	Other files whose content links to this one via `[[name]]`.
 	"""
 	backlinks: [FsNode!]!
+}
+
+"""
+Who authored a workspace node. Mirrors [`WorkspaceOrigin`] (issue #326).
+
+Flattened into `kind` + optional `agentId` rather than exposed as a GraphQL
+union: `agentId` is non-null exactly when `kind` is `agent`, and a union of
+two empty types plus one single-field type buys a client nothing but three
+inline fragments. The Rust type keeps the invariant; this is its projection.
+"""
+type WorkspaceOrigin {
+	"""
+	`seed`, `operator` or `agent`.
+	"""
+	kind: String!
+	"""
+	The agent's roster id — set only when `kind` is `agent`.
+	"""
+	agentId: String
 }
 
 """

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -801,6 +801,14 @@ async fn memory_page_reflects_upserts() {
     );
 }
 
+/// An unpopulated surface resolves to `[]`, never to `null` or an error.
+///
+/// `workspaceTree` is the exception and states why: since issue #551 a company
+/// is never born with an empty tree — boot provisions the reserved `Agents/`
+/// root plus a folder per manifest agent — so what it proves here is that the
+/// resolver answers with exactly that and invents nothing else. It also pins
+/// the authorship projection (#326), which is the only place in the GraphQL
+/// surface where `WorkspaceOrigin` is rendered.
 #[tokio::test]
 async fn empty_surfaces_resolve_to_empty_lists() {
     let home_dir = home();
@@ -808,11 +816,29 @@ async fn empty_surfaces_resolve_to_empty_lists() {
     let app = router(state_with_rich_company(&home).await);
     let value = query(
         app,
-        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { id } inboxes { key } skills { id } workflows { id } } }"}"#,
+        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { name createdBy { kind agentId } } inboxes { key } skills { id } workflows { id } } }"}"#,
     )
     .await;
     let company = &value["data"]["company"];
-    assert_eq!(company["workspaceTree"].as_array().unwrap().len(), 0);
+    let tree = company["workspaceTree"].as_array().unwrap();
+    let mut names: Vec<&str> = tree
+        .iter()
+        .map(|node| node["name"].as_str().unwrap())
+        .collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["Agents", "maya"]);
+    let root = tree
+        .iter()
+        .find(|node| node["name"] == serde_json::json!("Agents"))
+        .unwrap();
+    assert_eq!(root["createdBy"]["kind"], "seed");
+    assert!(root["createdBy"]["agentId"].is_null());
+    let folder = tree
+        .iter()
+        .find(|node| node["name"] == serde_json::json!("maya"))
+        .unwrap();
+    assert_eq!(folder["createdBy"]["kind"], "agent");
+    assert_eq!(folder["createdBy"]["agentId"], "maya");
     assert_eq!(company["inboxes"].as_array().unwrap().len(), 0);
     assert_eq!(company["skills"].as_array().unwrap().len(), 0);
     assert_eq!(company["workflows"].as_array().unwrap().len(), 0);

--- a/src/server/graphql/workspace.rs
+++ b/src/server/graphql/workspace.rs
@@ -8,7 +8,41 @@ use async_graphql::{ID, SimpleObject};
 use super::iso8601;
 use crate::company::runtime::CompanyRuntime;
 use crate::company::workspace_links::file_with_backlinks;
-use crate::ports::workspace::{NodeKind, WorkspaceNode};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
+
+/// Who authored a workspace node. Mirrors [`WorkspaceOrigin`] (issue #326).
+///
+/// Flattened into `kind` + optional `agentId` rather than exposed as a GraphQL
+/// union: `agentId` is non-null exactly when `kind` is `agent`, and a union of
+/// two empty types plus one single-field type buys a client nothing but three
+/// inline fragments. The Rust type keeps the invariant; this is its projection.
+#[derive(SimpleObject, Clone)]
+#[graphql(name = "WorkspaceOrigin")]
+pub struct WorkspaceOriginGql {
+    /// `seed`, `operator` or `agent`.
+    pub kind: String,
+    /// The agent's roster id — set only when `kind` is `agent`.
+    pub agent_id: Option<String>,
+}
+
+impl From<WorkspaceOrigin> for WorkspaceOriginGql {
+    fn from(origin: WorkspaceOrigin) -> Self {
+        match origin {
+            WorkspaceOrigin::Seed => Self {
+                kind: "seed".to_string(),
+                agent_id: None,
+            },
+            WorkspaceOrigin::Operator => Self {
+                kind: "operator".to_string(),
+                agent_id: None,
+            },
+            WorkspaceOrigin::Agent { id } => Self {
+                kind: "agent".to_string(),
+                agent_id: Some(id),
+            },
+        }
+    }
+}
 
 /// One node (folder or file) in the workspace tree. Mirrors [`WorkspaceNode`].
 #[derive(SimpleObject, Clone)]
@@ -24,6 +58,10 @@ pub struct FsNodeGql {
     pub parent_id: Option<ID>,
     /// When it was last updated, ISO-8601 UTC.
     pub updated_at: String,
+    /// Who created the node.
+    pub created_by: WorkspaceOriginGql,
+    /// Who last wrote the node's content (a rename or move does not change it).
+    pub updated_by: WorkspaceOriginGql,
 }
 
 impl From<WorkspaceNode> for FsNodeGql {
@@ -38,6 +76,8 @@ impl From<WorkspaceNode> for FsNodeGql {
             kind: kind.to_string(),
             parent_id: node.parent_id.map(ID),
             updated_at: iso8601(node.updated_at_millis),
+            created_by: node.created_by.into(),
+            updated_by: node.updated_by.into(),
         }
     }
 }
@@ -54,6 +94,10 @@ pub struct WorkspaceFileGql {
     pub content: String,
     /// When it was last updated, ISO-8601 UTC.
     pub updated_at: String,
+    /// Who created this file.
+    pub created_by: WorkspaceOriginGql,
+    /// Who last wrote the content above.
+    pub updated_by: WorkspaceOriginGql,
     /// Other files whose content links to this one via `[[name]]`.
     pub backlinks: Vec<FsNodeGql>,
 }
@@ -87,6 +131,8 @@ pub(crate) async fn resolve_file(
         name: node.name,
         content,
         updated_at: iso8601(node.updated_at_millis),
+        created_by: node.created_by.into(),
+        updated_by: node.updated_by.into(),
         backlinks: backlinks.into_iter().map(FsNodeGql::from).collect(),
     }))
 }

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -29,9 +29,6 @@
 //!
 //! ## Known limits (issue #177 — documented, not worked around)
 //!
-//! * **No authorship.** [`WorkspaceNode`] carries no author/origin field, so a
-//!   note an agent wrote is indistinguishable from one the operator typed.
-//!   Tracked by issue #326.
 //! * **No live push.** A write that lands while the tab is open is only visible
 //!   on a refetch (refresh button / window focus). Tracked by issue #327.
 //! * **No CAS on the console write path.** Agent writes require an
@@ -79,6 +76,15 @@ struct FsNode {
     #[serde(skip_serializing_if = "Option::is_none")]
     content: Option<String>,
     updated_at: u64,
+    /// Who created the node, and who last wrote its body (issue #326).
+    ///
+    /// Always serialized, unlike `parentId` / `content` above: the console
+    /// renders an authorship badge off these, and an absent field there would
+    /// be indistinguishable from "unknown" when the honest answer is
+    /// `operator`. The port already defaults a legacy node to `operator`, so
+    /// this is never null.
+    created_by: WorkspaceOrigin,
+    updated_by: WorkspaceOrigin,
 }
 
 impl FsNode {
@@ -90,6 +96,8 @@ impl FsNode {
             parent_id: node.parent_id,
             content,
             updated_at: node.updated_at_millis,
+            created_by: node.created_by,
+            updated_by: node.updated_by,
         }
     }
 }
@@ -106,6 +114,9 @@ struct WorkspaceFileBody {
     name: String,
     content: String,
     updated_at: u64,
+    /// Who created this note, and who last wrote the body above (issue #326).
+    created_by: WorkspaceOrigin,
+    updated_by: WorkspaceOrigin,
     /// Other files whose content links to this one via `[[name]]`.
     backlinks: Vec<FsNode>,
 }
@@ -207,6 +218,8 @@ async fn read_file(
         name: node.name,
         content,
         updated_at: node.updated_at_millis,
+        created_by: node.created_by,
+        updated_by: node.updated_by,
         backlinks: backlinks
             .into_iter()
             .map(|node| FsNode::from_node(node, None))

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -50,7 +50,7 @@ use crate::AppState;
 use crate::company::workspace_links::file_with_backlinks;
 use crate::error::OpenCompanyError;
 use crate::ports::generate_id;
-use crate::ports::workspace::{NodeKind, WorkspaceNode};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
@@ -224,6 +224,9 @@ async fn create_node(
         kind: body.kind,
         parent_id: body.parent_id,
         updated_at_millis: crate::ports::now_millis(),
+        // These routes are the console's, and the console is the operator.
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
     };
     company
         .runtime
@@ -245,7 +248,12 @@ async fn write_file(
     let node = company
         .runtime
         .workspace()
-        .write(company.id(), &node_id, &body.content)
+        .write(
+            company.id(),
+            &node_id,
+            &body.content,
+            WorkspaceOrigin::Operator,
+        )
         .await?;
     Ok(Json(WriteAck {
         updated_at: node.updated_at_millis,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -32,6 +32,22 @@ fn manifest() -> CompanyManifest {
     .unwrap()
 }
 
+/// The sorted node names in a workspace tree body.
+///
+/// A freshly-built company is no longer an empty tree: boot provisions the
+/// reserved `Agents/` root and one folder per manifest agent (issue #551), so
+/// the tests below name what they expect rather than counting to zero.
+fn provisioned_names(tree: &serde_json::Value) -> Vec<String> {
+    let mut names: Vec<String> = tree
+        .as_array()
+        .expect("the tree read is an array")
+        .iter()
+        .map(|node| node["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
 async fn state_with_company(home: &std::path::Path) -> AppState {
     use crate::ports::CompanyStore;
     let store = FsCompanyStore::new(home.to_path_buf());
@@ -1205,11 +1221,18 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
     let home = home_dir.path().to_path_buf();
     let state = state_with_company(&home).await;
 
-    // A workspace with nothing seeded into it reads as an empty tree, not a 404
-    // and not a fixture.
+    // A workspace with nothing seeded into it reads as a real tree, not a 404
+    // and not a fixture. It is not *empty*, though: boot provisions the
+    // reserved `Agents/` root plus one folder per manifest agent (issue #551),
+    // and the manifest here has one agent — so `Agents` and `Agents/ceo`.
     let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(tree.as_array().unwrap().len(), 0);
+    assert_eq!(
+        provisioned_names(&tree),
+        vec!["Agents", "ceo"],
+        "a fresh company starts with just its agent folders"
+    );
+    let provisioned = tree.as_array().unwrap().len();
 
     let (_, folder) = send(
         &state,
@@ -1253,7 +1276,7 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
     let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
     assert_eq!(status, StatusCode::OK);
     let tree = tree.as_array().unwrap();
-    assert_eq!(tree.len(), 3);
+    assert_eq!(tree.len(), provisioned + 3);
     for node in tree {
         assert!(
             node.get("content").is_none(),
@@ -1268,6 +1291,25 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
     assert_eq!(listed["name"], "voice.md");
     assert_eq!(listed["kind"], "file");
     assert_eq!(listed["parentId"], json!(folder_id));
+    // Authorship rides every node of the tree read (issue #326). These routes
+    // are the console's, so the console is the operator.
+    assert_eq!(listed["createdBy"], json!({"kind": "operator"}));
+    assert_eq!(listed["updatedBy"], json!({"kind": "operator"}));
+    // …and the provisioner's own nodes say what they are, so the console can
+    // tell "the runtime laid this down" from "somebody wrote this".
+    let agents_root = tree
+        .iter()
+        .find(|node| node["name"] == json!("Agents"))
+        .expect("the Agents root is in the tree");
+    assert_eq!(agents_root["createdBy"], json!({"kind": "seed"}));
+    let ceo_folder = tree
+        .iter()
+        .find(|node| node["name"] == json!("ceo"))
+        .expect("Agents/ceo is in the tree");
+    assert_eq!(
+        ceo_folder["createdBy"],
+        json!({"kind": "agent", "id": "ceo"})
+    );
 
     // The file read carries the body and the inbound backlink, computed server
     // side — the console derives neither.
@@ -1287,6 +1329,8 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
             .contains("Warm and concise")
     );
     assert!(file["updatedAt"].is_number());
+    assert_eq!(file["createdBy"], json!({"kind": "operator"}));
+    assert_eq!(file["updatedBy"], json!({"kind": "operator"}));
     let backlinks = file["backlinks"].as_array().unwrap();
     assert_eq!(backlinks.len(), 1);
     assert_eq!(backlinks[0]["id"], json!(brief_id));
@@ -1387,7 +1431,8 @@ async fn workspace_reads_are_isolated_between_companies() {
     assert_eq!(status, StatusCode::OK);
     let note_id = note["id"].as_str().unwrap().to_string();
 
-    // B's own workspace is empty — A's note is not in it.
+    // B's own workspace holds only its own provisioned agent folders — A's
+    // note is not in it.
     let (status, tree_b) = send_auth(
         &state,
         "GET",
@@ -1397,7 +1442,7 @@ async fn workspace_reads_are_isolated_between_companies() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(tree_b.as_array().unwrap().len(), 0);
+    assert_eq!(provisioned_names(&tree_b), vec!["Agents", "ceo"]);
 
     // Even naming A's node id explicitly, B's scope does not resolve it.
     let (status, _) = send_auth(

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -34,7 +34,7 @@ use crate::ports::types::{
 };
 use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
 use crate::ports::users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore};
-use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
 /// A minimal valid manifest used to seed [`CompanyRecord`]s in the suite.
 fn sample_manifest() -> crate::company::CompanyManifest {
@@ -1843,16 +1843,26 @@ pub async fn assert_skill_state_store(skills: Arc<dyn SkillStateStore>) {
 }
 
 /// Asserts the [`WorkspaceStore`] contract: isolation, create/read/write,
-/// rename+move (with cycle rejection), recursive delete, and the seeding gate.
+/// rename+move (with cycle rejection), recursive delete, the seeding gate, and
+/// the authorship stamps (issue #326).
 pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
     let alpha = CompanyId::new("alpha");
     let beta = CompanyId::new("beta");
+    let agent = || WorkspaceOrigin::Agent {
+        id: "ceo".to_string(),
+    };
     let node = |id: &str, name: &str, kind: NodeKind, parent: Option<&str>| WorkspaceNode {
         id: id.to_string(),
         name: name.to_string(),
         kind,
         parent_id: parent.map(str::to_string),
         updated_at_millis: now_millis(),
+        created_by: WorkspaceOrigin::Agent {
+            id: "ceo".to_string(),
+        },
+        updated_by: WorkspaceOrigin::Agent {
+            id: "ceo".to_string(),
+        },
     };
 
     assert!(ws.is_empty(&alpha).await.unwrap());
@@ -1882,11 +1892,33 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
     assert_eq!(content, "# Voice");
     assert_eq!(ws.read(&alpha, "root").await.unwrap().unwrap().1, "");
 
-    // Overwrite content.
-    ws.write(&alpha, "note", "# Voice v2").await.unwrap();
+    // Authorship round-trips through the backend's own storage (issue #326).
+    // Every backend persists the node as opaque JSON, so this is the assertion
+    // that a backend did not quietly drop a field it does not know about.
+    assert_eq!(read_node.created_by, agent(), "created_by must round-trip");
+    assert_eq!(read_node.updated_by, agent(), "updated_by must round-trip");
+
+    // Overwrite content: `updated_by` follows the writer, `created_by` does not.
+    let written = ws
+        .write(&alpha, "note", "# Voice v2", WorkspaceOrigin::Operator)
+        .await
+        .unwrap();
     assert_eq!(
-        ws.read(&alpha, "note").await.unwrap().unwrap().1,
-        "# Voice v2"
+        written.updated_by,
+        WorkspaceOrigin::Operator,
+        "a write must restamp updated_by with its author"
+    );
+    assert_eq!(
+        written.created_by,
+        agent(),
+        "a write must never rewrite created_by"
+    );
+    let (reread, body) = ws.read(&alpha, "note").await.unwrap().unwrap();
+    assert_eq!(body, "# Voice v2");
+    assert_eq!(
+        (reread.created_by, reread.updated_by),
+        (agent(), WorkspaceOrigin::Operator),
+        "the write's stamps must be what the store persisted, not just what it returned"
     );
 
     // A second folder to move under.
@@ -1919,6 +1951,15 @@ pub async fn assert_workspace_store(ws: Arc<dyn WorkspaceStore>) {
         .unwrap();
     assert_eq!(moved.name, "voice-final.md");
     assert_eq!(moved.parent_id.as_deref(), Some("root2"));
+    // A rename/move leaves BOTH origins alone. This is the load-bearing half of
+    // the #326 split: if a move restamped `updated_by`, an operator tidying an
+    // agent's note into another folder would silently take credit for a body it
+    // never touched.
+    assert_eq!(
+        (moved.created_by.clone(), moved.updated_by.clone()),
+        (agent(), WorkspaceOrigin::Operator),
+        "rename_move must not restamp authorship"
+    );
     assert_eq!(
         ws.read(&alpha, "note").await.unwrap().unwrap().1,
         "# Voice v2",

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -36,7 +36,7 @@ use crate::ports::tasks::{TaskRecord, TaskStore};
 use crate::ports::types::CompanyId;
 use crate::ports::usage::{UsageMeter, UsageSample, retention_cutoff};
 use crate::ports::users::{InviteRecord, UserRecord, UserStore};
-use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 use crate::store::fs::{append_line, io_err, path_lock, read_jsonl, read_optional, write_atomic};
 use crate::store::paths::Bundle;
 
@@ -717,7 +717,13 @@ impl WorkspaceStore for FsOps {
         Ok(Some((node, content)))
     }
 
-    async fn write(&self, company: &CompanyId, id: &str, content: &str) -> Result<WorkspaceNode> {
+    async fn write(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        content: &str,
+        author: WorkspaceOrigin,
+    ) -> Result<WorkspaceNode> {
         let path = self.bundle(company).workspace_index_json();
         let lock = path_lock(&path);
         let _guard = lock.lock().await;
@@ -731,6 +737,9 @@ impl WorkspaceStore for FsOps {
             ));
         }
         node.updated_at_millis = now_millis();
+        // Authorship rides the same stamp as the timestamp: "when the body last
+        // changed" and "who changed it" are one fact and must never drift apart.
+        node.updated_by = author;
         let node = node.clone();
         let file = self.physical_path(company, &index, id)?;
         if let Some(parent) = file.parent() {
@@ -1184,6 +1193,8 @@ mod test {
                 kind: NodeKind::Folder,
                 parent_id: None,
                 updated_at_millis: now,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
             },
             None,
         )
@@ -1198,6 +1209,8 @@ mod test {
                 kind: NodeKind::File,
                 parent_id: Some("f1".into()),
                 updated_at_millis: now,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
             },
             Some("# Voice"),
         )

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1755,6 +1755,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         company: &CompanyId,
         id: &str,
         content: &str,
+        author: crate::ports::workspace::WorkspaceOrigin,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let doc = self
@@ -1775,6 +1776,9 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             ));
         }
         node.updated_at_millis = now_millis();
+        // Authorship rides the same stamp as the timestamp. The node is stored
+        // as opaque JSON in `node_json`, so this needs no schema change.
+        node.updated_by = author;
         self.collection("workspace_nodes")
             .update_one(
                 doc! {"company_id": company.as_ref(), "node_id": id},

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2022,6 +2022,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         company: &CompanyId,
         id: &str,
         content: &str,
+        author: crate::ports::workspace::WorkspaceOrigin,
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let conn = self.conn();
@@ -2045,6 +2046,9 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ));
         }
         node.updated_at_millis = now_millis();
+        // Authorship rides the same stamp as the timestamp. The node is stored
+        // as opaque JSON, so this needs no column and no migration.
+        node.updated_by = author;
         conn.execute(
             "UPDATE workspace_nodes SET node_json = ?1, content = ?2, updated_ms = ?3 \
              WHERE company_id = ?4 AND id = ?5",


### PR DESCRIPTION
## Summary

The workspace is meant to be the shared space every agent references and every human collaborator sees, but agent output could never enter it. `workspace_write` requires an `expected_updated_at` compare-and-swap token, and only an *existing* note has one — so with no create tool, `WorkspaceStore::create` had exactly two production callers: the seeder and the operator's REST handler. An agent's work stayed in its private sandbox or in a task artifact, neither of which any other agent can read.

This adds `workspace_create`, provisions a reserved `Agents/<agent-id>/` folder per agent, and — folding in #326 — records authorship on every node so an agent-written file and an operator-typed one are finally distinguishable.

Closes #551. Closes #326.

## API Or Behavior Changes

**New agent tool — `workspace_create`.** Creates a folder or a file with optional initial content. Wired under the same explicit `workspace` / `workspace.write` grant as `workspace_write`; a bare `*` confers nothing. Classified as a per-call consequence, so it parks under supervised policy and is denied under readonly, matching `workspace_write`.

**Agent writes are deliberately NOT confined to the agent's own folder.** `workspace_write` keeps its existing whole-tree reach and `workspace_create` matches it. Gating create while overwrite stays free would protect nothing — overwrite is strictly the more destructive verb. `Agents/<agent-id>/` is an organizational and attribution unit, not an enforcement boundary, and the tool descriptions steer agents to their own folder as the default home for what they produce. The controls that do apply: company-level tenancy (unchanged and structural), the explicit grant, the CAS token forcing read-before-write, policy parking under supervised mode, and the authorship trail below. Rename, move and delete remain operator-only.

**`WorkspaceNode` gains `createdBy` and `updatedBy`** (`WorkspaceOrigin`: `seed` / `operator` / `agent` + id), surfaced on the REST bodies, the GraphQL projections and the console. `createdBy` is immutable; `updatedBy` is stamped by content writes only — a rename deliberately does not touch it, so an operator rename cannot mask agent authorship of the current body. Pre-existing nodes deserialize as `operator`, which is direction-honest (before this change the tree was operator-owned by definition) and needs no data migration on any backend, since all three persist the node as opaque JSON.

**`WorkspaceStore::write` takes an `author` argument.** Repo-internal only; every caller and the test double are updated in the same change.

**A new company's Workspace tab is no longer empty** — it opens on `Agents/` with a folder per agent. A company with no agents mints nothing. Three tests that asserted emptiness now name what they expect instead.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --locked --all-targets` and `cargo check --locked --all-features --all-targets`)
- [x] `cargo test` — 1762 passed, 0 failed
- [x] `cargo build --locked --features openhuman,tinycortex,mcp --bin opencompany`

Also run, matching the CI lanes:

- [x] `cargo test --locked --features sqlite --lib store::sqlite` — 25 passed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — 2632 passed
- [x] `cargo test --locked --features runner --lib runner` — 74 passed
- [x] `cargo test --locked --features tinyplace --lib` — 1819 passed
- [x] `cargo test --locked --features openhuman,mcp,telegram --lib harness::build::tests` — 19 passed
- [x] `frontend`: `npm run typecheck`, `npm run build`, `npx vitest run` — 20 files, 204 tests passed

New coverage: the conformance suite pins authorship across all three backends (origin round-trip, a write flipping `updated_by`, a rename leaving it alone); provisioning is pinned at boot, on a roster rebuild, for the adopt/warn/skip collision cases, for idempotency and for the empty-roster case; `workspace_create` is pinned for both kinds, for a create under `Standards/` carrying `createdBy = agent` (which pins the unconfined decision), for already-exists, missing-parent, folder-with-content and content-cap refusals; and one test walks the shared-memory path end to end — agent A creates, agent B reads.

MongoDB's conformance run self-skips without a live `mongod`. That gap is not specific to this PR — it is filed as #555.

## Documentation

Updated `docs/spec/runtime/ports-console.md`, `docs/spec/runtime/api.md`, `docs/spec/runtime/manifest.md`, `docs/spec/company-brain/approvals.md`, `docs/modules/runtime/README.md` and `docs/modules/server/README.md`, plus module docs in `ports/workspace.rs`, `harness/workspace_tools.rs` and `server/ops/workspace.rs`. The #326 known-limit note in `server/ops/workspace.rs` is removed since this PR closes it; #327's stays.

## Related

Part of a three-PR sequence making the workspace a genuine shared resource space:

- **This PR (#551 + #326)** — agents can create in the shared tree; every node records who made it.
- **#552** — a published deliverable lands in the tree as well as on the task card, and the tab updates live (#327).
- **#553** — the tree can hold bytes, so a generated image stops being a dangling sha256.

#555 (MongoDB's suite never runs in CI) was filed off the back of this work and is independent.
