### PR TITLE
tests: build Composio fixtures from the classifier's own action key

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -5620,7 +5620,7 @@ members = ["eng1", "eng2"]
             None,
         )
         .with_requests(requests.clone());
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = crate::policy::test_support::composio_send_args();
         let request = ToolPolicyRequest::new(
             "composio_execute",
             args.clone(),
@@ -5856,7 +5856,14 @@ members = ["eng1", "eng2"]
         let log: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
         let requests = crate::harness::policy::ApprovalRequestQueue::default();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        // Issue #470: a real catalogued send, with the action's own parameters
+        // under `arguments` where the tool's schema puts them — so the
+        // re-dispatch path this test covers carries a call the classifier can
+        // actually read.
+        let args = crate::policy::test_support::composio_args_with(
+            crate::policy::test_support::COMPOSIO_SEND_SLUG,
+            serde_json::json!({ "to": "a@b.test" }),
+        );
         requests
             .grants()
             .grant(crate::runtime::grants::GrantedCall {

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -950,6 +950,15 @@ mod tests {
     use super::*;
     use oh::agent::tool_policy::{ToolCallContext, ToolPolicyRequest};
 
+    // Issue #470: the `composio_execute` fixtures are built here, from the same
+    // key the classifier reads, so a call in a test reaches the same catalogue
+    // lookup a call in production does.
+    use crate::policy::test_support::{
+        COMPOSIO_OTHER_SEND_SLUG, COMPOSIO_READ_SLUG, COMPOSIO_SEND_SLUG, composio_args,
+        composio_read_args, composio_send_args, composio_unclassified_args,
+        composio_unclassified_args_numbered,
+    };
+
     fn policy(mode: &str, always: &[&str], auto_under: Option<f64>) -> ApprovalPolicy {
         let p = Policy {
             mode: mode.to_string(),
@@ -1397,7 +1406,7 @@ mod tests {
     #[tokio::test]
     async fn require_approval_records_the_request_to_park() {
         let (p, queue) = queued_policy("supervised", &[]);
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         assert!(matches!(
             p.check(&request("composio_execute", args.clone())).await,
             ToolPolicyDecision::RequireApproval { .. }
@@ -1413,6 +1422,65 @@ mod tests {
             queued[0].reason.contains("supervised"),
             "the operator-facing reason rides along: {}",
             queued[0].reason
+        );
+    }
+
+    /// Issue #470, at the layer that projects a blocked call onto the effect
+    /// the operator's card is built from.
+    ///
+    /// The fixtures above used to name their action under a key nothing reads,
+    /// so every Composio test in this module classified through the
+    /// unknown-is-a-send fallback and none of them ever reached the catalogue.
+    /// Read and send came out identical, and a regression in the split would
+    /// have failed nothing here. This asserts they come out different, and
+    /// asserts the classification rather than the parking decision — so it
+    /// stays honest across issue #559, which changes whether a read parks but
+    /// not what it is.
+    #[tokio::test]
+    async fn a_composio_read_and_a_composio_send_are_classified_differently() {
+        let read = composio_read_args();
+        let send = composio_send_args();
+
+        assert_eq!(
+            classify_group("composio_execute", &read),
+            EffectGroup::Other,
+            "`{COMPOSIO_READ_SLUG}` is tagged `Read` in the vendored catalogue; \
+             if this fails the lookup is not being reached"
+        );
+        assert!(
+            grantable("composio_execute", &read),
+            "a read scoped to one connected account is what a standing grant \
+             can honestly describe"
+        );
+
+        assert_eq!(
+            classify_group("composio_execute", &send),
+            EffectGroup::Send,
+            "`{COMPOSIO_SEND_SLUG}` is tagged `Write`"
+        );
+        assert!(!grantable("composio_execute", &send));
+
+        // The cautious fallback still has its own coverage, and still says
+        // send — but now because the catalogue was asked and had no answer,
+        // not because the classifier never saw an action at all.
+        let unknown = composio_unclassified_args();
+        assert_eq!(
+            classify_group("composio_execute", &unknown),
+            EffectGroup::Send
+        );
+        assert!(!grantable("composio_execute", &unknown));
+
+        // And the split survives the round trip through the park queue: the
+        // group asserted above is the one the operator's card is built from.
+        let (p, queue) = queued_policy("supervised", &[]);
+        let _ = p.check(&request("composio_execute", send.clone())).await;
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].effect.group, EffectGroup::Send);
+        assert_eq!(
+            queued[0].effect.payload, send,
+            "the card shows the arguments the agent actually sent, action key \
+             included"
         );
     }
 
@@ -1467,23 +1535,32 @@ mod tests {
     #[tokio::test]
     async fn a_retried_call_is_recorded_once() {
         let (p, queue) = queued_policy("supervised", &[]);
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         for _ in 0..3 {
             let _ = p.check(&request("composio_execute", args.clone())).await;
         }
         assert_eq!(queue.queued(), 1, "the same call parks once");
 
-        // A different call to the same tool is a distinct request.
+        // A different call to the same tool is a distinct request. Another
+        // catalogued send, so the second call is classified rather than merely
+        // unrecognised.
         let _ = p
             .check(&request(
                 "composio_execute",
-                serde_json::json!({ "tool_slug": "SLACK_POST" }),
+                composio_args(COMPOSIO_OTHER_SEND_SLUG),
             ))
             .await;
         assert_eq!(queue.queued(), 2);
     }
 
     /// The drain is capped, so a runaway turn can't flood the operator's queue.
+    ///
+    /// The slugs here are deliberately uncatalogued (issue #470): this test
+    /// wants many calls the queue treats as distinct and is indifferent to what
+    /// any of them classify as, so naming real actions would only invite a
+    /// reader to think the classification mattered. They do still land under
+    /// the real action key, so each one reaches the catalogue lookup and misses
+    /// it — the honest fallback, rather than a call carrying no action at all.
     #[tokio::test]
     async fn the_drain_is_capped_and_empties_the_queue() {
         let (p, queue) = queued_policy("supervised", &[]);
@@ -1491,7 +1568,7 @@ mod tests {
             let _ = p
                 .check(&request(
                     "composio_execute",
-                    serde_json::json!({ "tool_slug": format!("TOOL_{i}") }),
+                    composio_unclassified_args_numbered(i),
                 ))
                 .await;
         }
@@ -1538,7 +1615,7 @@ mod tests {
     #[tokio::test]
     async fn a_granted_call_is_allowed_once_and_then_parks_again() {
         let (p, grants) = granting_policy("supervised", &[], "finance");
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         grants.grant(granted("finance", "composio_execute", args.clone()));
 
         assert_eq!(
@@ -1593,7 +1670,7 @@ mod tests {
     #[tokio::test]
     async fn a_grant_does_not_travel_to_another_agent() {
         let (marketing, grants) = granting_policy("supervised", &[], "marketing");
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         // The grant belongs to `finance`.
         grants.grant(granted("finance", "composio_execute", args.clone()));
 
@@ -1727,7 +1804,7 @@ mod tests {
     fn grants_survive_a_queue_clear() {
         let queue = ApprovalRequestQueue::default();
         let grants = queue.grants();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         grants.grant(crate::runtime::grants::GrantedCall {
             approval_id: crate::ports::types::ApprovalId::new("appr-1"),
             agent: "finance".into(),

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -148,7 +148,13 @@ pub const COMPOSIO_EXECUTE: &str = "composio_execute";
 
 /// The argument key `composio_execute` carries the action slug under, on the
 /// wire and in both this crate's tool and openhuman's.
-const COMPOSIO_ACTION_KEY: &str = "tool";
+///
+/// `pub(crate)` so the test fixtures in
+/// [`crate::policy::test_support`] build their arguments from the same constant
+/// this classifier reads. Issue #470: fixtures across five modules hard-coded a
+/// key of their own, the two drifted apart, and every one of those tests
+/// silently stopped reaching the catalogue lookup it claimed to cover.
+pub(crate) const COMPOSIO_ACTION_KEY: &str = "tool";
 
 /// Every tool this crate can wire onto an agent, and what it can reach.
 ///

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -400,14 +400,35 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
 /// might do anything, so it parks and it cannot be granted standing. Same for a
 /// slug whose toolkit has no catalogue, a missing or non-string `tool`
 /// argument, and — in a build without the harness compiled in — every slug.
+///
+/// ## Two different reasons for the same verdict
+///
+/// "The catalogue has never heard of this slug" and "these arguments carry no
+/// slug at all" both end in a send, and that is right — but only one of them is
+/// a caller bug. Issue #470 survived for as long as it did precisely because
+/// the two were indistinguishable from outside: fixtures named their action
+/// under a key nothing reads, every call fell through to the fallback, and the
+/// verdicts still looked plausible. The verdict stays cautious either way; the
+/// second case now says so in the log, via [`ActionKeyMiss`], so a caller
+/// building the wrong argument shape is visible rather than silently safe.
 fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     let send = Consequence {
         group: EffectGroup::Send,
         reach: Reach::Consequence,
         standing: Standing::PerCall,
     };
-    let Some(slug) = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()) else {
-        return send;
+    let slug = match composio_action_slug(args) {
+        Ok(slug) => slug,
+        Err(miss) => {
+            tracing::warn!(
+                "[policy] a '{COMPOSIO_EXECUTE}' call carries no readable \
+                 '{COMPOSIO_ACTION_KEY}' argument ({}); classifying it as a send, which is \
+                 the cautious answer but not the one the catalogue would have given — the \
+                 caller is building an argument shape the tool's own schema rejects",
+                miss.describe()
+            );
+            return send;
+        }
     };
     if composio_action_is_read(slug) {
         // A read still reaches a third-party account, so `readonly` denies it
@@ -422,6 +443,57 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     } else {
         send
     }
+}
+
+/// Why a `composio_execute` call carries no action slug this classifier can
+/// read (issue #470).
+///
+/// Every variant classifies as a send, so this changes no verdict. It exists so
+/// the log line can say *which* shape arrived: a caller that omits the key, one
+/// that sends a number where a slug belongs, and one naming an action the
+/// catalogue has never heard of are three different mistakes, and only the last
+/// is a legitimate call to an unclassified action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ActionKeyMiss {
+    /// The arguments are not a JSON object at all.
+    NotAnObject,
+    /// An object, but with no [`COMPOSIO_ACTION_KEY`] property — the shape the
+    /// `tool_slug` fixtures of #470 had.
+    KeyAbsent,
+    /// The key is present but not a string.
+    NotAString,
+    /// The key is present and a string, but empty, so no lookup can succeed.
+    Empty,
+}
+
+impl ActionKeyMiss {
+    /// A short phrase for the log line, in the caller's terms.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            Self::NotAnObject => "the arguments are not an object",
+            Self::KeyAbsent => "the key is absent",
+            Self::NotAString => "the key is present but not a string",
+            Self::Empty => "the key is present but empty",
+        }
+    }
+}
+
+/// The action slug in a `composio_execute` call's arguments, or why there
+/// isn't one.
+pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, ActionKeyMiss> {
+    let Some(object) = args.as_object() else {
+        return Err(ActionKeyMiss::NotAnObject);
+    };
+    let Some(value) = object.get(COMPOSIO_ACTION_KEY) else {
+        return Err(ActionKeyMiss::KeyAbsent);
+    };
+    let Some(slug) = value.as_str() else {
+        return Err(ActionKeyMiss::NotAString);
+    };
+    if slug.trim().is_empty() {
+        return Err(ActionKeyMiss::Empty);
+    }
+    Ok(slug)
 }
 
 /// Which slice of a tool one standing grant is confined to (issue #457).
@@ -453,7 +525,10 @@ pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String>
     if !tool.eq_ignore_ascii_case(COMPOSIO_EXECUTE) {
         return None;
     }
-    let slug = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str())?;
+    // Same reader as the classifier, so a call it could not read a slug out of
+    // cannot resolve a toolkit here either — a scoped grant refuses to admit
+    // `None`, which is the safe direction.
+    let slug = composio_action_slug(args).ok()?;
     composio_toolkit_of(slug)
 }
 
@@ -675,6 +750,62 @@ mod tests {
                 "an unclassifiable action must read as a send: {args}"
             );
             assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// Same verdict, different reasons — and the reasons are now separable
+    /// (issue #470). A slug the catalogue cannot place is a legitimate call to
+    /// an unclassified action; an argument shape with no readable slug is a
+    /// caller bug that the send verdict would otherwise hide, which is exactly
+    /// how the `tool_slug` fixtures passed for as long as they did.
+    #[test]
+    fn a_missing_action_key_is_distinguishable_from_an_unknown_action() {
+        assert_eq!(
+            composio_action_slug(&json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" })),
+            Ok("NOTAREALTOOLKIT_LIST_THINGS"),
+            "an uncatalogued slug is still a slug — the catalogue, not this reader, \
+             is what declines it"
+        );
+        for (args, expected) in [
+            (
+                json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+                ActionKeyMiss::KeyAbsent,
+            ),
+            (
+                json!({ "arguments": { "owner": "acme" } }),
+                ActionKeyMiss::KeyAbsent,
+            ),
+            (json!({}), ActionKeyMiss::KeyAbsent),
+            (json!({ "tool": 7 }), ActionKeyMiss::NotAString),
+            (json!({ "tool": null }), ActionKeyMiss::NotAString),
+            (json!({ "tool": "" }), ActionKeyMiss::Empty),
+            (json!({ "tool": "   " }), ActionKeyMiss::Empty),
+            (json!("GMAIL_SEND_EMAIL"), ActionKeyMiss::NotAnObject),
+            (json!(null), ActionKeyMiss::NotAnObject),
+        ] {
+            assert_eq!(composio_action_slug(&args), Err(expected), "{args}");
+            // …and the verdict is unchanged by any of it: the log line is the
+            // only thing that differs, so this can never loosen a decision.
+            assert_eq!(
+                consequence_of(COMPOSIO_EXECUTE, &args).group,
+                EffectGroup::Send,
+                "{args}"
+            );
+        }
+    }
+
+    /// A grant scope is read through the same reader, so a call whose slug the
+    /// classifier could not find cannot resolve a toolkit either — `None`, and
+    /// a scoped grant refuses to admit `None`.
+    #[test]
+    fn an_unreadable_action_key_resolves_no_grant_scope() {
+        for args in [
+            json!({ "tool_slug": "GITHUB_LIST_PULL_REQUESTS" }),
+            json!({ "tool": "" }),
+            json!({ "tool": 7 }),
+            json!({}),
+        ] {
+            assert_eq!(standing_scope_of(COMPOSIO_EXECUTE, &args), None, "{args}");
         }
     }
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -14,5 +14,12 @@
 pub mod consequence;
 pub mod gate;
 
+/// Shared `composio_execute` call fixtures (issue #470). Test-only, and
+/// deliberately here rather than in any one test module: the key they build
+/// their arguments under is the classifier's own constant, which is what stops
+/// a fixture and the code under test from drifting apart again.
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub use consequence::{Consequence, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};

--- a/src/policy/test_support.rs
+++ b/src/policy/test_support.rs
@@ -1,0 +1,230 @@
+//! Shared `composio_execute` call fixtures for the approval tests (issue #470).
+//!
+//! # Why this module exists
+//!
+//! `composio_execute` carries every Composio action under one tool name, so the
+//! approval verdict is a property of the **action slug in its arguments**. The
+//! tool's own schema declares that slug under `"tool"`
+//! (`required: ["tool"]`, `additionalProperties: false`, see
+//! [`crate::harness::composio`]), and
+//! [`consequence_of`](crate::policy::consequence::consequence_of) reads it back
+//! under [`COMPOSIO_ACTION_KEY`].
+//!
+//! Fixtures in five modules used to hard-code a key of their own — `tool_slug`
+//! — which neither side accepts. Every one of them was therefore a call with
+//! **no recognisable action**: the classifier could not find a slug, fell
+//! through to the cautious "unknown is a send" verdict, and the test passed
+//! without ever reaching the catalogue lookup it was credited with exercising.
+//! The assertions were right; the inputs never arrived. A regression in the
+//! read/send split would not have failed one of them.
+//!
+//! # What keeps it from drifting again
+//!
+//! [`composio_args`] builds the key from [`COMPOSIO_ACTION_KEY`] itself rather
+//! than from a literal, so a fixture cannot disagree with the classifier: the
+//! two now read the same constant. Renaming the wire key moves both together.
+//!
+//! # Choosing a slug
+//!
+//! The slugs below are real entries in the vendored provider catalogue, so they
+//! exercise the lookup rather than the fallback. Do not invent a plausible-
+//! looking slug for a fixture that is meant to classify — an uncatalogued slug
+//! reads as a send, which is often the verdict the test expected anyway, and
+//! that is exactly how #470 stayed invisible. When a test genuinely wants an
+//! action nobody has classified, reach for
+//! [`COMPOSIO_UNCLASSIFIED_SLUG`] and say so in its name.
+//!
+//! # A note on the two lanes
+//!
+//! The catalogue is vendored with openhuman and linked in only under that
+//! feature. Without it [`composio_action_is_read`] answers `false` for
+//! everything, so [`composio_read_args`] classifies as a **send** in the
+//! default build. That is deliberate and pinned below in both directions — a
+//! test that asserts the read verdict must be `#[cfg(feature = "openhuman")]`.
+//!
+//! [`composio_action_is_read`]: crate::policy::consequence
+//! [`COMPOSIO_ACTION_KEY`]: crate::policy::consequence::COMPOSIO_ACTION_KEY
+
+use serde_json::Value;
+
+use crate::policy::consequence::COMPOSIO_ACTION_KEY;
+
+/// A Composio action the vendored catalogue tags `Write`: sending mail.
+///
+/// Classifies as [`EffectGroup::Send`](crate::ports::types::EffectGroup::Send)
+/// with [`Standing::PerCall`](crate::policy::Standing::PerCall) — and does so
+/// through the catalogue, not through the unknown-slug fallback.
+pub(crate) const COMPOSIO_SEND_SLUG: &str = "GMAIL_SEND_EMAIL";
+
+/// A second catalogued `Write`, on a different toolkit.
+///
+/// For tests that need two calls the queue must treat as distinct without
+/// either of them being unclassifiable.
+pub(crate) const COMPOSIO_OTHER_SEND_SLUG: &str = "SLACK_POST_MESSAGE_TO_CHANNEL";
+
+/// A Composio action the vendored catalogue tags `Read`: listing a repository's
+/// pull requests.
+///
+/// Classifies as [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other)
+/// with [`Standing::Grantable`](crate::policy::Standing::Grantable) — **under
+/// the `openhuman` feature only**. See the lane note in the module docs.
+pub(crate) const COMPOSIO_READ_SLUG: &str = "GITHUB_LIST_PULL_REQUESTS";
+
+/// An action slug whose toolkit the catalogue has never heard of.
+///
+/// The cautious fallback deserves its own coverage, so this exists to be
+/// requested deliberately and named as such at the call site — never as the
+/// accidental result of a typo'd key.
+pub(crate) const COMPOSIO_UNCLASSIFIED_SLUG: &str = "NOTAREALTOOLKIT_DO_SOMETHING";
+
+/// A `composio_execute` argument object naming `slug`, keyed the way the tool
+/// and the classifier both key it.
+pub(crate) fn composio_args(slug: &str) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert(COMPOSIO_ACTION_KEY.to_string(), Value::String(slug.into()));
+    Value::Object(args)
+}
+
+/// [`composio_args`], plus the action's own parameters under `"arguments"` —
+/// the only other property the tool's schema admits.
+pub(crate) fn composio_args_with(slug: &str, arguments: Value) -> Value {
+    let mut args = composio_args(slug);
+    args["arguments"] = arguments;
+    args
+}
+
+/// A call the catalogue classifies as a send.
+pub(crate) fn composio_send_args() -> Value {
+    composio_args(COMPOSIO_SEND_SLUG)
+}
+
+/// A call the catalogue classifies as a read — under the `openhuman` feature.
+pub(crate) fn composio_read_args() -> Value {
+    composio_args(COMPOSIO_READ_SLUG)
+}
+
+/// A call naming an action the catalogue cannot place, so it reads as a send
+/// through the cautious fallback rather than through the lookup.
+pub(crate) fn composio_unclassified_args() -> Value {
+    composio_args(COMPOSIO_UNCLASSIFIED_SLUG)
+}
+
+/// The `i`th of a run of distinct, deliberately uncatalogued calls.
+///
+/// For the over-cap tests, whose point is the *number* of parked requests: they
+/// need many calls the queue treats as distinct and care nothing for what any
+/// of them classify as. The slug still lands under the real key, so these
+/// reach the catalogue lookup and miss it — an honest fallback rather than a
+/// call with no action at all.
+pub(crate) fn composio_unclassified_args_numbered(i: usize) -> Value {
+    composio_args(&format!("NOTAREALTOOLKIT_ACTION_{i}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::Standing;
+    #[cfg(feature = "openhuman")]
+    use crate::policy::consequence::Reach;
+    use crate::policy::consequence::{COMPOSIO_EXECUTE, consequence_of};
+    use crate::ports::types::EffectGroup;
+
+    /// The guarantee the whole module exists for: a fixture reaches the
+    /// classifier's action key. Asserted against the constant *and* against the
+    /// literal, because agreeing with `COMPOSIO_ACTION_KEY` while both drift off
+    /// the tool's declared schema would reproduce #470 with the helper in place.
+    #[test]
+    fn a_fixture_names_its_action_under_the_key_the_tool_declares() {
+        let args = composio_send_args();
+        assert_eq!(
+            args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG)
+        );
+        assert_eq!(
+            args.get("tool").and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG),
+            "`tool` is what `composio_execute`'s schema requires; if this fails \
+             the wire key moved and the tool's schema has to move with it"
+        );
+        assert!(
+            args.get("tool_slug").is_none(),
+            "the key #470 was about must not come back"
+        );
+    }
+
+    /// The action's own parameters ride under `arguments`, which is the only
+    /// other property the tool's schema admits — a fixture that spread them at
+    /// the top level would be rejected by `additionalProperties: false`.
+    #[test]
+    fn action_parameters_ride_under_arguments() {
+        let args = composio_args_with(COMPOSIO_SEND_SLUG, serde_json::json!({ "to": "a@b.test" }));
+        assert_eq!(
+            args.get("tool").and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG)
+        );
+        assert_eq!(args["arguments"]["to"], "a@b.test");
+        assert_eq!(
+            args.as_object().map(|o| o.len()),
+            Some(2),
+            "`tool` and `arguments` are the whole of the declared schema"
+        );
+    }
+
+    /// The send fixture is a send *through the catalogue*. True in both lanes,
+    /// but for different reasons — which is why the read fixture below is
+    /// pinned separately per lane.
+    #[test]
+    fn the_send_fixture_classifies_as_a_send() {
+        for args in [
+            composio_send_args(),
+            composio_args(COMPOSIO_OTHER_SEND_SLUG),
+        ] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(verdict.group, EffectGroup::Send, "{args}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// The fixture the fallback tests want: an action nobody has classified,
+    /// asked for on purpose. Same verdict in both lanes.
+    #[test]
+    fn the_unclassified_fixture_falls_back_to_a_send() {
+        for args in [
+            composio_unclassified_args(),
+            composio_unclassified_args_numbered(0),
+            composio_unclassified_args_numbered(7),
+        ] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(verdict.group, EffectGroup::Send, "{args}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// The one that #470 was really about: with the catalogue linked in, the
+    /// read fixture is classified as a read — by the lookup, not by luck.
+    ///
+    /// This is the assertion the old `tool_slug` fixtures could not have made.
+    /// Break the catalogue lookup and this fails, which is the property the
+    /// negative control in #559 is built on.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_read_fixture_classifies_as_a_read() {
+        let verdict = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
+        assert_eq!(verdict.group, EffectGroup::Other);
+        assert_eq!(verdict.standing, Standing::Grantable);
+        // Today a read still parks under `supervised`. Issue #559 moves this
+        // off `Consequence`; the two assertions above are what stay put.
+        assert_eq!(verdict.reach, Reach::Consequence);
+    }
+
+    /// And the other lane, stated rather than left to be discovered: without
+    /// the harness feature the catalogue is not linked in, so the read fixture
+    /// classifies as a send. A test that wants the read verdict must be gated.
+    #[test]
+    #[cfg(not(feature = "openhuman"))]
+    fn without_the_catalogue_the_read_fixture_is_a_send() {
+        let verdict = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
+        assert_eq!(verdict.group, EffectGroup::Send);
+        assert_eq!(verdict.standing, Standing::PerCall);
+    }
+}

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2760,7 +2760,12 @@ mod test {
     #[tokio::test]
     async fn approving_a_harness_tool_call_mints_a_grant_instead_of_executing() {
         let home_dir = tmp_home();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        // Issue #470: a catalogued send, keyed the way `composio_execute`'s
+        // schema keys it, with the action's parameters under `arguments`.
+        let args = crate::policy::test_support::composio_args_with(
+            crate::policy::test_support::COMPOSIO_SEND_SLUG,
+            serde_json::json!({ "to": "a@b.test" }),
+        );
         let (rt, id) = park_one(
             home_dir.path().to_path_buf(),
             harness_effect("finance", "composio_execute", args.clone()),
@@ -3204,7 +3209,7 @@ mod test {
             amount_usd: None,
             established_thread: false,
             first_time_counterparty: false,
-            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            payload: crate::policy::test_support::composio_send_args(),
             agent: None,
             run_id: None,
         };

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -1988,7 +1988,7 @@ mod test {
             approval_id: ApprovalId::new(id),
             agent: "finance".into(),
             tool: "composio_execute".into(),
-            args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            args: crate::policy::test_support::composio_send_args(),
             at_millis,
             origin_thread: None,
         }
@@ -2021,7 +2021,7 @@ mod test {
         assert_eq!(replayed[0].tool, "composio_execute");
         assert_eq!(
             replayed[0].args,
-            serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            crate::policy::test_support::composio_send_args(),
             "the exact arguments the operator approved survive the restart"
         );
     }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3675,6 +3675,12 @@ mod test {
     /// makes approving it mint a single-use grant rather than execute it
     /// (issue #243) — which is the whole reason a lost continuation hurts: the
     /// grant is spent on a turn that never happens.
+    ///
+    /// The payload names an action the vendored catalogue tags `Write`, so
+    /// `consequence_of` classifies it as a send on its merits. Until issue #470
+    /// it named the slug under `tool_slug`, a key neither the tool nor the
+    /// classifier reads — so it was a call with no action at all, and it
+    /// reached the per-call verdict through the unknown-slug fallback instead.
     fn gated_tool_call() -> crate::ports::types::Effect {
         crate::ports::types::Effect {
             kind: "composio_execute".into(),
@@ -3682,7 +3688,7 @@ mod test {
             amount_usd: None,
             established_thread: false,
             first_time_counterparty: false,
-            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            payload: crate::policy::test_support::composio_send_args(),
             agent: Some("ceo".into()),
             run_id: None,
         }
@@ -3690,11 +3696,11 @@ mod test {
 
     /// A tool call an operator MAY grant a standing permission for (issue
     /// #431), which `gated_tool_call` deliberately is not: its Composio payload
-    /// names no action slug, so `consequence_of` cannot classify it as a read
-    /// and it stays a per-call decision. `file_write` is declared grantable in
-    /// `src/policy/consequence.rs` and carries an agent, so it satisfies both
-    /// halves of `check_broadly_grantable` — it mutates, but only the agent's
-    /// own sandboxed workspace.
+    /// names an action the catalogue tags `Write`, so `consequence_of` reads it
+    /// as a send and it stays a per-call decision. `file_write` is declared
+    /// grantable in `src/policy/consequence.rs` and carries an agent, so it
+    /// satisfies both halves of `check_broadly_grantable` — it mutates, but
+    /// only the agent's own sandboxed workspace.
     fn grantable_tool_call() -> crate::ports::types::Effect {
         crate::ports::types::Effect {
             kind: "file_write".into(),
@@ -5295,9 +5301,16 @@ mod test {
             for event in &req.events {
                 match event {
                     CompanyEvent::OperatorMessage { .. } => {
+                        // Deliberately uncatalogued slugs (issue #470): this
+                        // brain exists to park a *number* of distinct calls and
+                        // is indifferent to how any of them classify. They
+                        // still land under the real action key, so each reaches
+                        // the catalogue lookup and misses it, rather than
+                        // carrying no action for the classifier to find.
                         for i in 0..self.parks {
                             let mut effect = gated_tool_call();
-                            effect.payload = serde_json::json!({ "tool_slug": format!("T{i}") });
+                            effect.payload =
+                                crate::policy::test_support::composio_unclassified_args_numbered(i);
                             host.park_effect(effect).await?;
                         }
                     }


### PR DESCRIPTION
## Summary

Fixes #470.

Composio test fixtures across five modules built their `composio_execute` arguments as
`{"tool_slug": "GMAIL_SEND_EMAIL"}`. Neither the tool nor the classifier reads that key:
`composio_execute`'s schema declares `"tool"` (`required: ["tool"]`,
`additionalProperties: false` — `src/harness/composio.rs:840-853`) and `consequence_of`
reads it back under `COMPOSIO_ACTION_KEY = "tool"` (`src/policy/consequence.rs:151`).

Every one of those fixtures was therefore a call with **no recognisable action**. The
classifier could not find a slug, fell through to the cautious "unknown is a send"
verdict, and the test passed — without ever reaching the catalogue lookup it was
credited with exercising. The assertions were right; the inputs never arrived.

**Why the wrong key looked plausible.** `tool_slug` is not a typo — it is the wire key of
a *different* tool. openhuman's own Composio direct tool declares `tool_slug` /
`action_name`
(`vendor/openhuman/src/openhuman/integrations/composio/tools/direct.rs:713-737`), while
opencompany's `composio_execute` declares `tool`. Two tools, two key names, and fixtures
borrowed from the wrong one. That is why this is fixed with a shared helper keyed off the
classifier's own constant rather than with fifteen careful edits.

### What changed

- **New `src/policy/test_support.rs`** (test-only) — the shared fixture builders. They
  construct the argument object from `COMPOSIO_ACTION_KEY` **itself**, not from a
  literal, so a fixture and the code under test can no longer disagree: renaming the wire
  key moves both together. `COMPOSIO_ACTION_KEY` became `pub(crate)` for this.
- **All 15 occurrences corrected** across `src/harness/policy.rs` (7),
  `src/harness/brain.rs` (2), `src/runtime/cycle.rs` (2), `src/runtime/journal.rs` (2)
  and `src/server/operator.rs` (2). The issue body names four files; `src/harness/brain.rs`
  — the re-dispatch path — is the fifth.
- **The two synthetic loops keep unrecognisable slugs**, as they should:
  `harness/policy.rs`'s over-cap drain test and `server/operator.rs`'s `MultiParkBrain`
  want a *number* of distinct calls and are indifferent to how any of them classify. They
  now say so, via a `composio_unclassified_args_numbered()` helper named for the intent —
  and their slugs land under the real key, so each one reaches the catalogue lookup and
  misses it, rather than carrying no action at all.
- **Action parameters moved under `arguments`**, where the schema puts them. Two fixtures
  spread `"to": "a@b.test"` at the top level, which `additionalProperties: false` rejects.
- **A doc comment that documented the bug as intent.** `src/server/operator.rs:3691` read
  "`gated_tool_call` deliberately is not [grantable]: its Composio payload names no action
  slug, so `consequence_of` cannot classify it as a read". It now names a catalogued
  `Write` action and is a send *on its merits* — which is exactly the "Related" note in
  #470 about `gated_tool_call()` being refused a standing scope for the wrong reason.
- **New coverage for the split** at the layer that projects a blocked call onto the
  operator's card: `a_composio_read_and_a_composio_send_are_classified_differently`
  (`src/harness/policy.rs`), plus per-lane classification pins on each fixture in
  `test_support`'s own test module.

### Deliberately asserting classification, not parking

The new tests assert what a call *is* (`EffectGroup`, `Standing`), not whether it parks.
That keeps them honest across #559, which changes whether a read parks but not what it is
— and #559's negative control is the reason this PR comes first.

### The two lanes

`src/harness/*` compiles only under `--features openhuman`, so 9 of the 15 fixtures do not
exist in the plain lane at all. The vendored catalogue is likewise linked in only under
that feature, so `composio_read_args()` classifies as a **send** in the default build.
That is now pinned explicitly in both directions rather than left to be discovered.

## API Or Behavior Changes

None. Test-only, plus `COMPOSIO_ACTION_KEY` widening from private to `pub(crate)`. No
production code path changes; the tool and the classifier already agreed on `tool`.

## Tests

All exit-code gated (unpiped redirect, `EXIT:$?` read directly).

- [x] `cargo fmt --all -- --check` — EXIT:0.
- [x] `cargo clippy --all-targets -- -D warnings` — EXIT:0 (default lane).
      Gated lane run as CI runs it:
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
      — EXIT:0.
- [x] `cargo build --all-targets` — ran as `cargo check --all-targets` in both lanes
      (default; and `--features openhuman,tinycortex`), plus the two clippy runs above,
      which build all targets. Narrower than a full `build` (no codegen), broader in
      feature coverage.
- [x] `cargo test` — `cargo test --lib` (default lane): **1832 passed, 0 failed**, EXIT:0.
      `cargo test --locked --features openhuman,tinycortex` (full gated lane, integration
      targets included): EXIT:0, all six targets green — **2738 + 10 + 1 + 11 + 2 passed,
      0 failed** (one target reports 0 passed / 1 ignored).

### Negative controls

Two, because they prove different things.

**A — revert the fix itself.** Point `composio_args()` back at `"tool_slug"`, change
nothing else. Gated lane, EXIT:101, **4 failed**:

```
harness::policy::tests::a_composio_read_and_a_composio_send_are_classified_differently
policy::test_support::tests::a_fixture_names_its_action_under_the_key_the_tool_declares
policy::test_support::tests::action_parameters_ride_under_arguments
policy::test_support::tests::the_read_fixture_classifies_as_a_read
```

The interesting part is what **still passed**: every pre-existing test whose fixture this
PR corrected — `require_approval_records_the_request_to_park`,
`a_retried_call_is_recorded_once`, `a_granted_call_is_allowed_once_and_then_parks_again`,
`grants_survive_a_queue_clear` — plus `the_send_fixture_classifies_as_a_send` and
`the_unclassified_fixture_falls_back_to_a_send`. That is issue #470 reproduced on demand:
with the wrong key, the send-shaped assertions are satisfied by the fallback and notice
nothing. Only a test that asserts a *read* can tell the difference.

**B — break the catalogue lookup**, as the issue's "How to verify" asks: in
`composio_action_is_read`, `Some(ToolScope::Read)` → `Some(ToolScope::Admin)`. Gated lane,
EXIT:101, **10 failed**, including both tests this PR adds:

```
harness::policy::tests::a_composio_read_and_a_composio_send_are_classified_differently   <- new
policy::test_support::tests::the_read_fixture_classifies_as_a_read                       <- new
harness::policy::tests::a_composio_read_may_be_granted_standing_and_a_send_may_not
harness::policy::tests::a_grant_from_before_scopes_existed_still_admits_its_tool
harness::policy::tests::a_grant_scoped_to_one_provider_does_not_admit_another_providers_read
harness::policy::tests::a_standing_grant_on_a_composio_read_does_not_admit_a_send
policy::consequence::tests::a_composio_read_is_grantable_and_a_send_is_not
policy::consequence::tests::lookup_ignores_case
runtime::cycle::test::a_composio_read_is_offerable_and_a_composio_send_is_not
runtime::cycle::test::a_standing_grant_on_a_composio_read_records_the_toolkit_it_was_shown_for
```

Both controls restored; the tree is green again (**2738 passed, 0 failed**, EXIT:0).

### One correction to the issue's framing

#470 says a regression in the read/send split "would not fail a single existing test".
Control B shows that is too strong: **8 pre-existing tests do catch it**, in
`policy::consequence`, `runtime::cycle` and `harness::policy` — they were already written
against `"tool"`. What the *15 fixtures* were blind to is exactly what control A isolates:
their key could drift back tomorrow and nothing except the tests added here would notice.
The coverage hole is real and this PR closes it; it was just narrower than the issue body
claims, and worth stating accurately since #559's negative control is being planned
against it.

## Documentation

The rationale lives in `src/policy/test_support.rs`'s module docs — why the module exists,
what stops the key drifting again, how to choose a slug, and why a read-verdict assertion
must be feature-gated. No user-facing docs affected.
