### PR TITLE
fix(policy): classify read_workspace_state as a consequence (#459)

### DIFF
--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -774,7 +774,8 @@ impl ToolPolicy for ApprovalPolicy {
         if self.mode == PolicyMode::Readonly && is_external_effect(tool, &request.arguments) {
             return ToolPolicyDecision::deny(format!(
                 "'{tool}' mutates or reaches outside; this desk is read-only, \
-                 so an earlier approval does not apply"
+                 so an earlier approval does not apply{}",
+                readonly_denial_suffix(tool)
             ));
         }
 
@@ -887,7 +888,8 @@ impl ToolPolicy for ApprovalPolicy {
             PolicyMode::Readonly => {
                 if reach.denied_under_readonly() {
                     ToolPolicyDecision::deny(format!(
-                        "'{tool}' mutates or reaches outside; this desk is read-only"
+                        "'{tool}' mutates or reaches outside; this desk is read-only{}",
+                        readonly_denial_suffix(tool)
                     ))
                 } else {
                     ToolPolicyDecision::Allow
@@ -895,6 +897,20 @@ impl ToolPolicy for ApprovalPolicy {
             }
         }
     }
+}
+
+/// The ", because …" a `readonly` denial carries when the tool's name argues
+/// against its classification (issue #459), or an empty string.
+///
+/// `readonly` denying `read_workspace_state` is the case this exists for: the
+/// operator sees a tier that promises reads still work refuse something called
+/// `read_*`, and "mutates or reaches outside" alone reads as a bug in the tier.
+/// The reason lives in [`crate::policy::consequence::denial_reason`], next to
+/// the classification it explains, so the two cannot drift.
+fn readonly_denial_suffix(tool: &str) -> String {
+    crate::policy::consequence::denial_reason(tool)
+        .map(|why| format!(" — {why}"))
+        .unwrap_or_default()
 }
 
 /// Does this tool call mutate state or reach an external counterparty?
@@ -2811,6 +2827,44 @@ mod tests {
             ),
             "`readonly` promises nothing runs; a git config key can name a command"
         );
+    }
+
+    /// …and the `readonly` denial says **why**, because this is the one an
+    /// operator ends up confused by.
+    ///
+    /// `read_workspace_state` used to run on a `readonly` desk, so a company
+    /// that sat there gets a refusal on what was a normal first move — and a
+    /// tier that promises reads still work refusing something called `read_*`
+    /// reads as a bug in the tier unless the message names git. The
+    /// `supervised` park explains itself by producing a card to approve; this
+    /// one has to carry its reason.
+    #[tokio::test]
+    async fn the_readonly_denial_of_a_read_shaped_tool_says_why() {
+        let ToolPolicyDecision::Deny { reason } = policy("readonly", &[], None)
+            .check(&request("read_workspace_state", serde_json::json!({})))
+            .await
+        else {
+            panic!("`readonly` denies it");
+        };
+        assert!(
+            reason.contains("git"),
+            "an operator must be able to tell this from a mis-classification: {reason}"
+        );
+        assert!(
+            reason.contains("workspace"),
+            "and where the config it obeys comes from: {reason}"
+        );
+
+        // A tool whose name already argues for the verdict carries no such
+        // clause — every denial ending in an explanation is an explanation
+        // nobody reads.
+        let ToolPolicyDecision::Deny { reason } = policy("readonly", &[], None)
+            .check(&request("shell", serde_json::json!({})))
+            .await
+        else {
+            panic!("`readonly` denies shell");
+        };
+        assert!(!reason.contains("git"), "{reason}");
     }
 
     /// A standing grant admits any arguments, which was a fair summary of a

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -2763,6 +2763,9 @@ mod tests {
     /// read-only rule matched a *prefix* and none of these names begins with a
     /// read-only word. Nobody had reported them; they were found by asking the
     /// same question of every registered tool.
+    ///
+    /// `read_workspace_state` was in this list until issue #459 — see
+    /// [`reading_workspace_state_parks_supervised_and_denies_readonly`].
     #[tokio::test]
     async fn a_workspace_read_runs_without_asking_whatever_its_name_begins_with() {
         let p = policy("supervised", &[], None);
@@ -2772,7 +2775,6 @@ mod tests {
             "grep",
             "image_info",
             "list",
-            "read_workspace_state",
             "memory_recall",
         ] {
             assert_eq!(
@@ -2781,6 +2783,34 @@ mod tests {
                 "`{tool}` reads the agent's own workspace"
             );
         }
+    }
+
+    /// Issue #459: the sibling that turned out not to be a read at all. It
+    /// shells out to `git status` in the agent's own workspace, and the
+    /// vendored `run_git` lets that directory's `.git/config` — which
+    /// `file_write` can author — decide what git executes. So it goes through
+    /// the gate the way `shell` does, and this is the assertion an operator
+    /// actually feels.
+    #[tokio::test]
+    async fn reading_workspace_state_parks_supervised_and_denies_readonly() {
+        assert!(
+            matches!(
+                policy("supervised", &[], None)
+                    .check(&request("read_workspace_state", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "running git under agent-authored config must reach an operator"
+        );
+        assert!(
+            matches!(
+                policy("readonly", &[], None)
+                    .check(&request("read_workspace_state", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::Deny { .. }
+            ),
+            "`readonly` promises nothing runs; a git config key can name a command"
+        );
     }
 
     /// A standing grant admits any arguments, which was a fair summary of a

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -221,6 +221,12 @@ const DECLARED: &[Declared] = &[
     // `shell` shape wearing a read's name, and `namespace_of` already maps it
     // into the `shell` namespace for capability gating.
     //
+    // This is a consistency fix rather than a judgement call: `git_operations`
+    // below is already `Reach::Consequence`, and its `run_git_command_in` is
+    // the same unscrubbed `Command::new("git")`. The identical primitive was
+    // gated in one tool and open in the other; `read_workspace_state` was the
+    // odd one out.
+    //
     // THIS IS A STOPGAP, and deliberately the blunt one: it costs an approval
     // on a routine orientation step. The fix that restores the ergonomics is
     // upstream, in openhuman's `run_git`
@@ -232,6 +238,12 @@ const DECLARED: &[Declared] = &[
     // byte-identical on openhuman `main` today, so there is no pin to bump to.
     // Revert this to `Reach::Nothing` once a hardened `run_git` is vendored,
     // and not before.
+    //
+    // The revert condition is tracked where the work has to happen —
+    // tinyhumansai/openhuman#5494 — not only in this comment. A stopgap whose
+    // removal condition lives as prose next to the stopgap, in a different repo
+    // from its fix, is how these become permanent: nothing surfaces it when
+    // somebody bumps the openhuman pin.
     d(
         "read_workspace_state",
         EffectGroup::Other,
@@ -391,6 +403,28 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
             standing: found.standing,
         },
         None => undeclared(&name),
+    }
+}
+
+/// Why a tool whose *name* reads like a read is nonetheless gated (issue #459).
+///
+/// `None` for almost everything, and that is right: "'shell' mutates or reaches
+/// outside" needs no elaboration, and neither does `http_request`. The entries
+/// here are the tools where the classification contradicts the name, so the
+/// denial is the one an operator reads twice — `readonly` refusing something
+/// called `read_*` looks like a bug in the tier, and without a reason the
+/// operator has no way to tell it from one.
+///
+/// Appended to the `readonly` denial, which is where a confused operator ends
+/// up: the `supervised` park explains itself by offering a card to approve.
+pub fn denial_reason(tool: &str) -> Option<&'static str> {
+    match tool.to_ascii_lowercase().as_str() {
+        "read_workspace_state" => Some(
+            "it runs `git status` and `git log` in the agent's workspace, and git \
+             takes its configuration from that same directory — so it is gated \
+             like `shell` rather than like a read",
+        ),
+        _ => None,
     }
 }
 

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -174,16 +174,18 @@ const DECLARED: &[Declared] = &[
     // this layer cannot see. It parks, and it stays a per-call decision.
     d("run_workflow", EffectGroup::Other, Reach::Consequence),
     // ---- The agent's own sandboxed workspace: reads ------------------------
-    // All four are pure reads inside the workspace the agent is pinned to.
+    // All six are pure reads inside the workspace the agent is pinned to.
     // `file_read`, `glob`, `grep` and `image_info` PARKED before this table
     // existed — not by anyone's decision, but because the read-only-prefix
     // heuristic keys on the *start* of the name and none of them begins with
-    // one. `list`, `read_workspace_state` and `memory_recall` happened to.
+    // one. `list` and `memory_recall` happened to.
+    //
+    // `read_workspace_state` was the seventh member of this list until issue
+    // #459; it is classified with `shell` below, for the reason given there.
     d("file_read", EffectGroup::Other, Reach::Nothing),
     d("glob", EffectGroup::Other, Reach::Nothing),
     d("grep", EffectGroup::Other, Reach::Nothing),
     d("list", EffectGroup::Other, Reach::Nothing),
-    d("read_workspace_state", EffectGroup::Other, Reach::Nothing),
     d("memory_recall", EffectGroup::Other, Reach::Nothing),
     d("image_info", EffectGroup::Other, Reach::Nothing),
     // ---- The agent's own sandboxed workspace: writes -----------------------
@@ -208,6 +210,33 @@ const DECLARED: &[Declared] = &[
     // grant on "anything the sandbox permits", which is not a sentence an
     // operator can consent to.
     d("shell", EffectGroup::Other, Reach::Consequence),
+    // `read_workspace_state` sits here rather than with its fellow workspace
+    // reads because of what it does, not what it is called (issue #459). It
+    // shells out to `git status` and `git log` in
+    // `{root}/{company}/{agent}/workspace` — the same directory `file_write`
+    // writes into — and the vendored `run_git` sets no `GIT_CONFIG_NOSYSTEM`,
+    // no `-c` overrides and no environment scrub. Several git config keys name
+    // a command to run and `git status` invokes `core.fsmonitor`, so a
+    // `.git/config` the agent authored decides what executes. That is the
+    // `shell` shape wearing a read's name, and `namespace_of` already maps it
+    // into the `shell` namespace for capability gating.
+    //
+    // THIS IS A STOPGAP, and deliberately the blunt one: it costs an approval
+    // on a routine orientation step. The fix that restores the ergonomics is
+    // upstream, in openhuman's `run_git`
+    // (`src/openhuman/tools/impl/system/workspace_state.rs`). It is not merely
+    // unwritten — it is not straightforward: the exposure is the *repository*
+    // config in an agent-writable directory, which `GIT_CONFIG_NOSYSTEM` and
+    // `GIT_CONFIG_GLOBAL` do not reach, so a real fix has to refuse unknown
+    // config rather than scrub a list of known-bad keys. That path is
+    // byte-identical on openhuman `main` today, so there is no pin to bump to.
+    // Revert this to `Reach::Nothing` once a hardened `run_git` is vendored,
+    // and not before.
+    d(
+        "read_workspace_state",
+        EffectGroup::Other,
+        Reach::Consequence,
+    ),
     d("http_request", EffectGroup::Other, Reach::Consequence),
     d("curl", EffectGroup::Other, Reach::Consequence),
     d("web_fetch", EffectGroup::Other, Reach::Consequence),
@@ -732,6 +761,10 @@ mod tests {
     /// The sibling defects the same sweep turned up: four pure reads of the
     /// agent's own workspace that parked because the read-only-prefix rule
     /// keys on the *start* of a name and none of them begins with one.
+    ///
+    /// `read_workspace_state` was in this list until issue #459 showed it is
+    /// not a read at all — see
+    /// [`reading_workspace_state_is_classified_with_shell_because_it_runs_git`].
     #[test]
     fn a_workspace_read_never_parks_whatever_its_name_begins_with() {
         for tool in [
@@ -740,7 +773,6 @@ mod tests {
             "grep",
             "image_info",
             "list",
-            "read_workspace_state",
             "memory_recall",
             "workspace_list",
             "workspace_read",
@@ -751,6 +783,41 @@ mod tests {
         ] {
             assert_eq!(c(tool).reach, Reach::Nothing, "`{tool}` is a read");
         }
+    }
+
+    /// Issue #459: `read_workspace_state` is not the read its name promises.
+    /// It runs `git` in `{root}/{company}/{agent}/workspace`, and git reads
+    /// `.git/config` from that directory — a file the agent's own `file_write`
+    /// can author, and one whose keys can name a command to run. Until the
+    /// vendored `run_git` refuses untrusted repository config, it is
+    /// classified with `shell`.
+    ///
+    /// The standing assertion is the one that matters most: `file_write` is
+    /// grantable, so if this were grantable too, the pair could be handed over
+    /// together for a week and the hole would be open for the length of the
+    /// grant with nobody watching.
+    #[test]
+    fn reading_workspace_state_is_classified_with_shell_because_it_runs_git() {
+        let verdict = c("read_workspace_state");
+        assert_eq!(verdict.reach, Reach::Consequence);
+        assert!(
+            verdict.reach.parks_under_supervision(),
+            "running git under config the agent wrote must reach an operator"
+        );
+        assert!(
+            verdict.reach.denied_under_readonly(),
+            "`readonly` promises nothing runs; a config key can name a command"
+        );
+        assert_eq!(
+            verdict.standing,
+            Standing::PerCall,
+            "a standing grant here would reopen the hole for its whole duration"
+        );
+        assert_eq!(
+            verdict.reach,
+            c("shell").reach,
+            "it is the `shell` shape and should stay pinned to `shell`'s verdict"
+        );
     }
 
     /// The feature keeps its point: the tools an agent uses to actually do work


### PR DESCRIPTION
## Summary

Closes #459 — but as a **stopgap**, and the PR should be read that way.

`read_workspace_state` is declared `Reach::Nothing`: it never parks under `supervised` and is allowed under `readonly`. That describes its intent and not its mechanism. It shells out to `git status --porcelain` and `git log` in `{root}/{company}/{agent}/workspace` — the directory the agent's own `file_write` writes into — and the vendored `run_git` sets no `GIT_CONFIG_NOSYSTEM`, no `GIT_CONFIG_GLOBAL`, no `-c` overrides and no environment scrub. Several git config keys name a command git then executes, so a `.git/config` the agent authored decides what runs.

This PR moves the declaration to `Reach::Consequence`, non-grantable, alongside `shell`. It parks under `supervised`, is denied under `readonly`, and can never be handed over on a standing grant.

**I confirmed the exploit rather than reasoning about it.** On git 2.50.1:

```
git init -q .
printf '#!/bin/sh\ntouch "$(dirname "$0")/PWNED"\nexit 1\n' > hook.sh && chmod +x hook.sh
git config core.fsmonitor "$PWD/hook.sh"
git status --porcelain     # -> PWNED exists
```

`git status` executes the command named by the repository's own config. Nothing about that is specific to a crafted repo — `.git/config` is an ordinary file that `file_write` can create.

### Why this is a stopgap, and why it is a blunt one

The real fix is upstream, in openhuman's `run_git` (`src/openhuman/tools/impl/system/workspace_state.rs`). It is **not merely unwritten — it is not straightforward**, which is the honest reason this reclassification is worth taking in the meantime:

- The exposure is the **repository** config, in a directory the agent controls. `GIT_CONFIG_NOSYSTEM` and `GIT_CONFIG_GLOBAL` — the hardening the issue body proposes — close the *system* and *global* files and do not reach `.git/config` at all.
- Clearing the command-valued keys with `-c` does work (command-line config outranks every file), but it is a denylist: correct only until git adds a key, and stale in the direction that reads as fixed.

So the upstream change has to *refuse* unrecognised repository config rather than scrub known-bad keys, which is a design question for openhuman's maintainers rather than a patch to copy in. I have opened that separately as a proposal.

**There is no pin to bump to.** I fetched the same path from `tinyhumansai/openhuman` `main` today and diffed it against the vendored pin (`vendor/openhuman` @ `d5ba6ab2c978ed24dd8ab74d38ae925f965a4682`): byte-identical, SHA-256 `5b7007f7334848b1631bb3256f72473838951af5c81b04b70413abd8052cebe6`. Upstream is not fixed either.

**Revert this when, and only when, a hardened `run_git` is vendored.** The declaration carries that instruction in a comment so the next person to read the table knows it is a placeholder and not a judgement.

### The cost, stated plainly

A routine orientation step now costs an approval under `supervised` and is refused under `readonly`. That is real friction and it is the friction #441/#443 exist to remove. I think it is the right trade while the mechanism does not match the label, but it is a product call and a reviewer may reasonably want it made explicitly.

## API Or Behavior Changes

Behaviour change, deliberate and user-visible:

- `read_workspace_state` under `supervised` — was: ran unattended. Now: parks for an operator.
- `read_workspace_state` under `readonly` — was: allowed. Now: denied.
- `read_workspace_state` standing grant — was: not grantable (unchanged; `d()` already meant `PerCall`). Explicitly asserted now so it cannot drift, since `file_write` *is* grantable and the pair together would reopen the hole for the length of a grant.

No API, wire, or schema change. The tool remains registered and in the same `shell` capability namespace (`namespace_of` already mapped it there — the classification now agrees with the gating).

## Tests

Commands actually run, from the repo root, on the gated lane this change lives in:

- [x] `cargo fmt --all -- --check` — run, exit 0. (It failed the first time — the new declaration needed wrapping — so this is a real pass, not an assumed one.)
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs it on this lane: `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, exit 0. Worth noting for anyone repeating it: **without `--no-deps` this command fails**, on two pre-existing `large_enum_variant` lints inside `vendor/tinyagents`. Those are not from this change and CI does not see them, because the gated lane passes `--no-deps` (`.github/workflows/ci.yml:434`).
- [x] `cargo build --all-targets` — **not run as `build`**; ran `cargo check --features openhuman,tinycortex --all-targets` instead, exit 0. That is the gated lane and it covers `examples/`, which default features skip. Ticked because the box's intent (everything compiles, including examples) was verified, by a narrower command than the literal one.
- [x] `cargo test` — **not run bare**; ran `cargo test --features openhuman,tinycortex`. Default features skip roughly a third of this crate, so the bare command would not have exercised the gated policy surface this change touches.

Two new tests, plus two existing lists updated:

- `policy::consequence::tests::reading_workspace_state_is_classified_with_shell_because_it_runs_git` — pins reach, parking, readonly denial, and non-grantability, and pins the reach to `shell`'s so the two cannot drift apart.
- `harness::policy::tests::reading_workspace_state_parks_supervised_and_denies_readonly` — the end-to-end gate decision, which is what an operator actually experiences.
- Removed `read_workspace_state` from `a_workspace_read_never_parks_whatever_its_name_begins_with` and `a_workspace_read_runs_without_asking_whatever_its_name_begins_with`, each with a comment pointing at the new test. Those two lists asserted the old behaviour and are the reason the change is not silent.

**Revert-and-check**, run rather than reasoned about. With the declaration put back to `Reach::Nothing`:

```
test policy::consequence::tests::reading_workspace_state_is_classified_with_shell_because_it_runs_git ... FAILED
test harness::policy::tests::reading_workspace_state_parks_supervised_and_denies_readonly ... FAILED
test result: FAILED. 0 passed; 2 failed
```

and both pass again once restored. Being precise about what that does and does not prove: the two **new** tests carry the whole proof. The two **edited** lists still pass under the revert — removing an entry from a list cannot fail — so they are a necessary consequence of the change, not evidence for it. I mention it because "I edited four tests" would otherwise read as four tests' worth of assurance, and it is two.

## Documentation

No doc change needed — `grep -rn "read_workspace_state" docs/` returns nothing; the classification is documented at the declaration site, which is where this table's reasoning lives by convention. The stopgap status, the upstream dependency and the revert condition are all recorded in the comment above the entry.
