### PR TITLE
fix(e2e): grant search in e2e_harness so node-config validation passes

### DIFF
--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -41,7 +41,14 @@ admins = ["harness-e2e@tinyhumans.ai"]
 # Both forms are needed: this list is matched with exact/glob semantics, so bare
 # `workspace` covers an agent asking for `workspace` but NOT one asking for
 # `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
-allow = ["composio", "mcp:*", "workspace", "workspace.*"]
+#
+# `search` is granted for the console workflow specs: the node-config e2e authors
+# a `tool_call` node with slug `web_search`, and author-time validation (#540)
+# rejects a `search`-namespace slug unless the company grants `search` explicitly
+# (a `*` wildcard never confers the priced family). Without this the save 400s and
+# the spec's dialog never closes. No agent below lists a search tool, so this only
+# widens the company ceiling for the workflow author, not any agent's turn.
+allow = ["composio", "mcp:*", "workspace", "workspace.*", "search"]
 
 [[agent]]
 id = "ceo"


### PR DESCRIPTION
## Summary
Grant `search` in the `e2e_harness` company so the console workflow node-config e2e can author a `web_search` `tool_call` node. Restores a green `Console E2E (live brain)` on `main`.

## Problem
`main` went red after two Wave-1 workflow PRs merged without CI'ing against each other (stacked-PR cascade):
- #547 (G18) added `frontend/test/e2e/workflow-node-config.spec.ts`, which authors a `tool_call` node with slug `web_search` and saves it.
- #546 (G15) added author-time validation: a `tool_call` slug's namespace must be granted by the company's `[tools].allow`, and the priced `search` family requires an **explicit** `search` grant (a `*` wildcard never confers it).

`e2e_harness` granted only `["composio", "mcp:*", "workspace", "workspace.*"]`. So the authored `web_search` save now 400s, the creator dialog never closes, and the spec fails:

```
✘ workflow-node-config.spec.ts:49 › authoring a tool_call node's config through the form round-trips to the host
  Error: expect(locator).toBeHidden() failed — Locator: getByRole('dialog') — Received: visible
```

The failure reproduces on the #546 merge commit (`d67206f4`) and blocks #548, which rides the same base.

## Solution
Add `"search"` to `e2e_harness`'s `[tools].allow`. The node-config spec authors a real `web_search` node, and its host must grant that namespace for the author-time gate to accept it. No agent in the manifest lists a search tool, so this only widens the company ceiling for the workflow author — it does not hand any agent a search tool at its turn.

## Submission Checklist
- [x] `python3 -c 'import tomllib; …'` — manifest parses, `search` present in `[tools].allow`
- [x] Fix is provably correct by construction: `grants_search_explicit(["…","search"]) == true` (pinned by the existing unit test in `src/runtime/tools.rs`)
- [ ] `Console E2E (live brain)` — proven by CI on this PR (no local host)

## Impact
Test harness data only — one grant added to a fixture company. No product code, no API change.

## Related
Fixes the `main` regression from #546 × #547. Unblocks #548.