### PR TITLE
fix: address the tinysweeper findings on #543

### DIFF
--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -241,7 +241,7 @@ whose desktop keeps working.
 The flow runs the opposite way to OAuth's device flow, which removes a problem
 rather than solving it:
 
-1. A **signed-in** human asks for a pairing code (`POST …/devices/pair`).
+1. A **signed-in** human asks for a pairing code (`POST …/devices`).
    Authentication has already happened; nothing is pending approval.
 2. They paste it into the desktop client.
 3. The client redeems it (`POST …/devices/claim`) and receives a session token

--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -96,10 +96,44 @@ export function registerConnection(
   return pending;
 }
 
-/** Drops a host from the core. */
+/**
+ * Drops a host from the core.
+ *
+ * Sequenced after any registration still in flight. This and
+ * `registerConnection` race the same way a request does: `oc_connect` resolving
+ * *after* `oc_disconnect` landed would leave the connection registered in the
+ * core while the console believes it is gone — a dangling entry that the next
+ * `registerConnection` for a reused id may or may not overwrite cleanly.
+ *
+ * Stays synchronous because callers are React event handlers, so the ordering
+ * is expressed by chaining onto the pending promise rather than by awaiting it.
+ * The map entry is cleared only once the disconnect has been issued; deleting
+ * it up front is what dropped the ordering in the first place.
+ */
 export function forgetConnection(id: string): void {
-  registrations.delete(id);
-  void bridge()?.invoke("oc_disconnect", { connectionId: id });
+  const desktop = bridge();
+  if (!desktop) {
+    registrations.delete(id);
+    return;
+  }
+  const pending = registrations.get(id) ?? Promise.resolve();
+  const disconnected: Promise<void> = pending
+    .then(() => desktop.invoke<void>("oc_disconnect", { connectionId: id }))
+    .then(
+      () => undefined,
+      (error: unknown) => {
+        console.error(`[desktop] could not drop connection ${id}`, error);
+      },
+    )
+    .finally(() => {
+      // Only remove the entry this call created. A `registerConnection` that
+      // landed while the disconnect was in flight owns the id now, and clearing
+      // its promise would let a request run before its registration.
+      if (registrations.get(id) === disconnected) registrations.delete(id);
+    });
+  // Parked under the same id so a `connectionReady` in between waits for the
+  // disconnect rather than racing past it.
+  registrations.set(id, disconnected);
 }
 
 /**

--- a/frontend/src/components/device-pairing.tsx
+++ b/frontend/src/components/device-pairing.tsx
@@ -94,9 +94,17 @@ export function DevicePairing() {
               variant="outline"
               size="sm"
               onClick={() => {
-                void forgetDevice(scope.connection).then(() =>
-                  unpairConnection(scope.connection),
-                );
+                setError(null);
+                void forgetDevice(scope.connection)
+                  .then(() => unpairConnection(scope.connection))
+                  // Without this the rejection is unhandled, `unpairConnection`
+                  // never runs, and the button appears to do nothing — the row
+                  // still says "Paired" with no reason given.
+                  .catch((err: unknown) =>
+                    setError(
+                      err instanceof Error ? err.message : "could not forget this device",
+                    ),
+                  );
               }}
             >
               Forget on this machine

--- a/frontend/test/unit/desktop-bridge.test.ts
+++ b/frontend/test/unit/desktop-bridge.test.ts
@@ -95,30 +95,64 @@ describe("registering connections with the core", () => {
     expect(JSON.stringify(connect?.args)).not.toContain("device-abc");
   });
 
-  it("keeps the token out of the console when pairing", async () => {
-    // The property the whole keychain exists for. `oc_pair_device` answers
-    // with what a person needs to see and nothing else — a console that
-    // received the token, even to hand it straight back, would be a console an
-    // injected script could read it from.
+  it("asks the core to pair, and passes the code and label through", async () => {
+    // What this CAN assert from the console: the command shape. Whether a token
+    // comes back is decided in Rust by `PairedDevice`, which has no token
+    // field — a mock here proves nothing about that, and the earlier version of
+    // this test omitted `token` from its own fixture and then asserted the
+    // absence of it, which is a test checking itself. The real guarantee is the
+    // Rust-side `a_paired_device_carries_no_token`.
     (window as unknown as { __TAURI__: { invoke: unknown } }).__TAURI__.invoke = (
       command: string,
       args: Record<string, unknown>,
     ) => {
       calls.push({ command, args });
-      return Promise.resolve({
-        company: "acme",
-        deviceId: "dev-1",
-        expiresAtMillis: 1,
-      });
+      return Promise.resolve({ company: "acme", deviceId: "dev-1", expiresAtMillis: 1 });
     };
 
     const device = await pairDevice("conn-1", "https://acme.test", "the-code", "Ada's Mac");
     expect(device).toEqual({ company: "acme", deviceId: "dev-1", expiresAtMillis: 1 });
-    expect(Object.keys(device)).not.toContain("token");
     expect(calls.at(-1)).toMatchObject({
       command: "oc_pair_device",
-      args: { connectionId: "conn-1", code: "the-code", label: "Ada's Mac" },
+      args: {
+        connectionId: "conn-1",
+        baseUrl: "https://acme.test",
+        code: "the-code",
+        label: "Ada's Mac",
+      },
     });
+  });
+
+  it("does not disconnect before a registration still in flight has landed", async () => {
+    // `oc_connect` resolving after `oc_disconnect` landed would leave the
+    // connection registered in the core while the console believes it is gone.
+    const order: string[] = [];
+    let releaseConnect: (() => void) | undefined;
+    (window as unknown as { __TAURI__: { invoke: unknown } }).__TAURI__.invoke = (
+      command: string,
+    ) => {
+      if (command === "oc_connect") {
+        return new Promise<void>((resolve) => {
+          releaseConnect = () => {
+            order.push("oc_connect");
+            resolve();
+          };
+        });
+      }
+      order.push(command);
+      return Promise.resolve();
+    };
+
+    const pending = registerConnection("conn-race", "https://acme.test");
+    forgetConnection("conn-race");
+    // Nothing has gone out yet: the connect is parked, so the disconnect is too.
+    expect(order).toEqual([]);
+
+    releaseConnect?.();
+    await pending;
+    await connectionReady("conn-race");
+
+    expect(order).toEqual(["oc_connect", "oc_disconnect"]);
   });
 
   it("re-announces when a connection adopts a new credential", async () => {
@@ -139,6 +173,9 @@ describe("registering connections with the core", () => {
     const id = addConnection({ baseUrl: "https://acme.test" });
     await connectionReady(id);
     removeConnection(id);
+    // The disconnect is sequenced behind any registration still in flight, so
+    // it is issued on a later tick rather than synchronously.
+    await connectionReady(id);
 
     expect(calls.filter((c) => c.command === "oc_disconnect")).toEqual([
       { command: "oc_disconnect", args: { connectionId: id } },

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -188,15 +188,24 @@ pub async fn oc_pair_device(
 
     // Re-register so the credential takes effect without waiting for a reload.
     // The console cannot do this itself — it has nothing to pass.
-    if let Ok(existing) = proxy.connection(&connection_id).await {
+    //
+    // The session is read back from the keychain rather than reused from the
+    // claim: what matters is what the store will hand out on the *next* boot,
+    // so a write that did not survive surfaces here rather than as a mysterious
+    // 401 later. A miss is `Credential::None`, never `Device("")` — an empty
+    // session header is a credential that authenticates as nobody while looking
+    // like one to every check that only asks whether a device is paired.
+    if let Ok(base_url) = proxy.base_url(&connection_id).await {
+        let credential = match crate::keychain::device_session(&connection_id) {
+            Some(session) => Credential::Device(session),
+            None => Credential::None,
+        };
         proxy
             .upsert(
                 connection_id.clone(),
                 Connection {
-                    base_url: existing.base_url,
-                    credential: Credential::Device(
-                        crate::keychain::device_session(&connection_id).unwrap_or_default(),
-                    ),
+                    base_url,
+                    credential,
                 },
             )
             .await;
@@ -220,12 +229,12 @@ pub async fn oc_forget_device(
     connection_id: String,
 ) -> Result<(), String> {
     crate::keychain::forget_device(&connection_id).map_err(|error| error.to_string())?;
-    if let Ok(existing) = proxy.connection(&connection_id).await {
+    if let Ok(base_url) = proxy.base_url(&connection_id).await {
         proxy
             .upsert(
                 connection_id,
                 Connection {
-                    base_url: existing.base_url,
+                    base_url,
                     credential: Credential::None,
                 },
             )

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -251,3 +251,32 @@ pub fn oc_embedded(state: State<'_, crate::AppHandleState>) -> Option<EmbeddedIn
         data_dir: state.data_dir.display().to_string(),
     })
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The guarantee the console cannot make about itself.
+    ///
+    /// `pairDevice` in the console returns whatever the core sends, so a mock
+    /// there proves nothing — this is where "the token never reaches the
+    /// webview" is actually enforced, by a type that has nowhere to put one.
+    /// If a `token` field is ever added to `PairedDevice`, this fails.
+    #[test]
+    fn a_paired_device_carries_no_token() {
+        let wire = serde_json::to_value(PairedDevice {
+            company: "acme".into(),
+            device_id: "dev-1".into(),
+            expires_at_millis: 1,
+        })
+        .expect("serialise");
+
+        let object = wire.as_object().expect("an object");
+        assert_eq!(
+            object.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["company", "deviceId", "expiresAtMillis"],
+            "pairing must answer with these three fields and nothing else"
+        );
+        assert!(!wire.to_string().to_lowercase().contains("token"));
+    }
+}

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -168,10 +168,15 @@ impl ProxyRegistry {
         self.connections.read().await.keys().cloned().collect()
     }
 
-    /// One registered connection, for a caller that needs its base url without
-    /// making a request — re-registering after a credential changes.
-    pub async fn connection(&self, id: &str) -> Result<Connection, ProxyError> {
-        self.get(id).await
+    /// The base url a connection is registered against.
+    ///
+    /// Returns the url alone, never the [`Connection`]: `get` is private
+    /// precisely so a credential cannot leave this registry, and a public
+    /// accessor handing back the whole struct would put `Credential::Device`
+    /// one `serde` derive away from the webview. The only caller needs the url
+    /// — to re-register after a credential changes — so the url is all it gets.
+    pub async fn base_url(&self, id: &str) -> Result<String, ProxyError> {
+        self.get(id).await.map(|connection| connection.base_url)
     }
 
     async fn get(&self, id: &str) -> Result<Connection, ProxyError> {
@@ -479,6 +484,33 @@ mod test {
         for name in ["content-type", "accept", "x-request-id"] {
             assert!(!reserved(name), "{name} must pass");
         }
+    }
+
+    #[tokio::test]
+    async fn the_public_accessor_hands_back_no_credential() {
+        // `get` is private so a credential cannot leave this registry. The one
+        // public accessor exists for a caller that needs somewhere to re-point
+        // a connection, and it must stay a url — a `Connection` here would put
+        // `Credential::Device` one `serde` derive away from the webview.
+        let registry = ProxyRegistry::new();
+        registry
+            .upsert(
+                "primary".into(),
+                Connection {
+                    base_url: "https://acme.test".into(),
+                    credential: Credential::Device("acme.the-secret".into()),
+                },
+            )
+            .await;
+
+        let url = registry
+            .base_url("primary")
+            .await
+            .expect("a registered host");
+        assert_eq!(url, "https://acme.test");
+        // The type is what enforces this; the assertion is here so a future
+        // widening of the return type has to delete a test that says why.
+        assert!(!url.contains("the-secret"));
     }
 
     #[test]

--- a/src/server/users/devices.rs
+++ b/src/server/users/devices.rs
@@ -18,7 +18,7 @@
 //! Turning the flow around removes the problem instead of solving it:
 //!
 //! 1. A **signed-in human** asks their console for a pairing code
-//!    (`POST …/devices/pair`). Authentication already happened; nothing is
+//!    (`POST …/devices`). Authentication already happened; nothing is
 //!    pending approval.
 //! 2. They paste it into the desktop client.
 //! 3. The client redeems it (`POST …/devices/claim`) and receives a session


### PR DESCRIPTION
## Summary

The `tinysweeper` findings on #543, which landed after it merged. Six of the seven, each with the test that would have caught it. Three commits.

## Problem

All six are mine, from #543. The two that matter:

**`ProxyRegistry::connection` returned the credential** (high). I added a public accessor returning the whole `Connection` — including `Credential::Device(token)` — to a module whose entire argument is that the token never reaches the webview. `get` was private for exactly that reason, and the one caller wanted a base url. That is a hole I opened in the thing I had just spent two commits defending.

**`device_session(..).unwrap_or_default()`** turned a failed keychain read into `Credential::Device("")`. Not `None`: a device credential with a blank token, sent as a session header on every later request, authenticating as nobody while looking paired to anything that only asks whether a device credential exists.

And one worth naming for its own sake: **the pairing test was asserting its own fixture.** It checked `Object.keys(device)` had no `"token"` against a mock that never included one. It would have passed had `pairDevice` forwarded the core's response wholesale — which is the only way the bug could have happened. That is the failure mode I opened #536's review complaining about, committed by me, three commits later.

## Solution

| Commit | What |
|---|---|
| `f6bb9aed` | `connection` → `base_url` returning a `String`; a keychain miss is `Credential::None`, never `Device("")` |
| `25bee2a1` | Sequence `oc_disconnect` behind an in-flight `oc_connect`; `.catch()` on unpair; replace the self-checking test |
| `b098c876` | Name the real pairing endpoint; assert the no-token guarantee in Rust, where the type enforces it |

Detail on the three smaller ones:

- **The disconnect race.** `forgetConnection` deleted the pending registration and fired `oc_disconnect` without waiting for the `oc_connect` already in flight — the exact race the module header warns about, applied everywhere except there. If the connect resolved second, the core kept a connection the console believed was gone. Now chained onto the pending promise and parked under the same id, so a `connectionReady` in between waits for it.
- **The unpair button** had no `.catch()`, so a rejection went unhandled, `unpairConnection` never ran, and the row went on saying "Paired" with no reason given.
- **`POST …/devices/pair` does not exist.** `router()` puts `start_pairing` on `.post()` of `/devices`. Both the module docstring (pre-existing, from #536) and my spec text named a path that would 404. The routes list was already right, which is what made the disagreement visible.

The no-token guarantee now lives in `src-tauri/src/commands.rs` as a test over `PairedDevice`'s serialised field list. The console cannot make that promise about itself — it returns whatever the core sends — so asserting it there was theatre.

## Not addressed

`Swatinem/rust-cache@v2` being a mutable tag. The point is fair, but every job in `ci.yml` uses mutable tags (`actions/checkout@v7`, `dtolnay/rust-toolchain@stable`, `Swatinem/rust-cache@v2`), so pinning only the lane I added would be inconsistent without being safer. It is a repo-wide policy call — happy to do the sweep as its own PR if you want it.

## Submission Checklist

- [x] `cargo fmt --all -- --check` clean, both workspaces
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings` clean
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --locked` — 81 passing
- [x] `cargo test --locked --lib server::users` — 96 passing
- [x] Console: `typecheck` clean, 198 unit tests, `npm run build` clean
- [x] New tests fail without their fix — the accessor test, the ordering test and the `PairedDevice` test each go red when reverted
- [ ] Not exercised on a packaged desktop build

## Impact

Closes the credential-exposure hole #543 opened, stops an empty device credential ever being minted, and removes a test that asserted nothing. No behaviour change for the browser build.

One behaviour change worth naming: `forgetConnection` now issues its disconnect on a later tick rather than synchronously. The one test that assumed otherwise is updated rather than worked around.

## Related

Follows tinyhumansai/opencompany#543. Findings from the `tinysweeper` review there.
