### PR TITLE
feat(workspace): a published deliverable lands in the shared tree, and the tab follows live (#552, #327)

### DIFF
--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -276,8 +276,10 @@ prompt = "Weekly review and operator digest"
     a `mkdir -p`. The single exception is the agent's own
     `Agents/<agent-id>/`, which is created on demand when the agent writes
     directly into it, because that folder is minted on first use rather than
-    provisioned at boot and this call is the only thing that ever brings it into
-    existence. Renaming and deleting stay operator-only.
+    provisioned at boot. Since issue #552 this call is one of two paths that
+    bring it into existence; publishing a deliverable
+    (`artifact_mirror::materialize`) is the other, and both go through the same
+    `ensure_agent_folder` seam. Renaming and deleting stay operator-only.
 
     Agent writes are **unconfined**: an agent may create or edit anywhere in its
     company's tree. Confining creation while leaving overwrite free would

--- a/frontend/src/api/artifacts.ts
+++ b/frontend/src/api/artifacts.ts
@@ -39,6 +39,22 @@ export interface ArtifactVersion {
   stepSeq?: number;
   /** Why this revision exists, e.g. `"operator edit before approval"`. */
   note?: string;
+  /**
+   * The workspace node this revision's body was mirrored into (#552).
+   *
+   * A published deliverable lives twice: here, as the authoritative version
+   * history, and as one note in the shared workspace tree holding the current
+   * body. This is the link, and it is what the "Open in workspace" control
+   * navigates to.
+   *
+   * Per *version*, not per record: an operator may delete a published note, and
+   * the next publish materializes a fresh one — so an older version names the
+   * node that actually held it, which may no longer exist.
+   *
+   * Absent on a legacy capture, on an artifact recorded while the host had no
+   * workspace store, and on one whose node write failed.
+   */
+  workspaceNodeId?: string;
 }
 
 /** What happened to one diff line. */

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -44,6 +44,7 @@ import {
 import { TourController } from "@/tour/TourController";
 import { useCompany } from "@/hooks/use-company";
 import { type AgentReplyEvent, type CompanyStreamEvent, useEvents } from "@/hooks/use-events";
+import type { WorkspaceEvent } from "@/views/WorkspaceView";
 import { useHashView } from "@/hooks/use-hash-view";
 import { toast } from "sonner";
 
@@ -267,6 +268,15 @@ export function AppShell({
   // React batch still means "re-read" — the frame-loss the workflow canvas had
   // to fold an event window to avoid cannot happen to a tick.
   const [taskEventTick, setTaskEventTick] = useState(0);
+  // Issue #327: the latest workspace write, as the Workspace view needs it.
+  //
+  // The payload-carrying variant of the `taskEventTick` pattern above, and the
+  // one place a counter genuinely is not enough: the view always refetches the
+  // tree, but what it does to the OPEN note depends on which node moved — leave
+  // it alone, refetch it, or close the pane because it was deleted. `tick` rides
+  // alongside so two frames naming the same node in one React batch are still
+  // two events rather than a state update React coalesces away.
+  const [workspaceEvent, setWorkspaceEvent] = useState<WorkspaceEvent | null>(null);
   // Issue #228: bumped on every `workflow_run_finished` so the Workflows view
   // refreshes its run history live. Same shape as `taskEventTick` — a counter,
   // not the payload, so the view owns what it refetches.
@@ -862,6 +872,18 @@ export function AppShell({
     pendingApprovals: pending,
     onAgentReply: injectAgentReply,
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
+    // Issue #327. The payload is carried, not folded into a counter — see
+    // `workspaceEvent` above. The view still re-reads the tree from the host
+    // rather than patching it from the frame: the frame carries no node name
+    // and no body by design.
+    onWorkspaceEvent: useCallback((event: CompanyStreamEvent) => {
+      if (event.type !== "workspace_changed") return;
+      setWorkspaceEvent((prev) => ({
+        tick: (prev?.tick ?? 0) + 1,
+        nodeId: event.nodeId,
+        change: event.change,
+      }));
+    }, []),
     onTurnEvent,
     onWorkflowRunEvent: useCallback((event: CompanyStreamEvent) => {
       // Both halves. The tick refreshes the durable history; the frames drive
@@ -1043,7 +1065,20 @@ export function AppShell({
                 </div>
               }
             >
-              <WorkspaceView client={client} company={company} />
+              <WorkspaceView
+                client={client}
+                company={company}
+                // Issue #327: live writes, so a note an agent creates or a
+                // deliverable the publish drain lands shows up without a
+                // refresh.
+                event={workspaceEvent}
+                // Issue #552: the Artifacts tab's "Open in workspace" link
+                // sets `#/workspace/<nodeId>`, and `useHashView` hands the
+                // second segment back unvalidated — only this view knows
+                // which node ids exist, so it resolves an unknown one against
+                // the host rather than this shell guessing here.
+                initialNodeId={sub}
+              />
             </Suspense>
           )}
           {view === "approvals" && (

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -54,6 +54,25 @@ export type CompanyStreamEvent =
       /** Absent on a removed card, which is in no column. */
       column?: string;
     }
+  // A workspace node was written (issue #327) — created, overwritten, moved or
+  // deleted. `task_card_changed`'s counterpart for the note tree, and missing
+  // for the same reason: the Workspace tab could only learn about a write by
+  // refetching on refresh or refocus, which is a long time to be wrong now that
+  // agents create notes and published deliverables land in the tree.
+  //
+  // Deliberately thin, like its board sibling: an id and what happened. There
+  // is **no node name and no body** on purpose — a note's text lives on
+  // `GET …/workspace`, and the view reacts to this frame by re-reading that, so
+  // the tree's content has exactly one source.
+  | {
+      type: "workspace_changed";
+      seq: number;
+      atMillis: number;
+      nodeId: string;
+      /** `opened` | `updated` | `removed`, widened so an unknown word from a
+       *  newer host is not a type error. */
+      change: string;
+    }
   // A dispatched card's run finished (issue #185). The host has projected this
   // since #185; the console named no type for it, so it fell through to
   // `default:` and was dropped — the same "the view does not subscribe" half of
@@ -272,6 +291,22 @@ interface Options {
    */
   onTaskEvent?: (event: CompanyStreamEvent) => void;
   /**
+   * Called for each `workspace_changed` frame (issue #327) so the Workspace
+   * view can re-read the tree — and the open note — live.
+   *
+   * Unlike {@link Options.onTaskEvent}, this one takes the **payload**, not
+   * just a counter. The view's reaction depends on *which* node moved: the tree
+   * is always refetched, but the open note is only refetched when the frame
+   * names it, and a `removed` frame naming the open note has to close the pane
+   * rather than refetch a note that is gone. A counter cannot say any of that.
+   *
+   * The frame-loss trap that forced the workflow canvas to fold an event
+   * *window* does not apply, because the tree refetch is unconditional: a
+   * dropped frame costs at most one stale render of the open note, never wrong
+   * tree state.
+   */
+  onWorkspaceEvent?: (event: CompanyStreamEvent) => void;
+  /**
    * Called for each live turn-progress frame (`tool_call`, `tool_result`) so the
    * chat can render the tool timeline as the turn runs, then reconcile against
    * the folded steps on the final reply.
@@ -325,7 +360,7 @@ interface Options {
  * Derived from `Options` rather than restated so the two cannot drift, and so
  * each callback keeps the documentation written against it above.
  */
-type Subscribers = Omit<Options, "pendingApprovals">;
+export type Subscribers = Omit<Options, "pendingApprovals">;
 
 /**
  * Opens an `EventSource` on `{scope}/events` for the active company and turns
@@ -343,6 +378,7 @@ export function useEvents(
     pendingApprovals,
     onAgentReply,
     onTaskEvent,
+    onWorkspaceEvent,
     onTurnEvent,
     onWorkflowRunEvent,
     onWorkflowChanged,
@@ -358,6 +394,10 @@ export function useEvents(
   useEffect(() => {
     onTaskEventRef.current = onTaskEvent;
   }, [onTaskEvent]);
+  const onWorkspaceEventRef = useRef(onWorkspaceEvent);
+  useEffect(() => {
+    onWorkspaceEventRef.current = onWorkspaceEvent;
+  }, [onWorkspaceEvent]);
   const onTurnEventRef = useRef(onTurnEvent);
   useEffect(() => {
     onTurnEventRef.current = onTurnEvent;
@@ -414,6 +454,7 @@ export function useEvents(
           handleEvent(event, {
             onAgentReply: onAgentReplyRef.current,
             onTaskEvent: onTaskEventRef.current,
+            onWorkspaceEvent: onWorkspaceEventRef.current,
             onTurnEvent: onTurnEventRef.current,
             onWorkflowRunEvent: onWorkflowRunEventRef.current,
             onWorkflowChanged: onWorkflowChangedRef.current,
@@ -441,11 +482,20 @@ export function useEvents(
   }, [client, company]);
 }
 
-/** Routes one parsed event to its toast / transcript side effect. */
-function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers): void {
+/**
+ * Routes one parsed event to its toast / transcript side effect.
+ *
+ * Exported for tests. This function has been bitten three times by a frame the
+ * host was already sending falling through to `default:` and vanishing with
+ * nothing to debug (#464 for the board, #371 for the canvas, #384 for the
+ * picker), so which subscriber a type reaches is worth pinning directly rather
+ * than only through a mounted hook.
+ */
+export function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers): void {
   const {
     onAgentReply,
     onTaskEvent,
+    onWorkspaceEvent,
     onTurnEvent,
     onWorkflowRunEvent,
     onWorkflowChanged,
@@ -489,6 +539,15 @@ function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers): void 
     case "task_card_changed":
     case "desk_task_completed":
       onTaskEvent?.(event);
+      break;
+    // Issue #327, and **no toast** for the same reason the board frames above
+    // raise none — more strongly, if anything. A workspace write is not an
+    // attention signal: an autosaving editor fires one per settled keystroke
+    // burst, and every published deliverable adds more. Toasting those would
+    // train the operator to dismiss the toasts that do matter. The note
+    // appearing, changing or vanishing in the tree IS the notification.
+    case "workspace_changed":
+      onWorkspaceEvent?.(event);
       break;
     case "agent_reply":
       onAgentReply?.({

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   FileText,
+  FolderOpen,
   History,
   Image as ImageIcon,
   Loader2,
@@ -511,6 +512,28 @@ function ArtifactDetail({
         <p className="mt-2 text-[11px] text-muted-foreground">
           Created {whenOf(artifact.createdAtMillis)} · updated {whenOf(artifact.updatedAtMillis)}
         </p>
+        {shown?.workspaceNodeId && (
+          // Issue #552: a published deliverable also lives in the shared
+          // workspace tree, which is where teammates and the operator actually
+          // browse. Without this the two surfaces are related only in the
+          // host's data.
+          //
+          // Read off the *shown* version, not the record: the node id is per
+          // version, so an older revision points at the note that held it —
+          // which the operator may since have deleted. The hash router follows
+          // `hashchange`, so setting the hash is the whole navigation; no
+          // navigate prop is threaded down for one link.
+          <button
+            type="button"
+            className="mt-2 inline-flex items-center gap-1.5 text-[11px] font-medium text-primary hover:underline"
+            onClick={() => {
+              window.location.hash = `/workspace/${shown.workspaceNodeId}`;
+            }}
+          >
+            <FolderOpen className="size-3" />
+            Open in workspace
+          </button>
+        )}
       </div>
 
       {pinnedBehindLatest && latest && (

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -165,6 +165,100 @@ export function migrationBannerText(files: number, folders: number): string {
 /** What the editor's status line is currently reporting. */
 type SaveState = "idle" | "saving" | "saved" | "error";
 
+/**
+ * Text the operator wrote into a note that no longer exists, held out of the
+ * editor so it can be handed back (issue #552 review).
+ *
+ * The `name` is the vanished note's, kept only so the banner can say *which*
+ * note this came out of — an operator with three tabs of notes open all week
+ * cannot identify a loose paragraph otherwise.
+ */
+interface Rescued {
+  name: string;
+  content: string;
+}
+
+/** What a live write means for the open note, once the refreshed tree is in. */
+export type OpenNotePlan =
+  /** Nothing to do: the note is untouched, or the operator is mid-edit. */
+  | { kind: "leave" }
+  /** Re-read the open note's body — it changed underneath a reader. */
+  | { kind: "reload" }
+  /**
+   * The open note no longer exists. `rescue` carries the operator's unsaved
+   * text, or `null` when the buffer matched what the host already had.
+   */
+  | { kind: "vanished"; rescue: string | null };
+
+/**
+ * Decide what a `workspace_changed` frame means for the note in the pane.
+ *
+ * Split out of the effect because "is the open note still there?" is the whole
+ * bug and it is not a question the *frame* can answer. `WorkspaceAnnouncer`
+ * emits exactly one `removed` frame naming the node the operator deleted — the
+ * **folder** — and never one per descendant, so a note three folders down
+ * disappears without any frame ever saying its id. The effect used to compare
+ * `event.nodeId` against `openId`, decide the frame was about somebody else,
+ * and return: the note left the tree, the pane stayed open on it, and the
+ * debounced autosave behind it went on to 404 against a node that was gone.
+ *
+ * So disappearance is read off the **refreshed tree**, which knows about every
+ * descendant, and the frame is consulted only for the case the tree cannot
+ * settle — a refetch that failed (`tree === null`) while the frame itself said
+ * the open note was removed. When both are silent the note is treated as alive,
+ * which is the safe direction: a pane wrongly closed loses the operator's
+ * place, and there is no reading of the evidence here that says to close it.
+ */
+export function planOpenNote({
+  openId,
+  event,
+  tree,
+  mode,
+  draft,
+  saved,
+}: {
+  /** The note in the pane, or `null` when none is open. */
+  openId: string | null;
+  /** The frame that just arrived. */
+  event: WorkspaceEvent;
+  /** The tree as refetched *after* the frame, or `null` if that read failed. */
+  tree: FsNode[] | null;
+  /** Which tab the pane is on. */
+  mode: "read" | "edit";
+  /** The editor's buffer, or `null` when the operator is not editing. */
+  draft: string | null;
+  /** The body the host last acknowledged, as the pane holds it. */
+  saved: string | null | undefined;
+}): OpenNotePlan {
+  if (!openId) return { kind: "leave" };
+  const goneFromTree = tree !== null && !tree.some((n) => n.id === openId);
+  const removedOutright = event.change === "removed" && event.nodeId === openId;
+  if (goneFromTree || removedOutright) {
+    return { kind: "vanished", rescue: unsavedDraft(draft, saved) };
+  }
+  // Not the open note's frame — the tree refresh above is the whole reaction.
+  if (event.nodeId !== openId) return { kind: "leave" };
+  // Never clobber an in-progress edit: in edit mode the operator has a dirty
+  // buffer and an autosave in flight, and replacing the body underneath them
+  // would discard typing no refetch can get back. They see the change when they
+  // switch back to Read, which refetches anyway.
+  return mode === "read" ? { kind: "reload" } : { kind: "leave" };
+}
+
+/**
+ * The words that would be lost if the open note went away right now, or `null`
+ * when the buffer says nothing the host does not already have.
+ *
+ * Compares against the acknowledged body rather than trusting the mere presence
+ * of a draft: switching to Edit seeds the buffer from a fresh read, so a note
+ * merely *opened* for editing and then deleted elsewhere has nothing to rescue
+ * and should close quietly instead of pushing a banner at the operator.
+ */
+function unsavedDraft(draft: string | null, saved: string | null | undefined): string | null {
+  if (draft === null) return null;
+  return draft === (saved ?? "") ? null : draft;
+}
+
 /** Formats an epoch-millis instant for the open note's header. */
 function formatUpdated(ms: number): string {
   if (!ms) return "—";
@@ -221,6 +315,10 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
   const [mode, setMode] = useState<"read" | "edit">("read");
   const [draft, setDraft] = useState<string | null>(null);
   const [saveState, setSaveState] = useState<SaveState>("idle");
+  // Text salvaged from a note that was deleted while the operator was writing
+  // in it. Deliberately outside the editor's own state: `draft` belongs to
+  // whatever note is open, and this text belongs to one that no longer is.
+  const [rescued, setRescued] = useState<Rescued | null>(null);
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
   const [prompt, setPrompt] = useState<PromptState | null>(null);
@@ -247,14 +345,20 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
 
   /* ---- tree ---- */
 
+  // Resolves to the tree it just installed, or `null` when this read answered
+  // nothing authoritative — it failed, or a newer read has already superseded
+  // it. Callers that only want the side effect ignore it; the live-writes
+  // effect needs the nodes themselves, because "did the open note survive this
+  // write?" is a question only the refreshed list can answer and reading it
+  // back out of `nodes` would race React's own state update.
   const loadTree = useCallback(
-    async (opts?: { silent?: boolean }) => {
+    async (opts?: { silent?: boolean }): Promise<FsNode[] | null> => {
       const mine = ++treeGen.current;
       if (opts?.silent) setRefreshing(true);
       else setLoading(true);
       try {
         const tree = await fetchTree(client, company);
-        if (mine !== treeGen.current) return;
+        if (mine !== treeGen.current) return null;
         setNodes(tree);
         setError(null);
         if (!expandedSeeded.current) {
@@ -267,9 +371,11 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
             ),
           );
         }
+        return tree;
       } catch (e) {
-        if (mine !== treeGen.current) return;
+        if (mine !== treeGen.current) return null;
         setError(message(e, "could not load the workspace"));
+        return null;
       } finally {
         if (mine === treeGen.current) {
           setLoading(false);
@@ -288,6 +394,9 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
     setOpenFile(null);
     setDraft(null);
     setSaveState("idle");
+    // Another company's note is another namespace, and rescued text offering to
+    // be saved into the wrong workspace is worse than no offer at all.
+    setRescued(null);
     setExpanded(new Set());
     void loadTree();
     return () => {
@@ -429,26 +538,92 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
   //     autosave in flight; replacing the body underneath them would discard
   //     typing that no refetch can get back. They see the change when they
   //     switch back to Read, which already refetches.
-  //  3. **A deleted open note closes the pane** rather than being refetched —
-  //     re-reading it would only 404 and leave an error where a note was.
+  //  3. **A vanished open note closes the pane** rather than being refetched —
+  //     re-reading it would only 404 and leave an error where a note was. Which
+  //     notes vanished is settled against the refreshed tree, not against the
+  //     frame's id; [`planOpenNote`] carries the reasoning.
   useEffect(() => {
     if (!event) return;
-    void loadTree({ silent: true });
-    if (!openId || event.nodeId !== openId) return;
-    if (event.change === "removed") {
-      setOpenId(null);
-      setOpenFile(null);
-      setDraft(null);
-      setFileError(null);
-      setSaveState("idle");
-      return;
-    }
-    if (mode === "read") void loadFile(openId);
+    const frame = event;
+    void (async () => {
+      const tree = await loadTree({ silent: true });
+      const plan = planOpenNote({
+        openId,
+        event: frame,
+        tree,
+        mode,
+        draft,
+        saved: openFile?.content,
+      });
+      if (plan.kind === "leave") return;
+      if (plan.kind === "reload") {
+        if (openId) void loadFile(openId);
+        return;
+      }
+      closeVanished(plan.rescue);
+    })();
     // `event.tick` is the dependency that makes a repeat write on the same node
     // re-run this; `mode` and `openId` are read, not watched, so switching to
     // Read does not replay the last frame.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [event?.tick]);
+
+  /**
+   * The open note stopped existing while the pane held it.
+   *
+   * Cancelling the debounced save comes first and is not a tidiness step: the
+   * timer is still armed on a node the host no longer has, so leaving it would
+   * fire one guaranteed-404 write for a note that is already gone.
+   *
+   * Dropping the operator's words is the one thing this must not do. Everything
+   * else in this view can be re-read from the host; unsaved typing cannot, and
+   * the old handler cleared `draft` on its way out. So the text moves into a
+   * banner that offers it back rather than leaving with the note it was written
+   * in. A buffer with nothing unsaved in it closes silently, as it always did —
+   * a banner for text the host already has is noise.
+   */
+  function closeVanished(rescue: string | null) {
+    if (timer.current) {
+      clearTimeout(timer.current);
+      timer.current = null;
+    }
+    // Preferred over the plan's answer because it is a ref and therefore
+    // current: the operator can keep typing during the tree refetch above, and
+    // those keystrokes reach `pending` while the plan was computed from the
+    // `draft` of the render the frame arrived in.
+    const job = pending.current;
+    pending.current = null;
+    const keep = job?.content ?? rescue;
+    if (keep !== null) {
+      const gone = nodeById(nodes, openId);
+      setRescued({ name: gone ? titleOf(gone) : "Untitled", content: keep });
+    }
+    setOpenId(null);
+    setOpenFile(null);
+    setDraft(null);
+    setFileError(null);
+    setSaveState("idle");
+  }
+
+  /** Land rescued text in the workspace as a note of its own. */
+  async function saveRescued() {
+    if (!rescued) return;
+    // Cleared only on success: a failed create toasts and leaves the banner
+    // standing, because dismissing it would destroy the last copy of the text.
+    if (await createAndOpen(`${rescued.name} (recovered)`, rescued.content)) setRescued(null);
+  }
+
+  async function copyRescued() {
+    if (!rescued) return;
+    try {
+      await navigator.clipboard.writeText(rescued.content);
+      toast.success("Copied your unsaved text.");
+    } catch {
+      // No clipboard permission, or an insecure origin. The text is rendered in
+      // the banner either way, so say so rather than leaving a dead button.
+      toast.error("Couldn't copy — select the text above and copy it yourself.");
+    }
+  }
 
   /* ---- deep link into one note (#552) ---- */
 
@@ -569,7 +744,10 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
 
   /* ---- mutations (apply-on-ack) ---- */
 
-  async function createAndOpen(name: string, content?: string) {
+  // Answers whether the note actually landed, which only the rescue banner
+  // reads: it is holding the last copy of some text and must not clear itself
+  // on a create that failed.
+  async function createAndOpen(name: string, content?: string): Promise<boolean> {
     try {
       const created = await createNode(client, company, {
         name: ensureMdExt(name.trim() || "Untitled"),
@@ -595,8 +773,10 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
       setDraft(content ?? "");
       setSaveState("idle");
       setMode("edit");
+      return true;
     } catch (e) {
       toast.error(message(e, "could not create the note"));
+      return false;
     }
   }
 
@@ -786,6 +966,40 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
               <Button size="sm" variant="ghost" disabled={importing} onClick={discardLegacy}>
                 Discard
               </Button>
+            </AlertDescription>
+          </Alert>
+        )}
+        {/* Words rescued from a note that was deleted out from under the
+            editor. Rendered above whatever is in the pane rather than inside
+            it, because the note this text came from is gone and there is no
+            longer a pane it belongs to — and it stays until the operator does
+            something with it, since dismissing it on the next click is how the
+            last copy of a paragraph gets thrown away. */}
+        {rescued && (
+          <Alert className="m-3 mb-0 w-auto" data-testid="workspace-rescued-banner">
+            <AlertDescription className="flex flex-col items-stretch gap-2">
+              <span>
+                “{rescued.name}” was deleted while you were writing in it. Your unsaved text is
+                below — save it as a new note, or copy it out.
+              </span>
+              <Textarea
+                readOnly
+                value={rescued.content}
+                aria-label="Your unsaved text"
+                data-testid="workspace-rescued-text"
+                className="max-h-48 resize-none font-mono text-xs"
+              />
+              <span className="flex flex-wrap gap-2">
+                <Button size="sm" onClick={() => void saveRescued()}>
+                  Save as new note
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => void copyRescued()}>
+                  Copy
+                </Button>
+                <Button size="sm" variant="ghost" onClick={() => setRescued(null)}>
+                  Discard
+                </Button>
+              </span>
             </AlertDescription>
           </Alert>
         )}

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -71,9 +71,42 @@ import {
 } from "@/lib/workspace";
 import { useLocalScope } from "@/connections/ConnectionContext";
 
+/**
+ * The latest workspace write off the SSE feed (issue #327), as the shell hands
+ * it down.
+ *
+ * `tick` is what makes this a stream of *events* rather than a piece of state:
+ * two frames naming the same node in one React batch would otherwise collapse
+ * into one object React considers unchanged, and the second write would never
+ * be reacted to.
+ */
+export interface WorkspaceEvent {
+  /** Monotonic, bumped per frame. */
+  tick: number;
+  /** The node that moved. */
+  nodeId: string;
+  /** `opened` | `updated` | `removed`, widened for a newer host's vocabulary. */
+  change: string;
+}
+
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * The latest write anywhere in this company's tree (issue #327). `null` until
+   * one arrives, and on a host with no `/events` route — where this view keeps
+   * exactly its old refresh-and-refocus behaviour.
+   */
+  event?: WorkspaceEvent | null;
+  /**
+   * A node to open on arrival (issue #552), from the `#/workspace/<nodeId>`
+   * hash segment the Artifacts tab's "Open in workspace" link sets.
+   *
+   * Unvalidated, as `useHashView` documents: an id that names nothing resolves
+   * against the host and simply reports that the note could not be opened,
+   * which is the same thing a stale bookmark does.
+   */
+  initialNodeId?: string | null;
 }
 
 /** How long typing settles before the editor pushes a save to the host. */
@@ -173,7 +206,7 @@ function message(e: unknown, fallback: string): string {
  * (#326), and there is no live push, so a write that lands while the tab is open
  * appears on refresh/refocus rather than instantly (#327).
  */
-export function WorkspaceView({ client, company }: Props) {
+export function WorkspaceView({ client, company, event, initialNodeId }: Props) {
   // Which (connection, company) this subtree's browser-local state belongs to.
   const scope = useLocalScope();
   const [nodes, setNodes] = useState<FsNode[]>([]);
@@ -364,9 +397,9 @@ export function WorkspaceView({ client, company }: Props) {
 
   /* ---- refresh on refocus ---- */
 
-  // No live push (#327): a note written by an agent or another browser is
-  // invisible until we ask again. Coming back to the tab is the moment an
-  // operator most expects to see current state, so refetch quietly there.
+  // The fallback half, kept: a host with no `/events` route, or a dropped
+  // stream, leaves this view exactly as it behaved before #327. Coming back to
+  // the tab is the moment an operator most expects to see current state.
   useEffect(() => {
     const refresh = () => {
       if (document.visibilityState === "visible") void loadTree({ silent: true });
@@ -378,6 +411,58 @@ export function WorkspaceView({ client, company }: Props) {
       document.removeEventListener("visibilitychange", refresh);
     };
   }, [loadTree]);
+
+  /* ---- live writes (#327) ---- */
+
+  // A note written by an agent, by the publish drain, or by another browser
+  // used to be invisible until the operator refreshed or refocused. Now the
+  // host announces every workspace write and this reacts to it.
+  //
+  // Three rules, and the middle one is the one with teeth:
+  //
+  //  1. **Always refetch the tree, silently.** The frame carries no name and no
+  //     body by design, so the tree read is where content comes from — and a
+  //     silent refetch means a note appearing elsewhere never flickers the
+  //     explorer or steals the operator's place.
+  //  2. **Never clobber an in-progress edit.** The open note is refetched only
+  //     in read mode. In edit mode the operator has a dirty buffer and an
+  //     autosave in flight; replacing the body underneath them would discard
+  //     typing that no refetch can get back. They see the change when they
+  //     switch back to Read, which already refetches.
+  //  3. **A deleted open note closes the pane** rather than being refetched —
+  //     re-reading it would only 404 and leave an error where a note was.
+  useEffect(() => {
+    if (!event) return;
+    void loadTree({ silent: true });
+    if (!openId || event.nodeId !== openId) return;
+    if (event.change === "removed") {
+      setOpenId(null);
+      setOpenFile(null);
+      setDraft(null);
+      setFileError(null);
+      setSaveState("idle");
+      return;
+    }
+    if (mode === "read") void loadFile(openId);
+    // `event.tick` is the dependency that makes a repeat write on the same node
+    // re-run this; `mode` and `openId` are read, not watched, so switching to
+    // Read does not replay the last frame.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [event?.tick]);
+
+  /* ---- deep link into one note (#552) ---- */
+
+  // The Artifacts tab's "Open in workspace" link sets `#/workspace/<nodeId>`,
+  // and the shell hands that segment down. Opened once per id: `open()` sets
+  // `openId`, and re-running on every render would fight an operator who then
+  // clicked a different note.
+  const landedOn = useRef<string | null>(null);
+  useEffect(() => {
+    if (!initialNodeId || landedOn.current === initialNodeId) return;
+    landedOn.current = initialNodeId;
+    void open(initialNodeId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialNodeId]);
 
   /* ---- migration off the retired localStorage scratchpad ---- */
 

--- a/frontend/test/unit/workspace-events.test.ts
+++ b/frontend/test/unit/workspace-events.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const toasts = vi.hoisted(() => ({
+  base: vi.fn(),
+  success: vi.fn(),
+  error: vi.fn(),
+  warning: vi.fn(),
+  info: vi.fn(),
+}));
+
+vi.mock("sonner", () => {
+  const toast = Object.assign(toasts.base, {
+    success: toasts.success,
+    error: toasts.error,
+    warning: toasts.warning,
+    info: toasts.info,
+  });
+  return { toast };
+});
+
+const { handleEvent } = await import("@/hooks/use-events");
+type Ev = import("@/hooks/use-events").CompanyStreamEvent;
+type Subs = import("@/hooks/use-events").Subscribers;
+
+/**
+ * Issue #327: the console half of "the workspace announces its own writes".
+ *
+ * The host now projects a `workspace_changed` frame, but this file's own docs
+ * record that a frame the host sends and this switch does not name is silently
+ * dropped — it has happened three times (#464, #371, #384), and each time the
+ * surface stayed stale with nothing to debug. So the routing is pinned here.
+ */
+describe("workspace_changed routing", () => {
+  function subscribers() {
+    return {
+      onAgentReply: vi.fn(),
+      onTaskEvent: vi.fn(),
+      onWorkspaceEvent: vi.fn(),
+      onTurnEvent: vi.fn(),
+      onWorkflowRunEvent: vi.fn(),
+      onWorkflowChanged: vi.fn(),
+      onApprovalEvent: vi.fn(),
+    } satisfies Subs;
+  }
+
+  const frame = (change: string): Ev => ({
+    type: "workspace_changed",
+    seq: 7,
+    atMillis: 1,
+    nodeId: "n-1",
+    change,
+  });
+
+  beforeEach(() => {
+    for (const fn of Object.values(toasts)) fn.mockClear();
+  });
+
+  it("reaches the workspace subscriber and no other", () => {
+    const subs = subscribers();
+    handleEvent(frame("updated"), subs);
+
+    expect(subs.onWorkspaceEvent).toHaveBeenCalledTimes(1);
+    expect(subs.onWorkspaceEvent).toHaveBeenCalledWith(frame("updated"));
+    // The board's subscriber is the tempting mis-wire: both frames are "a store
+    // changed", but they refetch different surfaces, and crossing them would
+    // make every note save re-read the board.
+    expect(subs.onTaskEvent).not.toHaveBeenCalled();
+    expect(subs.onWorkflowChanged).not.toHaveBeenCalled();
+    expect(subs.onApprovalEvent).not.toHaveBeenCalled();
+    expect(subs.onTurnEvent).not.toHaveBeenCalled();
+    expect(subs.onAgentReply).not.toHaveBeenCalled();
+  });
+
+  it("carries the payload, not just the fact that something happened", () => {
+    // Unlike the board's counter-based subscriber, the view's reaction depends
+    // on WHICH node moved — the open note is refetched only when the frame
+    // names it, and a removal closes the pane. A counter cannot say that.
+    const subs = subscribers();
+    handleEvent(frame("removed"), subs);
+    const [received] = subs.onWorkspaceEvent.mock.calls[0] as [Ev];
+    expect(received).toMatchObject({ nodeId: "n-1", change: "removed" });
+  });
+
+  it("raises no toast for any change word", () => {
+    // A workspace write is not an attention signal: an autosaving editor fires
+    // one per settled keystroke burst and every published deliverable adds
+    // more. Toasting those would train the operator to dismiss the toasts that
+    // do matter.
+    const subs = subscribers();
+    for (const change of ["opened", "updated", "removed"]) handleEvent(frame(change), subs);
+
+    expect(subs.onWorkspaceEvent).toHaveBeenCalledTimes(3);
+    for (const fn of Object.values(toasts)) expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a change word a newer host invented", () => {
+    // `change` is widened past the host's three words on purpose, so a newer
+    // host cannot make this a type error — and an unknown word must still
+    // refetch rather than be dropped.
+    const subs = subscribers();
+    handleEvent(frame("restored"), subs);
+    expect(subs.onWorkspaceEvent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/test/unit/workspace-open-note-plan.test.ts
+++ b/frontend/test/unit/workspace-open-note-plan.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+
+import { planOpenNote } from "@/views/WorkspaceView";
+import type { FsNode } from "@/lib/workspace";
+import type { WorkspaceEvent } from "@/views/WorkspaceView";
+
+/**
+ * What a live workspace write (issue #327) means for the note in the pane.
+ *
+ * The case this file exists for is the **ancestor delete**: the host announces
+ * one `removed` frame naming the node somebody deleted — a folder — and never
+ * one per descendant. So an open note inside that folder disappears with no
+ * frame that ever says its id, and the id comparison this used to run declared
+ * the frame somebody else's business. The pane stayed open on a note that was
+ * gone, holding a draft and an armed autosave whose only possible outcome was a
+ * 404, and the operator's unsaved words left with it.
+ *
+ * Both directions are pinned below, and so is the thing neither must ever do:
+ * discard text the host does not already have.
+ */
+
+const OPEN = "n-note";
+const FOLDER = "n-folder";
+
+/** A tree with the open note living inside a folder. */
+const withNote: FsNode[] = [
+  {
+    id: FOLDER,
+    name: "Campaigns",
+    kind: "folder",
+    parentId: null,
+    updatedAt: 1,
+    createdBy: { kind: "operator" },
+    updatedBy: { kind: "operator" },
+  },
+  {
+    id: OPEN,
+    name: "Launch.md",
+    kind: "file",
+    parentId: FOLDER,
+    updatedAt: 1,
+    createdBy: { kind: "operator" },
+    updatedBy: { kind: "operator" },
+  },
+];
+
+/** The same tree after the folder — and everything under it — was deleted. */
+const withoutFolder: FsNode[] = [];
+
+const frame = (nodeId: string, change: string): WorkspaceEvent => ({
+  tick: 1,
+  nodeId,
+  change,
+});
+
+/** The open note, being edited, with a paragraph the host has never seen. */
+const dirty = { draft: "half-written paragraph", saved: "" };
+
+describe("planOpenNote", () => {
+  it("rescues the draft when the open note itself is deleted", () => {
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(OPEN, "removed"),
+      tree: withoutFolder,
+      mode: "edit",
+      ...dirty,
+    });
+
+    expect(plan).toEqual({ kind: "vanished", rescue: "half-written paragraph" });
+  });
+
+  it("rescues the draft when an ANCESTOR folder is deleted", () => {
+    // The regression. The frame names the folder and says nothing about the
+    // open note, so the old id comparison returned early — and the note was
+    // already out of the tree by the time it did.
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(FOLDER, "removed"),
+      tree: withoutFolder,
+      mode: "edit",
+      ...dirty,
+    });
+
+    expect(plan).toEqual({ kind: "vanished", rescue: "half-written paragraph" });
+  });
+
+  it("never asks for a re-read of a note that is gone", () => {
+    // The one thing a vanished note must not produce. `reload` is the only
+    // plan that goes back to the host for this id, and against a deleted node
+    // it can only 404 — which is what left an error where a note used to be.
+    for (const named of [OPEN, FOLDER]) {
+      const plan = planOpenNote({
+        openId: OPEN,
+        event: frame(named, "removed"),
+        tree: withoutFolder,
+        mode: "read",
+        draft: null,
+        saved: "body",
+      });
+      expect(plan.kind).toBe("vanished");
+    }
+  });
+
+  it("closes quietly when the buffer holds nothing the host lacks", () => {
+    // Opening a note in Edit seeds the buffer from a fresh read, so a note
+    // merely opened and then deleted elsewhere has nothing to hand back. A
+    // banner offering the operator their own unchanged text is noise.
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(FOLDER, "removed"),
+      tree: withoutFolder,
+      mode: "edit",
+      draft: "body",
+      saved: "body",
+    });
+
+    expect(plan).toEqual({ kind: "vanished", rescue: null });
+  });
+
+  it("leaves a surviving open note alone when the frame is somebody else's", () => {
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame("n-elsewhere", "updated"),
+      tree: withNote,
+      mode: "read",
+      draft: null,
+      saved: "body",
+    });
+
+    expect(plan).toEqual({ kind: "leave" });
+  });
+
+  it("re-reads the open note when the frame names it and nobody is typing", () => {
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(OPEN, "updated"),
+      tree: withNote,
+      mode: "read",
+      draft: null,
+      saved: "body",
+    });
+
+    expect(plan).toEqual({ kind: "reload" });
+  });
+
+  it("refuses to re-read over an in-progress edit", () => {
+    // Rule 2 of the effect, kept: replacing the body under a dirty buffer would
+    // discard typing that no refetch can get back.
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(OPEN, "updated"),
+      tree: withNote,
+      mode: "edit",
+      ...dirty,
+    });
+
+    expect(plan).toEqual({ kind: "leave" });
+  });
+
+  it("does not close the pane because the tree refetch failed", () => {
+    // `null` is "this read answered nothing", not "the note is gone". Closing
+    // on it would cost the operator their place every time the host hiccuped.
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame("n-elsewhere", "removed"),
+      tree: null,
+      mode: "edit",
+      ...dirty,
+    });
+
+    expect(plan).toEqual({ kind: "leave" });
+  });
+
+  it("still trusts a removal frame naming the open note when the refetch failed", () => {
+    // The one case the frame settles and the tree cannot: it says outright that
+    // this id is gone, so the armed autosave behind the pane has to be stopped
+    // even though no refreshed list arrived to confirm it.
+    const plan = planOpenNote({
+      openId: OPEN,
+      event: frame(OPEN, "removed"),
+      tree: null,
+      mode: "edit",
+      ...dirty,
+    });
+
+    expect(plan).toEqual({ kind: "vanished", rescue: "half-written paragraph" });
+  });
+
+  it("has nothing to decide when no note is open", () => {
+    const plan = planOpenNote({
+      openId: null,
+      event: frame(OPEN, "removed"),
+      tree: withoutFolder,
+      mode: "read",
+      draft: null,
+      saved: null,
+    });
+
+    expect(plan).toEqual({ kind: "leave" });
+  });
+});

--- a/src/app/boot.rs
+++ b/src/app/boot.rs
@@ -131,6 +131,17 @@ mod test {
         );
     }
 
+    /// How long [`releasing_the_instance_frees_the_root`] waits for a released
+    /// root to become takeable, and how long it sleeps between attempts.
+    ///
+    /// The window this rides out is measured in microseconds (see the test's
+    /// own comment), so two seconds is several orders of magnitude of headroom
+    /// — generous enough that only a genuinely stuck lock exhausts it, short
+    /// enough that a real regression fails the suite promptly rather than
+    /// looking like a hang.
+    const RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+    const RELEASE_POLL: std::time::Duration = std::time::Duration::from_millis(10);
+
     #[tokio::test]
     async fn releasing_the_instance_frees_the_root() {
         // A desktop app restarted after a clean quit must be able to start.
@@ -140,8 +151,36 @@ mod test {
                 .await
                 .unwrap(),
         );
-        let again = prepare_instance(Some(dir.path().to_path_buf())).await;
-        assert!(again.is_ok(), "a released root must be takeable: {again:?}");
+
+        // Retried rather than asserted in the same instant, because an instant
+        // re-acquire is stricter than the lock promises. `store::lock`'s "The
+        // fork window" section states it outright: the lock belongs to the open
+        // file description, so between `fork()` and `exec()` a child transiently
+        // shares every descriptor its parent held. This binary spawns
+        // subprocesses in sibling tests (`app::journal`'s vendored-seam and
+        // keyring-pin children), and one landing in this test's release window
+        // keeps the just-released root locked for the microseconds until the
+        // child `exec`s and its `O_CLOEXEC` copy closes.
+        //
+        // So this asserts what the lock actually guarantees — that the root
+        // *becomes* takeable — and not that it is takeable within one
+        // instruction. A lock that never releases still fails: the loop reports
+        // the last refusal after the timeout rather than passing quietly, which
+        // is what stops the retry being a blindfold over a real regression.
+        let deadline = std::time::Instant::now() + RELEASE_TIMEOUT;
+        let mut attempts = 0;
+        let last = loop {
+            attempts += 1;
+            match prepare_instance(Some(dir.path().to_path_buf())).await {
+                Ok(_) => return,
+                Err(e) if std::time::Instant::now() >= deadline => break e,
+                Err(_) => tokio::time::sleep(RELEASE_POLL).await,
+            }
+        };
+        panic!(
+            "a released root must become takeable, but {attempts} attempts over \
+             {RELEASE_TIMEOUT:?} were all refused; last error: {last}"
+        );
     }
 
     #[tokio::test]

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -493,10 +493,21 @@ fn manifest(policy_mode: &str) -> CompanyManifest {
     toml::from_str(&toml_src).expect("valid manifest")
 }
 
+/// How many events a fresh company already has in its journal by the time it
+/// finishes booting (issue #327).
+///
+/// Boot lays down the reserved workspace roots, and since #327 the workspace
+/// store announces its own writes — so one `WorkspaceChanged` per root is
+/// journalled before any operator message arrives. Derived from `SYSTEM_ROOTS`
+/// rather than written as a literal, so adding a root cannot silently
+/// desynchronise the scripted cycle id below from the one the runtime computes.
+const BOOT_JOURNAL_EVENTS: u64 = crate::company::workspace_scaffold::SYSTEM_ROOTS.len() as u64;
+
 /// The deterministic first-cycle id a real runtime for `Acme` produces: the
-/// company id slugs to `acme`, the first event lands at seq 0.
+/// company id slugs to `acme`, and the first *cycle* event lands at the first
+/// sequence boot did not already use.
 fn runtime_cid() -> String {
-    wire::cycle_id("opencompany:acme", "acme", 0)
+    wire::cycle_id("opencompany:acme", "acme", BOOT_JOURNAL_EVENTS)
 }
 
 #[tokio::test]

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -186,6 +186,18 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
         // same reason they stay off the operator SSE projection: this body is
         // sent to the inference sidecar, and a board write is not a place to
         // hand it operator-authored text nobody asked to send.
+        // Issue #327: the tree's counterpart to the board announcement below,
+        // and on exactly its terms — written for completeness, not for a live
+        // path, since a workspace write starts no cycle and a brain therefore
+        // never sees one here. Structural only: the node's NAME is deliberately
+        // absent, because it is operator-authored free text and this body goes
+        // to the inference sidecar.
+        CompanyEvent::WorkspaceChanged { node_id, change } => (
+            Role::System,
+            "workspace".to_string(),
+            format!("Workspace node {node_id} {change}"),
+            "workspace.changed",
+        ),
         CompanyEvent::TaskCardChanged {
             task_id,
             change,

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -1,0 +1,766 @@
+//! The seam between a task artifact and the shared workspace tree (issue #552,
+//! folding in #327's missing push channel).
+//!
+//! # The problem this closes
+//!
+//! `publish_artifact` used to drain into the [`ArtifactStore`] and stop. An
+//! artifact is reachable from exactly one place — the Artifacts tab of one
+//! card — so a deliverable an agent explicitly published was invisible to the
+//! operator browsing the workspace and to every *other* agent, whose only view
+//! of shared company state is the note tree. "The CMO wrote the launch brief"
+//! had no answer anyone could navigate to.
+//!
+//! # Two surfaces, one truth
+//!
+//! A published deliverable now lives twice, and the split is deliberate:
+//!
+//! * The **artifact chain is authoritative**. It holds the full version
+//!   history, the authorship of each revision, and therefore
+//!   [`ArtifactRecord::human_edit_diff`] — the one quality datum the artifact
+//!   port exists to produce.
+//! * The **workspace node is a projection** holding the *current* body only.
+//!   It is what makes the deliverable browsable and readable by teammates.
+//!
+//! The rejected alternative was to make the node the storage and have the
+//! artifact reference it. That would push versioning down into
+//! [`WorkspaceStore`] across all three backends, turn every artifact read into
+//! a two-store join, and re-open the `(task_id, source)` identity contract that
+//! #244 settled. A projection costs one extra write; the inversion costs the
+//! port.
+//!
+//! **The invariant**: `node.body == chain.latest().body` after any successful
+//! write on either surface.
+//!
+//! # Ordering: chain first, wherever there is a choice
+//!
+//! Every path here writes the chain before the node when it can. The two
+//! failure modes are not symmetric:
+//!
+//! * Chain ahead of node — a stale node. Visible, harmless, and self-healing:
+//!   the next write on either surface reconciles it.
+//! * Node ahead of chain — an edit to a published deliverable that the version
+//!   history never recorded. That is silent, permanent, and corrupts
+//!   `human_edit_diff`, which is the exact rot the artifact port was built to
+//!   prevent.
+//!
+//! So a failed mirror is logged and tolerated in the first direction and
+//! avoided in the second. One path cannot have it: the agent's
+//! `workspace_write` tool must complete its compare-and-swap before it knows
+//! the write landed at all, so there the node necessarily moves first. It is
+//! the narrowest window available rather than a different policy.
+//!
+//! # Why this module is in the default build
+//!
+//! [`mirror_node_edit`] has three callers across two layers — the console's
+//! workspace `PUT` and artifact-append routes (`src/server/ops/`, always
+//! compiled) and the agent's `workspace_write` tool (`src/harness/`, compiled
+//! only under the `openhuman` feature). The shared half therefore cannot live
+//! in the harness, or the default build could not reach it.
+
+use crate::Result;
+use crate::error::OpenCompanyError;
+use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord, ArtifactStore};
+use crate::ports::now_millis;
+use crate::ports::types::CompanyId;
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+use super::workspace_scaffold::{create_folder, ensure_agent_folder};
+
+/// One publish, as [`materialize`] needs it.
+///
+/// A struct rather than seven positional parameters: five of the fields are
+/// `&str`, so a call site that transposed `task_id` and `source` would compile
+/// perfectly and file every deliverable in the wrong folder.
+#[derive(Debug, Clone, Copy)]
+pub struct PublishTarget<'a> {
+    /// The agent that published this file — the owner of the `Agents/<id>/`
+    /// folder it lands under, and the authorship stamped on every node created
+    /// or written along the way.
+    pub agent_id: &'a str,
+    /// The card the publish belongs to. Names the folder beneath the agent's,
+    /// so two tasks by one agent cannot collide on a common filename.
+    pub task_id: &'a str,
+    /// The normalized workspace-relative path the agent published, e.g.
+    /// `specs/launch.md`. Interior segments become folders.
+    pub source: &'a str,
+    /// The body to store — the file's text, or the reference block a
+    /// non-UTF-8 or over-cap file produced. Written verbatim.
+    pub body: &'a str,
+    /// The node the previous version of this artifact was mirrored into, when
+    /// there was one. Reused if it still resolves; see [`materialize`].
+    pub existing_node_id: Option<&'a str>,
+}
+
+/// Put `target`'s body into the shared tree and return the node id holding it.
+///
+/// The layout is `Agents/<agent-id>/<task-id>/<source…>`. The agent's folder is
+/// minted on demand by
+/// [`ensure_agent_folder`](super::workspace_scaffold::ensure_agent_folder) —
+/// member folders appear the first time somebody produces something, so this
+/// must **call** it rather than assume it exists.
+///
+/// # Interior path segments become folders
+///
+/// `specs/launch.md` lands as `…/<task-id>/specs/launch.md`, not as a file
+/// literally named `specs/launch.md`. Flattening to the basename would make
+/// `specs/a.md` and `docs/a.md` — two genuinely different deliverables of one
+/// task — collide on one node and overwrite each other.
+///
+/// # Re-publish reuses the node, unless the operator removed it
+///
+/// `existing_node_id` is reused when it still resolves to a file, so a second
+/// publish of the same path revises the note the operator has been reading
+/// rather than opening a rival beside it. When it is absent (a pre-#552 record)
+/// or no longer resolves (the operator deleted it, and deletions stick), a
+/// fresh node is materialized and the *new* version carries the new id. Older
+/// versions keep the id of the node that actually held them — honest history,
+/// the same shape as `run_id`.
+///
+/// # Ambiguity is refused, never guessed
+///
+/// Identity here is by path and no backend enforces unique sibling names, so
+/// every lookup is check-then-act. A name carried by a node of the wrong kind,
+/// or by more than one node, is a [`Conflict`](OpenCompanyError::Conflict)
+/// rather than a coin flip — the same fail-closed rule
+/// [`workspace_scaffold`](super::workspace_scaffold) applies one level up.
+pub async fn materialize(
+    workspace: &dyn WorkspaceStore,
+    company: &CompanyId,
+    target: PublishTarget<'_>,
+) -> Result<String> {
+    // The cheap path, and the common one on a re-publish: the node from last
+    // time still exists, so revise it in place and keep every reference to it
+    // (the console's deep link, an operator's bookmark) working.
+    if let Some(existing) = target.existing_node_id
+        && let Some((node, _)) = workspace.read(company, existing).await?
+        && node.kind == NodeKind::File
+    {
+        workspace
+            .write(company, existing, target.body, origin(target.agent_id))
+            .await?;
+        return Ok(existing.to_string());
+    }
+
+    let segments = split_source(target.source)?;
+    let (dirs, filename) = segments
+        .split_last()
+        .map(|(last, rest)| (rest, *last))
+        .expect("split_source rejects an empty path");
+
+    let agent_folder = ensure_agent_folder(workspace, company, target.agent_id).await?;
+
+    // One tree read, then a walk that keeps its own view current: each folder
+    // this creates is pushed onto `nodes`, so a `specs/deep/note.md` resolves
+    // its second segment against the first segment it just minted rather than
+    // against a snapshot that predates it.
+    let mut nodes = workspace.tree(company).await?;
+    let mut parent = agent_folder;
+    for name in std::iter::once(target.task_id).chain(dirs.iter().copied()) {
+        parent = resolve_folder(
+            workspace,
+            company,
+            &mut nodes,
+            &parent,
+            name,
+            target.agent_id,
+        )
+        .await?;
+    }
+
+    match resolve_file(&nodes, &parent, filename)? {
+        // A node is already there under this exact path — an earlier publish
+        // whose id we lost, or a note the agent wrote by hand. Revising it is
+        // the only non-destructive answer: minting a rival would leave the path
+        // permanently ambiguous, which the tool layer's resolver then refuses
+        // for every agent.
+        Some(id) => {
+            workspace
+                .write(company, &id, target.body, origin(target.agent_id))
+                .await?;
+            Ok(id)
+        }
+        None => {
+            let node = WorkspaceNode {
+                id: crate::ports::generate_id(),
+                name: filename.to_string(),
+                kind: NodeKind::File,
+                parent_id: Some(parent),
+                updated_at_millis: now_millis(),
+                created_by: origin(target.agent_id),
+                updated_by: origin(target.agent_id),
+            };
+            workspace.create(company, &node, Some(target.body)).await?;
+            Ok(node.id)
+        }
+    }
+}
+
+/// Record an edit to `node_id` on the artifact chain that owns it, when one
+/// does.
+///
+/// The reverse lookup that keeps the two surfaces from diverging: a workspace
+/// node the operator (or an agent) rewrites may be a *published deliverable*,
+/// and an edit to one that never reached the version history is exactly the
+/// silent corruption the artifact port exists to prevent.
+///
+/// Returns `None` — and touches nothing — when `node_id` names an ordinary
+/// note. Most of the tree is ordinary notes, so this is the common answer and
+/// deliberately not an error.
+///
+/// # The scan, named rather than hidden
+///
+/// This lists the company's artifacts and looks for one whose *latest* version
+/// carries `node_id`. That is a linear scan per save. It is bounded by what
+/// artifacts are — a task's drafts and posts, not a repository — and buying an
+/// index before there is a workload to size it against would be guessing. The
+/// latest version rather than any version is the point: an operator's deletion
+/// of a node sticks, so an old version's id names a node that is gone, and
+/// matching on it would mirror today's edit into yesterday's history.
+pub async fn mirror_node_edit(
+    artifacts: &dyn ArtifactStore,
+    company: &CompanyId,
+    node_id: &str,
+    body: &str,
+    author: ArtifactAuthor,
+    author_id: &str,
+    note: Option<String>,
+) -> Result<Option<MirroredEdit>> {
+    let Some(mut record) = published_record_for_node(artifacts, company, node_id).await? else {
+        return Ok(None);
+    };
+    let version = record.push_version(body, author, author_id, now_millis(), note);
+    // The appended version lives in the same node as the one before it. Without
+    // this the *next* edit's reverse lookup — which reads the latest version —
+    // would find nothing and silently stop mirroring.
+    record.stamp_workspace_node(node_id);
+    artifacts.upsert(company, &record).await?;
+    Ok(Some(MirroredEdit {
+        artifact_id: record.id,
+        version,
+    }))
+}
+
+/// What [`mirror_node_edit`] appended, for a caller that wants to log or return
+/// it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MirroredEdit {
+    /// The artifact the edit was recorded on.
+    pub artifact_id: String,
+    /// The version number the edit became.
+    pub version: u32,
+}
+
+/// The artifact whose current body lives in `node_id`, if any.
+///
+/// Shared by [`mirror_node_edit`] and the console's artifact-append route,
+/// which needs the same "is this a published deliverable?" answer from the
+/// other direction.
+pub async fn published_record_for_node(
+    artifacts: &dyn ArtifactStore,
+    company: &CompanyId,
+    node_id: &str,
+) -> Result<Option<ArtifactRecord>> {
+    Ok(artifacts
+        .list(company, None)
+        .await?
+        .into_iter()
+        .find(|record| record.workspace_node_id() == Some(node_id)))
+}
+
+/// This agent's authorship stamp. A published deliverable is the agent's work,
+/// so every node created or written along its path is attributed to it.
+fn origin(agent_id: &str) -> WorkspaceOrigin {
+    WorkspaceOrigin::Agent {
+        id: agent_id.to_string(),
+    }
+}
+
+/// Split a normalized publish path into its segments, rejecting anything that
+/// cannot name a chain of workspace nodes.
+///
+/// The publish tool normalizes before it gets here, so this is a guard against
+/// a hand-built `PendingPublish` rather than the ordinary path — but a `..`
+/// reaching [`WorkspaceStore::create`] as a node *name* would render a
+/// traversal-shaped path in the console, and the sqlite and mongodb backends do
+/// not reject one.
+fn split_source(source: &str) -> Result<Vec<&str>> {
+    let segments: Vec<&str> = source
+        .split('/')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if segments.is_empty() {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "`{source}` names no workspace path segments, so it cannot be published into the tree"
+        )));
+    }
+    for segment in &segments {
+        if *segment == "." || *segment == ".." || segment.contains('\\') || segment.contains('\0') {
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "`{source}` contains a segment that cannot name a workspace node"
+            )));
+        }
+    }
+    Ok(segments)
+}
+
+/// Adopt-or-create the folder `name` under `parent`, keeping `nodes` current.
+async fn resolve_folder(
+    workspace: &dyn WorkspaceStore,
+    company: &CompanyId,
+    nodes: &mut Vec<WorkspaceNode>,
+    parent: &str,
+    name: &str,
+    agent_id: &str,
+) -> Result<String> {
+    let matches: Vec<&WorkspaceNode> = children_named(nodes, parent, name);
+    match matches.as_slice() {
+        [one] if one.kind == NodeKind::Folder => Ok(one.id.clone()),
+        [_] => Err(OpenCompanyError::Conflict(format!(
+            "`{name}` already exists as a note, not a folder, so a deliverable cannot be published \
+             beneath it"
+        ))),
+        [] => {
+            let id = create_folder(
+                workspace,
+                company,
+                name,
+                Some(parent.to_string()),
+                origin(agent_id),
+            )
+            .await?;
+            nodes.push(WorkspaceNode {
+                id: id.clone(),
+                name: name.to_string(),
+                kind: NodeKind::Folder,
+                parent_id: Some(parent.to_string()),
+                updated_at_millis: now_millis(),
+                created_by: origin(agent_id),
+                updated_by: origin(agent_id),
+            });
+            Ok(id)
+        }
+        many => Err(OpenCompanyError::Conflict(format!(
+            "{count} nodes under this folder are named `{name}`, so the path is ambiguous",
+            count = many.len()
+        ))),
+    }
+}
+
+/// The existing file `name` under `parent`, or `None` when the name is free.
+fn resolve_file(nodes: &[WorkspaceNode], parent: &str, name: &str) -> Result<Option<String>> {
+    let matches = children_named(nodes, parent, name);
+    match matches.as_slice() {
+        [one] if one.kind == NodeKind::File => Ok(Some(one.id.clone())),
+        [_] => Err(OpenCompanyError::Conflict(format!(
+            "`{name}` already exists as a folder, not a note, so a deliverable cannot be published \
+             over it"
+        ))),
+        [] => Ok(None),
+        many => Err(OpenCompanyError::Conflict(format!(
+            "{count} nodes under this folder are named `{name}`, so the path is ambiguous",
+            count = many.len()
+        ))),
+    }
+}
+
+/// Every node directly under `parent` carrying `name`.
+fn children_named<'a>(
+    nodes: &'a [WorkspaceNode],
+    parent: &str,
+    name: &str,
+) -> Vec<&'a WorkspaceNode> {
+    nodes
+        .iter()
+        .filter(|node| node.parent_id.as_deref() == Some(parent) && node.name == name)
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::company::workspace_scaffold::AGENTS_ROOT;
+    use crate::ports::artifacts::ArtifactKind;
+    use crate::store::FsOps;
+
+    /// One `FsOps` backing both ports, so a test exercises the real stores
+    /// rather than a stub that cannot tell a create from an overwrite.
+    fn stores() -> (tempfile::TempDir, Arc<FsOps>, CompanyId) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ops = Arc::new(FsOps::new(dir.path()));
+        (dir, ops, CompanyId::new("mirror-co"))
+    }
+
+    /// A node's rendered path, so an assertion reads as a path rather than a
+    /// ULID.
+    async fn path_of(ws: &dyn WorkspaceStore, company: &CompanyId, id: &str) -> String {
+        let nodes = ws.tree(company).await.unwrap();
+        let mut parts = Vec::new();
+        let mut cursor = Some(id.to_string());
+        while let Some(current) = cursor {
+            let Some(node) = nodes.iter().find(|n| n.id == current) else {
+                break;
+            };
+            parts.push(node.name.clone());
+            cursor = node.parent_id.clone();
+        }
+        parts.reverse();
+        parts.join("/")
+    }
+
+    fn target<'a>(source: &'a str, body: &'a str) -> PublishTarget<'a> {
+        PublishTarget {
+            agent_id: "cmo",
+            task_id: "t-1",
+            source,
+            body,
+            existing_node_id: None,
+        }
+    }
+
+    /// The headline: a published deliverable lands in the shared tree, under
+    /// the publishing agent's own folder, attributed to it.
+    ///
+    /// The agent folder is asserted rather than assumed because it does not
+    /// exist beforehand — member folders are minted on first use (#570), so
+    /// this proves `materialize` calls the minter instead of expecting a
+    /// folder somebody else laid down.
+    #[tokio::test]
+    async fn a_publish_lands_under_the_agents_own_folder_it_mints() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let id = materialize(ws, &co, target("launch.md", "# Launch"))
+            .await
+            .expect("materialize");
+
+        assert_eq!(
+            path_of(ws, &co, &id).await,
+            format!("{AGENTS_ROOT}/cmo/t-1/launch.md")
+        );
+        let (node, body) = ws.read(&co, &id).await.unwrap().expect("the node exists");
+        assert_eq!(body, "# Launch");
+        assert_eq!(node.kind, NodeKind::File);
+        assert_eq!(
+            node.created_by,
+            WorkspaceOrigin::Agent {
+                id: "cmo".to_string()
+            },
+            "a published deliverable is the agent's work, and the tree must say so"
+        );
+    }
+
+    /// Interior segments become folders. Flattening to the basename would make
+    /// two genuinely different deliverables of one task collide on one node —
+    /// so the same basename in two directories must be two nodes.
+    #[tokio::test]
+    async fn the_same_basename_in_two_directories_is_two_nodes() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let spec = materialize(ws, &co, target("specs/a.md", "spec body"))
+            .await
+            .unwrap();
+        let doc = materialize(ws, &co, target("docs/a.md", "doc body"))
+            .await
+            .unwrap();
+
+        assert_ne!(spec, doc, "one node for two paths would lose a deliverable");
+        assert_eq!(
+            path_of(ws, &co, &spec).await,
+            format!("{AGENTS_ROOT}/cmo/t-1/specs/a.md")
+        );
+        assert_eq!(
+            path_of(ws, &co, &doc).await,
+            format!("{AGENTS_ROOT}/cmo/t-1/docs/a.md")
+        );
+        assert_eq!(ws.read(&co, &spec).await.unwrap().unwrap().1, "spec body");
+        assert_eq!(ws.read(&co, &doc).await.unwrap().unwrap().1, "doc body");
+    }
+
+    /// Re-publishing with the node from last time revises **that** node, so the
+    /// operator's open tab, deep link and backlinks all keep working. Nothing
+    /// new is created.
+    #[tokio::test]
+    async fn a_republish_revises_the_same_node() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("launch.md", "draft one"))
+            .await
+            .unwrap();
+        let before = ws.tree(&co).await.unwrap().len();
+
+        let again = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                existing_node_id: Some(&first),
+                ..target("launch.md", "draft two")
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(again, first, "a re-publish must not open a rival node");
+        assert_eq!(ws.tree(&co).await.unwrap().len(), before, "nothing created");
+        assert_eq!(ws.read(&co, &first).await.unwrap().unwrap().1, "draft two");
+    }
+
+    /// The operator's deletions stick. A re-publish whose remembered node is
+    /// gone mints a fresh one rather than resurrecting the old id — and the
+    /// path is the same, so the deliverable reappears where it belongs.
+    #[tokio::test]
+    async fn a_republish_after_the_operator_deleted_the_node_mints_a_fresh_one() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("launch.md", "draft one"))
+            .await
+            .unwrap();
+        assert!(ws.delete(&co, &first).await.unwrap());
+
+        let again = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                existing_node_id: Some(&first),
+                ..target("launch.md", "draft two")
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_ne!(again, first, "a deleted node must not be resurrected by id");
+        assert_eq!(
+            path_of(ws, &co, &again).await,
+            format!("{AGENTS_ROOT}/cmo/t-1/launch.md"),
+            "the replacement belongs at the same path"
+        );
+        assert_eq!(ws.read(&co, &again).await.unwrap().unwrap().1, "draft two");
+    }
+
+    /// Losing the id but not the node — a pre-#552 record re-published — must
+    /// adopt what is already at the path rather than mint a duplicate beside
+    /// it. Two nodes on one path is precisely the ambiguity the tool layer's
+    /// resolver then refuses for every agent.
+    #[tokio::test]
+    async fn a_publish_over_an_existing_path_adopts_it_rather_than_duplicating() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("launch.md", "draft one"))
+            .await
+            .unwrap();
+        // `existing_node_id: None` is exactly what a pre-#552 artifact carries.
+        let again = materialize(ws, &co, target("launch.md", "draft two"))
+            .await
+            .unwrap();
+
+        assert_eq!(again, first, "the node already at the path must be adopted");
+        assert_eq!(ws.read(&co, &first).await.unwrap().unwrap().1, "draft two");
+    }
+
+    /// A folder sitting where the note should go is refused, not overwritten:
+    /// the deliverable would otherwise vanish into a name that resolves to
+    /// something else entirely.
+    #[tokio::test]
+    async fn a_folder_in_the_notes_place_is_refused() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        // Publish once to lay down `Agents/cmo/t-1/`, then put a folder where
+        // the next publish's note wants to be.
+        let sibling = materialize(ws, &co, target("other.md", "x")).await.unwrap();
+        let parent = ws
+            .read(&co, &sibling)
+            .await
+            .unwrap()
+            .unwrap()
+            .0
+            .parent_id
+            .unwrap();
+        create_folder(
+            ws,
+            &co,
+            "launch.md",
+            Some(parent),
+            WorkspaceOrigin::Operator,
+        )
+        .await
+        .unwrap();
+
+        let refused = materialize(ws, &co, target("launch.md", "body"))
+            .await
+            .expect_err("a folder in the note's place must be refused");
+        assert!(
+            refused.to_string().contains("already exists as a folder"),
+            "unexpected refusal: {refused}"
+        );
+    }
+
+    /// A traversal segment reaching `create` as a node *name* would render a
+    /// path the console cannot navigate, and the sqlite/mongodb backends do not
+    /// reject one — so the guard lives here.
+    #[tokio::test]
+    async fn a_traversal_segment_is_refused() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        for bad in ["../escape.md", "specs/../../escape.md", "   "] {
+            assert!(
+                materialize(ws, &co, target(bad, "body")).await.is_err(),
+                "`{bad}` must not name a workspace path"
+            );
+        }
+    }
+
+    // -- mirror_node_edit ---------------------------------------------------
+
+    /// An edit to a published node is recorded on the artifact chain, as a new
+    /// version by the editing author — which is what keeps `human_edit_diff`
+    /// answerable after the operator revises a deliverable in the console.
+    #[tokio::test]
+    async fn an_edit_to_a_published_node_appends_an_operator_version() {
+        let (_dir, ops, co) = stores();
+        let artifacts: &dyn ArtifactStore = ops.as_ref();
+
+        let mut record = ArtifactRecord::new(
+            "a-1",
+            "t-1",
+            "Launch",
+            ArtifactKind::Markdown,
+            "agent draft",
+            "cmo",
+            1,
+        );
+        record.stamp_workspace_node("node-1");
+        artifacts.upsert(&co, &record).await.unwrap();
+
+        let mirrored = mirror_node_edit(
+            artifacts,
+            &co,
+            "node-1",
+            "operator draft",
+            ArtifactAuthor::Operator,
+            "operator",
+            Some("operator edit before approval".to_string()),
+        )
+        .await
+        .unwrap()
+        .expect("a published node's edit is recorded");
+
+        assert_eq!(mirrored.artifact_id, "a-1");
+        assert_eq!(mirrored.version, 2);
+
+        let stored = artifacts.get(&co, "a-1").await.unwrap().unwrap();
+        assert_eq!(stored.latest().unwrap().body, "operator draft");
+        assert_eq!(stored.latest().unwrap().author, ArtifactAuthor::Operator);
+        assert_eq!(
+            stored.workspace_node_id(),
+            Some("node-1"),
+            "the appended version must carry the node too, or the NEXT edit's \
+             reverse lookup finds nothing and mirroring silently stops"
+        );
+        assert!(
+            stored.human_edit_diff().is_some(),
+            "the whole reason the chain must see console edits"
+        );
+    }
+
+    /// Most of the tree is ordinary notes. Editing one touches no artifact and
+    /// is not an error — the common answer, and deliberately silent.
+    #[tokio::test]
+    async fn an_edit_to_an_unpublished_node_records_nothing() {
+        let (_dir, ops, co) = stores();
+        let artifacts: &dyn ArtifactStore = ops.as_ref();
+
+        let mut published = ArtifactRecord::new(
+            "a-1",
+            "t-1",
+            "Launch",
+            ArtifactKind::Markdown,
+            "body",
+            "cmo",
+            1,
+        );
+        published.stamp_workspace_node("node-1");
+        artifacts.upsert(&co, &published).await.unwrap();
+
+        let mirrored = mirror_node_edit(
+            artifacts,
+            &co,
+            "some-other-note",
+            "new body",
+            ArtifactAuthor::Operator,
+            "operator",
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert!(mirrored.is_none());
+        let stored = artifacts.get(&co, "a-1").await.unwrap().unwrap();
+        assert_eq!(
+            stored.versions.len(),
+            1,
+            "an unrelated note must not append"
+        );
+    }
+
+    /// The lookup matches the **latest** version's node, not any version's. An
+    /// artifact whose node the operator deleted and which was re-published into
+    /// a new one must mirror into the new node — matching on the stale id would
+    /// write today's edit into yesterday's history.
+    #[tokio::test]
+    async fn the_lookup_matches_the_current_node_not_a_retired_one() {
+        let (_dir, ops, co) = stores();
+        let artifacts: &dyn ArtifactStore = ops.as_ref();
+
+        let mut record = ArtifactRecord::new(
+            "a-1",
+            "t-1",
+            "Launch",
+            ArtifactKind::Markdown,
+            "v1",
+            "cmo",
+            1,
+        );
+        record.stamp_workspace_node("node-old");
+        record.push_version("v2", ArtifactAuthor::Agent, "cmo", 2, None);
+        record.stamp_workspace_node("node-new");
+        artifacts.upsert(&co, &record).await.unwrap();
+
+        assert!(
+            mirror_node_edit(
+                artifacts,
+                &co,
+                "node-old",
+                "edit",
+                ArtifactAuthor::Operator,
+                "operator",
+                None,
+            )
+            .await
+            .unwrap()
+            .is_none(),
+            "the retired node no longer addresses this artifact"
+        );
+        assert!(
+            mirror_node_edit(
+                artifacts,
+                &co,
+                "node-new",
+                "edit",
+                ArtifactAuthor::Operator,
+                "operator",
+                None,
+            )
+            .await
+            .unwrap()
+            .is_some()
+        );
+    }
+}

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -49,6 +49,21 @@
 //! the write landed at all, so there the node necessarily moves first. It is
 //! the narrowest window available rather than a different policy.
 //!
+//! # The guarantee is owed to deliverables, not to every note
+//!
+//! "Avoided in the second direction" is a promise about *published* nodes, and
+//! it costs something to keep: the reverse lookup runs on every save, so a
+//! strict reading would make an unreachable artifact store refuse edits to
+//! ordinary notes too — notes with no chain to corrupt, on a save that
+//! otherwise never touches that store. That trades the whole tree's
+//! availability for a guarantee none of it is owed.
+//!
+//! [`mirror_node_edit`] therefore separates *cannot record* from *cannot tell*
+//! (see [`MirrorOutcome`]). Its callers keep failing closed once a node is
+//! known to be a deliverable, and choose for themselves what an unanswerable
+//! store means. The console `PUT` takes the availability side and says so in
+//! its own doc, including what that costs when the store is down.
+//!
 //! # Why this module is in the default build
 //!
 //! [`mirror_node_edit`] has three callers across two layers — the console's
@@ -203,9 +218,25 @@ pub async fn materialize(
 /// and an edit to one that never reached the version history is exactly the
 /// silent corruption the artifact port exists to prevent.
 ///
-/// Returns `None` — and touches nothing — when `node_id` names an ordinary
-/// note. Most of the tree is ordinary notes, so this is the common answer and
-/// deliberately not an error.
+/// Answers [`MirrorOutcome::Ordinary`] — and touches nothing — when `node_id`
+/// names an ordinary note. Most of the tree is ordinary notes, so this is the
+/// common answer and deliberately not an error.
+///
+/// # Two failures, told apart on purpose
+///
+/// The lookup and the append fail for different reasons and are not returned
+/// alike. A failed **append** is an `Err`: the store answered, so this node is
+/// known to be a published deliverable, and the caller must not write the node
+/// behind a version that was never recorded. A failed **lookup** is
+/// [`MirrorOutcome::Undetermined`] inside `Ok`, because it establishes nothing
+/// — the node may be a deliverable or may be one of the ordinary notes that
+/// are nearly the whole tree, and only the caller knows whether its own work
+/// can proceed without that answer.
+///
+/// Collapsing the second into [`MirrorOutcome::Ordinary`] would read as "no
+/// chain here, carry on" on every store fault, which is precisely how the
+/// fail-closed guarantee for deliverables would stop applying without anything
+/// appearing to change.
 ///
 /// # The scan, named rather than hidden
 ///
@@ -224,20 +255,48 @@ pub async fn mirror_node_edit(
     author: ArtifactAuthor,
     author_id: &str,
     note: Option<String>,
-) -> Result<Option<MirroredEdit>> {
-    let Some(mut record) = published_record_for_node(artifacts, company, node_id).await? else {
-        return Ok(None);
+) -> Result<MirrorOutcome> {
+    let mut record = match published_record_for_node(artifacts, company, node_id).await {
+        Ok(Some(record)) => record,
+        Ok(None) => return Ok(MirrorOutcome::Ordinary),
+        Err(err) => return Ok(MirrorOutcome::Undetermined(err)),
     };
     let version = record.push_version(body, author, author_id, now_millis(), note);
     // The appended version lives in the same node as the one before it. Without
     // this the *next* edit's reverse lookup — which reads the latest version —
     // would find nothing and silently stop mirroring.
     record.stamp_workspace_node(node_id);
+    // Fail-closed, and the one place in this function that is: the lookup
+    // succeeded, so this node *is* a deliverable, and a caller that wrote it
+    // anyway would leave the history claiming the agent's draft shipped
+    // unchanged.
     artifacts.upsert(company, &record).await?;
-    Ok(Some(MirroredEdit {
+    Ok(MirrorOutcome::Recorded(MirroredEdit {
         artifact_id: record.id,
         version,
     }))
+}
+
+/// What [`mirror_node_edit`] was able to do — and, when it could not act,
+/// whether the caller may carry on without it.
+///
+/// [`Ordinary`](MirrorOutcome::Ordinary) and
+/// [`Undetermined`](MirrorOutcome::Undetermined) both mean "nothing was
+/// recorded", and that is the whole reason they are separate variants rather
+/// than one absent value: the first is a complete answer from a healthy store
+/// and the second is no answer at all.
+#[derive(Debug)]
+pub enum MirrorOutcome {
+    /// `node_id` is a published deliverable, and this edit is now a version on
+    /// its chain.
+    Recorded(MirroredEdit),
+    /// The store answered, and `node_id` names no artifact — an ordinary note.
+    /// There is no chain here for a node write to get ahead of.
+    Ordinary,
+    /// The store could not be read, so whether `node_id` is published is
+    /// **unknown** rather than "no". Carries the fault so a caller that
+    /// tolerates it can still say why in a log.
+    Undetermined(OpenCompanyError),
 }
 
 /// What [`mirror_node_edit`] appended, for a caller that wants to log or return
@@ -639,7 +698,7 @@ mod test {
         record.stamp_workspace_node("node-1");
         artifacts.upsert(&co, &record).await.unwrap();
 
-        let mirrored = mirror_node_edit(
+        let MirrorOutcome::Recorded(mirrored) = mirror_node_edit(
             artifacts,
             &co,
             "node-1",
@@ -649,8 +708,9 @@ mod test {
             Some("operator edit before approval".to_string()),
         )
         .await
-        .unwrap()
-        .expect("a published node's edit is recorded");
+        .unwrap() else {
+            panic!("a published node's edit is recorded");
+        };
 
         assert_eq!(mirrored.artifact_id, "a-1");
         assert_eq!(mirrored.version, 2);
@@ -701,7 +761,7 @@ mod test {
         .await
         .unwrap();
 
-        assert!(mirrored.is_none());
+        assert!(matches!(mirrored, MirrorOutcome::Ordinary), "{mirrored:?}");
         let stored = artifacts.get(&co, "a-1").await.unwrap().unwrap();
         assert_eq!(
             stored.versions.len(),
@@ -734,21 +794,23 @@ mod test {
         artifacts.upsert(&co, &record).await.unwrap();
 
         assert!(
-            mirror_node_edit(
-                artifacts,
-                &co,
-                "node-old",
-                "edit",
-                ArtifactAuthor::Operator,
-                "operator",
-                None,
-            )
-            .await
-            .unwrap()
-            .is_none(),
+            matches!(
+                mirror_node_edit(
+                    artifacts,
+                    &co,
+                    "node-old",
+                    "edit",
+                    ArtifactAuthor::Operator,
+                    "operator",
+                    None,
+                )
+                .await
+                .unwrap(),
+                MirrorOutcome::Ordinary
+            ),
             "the retired node no longer addresses this artifact"
         );
-        assert!(
+        assert!(matches!(
             mirror_node_edit(
                 artifacts,
                 &co,
@@ -759,8 +821,116 @@ mod test {
                 None,
             )
             .await
-            .unwrap()
-            .is_some()
+            .unwrap(),
+            MirrorOutcome::Recorded(_)
+        ));
+    }
+
+    // -- the two store faults, told apart --------------------------------
+
+    /// An artifact store with one chosen fault, so a test can ask for exactly
+    /// the failure it means: unreadable (`list`) or unwritable (`upsert`).
+    struct FaultyArtifacts {
+        listed: Vec<ArtifactRecord>,
+        list_fails: bool,
+        upsert_fails: bool,
+    }
+
+    #[async_trait::async_trait]
+    impl ArtifactStore for FaultyArtifacts {
+        async fn list(&self, _: &CompanyId, _: Option<&str>) -> Result<Vec<ArtifactRecord>> {
+            if self.list_fails {
+                return Err(OpenCompanyError::Store("the artifact store is down".into()));
+            }
+            Ok(self.listed.clone())
+        }
+        async fn get(&self, _: &CompanyId, _: &str) -> Result<Option<ArtifactRecord>> {
+            Ok(None)
+        }
+        async fn upsert(&self, _: &CompanyId, _: &ArtifactRecord) -> Result<()> {
+            if self.upsert_fails {
+                return Err(OpenCompanyError::Store("the disk is full".into()));
+            }
+            Ok(())
+        }
+        async fn delete(&self, _: &CompanyId, _: &str) -> Result<bool> {
+            Ok(false)
+        }
+    }
+
+    fn published_as(node_id: &str) -> ArtifactRecord {
+        let mut record = ArtifactRecord::new(
+            "a-1",
+            "t-1",
+            "Launch",
+            ArtifactKind::Markdown,
+            "agent draft",
+            "cmo",
+            1,
+        );
+        record.stamp_workspace_node(node_id);
+        record
+    }
+
+    /// A store that cannot be listed establishes **nothing**, and must not be
+    /// reported as the ordinary-note answer.
+    ///
+    /// This is the variant that carries the whole guarantee: `Ordinary` is what
+    /// callers are entitled to write a node behind. If a read fault collapsed
+    /// into it, every published deliverable would silently lose its fail-closed
+    /// protection the moment the store got sick — the one moment it matters.
+    #[tokio::test]
+    async fn an_unreadable_store_is_undetermined_not_ordinary() {
+        let co = CompanyId::new("acme");
+        let artifacts = FaultyArtifacts {
+            listed: Vec::new(),
+            list_fails: true,
+            upsert_fails: false,
+        };
+
+        let outcome = mirror_node_edit(
+            &artifacts,
+            &co,
+            "node-1",
+            "edit",
+            ArtifactAuthor::Operator,
+            "operator",
+            None,
+        )
+        .await
+        .expect("an unreadable store is the caller's decision, not an error");
+
+        assert!(
+            matches!(outcome, MirrorOutcome::Undetermined(_)),
+            "a read fault must stay distinguishable from `Ordinary`: {outcome:?}"
+        );
+    }
+
+    /// Once the store has answered and named this node a deliverable, a version
+    /// that cannot be appended is an error — the caller must not go on to write
+    /// the node, because that is the silent, permanent direction.
+    #[tokio::test]
+    async fn a_refused_append_on_a_published_node_still_fails_closed() {
+        let co = CompanyId::new("acme");
+        let artifacts = FaultyArtifacts {
+            listed: vec![published_as("node-1")],
+            list_fails: false,
+            upsert_fails: true,
+        };
+
+        assert!(
+            mirror_node_edit(
+                &artifacts,
+                &co,
+                "node-1",
+                "edit",
+                ArtifactAuthor::Operator,
+                "operator",
+                None,
+            )
+            .await
+            .is_err(),
+            "a known deliverable whose version cannot be recorded must refuse the save"
         );
     }
 }

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -5,6 +5,10 @@
 //! report its effective configuration. The cognition kernel (Brain, cycle
 //! loop, stores) lands in later phases; see `docs/spec/roadmap.md`.
 
+/// Issue #552: the seam between a task artifact and the shared workspace tree.
+/// Always compiled — the console's workspace and artifact routes reach it in
+/// every build, and only the publish drain's half is behind `openhuman`.
+pub mod artifact_mirror;
 pub mod composio;
 #[cfg(test)]
 mod content_test;

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -261,7 +261,11 @@ fn find(nodes: &[WorkspaceNode], parent: Option<&str>, name: &str) -> Found {
 }
 
 /// Create one folder and hand back its id.
-async fn create_folder(
+///
+/// `pub(crate)` so [`artifact_mirror`](crate::company::artifact_mirror) mints
+/// the folders beneath `Agents/<id>/` the same way this module mints the ones
+/// above them — one creation shape, one set of origin-stamping rules.
+pub(crate) async fn create_folder(
     store: &dyn WorkspaceStore,
     company: &CompanyId,
     name: &str,

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 
 use crate::Result;
+use crate::company::artifact_mirror;
 use crate::company::steer::{InflightEntry, InflightKind, SteerAction, cap_redirect};
 use crate::harness::build::agent_workspace;
 use crate::harness::confine;
@@ -1482,9 +1483,13 @@ impl HarnessBrain {
             // The revision THIS run wrote (#339). A fresh record is always its
             // own v1; an extended one takes whatever `push_version` numbered.
             let mut version = 1;
+            // The node the PREVIOUS version was mirrored into, read before the
+            // push below appends a version whose own node is not chosen yet.
+            let mut prior_node = None;
             let mut record = match existing {
                 Some(index) => {
                     let mut found = on_card.remove(index);
+                    prior_node = found.workspace_node_id().map(str::to_string);
                     version = found.push_version(
                         &pending.body,
                         ArtifactAuthor::Agent,
@@ -1521,6 +1526,48 @@ impl HarnessBrain {
             };
             if let Some(run_id) = run_id {
                 record.stamp_run(run_id);
+            }
+            // Issue #552: the deliverable also goes into the shared workspace
+            // tree, which is the one surface the operator browses and every
+            // other agent can read. The artifact chain above stays the
+            // authoritative version history; the node holds the current body.
+            //
+            // **A failed mirror does not lose the deliverable.** An explicit
+            // publish that could not be filed into the tree is still recorded
+            // as an artifact — dropping a produced file over tree bookkeeping
+            // would be far worse than a deliverable the operator has to reach
+            // through the Artifacts tab. So this logs at `error` (loudly: the
+            // tree is where people look) and continues with no node id, which
+            // is exactly what a pre-#552 record carries. The next publish of
+            // the same path retries and heals it.
+            //
+            // The node is written before the artifact upsert because the id it
+            // returns is what gets stamped onto this version, and doing it
+            // afterwards would need a second upsert. The residual is narrow and
+            // named: if the upsert below then fails, a re-published node shows
+            // a body one version ahead of the chain until the next write on
+            // either surface reconciles them.
+            if let Some(workspace) = self.deps.workspace.as_ref() {
+                let target = artifact_mirror::PublishTarget {
+                    agent_id: author,
+                    task_id: &card.id,
+                    source: &pending.source,
+                    body: &pending.body,
+                    existing_node_id: prior_node.as_deref(),
+                };
+                match artifact_mirror::materialize(workspace.as_ref(), &self.record.id, target)
+                    .await
+                {
+                    Ok(node_id) => record.stamp_workspace_node(node_id),
+                    Err(err) => tracing::error!(
+                        task_id = %card.id,
+                        agent = %author,
+                        source = %pending.source,
+                        error = %err,
+                        "[publish] could not put the published file into the company workspace; \
+                         it is still recorded as an artifact"
+                    ),
+                }
             }
             artifacts.upsert(&self.record.id, &record).await?;
             written.push(TaskOutputArtifact {
@@ -2585,6 +2632,25 @@ members = ["engineer"]
     /// [`FsOps`] handle (it implements both), so a dispatch's versioned output
     /// is observable.
     fn brain_with_artifacts(dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+        brain_with_stores(dir, false)
+    }
+
+    /// As [`brain_with_artifacts`], but with the workspace store wired to the
+    /// same [`FsOps`] handle too (it implements all three), so issue #552's
+    /// dual write into the shared tree is observable.
+    ///
+    /// A separate constructor rather than a change to the one above: leaving
+    /// `brain_with_artifacts` workspace-less is what keeps every pre-existing
+    /// publish test on the artifact-only path, which is the guarantee that an
+    /// unwired workspace behaves exactly as it did before this cell.
+    fn brain_with_artifacts_and_workspace(dir: &std::path::Path) -> (HarnessBrain, Arc<FsOps>) {
+        brain_with_stores(dir, true)
+    }
+
+    fn brain_with_stores(
+        dir: &std::path::Path,
+        with_workspace: bool,
+    ) -> (HarnessBrain, Arc<FsOps>) {
         let ops = Arc::new(FsOps::new(dir));
         let deps = HarnessDeps {
             provider: Arc::new(MockProvider::new("mock: ")),
@@ -2619,7 +2685,7 @@ members = ["engineer"]
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
             search: None,
-            workspace: None,
+            workspace: with_workspace.then(|| ops.clone() as Arc<dyn crate::ports::WorkspaceStore>),
         };
         (
             HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record_two()),
@@ -2627,6 +2693,294 @@ members = ["engineer"]
         )
     }
 
+    // -- issue #552: a published deliverable reaches the shared workspace -----
+
+    /// The headline of #552. A published file used to reach the artifact store
+    /// and stop, which left it visible only in the Artifacts tab of one card.
+    /// It must now also land in the shared tree, under the publishing agent's
+    /// own folder, attributed to that agent — and the version that wrote it
+    /// must carry the node id, which is the link the console's cross-link and
+    /// every later mirror depend on.
+    #[tokio::test]
+    async fn a_publish_lands_in_the_shared_workspace_and_the_version_names_the_node() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+        use crate::ports::workspace::{WorkspaceOrigin, WorkspaceStore};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts_and_workspace(dir.path());
+        let company = CompanyId::new("acme");
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![PendingPublish {
+                    agent: "maya".to_string(),
+                    source: "specs/launch.md".to_string(),
+                    title: "Launch spec".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "the spec body".to_string(),
+                }],
+                Some("run-1"),
+            )
+            .await
+            .expect("records");
+
+        let listed = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        let node_id = listed[0]
+            .workspace_node_id()
+            .expect("the version must name the node its body was mirrored into");
+
+        let (node, body) = WorkspaceStore::read(&*ops, &company, node_id)
+            .await
+            .unwrap()
+            .expect("the node exists in the shared tree");
+        assert_eq!(body, "the spec body");
+        assert_eq!(node.name, "launch.md");
+        assert_eq!(
+            node.created_by,
+            WorkspaceOrigin::Agent {
+                id: "maya".to_string()
+            },
+            "the tree must say which teammate produced this"
+        );
+    }
+
+    /// The "zero tool work" claim in #552, proven rather than asserted: a
+    /// second agent reads the first agent's deliverable through the ordinary
+    /// `workspace_read` path, with nothing published-specific involved.
+    ///
+    /// The read goes through the *same* index-and-resolve the tool uses (a
+    /// company-scoped `tree()` then a `read()` by id), so what this pins is
+    /// that the node is reachable by path from the shared tree — which is
+    /// exactly what makes it readable by every teammate.
+    #[tokio::test]
+    async fn a_second_agent_can_read_what_the_first_published() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::workspace::WorkspaceStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts_and_workspace(dir.path());
+        let company = CompanyId::new("acme");
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![PendingPublish {
+                    agent: "maya".to_string(),
+                    source: "launch.md".to_string(),
+                    title: "Launch spec".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "what maya produced".to_string(),
+                }],
+                None,
+            )
+            .await
+            .expect("records");
+
+        // Agent B knows nothing about the artifact. It walks the shared tree by
+        // path, exactly as `workspace_list` / `workspace_read` do.
+        let nodes = WorkspaceStore::tree(&*ops, &company).await.unwrap();
+        let name_of = |id: &str| nodes.iter().find(|n| n.id == id).map(|n| n.name.clone());
+        let found = nodes
+            .iter()
+            .find(|n| {
+                n.name == "launch.md"
+                    && n.parent_id
+                        .as_deref()
+                        .and_then(name_of)
+                        .is_some_and(|parent| parent == "t-1")
+            })
+            .expect("agent B finds the deliverable by browsing the shared tree");
+
+        let (_, body) = WorkspaceStore::read(&*ops, &company, &found.id)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(body, "what maya produced");
+    }
+
+    /// A re-publish revises the SAME node rather than opening a rival beside
+    /// it, so the operator's open tab and any link to it keep working — and
+    /// the new version carries the same node id, which is what lets the next
+    /// re-publish find it again.
+    #[tokio::test]
+    async fn a_republish_updates_the_same_node() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+        use crate::ports::workspace::WorkspaceStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts_and_workspace(dir.path());
+        let company = CompanyId::new("acme");
+        let c = card("t-1", "maya");
+        let publish = |body: &str| PendingPublish {
+            agent: "maya".to_string(),
+            source: "specs/launch.md".to_string(),
+            title: "Launch spec".to_string(),
+            kind: crate::ports::artifacts::ArtifactKind::Markdown,
+            note: None,
+            body: body.to_string(),
+        };
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish("v1")], Some("run-1"))
+            .await
+            .unwrap();
+        let first_node = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap()[0]
+            .workspace_node_id()
+            .expect("v1 named a node")
+            .to_string();
+        let tree_before = WorkspaceStore::tree(&*ops, &company).await.unwrap().len();
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish("v2")], Some("run-2"))
+            .await
+            .unwrap();
+
+        let record = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap()[0]
+            .clone();
+        assert_eq!(record.versions.len(), 2, "one record, two versions");
+        assert_eq!(
+            record.workspace_node_id(),
+            Some(first_node.as_str()),
+            "the second version must name the node the first one already had"
+        );
+        assert_eq!(
+            WorkspaceStore::tree(&*ops, &company).await.unwrap().len(),
+            tree_before,
+            "a re-publish must create no new nodes"
+        );
+        assert_eq!(
+            WorkspaceStore::read(&*ops, &company, &first_node)
+                .await
+                .unwrap()
+                .unwrap()
+                .1,
+            "v2",
+            "the node holds the current body"
+        );
+    }
+
+    /// An unwired workspace must behave **exactly** as before this cell: the
+    /// artifact is recorded, nothing is attempted against a tree that does not
+    /// exist, and no version claims a node.
+    ///
+    /// This is what keeps every pre-#552 publish test honest, since they all
+    /// run on this path.
+    #[tokio::test]
+    async fn without_a_workspace_store_the_publish_path_is_unchanged() {
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts(dir.path());
+        let company = CompanyId::new("acme");
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![PendingPublish {
+                    agent: "maya".to_string(),
+                    source: "specs/launch.md".to_string(),
+                    title: "Launch spec".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "body".to_string(),
+                }],
+                None,
+            )
+            .await
+            .expect("the artifact is still recorded");
+
+        let listed = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(
+            listed[0].workspace_node_id(),
+            None,
+            "with no tree to mirror into, a version names no node"
+        );
+    }
+
+    /// A deliverable is never dropped for tree bookkeeping. When the node
+    /// cannot be written — here a `Standards` *file* squatting the `Agents`
+    /// root name, which the fail-closed resolver refuses rather than guesses —
+    /// the artifact is still recorded, just without a node id.
+    ///
+    /// The opposite behaviour (propagating the error) would lose an explicitly
+    /// published file because a folder could not be made, which is the worse
+    /// of the two failures by a wide margin.
+    #[tokio::test]
+    async fn a_failed_node_write_still_records_the_artifact() {
+        use crate::company::workspace_scaffold::AGENTS_ROOT;
+        use crate::harness::publish::PendingPublish;
+        use crate::ports::artifacts::ArtifactStore;
+        use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, ops) = brain_with_artifacts_and_workspace(dir.path());
+        let company = CompanyId::new("acme");
+
+        // A *file* named `Agents` at the workspace root. The minter refuses to
+        // resolve a folder through it rather than clobbering an operator's note.
+        WorkspaceStore::create(
+            &*ops,
+            &company,
+            &WorkspaceNode {
+                id: crate::ports::generate_id(),
+                name: AGENTS_ROOT.to_string(),
+                kind: NodeKind::File,
+                parent_id: None,
+                updated_at_millis: now_millis(),
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
+            },
+            Some("an operator's note, in the way"),
+        )
+        .await
+        .unwrap();
+
+        let written = brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![PendingPublish {
+                    agent: "maya".to_string(),
+                    source: "launch.md".to_string(),
+                    title: "Launch spec".to_string(),
+                    kind: crate::ports::artifacts::ArtifactKind::Markdown,
+                    note: None,
+                    body: "the deliverable".to_string(),
+                }],
+                None,
+            )
+            .await
+            .expect("a tree that refuses must not fail the publish");
+
+        assert_eq!(written.len(), 1, "the deliverable is still recorded");
+        let listed = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        assert_eq!(listed[0].latest().unwrap().body, "the deliverable");
+        assert_eq!(
+            listed[0].workspace_node_id(),
+            None,
+            "no node was written, so no version may claim one"
+        );
+    }
     fn card(id: &str, assignee: &str) -> TaskRecord {
         TaskRecord {
             id: id.to_string(),

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1529,24 +1529,43 @@ impl HarnessBrain {
             }
             // Issue #552: the deliverable also goes into the shared workspace
             // tree, which is the one surface the operator browses and every
-            // other agent can read. The artifact chain above stays the
+            // other agent can read. The artifact chain here stays the
             // authoritative version history; the node holds the current body.
             //
+            // # Chain first, without exception
+            //
+            // A re-publish inherits the node the previous version named, so the
+            // version can be written *before* the tree is touched. That
+            // ordering is the load-bearing half of keeping the chain
+            // authoritative, not a preference: a node one version ahead of the
+            // chain is the tree showing content the version history has no
+            // record of, which makes `human_edit_diff` quietly wrong rather
+            // than loudly broken — the same #187 rot arriving by a different
+            // door. Requiring the store to half-fail bounds how *often* that
+            // happens and not at all how bad it is, and on a data path a silent
+            // wrong answer outlives the incident that caused it.
+            //
+            // A *fresh* publish has no node id to inherit, so its v1 is stored
+            // unlinked and the link is stamped by the second upsert below. Note
+            // what that buys beyond ordering: because the record is written
+            // first, a node is only ever created for a deliverable that is
+            // already recorded, so this path can no longer leave a node in the
+            // tree with no artifact behind it at all.
+            if let Some(node_id) = prior_node.as_deref() {
+                // Inherit before storing, so a failure anywhere below leaves
+                // the version pointing at the node that currently holds it.
+                record.stamp_workspace_node(node_id);
+            }
+            artifacts.upsert(&self.record.id, &record).await?;
+
             // **A failed mirror does not lose the deliverable.** An explicit
             // publish that could not be filed into the tree is still recorded
             // as an artifact — dropping a produced file over tree bookkeeping
             // would be far worse than a deliverable the operator has to reach
             // through the Artifacts tab. So this logs at `error` (loudly: the
-            // tree is where people look) and continues with no node id, which
+            // tree is where people look) and leaves the version unlinked, which
             // is exactly what a pre-#552 record carries. The next publish of
-            // the same path retries and heals it.
-            //
-            // The node is written before the artifact upsert because the id it
-            // returns is what gets stamped onto this version, and doing it
-            // afterwards would need a second upsert. The residual is narrow and
-            // named: if the upsert below then fails, a re-published node shows
-            // a body one version ahead of the chain until the next write on
-            // either surface reconciles them.
+            // the same source retries and heals it.
             if let Some(workspace) = self.deps.workspace.as_ref() {
                 let target = artifact_mirror::PublishTarget {
                     agent_id: author,
@@ -1558,7 +1577,34 @@ impl HarnessBrain {
                 match artifact_mirror::materialize(workspace.as_ref(), &self.record.id, target)
                     .await
                 {
-                    Ok(node_id) => record.stamp_workspace_node(node_id),
+                    Ok(node_id) => {
+                        // A second write only when the link actually changed:
+                        // a fresh publish (nothing was inherited) or a
+                        // re-publish whose node the operator deleted, which
+                        // `materialize` replaces with a new one. The ordinary
+                        // re-publish reuses its node and stores once.
+                        if record.workspace_node_id() != Some(node_id.as_str()) {
+                            record.stamp_workspace_node(&node_id);
+                            // Warn rather than `?`: at this point BOTH surfaces
+                            // already hold this body and only the pointer
+                            // between them is missing, so failing the batch
+                            // would discard the remaining publishes' records to
+                            // report a link that heals on the next publish —
+                            // `materialize` finds an existing node by path and
+                            // re-adopts it rather than duplicating.
+                            if let Err(err) = artifacts.upsert(&self.record.id, &record).await {
+                                tracing::warn!(
+                                    task_id = %card.id,
+                                    source = %pending.source,
+                                    node = %node_id,
+                                    error = %err,
+                                    "[publish] the deliverable and its note are both stored but \
+                                     could not be linked; the next publish of this source \
+                                     re-adopts the note and repairs it"
+                                );
+                            }
+                        }
+                    }
                     Err(err) => tracing::error!(
                         task_id = %card.id,
                         agent = %author,
@@ -1569,7 +1615,6 @@ impl HarnessBrain {
                     ),
                 }
             }
-            artifacts.upsert(&self.record.id, &record).await?;
             written.push(TaskOutputArtifact {
                 artifact_id: record.id.clone(),
                 version,
@@ -2652,6 +2697,23 @@ members = ["engineer"]
         with_workspace: bool,
     ) -> (HarnessBrain, Arc<FsOps>) {
         let ops = Arc::new(FsOps::new(dir));
+        let artifacts = ops.clone() as Arc<dyn crate::ports::artifacts::ArtifactStore>;
+        brain_with_injected_artifacts(dir, ops, artifacts, with_workspace)
+    }
+
+    /// As [`brain_with_stores`], but with the artifact store supplied by the
+    /// caller — so a test can make `upsert` refuse and observe what the publish
+    /// drain did to the *tree* before it got there.
+    ///
+    /// That is the only way to pin issue #552's write ordering. An ordering
+    /// described in a comment is not an ordering: the next refactor reorders it
+    /// and nothing objects.
+    fn brain_with_injected_artifacts(
+        dir: &std::path::Path,
+        ops: Arc<FsOps>,
+        artifacts: Arc<dyn crate::ports::artifacts::ArtifactStore>,
+        with_workspace: bool,
+    ) -> (HarnessBrain, Arc<FsOps>) {
         let deps = HarnessDeps {
             provider: Arc::new(MockProvider::new("mock: ")),
             provider_slug: "mock".to_string(),
@@ -2661,7 +2723,7 @@ members = ["engineer"]
             workspace_root: dir.to_path_buf(),
             model_override: None,
             tasks: Some(ops.clone()),
-            artifacts: Some(ops.clone()),
+            artifacts: Some(artifacts),
             skills: None,
             skills_source_dir: None,
             skills_registry: std::sync::Arc::from([]),
@@ -2693,6 +2755,306 @@ members = ["engineer"]
         )
     }
 
+    // -- issue #552: the write ordering, proven by failure injection ---------
+
+    /// An [`ArtifactStore`](crate::ports::artifacts::ArtifactStore) that refuses
+    /// `upsert` from the Nth call onward, delegating everything else.
+    ///
+    /// The instrument the ordering tests need: with the artifact write made to
+    /// fail at a chosen point, what the *tree* holds afterwards says
+    /// unambiguously which surface was written first.
+    struct FailingArtifacts {
+        inner: Arc<FsOps>,
+        /// How many `upsert` calls succeed before the rest refuse.
+        allowed: std::sync::atomic::AtomicUsize,
+        seen: std::sync::atomic::AtomicUsize,
+    }
+
+    impl FailingArtifacts {
+        fn new(inner: Arc<FsOps>, allowed: usize) -> Arc<Self> {
+            Arc::new(Self {
+                inner,
+                allowed: std::sync::atomic::AtomicUsize::new(allowed),
+                seen: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+
+        /// Let every later `upsert` through again, so a test can publish
+        /// normally after the injected failure and watch the repair.
+        fn heal(&self) {
+            self.allowed
+                .store(usize::MAX, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl crate::ports::artifacts::ArtifactStore for FailingArtifacts {
+        async fn list(
+            &self,
+            company: &CompanyId,
+            task_id: Option<&str>,
+        ) -> crate::Result<Vec<ArtifactRecord>> {
+            crate::ports::artifacts::ArtifactStore::list(&*self.inner, company, task_id).await
+        }
+        async fn get(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> crate::Result<Option<ArtifactRecord>> {
+            crate::ports::artifacts::ArtifactStore::get(&*self.inner, company, id).await
+        }
+        async fn upsert(
+            &self,
+            company: &CompanyId,
+            artifact: &ArtifactRecord,
+        ) -> crate::Result<()> {
+            let n = self.seen.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if n >= self.allowed.load(std::sync::atomic::Ordering::SeqCst) {
+                return Err(crate::error::OpenCompanyError::Store(
+                    "artifact store is down".to_string(),
+                ));
+            }
+            crate::ports::artifacts::ArtifactStore::upsert(&*self.inner, company, artifact).await
+        }
+        async fn delete(&self, company: &CompanyId, id: &str) -> crate::Result<bool> {
+            crate::ports::artifacts::ArtifactStore::delete(&*self.inner, company, id).await
+        }
+    }
+
+    fn publish_of(source: &str, body: &str) -> crate::harness::publish::PendingPublish {
+        crate::harness::publish::PendingPublish {
+            agent: "maya".to_string(),
+            source: source.to_string(),
+            title: "Launch spec".to_string(),
+            kind: crate::ports::artifacts::ArtifactKind::Markdown,
+            note: None,
+            body: body.to_string(),
+        }
+    }
+
+    /// The named node under `Agents/maya/t-1/`, with its body — the tree's own
+    /// answer, read without going through the artifact chain at all.
+    async fn note_in_tree(
+        ops: &FsOps,
+        company: &CompanyId,
+        name: &str,
+    ) -> Option<(String, String)> {
+        use crate::ports::workspace::WorkspaceStore;
+        let nodes = WorkspaceStore::tree(ops, company).await.unwrap();
+        let found = nodes.iter().find(|n| n.name == name)?;
+        let (_, body) = WorkspaceStore::read(ops, company, &found.id)
+            .await
+            .unwrap()?;
+        Some((found.id.clone(), body))
+    }
+
+    /// **Chain first, proven.** A re-publish whose artifact write fails must
+    /// leave the note holding the PREVIOUS body — the version was stored before
+    /// the tree was touched, so a refused version means an untouched tree.
+    ///
+    /// The opposite ordering is what this rules out, and it is not a stylistic
+    /// difference: a note one version ahead of the chain shows the operator
+    /// content the version history has no record of, which makes
+    /// `human_edit_diff` quietly wrong rather than loudly broken — the same rot
+    /// the artifact port exists to prevent, arriving through the tree instead.
+    #[tokio::test]
+    async fn a_refused_republish_leaves_the_note_on_the_previous_body() {
+        use crate::ports::artifacts::ArtifactStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        // v1 costs two upserts: the record, then the link once the node exists.
+        let artifacts = FailingArtifacts::new(ops.clone(), 2);
+        let (brain, _) =
+            brain_with_injected_artifacts(dir.path(), ops.clone(), artifacts.clone(), true);
+        let company = CompanyId::new("acme");
+        let c = card("t-1", "maya");
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v1")], None)
+            .await
+            .expect("the first publish lands");
+        let (node_id, body) = note_in_tree(&ops, &company, "launch.md")
+            .await
+            .expect("v1 is in the tree");
+        assert_eq!(body, "v1");
+
+        // Now the artifact store refuses. The re-publish must fail *before*
+        // reaching the tree.
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v2")], None)
+            .await
+            .expect_err("a refused artifact write fails the publish");
+
+        let (still, body) = note_in_tree(&ops, &company, "launch.md")
+            .await
+            .expect("the note is still there");
+        assert_eq!(still, node_id, "no rival note was minted");
+        assert_eq!(
+            body, "v1",
+            "the tree must not hold a body the version history never recorded"
+        );
+        // And the chain is unchanged too — one version, not a half-written two.
+        let stored = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        assert_eq!(stored[0].versions.len(), 1);
+        assert_eq!(stored[0].latest().unwrap().body, "v1");
+    }
+
+    /// The same ordering on a **fresh** publish: an artifact write that fails
+    /// creates nothing in the tree at all.
+    ///
+    /// This is what makes the fresh path's residual an *orphan note* rather
+    /// than a lost deliverable — a node is only ever created for a deliverable
+    /// that is already recorded, so this path cannot leave a file in the tree
+    /// with no artifact behind it.
+    #[tokio::test]
+    async fn a_refused_first_publish_creates_nothing_in_the_tree() {
+        use crate::ports::workspace::WorkspaceStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        let artifacts = FailingArtifacts::new(ops.clone(), 0);
+        let (brain, _) = brain_with_injected_artifacts(dir.path(), ops.clone(), artifacts, true);
+        let company = CompanyId::new("acme");
+
+        brain
+            .record_published_artifacts(
+                &card("t-1", "maya"),
+                "maya",
+                vec![publish_of("launch.md", "v1")],
+                None,
+            )
+            .await
+            .expect_err("a refused artifact write fails the publish");
+
+        assert!(
+            note_in_tree(&ops, &company, "launch.md").await.is_none(),
+            "no note may exist for a deliverable that was never recorded"
+        );
+        assert!(
+            WorkspaceStore::tree(&*ops, &company)
+                .await
+                .unwrap()
+                .is_empty(),
+            "not even the agent's folder is minted for a publish that failed"
+        );
+    }
+
+    /// The fresh path's one residual, and its repair.
+    ///
+    /// A fresh publish has no node id to inherit, so v1 is stored unlinked and
+    /// a *second* artifact write stamps the link. If that second write fails,
+    /// both surfaces hold the body and only the pointer between them is
+    /// missing. That is deliberately warned-and-tolerated rather than fatal:
+    /// failing would discard the rest of the batch to report a link that the
+    /// next publish repairs.
+    ///
+    /// The repair is the half worth proving. `materialize` find-or-creates by
+    /// path, so the next publish of the same source **re-adopts the very same
+    /// note** rather than duplicating it — which is what makes the orphan
+    /// self-healing rather than permanent.
+    #[tokio::test]
+    async fn an_unlinked_first_publish_is_repaired_by_the_next_one() {
+        use crate::ports::artifacts::ArtifactStore;
+        use crate::ports::workspace::WorkspaceStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        // Exactly one upsert succeeds: the record lands, the link does not.
+        let artifacts = FailingArtifacts::new(ops.clone(), 1);
+        let (brain, _) =
+            brain_with_injected_artifacts(dir.path(), ops.clone(), artifacts.clone(), true);
+        let company = CompanyId::new("acme");
+        let c = card("t-1", "maya");
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v1")], None)
+            .await
+            .expect("a missing link must not fail the publish");
+
+        // Both surfaces hold the body; only the pointer is absent.
+        let (orphan, body) = note_in_tree(&ops, &company, "launch.md")
+            .await
+            .expect("the note was still written");
+        assert_eq!(body, "v1");
+        let stored = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        assert_eq!(stored[0].latest().unwrap().body, "v1");
+        assert_eq!(
+            stored[0].workspace_node_id(),
+            None,
+            "this is the orphan: recorded and written, but not linked"
+        );
+
+        // The next publish of the same source repairs it.
+        artifacts.heal();
+        let nodes_before = WorkspaceStore::tree(&*ops, &company).await.unwrap().len();
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v2")], None)
+            .await
+            .expect("the repairing publish lands");
+
+        let stored = ArtifactStore::list(&*ops, &company, Some("t-1"))
+            .await
+            .unwrap();
+        assert_eq!(stored[0].versions.len(), 2, "one record, extended");
+        assert_eq!(
+            stored[0].workspace_node_id(),
+            Some(orphan.as_str()),
+            "the very same note is re-adopted, which is what makes the orphan self-healing"
+        );
+        assert_eq!(
+            WorkspaceStore::tree(&*ops, &company).await.unwrap().len(),
+            nodes_before,
+            "re-adoption, not duplication: no rival note beside the orphan"
+        );
+        assert_eq!(
+            WorkspaceStore::read(&*ops, &company, &orphan)
+                .await
+                .unwrap()
+                .unwrap()
+                .1,
+            "v2"
+        );
+    }
+
+    /// The ordinary re-publish stores **once**, not twice. The second artifact
+    /// write exists only for a link that actually changed — a fresh publish, or
+    /// a note the operator deleted — and a re-publish that reuses its note has
+    /// nothing to restate.
+    #[tokio::test]
+    async fn an_ordinary_republish_writes_the_artifact_once() {
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        let artifacts = FailingArtifacts::new(ops.clone(), usize::MAX);
+        let (brain, _) =
+            brain_with_injected_artifacts(dir.path(), ops.clone(), artifacts.clone(), true);
+        let c = card("t-1", "maya");
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v1")], None)
+            .await
+            .unwrap();
+        // v1: the record, then the link once the node id exists.
+        assert_eq!(
+            artifacts.seen.load(std::sync::atomic::Ordering::SeqCst),
+            2,
+            "a fresh publish stores the record, then stamps the link"
+        );
+
+        brain
+            .record_published_artifacts(&c, "maya", vec![publish_of("launch.md", "v2")], None)
+            .await
+            .unwrap();
+        assert_eq!(
+            artifacts.seen.load(std::sync::atomic::Ordering::SeqCst),
+            3,
+            "a re-publish inherits its note, so one store is enough"
+        );
+    }
     // -- issue #552: a published deliverable reaches the shared workspace -----
 
     /// The headline of #552. A published file used to reach the artifact store

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -472,6 +472,11 @@ pub fn build_agent(
         Some(store) if grants_cover(grants, "workspace") => {
             Some(crate::harness::workspace_tools::workspace_tools(
                 store.clone(),
+                // Issue #552: so an overwrite of a *published* note is recorded
+                // on that deliverable's artifact chain rather than diverging
+                // from it. Read-only for the write tool's mirroring — no tool
+                // here opens or deletes an artifact.
+                deps.artifacts.clone(),
                 company.clone(),
                 manifest_agent.id.clone(),
                 workspace_writes,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -2423,6 +2423,28 @@ mod tests {
         );
     }
 
+    /// **Issue #327.** A workspace write summarizes structurally — the change
+    /// word and the node id, nothing else.
+    ///
+    /// The node's *name* is the exclusion with teeth. It is operator-authored
+    /// free text that routinely carries the substance of the note ("Q3 layoffs
+    /// shortlist"), and this string is a non-sensitive one-liner for the
+    /// insight surface, which is precisely where free text does not belong.
+    /// Same reasoning as the recipient exclusion two tests up; the arm was
+    /// written this way, and this is what pins it.
+    #[test]
+    fn a_workspace_write_summarizes_to_the_change_and_node_without_the_notes_name() {
+        let summary = summarize_event(&CompanyEvent::WorkspaceChanged {
+            node_id: "n-42".to_string(),
+            change: "updated".to_string(),
+        });
+
+        // Exact, not `contains`: the whole claim is that nothing *else* is in
+        // here. A future arm that looked the node up to add its name would keep
+        // passing every `contains` assertion and fail this one.
+        assert_eq!(summary, "workspace updated: n-42");
+    }
+
     #[test]
     fn orchestrator_id_prefers_the_tagged_agent() {
         let roster = vec![

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -781,6 +781,14 @@ fn summarize_event(event: &CompanyEvent) -> String {
             Some(column) => format!("card {change}: {task_id} → {column}"),
             None => format!("card {change}: {task_id}"),
         },
+        // Issue #327. Structural only, like the board arm above: the id and the
+        // change word, from a fixed vocabulary. The node's NAME is deliberately
+        // absent — it is operator-authored free text, and this string is a
+        // non-sensitive one-liner for the insight surface, which is exactly
+        // where free text does not belong.
+        CompanyEvent::WorkspaceChanged { node_id, change } => {
+            format!("workspace {change}: {node_id}")
+        }
         CompanyEvent::ScheduleFired { cron, .. } => format!("schedule fired: {cron}"),
         CompanyEvent::WebhookReceived { channel, .. } => format!("webhook on {channel}"),
         CompanyEvent::A2aTaskReceived { from, .. } => format!("A2A task from {from}"),

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -160,7 +160,7 @@ use serde_json::{Value, json};
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
-use crate::company::artifact_mirror::mirror_node_edit;
+use crate::company::artifact_mirror::{MirrorOutcome, mirror_node_edit};
 use crate::company::workspace_scaffold::AGENTS_ROOT;
 use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactStore};
@@ -1232,8 +1232,14 @@ impl Tool for WorkspaceWriteTool {
                 // Ordinary notes are the overwhelming majority and match no
                 // artifact, so this is a no-op for almost every call. It is not
                 // a publish: no queue, no claim, #445 untouched.
-                if let Some(artifacts) = self.workspace.artifacts.as_ref()
-                    && let Err(err) = mirror_node_edit(
+                if let Some(artifacts) = self.workspace.artifacts.as_ref() {
+                    // A refused append and an unreadable store are told apart
+                    // for callers that still have a decision left to make. This
+                    // one does not: the node is already written, so both mean
+                    // the same thing here — the chain is behind and nothing can
+                    // undo it — and both warn rather than fail a write that
+                    // succeeded.
+                    let unrecorded = match mirror_node_edit(
                         artifacts.as_ref(),
                         &self.workspace.company,
                         &node.id,
@@ -1243,16 +1249,21 @@ impl Tool for WorkspaceWriteTool {
                         None,
                     )
                     .await
-                {
-                    tracing::warn!(
-                        company = %self.workspace.company,
-                        agent = %self.workspace.agent_id,
-                        node = %node.id,
-                        error = %err,
-                        "[workspace] overwrote a published note but could not record the \
-                         revision on its artifact; the chain is one version behind until the \
-                         next write on either surface"
-                    );
+                    {
+                        Ok(MirrorOutcome::Recorded(_) | MirrorOutcome::Ordinary) => None,
+                        Ok(MirrorOutcome::Undetermined(err)) | Err(err) => Some(err),
+                    };
+                    if let Some(err) = unrecorded {
+                        tracing::warn!(
+                            company = %self.workspace.company,
+                            agent = %self.workspace.agent_id,
+                            node = %node.id,
+                            error = %err,
+                            "[workspace] overwrote a note whose artifact chain could not be \
+                             updated; if it was a published deliverable the chain is one \
+                             version behind until the next write on either surface"
+                        );
+                    }
                 }
                 Ok(ToolResult::success(format!(
                     "Overwrote the workspace note `{path}` (id={id}); it is now {bytes} bytes. \

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -160,8 +160,10 @@ use serde_json::{Value, json};
 use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
+use crate::company::artifact_mirror::mirror_node_edit;
 use crate::company::workspace_scaffold::AGENTS_ROOT;
 use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
+use crate::ports::artifacts::{ArtifactAuthor, ArtifactStore};
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
@@ -272,6 +274,13 @@ pub struct CompanyWorkspace {
     store: Arc<dyn WorkspaceStore>,
     company: CompanyId,
     agent_id: String,
+    /// The company's artifact store, when one is wired (issue #552).
+    ///
+    /// Held only so [`WorkspaceWriteTool`] can record an agent's overwrite of a
+    /// *published* note onto that deliverable's version chain. `None` — the
+    /// default, and every construction site but the agent builder's — means the
+    /// write tool behaves exactly as it did before #552.
+    artifacts: Option<Arc<dyn ArtifactStore>>,
 }
 
 impl CompanyWorkspace {
@@ -281,7 +290,20 @@ impl CompanyWorkspace {
             store,
             company,
             agent_id,
+            artifacts: None,
         }
+    }
+
+    /// Wire the artifact store, so an overwrite of a published note is recorded
+    /// on its chain (issue #552).
+    ///
+    /// A builder rather than a fourth parameter on [`new`](Self::new): the
+    /// artifact store is irrelevant to the two read tools and to every test
+    /// that exercises path resolution, and widening the constructor would make
+    /// them all pass a `None` that means nothing to them.
+    pub fn with_artifacts(mut self, artifacts: Option<Arc<dyn ArtifactStore>>) -> Self {
+        self.artifacts = artifacts;
+        self
     }
 
     /// This agent's origin, for stamping [`WorkspaceNode::created_by`] /
@@ -1191,15 +1213,57 @@ impl Tool for WorkspaceWriteTool {
             )
             .await
         {
-            Ok(node) => Ok(ToolResult::success(format!(
-                "Overwrote the workspace note `{path}` (id={id}); it is now {bytes} bytes. Its \
-                 new revision is rev={rev} — pass that as `expected_updated_at` if you edit it \
-                 again this turn.",
-                path = entry.path,
-                id = node.id,
-                bytes = content.len(),
-                rev = node.updated_at_millis,
-            ))),
+            Ok(node) => {
+                // Issue #552: the note this agent just overwrote may be another
+                // agent's *published deliverable*, whose authoritative history
+                // is the artifact chain. An overwrite the chain never saw is
+                // the same silent divergence a console save would cause, one
+                // surface over — and it is the version history, not the tree,
+                // that the Artifacts tab and `human_edit_diff` read.
+                //
+                // Node first here, unlike the console routes, and forced rather
+                // than chosen: the write above carries the `expected_updated_at`
+                // compare-and-swap, so until it returns there is nothing to
+                // record — a version appended before it would claim an edit
+                // that a stale-revision refusal then never made. The window is
+                // one store round trip, and a failure warns rather than
+                // reporting a successful write as failed.
+                //
+                // Ordinary notes are the overwhelming majority and match no
+                // artifact, so this is a no-op for almost every call. It is not
+                // a publish: no queue, no claim, #445 untouched.
+                if let Some(artifacts) = self.workspace.artifacts.as_ref()
+                    && let Err(err) = mirror_node_edit(
+                        artifacts.as_ref(),
+                        &self.workspace.company,
+                        &node.id,
+                        content,
+                        ArtifactAuthor::Agent,
+                        &self.workspace.agent_id,
+                        None,
+                    )
+                    .await
+                {
+                    tracing::warn!(
+                        company = %self.workspace.company,
+                        agent = %self.workspace.agent_id,
+                        node = %node.id,
+                        error = %err,
+                        "[workspace] overwrote a published note but could not record the \
+                         revision on its artifact; the chain is one version behind until the \
+                         next write on either surface"
+                    );
+                }
+                Ok(ToolResult::success(format!(
+                    "Overwrote the workspace note `{path}` (id={id}); it is now {bytes} bytes. \
+                     Its new revision is rev={rev} — pass that as `expected_updated_at` if you \
+                     edit it again this turn.",
+                    path = entry.path,
+                    id = node.id,
+                    bytes = content.len(),
+                    rev = node.updated_at_millis,
+                )))
+            }
             Err(e) => Ok(ToolResult::error(format!(
                 "Could not overwrite `{}`: {e}",
                 entry.path
@@ -1478,11 +1542,12 @@ impl Tool for WorkspaceCreateTool {
 /// second.
 pub fn workspace_tools(
     store: Arc<dyn WorkspaceStore>,
+    artifacts: Option<Arc<dyn ArtifactStore>>,
     company: CompanyId,
     agent_id: String,
     can_write: bool,
 ) -> Vec<Box<dyn Tool>> {
-    let workspace = CompanyWorkspace::new(store, company, agent_id);
+    let workspace = CompanyWorkspace::new(store, company, agent_id).with_artifacts(artifacts);
     let mut tools: Vec<Box<dyn Tool>> = vec![
         Box::new(WorkspaceListTool::new(workspace.clone())),
         Box::new(WorkspaceReadTool::new(workspace.clone())),
@@ -3029,6 +3094,172 @@ mod tests {
         assert_eq!(after.updated_by, agent_origin());
     }
 
+    // -- issue #552: an overwrite of a published note reaches its chain ------
+
+    /// A note in the shared tree may be another agent's published deliverable,
+    /// whose authoritative history is the artifact chain. An agent overwriting
+    /// one must record the revision there too — otherwise the Artifacts tab and
+    /// `human_edit_diff`, which read the chain and not the tree, would keep
+    /// showing a body that no longer exists.
+    ///
+    /// Recorded as an **agent** version stamped with this agent's id, so an
+    /// overwrite by a teammate never masquerades as the human edit the port
+    /// exists to isolate.
+    #[tokio::test]
+    async fn overwriting_a_published_note_records_the_revision_on_its_artifact() {
+        use crate::ports::artifacts::{ArtifactKind, ArtifactRecord};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        let store: Arc<dyn WorkspaceStore> = ops.clone();
+        let artifacts: Arc<dyn ArtifactStore> = ops.clone();
+        let id = CompanyId::new("acme");
+
+        let node = WorkspaceNode {
+            id: "n-deliverable".to_string(),
+            name: "launch.md".to_string(),
+            kind: NodeKind::File,
+            parent_id: None,
+            updated_at_millis: 2_000,
+            created_by: WorkspaceOrigin::Agent {
+                id: "maya".to_string(),
+            },
+            updated_by: WorkspaceOrigin::Agent {
+                id: "maya".to_string(),
+            },
+        };
+        store
+            .create(&id, &node, Some("maya's draft"))
+            .await
+            .unwrap();
+
+        let mut published = ArtifactRecord::new(
+            "art-1",
+            "t-1",
+            "Launch spec",
+            ArtifactKind::Markdown,
+            "maya's draft",
+            "maya",
+            1,
+        );
+        published.stamp_workspace_node("n-deliverable");
+        artifacts.upsert(&id, &published).await.unwrap();
+
+        let tool = WorkspaceWriteTool::new(
+            CompanyWorkspace::new(store.clone(), id.clone(), TEST_AGENT.to_string())
+                .with_artifacts(Some(artifacts.clone())),
+        );
+        let result = tool
+            .execute(json!({
+                "id": "n-deliverable",
+                "content": "the ceo's revision",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text(&result));
+
+        let stored = artifacts.get(&id, "art-1").await.unwrap().unwrap();
+        assert_eq!(stored.versions.len(), 2, "the chain must see the overwrite");
+        assert_eq!(stored.latest().unwrap().body, "the ceo's revision");
+        assert_eq!(stored.latest().unwrap().author, ArtifactAuthor::Agent);
+        assert_eq!(
+            stored.latest().unwrap().author_id,
+            TEST_AGENT,
+            "an agent overwrite must not be filed as the operator's human edit"
+        );
+        assert_eq!(
+            stored.workspace_node_id(),
+            Some("n-deliverable"),
+            "the new version keeps the node, or the next overwrite mirrors nothing"
+        );
+        assert!(
+            stored.human_edit_diff().is_none(),
+            "two agent versions are not a human edit"
+        );
+    }
+
+    /// Nearly every note is an ordinary note. Overwriting one records nothing
+    /// on any artifact — and a refused write records nothing either, because
+    /// the mirror runs only after the CAS'd store write actually lands.
+    #[tokio::test]
+    async fn an_ordinary_or_refused_write_records_no_artifact_version() {
+        use crate::ports::artifacts::{ArtifactKind, ArtifactRecord};
+
+        let dir = tempfile::tempdir().unwrap();
+        let ops = Arc::new(FsOps::new(dir.path()));
+        let store: Arc<dyn WorkspaceStore> = ops.clone();
+        let artifacts: Arc<dyn ArtifactStore> = ops.clone();
+        let id = CompanyId::new("acme");
+
+        let node = WorkspaceNode {
+            id: "n-plain".to_string(),
+            name: "notes.md".to_string(),
+            kind: NodeKind::File,
+            parent_id: None,
+            updated_at_millis: 2_000,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
+        };
+        store.create(&id, &node, Some("a note")).await.unwrap();
+
+        // An artifact exists, but points at a different node.
+        let mut published = ArtifactRecord::new(
+            "art-1",
+            "t-1",
+            "Launch spec",
+            ArtifactKind::Markdown,
+            "deliverable",
+            "maya",
+            1,
+        );
+        published.stamp_workspace_node("n-deliverable");
+        artifacts.upsert(&id, &published).await.unwrap();
+
+        let tool = WorkspaceWriteTool::new(
+            CompanyWorkspace::new(store.clone(), id.clone(), TEST_AGENT.to_string())
+                .with_artifacts(Some(artifacts.clone())),
+        );
+
+        // An ordinary note: the write lands, the chain is untouched.
+        assert!(
+            !tool
+                .execute(json!({
+                    "id": "n-plain",
+                    "content": "an edited note",
+                    "expected_updated_at": 2_000,
+                }))
+                .await
+                .unwrap()
+                .is_error
+        );
+
+        // A stale revision: the write is refused, so nothing may be recorded —
+        // a version appended before the CAS would claim an edit never made.
+        assert!(
+            tool.execute(json!({
+                "id": "n-plain",
+                "content": "clobber",
+                "expected_updated_at": 1,
+            }))
+            .await
+            .unwrap()
+            .is_error
+        );
+
+        assert_eq!(
+            artifacts
+                .get(&id, "art-1")
+                .await
+                .unwrap()
+                .unwrap()
+                .versions
+                .len(),
+            1,
+            "neither an unrelated note nor a refused write may touch the chain"
+        );
+    }
+
     // -- wiring -------------------------------------------------------------
 
     #[test]
@@ -3038,6 +3269,7 @@ mod tests {
 
         let read_only = workspace_tools(
             store.clone(),
+            None,
             CompanyId::new("acme"),
             TEST_AGENT.to_string(),
             false,
@@ -3045,7 +3277,13 @@ mod tests {
         let names: Vec<&str> = read_only.iter().map(|t| t.name()).collect();
         assert_eq!(names, vec![WORKSPACE_LIST_TOOL, WORKSPACE_READ_TOOL]);
 
-        let writable = workspace_tools(store, CompanyId::new("acme"), TEST_AGENT.to_string(), true);
+        let writable = workspace_tools(
+            store,
+            None,
+            CompanyId::new("acme"),
+            TEST_AGENT.to_string(),
+            true,
+        );
         let names: Vec<&str> = writable.iter().map(|t| t.name()).collect();
         assert_eq!(
             names,
@@ -3063,7 +3301,13 @@ mod tests {
     fn declared_permission_levels_match_what_each_tool_does() {
         let dir = tempfile::tempdir().unwrap();
         let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
-        let tools = workspace_tools(store, CompanyId::new("acme"), TEST_AGENT.to_string(), true);
+        let tools = workspace_tools(
+            store,
+            None,
+            CompanyId::new("acme"),
+            TEST_AGENT.to_string(),
+            true,
+        );
         assert_eq!(tools[0].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[1].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[2].permission_level(), PermissionLevel::Write);

--- a/src/ports/artifacts.rs
+++ b/src/ports/artifacts.rs
@@ -113,6 +113,39 @@ pub struct ArtifactVersion {
     /// loads with `None`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub run_id: Option<String>,
+    /// The workspace node this revision's body was mirrored into (issue #552).
+    ///
+    /// # What the two surfaces are, and which one is authoritative
+    ///
+    /// A published deliverable now lives twice: here, as the **authoritative
+    /// version history**, and as one node in the company's shared workspace
+    /// tree, which holds only the *current* body. The tree is the surface every
+    /// agent and the operator can browse, so a deliverable that never reached
+    /// it was invisible to everybody but the Artifacts tab of one card.
+    ///
+    /// The chain stays the truth. The node is a projection of its latest
+    /// version, and this field is the link between them. The invariant both
+    /// write paths keep is `node.body == chain.latest().body` after any
+    /// successful write on either surface.
+    ///
+    /// # Per version, not per record — and deliberately so
+    ///
+    /// Same reasoning as [`run_id`](Self::run_id) directly above. An operator
+    /// may delete a published node (deletions stick), and the next publish of
+    /// that path materializes a **fresh** node with a new id. Recording the id
+    /// per record would rewrite history and claim the old versions had always
+    /// lived in the new node; recording it per version says the honest thing —
+    /// v1 and v2 were mirrored into a node that no longer exists, v3 into this
+    /// one.
+    ///
+    /// `None` for a version nobody mirrored: an artifact recorded while no
+    /// workspace store was wired, a version whose node write failed (the
+    /// deliverable is still recorded — see
+    /// `harness::publish_node`), and every artifact stored before this field
+    /// existed. Artifacts persist as a JSON blob on every backend, so this
+    /// needs **no schema migration** and a pre-#552 record loads with `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workspace_node_id: Option<String>,
 }
 
 /// A versioned output of one task.
@@ -206,6 +239,7 @@ impl ArtifactRecord {
                 step_seq: None,
                 note: None,
                 run_id: None,
+                workspace_node_id: None,
             }],
             created_at_millis: at_millis,
             updated_at_millis: at_millis,
@@ -260,6 +294,7 @@ impl ArtifactRecord {
             step_seq: None,
             note,
             run_id: None,
+            workspace_node_id: None,
         });
         self.updated_at_millis = at_millis;
         next
@@ -276,6 +311,32 @@ impl ArtifactRecord {
         if let Some(latest) = self.versions.last_mut() {
             latest.run_id = Some(run_id.into());
         }
+    }
+
+    /// Stamps the newest revision with the workspace node its body was mirrored
+    /// into (#552).
+    ///
+    /// [`stamp_run`](Self::stamp_run)'s sibling, and a separate call for
+    /// exactly the same reason: only the two mirroring paths (the publish drain
+    /// and the console's node write) have a node to name, and widening
+    /// [`push_version`](Self::push_version) / [`new`](Self::new) would make the
+    /// REST create route, the conformance suite and every test pass a `None`
+    /// that means nothing to them. A no-op on an empty record.
+    pub fn stamp_workspace_node(&mut self, node_id: impl Into<String>) {
+        if let Some(latest) = self.versions.last_mut() {
+            latest.workspace_node_id = Some(node_id.into());
+        }
+    }
+
+    /// The workspace node the newest revision was mirrored into, if any.
+    ///
+    /// The re-publish and console-edit paths both ask this question — "is there
+    /// already a node for this deliverable?" — and both must ask it of the
+    /// *latest* version rather than of any version, because an operator's
+    /// deletion of a node is honoured: older versions keep pointing at the node
+    /// that held them, and only the newest says where the body lives now.
+    pub fn workspace_node_id(&self) -> Option<&str> {
+        self.latest()?.workspace_node_id.as_deref()
     }
 
     /// The diff of what a human changed before approving: the last
@@ -481,6 +542,7 @@ mod test {
             step_seq: None,
             note: None,
             run_id: None,
+            workspace_node_id: None,
         }
     }
 
@@ -528,7 +590,77 @@ mod test {
         let mut a = ArtifactRecord::new("a1", "t-1", "Draft", ArtifactKind::Text, "one", "ceo", 1);
         a.versions.clear();
         a.stamp_run("run-1");
+        a.stamp_workspace_node("n-1");
         assert!(a.versions.is_empty());
+    }
+
+    /// Issue #552: the workspace node a revision was mirrored into is recorded
+    /// **on that revision**, for the same reason `run_id` is one field up.
+    ///
+    /// The case that forces it: an operator deletes a published node (deletions
+    /// stick), and the next publish materializes a fresh one. v1 must keep
+    /// naming the node that actually held it — a record-level field would
+    /// rewrite history and claim it had always lived in the new node.
+    #[test]
+    fn each_revision_remembers_the_node_it_was_mirrored_into() {
+        let mut a =
+            ArtifactRecord::new("a1", "t-1", "Spec", ArtifactKind::Markdown, "v1", "ceo", 1);
+        a.stamp_workspace_node("node-old");
+        assert_eq!(a.workspace_node_id(), Some("node-old"));
+
+        // Re-publish after the operator deleted `node-old`: a fresh node, and
+        // the old version keeps pointing at the one that held it.
+        a.push_version("v2", ArtifactAuthor::Agent, "ceo", 2, None);
+        a.stamp_workspace_node("node-new");
+        assert_eq!(
+            a.version(1).unwrap().workspace_node_id.as_deref(),
+            Some("node-old")
+        );
+        assert_eq!(
+            a.version(2).unwrap().workspace_node_id.as_deref(),
+            Some("node-new")
+        );
+        assert_eq!(
+            a.workspace_node_id(),
+            Some("node-new"),
+            "the record-level answer is the newest revision's node, which is where the body lives"
+        );
+
+        let json = serde_json::to_string(&a).expect("serialize");
+        assert!(json.contains(r#""workspaceNodeId":"node-old""#), "{json}");
+        assert_eq!(a, serde_json::from_str(&json).expect("round trip"));
+    }
+
+    /// A pre-#552 blob is exactly what an unmirrored record serializes to — the
+    /// field is skipped when absent — so it must still load, with `None`. All
+    /// three backends store an artifact as an opaque JSON blob, so this
+    /// `#[serde(default)]` is the whole of the migration.
+    #[test]
+    fn a_pre_mirror_record_loads_with_no_workspace_node() {
+        let legacy = r##"{
+            "id": "a1",
+            "taskId": "t-1",
+            "title": "Launch spec",
+            "kind": "markdown",
+            "versions": [
+                {
+                    "version": 1,
+                    "body": "# Spec",
+                    "author": "agent",
+                    "authorId": "maya",
+                    "createdAtMillis": 5
+                }
+            ],
+            "createdAtMillis": 5,
+            "updatedAtMillis": 5,
+            "source": "specs/launch.md"
+        }"##;
+        let loaded: ArtifactRecord =
+            serde_json::from_str(legacy).expect("a pre-#552 record parses");
+        assert_eq!(loaded.workspace_node_id(), None);
+        // Round-tripping one must not mint a node id for it.
+        let json = serde_json::to_string(&loaded).unwrap();
+        assert!(!json.contains("workspaceNodeId"), "{json}");
     }
 
     #[test]

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -711,6 +711,42 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         column: Option<String>,
     },
+    /// A workspace node was written (issue #327) — created, changed, or
+    /// removed.
+    ///
+    /// [`TaskCardChanged`](Self::TaskCardChanged)'s counterpart for the note
+    /// tree, and missing for exactly the same reason: nothing on the feed said
+    /// the workspace had moved, so a console with the Workspace tab open saw an
+    /// agent's write only on a manual refresh or a window refocus. Now that
+    /// agents create notes (#551) and published deliverables land in the tree
+    /// (#552), that stale window is where most of the tree's activity happens.
+    ///
+    /// **Emitted from the store, not from the callers.** Appended by the
+    /// [`WorkspaceAnnouncer`](crate::runtime::WorkspaceAnnouncer) decorator
+    /// wrapping the company's
+    /// [`WorkspaceStore`](crate::ports::workspace::WorkspaceStore) — the one
+    /// place the seeder, the console routes, the agent tools and the publish
+    /// drain all pass through. An emit per call site is the shape of the bug:
+    /// correct only for the paths somebody remembered.
+    ///
+    /// **A record, never a stimulus.** Appended after the write it describes and
+    /// never fed into a cycle. A note that started work by existing would
+    /// re-enter this store and announce again.
+    ///
+    /// Additive: old logs never carry it, and its presence doesn't change how
+    /// any existing variant serializes.
+    WorkspaceChanged {
+        /// The written node's id.
+        node_id: String,
+        /// What happened to it, as a stable wire word: `opened` (the write
+        /// brought the node into existence), `updated` (its body or its place
+        /// in the tree changed), or `removed` (it was deleted).
+        ///
+        /// The same three words [`TaskCardChanged`](Self::TaskCardChanged)
+        /// uses, deliberately — a console that already knows how to read one
+        /// change vocabulary should not have to learn a second.
+        change: String,
+    },
     /// A dispatched board task finished its run (issue #185) — the terminal
     /// anchor a per-task timeline ends on and a lineage rollup counts.
     ///
@@ -1094,6 +1130,7 @@ impl CompanyEvent {
             Self::WorkflowDeleted { .. } => "WorkflowDeleted",
             Self::TaskSteered { .. } => "TaskSteered",
             Self::TaskCardChanged { .. } => "TaskCardChanged",
+            Self::WorkspaceChanged { .. } => "WorkspaceChanged",
             Self::DeskTaskCompleted { .. } => "DeskTaskCompleted",
             Self::EmergencyPauseChanged { .. } => "EmergencyPauseChanged",
             Self::TaskDiscussionPosted { .. } => "TaskDiscussionPosted",
@@ -1142,7 +1179,30 @@ impl CompanyEvent {
             Self::WorkflowRunStarted { .. }
             | Self::WorkflowRunFinished { .. }
             | Self::WorkflowNodeFinished { .. }
-            | Self::McpCallFailed { .. } => Prunable,
+            | Self::McpCallFailed { .. }
+            // Issue #327, and the one place this diverges from its sibling
+            // `TaskCardChanged` — which is Permanent — so the reasoning is
+            // spelled out rather than assumed.
+            //
+            // It passes all three of the tests the doc comment above sets. It
+            // is not evidence: the tree IS the record of what the workspace
+            // holds, and this frame carries no body, only "something moved".
+            // Nothing points at it: no entry is addressed by its sequence, the
+            // way a reaction or a redaction tombstone addresses a chat message.
+            // And nothing reads it back: no boot-time fold consults it, unlike
+            // `WorkflowReportDelivered`.
+            //
+            // What it is instead is high-volume machine exhaust — one frame per
+            // keystroke-debounced console save, per agent write, per seeded
+            // node at first boot — whose entire meaning is "re-read the tree",
+            // and which is worthless the moment the console has done so.
+            //
+            // `TaskCardChanged` stays Permanent because a board card's
+            // lifecycle is the company's work history. A note's revision
+            // history is not kept here at all: for a published deliverable it
+            // lives on the artifact chain (#552), and for an ordinary note it
+            // is not kept anywhere, which pruning this does not change.
+            | Self::WorkspaceChanged { .. } => Prunable,
 
             Self::OperatorMessage { .. }
             | Self::WebhookReceived { .. }
@@ -4314,6 +4374,51 @@ mod test {
                 error: None,
                 cancelled: false,
             }
+        );
+    }
+
+    /// Issue #327: the workspace announcement survives the JSONL round trip the
+    /// journal puts every event through, and carries its discriminant.
+    #[test]
+    fn workspace_changed_round_trips() {
+        let event = CompanyEvent::WorkspaceChanged {
+            node_id: "n-1".to_string(),
+            change: "updated".to_string(),
+        };
+        assert_eq!(round_trip(&event), event);
+        assert_eq!(event.kind(), "WorkspaceChanged");
+        let json = serde_json::to_string(&event).expect("serialize");
+        assert!(json.contains(r#""kind":"WorkspaceChanged""#), "{json}");
+        assert!(json.contains(r#""node_id":"n-1""#), "{json}");
+    }
+
+    /// The one variant whose retention class diverges from its sibling's, so
+    /// the choice is pinned rather than left to the next reader's memory.
+    ///
+    /// `WorkspaceChanged` is Prunable: it is high-volume machine exhaust whose
+    /// whole meaning is "re-read the tree", nothing addresses it by sequence,
+    /// and nothing folds it at boot. `TaskCardChanged` stays Permanent because
+    /// a board card's lifecycle is the company's work history.
+    #[test]
+    fn a_workspace_announcement_is_prunable_though_its_board_sibling_is_not() {
+        use crate::ports::events::RetentionClass;
+
+        assert_eq!(
+            CompanyEvent::WorkspaceChanged {
+                node_id: "n-1".to_string(),
+                change: "updated".to_string(),
+            }
+            .retention_class(),
+            RetentionClass::Prunable
+        );
+        assert_eq!(
+            CompanyEvent::TaskCardChanged {
+                task_id: "t-1".to_string(),
+                change: "opened".to_string(),
+                column: Some("todo".to_string()),
+            }
+            .retention_class(),
+            RetentionClass::Permanent
         );
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -49,6 +49,7 @@ use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::handover::RuntimeHandover;
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::tools::{StubToolProvider, grant_matches};
+use crate::runtime::workspace_events::WorkspaceAnnouncer;
 use crate::store::paths::Bundle;
 use crate::store::{
     FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsMemoryStore, FsOps, FsSecretStore,
@@ -804,7 +805,15 @@ impl RuntimeBuilder {
                     self.tasks.unwrap_or_else(|| fs_ops.clone()),
                     events.clone(),
                 )),
-                workspace: self.workspace.unwrap_or_else(|| fs_ops.clone()),
+                // Issue #327: and the tree announces its own writes, for the
+                // same reason and in the same place. Every writer — the
+                // console routes, the agent tools, the publish drain, the
+                // seeder below — passes through this port, so none of them has
+                // to remember to emit. See [`WorkspaceAnnouncer`].
+                workspace: Arc::new(WorkspaceAnnouncer::new(
+                    self.workspace.unwrap_or_else(|| fs_ops.clone()),
+                    events.clone(),
+                )),
                 facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
                 artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
                 runs: self.runs.unwrap_or_else(|| fs_ops.clone()),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1265,6 +1265,11 @@ fn cycle_task_id(
             // in the approval gate, not by starting or claiming a cycle, so it
             // names no card and competes with none.
             | CompanyEvent::EmergencyPauseChanged { .. }
+            // Issue #327: joins `TaskCardChanged` below on the same terms — a
+            // record of a write that already happened, appended by the
+            // workspace store after it. A note that started a cycle merely by
+            // being written would re-enter that store and announce again.
+            | CompanyEvent::WorkspaceChanged { .. }
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }
@@ -1394,6 +1399,11 @@ fn cycle_thread_id(
             // in the approval gate, not by starting or claiming a cycle, so it
             // names no card and competes with none.
             | CompanyEvent::EmergencyPauseChanged { .. }
+            // Issue #327: joins `TaskCardChanged` below on the same terms — a
+            // record of a write that already happened, appended by the
+            // workspace store after it. A note that started a cycle merely by
+            // being written would re-enter that store and announce again.
+            | CompanyEvent::WorkspaceChanged { .. }
             | CompanyEvent::AgentReply { .. }
             | CompanyEvent::ApprovalParked { .. }
             | CompanyEvent::MemoryFactDeleted { .. }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2495,14 +2495,22 @@ mod test {
         assert_eq!(report.responses[0].text, "You said: hi");
 
         // (b) the event was appended to the log.
+        //
+        // Filtered rather than counted: since issue #327 boot's workspace
+        // scaffold journals a `WorkspaceChanged` per reserved root, so the log
+        // already holds entries this test is not about.
         let stored = rt
             .events
             .read_from(rt.id(), EventSeq::new(0), 10)
             .await
             .unwrap();
-        assert_eq!(stored.len(), 1);
+        let operator: Vec<_> = stored
+            .iter()
+            .filter(|e| matches!(e.event, CompanyEvent::OperatorMessage { .. }))
+            .collect();
+        assert_eq!(operator.len(), 1);
         assert_eq!(
-            stored[0].event,
+            operator[0].event,
             CompanyEvent::OperatorMessage {
                 parent: None,
                 text: "hi".into(),

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -4468,6 +4468,38 @@ mod test {
             cycle_task_id(&[dispatched("t-1"), resolved("appr-none")], approval_task),
             None,
         );
+
+        // Issue #327: a workspace write is a record of something that already
+        // happened, so it is neutral on both counts. Alone it names no card…
+        assert_eq!(cycle_task_id(&[workspace_changed()], approval_task), None);
+        // …and — the arm that actually matters — it must not *disqualify* a
+        // dispatch it happens to share a batch with. An agent writing a note
+        // while its cycle runs is the ordinary case, and treating that write as
+        // a rival trigger would strip the card off its own stamp.
+        assert_eq!(
+            cycle_task_id(&[dispatched("t-1"), workspace_changed()], approval_task),
+            Some("t-1".into()),
+            "a workspace write must not disqualify the dispatch beside it",
+        );
+        assert_eq!(
+            cycle_task_id(
+                &[workspace_changed(), dispatched("t-1"), workspace_changed()],
+                approval_task
+            ),
+            Some("t-1".into()),
+            "and not from either side of it",
+        );
+    }
+
+    /// One workspace write (issue #327), for the neutrality assertions in both
+    /// `cycle_*_id` tests. Shared because it is the same claim made twice: an
+    /// event neutral for the card but not for the thread would mis-stamp every
+    /// cycle that answered a message and touched the tree.
+    fn workspace_changed() -> CompanyEvent {
+        CompanyEvent::WorkspaceChanged {
+            node_id: "n-1".into(),
+            change: "updated".into(),
+        }
     }
 
     /// The conversation key (#379): which chat thread a cycle is answering, read
@@ -4633,6 +4665,10 @@ mod test {
                 steps: Vec::new(),
                 task_id: None,
             },
+            // Issue #327: appended by the workspace store after the write it
+            // describes. An agent that answers a message and touches the tree
+            // in the same turn must keep its channel stamp.
+            workspace_changed(),
         ] {
             assert_eq!(
                 cycle_thread_id(
@@ -4643,6 +4679,11 @@ mod test {
                 "{record:?} is a record, not a trigger, and must not disqualify the batch",
             );
         }
+        // And alone it claims no conversation of its own.
+        assert_eq!(
+            cycle_thread_id(&[workspace_changed()], approval_thread),
+            None,
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -96,6 +96,11 @@ pub mod workflow_scheduler;
 /// Issue #395: the supervisor-registration + outcome-journalling discipline
 /// every workflow entry point owes, in one place. See [`workflow_spawn`].
 pub mod workflow_spawn;
+/// Issue #327: [`WorkspaceAnnouncer`] — [`BoardAnnouncer`]'s counterpart for the
+/// note tree. A note created, overwritten, moved or deleted by *anything* — the
+/// console, an agent tool, the publish drain, the seeder — reaches a watching
+/// console without a reload. See [`workspace_events`].
+pub mod workspace_events;
 
 pub use advance::{SYSTEM_ATTRIBUTION, advance_settled_card, append_result};
 pub use board_events::{BoardAnnouncer, CHANGE_OPENED, CHANGE_REMOVED, CHANGE_UPDATED};
@@ -116,6 +121,7 @@ pub use workflow_outcome::{
 pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
 pub use workflow_spawn::WorkflowSpawn;
+pub use workspace_events::WorkspaceAnnouncer;
 
 // The assembly struct lives under `company/` to match the `ports.md` sketch
 // (`src/company/runtime.rs`); re-export it here as the kernel's public surface.

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -388,16 +388,21 @@ mod test {
         assert_eq!(scheduler.tick().await.unwrap(), 1);
 
         // A ScheduleFired event landed in the log and the brain answered.
+        //
+        // Filtered rather than counted: since issue #327 boot's workspace
+        // scaffold journals a `WorkspaceChanged` per reserved root, so the log
+        // is not empty before the tick. This test is about the cron firing
+        // once, which is a question about `ScheduleFired` entries specifically.
         let events = rt
             .events
             .read_from(rt.id(), EventSeq::new(0), 10)
             .await
             .unwrap();
-        assert_eq!(events.len(), 1);
-        assert!(matches!(
-            events[0].event,
-            CompanyEvent::ScheduleFired { .. }
-        ));
+        let fired: Vec<_> = events
+            .iter()
+            .filter(|e| matches!(e.event, CompanyEvent::ScheduleFired { .. }))
+            .collect();
+        assert_eq!(fired.len(), 1);
 
         // A second tick within the same minute does not re-fire (dedupe).
         clock.advance(30_000);
@@ -416,7 +421,13 @@ mod test {
             .read_from(rt.id(), EventSeq::new(0), 10)
             .await
             .unwrap();
-        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e.event, CompanyEvent::ScheduleFired { .. }))
+                .count(),
+            2
+        );
     }
 
     #[tokio::test]

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -1,0 +1,479 @@
+//! Issue #327: the workspace announces its own writes.
+//!
+//! A note can change on several paths — the console's create / `PUT` /
+//! rename-move / delete routes, an agent's `workspace_create` and
+//! `workspace_write` tools (issue #551), the publish drain materializing a
+//! deliverable (issue #552), the boot seeder — and before this nothing on the
+//! company feed said so. The Workspace tab's own module docs named the gap: "a
+//! write that lands while the tab is open is only visible on a refetch (refresh
+//! button / window focus)".
+//!
+//! That was tolerable when the operator was the only writer. It stopped being
+//! tolerable the moment agents could create notes and published deliverables
+//! started landing in the tree, because then most of what appears in the
+//! workspace appears while nobody is touching it.
+//!
+//! ## Why the store, and not the callers
+//!
+//! [`WorkspaceAnnouncer`] is a decorator over the company's [`WorkspaceStore`],
+//! wrapped in once by [`RuntimeBuilder`](crate::runtime::RuntimeBuilder) — the
+//! same shape [`BoardAnnouncer`](crate::runtime::BoardAnnouncer) uses, and for
+//! the same reason its module docs give: every writer already goes through this
+//! port, so the announcement is emitted **once, where notes are actually
+//! written**, rather than once per call site that happens to write one.
+//!
+//! That is the fix, not an implementation detail. An emit at each write site is
+//! the same shape as the bug: correct only for the paths somebody remembered,
+//! and silent for the next one added. Here a new writer cannot forget, because
+//! it does not get a say.
+//!
+//! ## What it is not
+//!
+//! * **Not a stimulus.** The event is appended after the write and never fed
+//!   into a cycle. A note that started work merely by existing would re-enter
+//!   this store and announce again.
+//! * **Not the tree's truth.** The store is. The frame says *something in the
+//!   workspace changed*; a console reacts by re-reading the tree it already
+//!   knows how to read. That is why a lost frame degrades to "one stale render"
+//!   and never to wrong state — and why the frame carries no node name and no
+//!   body.
+//! * **Not a failure path.** Record-keeping never fails the work it records: an
+//!   event log that refuses is logged and swallowed. A note that was written
+//!   stays written.
+//!
+//! ## The boot burst, named rather than discovered
+//!
+//! Seeding a new company's workspace from its bundle calls [`create`] once per
+//! node, and the system-root scaffold adds two more — so first boot emits a
+//! burst of `opened` frames. Nothing is listening (the SSE stream is opened by
+//! a console, which cannot be attached to a company that is still being built),
+//! and each frame is [`Prunable`](crate::ports::events::RetentionClass), so the
+//! burst costs a bounded number of journal lines once in a company's life. It
+//! is left alone deliberately: suppressing it would need the seeder to reach
+//! past the port it shares with every other writer, which is exactly the
+//! per-caller special-casing this decorator exists to remove.
+//!
+//! [`create`]: WorkspaceStore::create
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::error::Result;
+use crate::ports::events::EventLog;
+use crate::ports::types::{CompanyEvent, CompanyId};
+use crate::ports::workspace::{WorkspaceNode, WorkspaceStore};
+use crate::runtime::board_events::{CHANGE_OPENED, CHANGE_REMOVED, CHANGE_UPDATED};
+
+/// A [`WorkspaceStore`] that appends a
+/// [`WorkspaceChanged`](CompanyEvent::WorkspaceChanged) to the company's event
+/// log after any write that actually changed the tree.
+///
+/// Reads pass straight through. See the module docs for why this lives at the
+/// store rather than at the callers.
+pub struct WorkspaceAnnouncer {
+    inner: Arc<dyn WorkspaceStore>,
+    events: Arc<dyn EventLog>,
+}
+
+impl WorkspaceAnnouncer {
+    /// Wraps `inner`, announcing onto `events`.
+    pub fn new(inner: Arc<dyn WorkspaceStore>, events: Arc<dyn EventLog>) -> Self {
+        Self { inner, events }
+    }
+
+    /// Appends one announcement, best-effort.
+    ///
+    /// A refusing event log is warned about and swallowed: the workspace write
+    /// it describes has already succeeded and must not be undone (or reported
+    /// as failed) because the *record* of it could not be filed.
+    async fn announce(&self, company: &CompanyId, node_id: &str, change: &str) {
+        let event = CompanyEvent::WorkspaceChanged {
+            node_id: node_id.to_string(),
+            change: change.to_string(),
+        };
+        if let Err(err) = self.events.append(company, event).await {
+            tracing::warn!(
+                company = %company,
+                node = %node_id,
+                change = %change,
+                error = %err,
+                "could not announce a workspace write"
+            );
+        }
+    }
+
+    /// The node with `id` as the tree holds it now, or `None`.
+    ///
+    /// Reads the tree rather than [`WorkspaceStore::read`] on purpose: `read`
+    /// returns the note's whole body, and this only ever needs the name and the
+    /// parent. A read that fails yields `None` rather than propagating — the
+    /// caller uses it only to decide whether to speak, and refusing a write
+    /// because the *prior* state could not be read would fail workspace writes
+    /// for a diagnostic.
+    async fn current(&self, company: &CompanyId, id: &str) -> Option<WorkspaceNode> {
+        self.inner
+            .tree(company)
+            .await
+            .ok()?
+            .into_iter()
+            .find(|node| node.id == id)
+    }
+}
+
+#[async_trait]
+impl WorkspaceStore for WorkspaceAnnouncer {
+    async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
+        self.inner.tree(company).await
+    }
+
+    async fn read(&self, company: &CompanyId, id: &str) -> Result<Option<(WorkspaceNode, String)>> {
+        self.inner.read(company, id).await
+    }
+
+    async fn is_empty(&self, company: &CompanyId) -> Result<bool> {
+        self.inner.is_empty(company).await
+    }
+
+    /// Writes through, then announces `updated`.
+    ///
+    /// Unconditional, unlike [`BoardAnnouncer`](crate::runtime::BoardAnnouncer)'s
+    /// identical-re-save suppression: a `write` always advances the node's
+    /// `updated_at_millis`, which is the revision token the agent tools' CAS
+    /// compares against, so a write that stores the same bytes has still
+    /// changed the node in the way that matters. Detecting "same body" would
+    /// also cost a full read of every note on every save, to save a refetch.
+    async fn write(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        content: &str,
+        author: crate::ports::workspace::WorkspaceOrigin,
+    ) -> Result<WorkspaceNode> {
+        let node = self.inner.write(company, id, content, author).await?;
+        self.announce(company, id, CHANGE_UPDATED).await;
+        Ok(node)
+    }
+
+    /// Creates through, then announces `opened`.
+    async fn create(
+        &self,
+        company: &CompanyId,
+        node: &WorkspaceNode,
+        content: Option<&str>,
+    ) -> Result<()> {
+        self.inner.create(company, node, content).await?;
+        self.announce(company, &node.id, CHANGE_OPENED).await;
+        Ok(())
+    }
+
+    /// Renames/moves through, then announces `updated` — unless nothing moved.
+    ///
+    /// **A rename that changes nothing says nothing.** The port takes `None` for
+    /// "leave this alone", so a call naming neither a new name nor a new parent
+    /// cannot have changed the tree; and a rename to the name a node already
+    /// carries is an ordinary console outcome (an operator opening the rename
+    /// dialog and pressing save). Announcing either would put a frame on the
+    /// feed for a tree that did not move — noise a console cannot distinguish
+    /// from a real change.
+    ///
+    /// The prior state is read before the call, so the comparison is against
+    /// what the tree actually held rather than against what the caller asked
+    /// for.
+    async fn rename_move(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        name: Option<&str>,
+        parent: Option<Option<&str>>,
+    ) -> Result<WorkspaceNode> {
+        let previous = self.current(company, id).await;
+        let node = self.inner.rename_move(company, id, name, parent).await?;
+        let moved = previous
+            .is_none_or(|before| before.name != node.name || before.parent_id != node.parent_id);
+        if moved {
+            self.announce(company, id, CHANGE_UPDATED).await;
+        }
+        Ok(node)
+    }
+
+    /// Deletes through, and announces only when a node was actually removed —
+    /// a delete of an id the tree never held changed nothing.
+    ///
+    /// One frame for the node named, even when it was a folder and the store
+    /// removed a whole subtree with it. The frame says *the tree moved*, and
+    /// the console's answer to that is to re-read the tree, which discovers
+    /// every descendant that went with it. A frame per descendant would be a
+    /// burst saying the same thing N times.
+    async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
+        let removed = self.inner.delete(company, id).await?;
+        if removed {
+            self.announce(company, id, CHANGE_REMOVED).await;
+        }
+        Ok(removed)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::ports::types::{EventSeq, StoredEvent};
+    use crate::ports::workspace::{NodeKind, WorkspaceOrigin};
+    use crate::store::FsOps;
+    use futures::stream::BoxStream;
+    use std::sync::Mutex;
+
+    #[derive(Default)]
+    struct MemLog {
+        appended: Mutex<Vec<CompanyEvent>>,
+    }
+
+    #[async_trait]
+    impl EventLog for MemLog {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> Result<EventSeq> {
+            let mut got = self.appended.lock().unwrap();
+            got.push(event);
+            Ok(EventSeq::new(got.len() as u64))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// An event log that refuses every append, so the "record-keeping never
+    /// fails the work it records" contract is tested rather than asserted.
+    struct BrokenLog;
+
+    #[async_trait]
+    impl EventLog for BrokenLog {
+        async fn append(&self, _id: &CompanyId, _event: CompanyEvent) -> Result<EventSeq> {
+            Err(crate::error::OpenCompanyError::Store(
+                "log is down".to_string(),
+            ))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// A real fs-backed tree behind the decorator, so it is exercised against a
+    /// genuine `WorkspaceStore` rather than a stub that cannot tell a create
+    /// from an overwrite.
+    fn wired() -> (
+        tempfile::TempDir,
+        WorkspaceAnnouncer,
+        Arc<MemLog>,
+        CompanyId,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let log = Arc::new(MemLog::default());
+        let store = WorkspaceAnnouncer::new(Arc::new(FsOps::new(dir.path())), log.clone());
+        (dir, store, log, CompanyId::new("announcer-co"))
+    }
+
+    fn note(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+        WorkspaceNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: NodeKind::File,
+            parent_id: parent.map(str::to_string),
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
+        }
+    }
+
+    fn changes(log: &MemLog) -> Vec<(String, String)> {
+        log.appended
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|event| match event {
+                CompanyEvent::WorkspaceChanged { node_id, change } => {
+                    (node_id.clone(), change.clone())
+                }
+                other => panic!("expected a workspace announcement, got {other:?}"),
+            })
+            .collect()
+    }
+
+    /// The headline of #327: a note written by *anything* announces itself, and
+    /// the first write of an id is an `opened` rather than an `updated`.
+    #[tokio::test]
+    async fn a_new_note_announces_that_it_opened() {
+        let (_dir, store, log, co) = wired();
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            changes(&log),
+            vec![("n-1".to_string(), "opened".to_string())]
+        );
+    }
+
+    /// An overwrite announces an update — the frame an agent's `workspace_write`
+    /// and the console's `PUT` both need, and the one the Workspace tab had no
+    /// way to learn about at all.
+    #[tokio::test]
+    async fn overwriting_a_note_announces_an_update() {
+        let (_dir, store, log, co) = wired();
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .unwrap();
+        store
+            .write(&co, "n-1", "new body", WorkspaceOrigin::Operator)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            changes(&log),
+            vec![
+                ("n-1".to_string(), "opened".to_string()),
+                ("n-1".to_string(), "updated".to_string()),
+            ]
+        );
+    }
+
+    /// A rename that renames announces; one that names no change is silent. A
+    /// frame for a tree that did not move is noise a console cannot tell from a
+    /// real change.
+    #[tokio::test]
+    async fn a_rename_announces_only_when_something_actually_moved() {
+        let (_dir, store, log, co) = wired();
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .unwrap();
+        log.appended.lock().unwrap().clear();
+
+        // A no-op: the port reads `None` as "leave this alone".
+        store.rename_move(&co, "n-1", None, None).await.unwrap();
+        assert!(changes(&log).is_empty(), "a no-op rename must be silent");
+
+        // A rename to the name it already carries is the same non-event — an
+        // operator opening the dialog and pressing save.
+        store
+            .rename_move(&co, "n-1", Some("brief.md"), None)
+            .await
+            .unwrap();
+        assert!(
+            changes(&log).is_empty(),
+            "renaming to the current name changed nothing"
+        );
+
+        store
+            .rename_move(&co, "n-1", Some("launch.md"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            changes(&log),
+            vec![("n-1".to_string(), "updated".to_string())]
+        );
+    }
+
+    /// A removed note announces its removal, and deleting an id the tree never
+    /// held announces nothing — it changed nothing.
+    #[tokio::test]
+    async fn a_deleted_note_announces_removal_and_an_absent_one_is_silent() {
+        let (_dir, store, log, co) = wired();
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .unwrap();
+        log.appended.lock().unwrap().clear();
+
+        assert!(!store.delete(&co, "never-existed").await.unwrap());
+        assert!(changes(&log).is_empty());
+
+        assert!(store.delete(&co, "n-1").await.unwrap());
+        assert_eq!(
+            changes(&log),
+            vec![("n-1".to_string(), "removed".to_string())]
+        );
+    }
+
+    /// Deleting a folder is one frame for the folder, not one per descendant.
+    /// The frame says the tree moved; the console re-reads the tree and
+    /// discovers everything that went with it.
+    #[tokio::test]
+    async fn deleting_a_folder_announces_once_not_once_per_descendant() {
+        let (_dir, store, log, co) = wired();
+        let folder = WorkspaceNode {
+            kind: NodeKind::Folder,
+            ..note("f-1", "Specs", None)
+        };
+        store.create(&co, &folder, None).await.unwrap();
+        store
+            .create(&co, &note("n-1", "a.md", Some("f-1")), Some("a"))
+            .await
+            .unwrap();
+        store
+            .create(&co, &note("n-2", "b.md", Some("f-1")), Some("b"))
+            .await
+            .unwrap();
+        log.appended.lock().unwrap().clear();
+
+        assert!(store.delete(&co, "f-1").await.unwrap());
+        assert_eq!(
+            changes(&log),
+            vec![("f-1".to_string(), "removed".to_string())],
+            "a subtree removal is one frame, not a burst saying the same thing"
+        );
+    }
+
+    /// Reads pass straight through and announce nothing — this decorator is
+    /// about writes, and a tab that refetched on every read would loop.
+    #[tokio::test]
+    async fn reads_announce_nothing() {
+        let (_dir, store, log, co) = wired();
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .unwrap();
+        log.appended.lock().unwrap().clear();
+
+        store.tree(&co).await.unwrap();
+        store.read(&co, "n-1").await.unwrap();
+        store.is_empty(&co).await.unwrap();
+        assert!(changes(&log).is_empty());
+    }
+
+    /// Record-keeping never fails the work it records: a refusing event log
+    /// leaves the write successful and the note in the tree.
+    #[tokio::test]
+    async fn a_refusing_event_log_does_not_fail_the_workspace_write() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = WorkspaceAnnouncer::new(Arc::new(FsOps::new(dir.path())), Arc::new(BrokenLog));
+        let co = CompanyId::new("announcer-broken");
+
+        store
+            .create(&co, &note("n-1", "brief.md", None), Some("body"))
+            .await
+            .expect("the write succeeds even when the announcement cannot be filed");
+        store
+            .write(&co, "n-1", "revised", WorkspaceOrigin::Operator)
+            .await
+            .expect("and so does the overwrite");
+        assert_eq!(store.tree(&co).await.unwrap().len(), 1);
+        assert_eq!(store.read(&co, "n-1").await.unwrap().unwrap().1, "revised");
+    }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -696,6 +696,23 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
         // *something moved*, not to carry the board. The console reacts by
         // re-reading the board it already knows how to read, which keeps the
         // card's content on exactly one route instead of two.
+        // Issue #327: the frame the Workspace tab was missing. This stream is
+        // deny-by-default — an event with no arm here is simply not projected —
+        // so without this the tab stays on refresh-and-refocus no matter what
+        // the store announces.
+        //
+        // Two keys, both structural, and both already reachable by the same
+        // operator through `GET {scope}/workspace`. There is deliberately **no
+        // node name and no body**: a note's text is operator- or agent-authored
+        // free text, and this frame's whole job is to say *something moved*.
+        // The console reacts by re-reading the tree it already knows how to
+        // read, which keeps the workspace's content on exactly one route.
+        CompanyEvent::WorkspaceChanged { node_id, change } => {
+            let mut o = envelope("workspace_changed");
+            o["nodeId"] = json!(node_id);
+            o["change"] = json!(change);
+            o
+        }
         CompanyEvent::TaskCardChanged {
             task_id,
             change,
@@ -4568,6 +4585,27 @@ mod test {
             v.get("column").is_none(),
             "a removed card is in no column: {v}"
         );
+    }
+
+    /// Issue #327: the workspace's own frame. The stream is deny-by-default, so
+    /// an event with no arm is silently unprojected — this is what proves the
+    /// arm exists at all.
+    ///
+    /// Also pins what is **not** on the wire: no node name, no body. A note's
+    /// text is operator- or agent-authored free text, and this frame's job is
+    /// to say something moved, not to carry the tree.
+    #[test]
+    fn projects_workspace_changed_without_a_name_or_a_body() {
+        let v = super::project_event(&stored(CompanyEvent::WorkspaceChanged {
+            node_id: "n-9".into(),
+            change: crate::runtime::CHANGE_UPDATED.into(),
+        }))
+        .expect("a workspace write must reach the console");
+        assert_eq!(v["type"], "workspace_changed");
+        assert_eq!(v["nodeId"], "n-9");
+        assert_eq!(v["change"], "updated");
+        assert!(v.get("name").is_none(), "no node name on the wire: {v}");
+        assert!(v.get("content").is_none(), "no body on the wire: {v}");
     }
 
     #[test]

--- a/src/server/ops/artifacts.rs
+++ b/src/server/ops/artifacts.rs
@@ -28,13 +28,19 @@ use crate::error::OpenCompanyError;
 use crate::ports::artifacts::{
     ArtifactAuthor, ArtifactDiff, ArtifactKind, ArtifactRecord, ArtifactVersion,
 };
+use crate::ports::workspace::WorkspaceOrigin;
 use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// The note stamped on a version created through the append route when the
 /// caller supplies none. Kept as a constant so the console can recognise it.
-const OPERATOR_EDIT_NOTE: &str = "operator edit before approval";
+///
+/// `pub(crate)` since issue #552: the workspace `PUT` route now records an
+/// operator's edit of a *published* note as a version too, and it has to say
+/// the same thing this route does — the console recognises the wording, and two
+/// spellings of one event would show up as two different kinds of edit.
+pub(crate) const OPERATOR_EDIT_NOTE: &str = "operator edit before approval";
 
 /// Builds the artifact route fragment.
 pub fn router() -> Router<AppState> {
@@ -188,6 +194,20 @@ async fn create_artifact(
 /// This is how a human edit is captured. The prior version is left untouched,
 /// so the diff between them stays computable forever; there is deliberately no
 /// route that rewrites a stored version.
+///
+/// # The node follows the chain (issue #552)
+///
+/// When the artifact is a *published* deliverable it also lives as a node in
+/// the shared workspace tree, and that node holds the current body. Appending
+/// here without updating it would leave the operator and every agent reading a
+/// draft the version history has already superseded — the same divergence from
+/// the other direction, and just as invisible.
+///
+/// Chain first, node second, matching the workspace `PUT`: the chain is
+/// authoritative, so a node that could not be updated is a stale projection
+/// that heals on the next write, and it must never fail the request that
+/// already recorded the version. A mirror failure therefore warns and returns
+/// the appended version.
 async fn append_version(
     company: ScopedCompany,
     Path(ArtifactPath { artifact_id }): Path<ArtifactPath>,
@@ -203,12 +223,43 @@ async fn append_version(
         ArtifactAuthor::Operator => Some(OPERATOR_EDIT_NOTE.to_string()),
         ArtifactAuthor::Agent => None,
     });
+    // Read from the version this one supersedes, before the push: the appended
+    // version has no node of its own until it inherits this one.
+    let mirror_target = record.workspace_node_id().map(str::to_string);
+    let origin = match author {
+        ArtifactAuthor::Operator => WorkspaceOrigin::Operator,
+        ArtifactAuthor::Agent => WorkspaceOrigin::Agent {
+            id: author_id.clone(),
+        },
+    };
+    let mirrored_body = body.body.clone();
     record.push_version(body.body, author, author_id, now_millis(), note);
+    if let Some(node_id) = &mirror_target {
+        // Carried onto the new version, or the *next* append's lookup finds no
+        // node and mirroring silently stops after one hop.
+        record.stamp_workspace_node(node_id);
+    }
     company
         .runtime
         .artifacts()
         .upsert(company.id(), &record)
         .await?;
+
+    if let Some(node_id) = mirror_target
+        && let Err(err) = company
+            .runtime
+            .workspace()
+            .write(company.id(), &node_id, &mirrored_body, origin)
+            .await
+    {
+        tracing::warn!(
+            artifact = %artifact_id,
+            node = %node_id,
+            error = %err,
+            "[artifacts] appended a version but could not update its workspace note; the note is \
+             stale until the next write on either surface"
+        );
+    }
     Ok(Json(record.into()))
 }
 

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -44,7 +44,7 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
-use crate::company::artifact_mirror::mirror_node_edit;
+use crate::company::artifact_mirror::{MirrorOutcome, mirror_node_edit};
 use crate::company::workspace_links::file_with_backlinks;
 use crate::error::OpenCompanyError;
 use crate::ports::artifacts::ArtifactAuthor;
@@ -274,10 +274,28 @@ async fn create_node(
 /// chooses. See [`artifact_mirror`](crate::company::artifact_mirror).
 ///
 /// An ordinary note — which is nearly all of them — matches no artifact, so the
-/// lookup returns `None` and this behaves exactly as it did before. The lookup
-/// is a scan of the company's artifacts per save; it is bounded by what
+/// lookup answers `Ordinary` and this behaves exactly as it did before. The
+/// lookup is a scan of the company's artifacts per save; it is bounded by what
 /// artifacts are (a task's drafts, not a repository) and is named as the place
 /// to add an index if it ever hurts.
+///
+/// # When the artifact store cannot answer at all
+///
+/// The lookup is the only reason this route reads the artifact store, and it
+/// runs for every note. Propagating its failure would mean an artifact-store
+/// fault rejects the save of a plain note — losing an operator's edit to a
+/// store that note does not depend on, to protect a chain it does not have.
+/// So a lookup that *fails* is warned about and the node write proceeds.
+///
+/// This is a deliberate narrowing of the ordering guarantee, not an exception
+/// to it. Fail-closed still holds wherever it can be applied: once the store
+/// answers and names this node a deliverable, a version that cannot be appended
+/// still refuses the save. What is given up is only the case where the store
+/// cannot be read at all — there, a published deliverable edited during the
+/// outage lands node-ahead-of-chain, the silent direction. The window is an
+/// unreachable artifact store, the alternative is refusing every note in the
+/// company for the same duration, and the divergence heals on the next
+/// successful save of that note.
 async fn write_file(
     company: ScopedCompany,
     Path(NodePath { node_id }): Path<NodePath>,
@@ -287,7 +305,7 @@ async fn write_file(
     // stamps one), so the lookup answers `None` for it and the `write` below
     // still rejects it — an extra read per save to pre-empt an error case would
     // cost every ordinary save to save nothing.
-    mirror_node_edit(
+    if let MirrorOutcome::Undetermined(err) = mirror_node_edit(
         company.runtime.artifacts().as_ref(),
         company.id(),
         &node_id,
@@ -296,7 +314,17 @@ async fn write_file(
         "operator",
         Some(OPERATOR_EDIT_NOTE.to_string()),
     )
-    .await?;
+    .await?
+    {
+        tracing::warn!(
+            company = %company.id(),
+            node = %node_id,
+            error = %err,
+            "[workspace] could not read the artifact store, so whether this note is a \
+             published deliverable is unknown; saving it anyway. If it was published, its \
+             chain is one version behind until the next successful save"
+        );
+    }
 
     let node = company
         .runtime

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -44,11 +44,14 @@ use axum::{Json, Router};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+use crate::company::artifact_mirror::mirror_node_edit;
 use crate::company::workspace_links::file_with_backlinks;
 use crate::error::OpenCompanyError;
+use crate::ports::artifacts::ArtifactAuthor;
 use crate::ports::generate_id;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
 use crate::server::error::ApiError;
+use crate::server::ops::artifacts::OPERATOR_EDIT_NOTE;
 use crate::server::ops::{ScopedCompany, scoped};
 
 /// Builds the workspace route fragment.
@@ -253,11 +256,48 @@ async fn create_node(
     Ok(Json(FsNode::from_node(node, content)))
 }
 
+/// `PUT …/workspace/file/{node_id}` — overwrite a note's body.
+///
+/// # A published deliverable is edited on both surfaces (issue #552)
+///
+/// Since #552 a note in this tree may be the projection of a task artifact, and
+/// an operator's save of one is *the human edit* — the single datum the artifact
+/// port exists to capture. Overwriting only the node would leave the version
+/// history saying the agent's draft was shipped unchanged, and
+/// `human_edit_diff` answering `None` for an artifact a human rewrote.
+///
+/// So the chain is written **first**, then the node. The two failure modes are
+/// not symmetric: a version recorded whose node write then fails leaves a stale
+/// node, which is visible and heals on the next write; a node written whose
+/// version was never recorded is silent, permanent, and corrupts the diff. Of
+/// the two, only the first is survivable, so it is the one this ordering
+/// chooses. See [`artifact_mirror`](crate::company::artifact_mirror).
+///
+/// An ordinary note — which is nearly all of them — matches no artifact, so the
+/// lookup returns `None` and this behaves exactly as it did before. The lookup
+/// is a scan of the company's artifacts per save; it is bounded by what
+/// artifacts are (a task's drafts, not a repository) and is named as the place
+/// to add an index if it ever hurts.
 async fn write_file(
     company: ScopedCompany,
     Path(NodePath { node_id }): Path<NodePath>,
     Json(body): Json<WriteFile>,
 ) -> Result<Json<WriteAck>, ApiError> {
+    // No kind check first: a folder id can never match an artifact (nothing
+    // stamps one), so the lookup answers `None` for it and the `write` below
+    // still rejects it — an extra read per save to pre-empt an error case would
+    // cost every ordinary save to save nothing.
+    mirror_node_edit(
+        company.runtime.artifacts().as_ref(),
+        company.id(),
+        &node_id,
+        &body.content,
+        ArtifactAuthor::Operator,
+        "operator",
+        Some(OPERATOR_EDIT_NOTE.to_string()),
+    )
+    .await?;
+
     let node = company
         .runtime
         .workspace()

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -5642,3 +5642,238 @@ async fn an_admin_is_refused_by_none_of_them() {
         );
     }
 }
+
+/// Issue #552: a published deliverable lives on two surfaces, and the console's
+/// workspace `PUT` is where an operator edits one. Saving that note must record
+/// an **operator version** on the artifact chain, because that edit is exactly
+/// the datum `human_edit_diff` exists to answer — and overwriting only the node
+/// would leave the history claiming the agent's draft shipped unchanged.
+///
+/// The ordering is asserted too: the version must be there when the node write
+/// is refused, since chain-ahead-of-node is the survivable direction and
+/// node-ahead-of-chain is the silent one.
+#[tokio::test]
+async fn saving_a_published_note_records_the_operators_edit_on_the_artifact() {
+    use crate::ports::artifacts::{ArtifactKind, ArtifactRecord, ArtifactStore};
+    use crate::ports::workspace::WorkspaceStore;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = state.registry().list()[0].clone();
+    let runtime = state.registry().get(&company).expect("company");
+
+    // A note in the tree…
+    let (status, note) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "launch.md", "kind": "file", "content": "the agent's draft"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let node_id = note["id"].as_str().expect("node id").to_string();
+
+    // …that is the projection of a published artifact.
+    let mut published = ArtifactRecord::new(
+        "art-1",
+        "t-1",
+        "Launch spec",
+        ArtifactKind::Markdown,
+        "the agent's draft",
+        "ceo",
+        1,
+    )
+    .with_source("launch.md");
+    published.stamp_workspace_node(&node_id);
+    ArtifactStore::upsert(runtime.artifacts().as_ref(), &company, &published)
+        .await
+        .expect("seed");
+
+    let (status, _) = send(
+        &state,
+        "PUT",
+        &format!("/api/v1/company/workspace/file/{node_id}"),
+        Some(json!({"content": "the operator's rewrite"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (status, artifact) = send(&state, "GET", "/api/v1/company/artifacts/art-1", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(artifact["versions"].as_array().unwrap().len(), 2);
+    assert_eq!(artifact["versions"][1]["body"], "the operator's rewrite");
+    assert_eq!(artifact["versions"][1]["author"], "operator");
+    assert_eq!(
+        artifact["versions"][1]["note"], "operator edit before approval",
+        "the wording the console recognises, shared with the append route"
+    );
+    assert_eq!(
+        artifact["versions"][1]["workspaceNodeId"], node_id,
+        "the appended version must inherit the node, or the NEXT save mirrors nothing"
+    );
+    assert!(
+        artifact["humanEditDiff"].is_object(),
+        "the whole point: a console edit of a deliverable is now diffable"
+    );
+
+    // And the node itself carries the operator's text.
+    let (node, body) = WorkspaceStore::read(runtime.workspace().as_ref(), &company, &node_id)
+        .await
+        .unwrap()
+        .expect("the note still exists");
+    assert_eq!(body, "the operator's rewrite");
+    assert_eq!(
+        node.updated_by,
+        crate::ports::workspace::WorkspaceOrigin::Operator
+    );
+}
+
+/// Nearly every note in the tree is an ordinary note, not a deliverable.
+/// Saving one must append nothing anywhere — the reverse lookup answering
+/// "no artifact owns this" is the common case, and deliberately silent.
+#[tokio::test]
+async fn saving_an_unpublished_note_appends_no_artifact_version() {
+    use crate::ports::artifacts::{ArtifactKind, ArtifactRecord, ArtifactStore};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = state.registry().list()[0].clone();
+    let runtime = state.registry().get(&company).expect("company");
+
+    // A published artifact exists, but points at a DIFFERENT node.
+    let mut published = ArtifactRecord::new(
+        "art-1",
+        "t-1",
+        "Launch spec",
+        ArtifactKind::Markdown,
+        "deliverable",
+        "ceo",
+        1,
+    );
+    published.stamp_workspace_node("some-other-node");
+    ArtifactStore::upsert(runtime.artifacts().as_ref(), &company, &published)
+        .await
+        .expect("seed");
+
+    let (_, note) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "notes.md", "kind": "file", "content": "just a note"})),
+    )
+    .await;
+    let node_id = note["id"].as_str().unwrap().to_string();
+
+    let (status, _) = send(
+        &state,
+        "PUT",
+        &format!("/api/v1/company/workspace/file/{node_id}"),
+        Some(json!({"content": "still just a note"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+
+    let (_, artifact) = send(&state, "GET", "/api/v1/company/artifacts/art-1", None).await;
+    assert_eq!(
+        artifact["versions"].as_array().unwrap().len(),
+        1,
+        "an ordinary note's save must not touch an unrelated artifact"
+    );
+}
+
+/// The other direction of the same invariant: appending a version through the
+/// Artifacts tab must push the new body into the deliverable's workspace note,
+/// or the tree keeps serving a draft the history has superseded.
+#[tokio::test]
+async fn appending_an_artifact_version_updates_its_workspace_note() {
+    use crate::ports::artifacts::{ArtifactKind, ArtifactRecord, ArtifactStore};
+    use crate::ports::workspace::WorkspaceStore;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = state.registry().list()[0].clone();
+    let runtime = state.registry().get(&company).expect("company");
+
+    let (_, note) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "launch.md", "kind": "file", "content": "v1"})),
+    )
+    .await;
+    let node_id = note["id"].as_str().unwrap().to_string();
+
+    let mut published = ArtifactRecord::new(
+        "art-1",
+        "t-1",
+        "Launch spec",
+        ArtifactKind::Markdown,
+        "v1",
+        "ceo",
+        1,
+    )
+    .with_source("launch.md");
+    published.stamp_workspace_node(&node_id);
+    ArtifactStore::upsert(runtime.artifacts().as_ref(), &company, &published)
+        .await
+        .expect("seed");
+
+    let (status, appended) = send(
+        &state,
+        "POST",
+        "/api/v1/company/artifacts/art-1/versions",
+        Some(json!({"body": "v2, edited in the Artifacts tab"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        appended["versions"][1]["workspaceNodeId"], node_id,
+        "the appended version keeps naming the node it lives in"
+    );
+
+    let (_, body) = WorkspaceStore::read(runtime.workspace().as_ref(), &company, &node_id)
+        .await
+        .unwrap()
+        .expect("the note exists");
+    assert_eq!(
+        body, "v2, edited in the Artifacts tab",
+        "the shared tree must not keep serving a superseded draft"
+    );
+}
+
+/// An artifact with no workspace note — a legacy capture, or one recorded
+/// while no tree was wired — appends exactly as it always did, with no node
+/// write attempted and nothing invented for it.
+#[tokio::test]
+async fn appending_to_an_unmirrored_artifact_touches_no_note() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, created) = send(
+        &state,
+        "POST",
+        "/api/v1/company/artifacts",
+        Some(json!({"taskId": "t-1", "title": "Draft", "body": "v1"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CREATED);
+    let id = created["id"].as_str().unwrap().to_string();
+
+    let (status, appended) = send(
+        &state,
+        "POST",
+        &format!("/api/v1/company/artifacts/{id}/versions"),
+        Some(json!({"body": "v2"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(appended["versions"].as_array().unwrap().len(), 2);
+    assert!(
+        appended["versions"][1].get("workspaceNodeId").is_none(),
+        "nothing may invent a node for an artifact that has none"
+    );
+}

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -5649,9 +5649,12 @@ async fn an_admin_is_refused_by_none_of_them() {
 /// the datum `human_edit_diff` exists to answer — and overwriting only the node
 /// would leave the history claiming the agent's draft shipped unchanged.
 ///
-/// The ordering is asserted too: the version must be there when the node write
-/// is refused, since chain-ahead-of-node is the survivable direction and
-/// node-ahead-of-chain is the silent one.
+/// The ordering is asserted too, by refusing the node write: an artifact
+/// stamped with a node id the tree does not have makes the chain append
+/// succeed and the node write fail, and the version must still be there
+/// afterwards. Chain-ahead-of-node is the survivable direction and
+/// node-ahead-of-chain is the silent one, so a failed save must land on the
+/// first.
 #[tokio::test]
 async fn saving_a_published_note_records_the_operators_edit_on_the_artifact() {
     use crate::ports::artifacts::{ArtifactKind, ArtifactRecord, ArtifactStore};
@@ -5726,6 +5729,54 @@ async fn saving_a_published_note_records_the_operators_edit_on_the_artifact() {
     assert_eq!(
         node.updated_by,
         crate::ports::workspace::WorkspaceOrigin::Operator
+    );
+
+    // -- and now the ordering, with the node write refused ------------------
+    //
+    // A deliverable whose node the operator deleted still carries that node's
+    // id on its latest version, so the reverse lookup matches and the append
+    // runs — then the write fails, because the node is gone. That is the
+    // failure this route's ordering was chosen for, and it is reachable
+    // without a mock: the refusal comes from the real store.
+    let mut orphaned = ArtifactRecord::new(
+        "art-2",
+        "t-1",
+        "Retired spec",
+        ArtifactKind::Markdown,
+        "the agent's draft",
+        "ceo",
+        1,
+    )
+    .with_source("retired.md");
+    orphaned.stamp_workspace_node("node-the-operator-deleted");
+    ArtifactStore::upsert(runtime.artifacts().as_ref(), &company, &orphaned)
+        .await
+        .expect("seed");
+
+    let (status, _) = send(
+        &state,
+        "PUT",
+        "/api/v1/company/workspace/file/node-the-operator-deleted",
+        Some(json!({"content": "an edit the tree cannot take"})),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "the node write must fail — there is no such node"
+    );
+
+    let (status, artifact) = send(&state, "GET", "/api/v1/company/artifacts/art-2", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        artifact["versions"].as_array().unwrap().len(),
+        2,
+        "the version must survive the refused node write: chain-ahead-of-node is \
+         the direction that heals, and this is the ordering that guarantees it"
+    );
+    assert_eq!(
+        artifact["versions"][1]["body"],
+        "an edit the tree cannot take"
     );
 }
 

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -5877,3 +5877,209 @@ async fn appending_to_an_unmirrored_artifact_touches_no_note() {
         "nothing may invent a node for an artifact that has none"
     );
 }
+
+/// An artifact store with one chosen fault, so a test can ask for exactly the
+/// failure it means: unreadable (`list`) or unwritable (`upsert`).
+struct FaultyArtifacts {
+    listed: Vec<crate::ports::artifacts::ArtifactRecord>,
+    list_fails: bool,
+    upsert_fails: bool,
+}
+
+#[async_trait::async_trait]
+impl crate::ports::artifacts::ArtifactStore for FaultyArtifacts {
+    async fn list(
+        &self,
+        _: &CompanyId,
+        _: Option<&str>,
+    ) -> crate::Result<Vec<crate::ports::artifacts::ArtifactRecord>> {
+        if self.list_fails {
+            return Err(crate::error::OpenCompanyError::Store(
+                "the artifact store is down".into(),
+            ));
+        }
+        Ok(self.listed.clone())
+    }
+    async fn get(
+        &self,
+        _: &CompanyId,
+        _: &str,
+    ) -> crate::Result<Option<crate::ports::artifacts::ArtifactRecord>> {
+        Ok(None)
+    }
+    async fn upsert(
+        &self,
+        _: &CompanyId,
+        _: &crate::ports::artifacts::ArtifactRecord,
+    ) -> crate::Result<()> {
+        if self.upsert_fails {
+            return Err(crate::error::OpenCompanyError::Store(
+                "the disk is full".into(),
+            ));
+        }
+        Ok(())
+    }
+    async fn delete(&self, _: &CompanyId, _: &str) -> crate::Result<bool> {
+        Ok(false)
+    }
+}
+
+/// [`state_with_company`] with the artifact store swapped for a faulty one, so
+/// the workspace `PUT` can be exercised against a store that will not answer.
+async fn state_with_faulty_artifacts(
+    home: &std::path::Path,
+    artifacts: FaultyArtifacts,
+) -> (AppState, CompanyId) {
+    let state = state_with_company(home).await;
+    let company = state.registry().list()[0].clone();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        .with_id(company.clone())
+        .with_artifacts(std::sync::Arc::new(artifacts))
+        .build()
+        .await
+        .expect("runtime");
+    // `insert` replaces, so the routes now resolve through the faulty store
+    // while the seeded admin on `state` carries over untouched.
+    state
+        .registry()
+        .insert(company.clone(), std::sync::Arc::new(runtime));
+    (state, company)
+}
+
+/// Issue #552 made every note save consult the artifact store, and an ordinary
+/// note must not inherit that store's health.
+///
+/// Nearly the whole tree is ordinary notes. They own no artifact chain, and
+/// their save touches the artifact store for one reason only — to ask whether
+/// they are a deliverable. When that question cannot be answered, refusing the
+/// save would discard an operator's typing to protect a chain the note does not
+/// have.
+#[tokio::test]
+async fn an_ordinary_note_still_saves_when_the_artifact_store_cannot_be_read() {
+    use crate::ports::workspace::WorkspaceStore;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, company) = state_with_faulty_artifacts(
+        &home,
+        FaultyArtifacts {
+            listed: Vec::new(),
+            list_fails: true,
+            upsert_fails: false,
+        },
+    )
+    .await;
+    let runtime = state.registry().get(&company).expect("company");
+
+    let (_, note) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "notes.md", "kind": "file", "content": "just a note"})),
+    )
+    .await;
+    let node_id = note["id"].as_str().expect("node id").to_string();
+
+    let (status, _) = send(
+        &state,
+        "PUT",
+        &format!("/api/v1/company/workspace/file/{node_id}"),
+        Some(json!({"content": "the operator kept typing"})),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "an unreadable artifact store must not reject a plain note's save"
+    );
+
+    let (_, body) = WorkspaceStore::read(runtime.workspace().as_ref(), &company, &node_id)
+        .await
+        .unwrap()
+        .expect("the note still exists");
+    assert_eq!(
+        body, "the operator kept typing",
+        "the edit must actually land, not merely report success"
+    );
+}
+
+/// The other direction, and the one the availability fix must not have cost:
+/// once the store *has* answered and named this node a published deliverable,
+/// a version that cannot be recorded still refuses the save.
+///
+/// This is the fail-closed guarantee the module exists for. A node written
+/// behind a version that was never appended is the silent, permanent direction
+/// — `human_edit_diff` would answer for a draft the operator had already
+/// rewritten.
+#[tokio::test]
+async fn a_published_note_refuses_the_save_when_its_version_cannot_be_recorded() {
+    use crate::ports::artifacts::{ArtifactKind, ArtifactRecord};
+    use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+
+    // The store answers the lookup — this node IS a deliverable — but refuses
+    // the append.
+    let mut published = ArtifactRecord::new(
+        "art-1",
+        "t-1",
+        "Launch spec",
+        ArtifactKind::Markdown,
+        "the agent's draft",
+        "ceo",
+        1,
+    );
+    published.stamp_workspace_node("node-published");
+    let (state, company) = state_with_faulty_artifacts(
+        &home,
+        FaultyArtifacts {
+            listed: vec![published],
+            list_fails: false,
+            upsert_fails: true,
+        },
+    )
+    .await;
+    let runtime = state.registry().get(&company).expect("company");
+
+    // The node the artifact points at, created directly so its id is the one
+    // the record was stamped with.
+    WorkspaceStore::create(
+        runtime.workspace().as_ref(),
+        &company,
+        &WorkspaceNode {
+            id: "node-published".to_string(),
+            name: "launch.md".to_string(),
+            kind: NodeKind::File,
+            parent_id: None,
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
+        },
+        Some("the agent's draft"),
+    )
+    .await
+    .expect("seed the node");
+
+    let (status, _) = send(
+        &state,
+        "PUT",
+        "/api/v1/company/workspace/file/node-published",
+        Some(json!({"content": "the operator's rewrite"})),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::OK,
+        "a deliverable whose version cannot be recorded must not have its node written"
+    );
+
+    let (_, body) = WorkspaceStore::read(runtime.workspace().as_ref(), &company, "node-published")
+        .await
+        .unwrap()
+        .expect("the note still exists");
+    assert_eq!(
+        body, "the agent's draft",
+        "the node must be untouched — writing it would strand the chain behind it"
+    );
+}


### PR DESCRIPTION
## Summary

`publish_artifact` drained into the `ArtifactStore` only, so a deliverable landed on its task card and nowhere else. The workspace tree is the one surface every agent can read, and there is no agent-facing artifact read tool anywhere in `src/harness/` — so an agent asked to build on another agent's output had no way to reach it. Separately, workspace writes emitted no company event, so a file written while the operator watched the Workspace tab appeared only after a refresh.

Publishing now writes both places: the versioned artifact on the card, and a note under `Agents/<agent>/<task>/` in the shared tree, linked so the two are one object seen twice. The tab follows writes live.

Closes #552. Closes #327.

## API Or Behavior Changes

**A published deliverable also becomes a workspace note.** The drain calls `ensure_agent_folder` (member folders are minted on first use, per #570), creates the `<task-id>/` child and any nested source folders, and writes the file. `ArtifactVersion` gains `workspace_node_id` (`serde(default)`, additive on all three backends' JSON blob storage — no migration; pre-existing records load as `None`). A second agent reads the result through the existing `workspace_read`; **no new tool was added**, which is the point of routing through the tree rather than building a second reader.

**The artifact chain stays authoritative; the note is its current-body projection.** The alternative — node as storage, artifact referencing it — would force versioning onto `WorkspaceStore` across three backends and turn every artifact read into a two-store join. **Invariant: the note never holds a body the version history has not recorded.**

**Writes are chain-first, uniformly.** A re-publish inherits the node its previous version named, stamps the link, stores the version, *then* mirrors into the note. A fresh publish has no id to inherit, so v1 is stored unlinked, the node is minted, and a second write stamps the link. Ordering is pinned by failure injection, not by comment: an `ArtifactStore` that refuses `upsert` from the Nth call leaves the note on the previous body, and a refused first publish creates nothing in the tree at all. Reverting to node-first makes both tests fail with the divergence they exist to catch.

**Residual, stated rather than hidden**: if the *second* artifact write fails after the node write succeeded, the version and the note both hold the same body and only the link between them is missing. `materialize` re-adopts by path, so the next publish of the same source reuses the same node and repairs the link — pinned by `an_unlinked_first_publish_is_repaired_by_the_next_one`. It requires a store failing mid-sequence, not a store being down, and it never misreports what a human changed.

**Edits on either surface stay in step.** A console PUT to a published note appends an `Operator` version *before* writing the note; `append_version` mirrors the new body into the linked note; an agent's `workspace_write` over a published note records onto the chain as an `Agent` version. Without these, an edit on one surface is invisible to the other and #187's `human_edit_diff` silently rots. Appended versions inherit the node id on all three paths — otherwise the next reverse lookup finds nothing and mirroring stops after one hop.

**New `CompanyEvent::WorkspaceChanged { node_id, change }`** (`opened` / `updated` / `removed`), classified **Prunable** — a pure refetch signal: the tree is the sole truth, nothing addresses it by sequence, nothing reads it back at boot, and it is high volume. This diverges from `TaskCardChanged`'s Permanent, where the board-lifecycle trail is itself evidence; flagging it since the default direction is keep-forever. A `WorkspaceAnnouncer` decorator emits at the store — mirroring `BoardAnnouncer`, whose docs name #327 as "the obvious next one" — so publish dual-writes, console PUTs, agent writes and deletes all announce with no per-caller emits. Folder deletion announces once, not once per descendant. Projected onto the operator SSE stream as `workspace_changed`; the stream is deny-by-default, so the explicit arm is what makes #327 actually fix.

**Console**: the Workspace tab refetches the tree on a live event and refetches the open file **only in read mode**, so an in-progress edit is never clobbered; a removed open node closes the pane. Artifact versions carrying a node id show "Open in workspace", deep-linking via the hash router.

**Also in this PR, unrelated and standalone (`5956f6c8`)**: `app::boot::test::releasing_the_instance_frees_the_root` no longer asserts that a released data root is re-acquirable *in the same instant*. `src/store/lock.rs` documents why that is stricter than the lock promises — the lock lives on the open file description, and a `fork()` before `exec()` briefly shares it. The test now retries to a 2 s ceiling and reports the attempt count with the last real error. **The lock itself is unchanged.** Verified not to be a blindfold: holding the first instance instead of dropping it fails the test in 2.01 s after 158 refused attempts.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --locked --all-targets` and `--all-features --all-targets`)
- [x] `cargo test` — 1813 passed, 0 failed
- [x] `cargo test --locked --features sqlite --lib store::sqlite` — 25 passed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — 2699 passed, 0 failed
- [x] `frontend`: `npm run typecheck`, `npm run build`, `npx vitest run` — 22 files, 236 tests passed

New coverage: `materialize` (folder find-vs-create through the minter, nested source segments, deleted-node recreate, same basename in two directories); the drain (dual-write, `None`-workspace no-op preserving today's behaviour byte-for-byte, node failure still records the artifact, re-publish updating the same node, the version carrying the id); four failure-injection tests pinning write ordering in both directions; the mirror hooks (a PUT on a published note appends an Operator version before the note write and `human_edit_diff` answers; a PUT on an unpublished note appends nothing; `append_version` mirrors); the announcer (cloned from `BoardAnnouncer`'s suite shape, including a refusing log not failing the write); serde round-trips; the SSE projection; and an end-to-end test proving agent A publishes and agent B reads it.

## Documentation

Module docs on the new `src/company/artifact_mirror.rs`, the announcer, and the amended publish drain carry the ordering argument and the residual. Note on placement: the plan put this module under `src/harness/`, which is `#[cfg(feature = "openhuman")]`, while its callers in `src/server/ops/` are always compiled — a default build would not have linked. It lives in `src/company/` instead, following the `workspace_links.rs` precedent.

One test-only consequence worth recording: the boot scaffold's `WorkspaceChanged` frames consume journal sequence 0, and `wire::cycle_id` embeds the first event's sequence. Five hosted-brain tests hardcoded `cycle_id(…, 0)` and two asserted total journal length. Production is unaffected (the id is derived at runtime), but those tests encoded an assumption that is now false. The count is derived from the system-roots list so adding a root cannot silently desynchronise it again.

## Related

Third of a sequence making the workspace a shared resource space:

- #551 + #326 — agents can create in the shared tree; nodes record their author (merged)
- #570 — `Agents/` and `Desks/` scaffolded, member folders minted on first use (PR #571; this PR is stacked on it)
- **This PR (#552 + #327)** — deliverables land in the tree and the tab follows live
- #553 — the tree can hold bytes, so a generated image stops being a dangling sha256


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workspace now starts with only `Agents/` and `Desks/` roots; individual folders are created when needed.
  - Published artifacts are mirrored to workspace notes, with edits synchronized back to artifact history.
  - Workspace updates refresh views live, support direct note links, and close deleted notes automatically.
  - Artifact details now include an “Open in workspace” action.
- **Documentation**
  - Updated workspace behavior, creation rules, and artifact synchronization guidance.
- **Bug Fixes**
  - Improved handling of workspace collisions, missing folders, failed synchronization, and event delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->