### PR TITLE
fix: address the tinysweeper findings on #588

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,7 +255,10 @@ jobs:
         with:
           components: clippy
 
-      - uses: Swatinem/rust-cache@v2
+      # Pinned to a commit, not the `v2` tag: a tag can be repointed by whoever
+      # owns the action, and whatever it then resolves to runs inside this
+      # workflow. This is v2.9.2. Bump it deliberately.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
 
       # Steps are ordered to fail fast and cheap: a compile break (the `E0062`
       # class of bug that motivated this job) surfaces before the lint pass
@@ -788,7 +791,10 @@ jobs:
       - run: npm run build
         working-directory: frontend
 
-      - uses: Swatinem/rust-cache@v2
+      # Pinned to a commit, not the `v2` tag: a tag can be repointed by whoever
+      # owns the action, and whatever it then resolves to runs inside this
+      # workflow. This is v2.9.2. Bump it deliberately.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6
         with:
           workspaces: src-tauri
 

--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -80,12 +80,21 @@ export function registerConnection(
   const desktop = bridge();
   if (!desktop) return Promise.resolve();
 
-  const pending = desktop
-    .invoke<void>("oc_connect", {
-      connectionId: id,
-      baseUrl,
-      platformToken: credential.platformToken ?? null,
-    })
+  // Chained onto whatever is already parked under this id, in both directions.
+  // `forgetConnection` sequences its disconnect behind a pending registration;
+  // without the same courtesy here, a re-register racing an in-flight
+  // `oc_disconnect` can land first and then be disconnected by it — the same
+  // ordering bug, mirrored. Whichever call came last wins, which is what a
+  // caller means by calling it.
+  const previous = registrations.get(id) ?? Promise.resolve();
+  const pending = previous
+    .then(() =>
+      desktop.invoke<void>("oc_connect", {
+        connectionId: id,
+        baseUrl,
+        platformToken: credential.platformToken ?? null,
+      }),
+    )
     .then(
       () => undefined,
       (error: unknown) => {

--- a/frontend/src/components/device-pairing.tsx
+++ b/frontend/src/components/device-pairing.tsx
@@ -110,7 +110,17 @@ export function DevicePairing() {
               Forget on this machine
             </Button>
           </div>
-        ) : (
+        ) : null}
+        {paired && error ? (
+          // The paired branch renders no form, so without this a failed forget
+          // sets state nobody can see: the row goes on saying "Paired" and the
+          // button appears to do nothing, which is the symptom the catch was
+          // added to prevent.
+          <p role="alert" className="mt-2 text-xs text-destructive">
+            {error}
+          </p>
+        ) : null}
+        {!paired ? (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Input
@@ -136,7 +146,7 @@ export function DevicePairing() {
               </p>
             ) : null}
           </div>
-        )}
+        ) : null}
       </CardContent>
     </Card>
   );

--- a/frontend/test/unit/desktop-bridge.test.ts
+++ b/frontend/test/unit/desktop-bridge.test.ts
@@ -145,7 +145,11 @@ describe("registering connections with the core", () => {
 
     const pending = registerConnection("conn-race", "https://acme.test");
     forgetConnection("conn-race");
-    // Nothing has gone out yet: the connect is parked, so the disconnect is too.
+    // Let the chained `oc_connect` actually be issued. `registerConnection`
+    // sequences behind whatever is parked under the id, so the invoke happens a
+    // microtask later rather than synchronously.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Nothing has completed yet: the connect is parked, so the disconnect is too.
     expect(order).toEqual([]);
 
     releaseConnect?.();
@@ -180,6 +184,49 @@ describe("registering connections with the core", () => {
     expect(calls.filter((c) => c.command === "oc_disconnect")).toEqual([
       { command: "oc_disconnect", args: { connectionId: id } },
     ]);
+  });
+
+  it("does not let a pending disconnect land on top of a fresh registration", async () => {
+    // The mirror of the test above. `forgetConnection` sequences behind a
+    // pending registration; if `registerConnection` did not do the same for a
+    // pending disconnect, a re-register racing an in-flight `oc_disconnect`
+    // could land first and then be torn down by it — the connection would be
+    // registered in the console and absent from the core.
+    const order: string[] = [];
+    let releaseDisconnect: (() => void) | undefined;
+    (window as unknown as { __TAURI__: { invoke: unknown } }).__TAURI__.invoke = (
+      command: string,
+    ) => {
+      if (command === "oc_disconnect") {
+        return new Promise<void>((resolve) => {
+          releaseDisconnect = () => {
+            order.push("oc_disconnect");
+            resolve();
+          };
+        });
+      }
+      order.push(command);
+      return Promise.resolve();
+    };
+
+    await registerConnection("conn-mirror", "https://acme.test");
+    forgetConnection("conn-mirror");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Re-register while the disconnect is still parked, then let every
+    // microtask drain WITHOUT releasing it. The second `oc_connect` must not
+    // have been issued yet: that is the difference chaining makes, and without
+    // it the invoke fires here and only the resolution order differs — which is
+    // not something an assertion on the final order can see.
+    const again = registerConnection("conn-mirror", "https://acme.test");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(order).toEqual(["oc_connect"]);
+
+    releaseDisconnect?.();
+    await again;
+
+    // The reconnect is last, so the core ends up holding the connection.
+    expect(order).toEqual(["oc_connect", "oc_disconnect", "oc_connect"]);
   });
 
   it("keeps a failed registration from resurfacing on every later request", async () => {

--- a/src-tauri/src/keychain.rs
+++ b/src-tauri/src/keychain.rs
@@ -197,13 +197,36 @@ fn select() -> Box<dyn SecretStore> {
     Box::new(MemoryStore::default())
 }
 
-/// Whether the OS store can be read at all.
+/// Whether the OS store is *reachable*, as opposed to merely empty.
 ///
-/// A read of a key that does not exist: it costs nothing, needs no write
-/// permission, and distinguishes "empty" from "unreachable" — which is the
-/// whole question. Probed once, because on macOS a failed access can prompt.
+/// Deliberately not `OsKeychain::get(..).is_ok()`. That method folds
+/// `NoStorageAccess` into `Ok(None)` on purpose — for a *read*, a locked store
+/// and an absent entry both mean "no credential here", and neither should
+/// surface to the console as an error. Reusing it as a probe collapses the one
+/// distinction the probe exists to make: a locked keychain answers `Ok(None)`,
+/// the probe reads that as "reachable", `select` commits to `OsKeychain`, and
+/// every later `remember_device` then fails on write — the exact opposite of
+/// the documented degrade-to-memory.
+///
+/// So this looks at the raw error instead. `NoEntry` means reachable and empty,
+/// which is what a fresh install looks like. Anything else means do not commit
+/// to this backend.
+///
+/// Probed once, because on macOS a failed access can prompt.
 fn os_store_answers() -> bool {
-    OsKeychain.get("probe:availability").is_ok()
+    let Ok(entry) = keyring::Entry::new(SERVICE, "probe:availability") else {
+        return false;
+    };
+    match entry.get_password() {
+        // Reachable, and something is there (a stale probe entry from an older
+        // build would land here too — harmless either way).
+        Ok(_) => true,
+        // Reachable and empty: the ordinary first-run answer.
+        Err(keyring::Error::NoEntry) => true,
+        // The store itself is not answering. This is the case the read path
+        // hides and the probe must not.
+        Err(_) => false,
+    }
 }
 
 /// The keychain key holding `connection`'s device session.
@@ -286,6 +309,49 @@ mod test {
         // reported `os`, every test above would be writing to a real keychain —
         // a modal prompt on macOS, and nothing at all on a headless runner.
         assert_eq!(store().name(), "memory");
+    }
+
+    /// A store that is reachable for reads but refuses every write.
+    ///
+    /// What a locked keychain looks like from here, and the shape the old probe
+    /// could not see: `get` answers `Ok(None)` either way, so a probe built on
+    /// the read path called this backend healthy and then failed on the first
+    /// `remember_device`.
+    struct LockedStore;
+
+    impl SecretStore for LockedStore {
+        fn get(&self, _key: &str) -> Result<Option<String>, KeychainError> {
+            Ok(None)
+        }
+        fn set(&self, _key: &str, _value: &str) -> Result<(), KeychainError> {
+            Err(KeychainError::Backend("the keychain is locked".into()))
+        }
+        fn delete(&self, _key: &str) -> Result<(), KeychainError> {
+            Err(KeychainError::Backend("the keychain is locked".into()))
+        }
+        fn name(&self) -> &'static str {
+            "locked"
+        }
+    }
+
+    #[test]
+    fn a_read_cannot_tell_a_locked_store_from_an_empty_one() {
+        // The property that makes the probe's own error inspection necessary:
+        // no amount of reading distinguishes these, so a probe built on `get`
+        // is a probe that always says yes.
+        assert_eq!(LockedStore.get("device-session:x").unwrap(), None);
+        assert_eq!(
+            MemoryStore::default().get("device-session:x").unwrap(),
+            None
+        );
+        // And the difference only shows on write, which is too late to choose a
+        // backend by.
+        assert!(LockedStore.set("device-session:x", "acme.tok").is_err());
+        assert!(
+            MemoryStore::default()
+                .set("device-session:x", "acme.tok")
+                .is_ok()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The four findings from `tinysweeper` on #588 (three of the six comments were the same unpinned-action point). Three commits.

## API Or Behavior Changes

- `registerConnection` now sequences behind whatever is parked under the same connection id, so its `oc_connect` is issued a microtask later rather than synchronously. `forgetConnection` already behaved this way.
- No user-visible change otherwise.

### The findings

**The keychain availability probe could not see the case it was written for.** `os_store_answers` was `OsKeychain::get(..).is_ok()`, and `get` folds `NoStorageAccess` into `Ok(None)` deliberately — for a read, a locked store and an absent entry both mean "no credential here". Reusing it as a probe collapsed the one distinction the probe exists to make: a locked keychain answered `Ok(None)`, the probe called it reachable, `select` committed to `OsKeychain`, and every later `remember_device` failed on write. The documented degrade-to-memory could not happen. The probe now inspects the raw error — `NoEntry` is reachable and empty, anything else is a store not to commit to.

**Registration did not chain onto a pending disconnect.** I fixed this in one direction in #564 and not the other. A re-register racing an in-flight `oc_disconnect` could land first and then be torn down by it, leaving the connection registered in the console and absent from the core.

**A failed unpair was invisible.** The `.catch()` I added in #564 set state that the paired branch cannot render — the error paragraph lived inside the unpaired branch only. A failed forget left the row saying "Paired" with nothing shown, which is the symptom the catch was added to prevent.

**`Swatinem/rust-cache@v2` is a moving tag**, pinned to 6323deb (v2.9.2). Both call sites, not only the desktop lane it was filed against: a file where one job is pinned and its neighbour is not invites the reader to assume the unpinned one was considered. I declined this on #564 as a repo-wide policy question; raised three times on one PR, it is cheaper to just do. `actions/checkout` and `dtolnay/rust-toolchain` are still on tags — a wider sweep is worth doing, but as its own change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --manifest-path src-tauri/Cargo.toml --all-targets --no-deps -- -D warnings`
- [x] `cargo test --manifest-path src-tauri/Cargo.toml --locked` — 82 passing
- [x] Console: `typecheck` clean, 199 unit tests, `npm run build` clean

Worth naming: **my first version of the ordering test passed without the fix.** Both orderings produce the same final sequence — only the invoke timing differs — so asserting on the final order proved nothing. It now drains microtasks with the disconnect still parked and asserts the second connect has not been issued, which does go red when the chaining is removed. The keychain test pins why a read cannot answer the reachability question at all: a locked store and an empty one are indistinguishable until you write.

## Documentation

No spec change — these are corrections to behaviour already described in `docs/spec/runtime/desktop.md` and the `keychain` module docs, not new behaviour.