### PR TITLE
fix(mcp): stop telling operators to restart for a live MCP change

### DIFF
--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3127,6 +3127,112 @@ description = "Builds the product."
         assert_eq!(pool.mcp_fingerprint_of(&rec.id).await, Some(after));
     }
 
+    /// Issue #566 — the effective-MCP fingerprint is one of the terms in
+    /// [`HarnessPool::ensure`]'s staleness check, which is exactly what lets the
+    /// console promise "no restart": a change confined to the MCP axis, with every
+    /// other fingerprinted input held stable, still rebuilds the roster on the next
+    /// `ensure`. This is the CI guard for that property. A refactor that drops
+    /// `mcp_fingerprint` from the staleness gate makes the second `ensure`
+    /// early-return without storing the new fingerprint — the value stops moving
+    /// across the mutation and the `assert_ne!` below fails, rather than the
+    /// restart requirement quietly returning.
+    #[tokio::test]
+    async fn mcp_fingerprint_participates_in_staleness_check() {
+        let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
+        let dir = tempfile::tempdir().unwrap();
+        let deps = HarnessDeps {
+            provider: Arc::new(MockProvider::new("mock: ")),
+            provider_slug: "mock".to_string(),
+            context: Arc::new(MockContext::default()),
+            store: Arc::new(RecordingStore::default()),
+            meter: None,
+            workspace_root: dir.path().to_path_buf(),
+            model_override: None,
+            tasks: None,
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: std::sync::Arc::from([]),
+            mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: McpFailureQueue::default(),
+            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+            approval_requests: ApprovalRequestQueue::default(),
+            secrets: Some(secrets.clone()),
+            web_allowed_domains: Vec::new(),
+            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            workflow_source_dir: None,
+            plan: None,
+            media: None,
+            composio: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+            run_supervisor: crate::runtime::RunSupervisor::default(),
+            delivery: None,
+            search: None,
+            workspace: None,
+        };
+        let pool = HarnessPool::new();
+        let rec = record();
+
+        // Cold build establishes the baseline fingerprint.
+        pool.ensure(&rec, &deps).await.expect("first ensure");
+        let baseline = pool
+            .mcp_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+
+        // Stability direction: with NO axis changed, `ensure` is a no-op — the gate
+        // reuses the cached roster and the fingerprint does not move.
+        pool.ensure(&rec, &deps).await.expect("redundant ensure");
+        assert_eq!(
+            pool.mcp_fingerprint_of(&rec.id).await,
+            Some(baseline),
+            "an unchanged MCP set must not move the fingerprint"
+        );
+        assert_eq!(pool.resident_companies().await, 1);
+
+        // Change ONLY the MCP axis (console-add a server into the live store); every
+        // other fingerprinted input is identical between the two `ensure` calls.
+        crate::company::mcp::save_runtime_index(
+            &rec.id,
+            secrets.as_ref(),
+            &[crate::company::McpServer {
+                name: "browserbase".into(),
+                endpoint: "https://api.browserbase.com/mcp".into(),
+                description: None,
+                command: None,
+                allowed_tools: Vec::new(),
+                disallowed_tools: Vec::new(),
+                timeout_secs: 30,
+                enabled: true,
+                auth_secret: None,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // Change direction: the MCP-only edit alone flips the fingerprint and
+        // rebuilds in place — proving the term is consulted by the staleness gate.
+        pool.ensure(&rec, &deps).await.expect("post-change ensure");
+        let changed = pool
+            .mcp_fingerprint_of(&rec.id)
+            .await
+            .expect("fingerprinted");
+        assert_ne!(
+            baseline, changed,
+            "an MCP-only change must move the staleness fingerprint (issue #566)"
+        );
+        assert_eq!(
+            pool.resident_companies().await,
+            1,
+            "same company, rebuilt in place — not a new residency"
+        );
+    }
+
     // --- Skill-delta freshness (issue #41) ----------------------------------
 
     /// An in-memory `SkillStateStore` whose delta set a test can mutate between

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3037,10 +3037,17 @@ description = "Builds the product."
         }
     }
 
-    /// A console-added MCP server reaches the agent on the NEXT `ensure` — the
-    /// roster is rebuilt because the effective set re-resolved from the LIVE
-    /// secret store (not the boot snapshot) changed its fingerprint. This is the
-    /// Parallel-Search / BrowserBase freshness bug, proven end-to-end.
+    /// A console-added MCP server reaches the agent on the NEXT `ensure`, with no
+    /// restart — the roster rebuilds because the effective set, re-resolved from
+    /// the LIVE secret store (not the boot snapshot), changed its fingerprint.
+    /// This is the Parallel-Search / BrowserBase freshness bug proven end-to-end,
+    /// and the CI guard for issue #566: the effective-MCP fingerprint is a *term*
+    /// of [`HarnessPool::ensure`]'s staleness check. Both directions are pinned —
+    /// an unchanged set holds the fingerprint (no needless rebuild), an MCP-only
+    /// change moves it (rebuilt in place, without a restart). A refactor that
+    /// drops the term makes the post-change `ensure` early-return without storing
+    /// the new fingerprint: the value stops moving across the mutation and the
+    /// `assert_ne!` fails, rather than the restart requirement quietly returning.
     #[tokio::test]
     async fn ensure_rebuilds_when_a_runtime_mcp_server_is_added() {
         let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
@@ -3089,6 +3096,16 @@ description = "Builds the product."
             .await
             .expect("fingerprinted");
 
+        // Stability direction: with no axis changed, a redundant `ensure` is a
+        // no-op — the gate reuses the cached roster and the fingerprint holds, so
+        // the change-direction assertion below can't pass by coincidence.
+        pool.ensure(&rec, &deps).await.expect("redundant ensure");
+        assert_eq!(
+            pool.mcp_fingerprint_of(&rec.id).await,
+            Some(before),
+            "an unchanged MCP set must not move the fingerprint"
+        );
+
         // Console-add a runtime MCP server directly into the live secret store.
         crate::company::mcp::save_runtime_index(
             &rec.id,
@@ -3108,122 +3125,16 @@ description = "Builds the product."
         .await
         .unwrap();
 
-        // Next ensure re-resolves from the live store → fingerprint changes →
-        // roster rebuilt, so the new server reaches the agent without a restart.
-        pool.ensure(&rec, &deps).await.expect("second ensure");
+        // Change direction: the next ensure re-resolves from the live store →
+        // fingerprint changes → roster rebuilt, so the new server reaches the
+        // agent without a restart.
+        pool.ensure(&rec, &deps).await.expect("post-add ensure");
         let after = pool
             .mcp_fingerprint_of(&rec.id)
             .await
             .expect("fingerprinted");
-        assert_ne!(before, after, "adding a server must change the fingerprint");
-        assert_eq!(
-            pool.resident_companies().await,
-            1,
-            "same company, rebuilt in place"
-        );
-
-        // A third ensure with no change is a no-op (fingerprint stable).
-        pool.ensure(&rec, &deps).await.expect("third ensure");
-        assert_eq!(pool.mcp_fingerprint_of(&rec.id).await, Some(after));
-    }
-
-    /// Issue #566 — the effective-MCP fingerprint is one of the terms in
-    /// [`HarnessPool::ensure`]'s staleness check, which is exactly what lets the
-    /// console promise "no restart": a change confined to the MCP axis, with every
-    /// other fingerprinted input held stable, still rebuilds the roster on the next
-    /// `ensure`. This is the CI guard for that property. A refactor that drops
-    /// `mcp_fingerprint` from the staleness gate makes the second `ensure`
-    /// early-return without storing the new fingerprint — the value stops moving
-    /// across the mutation and the `assert_ne!` below fails, rather than the
-    /// restart requirement quietly returning.
-    #[tokio::test]
-    async fn mcp_fingerprint_participates_in_staleness_check() {
-        let secrets: Arc<dyn SecretStore> = Arc::new(MemSecrets::default());
-        let dir = tempfile::tempdir().unwrap();
-        let deps = HarnessDeps {
-            provider: Arc::new(MockProvider::new("mock: ")),
-            provider_slug: "mock".to_string(),
-            context: Arc::new(MockContext::default()),
-            store: Arc::new(RecordingStore::default()),
-            meter: None,
-            workspace_root: dir.path().to_path_buf(),
-            model_override: None,
-            tasks: None,
-            artifacts: None,
-            skills: None,
-            skills_source_dir: None,
-            skills_registry: std::sync::Arc::from([]),
-            mcp_servers: Vec::new(),
-            facts: None,
-            events: None,
-            delegations: DelegationQueue::default(),
-            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
-            mcp_failures: McpFailureQueue::default(),
-            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
-            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
-            approval_requests: ApprovalRequestQueue::default(),
-            secrets: Some(secrets.clone()),
-            web_allowed_domains: Vec::new(),
-            capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
-            workflow_source_dir: None,
-            plan: None,
-            media: None,
-            composio: None,
-            steer: crate::company::steer::InflightRegistry::default(),
-            run_supervisor: crate::runtime::RunSupervisor::default(),
-            delivery: None,
-            search: None,
-            workspace: None,
-        };
-        let pool = HarnessPool::new();
-        let rec = record();
-
-        // Cold build establishes the baseline fingerprint.
-        pool.ensure(&rec, &deps).await.expect("first ensure");
-        let baseline = pool
-            .mcp_fingerprint_of(&rec.id)
-            .await
-            .expect("fingerprinted");
-
-        // Stability direction: with NO axis changed, `ensure` is a no-op — the gate
-        // reuses the cached roster and the fingerprint does not move.
-        pool.ensure(&rec, &deps).await.expect("redundant ensure");
-        assert_eq!(
-            pool.mcp_fingerprint_of(&rec.id).await,
-            Some(baseline),
-            "an unchanged MCP set must not move the fingerprint"
-        );
-        assert_eq!(pool.resident_companies().await, 1);
-
-        // Change ONLY the MCP axis (console-add a server into the live store); every
-        // other fingerprinted input is identical between the two `ensure` calls.
-        crate::company::mcp::save_runtime_index(
-            &rec.id,
-            secrets.as_ref(),
-            &[crate::company::McpServer {
-                name: "browserbase".into(),
-                endpoint: "https://api.browserbase.com/mcp".into(),
-                description: None,
-                command: None,
-                allowed_tools: Vec::new(),
-                disallowed_tools: Vec::new(),
-                timeout_secs: 30,
-                enabled: true,
-                auth_secret: None,
-            }],
-        )
-        .await
-        .unwrap();
-
-        // Change direction: the MCP-only edit alone flips the fingerprint and
-        // rebuilds in place — proving the term is consulted by the staleness gate.
-        pool.ensure(&rec, &deps).await.expect("post-change ensure");
-        let changed = pool
-            .mcp_fingerprint_of(&rec.id)
-            .await
-            .expect("fingerprinted");
         assert_ne!(
-            baseline, changed,
+            before, after,
             "an MCP-only change must move the staleness fingerprint (issue #566)"
         );
         assert_eq!(
@@ -3231,6 +3142,11 @@ description = "Builds the product."
             1,
             "same company, rebuilt in place — not a new residency"
         );
+
+        // Stability after the change too: a further ensure with no new change is
+        // a no-op and the fingerprint holds at its post-change value.
+        pool.ensure(&rec, &deps).await.expect("final no-op ensure");
+        assert_eq!(pool.mcp_fingerprint_of(&rec.id).await, Some(after));
     }
 
     // --- Skill-delta freshness (issue #41) ----------------------------------

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -10,8 +10,8 @@
 //! never echoed back — the read shape carries only an `authConfigured` bool.
 //!
 //! Both scope forms (`…/companies/{id}` and the single-company alias `…/company`)
-//! are registered by [`scoped`]. Agents pick up a change on their next harness
-//! rebuild; every mutating response says so via `note`.
+//! are registered by [`scoped`]. Agents pick up a change on their next turn with
+//! no restart; every mutating response says so via `note`.
 
 use axum::Router;
 use axum::extract::Path;
@@ -32,10 +32,11 @@ use crate::error::OpenCompanyError;
 use crate::server::error::ApiError;
 use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
-/// The reminder attached to every mutating response: a live agent's tool set is
-/// rebuilt lazily, so an edit reaches agents on the next harness rebuild.
-const REBUILD_NOTE: &str =
-    "Agents pick up this change on their next harness rebuild (restart the company).";
+/// The reminder attached to every mutating response: the effective MCP set is
+/// re-resolved and fingerprinted on every harness cycle (`HarnessPool::ensure`),
+/// so an edit reaches agents on the company's next turn with no restart. The
+/// `mcp_fingerprint` staleness term is what makes this a property of the design.
+const NEXT_TURN_NOTE: &str = "Agents pick up this change on their next turn — no restart needed.";
 
 /// Builds the MCP server management route fragment.
 pub fn router() -> Router<AppState> {
@@ -464,7 +465,7 @@ async fn mutation_response(
         .map_err(ApiError)?;
     Ok(Json(MutationResponse {
         server: dto_from_decl(decl, health),
-        note: REBUILD_NOTE.to_string(),
+        note: NEXT_TURN_NOTE.to_string(),
         test,
         warning,
     }))

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2416,7 +2416,19 @@ async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
     assert_eq!(added["server"]["name"], "notion");
     assert_eq!(added["server"]["source"], "runtime");
     assert_eq!(added["server"]["authConfigured"], true);
-    assert!(added["note"].as_str().unwrap().contains("rebuild"));
+    // Issue #566: a mutating MCP change reaches agents on the company's next turn
+    // (the effective set is re-fingerprinted every `HarnessPool::ensure` cycle), so
+    // the note must NOT instruct a restart. "no restart needed" is fine; the stale
+    // copy told operators to "restart the company" (mirrors the inference guard).
+    let note = added["note"].as_str().unwrap();
+    assert!(
+        note.contains("next turn"),
+        "note should promise next-turn pickup: {note}"
+    );
+    assert!(
+        !note.contains("restart the company"),
+        "mutating MCP response tells operator to restart: {note}"
+    );
 
     // The token must NOT appear anywhere in the add response.
     assert!(

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2418,16 +2418,17 @@ async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
     assert_eq!(added["server"]["authConfigured"], true);
     // Issue #566: a mutating MCP change reaches agents on the company's next turn
     // (the effective set is re-fingerprinted every `HarnessPool::ensure` cycle), so
-    // the note must NOT instruct a restart. "no restart needed" is fine; the stale
-    // copy told operators to "restart the company" (mirrors the inference guard).
+    // the note must state the no-restart contract outright — not merely avoid one
+    // stale phrase. Asserting the positive claim rejects any "restart required"
+    // variant too, which a bare `!contains("restart the company")` would let pass.
     let note = added["note"].as_str().unwrap();
     assert!(
         note.contains("next turn"),
         "note should promise next-turn pickup: {note}"
     );
     assert!(
-        !note.contains("restart the company"),
-        "mutating MCP response tells operator to restart: {note}"
+        note.contains("no restart needed"),
+        "mutating MCP response must state no restart is needed: {note}"
     );
 
     // The token must NOT appear anywhere in the add response.


### PR DESCRIPTION
## Summary

- Every mutating MCP response carried `REBUILD_NOTE`, telling the operator to **"restart the company"** to pick up the change. That is false: `HarnessPool::ensure` re-resolves and fingerprints the effective MCP set on every cycle, so an add / edit / enable / token change reaches agents on the company's **next turn with no restart**. Following the note cost an unnecessary restart (dropped conversation state + cold start) every time a server was touched.
- Replaced it with `NEXT_TURN_NOTE` stating what actually happens, and fixed the module + const docs that repeated the stale *"next harness rebuild"* wording.
- **Neighbour sweep** (the issue asked for it): the inference restart copy is the genuine boot-strand case (#266), correctly gated on `restartRequired`, and is left unchanged. Skills carry no restart copy. Nothing else instructs a restart for a live-refreshed axis.

## Guards (acceptance criteria)

- **AC1** — `write_test`: a mutating MCP response must promise next-turn pickup and must never instruct a restart (`!contains("restart the company")`, mirrors the existing inference note guard).
- **AC2** — `harness`: `ensure_rebuilds_when_a_runtime_mcp_server_is_added` pins the effective-MCP fingerprint as a term of `ensure()`'s staleness check, in both directions — an unchanged set holds the fingerprint (no needless rebuild), an MCP-only change moves it and rebuilds in place. A refactor that drops the term makes the fingerprint stop moving across an MCP-only change and fails CI, rather than silently restoring the restart requirement. _(The separate `mcp_fingerprint_participates_in_staleness_check` guard was folded into this test in review — the pre-change stability assertion was its only net-new coverage, so it now lives here and there is one `HarnessDeps` literal instead of two.)_

## Interaction with #567 (out of scope here, deliberately)

`NEXT_TURN_NOTE` is accurate whenever the MCP bridge is compiled in — every shipped image (`deploy-staging` `TENANT_FEATURES` includes `mcp`). On a build **without** the `mcp` feature the management routes still accept writes (they are ungated) but `registry_for_agent` never runs, so no agent receives the tool — making the note over-promise. That deployment-honesty gap is exactly **#567** (p1), deliberately split from this p2. No regression: the old `"restart the company"` note also lied on that build; this change only improves the shipping case.

## Test plan

- [x] Format — `cargo fmt --all -- --check`
- [x] Clippy — `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] Tests — `cargo test --features openhuman,tinycortex --lib` (2 targeted: AC1 `write_test` no-restart guard, AC2 `ensure_rebuilds_when_a_runtime_mcp_server_is_added`); re-verified after merging `main`

> Note: `src/harness/` is `#[cfg(feature = "openhuman")]`, so its tests only compile/run under `--features openhuman,tinycortex` (a bare `cargo test` silently filters them out).

Closes #566


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP server changes are now picked up by agents on their next turn without requiring a restart.
* **Bug Fixes**
  * Updated MCP configuration handling so live changes correctly refresh the active roster while preserving cached state when no changes occur.
* **Tests**
  * Added regression coverage for MCP-only configuration changes and updated expectations for agent update messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
