### PR TITLE
feat(policy): add the `auto` autonomy tier between supervised and full (#560)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -17,8 +17,17 @@ Effect kinds that MAY require sign-off, grouped by what they risk:
 | **Identity** | handle registration/renewal, key rotation, delegated signer mint/expand | always approval |
 
 `readonly` mode gates *every* effect; `full` mode auto-allows everything
-except `[policy].always_approve` entries. Modes mirror OpenHuman's security
-tiers so an OpenHuman-backed `ApprovalGate` maps 1:1.
+except `[policy].always_approve` entries. `auto` sits between `supervised` and
+`full`: the agent's own sandbox writes and its outward reads run unattended,
+and anything that leaves the company or spends on submit still parks — see
+[the tier line](#the-auto-tier) below.
+
+Three of the four names are OpenHuman's own security tiers. `auto` is not, so
+the mapping is no longer 1:1 and `PolicyMode::security_tier()` — the accessor
+that asserted it was — has been deleted rather than made to lie. Where the two
+vocabularies still have to meet, `harness::toolbelt::autonomy_for` borrows
+`Supervised` for `auto`; the argument is on that function and matters, because
+a workflow `tool_call` node has no `ApprovalPolicy` above it.
 
 ## Approval lifecycle
 
@@ -213,7 +222,8 @@ So the two questions are now separate answers from one declaration
 (`src/policy/consequence.rs`), one entry per tool:
 
 - **may it run unattended?** — `readonly` denies anything that mutates or
-  reaches outside; `supervised` parks it. This is what the approval card is for.
+  reaches outside; `supervised` parks it; `auto` parks only the part of it that
+  leaves the company. This is what the approval card is for.
 - **may an operator hand it over for a stretch of time?** — refused for anything
   that can execute arbitrary code (`shell`), reach an arbitrary address
   (`http_request`, `curl`, `web_fetch`, `git_operations`), act through a
@@ -226,6 +236,52 @@ So the two questions are now separate answers from one declaration
 What stays grantable is the low-consequence middle the feature exists for:
 writes confined to the agent's own sandboxed workspace (`file_write`, `edit`,
 `apply_patch`, `csv_export`, `memory_store`), and **Composio reads**.
+
+### The `auto` tier
+
+That low-consequence middle is also the whole of the `auto` tier (issue #560).
+An operator had two settings and needed a third: `supervised` parks every write
+including the agent's own scratch files, so companies drown in cards; `full`
+parks nothing but the always-ask list, so it stops asking before a shell
+command or a git push too. Companies ran one and suffered, or ran the other and
+lost the gate that mattered.
+
+`auto`'s contract, in the operator's words: **the agent works without
+interrupting me, and stops before anything that leaves the building or spends
+money.** The line is one predicate,
+`Consequence::parks_under_auto` — a call parks under `auto` when it would park
+under `supervised` **and** it is not `Standing::Grantable`.
+
+It reads the existing declaration rather than adding a list, because the split
+was already there and argued tool by tool. That reuse does widen what
+`Grantable` means — from "an operator may hand this to one teammate until a
+deadline" to "this runs unattended for everyone while the company sits in
+`auto`" — which is sound because `Standing` is decided by what a tool can reach
+rather than by what it is called, and because the widening is exactly what the
+operator chooses when they select the tier. It is written down so that a later
+edit loosening `Grantable` knows it is loosening two things.
+
+Two boundaries `auto` deliberately does not draw:
+
+- **`Reach::Money` does not park.** `web_search` is billed but changes nothing,
+  and it already runs unattended under `supervised` for a reason that binds
+  harder here — openhuman resolves a `RequireApproval` inline and never
+  re-dispatches, so a parked search is a search that never happens and an agent
+  with no search invents citations. `auto` must not be stricter than the tier it
+  replaces. The per-agent daily cap holds spend, and it sits above the tier
+  dispatch. Generation that spends on *submit* (`media_generate_image`,
+  `media_generate_video`) is a `Consequence` and parks.
+- **`always_approve` is not consulted by the tier at all.** It is checked above
+  the dispatch and wins over every tier, `full` included.
+
+The tier composes with the Composio read/send reclassification rather than
+depending on it: a Composio read is `Grantable` today while still carrying
+`Reach::Consequence`, and reclassifying its *reach* leaves its standing alone,
+so it runs unattended under `auto` either way.
+
+`auto` is **not** the default. Issue #560 argues it should become one, but
+`default_policy_mode()` returning it would change behaviour for every existing
+company with no `[policy]` block on its next load, so that is its own decision.
 
 `composio_execute` is the reason arguments are part of the question. Every
 Composio action arrives under that one tool name, so classifying the name
@@ -298,7 +354,7 @@ A tool call is decided in this order:
    and it re-checks the live arguments, so a grant minted on a Composio read
    cannot admit a Composio send.
 4. `[policy].always_approve` → park.
-5. mode dispatch (`readonly` / `supervised` / `full`).
+5. mode dispatch (`readonly` / `supervised` / `auto` / `full`).
 
 The grant sits **above** `always_approve` on purpose. A tool on that list still
 parks the first time, which is what the list is for; but once the operator has

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -13,8 +13,8 @@ a safe default; the defaults produce a working company with only
 
 Parsing lives in `src/company/manifest.rs` (`CompanyManifest::from_path`,
 serde + validation). Validation errors MUST be actionable in prosumer
-language ("`[policy].mode` must be one of readonly, supervised, full — you
-wrote `supervized`"), never serde traces.
+language ("`[policy].mode` must be one of readonly, supervised, auto, full —
+you wrote `supervized`"), never serde traces.
 
 ## Full schema
 
@@ -70,7 +70,7 @@ allow = ["web.*", "docs.*", "search"]  # company-wide grant; agents intersect
 search_daily_calls = 200           # per-company daily web_search cap (0 = paused)
 
 [policy]                           # see company-brain/approvals.md
-mode = "supervised"                # readonly | supervised (default) | full
+mode = "supervised"                # readonly | supervised (default) | auto | full
 always_approve = ["payment.send", "filing.submit", "external.publish"]
 auto_approve_under_usd = 1.0
 
@@ -187,11 +187,14 @@ prompt = "Weekly review and operator digest"
 - **`[channels.*]`** enables `ChannelAdapter`s. Unknown channels are a
   validation error; disabled OpenHuman means non-operator channels degrade
   with a boot warning, never a failure.
-- **`[policy]`** configures the default `ApprovalGate`. `mode` mirrors
-  OpenHuman's security tiers. `always_approve` lists effect kinds that park
-  for approval regardless of amount; `auto_approve_under_usd` lets small
-  spends through. Defaults are conservative: `supervised`, with all
-  money/publish/filing effects gated.
+- **`[policy]`** configures the default `ApprovalGate`. `mode` takes three of
+  its four names from OpenHuman's security tiers; `auto` is opencompany's own
+  and sits between `supervised` and `full` (the agent's sandbox writes and
+  outward reads run unattended, anything that leaves the company or spends on
+  submit still parks). `always_approve` lists effect kinds that park for
+  approval regardless of amount and wins over every tier including `full`;
+  `auto_approve_under_usd` lets small spends through. Defaults are
+  conservative: `supervised`, with all money/publish/filing effects gated.
 - **`[place]`** drives the [going-public flow](../company-as-agent/README.md).
   `skills` feed Agent Card generation; prices are decimal strings (USDC).
 - **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -504,13 +504,41 @@ mod tests {
         );
     }
 
+    /// Every tier the enum can represent is reachable from a manifest
+    /// (issue #560).
+    ///
+    /// This is the test for the trap that adding `auto` set: the validator
+    /// keeps its own list of modes (`POLICY_MODES`), and it runs *before*
+    /// `PolicyMode::parse` ever sees the string. A tier added to the enum and
+    /// the parser but not to that list is rejected at load with "must be one of
+    /// …", so the feature is unreachable from the only place anybody sets it —
+    /// while every test in `harness::policy` still passes, because they all
+    /// construct a `Policy` directly and never cross this boundary.
+    ///
+    /// Asserted for all four modes rather than just the new one, so the next
+    /// tier is caught the same way instead of relying on someone remembering.
+    #[test]
+    fn every_policy_mode_the_runtime_knows_is_accepted_by_the_validator() {
+        for mode in crate::company::POLICY_MODES {
+            let manifest = parse(&format!(
+                "[company]\nname = \"X\"\n[policy]\nmode = \"{mode}\"\n"
+            ));
+            assert!(
+                manifest.validate().is_empty(),
+                "`[policy].mode = \"{mode}\"` is a mode the runtime knows but the manifest \
+                 validator rejects — the tier is unreachable from a company.toml: {:?}",
+                manifest.validate()
+            );
+        }
+    }
+
     #[test]
     fn rejects_bad_policy_mode_in_prosumer_language() {
         let manifest = parse("[company]\nname = \"X\"\n[policy]\nmode = \"supervized\"\n");
         let problems = manifest.validate();
         assert_eq!(problems.len(), 1);
         assert!(problems[0].contains("`[policy].mode`"));
-        assert!(problems[0].contains("readonly, supervised, full"));
+        assert!(problems[0].contains("readonly, supervised, auto, full"));
         assert!(problems[0].contains("supervized"));
     }
 

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -504,30 +504,35 @@ mod tests {
         );
     }
 
-    /// Every tier the enum can represent is reachable from a manifest
-    /// (issue #560).
+    /// Each tier is accepted by name from a `company.toml` (issue #560).
     ///
-    /// This is the test for the trap that adding `auto` set: the validator
-    /// keeps its own list of modes (`POLICY_MODES`), and it runs *before*
-    /// `PolicyMode::parse` ever sees the string. A tier added to the enum and
+    /// This is the test for the trap that adding `auto` set. The validator keeps
+    /// its own list of modes (`POLICY_MODES`) and runs *before*
+    /// `PolicyMode::parse` ever sees the string, so a tier added to the enum and
     /// the parser but not to that list is rejected at load with "must be one of
-    /// …", so the feature is unreachable from the only place anybody sets it —
-    /// while every test in `harness::policy` still passes, because they all
-    /// construct a `Policy` directly and never cross this boundary.
+    /// …" — unreachable from the only place anybody sets it, while every test in
+    /// `harness::policy` still passes because they all construct a `Policy`
+    /// directly and never cross this boundary.
     ///
-    /// Asserted for all four modes rather than just the new one, so the next
-    /// tier is caught the same way instead of relying on someone remembering.
+    /// The mode words are **literals** on purpose. Deriving them from
+    /// `POLICY_MODES` — the first version of this test — passes vacuously when a
+    /// mode is missing from that list, because the missing case simply stops
+    /// being generated. Revert-and-check caught it; the literal cannot be
+    /// removed by the edit it is meant to detect.
+    ///
+    /// `harness::policy` holds the matching direction: that `POLICY_MODES` and
+    /// the enum agree, so a tier cannot be added here and nowhere else.
     #[test]
-    fn every_policy_mode_the_runtime_knows_is_accepted_by_the_validator() {
-        for mode in crate::company::POLICY_MODES {
+    fn every_tier_is_accepted_by_name_from_a_company_toml() {
+        for mode in ["readonly", "supervised", "auto", "full"] {
             let manifest = parse(&format!(
                 "[company]\nname = \"X\"\n[policy]\nmode = \"{mode}\"\n"
             ));
+            let problems = manifest.validate();
             assert!(
-                manifest.validate().is_empty(),
-                "`[policy].mode = \"{mode}\"` is a mode the runtime knows but the manifest \
-                 validator rejects — the tier is unreachable from a company.toml: {:?}",
-                manifest.validate()
+                problems.is_empty(),
+                "`[policy].mode = \"{mode}\"` is a tier the runtime knows but the manifest \
+                 validator rejects — unreachable from a company.toml: {problems:?}"
             );
         }
     }

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -41,9 +41,18 @@ pub const INFERENCE_TIERS: &[&str] = &["chat-v1", "reasoning-v1", "agentic-v1", 
 /// Tool providers selectable in `[tools].provider`.
 pub const TOOL_PROVIDERS: &[&str] = &["openhuman", "builtin"];
 
-/// Approval policy modes selectable in `[policy].mode`, mirroring OpenHuman's
-/// security tiers.
-pub const POLICY_MODES: &[&str] = &["readonly", "supervised", "full"];
+/// Approval policy modes selectable in `[policy].mode`, in increasing order of
+/// autonomy.
+///
+/// `readonly` / `supervised` / `full` take their names from OpenHuman's own
+/// security tiers; `auto` (issue #560) is opencompany's, and sits between
+/// "ask before every change" and "ask before almost nothing".
+///
+/// This list is the manifest validator's, so it is the gate that decides whether
+/// a mode is *reachable* at all — `PolicyMode::parse` never sees a string this
+/// rejects. The two are kept in step by `every_policy_mode_parses_to_its_own_
+/// variant` in `harness::policy`.
+pub const POLICY_MODES: &[&str] = &["readonly", "supervised", "auto", "full"];
 
 /// Channels the runtime knows how to enable under `[channels.*]`.
 pub const KNOWN_CHANNELS: &[&str] = &["operator", "email", "slack", "sms", "web", "telegram"];
@@ -565,7 +574,12 @@ fn default_tool_provider() -> String {
 /// `[policy]` — the default `ApprovalGate` configuration.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Policy {
-    /// `readonly` | `supervised` (default) | `full`.
+    /// `readonly` | `supervised` (default) | `auto` | `full`.
+    ///
+    /// The default stays `supervised` deliberately: issue #560 argues `auto`
+    /// should become it, but flipping it changes behaviour for every existing
+    /// company with no `[policy]` block on its next load, so that is its own
+    /// decision rather than a rider on adding the tier.
     #[serde(default = "default_policy_mode")]
     pub mode: String,
     /// Effect kinds that always park for approval regardless of amount.

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -125,6 +125,20 @@ pub enum PolicyMode {
 }
 
 impl PolicyMode {
+    /// Every tier, paired with the manifest word that selects it.
+    ///
+    /// Exists so the two halves of "a tier is reachable" can be checked against
+    /// something that is neither of them. The enum, [`parse`](Self::parse) and
+    /// [`POLICY_MODES`](crate::company::POLICY_MODES) are three lists that must
+    /// agree; a test that walks any one of them to check the others passes
+    /// vacuously when a tier is missing from the list it walked.
+    pub const ALL: [(&'static str, PolicyMode); 4] = [
+        ("readonly", Self::Readonly),
+        ("supervised", Self::Supervised),
+        ("auto", Self::Auto),
+        ("full", Self::Full),
+    ];
+
     /// Parses a manifest `[policy].mode` string; unknown values fall back to the
     /// safe `Supervised` default.
     ///
@@ -1007,8 +1021,8 @@ mod tests {
             .is_grantable()
     }
 
-    /// Every mode the manifest validator accepts parses to its own variant, and
-    /// nothing else does.
+    /// Every tier is reachable from a manifest, parses to its own variant, and
+    /// nothing else parses to any of them.
     ///
     /// This replaces `mode_maps_one_to_one_to_security_tiers`, which asserted
     /// the same thing through `PolicyMode::security_tier()` — a `&'static str`
@@ -1020,32 +1034,52 @@ mod tests {
     /// documented. Keeping a dead accessor alive by making it lie is worse than
     /// the deletion.
     ///
-    /// Pinning against `POLICY_MODES` rather than a literal list is the point:
-    /// the validator refuses any mode outside it, so a tier added to only one of
-    /// the two is either unreachable from a manifest or accepted and silently
-    /// downgraded to `Supervised` by the fallback. This fails in both
-    /// directions.
+    /// # Why it walks [`PolicyMode::ALL`] and not [`POLICY_MODES`]
+    ///
+    /// The first draft of this test walked `POLICY_MODES`, and a revert-and-check
+    /// caught it passing vacuously: deleting `"auto"` from that list does not
+    /// break a test that derives its cases from it — it just stops testing
+    /// `auto`. The same shape hid the trap this whole change turns on, since
+    /// `PolicyMode::parse` is never reached for a word the validator rejects.
+    ///
+    /// So the cases come from a third list, and the two under test are checked
+    /// against it in both directions: `ALL` → `parse`, and `ALL` ↔
+    /// `POLICY_MODES` by membership *and* by length, so a word in one and not
+    /// the other cannot pass. Adding a variant without extending `ALL` is caught
+    /// by the exhaustive `match` below, which the compiler will refuse.
     #[test]
-    fn every_policy_mode_parses_to_its_own_variant() {
+    fn every_tier_is_reachable_from_a_manifest_and_parses_to_itself() {
         use crate::company::POLICY_MODES;
 
-        let mut seen = Vec::new();
-        for mode in POLICY_MODES {
-            let parsed = PolicyMode::parse(mode);
-            assert!(
-                !seen.contains(&parsed),
-                "`{mode}` parsed to {parsed:?}, which another mode already claims — \
-                 a manifest-selectable tier is being silently downgraded"
+        // A new variant makes this match non-exhaustive — the compiler forces
+        // whoever adds it to come here, and the length assertions below then
+        // fail until `ALL` and `POLICY_MODES` are both extended.
+        for (word, mode) in PolicyMode::ALL {
+            let expected = match mode {
+                PolicyMode::Readonly => "readonly",
+                PolicyMode::Supervised => "supervised",
+                PolicyMode::Auto => "auto",
+                PolicyMode::Full => "full",
+            };
+            assert_eq!(word, expected, "ALL pairs `{word}` with the wrong variant");
+
+            assert_eq!(
+                PolicyMode::parse(word),
+                mode,
+                "`{word}` does not parse to {mode:?} — it is silently downgraded"
             );
-            seen.push(parsed);
+            assert!(
+                POLICY_MODES.contains(&word),
+                "`{word}` is a tier the runtime knows but the manifest validator rejects — \
+                 unreachable from a company.toml, and no policy-side test would notice"
+            );
         }
         assert_eq!(
-            seen.len(),
-            4,
-            "expected four selectable tiers, found {}: {seen:?}",
-            seen.len()
+            POLICY_MODES.len(),
+            PolicyMode::ALL.len(),
+            "POLICY_MODES {POLICY_MODES:?} and PolicyMode::ALL disagree about how many tiers \
+             exist"
         );
-        assert_eq!(PolicyMode::parse("auto"), PolicyMode::Auto);
 
         // Unknown falls back to supervised — the safe default, unchanged.
         assert_eq!(PolicyMode::parse("bogus"), PolicyMode::Supervised);

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -100,13 +100,26 @@ pub const POLICY_NAME: &str = "opencompany-approval";
 /// same way delegation is.
 pub const MAX_APPROVAL_REQUESTS_PER_TURN: usize = 8;
 
-/// The three approval tiers, mirroring OpenHuman's security tiers 1:1.
+/// The four approval tiers, in increasing order of autonomy.
+///
+/// Three of them mirror OpenHuman's own security tiers by name;
+/// [`Auto`](Self::Auto) (issue #560) does not, and is the reason this enum is no
+/// longer 1:1 with anything upstream. See
+/// [`autonomy_for`](crate::harness::toolbelt) for what that costs at the
+/// boundary and how it is paid.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PolicyMode {
     /// Read-only: mutating / external-effect tools are denied outright.
     Readonly,
     /// Supervised: external-effect tools require operator approval.
     Supervised,
+    /// Auto: the agent's own sandbox writes and outward reads run unattended;
+    /// anything that leaves the company or spends money still parks.
+    ///
+    /// The tier line itself is
+    /// [`Consequence::parks_under_auto`](crate::policy::Consequence::parks_under_auto),
+    /// which reads the existing declaration table rather than adding a list.
+    Auto,
     /// Full autonomy: tools run without approval (except `always_approve`).
     Full,
 }
@@ -114,20 +127,20 @@ pub enum PolicyMode {
 impl PolicyMode {
     /// Parses a manifest `[policy].mode` string; unknown values fall back to the
     /// safe `Supervised` default.
+    ///
+    /// The fallback is the *second* line of defence, not the first:
+    /// [`Manifest::validate`](crate::company::Manifest) rejects a mode outside
+    /// [`POLICY_MODES`](crate::company::POLICY_MODES) before a company ever
+    /// loads. This arm catches the paths that reach a `Policy` without going
+    /// through validation, and a new tier has to be added in **both** places —
+    /// parsing `"auto"` here while the validator still refuses it would make the
+    /// tier unreachable from a manifest, which is the only way anyone sets it.
     pub fn parse(mode: &str) -> Self {
         match mode.trim().to_ascii_lowercase().as_str() {
             "readonly" => Self::Readonly,
+            "auto" => Self::Auto,
             "full" => Self::Full,
             _ => Self::Supervised,
-        }
-    }
-
-    /// The openhuman security-tier word this mode maps to (1:1).
-    pub fn security_tier(self) -> &'static str {
-        match self {
-            Self::Readonly => "readonly",
-            Self::Supervised => "supervised",
-            Self::Full => "full",
         }
     }
 }
@@ -870,9 +883,30 @@ impl ToolPolicy for ApprovalPolicy {
         // operator who does want a per-call gate has
         // `[policy].always_approve = ["web_search"]`, which wins over every
         // tier including `full`.
-        let reach = crate::policy::consequence_of(tool, &request.arguments).reach;
+        let consequence = crate::policy::consequence_of(tool, &request.arguments);
+        let reach = consequence.reach;
         match self.mode {
             PolicyMode::Full => ToolPolicyDecision::Allow,
+            // `auto` sits between the two (issue #560): the agent's own sandbox
+            // writes and its outward reads run unattended, and anything that
+            // leaves the company or spends on submit still parks. The line is
+            // drawn by `parks_under_auto`, which reads the same declaration
+            // table this arm's neighbours read — see there for why it reuses
+            // `Standing` rather than introducing a second list, and for the two
+            // boundaries it deliberately does not draw.
+            PolicyMode::Auto => {
+                if consequence.parks_under_auto() {
+                    self.require_approval(
+                        tool,
+                        &request.arguments,
+                        format!(
+                            "'{tool}' leaves the company or spends money, and this desk runs auto"
+                        ),
+                    )
+                } else {
+                    ToolPolicyDecision::Allow
+                }
+            }
             PolicyMode::Supervised => {
                 if reach.parks_under_supervision() {
                     self.require_approval(
@@ -973,15 +1007,47 @@ mod tests {
             .is_grantable()
     }
 
+    /// Every mode the manifest validator accepts parses to its own variant, and
+    /// nothing else does.
+    ///
+    /// This replaces `mode_maps_one_to_one_to_security_tiers`, which asserted
+    /// the same thing through `PolicyMode::security_tier()` — a `&'static str`
+    /// getter whose only caller in the tree was that test. It was deleted with
+    /// issue #560 rather than given a fourth arm: its entire premise was a 1:1
+    /// correspondence with OpenHuman's security-tier words, and `auto` has no
+    /// such word. The two available arms were both wrong — `"auto"` names a tier
+    /// upstream does not have, and `"supervised"` breaks the 1:1 the function
+    /// documented. Keeping a dead accessor alive by making it lie is worse than
+    /// the deletion.
+    ///
+    /// Pinning against `POLICY_MODES` rather than a literal list is the point:
+    /// the validator refuses any mode outside it, so a tier added to only one of
+    /// the two is either unreachable from a manifest or accepted and silently
+    /// downgraded to `Supervised` by the fallback. This fails in both
+    /// directions.
     #[test]
-    fn mode_maps_one_to_one_to_security_tiers() {
-        assert_eq!(PolicyMode::parse("readonly").security_tier(), "readonly");
+    fn every_policy_mode_parses_to_its_own_variant() {
+        use crate::company::POLICY_MODES;
+
+        let mut seen = Vec::new();
+        for mode in POLICY_MODES {
+            let parsed = PolicyMode::parse(mode);
+            assert!(
+                !seen.contains(&parsed),
+                "`{mode}` parsed to {parsed:?}, which another mode already claims — \
+                 a manifest-selectable tier is being silently downgraded"
+            );
+            seen.push(parsed);
+        }
         assert_eq!(
-            PolicyMode::parse("supervised").security_tier(),
-            "supervised"
+            seen.len(),
+            4,
+            "expected four selectable tiers, found {}: {seen:?}",
+            seen.len()
         );
-        assert_eq!(PolicyMode::parse("full").security_tier(), "full");
-        // Unknown falls back to supervised.
+        assert_eq!(PolicyMode::parse("auto"), PolicyMode::Auto);
+
+        // Unknown falls back to supervised — the safe default, unchanged.
         assert_eq!(PolicyMode::parse("bogus"), PolicyMode::Supervised);
     }
 
@@ -994,6 +1060,129 @@ mod tests {
         );
         assert!(matches!(
             p.check(&request("payment.send", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+    }
+
+    /// Issue #560's contract, stated as the operator reads it: the agent works
+    /// without interrupting me, and stops before anything that leaves the
+    /// building or spends money.
+    ///
+    /// Both halves are asserted in one test on purpose. A tier is a *line*, and
+    /// a test that only checked the permissive half would pass just as happily
+    /// against `full` — which is precisely the mistake `auto` exists to avoid.
+    #[tokio::test]
+    async fn auto_runs_sandbox_writes_and_outward_reads_but_parks_anything_that_leaves() {
+        let p = policy("auto", &[], None);
+
+        // Runs unattended: the agent's own scratch space, this company's own
+        // memory, catalogue reads, and a read scoped to one connected account.
+        for (tool, args) in [
+            ("file_write", serde_json::json!({})),
+            ("edit", serde_json::json!({})),
+            ("apply_patch", serde_json::json!({})),
+            ("csv_export", serde_json::json!({})),
+            ("memory_store", serde_json::json!({})),
+            ("file_read", serde_json::json!({})),
+            ("mcp_list_tools", serde_json::json!({})),
+            ("composio_list_tools", serde_json::json!({})),
+            (
+                "composio_execute",
+                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
+            ),
+        ] {
+            assert_eq!(
+                p.check(&request(tool, args)).await,
+                ToolPolicyDecision::Allow,
+                "{tool} should run unattended under auto — the tier is unusable if it interrupts \
+                 the agent's own work"
+            );
+        }
+
+        // Still parks: arbitrary code, arbitrary addresses, a configured remote,
+        // operator-authored guidance, third-party effects, real money on submit,
+        // and a workflow whose contents this layer cannot see.
+        for (tool, args) in [
+            ("shell", serde_json::json!({})),
+            ("http_request", serde_json::json!({})),
+            ("curl", serde_json::json!({})),
+            ("web_fetch", serde_json::json!({})),
+            ("git_operations", serde_json::json!({})),
+            ("workspace_write", serde_json::json!({})),
+            ("workspace_create", serde_json::json!({})),
+            ("publish_artifact", serde_json::json!({})),
+            ("media_generate_image", serde_json::json!({})),
+            ("media_generate_video", serde_json::json!({})),
+            ("mcp_call_tool", serde_json::json!({})),
+            ("mcp_registry_tool_call", serde_json::json!({})),
+            ("run_workflow", serde_json::json!({})),
+            ("composio_authorize", serde_json::json!({})),
+            (
+                "composio_execute",
+                serde_json::json!({ "tool": "GMAIL_SEND_EMAIL" }),
+            ),
+            // An action the provider catalogue does not name is a send, so the
+            // cautious verdict survives into the new tier rather than being
+            // re-decided by it.
+            (
+                "composio_execute",
+                serde_json::json!({ "tool": "GITHUB_INVENT_A_NEW_VERB" }),
+            ),
+            // A tool nobody has declared must not run unattended by omission.
+            ("some_tool_nobody_declared", serde_json::json!({})),
+        ] {
+            assert!(
+                matches!(
+                    p.check(&request(tool, args)).await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "{tool} leaves the company or spends money and must still park under auto"
+            );
+        }
+    }
+
+    /// `always_approve` wins over `auto` exactly as it wins over `full`, and the
+    /// two tiers below `auto` are untouched by its arrival.
+    ///
+    /// The `readonly`/`supervised` half is not ceremony: `auto` was added by
+    /// widening a `match` on the mode and by adding a predicate next to the two
+    /// the other arms read, so the way this change fails is by moving a
+    /// neighbouring line, not by getting its own arm wrong.
+    #[tokio::test]
+    async fn auto_yields_to_always_approve_and_leaves_the_lower_tiers_alone() {
+        let auto = policy("auto", &["file_write"], None);
+        assert!(
+            matches!(
+                auto.check(&request("file_write", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a tool on the always-approve list must park even though auto would otherwise run it"
+        );
+
+        // `readonly` still denies a sandbox write outright rather than parking
+        // it, and still allows a pure read.
+        let readonly = policy("readonly", &[], None);
+        assert!(matches!(
+            readonly
+                .check(&request("file_write", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+        assert_eq!(
+            readonly
+                .check(&request("file_read", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
+
+        // `supervised` still parks the sandbox write `auto` now runs — the one
+        // difference between the tiers, asserted as a difference.
+        let supervised = policy("supervised", &[], None);
+        assert!(matches!(
+            supervised
+                .check(&request("file_write", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));

--- a/src/harness/toolbelt.rs
+++ b/src/harness/toolbelt.rs
@@ -16,10 +16,14 @@
 //!
 //! * Shell + code tools share one [`SecurityPolicy`] built by [`exec_security`],
 //!   pinned to the agent's workspace with `workspace_only`, high-risk commands
-//!   blocked, tool-install denied, and an autonomy level mapped 1:1 from the
-//!   company's [`PolicyMode`]. This is the *strict* policy — opencompany's own
+//!   blocked, tool-install denied, and an autonomy level mapped from the
+//!   company's [`PolicyMode`] by [`autonomy_for`] — no longer 1:1 since `auto`
+//!   (issue #560) has no upstream counterpart and borrows `Supervised`. This is
+//!   the *strict* policy — opencompany's own
 //!   [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) tool policy stays
-//!   the real fail-closed approval gate on top of it.
+//!   the real fail-closed approval gate on top of it, **except** on the workflow
+//!   `tool_call` path, where no such gate is installed and this policy is the
+//!   whole tier. See [`autonomy_for`].
 //! * Shell command audit is keyed on the agent's own workspace dir
 //!   ([`workspace_audit`]) so audit trails never cross tenants.
 //! * Web tools reuse OpenHuman's upstream SSRF guard (`url_guard`): every
@@ -153,11 +157,16 @@ pub fn namespace_of(tool_name: &str) -> Option<&'static str> {
 /// Extends the same `workspace_only` shape [`file_tools`](crate::harness::build)
 /// uses with the exec-relevant knobs:
 ///
-/// * `autonomy` is mapped **1:1** from the company [`PolicyMode`]
-///   (readonly/supervised/full → [`AutonomyLevel`] ReadOnly/Supervised/Full).
+/// * `autonomy` is mapped from the company [`PolicyMode`] — see
+///   [`autonomy_for`], which is **not** 1:1 since `auto` (issue #560) has no
+///   upstream counterpart, and which is a real security boundary on the
+///   workflow `tool_call` path rather than a mapping detail.
 /// * `block_high_risk_commands` is always on — destructive shell commands are
 ///   refused before they spawn.
-/// * `require_approval_for_medium_risk` mirrors Supervised mode.
+/// * `require_approval_for_medium_risk` covers Supervised **and** Auto, for the
+///   reason argued on [`autonomy_for`]: the flag is inert unless `autonomy` is
+///   `Supervised`, so leaving `auto` out of it would silently undo the very
+///   mapping chosen to keep `auto` from loosening shell execution.
 /// * `allow_tool_install` and `auto_approve_all` are always off — an embedded
 ///   company agent never installs OS packages nor blanket-approves itself.
 ///
@@ -173,18 +182,57 @@ pub fn exec_security(workspace: &Path, mode: PolicyMode) -> SecurityPolicy {
         action_dir: dir,
         workspace_only: true,
         block_high_risk_commands: true,
-        require_approval_for_medium_risk: mode == PolicyMode::Supervised,
+        require_approval_for_medium_risk: matches!(mode, PolicyMode::Supervised | PolicyMode::Auto),
         allow_tool_install: false,
         auto_approve_all: false,
         ..SecurityPolicy::default()
     }
 }
 
-/// The OpenHuman [`AutonomyLevel`] a company [`PolicyMode`] maps to (1:1).
+/// The OpenHuman [`AutonomyLevel`] a company [`PolicyMode`] maps to.
+///
+/// Three of the four map by name. `auto` (issue #560) has no upstream
+/// counterpart — OpenHuman's `AutonomyLevel` is `ReadOnly` / `Supervised` /
+/// `Full` — so it must borrow one, and **the borrowed level is a security
+/// decision, not a naming one.**
+///
+/// # Why `Supervised` and not `Full`
+///
+/// `auto` is more permissive than `supervised` at opencompany's own
+/// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy), which is where
+/// the tier is supposed to be expressed. Reaching for the matching *feel* here
+/// and mapping it to `Full` would loosen a different gate in the opposite
+/// direction, because this policy is not always sitting underneath that one:
+///
+/// * A workflow `tool_call` node runs through
+///   [`WorkflowToolInvoker`](crate::workflows::caps), which gates on the
+///   `[tools].allow` grant list and **this policy** — no `ApprovalPolicy` is
+///   installed on that path. (Workflow *agent* nodes go through the roster and
+///   do have one.) So for those nodes this is the whole tier.
+/// * Upstream, `AutonomyLevel::Full` stops asking about medium-risk shell
+///   commands: the approval arm in `command_checks` fires only when `autonomy
+///   == Supervised`. Mapping `auto` to `Full` would therefore let medium-risk
+///   commands run unapproved in workflow nodes on an `auto` company — while the
+///   tier's stated contract is that `shell` parks. The inverse of what the
+///   operator selected.
+///
+/// Mapping to `Supervised` costs nothing in the other direction. Every tool
+/// this policy governs — `shell`, the code runners, the web tools — is
+/// `Standing::PerCall` and therefore parks under `auto` at the authoritative
+/// layer anyway, so the stricter advisory tier underneath is never the thing
+/// the operator notices. `auto` buys its autonomy in tools this policy does not
+/// govern.
+///
+/// This is also why `require_approval_for_medium_risk` in [`exec_security`]
+/// lists `Auto` explicitly instead of leaving `mode == PolicyMode::Supervised`
+/// to answer it. That expression was exhaustive by accident and would have
+/// quietly returned `false` for the new variant — pairing `Supervised` autonomy
+/// with the medium-risk gate switched off, which is the loosening this mapping
+/// was chosen to prevent, arriving through the back door.
 fn autonomy_for(mode: PolicyMode) -> AutonomyLevel {
     match mode {
         PolicyMode::Readonly => AutonomyLevel::ReadOnly,
-        PolicyMode::Supervised => AutonomyLevel::Supervised,
+        PolicyMode::Supervised | PolicyMode::Auto => AutonomyLevel::Supervised,
         PolicyMode::Full => AutonomyLevel::Full,
     }
 }
@@ -679,7 +727,6 @@ mod tests {
             "supervised must approve medium-risk"
         );
 
-        // Autonomy tracks the mode 1:1; medium-risk approval is Supervised-only.
         let readonly = exec_security(ws, PolicyMode::Readonly);
         assert_eq!(readonly.autonomy, AutonomyLevel::ReadOnly);
         assert!(!readonly.require_approval_for_medium_risk);
@@ -687,6 +734,120 @@ mod tests {
         let full = exec_security(ws, PolicyMode::Full);
         assert_eq!(full.autonomy, AutonomyLevel::Full);
         assert!(!full.require_approval_for_medium_risk);
+    }
+
+    /// `auto` must not loosen shell execution (issue #560).
+    ///
+    /// This is the test for the decision argued on [`autonomy_for`], and it
+    /// guards a hole with no other guard: a workflow `tool_call` node has **no**
+    /// `ApprovalPolicy` above it, so this policy is the entire tier there.
+    /// `auto` is more permissive than `supervised` at the approval gate, and the
+    /// tempting mapping — matching that feel with `AutonomyLevel::Full` — would
+    /// silently drop the medium-risk shell gate for every workflow node on an
+    /// `auto` company, because upstream's approval arm fires only when
+    /// `autonomy == Supervised`.
+    ///
+    /// The second assertion is the subtler half. With autonomy mapped to
+    /// `Supervised`, `require_approval_for_medium_risk` becomes load-bearing —
+    /// and it was written as `mode == PolicyMode::Supervised`, an expression
+    /// that was exhaustive by accident and answers `false` for a variant added
+    /// beside it. Getting the mapping right and leaving that expression alone
+    /// would have reopened the same hole from the other side.
+    #[test]
+    fn auto_borrows_supervised_exec_security_rather_than_full() {
+        let ws = Path::new("/tmp/oc-toolbelt-policy-auto");
+        let auto = exec_security(ws, PolicyMode::Auto);
+
+        assert_eq!(
+            auto.autonomy,
+            AutonomyLevel::Supervised,
+            "auto must not inherit Full's exec autonomy — a workflow tool_call node has no \
+             approval gate above this policy"
+        );
+        assert!(
+            auto.require_approval_for_medium_risk,
+            "the medium-risk gate is inert unless autonomy is Supervised, so auto must opt in \
+             explicitly or the mapping above buys nothing"
+        );
+
+        // The rest of the hardening is tier-independent and stays so.
+        assert!(auto.block_high_risk_commands);
+        assert!(!auto.allow_tool_install);
+        assert!(!auto.auto_approve_all);
+        assert!(auto.workspace_only);
+    }
+
+    /// The mapping above, proven where it actually bites: at openhuman's own
+    /// command gate, on the class that separates the two candidate mappings.
+    ///
+    /// `auto_borrows_supervised_exec_security_rather_than_full` pins the two
+    /// fields; this pins what they *do*.
+    ///
+    /// # Which class actually distinguishes the mappings
+    ///
+    /// Worth stating, because the intuitive example is the wrong one. At
+    /// `gate_decision`, `Destructive` prompts under `Supervised` **and** under
+    /// `Full` — so `rm -rf /` cannot tell the two mappings apart, and a test
+    /// written around it would pass whichever mapping `autonomy_for` chose.
+    /// (`block_high_risk_commands` is a separate, unconditional refusal on the
+    /// `validate_command` path; it is not what `gate_decision` reports.)
+    ///
+    /// The one class `Full` actually loosens is `Write`: `Supervised` prompts,
+    /// `Full` allows. That makes `Write` the whole of the difference here, and
+    /// it is the ordinary case rather than an exotic one — an unrecognised
+    /// command is classified `Write` by fail-closed default. So mapping `auto`
+    /// to `Full` would have let routine state-changing shell commands run
+    /// unprompted in workflow `tool_call` nodes, which is exactly the tier
+    /// inversion `autonomy_for` argues against.
+    ///
+    /// Asserted on `CommandClass` directly rather than through
+    /// `classify_command`, so this pins the tier decision and not the
+    /// classifier's string heuristics.
+    #[test]
+    fn auto_gates_write_class_commands_exactly_as_supervised_does() {
+        use oh::security::{CommandClass, GateDecision};
+        let ws = Path::new("/tmp/oc-toolbelt-policy-auto-cmd");
+
+        let auto = exec_security(ws, PolicyMode::Auto);
+        let supervised = exec_security(ws, PolicyMode::Supervised);
+        let full = exec_security(ws, PolicyMode::Full);
+
+        // The load-bearing assertion: the class the two mappings disagree about.
+        assert_eq!(
+            auto.gate_decision(CommandClass::Write),
+            GateDecision::Prompt,
+            "a write-class command must still ask on an auto desk — mapping auto to Full would \
+             let it run unprompted in a workflow tool_call node, which has no approval gate above \
+             this policy"
+        );
+        assert_eq!(
+            full.gate_decision(CommandClass::Write),
+            GateDecision::Allow,
+            "guard for the assertion above: if Full ever stops allowing Write, this test no \
+             longer distinguishes the two mappings and must be rewritten"
+        );
+
+        // Everything else `auto` decides, it decides identically to `supervised`.
+        for class in [
+            CommandClass::Read,
+            CommandClass::Write,
+            CommandClass::Network,
+            CommandClass::Install,
+            CommandClass::Destructive,
+        ] {
+            assert_eq!(
+                auto.gate_decision(class),
+                supervised.gate_decision(class),
+                "auto must gate {class:?} exactly as supervised does"
+            );
+        }
+
+        // And it is not readonly either — an auto desk can still act.
+        let readonly = exec_security(ws, PolicyMode::Readonly);
+        assert_eq!(
+            readonly.gate_decision(CommandClass::Write),
+            GateDecision::Block
+        );
     }
 
     #[tokio::test]

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -107,9 +107,24 @@ impl Reach {
 /// operator-owned state is [`PerCall`](Self::PerCall) however innocuous its
 /// name; a read scoped to one connected account is
 /// [`Grantable`](Self::Grantable) however alarming the tool carrying it sounds.
+///
+/// # This now decides two different things (issue #560)
+///
+/// Since the `auto` tier, [`Consequence::parks_under_auto`] reads this field to
+/// mean "may run **unattended for everyone** while the company sits in `auto`"
+/// — a wider grant than the per-teammate, until-a-deadline one the name
+/// describes. Loosening a tool to [`Grantable`](Self::Grantable) for a
+/// delegation reason therefore also stops it parking under `auto`, for every
+/// agent, with no operator in the loop. That is sound because this field is
+/// decided by what a tool can *reach* rather than by what it is called — but it
+/// is two decisions in one edit, and the second one is easy to make by
+/// accident. `the_auto_tier_line_is_pinned_tool_by_tool` in this module's tests
+/// walks the whole table and fails loudly if a tool crosses that line.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Standing {
-    /// An operator may grant this to a teammate until a deadline.
+    /// An operator may grant this to a teammate until a deadline — **and**,
+    /// since issue #560, may run unattended under the `auto` tier. See the note
+    /// on [`Standing`] before loosening a tool to this.
     Grantable,
     /// Every call is its own decision.
     PerCall,
@@ -627,6 +642,95 @@ mod tests {
 
     fn c(tool: &str) -> Consequence {
         consequence_of(tool, &json!({}))
+    }
+
+    /// The `auto` line, named tool by tool and taken from the whole table
+    /// rather than a sample (issue #560).
+    ///
+    /// [`Consequence::parks_under_auto`] is easy to check as a predicate; what
+    /// an operator actually feels is *which tools* stopped asking. And since
+    /// #560, [`Standing::Grantable`] decides two things at once — may be
+    /// delegated to one teammate, **and** runs unattended for everyone under
+    /// `auto` — so an edit loosening one tool for a delegation reason moves it
+    /// across this line as a side effect.
+    ///
+    /// This walks [`declared_tools`], so a tool joining or leaving the
+    /// unattended set fails here and has to be named deliberately. The
+    /// predicate test alone would not notice.
+    #[test]
+    fn the_auto_tier_line_is_pinned_tool_by_tool() {
+        // The whole of what `auto` changes: parks for an operator under
+        // `supervised`, runs unattended under `auto`. Every entry is the
+        // agent's own sandbox or this company's own memory — nothing here
+        // leaves the building or spends money.
+        const MOVED_BY_AUTO: &[&str] = &[
+            "apply_patch",
+            "csv_export",
+            "edit",
+            "file_write",
+            "memory_store",
+        ];
+
+        let mut moved: Vec<&str> = declared_tools()
+            .filter(|tool| {
+                let verdict = c(tool);
+                verdict.reach.parks_under_supervision() && !verdict.parks_under_auto()
+            })
+            .collect();
+        moved.sort_unstable();
+        assert_eq!(
+            moved, MOVED_BY_AUTO,
+            "a tool crossed the `auto` line. If that is intended, say so here — \
+             `Standing::Grantable` now also means 'runs unattended for every agent \
+             while the company sits in auto', which is wider than the standing \
+             grant the field is named for"
+        );
+
+        // The other direction, spelled out: the tools an operator would be
+        // most alarmed to find running unattended still park.
+        for tool in [
+            "shell",
+            "http_request",
+            "git_operations",
+            "workspace_write",
+            "publish_artifact",
+            "media_generate_image",
+            "media_generate_video",
+            "mcp_call_tool",
+            "run_workflow",
+            "some_tool_nobody_declared",
+        ] {
+            assert!(
+                c(tool).parks_under_auto(),
+                "`{tool}` leaves the company, spends money, or cannot be seen into — \
+                 it must still park under auto"
+            );
+        }
+
+        // And the boundary `auto` deliberately does not draw: a billed read is
+        // not a park. `web_search` runs under `supervised` because openhuman
+        // resolves a `RequireApproval` inline — a parked search never happens —
+        // and `auto` must not be stricter than the tier it replaces. The daily
+        // cap is what holds spend.
+        assert!(!c("web_search").parks_under_auto());
+        assert!(c("web_search").reach.costs_money());
+    }
+
+    /// The argument-classified half of the same line: a Composio read runs
+    /// unattended under `auto`, a send does not — and the cautious fallback
+    /// keeps an unclassified action on the parking side.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_auto_line_reads_composio_arguments_not_the_tool_name() {
+        let auto = |slug: &str| {
+            consequence_of(COMPOSIO_EXECUTE, &json!({ "tool": slug })).parks_under_auto()
+        };
+        assert!(!auto("GITHUB_LIST_PULL_REQUESTS"), "a catalogue read runs");
+        assert!(auto("GMAIL_SEND_EMAIL"), "a send still parks");
+        assert!(
+            auto("GITHUB_INVENT_A_NEW_VERB"),
+            "an action nobody has classified is a send, in this tier too"
+        );
     }
 
     #[test]

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -133,6 +133,70 @@ pub struct Consequence {
     pub standing: Standing,
 }
 
+impl Consequence {
+    /// Does this park for an operator under `auto` (issue #560)?
+    ///
+    /// `auto` is the tier between `supervised` — which parks every write and
+    /// every outward read, so companies drown — and `full`, which parks nothing
+    /// but the `always_approve` list. Its contract, in the operator's words:
+    /// **the agent works without interrupting me, and stops before anything
+    /// that leaves the building or spends money.**
+    ///
+    /// # Why this reads two fields instead of adding a third
+    ///
+    /// The split `auto` needs is already declared. [`Standing::Grantable`]
+    /// marks exactly the calls whose consequence stays inside this company —
+    /// the agent's own scratch writes (`file_write`, `edit`, `apply_patch`,
+    /// `csv_export`, `memory_store`) and a read scoped to one connected account.
+    /// Everything that can execute arbitrary code, reach an arbitrary address,
+    /// overwrite operator-authored guidance, spend on generation, or perform an
+    /// effect this layer cannot see is [`Standing::PerCall`] — deliberately, and
+    /// argued tool by tool in [`DECLARED`]. So the tier is a *reader* of that
+    /// work, not a second table to be kept in step with it. A fresh list would
+    /// be the exact hand-maintained carve-out this module was written to delete,
+    /// and it would drift the same silent way.
+    ///
+    /// # What the operator is consenting to
+    ///
+    /// [`Standing`] answers "may an operator hand this to one teammate until a
+    /// deadline?", and this reuses it to mean "may it run unattended for
+    /// everyone while the company sits in `auto`?" — which is a genuinely wider
+    /// grant than a standing grant, not the same one. It is sound because
+    /// [`Standing`] is decided by what a tool can *reach* rather than by how
+    /// alarming its name is, and because the widening is exactly the choice the
+    /// operator makes when they select the tier. It is recorded here so a future
+    /// edit that loosens `Grantable` knows it is loosening two things.
+    ///
+    /// # Two boundaries this does not draw
+    ///
+    /// [`Reach::Money`] does **not** park. `web_search` is billed but changes
+    /// nothing, and it already runs unattended under `supervised` for a reason
+    /// that binds harder here: openhuman resolves a `RequireApproval` inline and
+    /// never re-dispatches, so a parked search is a search that never happens
+    /// and an agent with no search invents citations. `auto` must not be
+    /// stricter than the tier it replaces. The per-agent daily cap is the
+    /// boundary that actually holds spend, and it sits above the tier dispatch.
+    /// Generation that spends on *submit* — `media_generate_image`,
+    /// `media_generate_video` — is [`Reach::Consequence`] and `PerCall`, so it
+    /// parks.
+    ///
+    /// `always_approve` is not consulted here either: it is checked above the
+    /// tier dispatch in
+    /// [`ApprovalPolicy::check`](crate::harness::policy::ApprovalPolicy) and
+    /// wins over every tier, `full` included.
+    ///
+    /// # Stable across issue #559
+    ///
+    /// A Composio read is `Grantable` today while still carrying
+    /// [`Reach::Consequence`]; #559 reclassifies its *reach* without touching
+    /// its standing. This predicate returns `false` — runs unattended — in both
+    /// worlds, because the `Grantable` half already decides it. The two changes
+    /// can land in either order and neither can silently invert the other.
+    pub fn parks_under_auto(self) -> bool {
+        self.reach.parks_under_supervision() && !self.standing.is_grantable()
+    }
+}
+
 /// One tool's declaration.
 struct Declared {
     tool: &'static str,


### PR DESCRIPTION
## Summary

Adds `auto`, a fourth autonomy tier between `supervised` and `full` (#560).

An operator had two settings and needed a third. `supervised` parks every write — including the agent's own scratch files — so companies drown in cards. `full` parks nothing but the always-ask list, so it also stops asking before a shell command, an arbitrary HTTP request, or a git push. Companies ran one and suffered, or ran the other and lost the gate that mattered.

`auto`'s contract, as the operator reads it: **the agent works without interrupting me, and stops before anything that leaves the building or spends money.**

The tier line is one predicate, `Consequence::parks_under_auto`:

```rust
self.reach.parks_under_supervision() && !self.standing.is_grantable()
```

It reads the declaration table that already exists rather than adding a second list. `Standing::Grantable` already marks almost exactly the set `auto` wants to run — the agent's own sandbox writes (`file_write`, `edit`, `apply_patch`, `csv_export`, `memory_store`) and reads scoped to one connected account — and everything that can run arbitrary code, reach an arbitrary address, overwrite operator-authored guidance, spend on submit, or perform an effect this layer cannot see is `PerCall`, argued tool by tool in `DECLARED`. A fresh list would be exactly the hand-maintained carve-out `src/policy/consequence.rs` was written to delete.

### Named trap: the fifth site, which is not in the issue

The issue and its scoping comment name three exhaustive match sites. There is a **fourth consumer and a fifth site**, and the fifth is the one the feature turns on:

`POLICY_MODES` (`src/company/types.rs`) is the *manifest validator's* list, read at `manifest.rs:233`. It runs **before** `PolicyMode::parse` ever sees the string. Add the variant and the parse arm but not the list entry, and `[policy].mode = "auto"` is rejected at load with "must be one of readonly, supervised, full" — the tier is unreachable from the only place anybody sets it.

**And every test in `harness::policy` still passes**, because they all construct a `Policy` directly and never cross that boundary. Right assertion, input never reaches the code.

(The fourth consumer is `src/workflows/caps/mod.rs:125`, which parses the mode for the workflow capability bundle — see the `autonomy_for` section, where it matters.)

### Decision 1 — `autonomy_for(Auto)` maps to `Supervised`, not `Full`

This is a security decision, not a naming one, and the tempting answer is wrong.

`auto` is *more* permissive than `supervised` at opencompany's `ApprovalPolicy`. Matching that feel here and mapping to `AutonomyLevel::Full` would loosen a **different** gate, because this policy is not always sitting underneath that one:

- A workflow `tool_call` node runs through `WorkflowToolInvoker` (`src/workflows/caps/tools.rs`), which gates on the `[tools].allow` grant list and **this policy** — no `ApprovalPolicy` is installed on that path. (Workflow *agent* nodes go through the roster and do have one.) For those nodes this policy is the entire tier.
- Upstream `gate_decision` (`command_checks.rs:157`): `Supervised` prompts on `CommandClass::Write`; `Full` **allows** it. And `Write` is the fail-closed default class for any command not recognised as read/network/destructive — so this is the ordinary case, not an exotic one.

Mapping `auto` to `Full` would therefore let routine state-changing shell commands run unprompted in workflow nodes on an `auto` company, while the tier's stated contract is that `shell` parks. The inverse of what the operator selected.

It costs nothing in the other direction: every tool `exec_security` governs is `PerCall` and parks under `auto` at the authoritative layer anyway. `auto` buys its autonomy in tools this policy does not govern.

**Worth flagging for review:** the intuitive test case does not discriminate here. `Destructive` prompts under `Supervised` **and** under `Full`, so `rm -rf /` cannot tell the two mappings apart — a test written around it passes whichever mapping is chosen. I wrote that test first and it failed for this reason. `Write` is the whole of the difference, and that is what the test now asserts.

### Decision 2 — `require_approval_for_medium_risk` names `Auto` explicitly

`SecurityPolicy` set this from `mode == PolicyMode::Supervised` — exhaustive by accident, and it answers `false` for a new variant.

That is not cosmetic given Decision 1. The flag is **inert unless `autonomy == Supervised`**, so leaving it would have paired `Supervised` autonomy with the medium-risk gate switched off — the same loosening the mapping was chosen to prevent, arriving through the back door. Now `matches!(mode, Supervised | Auto)`.

### Public API removal — `PolicyMode::security_tier()` is **deleted**

Calling this out under its own heading so it is not discovered in the diff.

`security_tier()` was dead: repo-wide, its only references were its own test at `policy.rs:977-985`. It was deleted rather than given a fourth arm because **its documented premise is what this issue invalidates** — a 1:1 mapping onto OpenHuman's security-tier *words*, and `auto` has none. Both available arms were wrong: `"auto"` names a tier upstream does not have; `"supervised"` breaks the 1:1 the function exists to assert. Keeping a dead accessor alive by making it lie is worse than removing it.

Its load-bearing assertion — `parse("bogus") == Supervised`, the safe-fallback criterion — is preserved in the replacement test.

### Two boundaries `auto` deliberately does not draw

Stating these plainly rather than letting them read as oversights:

- **`Reach::Money` does not park.** `web_search` is billed but changes nothing, and it already runs unattended under `supervised` — for a reason that binds harder here: openhuman resolves a `RequireApproval` inline and never re-dispatches, so a parked search is a search that never happens and an agent with no search invents citations. `auto` must not be *stricter* than the tier it replaces. This is a pre-existing property of `supervised`, not something introduced here; the per-agent daily cap is the real spend boundary and it sits above the tier dispatch. Generation that spends on submit (`media_generate_image`, `media_generate_video`) is `Reach::Consequence` and parks.
- **`always_approve` is not consulted by the tier.** It is checked above the dispatch and wins over every tier, `full` included — asserted for `auto` by test.

### Sequencing: this composes with #559, it does not depend on it

The brief sequenced this after #559. That turns out to be unnecessary, and saying so here so nobody re-serialises them.

A Composio read is `Standing::Grantable` **today**, while still carrying `Reach::Consequence`. #559 reclassifies its *reach* and leaves its standing alone. `parks_under_auto` keys on both, and the `Grantable` half already decides the answer — so a Composio read runs unattended under `auto` in both worlds. **The two can land in either order and neither can silently invert the other.**

### Related

- #559 — the outward-read reclassification (composes; see above).
- #460 — fixes the workflow `tool_call` approval gap from the other side. That work and the `autonomy_for` reasoning here agree about the same hole; readable together.
- #562 — the console control for this tier.

### Not in this PR, by design

`default_policy_mode()` is **untouched** and still returns `"supervised"`. The issue asks whether `auto` should become the default; it is a one-line change, which is exactly why it wants a deliberate call rather than a rider — every company with no `[policy]` block changes behaviour on next load. Filed separately.

## API Or Behavior Changes

**Public API — removal:** `PolicyMode::security_tier()` is deleted (dead in-tree; see above).

**Public API — additions:** `PolicyMode::Auto` variant; `PolicyMode::ALL`; `Consequence::parks_under_auto()`. `PolicyMode` is a non-`#[non_exhaustive]` public enum, so the new variant is technically breaking for any external exhaustive match; there are none in-tree.

**Behaviour — new opt-in only.** `[policy].mode = "auto"` is now accepted and selects the new tier. No existing company changes behaviour: the default is unchanged, and `readonly` / `supervised` / `full` are untouched (asserted by test). An unknown mode string still falls back to `Supervised`.

**Manifest validation:** the error text for a bad `[policy].mode` now reads `readonly, supervised, auto, full`.

## Tests

Commands run locally, from a clone with `git submodule update --init --recursive`:

- [x] `cargo fmt --all -- --check` — **ran, exit 0.**
- [x] `cargo clippy --all-targets -- -D warnings` — **ran; fails, and the failures are pre-existing and not in this diff.** Both are `large size difference between variants` in `vendor/tinyagents/src/harness/agent_loop/stream.rs:48` and `:97`. This diff touches **zero** files under `vendor/` (`git diff --name-only upstream/main | grep -c '^vendor/'` → 0). `-p opencompany` does not avoid it — the vendored crate is a path dep and is linted either way. **No clippy finding in opencompany's own sources.** Flagging rather than claiming this box.
- [x] `cargo build --all-targets` — **not run as `build`; ran `cargo check --features openhuman,tinycortex --all-targets`, exit 0.** Narrower than the box (check, not build) and wider (the gated feature lane, which the plain command omits).
- [x] `cargo test` — **ran the gated lane, `cargo test --features openhuman,tinycortex`, exit 0: 2737 passed, 0 failed, 3 ignored** (plus the integration targets: 10, 1, 11, 2 passed). Ran the gated lane rather than bare `cargo test` because default features skip roughly a third of the code, including everything this change touches.

Exit codes captured from unpiped redirects, not from a pipeline's last stage.

### Revert-and-check

Every new test was proven to fail with its fix reverted, one revert at a time, verifying the edit applied before running:

| Revert | Test that must fail | Result |
| --- | --- | --- |
| Drop `"auto"` arm from `PolicyMode::parse` | `every_tier_is_reachable_from_a_manifest_and_parses_to_itself` | ✅ failed |
| Drop `"auto"` from `POLICY_MODES` | `every_tier_is_accepted_by_name_from_a_company_toml` | ✅ failed |
| `parks_under_auto` ignores `Standing` | `auto_runs_sandbox_writes_and_outward_reads_but_parks_anything_that_leaves` | ✅ failed |
| `autonomy_for` maps `Auto → Full` | `auto_borrows_supervised_exec_security_rather_than_full` | ✅ failed |
| `autonomy_for` maps `Auto → Full` | `auto_gates_write_class_commands_exactly_as_supervised_does` | ✅ failed |
| `require_approval_for_medium_risk` back to `mode == Supervised` | `auto_borrows_supervised_exec_security_rather_than_full` | ✅ failed |
| Remove the `always_approve` arm from `check()` | `auto_yields_to_always_approve_and_leaves_the_lower_tiers_alone` | ✅ failed |

**Two of these tests were vacuous on the first attempt, and revert-and-check is the only reason that is not still true.** Both walked `POLICY_MODES` to check `POLICY_MODES`, so deleting `"auto"` from it removed the *case* rather than failing the *assertion* — the identical shape to the trap they exist to catch. Fixed in `c653a60`: the policy-side cases now come from a third list (`PolicyMode::ALL`, kept honest by an exhaustive `match` the compiler will refuse to let drift), and the manifest-side cases are literals that the reverting edit cannot remove.

### Not verified

- **Not run in a live app.** No manual/end-to-end run of a company on `mode = "auto"`; the tier is proven at the policy and exec-security layers by unit test only.
- **The workflow `tool_call` path is reasoned about, not exercised.** The claim that no `ApprovalPolicy` sits above `WorkflowToolInvoker` comes from reading the construction path and confirming `consequence_of` has no call site there — not from a run.
- **No console/UI work** (#562).
- **Coverage percentage not measured.**

## Documentation

- `docs/spec/company-brain/approvals.md` — new **The `auto` tier** section (contract, why it reads `Standing`, the two boundaries it does not draw, the #559 composition, why it is not the default); tier list, mode dispatch and the "may it run unattended?" line updated; the deletion of `security_tier()` and the loss of the 1:1 mapping recorded.
- `docs/spec/runtime/manifest.md` — `[policy].mode` schema line, the prosumer validation-error example, and the `[policy]` description.
- Rustdoc carries the arguments at the sites that need them: `Consequence::parks_under_auto`, `autonomy_for` (the `Supervised`-not-`Full` argument), `exec_security`, `PolicyMode`, `PolicyMode::parse` (the validator/parse two-place trap), `POLICY_MODES`, and `Policy.mode`.

Both Markdown files remain under the 500-line limit (464 / 331).

Refs #560
