### PR TITLE
overview: draw ring 1 from the company's real desks instead of keyword-guessed departments

### DIFF
--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -7,7 +7,7 @@ import { discoverMcpTools, listMcpServers } from "@/api/mcp";
 import { listMemory, type MemoryEntry } from "@/api/memory";
 import { listSkills, type Skill } from "@/api/skills";
 import { listTasks, type Task } from "@/api/tasks";
-import { ApiError, type McpServer, type McpToolInfo } from "@/api/types";
+import { ApiError, type DeskDto, type McpServer, type McpToolInfo } from "@/api/types";
 import { fromDto, starterTeam, type TeamMember } from "@/lib/team";
 import { adapt, buildMemoryGraph } from "./overview/kg/adapter";
 import { buildKnowledgeGraph } from "./overview/kg/model";
@@ -28,6 +28,16 @@ interface Props {
 interface Sources {
   tasks: Task[];
   team: TeamMember[];
+  /**
+   * The company's desks — ring 1 (issue #486).
+   *
+   * Best-effort like every other source here. A host that cannot serve them
+   * draws a graph with no pillars, which is the same picture as a company that
+   * declares no desks. The org chart treats a failed `/desks` as a hard error
+   * because desks *are* that page; here they are one ring of five, and failing
+   * the whole graph over them would take the real rings down with them.
+   */
+  desks: DeskDto[];
   people: Person[];
   skills: Skill[];
   memories: MemoryEntry[];
@@ -49,6 +59,7 @@ interface Sources {
 const EMPTY: Sources = {
   tasks: [],
   team: starterTeam(),
+  desks: [],
   people: [],
   skills: [],
   memories: [],
@@ -76,14 +87,15 @@ function worthAsking(server: McpServer): boolean {
  * The command centre: the company's knowledge graph, and nothing else.
  *
  * The page is the graph — no header, no strip, no top bar (the shell hides its
- * own for this view). The company sits at the core, its departments are the
- * pillars, the jobs hang off each pillar, the teammate who does each job sits
- * above it, and their tools are the outer ring.
+ * own for this view). The company sits at the core, its desks are the pillars,
+ * the jobs hang off each pillar, the teammate who does each job sits above it,
+ * and their tools are the outer ring.
  *
- * Two of those rings are **derived**, not declared: a company manifest carries
- * no department field and no per-agent tool list, so `kg/adapter.ts` invents a
- * plausible structure rather than leaving the graph three rings short. See
- * `DERIVED_NOTICE` there — it is the standing caveat on this whole surface.
+ * The pillars are **declared**: they are the company's own desks (issue #486),
+ * not the keyword-matched guess that used to stand there. What is still derived
+ * is the tool assignments and the workflow templates — there is no per-agent
+ * tool list and no flow API. See `DERIVED_NOTICE` in `kg/adapter.ts`; it is the
+ * standing caveat on what remains.
  */
 export function Overview({ client, company }: Props) {
   const [sources, setSources] = useState<Sources>(EMPTY);
@@ -91,9 +103,11 @@ export function Overview({ client, company }: Props) {
   useEffect(() => {
     let live = true;
     void (async () => {
-      const [tasks, roster, people, skills, memories, mcp] = await Promise.all([
+      const [tasks, roster, desks, people, skills, memories, mcp] = await Promise.all([
         listTasks(client, company).catch(() => [] as Task[]),
         client.listTeam(company).catch(() => null),
+        // Ring 1 (issue #486). Best-effort: see `Sources.desks`.
+        client.listDesks(company).catch(() => [] as DeskDto[]),
         // Only an admin may list people; a member just gets no humans on the
         // graph, which is the right amount of information for them to have.
         listPeople(client, company).catch(() => [] as Person[]),
@@ -138,6 +152,7 @@ export function Overview({ client, company }: Props) {
       setSources({
         tasks,
         team: roster?.length ? roster.map(fromDto) : starterTeam(),
+        desks,
         people,
         skills,
         memories,
@@ -155,6 +170,7 @@ export function Overview({ client, company }: Props) {
     () =>
       adapt({
         members: sources.team,
+        desks: sources.desks,
         tasks: sources.tasks,
         people: sources.people,
         skills: sources.skills,

--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -32,25 +32,46 @@ dragged, and re-framing (selecting a node, opening the core) resets it.
 
 ## The derived rings — read this before trusting the org chart
 
-A company manifest has **no department field and no per-agent tool list**, and
-`[tools] allow` is company-wide. Two of the five rings above are therefore
-invented by `kg/adapter.ts`:
+**Ring 1 is no longer one of them.** Departments are the company's **desks**
+(issue #486) — a `[[group_chat]]` in the manifest, or an operator-created
+overlay desk. That is the one place the company declares how it is organised,
+and it is the same source the Company org chart reads. `assignDepartment` and
+its keyword table are gone.
 
-- **Departments** come from keyword-matching each teammate's role, falling back
-  to Operations.
-- **Tool assignments** are a deterministic deal from the company-wide tool list.
-- **Workflows and their stages** are templates — one routine per department —
-  because the console has no flow API; the Workflows canvas draws a single
-  hard-coded sample. Stages are dealt round-robin across the department's
-  agents.
-- **A human's department** is derived too: signing in says who someone is, not
-  what they work on. Admins sit with Operations; everyone else is spread
-  deterministically by their address.
+What is still invented by `kg/adapter.ts`:
+
+- **Tool assignments** are a deterministic deal from the company-wide tool list,
+  because `[tools] allow` is company-wide and `[[agent]]` has no `tools` field.
+- **Workflows and their stages** are templates, because the console has no flow
+  API; the Workflows canvas draws a single hard-coded sample. One routine is
+  dealt to each desk **by position**, wrapping, and its stages are dealt
+  round-robin across that desk's agents. Nothing ties a routine to what the desk
+  actually does — the console does not know.
 
 Both are deterministic, so nothing jumps between renders — but neither is
 something the company declared. `DERIVED_NOTICE` in `kg/adapter.ts` is the
-standing caveat. When `[[agent]]` grows `department` and `tools`, delete
-`assignDepartment` and `assignTools` and read them straight through.
+standing caveat. When `[[agent]]` grows `tools` (issue #363), delete
+`assignTools` and read it straight through.
+
+### Who the graph does not place
+
+Ring 1 can only place somebody the company seats. Two kinds of teammate it
+cannot, and the graph says so rather than guessing:
+
+- **A teammate on no desk.** They are on the roster and nowhere in the
+  structure, so they hang off the company core in a sector of their own, with no
+  pillar above them. Their open board cards are dropped, because ring 2 hangs
+  off ring 1 and there is no honest desk to hang them from.
+- **A human.** Desks staff agents, so the company declares no desk for a person
+  and this graph does not guess one — the same answer the org chart gives, for
+  the same reason. `assignHumanDepartment` is gone with `assignDepartment`:
+  spreading humans across *invented* buckets was self-consistent fiction, but
+  spreading them across *real desks* would assert a membership the desk's own
+  member list contradicts.
+
+An empty declared desk draws no pillar: `buildKnowledgeGraph` only draws a
+department somebody claims. That is pre-existing behaviour, not a decision this
+made.
 
 Everything else is real: a card's assignee, a skill's category, the tools a
 connected MCP server advertises, and who can sign in.

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -294,7 +294,11 @@ export function KnowledgeGraph({
         workerOfTask.set(e.source, e.target);
         taskOfWorker.set(e.target, e.source);
       }
-      if (e.kind === 'member') teamOfWorker.set(e.source, e.target);
+      // An unplaced worker's `member` edge points at the core, not a pillar
+      // (issue #486). It is still their one structural edge, but it is not a
+      // team: recording `self` here would give them a phantom pillar that owns
+      // their tools and swallows them into focus mode.
+      if (e.kind === 'member' && e.target.startsWith('team:')) teamOfWorker.set(e.source, e.target);
       if (e.kind === 'uses') {
         (toolsOfWorker.get(e.source) ?? toolsOfWorker.set(e.source, []).get(e.source)!).push(e.target);
         (workersOfTool.get(e.target) ?? workersOfTool.set(e.target, []).get(e.target)!).push(e.source);
@@ -492,7 +496,12 @@ export function KnowledgeGraph({
         toolIds: toolsByPillar.get(t.id) ?? [],
       };
     });
-    return radialRestLayout({ selfId: SELF_ID, pillars, ringR: RING_R, cx: CX, cy: CY });
+    // Workers with no pillar (issue #486): on the roster, on no desk. They get
+    // their own sector rather than a resting spot inside somebody else's.
+    const unplacedIds = graph.nodes
+      .filter((n) => (n.kind === 'employee' || n.kind === 'person') && !teamOfWorker.has(n.id))
+      .map((n) => n.id);
+    return radialRestLayout({ selfId: SELF_ID, pillars, unplacedIds, ringR: RING_R, cx: CX, cy: CY });
   }, [graph, tasksOfTeam, workersOfTeam, workersOfTool, teamOfWorker]);
 
   // Staggered label rows for the focused tree: within each band (tasks,
@@ -1608,7 +1617,11 @@ export function KnowledgeGraph({
   const humanCard = selectedHuman ? (
     <GraphHumanDetailCard
       person={selectedHuman}
-      deptName={byId.get(`team:${selectedHuman.departmentId}`)?.label ?? selectedHuman.departmentId}
+      // A human is always unplaced now (issue #486) — the company staffs desks
+      // with agents — so this reads "Not on a desk" rather than echoing the
+      // `UNPLACED` sentinel at the operator. The lookup stays for the case
+      // where a person does carry a drawn desk.
+      deptName={byId.get(`team:${selectedHuman.departmentId}`)?.label ?? 'Not on a desk'}
       color="var(--warn)"
       task={selectedHumanTask}
       tools={toolChips(selectedHumanId)}

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -12,24 +12,31 @@
 // | task → worker       | `task.assignee` on the board  | yes   |
 // | category → skill    | `skill.category`              | yes   |
 // | server → tool       | what the server advertises    | yes   |
-// | teammate → department | nothing                     | **derived** |
+// | teammate → department | `GET {scope}/desks`         | yes   |
 // | worker → tools      | nothing (`[tools] allow` is company-wide) | **derived** |
-// | human → department  | nothing (sign-in tells us who, not what) | **derived** |
 // | department → workflow | nothing (no flow API yet)   | **derived** |
 //
-// The four derived edges are placeholders: a company manifest has no department
-// field and no per-agent tool list, there is no flow API, and signing in says
-// who somebody is rather than what they work on. This module invents a
-// plausible structure rather than leaving most of the five rings empty. That is
-// a deliberate, and temporary, lie — `DERIVED_NOTICE` is the standing caveat.
-// As each field lands upstream, delete the matching `assign*` helper (or
-// `WORKFLOW_TEMPLATES`) and read the real value straight through.
+// Ring 1 used to be invented too: `assignDepartment` keyword-matched a role
+// string into one of five hardcoded buckets, falling back to Operations. It is
+// gone (issue #486). A desk — a `[[group_chat]]` or an operator-created overlay
+// desk — is the one place the company actually declares how it is organised, so
+// the departments are its desks and a teammate's department is the desk they
+// are seated on.
+//
+// The consequence is that the graph now has to answer a question the invention
+// let it dodge: **what about somebody the company declares no desk for?** They
+// are not placed — see `UNPLACED`. Nothing here invents a position for anyone.
+//
+// The two remaining derived edges are placeholders: there is no per-agent tool
+// list and no flow API. `DERIVED_NOTICE` is the standing caveat. As each lands
+// upstream, delete the matching helper (or `WORKFLOW_TEMPLATES`) and read the
+// real value straight through.
 
 import type { Person as HostPerson } from "@/api/auth";
 import type { Skill } from "@/api/skills";
 import type { Task } from "@/api/tasks";
 import type { MemoryEntry } from "@/api/memory";
-import type { McpServer, McpToolInfo } from "@/api/types";
+import type { DeskDto, McpServer, McpToolInfo } from "@/api/types";
 import type { TeamMember } from "@/lib/team";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import type { BrainGraphEdge, BrainGraphNode, MemoryGraph } from "./memory-core";
@@ -39,50 +46,73 @@ import type { Agent, Department, Person, SopTask, Workflow } from "./schemas";
 
 /** Shown wherever the derived structure is on screen. */
 export const DERIVED_NOTICE =
-  "Departments, workflows, and tool assignments are placeholders — this company doesn't declare them.";
+  "Workflows and tool assignments are placeholders — this company doesn't declare them. Departments are its real desks; anyone on no desk is shown unplaced.";
 
 /**
- * The department set. Keyed by the functional areas a small company actually
- * splits into, so the derived assignment lands somewhere plausible rather than
- * arbitrary. Colours are the console's chart hues.
- */
-const DEPARTMENTS: Department[] = [
-  { id: "dept-product", name: "Product", slug: "product", tagline: "What we build and why", color: "#2a78d6", order: 0 },
-  { id: "dept-engineering", name: "Engineering", slug: "engineering", tagline: "Building and running it", color: "#1baf7a", order: 1 },
-  { id: "dept-design", name: "Design", slug: "design", tagline: "How it looks and feels", color: "#eb6834", order: 2 },
-  { id: "dept-growth", name: "Growth", slug: "growth", tagline: "Finding and keeping users", color: "#4a3aa7", order: 3 },
-  { id: "dept-ops", name: "Operations", slug: "ops", tagline: "Keeping the machine running", color: "#eda100", order: 4 },
-];
-
-/**
- * Role keywords that place a teammate in a department, checked in order.
+ * The department a worker gets when the company declares no desk for them.
  *
- * Order matters where a title names two areas: "Product Designer" is a
- * designer, so Design is tested before Product, and Product's own words are
- * the ones no other area claims.
+ * Not a department: no `team:` node is ever built for it, so a worker carrying
+ * it draws no pillar and hangs off the company core instead of a desk. This is
+ * the graph's version of the org chart's "Not on a desk" section — `lib/org.ts`
+ * keeps the same people out of its tree for the same reason, and says so:
+ * inventing a position for them "is exactly the mistake the Overview graph
+ * makes when it keyword-matches a role into a department".
+ *
+ * Prefixed so it can never collide with a real desk: desk ids become
+ * `desk:<id>`, so a manifest desk literally named `unplaced` is `desk:unplaced`
+ * and stays distinct from this.
  */
-const ROLE_HINTS: { department: string; words: string[] }[] = [
-  { department: "dept-design", words: ["design", "ux", "ui", "brand", "creative"] },
-  { department: "dept-engineering", words: ["engineer", "developer", "backend", "frontend", "qa", "devops", "security", "infrastructure"] },
-  { department: "dept-growth", words: ["growth", "market", "sales", "writer", "content", "social", "campaign"] },
-  { department: "dept-product", words: ["product", "pm", "strategy", "research", "analyst", "data", "roadmap"] },
-  { department: "dept-ops", words: ["ops", "operation", "support", "finance", "legal", "front desk", "admin"] },
-];
+export const UNPLACED = "unplaced";
+
+/** A desk's department id. Namespaced so no desk id can collide with `UNPLACED`. */
+export function departmentIdOfDesk(deskId: string): string {
+  return `desk:${deskId}`;
+}
 
 /**
- * Which department a teammate belongs to.
- *
- * **Derived.** Their role text is matched against the hint words above; a role
- * that matches nothing falls to Operations, which is where unclassified work
- * really does end up. Deterministic, so a teammate does not move between
- * renders.
+ * The pillar colours, in order. The console's chart hues — the same five the
+ * hardcoded department list used, now dealt to desks by position. A company
+ * with more desks than hues wraps, which is a repeated tint rather than a
+ * wrong one.
  */
-export function assignDepartment(member: TeamMember): string {
-  const haystack = `${member.role} ${member.name}`.toLowerCase();
-  for (const hint of ROLE_HINTS) {
-    if (hint.words.some((word) => haystack.includes(word))) return hint.department;
-  }
-  return "dept-ops";
+const PILLAR_COLORS = ["#2a78d6", "#1baf7a", "#eb6834", "#4a3aa7", "#eda100"];
+
+/** `Product Design` → `product-design`, for the department's slug. */
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Ring 1: the company's desks, in the order the host serves them.
+ *
+ * **Declared, not derived.** A desk is a `[[group_chat]]` in the manifest or an
+ * operator-created overlay desk; either way the company said it exists and said
+ * who is on it. The order is the host's own — never re-sorted here, the same
+ * rule `lib/org.ts` follows for seats.
+ */
+export function deskDepartments(desks: DeskDto[]): Department[] {
+  return desks.map((desk, i) => ({
+    id: departmentIdOfDesk(desk.id),
+    name: desk.name,
+    slug: slugify(desk.name) || slugify(desk.id) || `desk-${i}`,
+    tagline: desk.description ?? "",
+    color: PILLAR_COLORS[i % PILLAR_COLORS.length],
+    order: i,
+  }));
+}
+
+/**
+ * Which desk a teammate is seated on, or `UNPLACED`.
+ *
+ * A teammate can sit on several desks — desks are flat, and nothing stops a
+ * manifest seating one agent twice. The graph's model gives an agent exactly
+ * one `departmentId`, so the **first** desk that names them wins, in the host's
+ * desk order. That under-reports the structure (the org chart shows both
+ * seats); it never invents one, which is the property that matters here.
+ */
+export function deskOfMember(id: string, desks: DeskDto[]): string {
+  const desk = desks.find((d) => d.members.includes(id));
+  return desk ? departmentIdOfDesk(desk.id) : UNPLACED;
 }
 
 /**
@@ -102,79 +132,81 @@ export function assignTools(index: number, tools: string[]): string[] {
 }
 
 /**
- * One standing routine per department.
+ * One standing routine per desk.
  *
- * **Derived.** The console has no flow API — the Workflows canvas draws a
- * single hard-coded sample — so these are plausible routines for each area
+ * **Derived, and now visibly so.** The console has no flow API — the Workflows
+ * canvas draws a single hard-coded sample — so these are plausible routines
  * rather than anything the company declared. They exist to show the shape a
- * real flow will take on the graph: a department runs a flow, and the flow
- * passes through several of that department's agents in turn.
+ * real flow will take on the graph: a desk runs a flow, and the flow passes
+ * through several of that desk's agents in turn.
+ *
+ * These used to be pinned to the five invented departments by id, which read as
+ * if each area had been given its own considered routine. With ring 1 drawn
+ * from real desks (issue #486) that pinning is gone: a routine is dealt to a
+ * desk **by position**, wrapping when there are more desks than routines. The
+ * arbitrariness is the honest part — the console does not know what a desk
+ * called "Front of house" actually runs, and pretending otherwise was the
+ * dodge. Kept only because deleting them would empty two of the five rings
+ * before there is anything to put back; deleting them here is #363's job, not
+ * this one's.
  */
-const WORKFLOW_TEMPLATES: Omit<Workflow, "agentIds">[] = [
+const WORKFLOW_ROUTINES: { slug: string; name: string; summary: string; stages: string[] }[] = [
   {
-    id: "flow-discovery",
-    departmentId: "dept-product",
+    slug: "discovery",
     name: "Discovery loop",
     summary: "Turn a raw request into a specced, prioritised piece of work.",
     stages: ["Intake", "Research", "Spec", "Prioritise"],
   },
   {
-    id: "flow-delivery",
-    departmentId: "dept-engineering",
+    slug: "delivery",
     name: "Ship it",
     summary: "Take a spec through build, review, and release.",
     stages: ["Plan", "Build", "Review", "Release"],
   },
   {
-    id: "flow-brand",
-    departmentId: "dept-design",
+    slug: "brand",
     name: "Make it look right",
     summary: "Draft, critique, and hand off the visuals for a piece of work.",
     stages: ["Brief", "Draft", "Critique", "Hand off"],
   },
   {
-    id: "flow-campaign",
-    departmentId: "dept-growth",
+    slug: "campaign",
     name: "Campaign run",
     summary: "Angle to published post, with the numbers read back after.",
     stages: ["Angle", "Write", "Publish", "Measure"],
   },
   {
-    id: "flow-triage",
-    departmentId: "dept-ops",
+    slug: "triage",
     name: "Inbound triage",
     summary: "Sort what arrives, answer it, and escalate what needs a person.",
     stages: ["Receive", "Sort", "Answer", "Escalate"],
   },
 ];
 
-/**
- * Which department a human belongs to.
- *
- * **Derived.** Signing in tells the console who someone is, not what they work
- * on. Admins sit with Operations — administering the company *is* operations —
- * and everyone else is spread deterministically across the departments that
- * exist, so humans read as part of the org rather than piled on one pillar.
- *
- * `departments` here is already filtered to the ones with an agent in them
- * (see `adapt` below), so it may not include Operations at all — a roster
- * that's all engineers and designers, say. Pointing an admin at "dept-ops"
- * regardless would hand `buildKnowledgeGraph` a department id no `team:`
- * node exists for, and it throws building the force-link edges. Falling back
- * to the same spread everyone else gets keeps every returned id inside
- * `departments`.
- */
-export function assignHumanDepartment(person: HostPerson, departments: Department[]): string {
-  if (departments.length === 0) return "dept-ops";
-  if (person.role === "admin") {
-    const ops = departments.find((d) => d.id === "dept-ops");
-    if (ops) return ops.id;
-  }
-  return departments[hash(person.email) % departments.length].id;
-}
+// `assignHumanDepartment` was deleted with `assignDepartment` (issue #486),
+// and the reason is worth keeping: it did not merely stay derived, it got
+// *worse* when ring 1 became real.
+//
+// It spread humans deterministically across the departments that existed. While
+// those were invented buckets that was internally consistent fiction — a made-up
+// person-to-made-up-bucket edge. Now the departments are the company's actual
+// desks, with membership the company declared. Dealing a human onto one would
+// claim they sit on a real desk whose real member list does not name them, and
+// the graph would contradict the org chart on a fact the operator can check.
+//
+// So a human is `UNPLACED`, which is what the org chart already decided for the
+// same people: "Desks staff agents, so the company declares no desk for a
+// person, and this chart does not guess one."
 
 export interface AdaptInput {
   members: TeamMember[];
+  /**
+   * The company's desks — ring 1, and the only declared statement of how this
+   * company is organised. An empty list is a company that declares no
+   * structure: it draws no pillars and everyone is unplaced, which is the true
+   * answer rather than a guessed one.
+   */
+  desks: DeskDto[];
   tasks: Task[];
   skills: Skill[];
   servers: McpServer[];
@@ -219,7 +251,7 @@ export function adapt(input: AdaptInput): Adapted {
 
   const agents: Agent[] = input.members.map((member, i) => ({
     id: member.id,
-    departmentId: assignDepartment(member),
+    departmentId: deskOfMember(member.id, input.desks),
     name: member.name,
     role: member.role,
     status: "active",
@@ -241,9 +273,18 @@ export function adapt(input: AdaptInput): Adapted {
     if (!isOpen(task)) continue;
     const member = input.members.find((m) => input.ownedBy(task, m));
     if (!member) continue;
+    // A task hangs off its owner's desk. An unplaced owner has none, and ring 2
+    // hangs off ring 1 — so their card is dropped rather than parked under a
+    // desk they are not on. That loses a real card from the graph, which is a
+    // genuine cost and the reason it is stated here rather than left to fall
+    // out of a guard in `model.ts`: the alternative is asserting a desk
+    // membership the company never declared, and the board still shows the
+    // card. Seat the teammate on a desk and it comes back.
+    const departmentId = deskOfMember(member.id, input.desks);
+    if (departmentId === UNPLACED) continue;
     tasks.push({
       id: task.id,
-      departmentId: assignDepartment(member),
+      departmentId,
       title: task.title,
       summary: task.note ?? "",
       steps: [
@@ -256,13 +297,17 @@ export function adapt(input: AdaptInput): Adapted {
     });
   }
 
-  // Only departments that ended up with somebody in them.
+  // Only desks that ended up with somebody on them. A declared desk with no
+  // members draws no pillar — `buildKnowledgeGraph` skips a department nobody
+  // claims, and matching that here keeps the two from disagreeing.
   const used = new Set(agents.map((a) => a.departmentId));
-  const departments = DEPARTMENTS.filter((d) => used.has(d.id));
+  const departments = deskDepartments(input.desks).filter((d) => used.has(d.id));
 
   const people: Person[] = input.people.map((p) => ({
     id: p.id,
-    departmentId: assignHumanDepartment(p, departments),
+    // Never a desk: the company staffs desks with agents and declares no desk
+    // for a person. See the note where `assignHumanDepartment` used to be.
+    departmentId: UNPLACED,
     // Falling back to the local part of the address keeps a real name off the
     // graph only when nobody has set one.
     name: p.displayName?.trim() || p.email.split("@")[0],
@@ -272,14 +317,22 @@ export function adapt(input: AdaptInput): Adapted {
     tools: [],
   }));
 
-  // A flow only makes sense where its department has agents to run it; each is
-  // wired through that department's agents in roster order.
-  const workflows: Workflow[] = WORKFLOW_TEMPLATES.filter((f) => used.has(f.departmentId)).map(
-    (f) => ({
-      ...f,
-      agentIds: agents.filter((a) => a.departmentId === f.departmentId).map((a) => a.id),
-    }),
-  );
+  // A flow only makes sense where its desk has agents to run it, and every
+  // drawn desk has some by construction. The routine is dealt by the desk's
+  // position, wrapping — see `WORKFLOW_ROUTINES` for why that arbitrariness is
+  // deliberate. The id is desk-scoped so two desks sharing a routine still get
+  // two distinct `flow:` nodes.
+  const workflows: Workflow[] = departments.map((d, i) => {
+    const routine = WORKFLOW_ROUTINES[i % WORKFLOW_ROUTINES.length];
+    return {
+      id: `${d.id}-${routine.slug}`,
+      departmentId: d.id,
+      name: routine.name,
+      summary: routine.summary,
+      stages: routine.stages,
+      agentIds: agents.filter((a) => a.departmentId === d.id).map((a) => a.id),
+    };
+  });
 
   return { departments, agents, people, workflows, tasks, toolLabels };
 }

--- a/frontend/src/views/overview/kg/model.ts
+++ b/frontend/src/views/overview/kg/model.ts
@@ -191,8 +191,18 @@ export function buildKnowledgeGraph(
     nodes.push({ id: w.nodeId, kind: w.kind, label: w.label, ring: RING[w.kind] });
     // Workers reach their team through their task; only a worker with no task
     // (a data gap the seed tests forbid) falls back to a direct member edge.
-    if (!assignedWorkers.has(w.nodeId) && drawn.has(w.deptId)) {
-      edges.push({ source: w.nodeId, target: `team:${w.deptId}`, kind: 'member' });
+    if (!assignedWorkers.has(w.nodeId)) {
+      if (drawn.has(w.deptId)) {
+        edges.push({ source: w.nodeId, target: `team:${w.deptId}`, kind: 'member' });
+      } else {
+        // No pillar to belong to — the company declares no desk for them
+        // (`adapter.ts`'s `UNPLACED`), or the caller handed us a department id
+        // that has no `team:` node. Either way they hang off the core: being on
+        // the company's roster is a fact, and belonging to one of its desks is
+        // not. Without this they would be edgeless, which the force layout
+        // leaves drifting and a reader cannot tell from a rendering fault.
+        edges.push({ source: w.nodeId, target: SELF_ID, kind: 'member' });
+      }
     }
     for (const slug of w.tools) {
       edges.push({ source: w.nodeId, target: toolNodeId(slug, w.deptId), kind: 'uses' });

--- a/frontend/src/views/overview/kg/tree-layout.ts
+++ b/frontend/src/views/overview/kg/tree-layout.ts
@@ -117,6 +117,13 @@ export type RestLayoutInput = {
     workerIds: string[];
     toolIds: string[];
   }[];
+  /**
+   * Workers the company declares no desk for (issue #486): they belong to no
+   * pillar, so they get a sector of their own on the worker ring rather than a
+   * position inside somebody else's wedge. Empty (or omitted) costs nothing —
+   * no sector is reserved and the wheel is exactly as it was.
+   */
+  unplacedIds?: string[];
   /** radius per depth: [self, team, task, worker, tool]. Omit to derive from width/height. */
   ringR?: number[];
   cx: number;
@@ -163,13 +170,18 @@ export function radialRestLayout(input: RestLayoutInput): RestLayoutResult {
   // while a sparse one stays tight. Centers sit at each span's midpoint, rotated
   // so the first pillar stays at `startAngle` — for a balanced graph (equal
   // weights) this reproduces the old evenly-spaced sunburst exactly.
-  const n = Math.max(1, pillars.length);
+  // The unplaced ride a sector of their own, sized like any other and placed
+  // last so the pillars keep the angles they would have had without them.
+  const unplaced = input.unplacedIds ?? [];
+  const sectors = pillars.length + (unplaced.length > 0 ? 1 : 0);
+  const n = Math.max(1, sectors);
   const weights = pillars.map((p) =>
     Math.max(
       1,
       (p.flowIds?.length ?? 0) + p.taskIds.length + (p.stepIds?.length ?? 0) + p.workerIds.length + p.toolIds.length,
     ),
   );
+  if (unplaced.length > 0) weights.push(Math.max(1, unplaced.length));
   const total = weights.reduce((s, w) => s + w, 0) || 1;
   const spans = weights.map((w) => (w / total) * Math.PI * 2);
   const centersRaw: number[] = [];
@@ -180,24 +192,35 @@ export function radialRestLayout(input: RestLayoutInput): RestLayoutResult {
   }
   const offset = startAngle - (centersRaw[0] ?? 0);
 
+  /** Spread `ids` across a sector's arc at radius `r`, symmetric about its centre. */
+  const ring = (ids: string[], r: number, center: number, half: number) => {
+    const k = ids.length;
+    ids.forEach((id, j) => {
+      const t = k <= 1 ? 0 : (j / (k - 1)) * 2 - 1; // -1 … 1, symmetric about the pillar
+      positions.set(id, polar(r, center + t * half));
+    });
+  };
+
   pillars.forEach((p, i) => {
     const center = centersRaw[i] + offset;
     positions.set(p.teamId, polar(ringR[1], center));
     const half = (spans[i] / 2) * SECTOR_FILL;
-    const ring = (ids: string[], r: number) => {
-      const k = ids.length;
-      ids.forEach((id, j) => {
-        const t = k <= 1 ? 0 : (j / (k - 1)) * 2 - 1; // -1 … 1, symmetric about the pillar
-        positions.set(id, polar(r, center + t * half));
-      });
-    };
     // Flows and stages share their ring with tasks and workers rather than
     // getting rings of their own: five rings is already the whole radius, and
     // interleaving them keeps each pillar's wedge readable.
-    ring([...(p.flowIds ?? []), ...p.taskIds], ringR[2]);
-    ring([...(p.stepIds ?? []), ...p.workerIds], ringR[3]);
-    ring(p.toolIds, ringR[4]);
+    ring([...(p.flowIds ?? []), ...p.taskIds], ringR[2], center, half);
+    ring([...(p.stepIds ?? []), ...p.workerIds], ringR[3], center, half);
+    ring(p.toolIds, ringR[4], center, half);
   });
+
+  // No `positions.set` at ring 1 for the unplaced sector: there is no pillar
+  // there and drawing one would be the invented department this replaced. The
+  // sector is empty all the way in, which is what "on no desk" looks like.
+  if (unplaced.length > 0) {
+    const i = pillars.length;
+    const center = centersRaw[i] + offset;
+    ring(unplaced, ringR[3], center, (spans[i] / 2) * SECTOR_FILL);
+  }
 
   return { positions };
 }

--- a/frontend/test/unit/overview-ring1.test.ts
+++ b/frontend/test/unit/overview-ring1.test.ts
@@ -1,0 +1,291 @@
+import { describe, expect, it } from "vitest";
+
+import type { Person as HostPerson } from "@/api/auth";
+import type { Task } from "@/api/tasks";
+import type { DeskDto } from "@/api/types";
+import type { TeamMember } from "@/lib/team";
+import { adapt, deskDepartments, deskOfMember, UNPLACED } from "@/views/overview/kg/adapter";
+import { buildKnowledgeGraph, SELF_ID } from "@/views/overview/kg/model";
+import { radialRestLayout } from "@/views/overview/kg/tree-layout";
+import { ownedBy } from "@/views/overview/pulse";
+
+/**
+ * Ring 1 of the Overview graph (issue #486).
+ *
+ * The graph used to guess this ring: `assignDepartment` keyword-matched a role
+ * string into one of five hardcoded buckets and fell back to Operations. It now
+ * reads the company's desks — the one structure the company declares.
+ *
+ * Every failure this guards is silent on screen. A wrong ring 1 still draws a
+ * clean five-ring sunburst; it just describes a company that does not exist:
+ *
+ * - a teammate placed by their job title rather than their desk looks correctly
+ *   filed, and contradicts the org chart two clicks away;
+ * - a human dealt onto a real desk asserts a membership that desk's own member
+ *   list denies;
+ * - a teammate on no desk given a department is the exact fabrication this
+ *   issue removed, and it is invisible once drawn;
+ * - workflows keyed to the deleted `dept-*` ids silently draw nothing, emptying
+ *   two of the five rings with no error anywhere.
+ */
+
+function member(id: string, role: string, name = id): TeamMember {
+  return { id, name, role, description: "", tone: "a", inboxEnabled: false };
+}
+
+/**
+ * Deliberately adversarial: every teammate's role points at a DIFFERENT
+ * department than the desk that seats them, so a test can only pass by reading
+ * the desk. `hedy` is a "Designer" seated on Engineering; `ada` is a "Backend
+ * Engineer" seated on Front of house.
+ */
+const ROSTER: TeamMember[] = [
+  member("hedy", "Designer"),
+  member("ada", "Backend Engineer"),
+  member("grace", "Growth Marketer"),
+];
+
+const ENGINEERING: DeskDto = {
+  id: "engineering",
+  name: "Engineering",
+  description: "Ships the product",
+  members: ["hedy"],
+};
+
+const FRONT_OF_HOUSE: DeskDto = {
+  id: "front-of-house",
+  name: "Front of house",
+  members: ["ada"],
+};
+
+const DESKS = [ENGINEERING, FRONT_OF_HOUSE];
+
+const BASE = {
+  tasks: [] as Task[],
+  skills: [],
+  servers: [],
+  toolsByServer: {},
+  people: [] as HostPerson[],
+  ownedBy,
+};
+
+function person(id: string, role: HostPerson["role"] = "member"): HostPerson {
+  return {
+    id,
+    email: `${id}@example.com`,
+    role,
+    status: "active",
+    hasPassword: true,
+    mustChangePassword: false,
+    createdAtMillis: 0,
+  } as HostPerson;
+}
+
+describe("ring 1 is the company's desks", () => {
+  it("names the pillars after the desks, in the host's order", () => {
+    // Served deliberately out of alphabetical order: the host's order is the
+    // hierarchy (`lib/org.ts` reads seats the same way), so a re-sort here
+    // would silently reorder the wheel. Sorted by name this would read
+    // Engineering first.
+    const depts = deskDepartments([FRONT_OF_HOUSE, ENGINEERING]);
+    expect(depts.map((d) => d.name)).toEqual(["Front of house", "Engineering"]);
+    // The order field is what puts a pillar on the wheel.
+    expect(depts.map((d) => d.order)).toEqual([0, 1]);
+    expect(depts[1].tagline).toBe("Ships the product");
+  });
+
+  it("namespaces desk ids so a desk cannot collide with the unplaced sentinel", () => {
+    const [dept] = deskDepartments([{ id: UNPLACED, name: "Unplaced", members: [] }]);
+    expect(dept.id).not.toBe(UNPLACED);
+    expect(dept.id).toBe(`desk:${UNPLACED}`);
+  });
+
+  it("seats a teammate by their desk, not by their job title", () => {
+    // The whole point: hedy is a Designer on the Engineering desk. The old
+    // keyword table put her in Design on the strength of the word "Designer".
+    const { agents, departments } = adapt({ ...BASE, members: ROSTER, desks: DESKS });
+    const hedy = agents.find((a) => a.id === "hedy")!;
+    expect(hedy.departmentId).toBe("desk:engineering");
+    expect(departments.find((d) => d.id === hedy.departmentId)!.name).toBe("Engineering");
+
+    const ada = agents.find((a) => a.id === "ada")!;
+    expect(ada.departmentId).toBe("desk:front-of-house");
+  });
+
+  it("gives a teammate on several desks the first one, and never two", () => {
+    const both: DeskDto = { id: "both", name: "Both", members: ["hedy"] };
+    // Host order decides: engineering is served first, so engineering wins.
+    expect(deskOfMember("hedy", [ENGINEERING, both])).toBe("desk:engineering");
+    expect(deskOfMember("hedy", [both, ENGINEERING])).toBe("desk:both");
+  });
+
+  it("draws no pillar for a desk nobody is on", () => {
+    const empty: DeskDto = { id: "empty", name: "Empty desk", members: [] };
+    const { departments } = adapt({ ...BASE, members: ROSTER, desks: [...DESKS, empty] });
+    expect(departments.map((d) => d.id)).not.toContain("desk:empty");
+  });
+});
+
+describe("nobody is given a position the company did not declare", () => {
+  it("leaves a teammate on no desk unplaced rather than in Operations", () => {
+    // grace is on neither desk. The old code read "Growth Marketer" and filed
+    // her under Growth; a role matching nothing at all fell back to Operations.
+    const { agents, departments } = adapt({ ...BASE, members: ROSTER, desks: DESKS });
+    const grace = agents.find((a) => a.id === "grace")!;
+    expect(grace.departmentId).toBe(UNPLACED);
+    // And no pillar was conjured to hold her.
+    expect(departments.map((d) => d.id)).not.toContain(UNPLACED);
+  });
+
+  it("leaves every human unplaced — desks staff agents", () => {
+    const { people } = adapt({
+      ...BASE,
+      members: ROSTER,
+      desks: DESKS,
+      people: [person("root", "admin"), person("member")],
+    });
+    expect(people).toHaveLength(2);
+    for (const p of people) expect(p.departmentId).toBe(UNPLACED);
+  });
+
+  it("drops an unplaced teammate's card rather than parking it on a desk", () => {
+    const card: Task = {
+      id: "t1",
+      title: "Write the launch post",
+      column: "doing",
+      priority: "high",
+      assignee: "grace",
+      updatedAt: 0,
+    };
+    const { tasks } = adapt({ ...BASE, members: ROSTER, desks: DESKS, tasks: [card] });
+    expect(tasks).toHaveLength(0);
+
+    // Seat her, and the same card comes back under that desk — proving it is
+    // the missing desk that drops it, not the card.
+    const seated = adapt({
+      ...BASE,
+      members: ROSTER,
+      desks: [...DESKS, { id: "growth", name: "Growth", members: ["grace"] }],
+      tasks: [card],
+    });
+    expect(seated.tasks.map((t) => t.departmentId)).toEqual(["desk:growth"]);
+  });
+
+  it("draws no pillars at all for a company that declares no desks", () => {
+    const { departments, agents, workflows } = adapt({ ...BASE, members: ROSTER, desks: [] });
+    expect(departments).toEqual([]);
+    expect(workflows).toEqual([]);
+    for (const a of agents) expect(a.departmentId).toBe(UNPLACED);
+  });
+});
+
+describe("the workflow ring survives desks replacing the hardcoded departments", () => {
+  it("hangs one routine off every drawn desk", () => {
+    // The templates used to be pinned to `dept-product`, `dept-engineering` and
+    // friends. Those ids no longer exist, so a template keyed to them matches
+    // no desk and the whole ring vanishes without an error.
+    const { workflows, departments } = adapt({ ...BASE, members: ROSTER, desks: DESKS });
+    expect(workflows).toHaveLength(departments.length);
+    expect(workflows.map((f) => f.departmentId).sort()).toEqual(
+      departments.map((d) => d.id).sort(),
+    );
+    // Desk-scoped ids: two desks dealt the same routine still get two nodes.
+    expect(new Set(workflows.map((f) => f.id)).size).toBe(workflows.length);
+    for (const f of workflows) expect(f.agentIds.length).toBeGreaterThan(0);
+  });
+});
+
+describe("the graph model places the unplaced without inventing a pillar", () => {
+  it("hangs an unplaced worker off the core, not off a team", () => {
+    const { agents, departments, people } = adapt({
+      ...BASE,
+      members: ROSTER,
+      desks: DESKS,
+      people: [person("root", "admin")],
+    });
+    const graph = buildKnowledgeGraph(agents, departments, people);
+
+    // No team node was created for the sentinel.
+    expect(graph.nodes.filter((n) => n.kind === "team").map((n) => n.id)).toEqual([
+      "team:desk:engineering",
+      "team:desk:front-of-house",
+    ]);
+
+    // grace and the human are on the graph — visible, not absent — and their
+    // one structural edge points at the company itself.
+    for (const nodeId of ["emp:grace", "person:root"]) {
+      expect(graph.nodes.some((n) => n.id === nodeId)).toBe(true);
+      const edges = graph.edges.filter((e) => e.source === nodeId);
+      expect(edges).toEqual([{ source: nodeId, target: SELF_ID, kind: "member" }]);
+    }
+
+    // A seated teammate still reaches their own desk, not the core.
+    expect(graph.edges).toContainEqual({
+      source: "emp:hedy",
+      target: "team:desk:engineering",
+      kind: "member",
+    });
+  });
+});
+
+describe("the rest layout gives the unplaced a sector of their own", () => {
+  const pillars = [
+    { teamId: "team:a", taskIds: [], workerIds: ["emp:x"], toolIds: [] },
+    { teamId: "team:b", taskIds: [], workerIds: ["emp:y"], toolIds: [] },
+  ];
+  const ringR = [0, 100, 150, 200, 250];
+  const at = (id: string, positions: Map<string, { x: number; y: number }>) => {
+    const p = positions.get(id)!;
+    return Math.round(Math.hypot(p.x - 500, p.y - 300));
+  };
+
+  it("rests them on the worker ring with no pillar above them", () => {
+    const { positions } = radialRestLayout({
+      selfId: "self",
+      pillars,
+      unplacedIds: ["emp:lost", "person:root"],
+      ringR,
+      cx: 500,
+      cy: 300,
+    });
+    // On ring 3, the worker ring — the same radius as a seated worker.
+    expect(at("emp:lost", positions)).toBe(ringR[3]);
+    expect(at("person:root", positions)).toBe(ringR[3]);
+    // Their sector has nothing at ring 1: no pillar was placed for them.
+    const ring1 = [...positions.entries()].filter(
+      ([, p]) => Math.round(Math.hypot(p.x - 500, p.y - 300)) === ringR[1],
+    );
+    expect(ring1.map(([id]) => id).sort()).toEqual(["team:a", "team:b"]);
+  });
+
+  it("does not move the pillars when there is nobody unplaced", () => {
+    const withNone = radialRestLayout({ selfId: "self", pillars, ringR, cx: 500, cy: 300 });
+    const withEmpty = radialRestLayout({
+      selfId: "self",
+      pillars,
+      unplacedIds: [],
+      ringR,
+      cx: 500,
+      cy: 300,
+    });
+    expect(withEmpty.positions.get("team:a")).toEqual(withNone.positions.get("team:a"));
+    expect(withEmpty.positions.get("team:b")).toEqual(withNone.positions.get("team:b"));
+  });
+
+  it("separates the unplaced sector from every pillar's wedge", () => {
+    const { positions } = radialRestLayout({
+      selfId: "self",
+      pillars,
+      unplacedIds: ["emp:lost"],
+      ringR,
+      cx: 500,
+      cy: 300,
+    });
+    // Not sitting on top of either desk's worker.
+    for (const seated of ["emp:x", "emp:y"]) {
+      const a = positions.get("emp:lost")!;
+      const b = positions.get(seated)!;
+      expect(Math.hypot(a.x - b.x, a.y - b.y)).toBeGreaterThan(20);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Ring 1 of the Overview knowledge graph was invented. `assignDepartment` keyword-matched each teammate's role string into one of five hardcoded buckets (`dept-product`, `dept-engineering`, …) and fell back to Operations when nothing matched, while the graph ignored `[[group_chat]]` entirely — the one place the company actually declares how it is organised.

Ring 1 is now the company's **desks**, read from `GET {scope}/desks`: the same declared source the Company org chart reads. `assignDepartment`, `ROLE_HINTS` and the hardcoded `DEPARTMENTS` list are deleted, as `frontend/src/views/overview/README.md` had been asking for.

Closes the ring-1 half of the caveat. `assignTools` and the workflow templates keep theirs — neither has a declared source yet.

### The route I took, and what it leaves for #363

Both this and **#363** delete `assignDepartment`, so whichever landed first was going to delete the other's target. This takes the **desks** route (structure the company already declares) rather than #363's manifest route (a new `[[agent]] department` field). #363 is not blocked — its scope shrinks to what it always uniquely owned:

- **`assignTools`** — still derived, still a deterministic deal from the company-wide `[tools] allow`. #363's own analysis of why a per-agent tool list is a permission statement rather than a display hint is untouched by this PR.
- **The derived workflow stages** — still templates; there is no flow API.
- **A per-agent `department` field**, if that is still wanted once desks are read. It would now be a *second* declaration of the same fact, which is worth deciding deliberately rather than by default.

⚠️ **#363 is assigned to @senamakel** (since 2026-08-04). There is no PR and no code activity on it, so nothing was in flight to collide with, but flagging it explicitly since this deletes code that issue names.

## API Or Behavior Changes

**No API changes.** `Overview` now calls the existing `client.listDesks()`; no new endpoint, no schema change.

Behaviour changes, all on the Overview graph:

1. **Pillars are desks.** A teammate's department is the desk that seats them, not their job title. A "Designer" on the Engineering desk now reads as Engineering.
2. **Nobody gets a position the company did not declare.** A teammate on no desk, and every human, are **unplaced**: their node is drawn on the worker ring in a sector of its own, hanging off the company core, with no pillar above them. This is the radial form of the org chart's existing `Unplaced` section ("Outside the tree on purpose … putting them under a node would be inventing structure").
3. **`assignHumanDepartment` is deleted.** Not scope creep — leaving it in would have made it *worse*. It spread humans across whatever departments existed; while those were invented buckets that was self-consistent fiction, but spreading them across **real desks** asserts a membership the desk's own member list denies, and the org chart two clicks away would contradict it on a fact the operator can check. The issue lists "a human's department" as a surviving caveat; I think that only held while ring 1 was fake, and I'd rather have this argued down in review than shipped silently either way.
4. **An unplaced teammate's open cards are dropped from the graph.** Ring 2 hangs off ring 1, and there is no honest desk to hang them from. This is a real loss of real data — stated in the code where the decision is made rather than left to fall out of a guard in `model.ts` — and the alternative was asserting a desk membership. The board still shows the card; seating the teammate brings it back.
5. **A company that declares no desks draws no pillars**, and everyone is unplaced. That is the true picture rather than a guessed one. (#363's acceptance criteria allow a declare-nothing company to fall back to inference; that is available to it, but it needs the inference this PR deletes, so it is #363's call to make, not this one's.)
6. **Workflows survive.** `WORKFLOW_TEMPLATES` were pinned to the deleted `dept-*` ids, so once the ids changed every template would have matched no department and the workflow ring would have **silently drawn nothing**. Routines are now dealt to desks by position (wrapping), with desk-scoped ids. The arbitrariness is deliberate and documented: the console does not know what a desk called "Front of house" runs, and the old per-department pinning read as if it did.
7. **A failed `/desks` degrades rather than throwing.** The org chart treats it as a hard error because desks *are* that page; here they are one ring of five, so a failure draws no pillars instead of taking the real rings down.

### Scope question the issue isolated — what ring 1 shows for a teammate on no desk

The issue asks for an answer "that is not a fabricated ring", and notes a radial layout has no natural "beside the tree". What I settled on:

- **Not a ring.** No "Unassigned" pillar is created. `UNPLACED` is a sentinel that never becomes a `team:` node, and it is namespaced (`desk:<id>` for real desks) so a manifest desk literally named `unplaced` cannot collide with it.
- **Visible, not absent.** `lib/org.ts` keeps unplaced teammates in the chart precisely so "the roster still adds up" and an unplaced teammate is "visible rather than absent". Dropping them from the graph would have been the cheaper change and I think the wrong one.
- **Attached to the core, not floating.** `forceRadial` pins nodes to their ring regardless of edges, so an edgeless node does not fly off — but it gets no rest position, drifts into pillar wedges, and reads as a rendering fault. A `member` edge to the core says the true thing (on the roster, on no desk) without naming a desk, and `radialRestLayout` gives them a sector with **nothing at ring 1** — the empty wedge is what "on no desk" looks like.

## Tests

New: `frontend/test/unit/overview-ring1.test.ts` (14 tests). The fixtures are adversarial on purpose — every teammate's role points at a *different* department than the desk that seats them, so a test can only pass by reading desk membership.

**Revert-and-check: 12 of the 14 were confirmed to fail with the fix reverted**, across 8 targeted reverts (each reverted, run, restored):

| Revert | Tests that failed |
|---|---|
| `model.ts` — drop the core attachment | 1 |
| `tree-layout.ts` — ignore the unplaced sector | 2 |
| `adapter.ts` — stop reading desk membership | 4 |
| humans dealt onto a real desk (old `assignHumanDepartment`) | 2 |
| workflows pinned to the old `dept-*` ids | 1 |
| desk ids not namespaced | 5 |
| draw a pillar for a desk nobody is on | 1 |
| re-sort desks by name instead of host order | 1 |

**One of these caught a vacuous test of mine.** The host-order assertion originally passed even when I re-sorted the desks by name, because my two fixture desks were already alphabetical. The fixture now serves them deliberately out of order, and the test fails under that revert. Reporting it rather than quietly fixing it.

The remaining **2 tests are boundary/regression guards that pass before and after by design**, and I am not claiming otherwise: "draws no pillars at all for a company that declares no desks" (empty-input path) and "does not move the pillars when there is nobody unplaced" (asserts this change does *not* perturb existing layouts).

Commands actually run, in `frontend/`:

- `pnpm test` → **2 failed | 23 passed** test files. The 2 failures (`tour-resume`, `connection-registry`, both `window.localStorage.clear is not a function`) are **pre-existing**: I stashed my entire diff and re-ran them on a clean `upstream/main` tree, and got the identical 23 failed tests. Not caused by, and not fixed by, this PR.
- `pnpm vitest run test/unit/overview-ring1.test.ts` → 14 passed
- `pnpm typecheck` → clean
- `pnpm typecheck:unit` → clean
- `pnpm typecheck:e2e` → clean
- `pnpm build` → clean

That is every frontend step CI runs (`ci.yml` runs `typecheck`, `typecheck:e2e`, `typecheck:unit`, `build`). Note `pnpm typecheck` alone covers **neither** test project — `test/unit` and `test/e2e` are standalone `tsc -p` projects — so the two extra typechecks are load-bearing here, not decoration.

**Not verified:** I did not run Playwright e2e (`pnpm e2e`) — it needs a live host. `test/e2e/org-tree.spec.ts` covers the org chart, which this does not touch. I also have not driven the graph in a browser, so the *visual* result of an unplaced sector (spacing, label crowding at a large roster) is argued from the layout maths and unit-tested positions, not seen. Worth a look from someone with the app running.

- [x] `cargo fmt --all -- --check` — **N/A, not run.** No Rust in this diff.
- [x] `cargo clippy --all-targets -- -D warnings` — **N/A, not run.** No Rust in this diff.
- [x] `cargo build --all-targets` — **N/A, not run.** No Rust in this diff.
- [x] `cargo test` — **N/A, not run.** No Rust in this diff. Ticked because CI counts the boxes; the frontend commands above are what was actually verified.

## Documentation

- `frontend/src/views/overview/README.md` — the "derived rings" section now says ring 1 is declared, and a new "Who the graph does not place" subsection states the unplaced rule for both teammates and humans, and why. The standing request to delete `assignDepartment` is replaced by the narrower one #363 still owns (`assignTools`).
- `DERIVED_NOTICE` (the on-screen legend caveat) no longer claims departments are placeholders, and now says anyone on no desk is shown unplaced.
- `Overview.tsx`'s module doc, and `adapter.ts`'s real/derived table at the top of the file, updated to match.
- The deleted `assignHumanDepartment` leaves a comment in its place explaining why it went, so the next reader does not reintroduce it.

Refs #486


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Company desks now define graph pillars and department placement.
  * Workers without a desk appear in separate sectors around the company core.
  * Human profiles clearly show “Not on a desk” when applicable.
  * Workflows are positioned according to occupied desks.

* **Bug Fixes**
  * Prevented unplaced workers from appearing in phantom departments.
  * Tasks belonging to unplaced members are no longer displayed incorrectly.
  * Graph loading remains available when desk information cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->