### PR TITLE
ci(mongodb): run the backend suite against a real server, and fix the limit-zero inversion it found (#555)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,142 @@ jobs:
           # Consumed minutes later by one job in the same run and never again.
           retention-days: 1
 
+  # Issue #555. The MongoDB backend's conformance suite, which until now RAN
+  # NOWHERE — the same defect as the SQLite step above, in the backend that
+  # carries the hosted product.
+  #
+  # `src/store/mongodb.rs` calls the same `src/store/conformance.rs` assertions
+  # the SQLite step rescued: 20 tests over the task / workspace / fact / skill /
+  # inbox / usage / run / user / session ports, plus isolation, append-only and
+  # monotonic-seq. None had ever executed. `cargo test` omits `--features
+  # mongodb`, `rust-gated` pins `openhuman,tinycortex`, and `Check
+  # (--all-features)` compiles the module without running it — three lanes touch
+  # the file, no lane ran it. `StorageKind::Mongodb` is what hosted tenants run,
+  # so the one storage backend under the deployed product was the one with no
+  # coverage, and `conformance.rs` is the only thing pinning the three backends
+  # to answer identically.
+  #
+  # It had already drifted. The first green run of this job was not green: the
+  # port contract reads a limit of zero as an empty page, `find().limit(0)` is
+  # MongoDB's *no limit* sentinel, and `list_runs` returned the whole collection
+  # where the fs and sqlite backends return nothing. See `FindLimit` in
+  # `src/store/mongodb.rs` — a live inversion sitting behind a green pipeline,
+  # which is the argument for this job stated better than the rest of this
+  # comment states it.
+  #
+  # A JOB, not a step — a DEPARTURE from the SQLite step's reasoning, so:
+  #
+  # `services:` is declared per JOB. Actions has no per-step service container,
+  # so "make it a step on `rust`" is not on the table; the container would have
+  # to attach to the whole job. That costs more than it looks. The runner pulls
+  # `mongo:7` and waits for its health check BEFORE the job's first step, so
+  # fmt, clippy, the default test run, the SQLite step and the binary build all
+  # start later — and `console-e2e` has `needs: rust` for that binary, which
+  # puts the wait on the run's CRITICAL PATH to serve a suite none of those
+  # steps touch. `rust` also has no `Swatinem/rust-cache`, so a second feature
+  # set built there recompiles cold on every run, in front of everything.
+  #
+  # A separate job pays a runner, a checkout and a toolchain install, exactly as
+  # the SQLite comment says — but pays them IN PARALLEL, where they are compute
+  # rather than wall clock, and amortises the compile in its own cache keyed to
+  # this feature set. The SQLite step's arithmetic held because its suite's cost
+  # was ALL setup and it needed no server; a service container is setup that
+  # cannot be shared no matter where it is declared. `rust-gated` is the in-repo
+  # precedent for the same trade: a separate job so the fast default lane keeps
+  # its turnaround and its `Rust` check name for branch protection.
+  #
+  # Scoped to `--lib store::mongodb` for the SQLite step's reason exactly: this
+  # lane runs the backend's own suite, and rerunning the ~1800 default tests
+  # under a feature that does not change them would buy no coverage.
+  #
+  # On EVERY PR, not behind a `paths:` filter on `src/store/**`. The failure
+  # guarded here is a port change that breaks one backend's implementation, and
+  # the author of such a change need never open `src/store/mongodb.rs` — a path
+  # filter would skip this lane on exactly the diff that most needs it.
+  rust-mongodb:
+    name: Rust (mongodb)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    services:
+      mongodb:
+        image: mongo:7
+        ports:
+          - 27017:27017
+        # The health check is the handshake, not decoration: steps begin as soon
+        # as the container is STARTED, and `mongod` accepts TCP before it will
+        # answer a command. Without this the first test races startup, and the
+        # driver's own server-selection retry would turn that into a 30s stall
+        # ending in a timeout rather than a legible failure.
+        options: >-
+          --health-cmd "mongosh --quiet --eval 'db.runCommand({ping:1})'"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 10
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+          submodules: true
+
+      # Same reason as the `rust` job: `tinyhumans-sdk` is an unconditional path
+      # dependency of the vendored openhuman crate (issue #499), so Cargo reads
+      # its manifest during resolution even where the feature selection excludes
+      # `openhuman`. A missing checkout fails THIS build too, not just a gated
+      # one. `submodules: true` is not recursive, hence the explicit init.
+      - name: Init vendored openhuman crate submodules
+        run: |
+          git -C vendor/openhuman submodule update --init --depth 1 \
+            vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
+            vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
+          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
+            vendor/tinyagents
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      # TWO different silent-success modes are guarded below, and neither guard
+      # catches the other's failure. Both are needed.
+      #
+      # `OPENCOMPANY_TEST_MONGODB_REQUIRED=1` turns "no server" from a skip into
+      # a panic (see `required()` in `src/store/mongodb.rs`). The suite's local
+      # default is to skip when `OPENCOMPANY_TEST_MONGODB_URI` is unset, which
+      # rightly keeps a laptop's `cargo test` offline — and which, left in place
+      # here, lets this job report `20 passed` in 0.00s having connected to
+      # nothing. That is measured, not hypothetical: it is what the suite does
+      # on this runner today, and reproducing it inside the lane built to end it
+      # would just move the bug one layer down.
+      #
+      # The count assertion catches the mode `REQUIRED` cannot. If the
+      # `store::mongodb` filter stops matching — module renamed, moved, or
+      # feature-gated away — cargo selects zero tests, prints `0 passed; 0
+      # failed` and exits 0, and `required()` never runs because `store()` is
+      # never called. Only a NUMBER separates "everything passed" from "nothing
+      # ran"; issue #481 established the same assertion for integration targets.
+      #
+      # `scripts/ci/assert-integration-targets-run.sh` is NOT reused: it walks
+      # the `[[test]]` targets `cargo metadata` reports — the files under
+      # `tests/` — and this suite is a `--lib` unit module it does not select.
+      # Same defect class, different target kind, so the count is read straight
+      # off cargo's summary line instead.
+      - name: Test the MongoDB backend
+        env:
+          OPENCOMPANY_TEST_MONGODB_URI: mongodb://localhost:27017
+          OPENCOMPANY_TEST_MONGODB_REQUIRED: "1"
+        run: |
+          set -euo pipefail
+          cargo test --locked --features mongodb --lib store::mongodb \
+            | tee "${RUNNER_TEMP}/mongodb-suite.log"
+          passed=$(sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' \
+            "${RUNNER_TEMP}/mongodb-suite.log" | head -n 1)
+          if [ -z "${passed}" ] || [ "${passed}" -eq 0 ]; then
+            echo "::error title=MongoDB suite ran nothing::cargo reported no passing tests for --lib store::mongodb, so this job is green while asserting nothing about the backend hosted tenants run. The filter selects no tests — see issue #555." >&2
+            exit 1
+          fi
+          echo "MongoDB backend suite: ${passed} tests passed."
+
   # Issue #202. The `Rust` job above builds DEFAULT FEATURES ONLY, so every line
   # behind `openhuman` (`src/harness/**`, `src/workflows/**`, `src/runtime/`
   # `delegation*`, and the `live_company_turn` example) and every line behind

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,9 +281,34 @@ jobs:
           git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
             vendor/tinyagents
 
-      - uses: dtolnay/rust-toolchain@stable
+      # Pinned to commit SHAs, while the sibling jobs above use the mutable
+      # `@stable` and `@v2` tags. A tag is a pointer its owner can move, and
+      # whatever it is moved to runs here with this workflow's token — so the
+      # version this repo audited is not necessarily the version it executes.
+      #
+      # THE INCONSISTENCY IS DELIBERATE, NOT AN OVERSIGHT. This job pins because
+      # it is the one being added; `rust`, `rust-gated` and the console jobs are
+      # left alone because a CI-lane PR is the wrong vehicle for a repo-wide
+      # supply-chain change, and burying it under the MongoDB work would make
+      # both harder to review. It is tracked separately. So do NOT reconcile
+      # this by unpinning here — reconcile it by pinning the others.
+      #
+      # Pinning ONE job is a marker and a directional improvement, not security:
+      # every job in this workflow shares a runner pool and the same secrets, so
+      # an unpinned sibling is still the weakest link until they all move.
+      #
+      # `toolchain: stable` is passed EXPLICITLY. Under `@stable` the REF made
+      # that choice — dtolnay keeps a branch per toolchain, each with its own
+      # `action.yml` default (verified: at the SHA below the default is indeed
+      # `stable`, and that commit is the head of the `stable` branch). A SHA no
+      # longer expresses the selection to a reader, and a future re-pin copied
+      # from the `nightly` branch would silently swap compilers with nothing in
+      # the diff to show it. The input says out loud what the ref used to.
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: stable
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
 
       # TWO different silent-success modes are guarded below, and neither guard
       # catches the other's failure. Both are needed.

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1577,7 +1577,7 @@ impl crate::ports::runs::RunStore for MongoStore {
         let runs = self.collection("runs");
         let mut find = runs
             .find(query)
-            .sort(doc! {"created_ms": 1, "attempt": -1, "run_id": -1});
+            .sort(doc! {"created_ms": -1, "attempt": -1, "run_id": -1});
         if let Some(limit) = filter.limit {
             match find_limit(limit) {
                 FindLimit::Empty => return Ok(Vec::new()),

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2005,6 +2005,65 @@ mod test {
             .is_ok_and(|value| !value.is_empty() && value != "0")
     }
 
+    /// The URI with any `user:password@` replaced by `***@`, for the panic
+    /// message below.
+    ///
+    /// The unreachable-server panic names the URI so the failure says *which*
+    /// server it could not reach — a bare "connection refused" in a CI log is
+    /// most of a debugging session. But a connection string carries its
+    /// credentials inline, and a panic lands in the CI log, the terminal
+    /// scrollback and any artifact that captures either. CI points at an
+    /// unauthenticated localhost, so nothing leaks there; a developer pointing
+    /// this suite at a real cluster is the case that would, and that is exactly
+    /// when the message is most useful. Redacting keeps the host and port,
+    /// which is the part worth printing.
+    fn redact_credentials(uri: &str) -> String {
+        let Some((scheme, rest)) = uri.split_once("://") else {
+            return uri.to_string();
+        };
+        // Userinfo, when present, precedes the first `/` of the path — so only
+        // an `@` before that boundary delimits it. A password may itself
+        // contain `@`, so split at the LAST one within the authority.
+        let authority_end = rest.find('/').unwrap_or(rest.len());
+        let (authority, tail) = rest.split_at(authority_end);
+        match authority.rfind('@') {
+            Some(at) => format!("{scheme}://***{}{tail}", &authority[at..]),
+            None => uri.to_string(),
+        }
+    }
+
+    #[test]
+    fn redaction_keeps_the_host_and_drops_the_credentials() {
+        // The CI shape: nothing to redact, nothing changed.
+        assert_eq!(
+            redact_credentials("mongodb://localhost:27017"),
+            "mongodb://localhost:27017"
+        );
+        // The shape that would leak.
+        assert_eq!(
+            redact_credentials("mongodb://user:hunter2@cluster.example:27017"),
+            "mongodb://***@cluster.example:27017"
+        );
+        // A password containing `@` — splitting at the FIRST one would leave
+        // the tail of the password in the message.
+        assert_eq!(
+            redact_credentials("mongodb://user:p@ss@cluster.example:27017"),
+            "mongodb://***@cluster.example:27017"
+        );
+        // An `@` in the path or query must not be mistaken for userinfo.
+        assert_eq!(
+            redact_credentials("mongodb://localhost:27017/db?replicaSet=a@b"),
+            "mongodb://localhost:27017/db?replicaSet=a@b"
+        );
+        // A credentialed URI that also carries a path keeps the path.
+        assert_eq!(
+            redact_credentials("mongodb+srv://u:p@host/admin?retryWrites=true"),
+            "mongodb+srv://***@host/admin?retryWrites=true"
+        );
+        // Not a URI at all: returned untouched rather than mangled.
+        assert_eq!(redact_credentials("localhost:27017"), "localhost:27017");
+    }
+
     async fn store() -> Option<Arc<MongoStore>> {
         let uri = match std::env::var("OPENCOMPANY_TEST_MONGODB_URI") {
             Ok(uri) => uri,
@@ -2035,9 +2094,12 @@ mod test {
         // than resolving lazily: an unreachable host fails HERE, after the
         // driver's server-selection timeout, instead of much later inside
         // whichever assertion happened to touch the database first.
-        let store = MongoStore::connect(&uri, &db)
-            .await
-            .unwrap_or_else(|err| panic!("could not reach the MongoDB server at {uri}: {err}"));
+        let store = MongoStore::connect(&uri, &db).await.unwrap_or_else(|err| {
+            panic!(
+                "could not reach the MongoDB server at {}: {err}",
+                redact_credentials(&uri)
+            )
+        });
         Some(Arc::new(store))
     }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -64,13 +64,38 @@ fn mongo_err(e: impl std::fmt::Display) -> OpenCompanyError {
     OpenCompanyError::Store(format!("mongodb error: {e}"))
 }
 
-/// The port contract's "read everything" sentinel (`usize::MAX`) means no
-/// limit; everything else maps onto the driver's `i64` limit.
-fn find_limit(limit: usize) -> Option<i64> {
-    if limit > i64::MAX as usize {
-        None
-    } else {
-        Some(limit as i64)
+/// How a port-contract limit maps onto a MongoDB `find`.
+///
+/// An enum with a distinct `Empty` arm, rather than the `Option<i64>` this used
+/// to be, because the two vocabularies disagree about ZERO and the disagreement
+/// is silent. `find().limit(0)` is MongoDB's *no limit* sentinel; every port in
+/// `crate::ports` means "an empty page" by a limit of zero, as the fs and sqlite
+/// backends implement it. Passing the number straight through therefore returned
+/// the WHOLE collection at the exact input where the caller asked for nothing.
+///
+/// Issue #555: that is how `list_runs` drifted from the other two backends, and
+/// it went unseen because `conformance.rs` — which asserts precisely this case —
+/// had never run against MongoDB in CI. `read_events_from`, `recent_traces` and
+/// `list_inbox` carried the same latent inversion; only the eviction path
+/// happened to guard it with an `if n > 0`.
+///
+/// So the zero case is a variant the compiler makes every call site, present and
+/// future, decide about — it cannot be forgotten into the driver's meaning again.
+enum FindLimit {
+    /// The caller asked for nothing. MUST NOT reach `find().limit()`.
+    Empty,
+    /// The port contract's "read everything" sentinel (`usize::MAX`), or any
+    /// value too large for the driver's `i64`.
+    Unlimited,
+    /// At most this many documents.
+    AtMost(i64),
+}
+
+fn find_limit(limit: usize) -> FindLimit {
+    match limit {
+        0 => FindLimit::Empty,
+        n if n > i64::MAX as usize => FindLimit::Unlimited,
+        n => FindLimit::AtMost(n as i64),
     }
 }
 
@@ -417,8 +442,10 @@ impl EventLog for MongoStore {
                 "seq": {"$gte": seq.value() as i64},
             })
             .sort(doc! {"seq": 1});
-        if let Some(limit) = find_limit(limit) {
-            find = find.limit(limit);
+        match find_limit(limit) {
+            FindLimit::Empty => return Ok(Vec::new()),
+            FindLimit::Unlimited => {}
+            FindLimit::AtMost(n) => find = find.limit(n),
         }
         let mut cursor = find.await.map_err(mongo_err)?;
         let mut out = Vec::new();
@@ -508,8 +535,10 @@ impl MemoryStore for MongoStore {
         let mut find = traces
             .find(doc! {"company_id": id.as_ref()})
             .sort(doc! {"seq": -1});
-        if let Some(limit) = find_limit(limit) {
-            find = find.limit(limit);
+        match find_limit(limit) {
+            FindLimit::Empty => return Ok(Vec::new()),
+            FindLimit::Unlimited => {}
+            FindLimit::AtMost(n) => find = find.limit(n),
         }
         let mut cursor = find.await.map_err(mongo_err)?;
         let mut out = Vec::new();
@@ -546,17 +575,24 @@ impl MemoryStore for MongoStore {
             EvictionPolicy::KeepRecent { n } => {
                 // Collect the seqs to keep (newest n), delete the rest.
                 //
+                // `KeepRecent { n: 0 }` keeps nothing, so there is no query to
+                // run — and must never become `find().limit(0)`, which would
+                // keep EVERYTHING and evict none of it. This arm is the old
+                // `if n > 0` guard, now stated in the shared vocabulary.
                 let mut keep = Vec::new();
-                if n > 0 {
-                    let mut find = traces
-                        .find(doc! {"company_id": id.as_ref()})
-                        .sort(doc! {"seq": -1});
-                    if let Some(limit) = find_limit(n) {
-                        find = find.limit(limit);
-                    }
-                    let mut cursor = find.await.map_err(mongo_err)?;
-                    while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
-                        keep.push(get_i64(&doc, "seq")?);
+                match find_limit(n) {
+                    FindLimit::Empty => {}
+                    limit => {
+                        let mut find = traces
+                            .find(doc! {"company_id": id.as_ref()})
+                            .sort(doc! {"seq": -1});
+                        if let FindLimit::AtMost(n) = limit {
+                            find = find.limit(n);
+                        }
+                        let mut cursor = find.await.map_err(mongo_err)?;
+                        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+                            keep.push(get_i64(&doc, "seq")?);
+                        }
                     }
                 }
                 traces
@@ -812,8 +848,10 @@ impl crate::ports::inbox::InboxStore for MongoStore {
             .find(doc! {"company_id": company.as_ref(), "inbox": key})
             .sort(doc! {"seq": 1})
             .skip(offset as u64);
-        if let Some(limit) = find_limit(limit) {
-            find = find.limit(limit);
+        match find_limit(limit) {
+            FindLimit::Empty => return Ok(Vec::new()),
+            FindLimit::Unlimited => {}
+            FindLimit::AtMost(n) => find = find.limit(n),
         }
         let mut cursor = find.await.map_err(mongo_err)?;
         let mut out = Vec::new();
@@ -1540,10 +1578,12 @@ impl crate::ports::runs::RunStore for MongoStore {
         let mut find = runs
             .find(query)
             .sort(doc! {"created_ms": -1, "attempt": -1, "run_id": -1});
-        if let Some(limit) = filter.limit
-            && let Some(limit) = find_limit(limit)
-        {
-            find = find.limit(limit);
+        if let Some(limit) = filter.limit {
+            match find_limit(limit) {
+                FindLimit::Empty => return Ok(Vec::new()),
+                FindLimit::Unlimited => {}
+                FindLimit::AtMost(n) => find = find.limit(n),
+            }
         }
         let mut cursor = find.await.map_err(mongo_err)?;
         let mut out = Vec::new();

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1577,7 +1577,7 @@ impl crate::ports::runs::RunStore for MongoStore {
         let runs = self.collection("runs");
         let mut find = runs
             .find(query)
-            .sort(doc! {"created_ms": -1, "attempt": -1, "run_id": -1});
+            .sort(doc! {"created_ms": 1, "attempt": -1, "run_id": -1});
         if let Some(limit) = filter.limit {
             match find_limit(limit) {
                 FindLimit::Empty => return Ok(Vec::new()),

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -545,6 +545,7 @@ impl MemoryStore for MongoStore {
         let removed = match policy {
             EvictionPolicy::KeepRecent { n } => {
                 // Collect the seqs to keep (newest n), delete the rest.
+                //
                 let mut keep = Vec::new();
                 if n > 0 {
                     let mut find = traces
@@ -1933,6 +1934,9 @@ fn mongo_workspace_descendants(
 /// The conformance suite needs a live server; there is no in-process MongoDB.
 /// Set `OPENCOMPANY_TEST_MONGODB_URI` (e.g. `mongodb://localhost:27017`) to
 /// run these; without it every test is a skip, keeping `cargo test` offline.
+///
+/// CI additionally sets `OPENCOMPANY_TEST_MONGODB_REQUIRED=1`, which turns that
+/// skip into a failure — see `required()` below.
 #[cfg(test)]
 mod test {
     use std::sync::atomic::{AtomicU64, Ordering};
@@ -1942,10 +1946,40 @@ mod test {
 
     static DB_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+    /// Whether a missing server must FAIL rather than skip. Issue #555.
+    ///
+    /// The `OPENCOMPANY_TEST_MONGODB_URI` skip above is right for a laptop with
+    /// no MongoDB — it keeps a default `cargo test` offline — and wrong for the
+    /// CI lane whose entire purpose is running this suite. There, an unset URI
+    /// is a misconfigured job, and the skip would report it as a pass: the
+    /// whole suite silently absent behind a green tick, which is the exact
+    /// defect this lane was added to fix, reintroduced one layer down.
+    ///
+    /// So CI sets this second variable and nothing else does. Set = the caller
+    /// has promised a reachable server, so not finding one is an error.
+    ///
+    /// `0` and the empty string read as unset, so the variable can be threaded
+    /// through a workflow matrix or a shell wrapper that always defines it.
+    fn required() -> bool {
+        std::env::var("OPENCOMPANY_TEST_MONGODB_REQUIRED")
+            .is_ok_and(|value| !value.is_empty() && value != "0")
+    }
+
     async fn store() -> Option<Arc<MongoStore>> {
-        let Ok(uri) = std::env::var("OPENCOMPANY_TEST_MONGODB_URI") else {
-            eprintln!("skipping: OPENCOMPANY_TEST_MONGODB_URI is not set");
-            return None;
+        let uri = match std::env::var("OPENCOMPANY_TEST_MONGODB_URI") {
+            Ok(uri) => uri,
+            Err(_) => {
+                assert!(
+                    !required(),
+                    "OPENCOMPANY_TEST_MONGODB_REQUIRED is set but \
+                     OPENCOMPANY_TEST_MONGODB_URI is not. This lane exists to run the \
+                     MongoDB conformance suite against a real server, so a skip here is \
+                     a misconfigured job rather than a pass — point the URI at the \
+                     service container."
+                );
+                eprintln!("skipping: OPENCOMPANY_TEST_MONGODB_URI is not set");
+                return None;
+            }
         };
         let nonce = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -1957,7 +1991,13 @@ mod test {
             nonce,
             DB_COUNTER.fetch_add(1, Ordering::Relaxed)
         );
-        let store = MongoStore::connect(&uri, &db).await.expect("connect");
+        // `connect` creates indexes, so it round-trips to the server rather
+        // than resolving lazily: an unreachable host fails HERE, after the
+        // driver's server-selection timeout, instead of much later inside
+        // whichever assertion happened to touch the database first.
+        let store = MongoStore::connect(&uri, &db)
+            .await
+            .unwrap_or_else(|err| panic!("could not reach the MongoDB server at {uri}: {err}"));
         Some(Arc::new(store))
     }
 


### PR DESCRIPTION
## Summary

Every test in `src/store/mongodb.rs` went through a `store()` helper that returned `None` when `OPENCOMPANY_TEST_MONGODB_URI` was unset, and `ci.yml` contained **no MongoDB reference at all** — no env var, no service container. Twenty tests, including the shared conformance suite that is the only thing pinning all three backends to answer identically, had never executed. MongoDB is the backend hosted tenants run.

This adds a `Rust (mongodb)` job with a real `mongo:7` service container.

**The lane's very first run found a live bug that was already in `main`.** `conformance_run_store` failed immediately: `find().limit(0)` is MongoDB's *no limit* sentinel, so a limit of zero returned the **entire collection** where fs and sqlite correctly return nothing. `read_events_from`, `recent_traces` and `list_inbox` carried the same inversion; only `evict` was accidentally guarded by an `if n > 0`. That is exactly the class of defect an unexecuted conformance suite is supposed to prevent, sitting undetected in the hosted backend because the suite pinning it never ran.

Closes #555.

## API Or Behavior Changes

**`Rust (mongodb)`, a dedicated job rather than a step.** The existing `Test the SQLite backend` step argues at length that a dedicated job pays for a runner, checkout, toolchain and cache before compiling anything. That reasoning does not transfer here, for three reasons now written into the workflow:

1. `services:` is **job-scoped** — the "make it a step" option does not exist; the container would attach to the whole `rust` job either way.
2. `rust` is on the critical path (`console-e2e` needs its binary). A service container gates the job's first step behind its health check — **measured at 24s** — spent in front of fmt, clippy, test and build, none of which touch MongoDB.
3. `rust` has no `Swatinem/rust-cache` (only `rust-gated` does), so a second feature set built there recompiles cold every run, ahead of everything. The dedicated job carries its own cache keyed to `--features mongodb`.

`rust-gated` is the in-repo precedent for exactly this trade.

**A MongoDB limit of zero now returns nothing, not everything.** `find_limit` returns a `FindLimit` enum with a distinct `Empty` arm instead of an `Option<i64>` whose `None` silently meant "no limit". The compiler now forces every call site — present and future — to decide what zero means, rather than letting it fall through to the driver's opposite interpretation.

**An unreachable server fails rather than skips, in CI only.** `OPENCOMPANY_TEST_MONGODB_REQUIRED=1` (set only by this job) turns the skip into a panic naming the missing variable or the unreachable server. Without it the job could go green having silently skipped everything — reintroducing the original bug one layer down. A local `cargo test` with the variable unset still skips cleanly and says why.

**The suite must be observed to have run.** Measured: with both variables unset the suite reports `20 passed` in 0.00s having connected to nothing — so a non-zero count alone does **not** prove execution, and `REQUIRED=1` alone does not catch a filter that selected no tests (`store()` is never called, so it cannot fire). Both gates are load-bearing and neither substitutes for the other. `scripts/ci/assert-integration-targets-run.sh` was **not** reused: it walks `cargo metadata`'s `[[test]]` targets, and this is a `--lib` unit module it does not select — same defect class, different target kind. Stated in the workflow comment.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --all-targets --features mongodb -- -D warnings`
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings`
- [x] `cargo build --all-targets` (via `cargo check --locked --all-targets` and `--all-features --all-targets`)
- [x] `cargo test` — 1796 passed, 0 failed
- [x] Local MongoDB run against `mongo:7` — 20 tests, 2.36s
- [x] `actionlint` clean; the `services` block independently YAML-parsed

Frontend is untouched by this change, so its gates were not run.

**Evidence the lane actually bites** — four runs, in commit order, rather than an assertion that it works:

| Run | Commit | `Rust (mongodb)` | What it showed |
|---|---|---|---|
| 1 | `bc65d43a` — lane only | **failure**, 3m14s | Service healthy, suite executed: `19 passed; 1 failed` on the real `list_runs` inversion |
| 2 | `2277377a` — the fix | success, 3m43s | `MongoDB backend suite: 20 tests passed.` |
| 3 | `0810e1b4` — deliberate break | **failure**, 2m04s | `left: ["r1","r2","r3"] right: ["r3","r2","r1"]` |
| 4 | `776d86f3` — revert | success, 2m26s | 20 passed; all six jobs green |

**`0810e1b4` and `776d86f3` are an intentional break-and-revert pair**, kept in history so the lane's ability to catch a regression is reviewable rather than claimed. Run 1 going red on a pre-existing bug was not staged — it is what the lane found the moment it first executed.

Three gate directions verified locally: URI unset + `REQUIRED=1` → panics naming the variable; both unset → skips cleanly; dead port → `could not reach the MongoDB server at …`.

**Runtime cost: no added wall clock.** Run 4 durations — `Rust (openhuman, tinycortex)` 19.5m (critical path), `Rust` 5m, `Console E2E` 3.5m, **`Rust (mongodb)` 2.4m**, `Console` 0.8m. The mongo job finishes ~2.8m into the run, roughly 17 minutes before the longest job. It adds 2.4–3.7 min of compute per run and nothing to the wall clock.

## Documentation

The workflow comment carries the job-versus-step reasoning, the health-check measurement, why `assert-integration-targets-run.sh` does not apply, and why both gates are needed. `FindLimit`'s doc states the zero-means-empty contract and why an enum replaced the `Option`.

Two things noticed but deliberately left out of scope: the sqlite step's comment justifies its cost by citing `Swatinem/rust-cache`, which that job does not actually use; and `RunFilter::with_limit` is documented only as "Caps the result count" and never states the zero semantics — part of why three implementations disagreed. `conformance.rs` now encodes that contract executably for all three backends, which is the stronger fix.

## Related

- #481 — established the non-zero-count assertion for this defect class
- #553 — adds GridFS to `MongoStore`; its conformance assertions are unpinnable in CI without this lane


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed MongoDB queries with a zero-result limit so they return no records instead of unexpectedly returning all records.
  * Improved handling of empty, unlimited, and limited result requests across event, trace, inbox, eviction, and run-list views.
  * Added clearer error reporting when MongoDB test connections cannot be established.

* **Tests**
  * Added automated MongoDB conformance testing against MongoDB 7 to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->