### PR TITLE
workflows: consult ApprovalPolicy for tool_call nodes

### DIFF
--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -111,7 +111,7 @@
 //! task to cancel, no connection to close.
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 
 use crate::Result;
 use crate::company::load_workflow_union;
@@ -141,6 +141,14 @@ pub const PAYLOAD_INPUT: &str = "input";
 pub const PAYLOAD_DELIVERED: &str = "delivered";
 /// The payload key holding the plain-prose statement of what approving costs.
 pub const PAYLOAD_NOTE: &str = "note";
+/// The payload key holding the toolbelt slug a policy-gated `tool_call` node
+/// would run (issue #460). Absent on an authored `requires_approval` gate,
+/// which stops the run without any particular call behind it.
+pub const PAYLOAD_TOOL: &str = "tool";
+/// The payload key holding the policy's own words for why it stopped this call
+/// (issue #460) — the same sentence the agent path puts on its card. Absent for
+/// the same reason as [`PAYLOAD_TOOL`].
+pub const PAYLOAD_REASON: &str = "reason";
 
 /// The reserved trigger-input key the delivery ledger rides into a continuation
 /// run under (issue #438).
@@ -254,31 +262,51 @@ fn delivery_ledger(input: &Value, deliveries: &[DeliveryReport]) -> Vec<Delivere
 /// It is folded into the card's ledger rather than looked up later for the same
 /// reason the input is copied in: a card that needs a side table is a card that
 /// stops working after a restart.
+///
+/// `tool` is `Some((slug, reason))` when the company's `ApprovalPolicy` is what
+/// stopped this node (issue #460), and `None` for an authored
+/// `requires_approval` gate, where no particular call is being decided. It is
+/// deliberately outside the dedupe identity ([`is_same_gate`]): it describes the
+/// *same* decision in more words, so two cards that differ only here are still
+/// one question.
 pub fn gate_effect(
     workflow_id: &str,
     node_id: &str,
     input: &Value,
     run_id: &str,
     deliveries: &[DeliveryReport],
+    tool: Option<(&str, &str)>,
 ) -> Effect {
+    let mut payload = Map::new();
+    payload.insert(PAYLOAD_WORKFLOW_ID.to_string(), json!(workflow_id));
+    payload.insert(PAYLOAD_NODE_ID.to_string(), json!(node_id));
+    // The whole trigger input, so the parked card is self-contained and a
+    // resume needs nothing but the journal. This is what makes
+    // approve-after-restart work.
+    payload.insert(PAYLOAD_INPUT.to_string(), input.clone());
+    // What must NOT be sent again when this card is approved.
+    payload.insert(
+        PAYLOAD_DELIVERED.to_string(),
+        json!(delivery_ledger(input, deliveries)),
+    );
+    // What approving costs, in the operator's own terms.
+    payload.insert(PAYLOAD_NOTE.to_string(), json!(CONTINUATION_NOTE));
+    // Issue #460: which call the policy stopped, and why. The keys are ABSENT
+    // rather than null on an authored gate — a card that names no tool is a
+    // different thing from one whose tool could not be determined, and a
+    // console reading `payload.tool` should be able to tell them apart.
+    if let Some((slug, reason)) = tool {
+        payload.insert(PAYLOAD_TOOL.to_string(), json!(slug));
+        payload.insert(PAYLOAD_REASON.to_string(), json!(reason));
+    }
+
     Effect {
         kind: WORKFLOW_APPROVE_KIND.to_string(),
         group: crate::ports::types::EffectGroup::Other,
         amount_usd: None,
         established_thread: false,
         first_time_counterparty: false,
-        payload: serde_json::json!({
-            PAYLOAD_WORKFLOW_ID: workflow_id,
-            PAYLOAD_NODE_ID: node_id,
-            // The whole trigger input, so the parked card is self-contained and
-            // a resume needs nothing but the journal. This is what makes
-            // approve-after-restart work.
-            PAYLOAD_INPUT: input.clone(),
-            // What must NOT be sent again when this card is approved.
-            PAYLOAD_DELIVERED: delivery_ledger(input, deliveries),
-            // What approving costs, in the operator's own terms.
-            PAYLOAD_NOTE: CONTINUATION_NOTE,
-        }),
+        payload: Value::Object(payload),
         // Native, not a teammate's tool call — see the doc above.
         agent: None,
         // The run that paused. Not the run the approval will start (which does
@@ -529,7 +557,7 @@ mod tests {
     use super::*;
 
     fn effect(workflow: &str, node: &str, input: Value) -> Effect {
-        gate_effect(workflow, node, &input, "run-1", &[])
+        gate_effect(workflow, node, &input, "run-1", &[], None)
     }
 
     /// A delivery row with `status`, as `deliver_outputs` would have returned it.
@@ -661,6 +689,7 @@ mod tests {
                 delivery("owner_summary", "owner", DeliveryStatus::Sent),
                 delivery("cold_note", "email", DeliveryStatus::Pending),
             ],
+            None,
         );
         assert_eq!(
             ledger(&e),
@@ -693,6 +722,7 @@ mod tests {
                 &Value::Null,
                 "run-1",
                 &[delivery("summary", "owner", status)],
+                None,
             );
             assert!(
                 ledger(&e).is_empty(),
@@ -714,6 +744,7 @@ mod tests {
                 delivery("summary", "owner", DeliveryStatus::Sent),
                 delivery("summary", "owner", DeliveryStatus::Sent),
             ],
+            None,
         );
         assert_eq!(ledger(&e).len(), 1);
     }
@@ -728,6 +759,7 @@ mod tests {
             &serde_json::json!({ "request": "x" }),
             "run-1",
             &[delivery("summary", "owner", DeliveryStatus::Sent)],
+            None,
         );
 
         let input = continuation_input(&card).expect("a well-formed card continues");
@@ -760,11 +792,12 @@ mod tests {
             &serde_json::json!({ "request": "x" }),
             "run-1",
             &[delivery("summary", "owner", DeliveryStatus::Sent)],
+            None,
         );
         let continuation = continuation_input(&first).expect("continues");
 
         // Run 2 skips the summary (delivering nothing) and pauses on gate-b.
-        let second = gate_effect("digest", "gate-b", &continuation, "run-2", &[]);
+        let second = gate_effect("digest", "gate-b", &continuation, "run-2", &[], None);
         assert_eq!(
             ledger(&second),
             vec![DeliveredReport {
@@ -801,6 +834,7 @@ mod tests {
             &serde_json::json!({ "request": "x" }),
             "run-1",
             &[delivery("summary", "owner", DeliveryStatus::Sent)],
+            None,
         );
         // The same gate, re-reached by the continuation the card started: same
         // input plus the approval… minus the approval, which the gate node
@@ -810,7 +844,7 @@ mod tests {
             .as_object_mut()
             .expect("object")
             .remove("approvals");
-        let re_reached = gate_effect("digest", "gate", &continuation, "run-2", &[]);
+        let re_reached = gate_effect("digest", "gate", &continuation, "run-2", &[], None);
 
         assert!(
             is_same_gate(&paused, &re_reached),
@@ -1022,7 +1056,7 @@ mode = "full"
         input: Value,
         deliveries: &[DeliveryReport],
     ) -> ApprovalId {
-        let effect = gate_effect("gated", "gate", &input, "run-that-paused", deliveries);
+        let effect = gate_effect("gated", "gate", &input, "run-that-paused", deliveries, None);
         let id = rt
             .approvals
             .park(rt.id(), effect.clone())

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -1,0 +1,472 @@
+//! Issue #460: the company's [`ApprovalPolicy`] decides which `tool_call` nodes
+//! stop for an operator, before the run reaches them.
+//!
+//! # The hole this closes
+//!
+//! [`WorkflowToolInvoker::invoke`](super::caps) resolves a slug's grant
+//! namespace, checks it fail-closed against `[tools].allow`, looks the tool up
+//! and executes it. [`ApprovalPolicy`] is never consulted, so a `tool_call`
+//! node running `shell` or `http_request` on a `supervised` company produced no
+//! approval card, no recorded decision and no grant accounting — while the
+//! *same call* from an agent node in the *same graph* did, ever since #395.
+//!
+//! What was NOT missing is exec-security: `[policy].mode` has always fed
+//! [`toolbelt::exec_security`](crate::harness::toolbelt), which sets the
+//! autonomy tier, blocks high-risk commands and confines execution to the
+//! workflow workspace. That layer is untouched here. The gap was the
+//! operator-facing half, and this closes only that.
+//!
+//! # Why the gate is not in the invoker
+//!
+//! The obvious shape — consult the policy inside `invoke` and refuse — is
+//! wrong twice over, and both reasons are load-bearing.
+//!
+//! **It would be a regression, not a fix.** An agent node parks *after* a turn
+//! that already happened: openhuman resolves the refusal inline, the model is
+//! told no and narrates it, and the node still succeeds. A `tool_call` node has
+//! no turn — the call **is** the node — so a refusal fails the node, and
+//! `on_error` defaults to `stop`. Under the default `supervised` mode
+//! [`consequence_of`](crate::policy::consequence_of) puts `shell`,
+//! `http_request`, `curl`, `web_fetch`, `apply_patch`, `csv_export` and
+//! `git_operations` at [`Reach::Consequence`](crate::policy::Reach), so
+//! refusing in the invoker would break essentially every effectful `tool_call`
+//! node on every default-mode company.
+//!
+//! **The card could not be honoured.** Approving a harness-projected tool call
+//! mints a single-use [`GrantedCall`](crate::runtime::grants::GrantedCall) that
+//! is redeemed by re-dispatching *the agent that asked*. There is no agent on
+//! this path, so nothing would ever redeem it: the grant would expire on its
+//! TTL and the operator would be told the agent did not act, about a call no
+//! agent ever made.
+//!
+//! And the seam says so itself. [`ToolInvoker::invoke`](tinyflows::caps::ToolInvoker)
+//! receives `(slug, args, conn)` — no node id, no run state. It cannot name the
+//! node on a card, and on a continuation it could not recognise a call the
+//! operator had already approved. A fix that has to invent both does not belong
+//! there.
+//!
+//! # Where it goes instead
+//!
+//! One level up, where the host holds both facts. [`run_workflow_inner`] already
+//! translates the graph **per run**, and holds the [`CompanyRecord`] (the mode
+//! and the grants) — so the policy verdict is taken there and written onto the
+//! node as the engine's own `requires_approval` flag.
+//!
+//! That flag is a **generic per-node** gate in tinyflows, not a node kind: the
+//! engine checks it before the node's work and, once the node's id is listed in
+//! the run input's `approvals` array, falls through and executes the node
+//! normally. So a marked `tool_call` node inherits every piece #395 already
+//! built, unchanged:
+//!
+//! * the engine pauses before the tool runs, and reports the node on
+//!   `pending_approvals`;
+//! * [`park_pending_gates`](super::runner) turns that into a decidable card;
+//! * [`resume_from_effect`](crate::runtime::workflow_resume) re-runs the graph
+//!   with the approval in the trigger input, and the call executes;
+//! * the #438 delivery ledger stops the continuation re-sending reports.
+//!
+//! It also means the gate is visible **on the canvas**, which is the other half
+//! of what #460 complains about: two node kinds in one graph, governed
+//! differently, with nothing saying which is which.
+//!
+//! # This is not #561
+//!
+//! #460's acceptance criteria ask for suspend/resume, and the issue's Related
+//! section points at #561 as the expensive way to get it. That reading is
+//! wrong, and the correction matters for anyone scoping the neighbouring
+//! issues: #561 is expensive because the fail-closed block lives in
+//! **openhuman's turn loop**, and approving therefore costs a re-dispatch. The
+//! workflow path never enters that loop. A paused tinyflows run is *settled*,
+//! and #395 already shipped resume-by-re-run for exactly this shape.
+//!
+//! # Deliberate deviations, stated rather than quietly satisfied
+//!
+//! * **Standing grants cannot apply "identically on both paths"** (a criterion
+//!   in #460's body). A standing grant is scoped to a teammate
+//!   ([`admits_scope`](crate::runtime::grants::StandingGrant::admits_scope)) and
+//!   a `tool_call` node has no teammate — it acts as the company. This module
+//!   therefore matches grants against a synthetic `workflow:{id}` principal,
+//!   which nothing mints for today, so the answer is always **fail-closed**: a
+//!   teammate's standing grant does not open a workflow node's gate. Widening
+//!   that is a consent decision for the maintainer, not one to make by
+//!   defaulting.
+//! * **A `Deny` verdict is not enforced here.** Under `readonly`,
+//!   [`ApprovalPolicy::check`] denies external effects outright. Honouring that
+//!   would be a *new refusal* on a path that runs today, i.e. exactly the
+//!   regression argued against above, and #460 is explicit that exec-security
+//!   (which already applies the `readonly` autonomy tier) is not the gap. Only
+//!   `RequireApproval` gates.
+//! * **An authored `requires_approval = false` does not win.** The policy adds
+//!   a gate the author did not ask for; an author cannot opt their node out of
+//!   the company's approval policy.
+//! * **`sub_workflow` children are not gated.** tinyflows cannot resume a child
+//!   across the boundary (`nodes/integration/sub_workflow.rs`), and a paused
+//!   child *halts the parent* with an unresumable error. Gating a child would
+//!   convert a working run into a dead one with no card to decide, so children
+//!   keep today's behaviour. This is a real residual hole in #460 and it needs
+//!   engine work to close.
+//! * **Dry runs are not gated.** Every effect is stubbed
+//!   ([`dry_run`](super::caps)), so there is nothing to approve, and pausing
+//!   would stop a dry run from walking the rest of the graph — which is the one
+//!   thing it exists to do.
+
+use serde_json::{Value, json};
+use tinyflows::model::{NodeKind, WorkflowGraph};
+
+use oh::agent::tool_policy::{ToolCallContext, ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
+use openhuman_core::openhuman as oh;
+
+use crate::harness::policy::ApprovalPolicy;
+use crate::ports::types::CompanyRecord;
+
+/// One `tool_call` node the company's policy stopped, and why.
+///
+/// Carried from the gate pass to [`park_pending_gates`](super::runner) so the
+/// operator's card can name the tool and the reason rather than a bare node id
+/// — the complaint #468 makes about the Approvals tab.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct GatedToolCall {
+    /// The node the engine will pause on.
+    pub node_id: String,
+    /// The toolbelt slug that node would have run.
+    pub slug: String,
+    /// The policy's own words for why it stopped — the same string the agent
+    /// path puts on its card.
+    pub reason: String,
+}
+
+/// Marks every `tool_call` node whose call the company's [`ApprovalPolicy`]
+/// would park, so the engine stops the run there.
+///
+/// Returns what was gated, in graph order. An empty result leaves the graph
+/// byte-identical to what [`translate`](super::translate) produced, so a `full`
+/// company — and every existing test — runs exactly as it did before.
+///
+/// # The policy instance is deliberately unshared
+///
+/// [`ApprovalPolicy::check`] has a side effect: a `RequireApproval` verdict
+/// **pushes the projected effect onto its request queue** for the brain to park.
+/// That is right on the agent path and wrong here — the shared queue is drained
+/// by [`park_gated_calls`](super::caps) and the chat cycle, both of which would
+/// park a *second*, tool-call-shaped card for the same decision, and that one
+/// carries the un-redeemable grant described in this module's docs. So this
+/// builds its own policy over the default private queue nobody drains
+/// ([`ApprovalPolicy::new`]'s documented behaviour), takes the verdict, and
+/// drops it. The gate card is the only card.
+///
+/// Leaving the agent unbound is what makes the grant arms fail closed: both
+/// [`consume_grant`] and `standing_grant_allows` short-circuit on a policy with
+/// no agent, which is precisely the synthetic-principal decision this module's
+/// docs record. The context below names that principal so a log line says which
+/// workflow asked.
+pub(crate) async fn apply_tool_call_gates(
+    graph: &mut WorkflowGraph,
+    record: &CompanyRecord,
+    workflow_id: &str,
+    run_id: &str,
+) -> Vec<GatedToolCall> {
+    // The manifest's `[policy]` verbatim — same mode, same `always_approve`,
+    // same `auto_approve_under_usd` the roster runs under. No per-agent budget:
+    // a workflow node is not a teammate, and the company-wide ceiling is
+    // enforced elsewhere.
+    let policy = ApprovalPolicy::new(&record.manifest.policy, None);
+    let mut gated = Vec::new();
+
+    for node in &mut graph.nodes {
+        if node.kind != NodeKind::ToolCall {
+            continue;
+        }
+        // A `tool_call` without a slug fails in the engine's own node with a
+        // clear error; there is no call to classify, so leave it be.
+        let Some(slug) = node.config.get("slug").and_then(Value::as_str) else {
+            continue;
+        };
+        let args = node
+            .config
+            .get("args")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        let request = ToolPolicyRequest::new(
+            slug,
+            args,
+            ToolCallContext::session(
+                run_id,
+                "workflow",
+                workflow_principal(workflow_id),
+                &node.id,
+                0,
+            ),
+        );
+        // Only `RequireApproval` gates — see the module docs on `Deny`.
+        let ToolPolicyDecision::RequireApproval { reason } = policy.check(&request).await else {
+            continue;
+        };
+
+        let slug = slug.to_string();
+        tracing::debug!(
+            company = %record.id,
+            workflow = workflow_id,
+            node = %node.id,
+            tool = %slug,
+            "workflow tool_call: the company's policy stops this call for an operator"
+        );
+        // Written LAST and unconditionally: the policy's gate outranks an
+        // authored `requires_approval`, in both directions. An author may add a
+        // gate the policy does not require; they may not remove one it does.
+        if let Value::Object(config) = &mut node.config {
+            config.insert("requires_approval".to_string(), json!(true));
+        }
+        gated.push(GatedToolCall {
+            node_id: node.id.clone(),
+            slug,
+            reason,
+        });
+    }
+
+    gated
+}
+
+/// The synthetic principal a workflow `tool_call` acts as.
+///
+/// Not a roster teammate, and deliberately shaped so it can never collide with
+/// one: nothing mints a grant for it, so every grant arm in
+/// [`ApprovalPolicy::check`] fails closed. It exists to make the policy's own
+/// log lines name the workflow that asked. Mirrors the label
+/// [`build_capabilities`](super::caps) already stamps on this run's search
+/// metering.
+fn workflow_principal(workflow_id: &str) -> String {
+    format!("workflow:{workflow_id}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::types::CompanyId;
+    use tinyflows::model::Node;
+
+    /// A company record whose `[policy]` is the only thing under test.
+    ///
+    /// `always_approve` is written explicitly on every call — including as an
+    /// empty list — because the manifest default is NOT empty
+    /// ([`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE) is
+    /// `payment.send` / `filing.submit` / `external.publish`). Letting it
+    /// default would make these tests read as if the tier decided something the
+    /// always-approve list had actually decided.
+    fn company(mode: &str, always_approve: &[&str]) -> CompanyRecord {
+        let always = always_approve
+            .iter()
+            .map(|entry| format!("\"{entry}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let manifest = toml::from_str(&format!(
+            r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "{mode}"
+always_approve = [{always}]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+description = "Runs Acme."
+"#
+        ))
+        .expect("valid manifest");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    fn tool_node(id: &str, slug: &str) -> Node {
+        Node {
+            id: id.to_string(),
+            kind: NodeKind::ToolCall,
+            type_version: 1,
+            name: String::new(),
+            config: json!({ "slug": slug }),
+            ports: Vec::new(),
+            position: None,
+        }
+    }
+
+    fn graph(nodes: Vec<Node>) -> WorkflowGraph {
+        WorkflowGraph {
+            id: Some("wf".to_string()),
+            nodes,
+            ..WorkflowGraph::default()
+        }
+    }
+
+    fn gate_ids(graph: &WorkflowGraph) -> Vec<&str> {
+        graph
+            .nodes
+            .iter()
+            .filter(|n| n.config.get("requires_approval") == Some(&json!(true)))
+            .map(|n| n.id.as_str())
+            .collect()
+    }
+
+    /// The defect itself: on the default `supervised` mode a `shell` node runs
+    /// with no operator card. It must now stop.
+    #[tokio::test]
+    async fn a_consequential_call_gates_under_supervised() {
+        let mut g = graph(vec![tool_node("run-it", "shell")]);
+        let gated = apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+
+        assert_eq!(gate_ids(&g), ["run-it"]);
+        assert_eq!(gated.len(), 1);
+        assert_eq!(gated[0].slug, "shell");
+        assert_eq!(gated[0].node_id, "run-it");
+        assert!(
+            gated[0].reason.contains("shell"),
+            "the card must name the tool: {}",
+            gated[0].reason
+        );
+    }
+
+    /// `full` autonomy is the operator saying "don't ask me". The graph must
+    /// come out byte-identical, or this change would gate companies that opted
+    /// out of gating.
+    #[tokio::test]
+    async fn full_autonomy_leaves_the_graph_untouched() {
+        let before = graph(vec![tool_node("run-it", "shell")]);
+        let mut after = before.clone();
+        let gated = apply_tool_call_gates(&mut after, &company("full", &[]), "wf", "run-1").await;
+
+        assert!(gated.is_empty());
+        assert_eq!(after.nodes[0].config, before.nodes[0].config);
+    }
+
+    /// A pure read of the agent's own workspace is `Reach::Nothing`, and a
+    /// metered read is `Reach::Money` — neither parks under supervision. Gating
+    /// either would stop runs that have nothing to decide, and for `web_search`
+    /// it would be worse than useless: consent for it happens once, at grant
+    /// time, via an explicit `search` grant a `*` cannot confer.
+    #[tokio::test]
+    async fn a_plain_read_and_a_metered_read_do_not_gate() {
+        let mut g = graph(vec![
+            tool_node("read", "read_workspace_state"),
+            tool_node("search", "web_search"),
+        ]);
+        let gated = apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+
+        assert!(gated.is_empty(), "{gated:?}");
+        assert!(gate_ids(&g).is_empty());
+    }
+
+    /// `always_approve` outranks the tier, exactly as it does on the agent
+    /// path — so a company can gate a metered read it wants to be asked about
+    /// even though `supervised` alone would let it through.
+    #[tokio::test]
+    async fn always_approve_gates_a_call_the_tier_would_allow() {
+        let mut g = graph(vec![tool_node("search", "web_search")]);
+        let gated =
+            apply_tool_call_gates(&mut g, &company("full", &["web_search"]), "wf", "run-1").await;
+
+        assert_eq!(gate_ids(&g), ["search"]);
+        assert!(gated[0].reason.contains("always-approve"), "{gated:?}");
+    }
+
+    /// An author may add a gate the policy does not require; they may not
+    /// remove one it does. Fail-closed in the one direction that matters.
+    #[tokio::test]
+    async fn an_authored_opt_out_cannot_remove_a_policy_gate() {
+        let mut node = tool_node("run-it", "shell");
+        node.config = json!({ "slug": "shell", "requires_approval": false });
+        let mut g = graph(vec![node]);
+
+        apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+
+        assert_eq!(g.nodes[0].config["requires_approval"], json!(true));
+    }
+
+    /// Only `tool_call` nodes are touched. An `agent` node already parks
+    /// through #395's drain, and gating it here would park the same call twice.
+    #[tokio::test]
+    async fn other_node_kinds_are_never_gated() {
+        let mut agent = tool_node("think", "shell");
+        agent.kind = NodeKind::Agent;
+        let mut http = tool_node("fetch", "http_request");
+        http.kind = NodeKind::HttpRequest;
+        let mut g = graph(vec![agent, http]);
+
+        let gated = apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+
+        assert!(gated.is_empty(), "{gated:?}");
+        assert!(gate_ids(&g).is_empty());
+    }
+
+    /// A slugless `tool_call` has no call to classify; the engine's own node
+    /// reports it. Gating it would turn a clear authoring error into a card an
+    /// operator cannot act on.
+    #[tokio::test]
+    async fn a_slugless_tool_call_is_left_alone() {
+        let mut node = tool_node("broken", "shell");
+        node.config = json!({});
+        let mut g = graph(vec![node]);
+
+        let gated = apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;
+
+        assert!(gated.is_empty());
+        assert!(gate_ids(&g).is_empty());
+    }
+
+    /// The load-bearing assumption of gating at translate time: for every tool
+    /// a `tool_call` node can actually reach, the verdict is decided by the
+    /// tool NAME alone. Node `args` may still carry unresolved `=`-expressions
+    /// when this pass runs, so a tool whose classification depends on its
+    /// arguments (`composio_execute` is the existing one) would be classified
+    /// against a template and could be gated wrongly in either direction.
+    ///
+    /// None are reachable today — `WORKFLOW_TOOL_NAMESPACES` is `shell` /
+    /// `code` / `web` / `search`, and `composio` is not in it. This fails the
+    /// moment that stops being true, rather than letting a call slip the gate
+    /// silently. Same stance `web_search_is_still_a_priced_call` takes in
+    /// `consequence.rs`.
+    #[test]
+    fn every_reachable_workflow_tool_is_classified_by_name_alone() {
+        use crate::policy::consequence_of;
+
+        // Every tool the invoker wires, across all four reachable namespaces.
+        for slug in [
+            "shell",
+            "read_workspace_state",
+            "apply_patch",
+            "git_operations",
+            "csv_export",
+            "web_fetch",
+            "http_request",
+            "curl",
+            "image_info",
+            "web_search",
+        ] {
+            let bare = consequence_of(slug, &json!({}));
+            for args in [
+                json!({ "action": "GMAIL_SEND_EMAIL" }),
+                json!({ "amount_usd": 500.0 }),
+                json!({ "command": "=item.cmd" }),
+            ] {
+                let with_args = consequence_of(slug, &args);
+                assert_eq!(
+                    bare.reach, with_args.reach,
+                    "`{slug}` changes reach with args {args} — it can no longer be gated at \
+                     translate time, where args may still be unresolved templates"
+                );
+            }
+        }
+    }
+}

--- a/src/workflows/gated_tool_call_test.rs
+++ b/src/workflows/gated_tool_call_test.rs
@@ -1,0 +1,264 @@
+//! Issue #460 — end-to-end proof that a `tool_call` node the company's policy
+//! stops does not execute, and leaves a card the operator can decide.
+//!
+//! # Why a unit test could not have caught this
+//!
+//! The same reason #395's could not, one node kind over. Every part worked
+//! alone: [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) classified
+//! the call, the engine paused a `requires_approval` node, `park_pending_gates`
+//! wrote a card, and `resume_from_effect` re-ran the graph. What was missing was
+//! that **nothing ever asked the policy about a `tool_call` node** — the
+//! invoker resolved the grant namespace and executed. Green tests, and a `shell`
+//! call an operator was never asked about.
+//!
+//! So this drives the real path: real graph, real `run_workflow`, real
+//! translation, real [`WorkflowToolInvoker`](super::caps), real exec-security,
+//! real gate and real on-disk journal. Nothing is stubbed — there is no model
+//! in this graph to script, which is precisely what makes a `tool_call` node
+//! different from #395's agent node.
+//!
+//! # The company gates under `full`, deliberately
+//!
+//! `always_approve = ["shell"]` with `mode = "full"` rather than
+//! `mode = "supervised"`, and the choice is load-bearing twice over. It is the
+//! stronger claim — the call is stopped whatever the tier, so no reader can
+//! attribute the stop to the classifier. And it keeps **exec-security out of the
+//! way**: `supervised` sets `require_approval_for_medium_risk`, so a `shell`
+//! call could be refused by the toolbelt's own layer, and a test that cannot
+//! tell those two refusals apart proves nothing about this change. Under `full`
+//! autonomy the shell genuinely runs — as
+//! [`the_same_call_executes_when_the_policy_does_not_gate_it`] shows — so the
+//! only thing that can stop it is the gate this issue adds.
+
+use std::sync::Arc;
+
+use serde_json::json;
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::harness::HarnessPool;
+use crate::ports::WorkflowRunContext;
+use crate::ports::types::CompanyRecord;
+use crate::runtime::workflow_resume::{
+    PAYLOAD_NODE_ID, PAYLOAD_REASON, PAYLOAD_TOOL, PAYLOAD_WORKFLOW_ID, WORKFLOW_APPROVE_KIND,
+};
+
+/// A graph whose only working node is a `tool_call` running `shell`. The
+/// `marker` file it writes is how a test tells "the call was stopped" from "the
+/// call ran and the run stopped afterwards" — a distinction no assertion on the
+/// run outcome alone can make.
+const TOOL_GRAPH: &str = r#"
+id = "gated-tool"
+name = "Gated tool"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "tool_call"
+name = "Work"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo ran > marker.txt"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#;
+
+/// A company that grants `shell` and gates it — under `full` autonomy, for the
+/// reasons in this module's docs.
+fn manifest(always_approve: &str) -> CompanyManifest {
+    toml::from_str(&format!(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = [{always_approve}]
+
+[tools]
+allow = ["shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#
+    ))
+    .expect("manifest parses")
+}
+
+fn record(always_approve: &str) -> CompanyRecord {
+    CompanyRecord {
+        manifest: manifest(always_approve),
+        ..super::gated_tool_turn_test::record()
+    }
+}
+
+/// Runs the tool graph once and hands back the journal, the run and the
+/// workspace root the `shell` node wrote into.
+async fn run_tool_graph(
+    dir: &std::path::Path,
+    always_approve: &str,
+) -> (
+    Arc<crate::runtime::journal::RuntimeJournal>,
+    crate::ports::WorkflowRun,
+    String,
+) {
+    // A base URL nothing calls: this graph has no agent node, so no model is
+    // reached. Passing a dead address is the assertion — if a turn were
+    // dispatched, the run would fail rather than quietly succeed.
+    let (deps, journal) =
+        super::gated_tool_turn_test::deps("http://127.0.0.1:1/unused".to_string(), dir);
+    let record = record(always_approve);
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(TOOL_GRAPH).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    let run = super::runner::run_workflow(pool, deps.clone(), &record, &file, json!({}), &ctx)
+        .await
+        .expect("the run settles — a gated node pauses it, it does not error");
+    (journal, run, run_id)
+}
+
+/// Whether the `shell` node's side effect happened anywhere under the workspace
+/// root. The per-run workflow workspace is a hashed path, so this looks for the
+/// marker rather than reconstructing the directory name.
+fn marker_written(root: &std::path::Path) -> bool {
+    fn walk(dir: &std::path::Path) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if walk(&path) {
+                    return true;
+                }
+            } else if path.file_name().is_some_and(|n| n == "marker.txt") {
+                return true;
+            }
+        }
+        false
+    }
+    walk(root)
+}
+
+/// The headline. The call the operator would have been asked about on the agent
+/// path must now be asked about on the `tool_call` path — and must not have
+/// happened.
+#[tokio::test]
+async fn a_policy_gated_tool_call_node_parks_instead_of_running() {
+    let dir = tempfile::tempdir().unwrap();
+    let (journal, run, run_id) = run_tool_graph(dir.path(), "\"shell\"").await;
+
+    // 1. The engine stopped at the node rather than running it.
+    assert_eq!(
+        run.pending_approvals,
+        vec!["work".to_string()],
+        "the gated tool_call node must pause the run"
+    );
+
+    // 2. The side effect did NOT happen. This is the defect itself: before this
+    //    change the shell ran and nobody was asked.
+    assert!(
+        !marker_written(dir.path()),
+        "the gated shell call must not have executed"
+    );
+
+    // 3. There is a card, and it is decidable.
+    let pending = journal.pending();
+    let card = pending
+        .iter()
+        .find(|p| p.effect.kind == WORKFLOW_APPROVE_KIND)
+        .unwrap_or_else(|| panic!("the paused node should be on the Approvals page: {pending:?}"));
+
+    assert_eq!(card.effect.payload[PAYLOAD_WORKFLOW_ID], "gated-tool");
+    assert_eq!(card.effect.payload[PAYLOAD_NODE_ID], "work");
+    assert_eq!(
+        card.effect.run_id.as_deref(),
+        Some(run_id.as_str()),
+        "the card must name the run waiting on it"
+    );
+    // 4. Issue #460's own addition: the card says which call, and why. A bare
+    //    node id is the complaint #468 makes about this surface.
+    assert_eq!(
+        card.effect.payload[PAYLOAD_TOOL], "shell",
+        "the card must name the tool, not just the node"
+    );
+    assert!(
+        card.effect.payload[PAYLOAD_REASON]
+            .as_str()
+            .is_some_and(|reason| reason.contains("shell")),
+        "the card must carry the policy's own reason: {:?}",
+        card.effect.payload[PAYLOAD_REASON]
+    );
+}
+
+/// The other half of the claim, and the one that keeps this change from being a
+/// regression: when the policy does NOT gate the call, the node runs exactly as
+/// it did before. Without this, every assertion above is also satisfied by a
+/// change that simply broke `tool_call` nodes.
+#[tokio::test]
+async fn the_same_call_executes_when_the_policy_does_not_gate_it() {
+    let dir = tempfile::tempdir().unwrap();
+    // Same graph, same company, same `full` tier — the ONLY difference is that
+    // `shell` is no longer on the always-approve list.
+    let (journal, run, _) = run_tool_graph(dir.path(), "").await;
+
+    assert!(
+        run.pending_approvals.is_empty(),
+        "an ungated tool_call must not pause the run: {:?}",
+        run.pending_approvals
+    );
+    assert!(
+        marker_written(dir.path()),
+        "the ungated shell call must have executed"
+    );
+    assert!(
+        journal
+            .pending()
+            .iter()
+            .all(|p| p.effect.kind != WORKFLOW_APPROVE_KIND),
+        "an ungated run must leave no gate card"
+    );
+}
+
+/// A card is only decidable if approving it can actually continue the run.
+///
+/// The continuation itself is #395's machinery and is tested there; what is new
+/// here is the *card this change parks*, which carries two payload keys #395
+/// never wrote. This pins that the resume path still reads it — the integration
+/// risk a unit test of either half alone would miss.
+#[tokio::test]
+async fn the_parked_card_produces_a_continuation_that_approves_the_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let (journal, _run, _) = run_tool_graph(dir.path(), "\"shell\"").await;
+
+    let pending = journal.pending();
+    let card = pending
+        .iter()
+        .find(|p| p.effect.kind == WORKFLOW_APPROVE_KIND)
+        .expect("a gate card");
+
+    let input = crate::runtime::workflow_resume::continuation_input(&card.effect)
+        .expect("a policy-gated card is a well-formed continuation");
+    let approvals = input["approvals"]
+        .as_array()
+        .expect("the continuation carries an approvals array");
+    assert!(
+        approvals.iter().any(|id| id == "work"),
+        "the continuation must approve the node that paused: {input}"
+    );
+}

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -15,6 +15,13 @@
 
 pub mod caps;
 pub mod delivery;
+/// Issue #460: the company's `ApprovalPolicy` decides which `tool_call` nodes
+/// stop for an operator, before the run reaches them.
+pub mod gate;
+/// Issue #460: end-to-end proof that a `tool_call` node the company's policy
+/// stops does not execute, and leaves a decidable card.
+#[cfg(test)]
+mod gated_tool_call_test;
 /// Issue #395: end-to-end proof that a tool call gated inside a workflow agent
 /// node reaches the Approvals page and survives the next chat cycle.
 #[cfg(test)]

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -164,7 +164,22 @@ async fn run_workflow_inner(
     input: Value,
     ctx: &WorkflowRunContext,
 ) -> Result<WorkflowRun> {
-    let graph = super::translate::translate(workflow);
+    let mut graph = super::translate::translate(workflow);
+    // Issue #460: the company's `ApprovalPolicy` decides which `tool_call`
+    // nodes stop for an operator, and says so by marking them with the engine's
+    // own `requires_approval` flag — so a gated tool call inherits #395's whole
+    // pause → park → resume path instead of needing a second one. BEFORE
+    // `compile`, because the flag is read off the compiled node config.
+    //
+    // Skipped for a dry run: every effect is stubbed, so there is nothing to
+    // approve, and pausing would stop the dry run walking the rest of the graph
+    // — the one thing it exists to do. See `super::gate` for why the gate is
+    // not in the invoker, and for the deviations this takes deliberately.
+    let gated = if ctx.dry_run {
+        Vec::new()
+    } else {
+        super::gate::apply_tool_call_gates(&mut graph, record, &workflow.id, &ctx.run_id).await
+    };
     let compiled = tinyflows::compiler::compile(&graph).map_err(map_engine_error)?;
     // Issue #371: the caller's run id, not a freshly minted one. Correlating the
     // run's progress events with the `WorkflowRunFinished` the caller journals
@@ -467,9 +482,12 @@ async fn run_workflow_inner(
         record,
         &workflow.id,
         &run_id,
-        &trigger_input,
-        &outcome.pending_approvals,
-        &deliveries,
+        PausedGates {
+            trigger_input: &trigger_input,
+            pending: &outcome.pending_approvals,
+            deliveries: &deliveries,
+            gated: &gated,
+        },
     )
     .await;
 
@@ -480,6 +498,25 @@ async fn run_workflow_inner(
         cancelled: false,
         nodes,
     })
+}
+
+/// What a settled run left for the operator to decide.
+///
+/// Grouped rather than passed as four more parameters because they only make
+/// sense together: the gates the engine paused on, the input a continuation has
+/// to be started with, what this run already delivered (so approving does not
+/// re-send it), and which of those gates the company's policy raised rather
+/// than an author (issue #460), so the card can name the call.
+struct PausedGates<'a> {
+    /// The trigger payload the paused run was started with.
+    trigger_input: &'a Value,
+    /// The node ids the engine reported on `pending_approvals`.
+    pending: &'a [String],
+    /// What this run actually routed (issue #438).
+    deliveries: &'a [crate::ports::DeliveryReport],
+    /// The policy-raised gates, so a card can say which tool and why. An
+    /// authored gate has no entry here and its card stays as #395 shipped it.
+    gated: &'a [super::gate::GatedToolCall],
 }
 
 /// Parks one approval card per gate the run paused on (issue #395).
@@ -522,10 +559,14 @@ async fn park_pending_gates(
     record: &CompanyRecord,
     workflow_id: &str,
     run_id: &str,
-    trigger_input: &Value,
-    pending: &[String],
-    deliveries: &[crate::ports::DeliveryReport],
+    paused: PausedGates<'_>,
 ) {
+    let PausedGates {
+        trigger_input,
+        pending,
+        deliveries,
+        gated,
+    } = paused;
     if pending.is_empty() {
         return;
     }
@@ -545,12 +586,20 @@ async fn park_pending_gates(
     };
 
     for node_id in pending {
+        // Issue #460: when the policy is what stopped this node, the card says
+        // which tool and why. An authored gate carries neither — nobody asked a
+        // question on its behalf — so it stays exactly as #395 shipped it.
+        let tool = gated
+            .iter()
+            .find(|gate| gate.node_id == *node_id)
+            .map(|gate| (gate.slug.as_str(), gate.reason.as_str()));
         let effect = crate::runtime::workflow_resume::gate_effect(
             workflow_id,
             node_id,
             trigger_input,
             run_id,
             deliveries,
+            tool,
         );
         if crate::runtime::workflow_resume::already_parked(&parking.journal, &effect) {
             tracing::debug!(


### PR DESCRIPTION
## Summary

Closes #460. A workflow `tool_call` node now consults the company's `ApprovalPolicy`, so the call an operator would be asked about on the agent path is asked about here too — with a card that names the tool, and an approval that actually resumes the run.

**The gate is not in the invoker, and that is the design.** The obvious shape — check the policy inside `WorkflowToolInvoker::invoke` and refuse — is wrong twice over:

1. **It would be a regression, not a fix.** An agent node parks *after* a turn that already happened: openhuman resolves the refusal inline, the model narrates it, and the node still succeeds. A `tool_call` node has no turn — the call **is** the node — so a refusal fails the node, and `on_error` defaults to `stop`. Under the default `supervised` mode, `consequence.rs:198-213` puts `shell`, `http_request`, `curl`, `web_fetch`, `apply_patch`, `csv_export` and `git_operations` at `Reach::Consequence`. Refusing in the invoker would break essentially every effectful `tool_call` node on every default-mode company.
2. **The card could not be honoured.** Approving a harness-projected tool call mints a single-use `GrantedCall` redeemed by *re-dispatching the agent that asked*. There is no agent on this path, so nothing would redeem it: the grant would expire on its TTL and the operator would be told the agent did not act, about a call no agent ever made.

And the seam says so itself — `ToolInvoker::invoke(slug, args, conn)` carries no node id and no run state, so it can neither name the node on a card nor recognise an already-approved call on a continuation.

So the verdict is taken one level up, in `run_workflow_inner`, which already translates the graph **per run** and holds the record's mode and grants. A gated node is marked with the engine's own `requires_approval` flag — a **generic per-node** gate in tinyflows, not a node kind (`engine.rs:1091-1176`), which pauses before the node's work and, once the id is in the run input's `approvals` array, falls through and executes it normally. A marked `tool_call` node therefore inherits everything #395 already built, unchanged: pause → `park_pending_gates` → decidable card → `resume_from_effect` re-runs → the call executes, with the #438 delivery ledger stopping re-delivery.

A side benefit: the gate is now visible **on the canvas**, which is the other half of what #460 complains about — two node kinds in one graph, governed differently, with nothing saying which is which.

### Correction to the issue: this is not #561

#460's Related section implies suspend/resume needs #561's expensive fix. That reading is wrong, and it matters for anyone scoping the neighbouring issues. #561 is expensive because the fail-closed block lives in **openhuman's turn loop**, so approving costs a re-dispatch. The workflow path never enters that loop: a paused tinyflows run is *settled*, and #395 already shipped resume-by-re-run (`src/runtime/workflow_resume.rs`) for exactly this shape.

## API Or Behavior Changes

**Behavior.** On a company whose policy would park a call, a `tool_call` node making that call now pauses the run and raises an approval card instead of executing silently. A `full`-autonomy company with nothing on `always_approve` is byte-identical to before (pinned by a test).

**API.** `workflow_resume::gate_effect` takes a new `tool: Option<(&str, &str)>` argument, and writes two new optional payload keys, `PAYLOAD_TOOL` / `PAYLOAD_REASON`, so the card names the call and the policy's reason rather than a bare node id — the complaint #468 makes about that surface. The keys are **absent**, not null, on an authored gate, and are deliberately outside `is_same_gate`'s dedupe identity: they describe the same decision in more words.

### Deliberate deviations — stated rather than quietly satisfied

- **Standing grants cannot apply "identically on both paths"** (a criterion in the issue body). A standing grant is scoped to a teammate (`admits_scope`); a `tool_call` node has no teammate — it acts as the company. This matches grants against a synthetic `workflow:{id}` principal that nothing mints for, so the answer is always **fail-closed**: a teammate's standing grant does not open a workflow node's gate. Widening that is a consent decision, and it should be made deliberately rather than by defaulting.
- **Denial does not route through `on_error`** (also a criterion). `workflow_resume` deliberately makes a denied card a no-op — the paused run is already settled, so "nothing runs" is the complete outcome. The engine *does* support a `{"rejected": [node]}` continuation, so this is buildable; it is left matching #395 rather than diverging inside this PR.
- **A `Deny` verdict is not enforced.** Under `readonly`, `ApprovalPolicy::check` denies external effects outright. Honouring that here would be a *new refusal* on a path that runs today — the regression argued against above — and #460 is explicit that exec-security (which already applies the `readonly` autonomy tier) is not the gap. Only `RequireApproval` gates.
- **`sub_workflow` children are not gated.** tinyflows cannot resume a child across the boundary, and a paused child *halts the parent* with an unresumable error (`nodes/integration/sub_workflow.rs`). Gating a child would convert a working run into a dead one with no card to decide. **This is a real residual hole in #460** and closing it needs engine work.
- **Dry runs are not gated.** Every effect is stubbed, so there is nothing to approve, and pausing would stop a dry run walking the rest of the graph.
- **An authored `requires_approval = false` does not win.** An author may add a gate the policy does not require; they may not remove one it does.

**Exec-security is untouched.** `[policy].mode` still feeds `toolbelt::exec_security`, which sets the autonomy tier, blocks high-risk commands and confines execution to the workflow workspace. That layer was never the gap and is not loosened to make room.

### Found while doing this — not fixed here

`GuardedHttpClient::request` (`src/workflows/caps/http.rs:52-60`) calls `tool.execute(args)` with **no `ApprovalPolicy` consultation either**. So an `http_request` *node kind* reaches an arbitrary external address on a `supervised` company with no card — the identical hole, one capability over. It is out of scope for #460, whose title and table are about the `tool_call` path (a `tool_call` node whose slug is `http_request` **is** covered by this PR). Worth its own issue.

## Tests

Commands run locally, on the gated lane — the plain lane does not compile this code:

- [x] `cargo fmt --all -- --check` — run, `EXIT:0`.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's own gated form, `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, `EXIT:0`. (Without `--no-deps` it fails inside vendored `tinyagents` before reaching this crate — pre-existing and unrelated.) It caught a real defect in this diff: `park_pending_gates` had gone to 8 arguments, now grouped into a `PausedGates` struct.
- [x] `cargo build --all-targets` — ran `cargo check --features openhuman,tinycortex --all-targets` (the lane's own command, `--all-targets` so examples are covered).
- [x] `cargo test` — ran `cargo test --features openhuman,tinycortex`: **2743 passed, 0 failed**, `EXIT:0`. NOT the bare `cargo test`: default features skip this module entirely, so a bare run proves nothing about this change. That full run predates the clippy refactor above; after it I re-ran `workflows::` + `runtime::workflow_resume` (**251 passed, 0 failed**) plus fmt and clippy, and the full suite again.

New tests:

- `src/workflows/gate.rs` — unit tests on the verdict: a consequential call gates under `supervised`; `full` leaves the graph byte-identical; a plain read and a metered read do not gate; `always_approve` gates a call the tier would allow; an authored opt-out cannot remove a policy gate; other node kinds are never touched; a slugless node is left alone.
- `every_reachable_workflow_tool_is_classified_by_name_alone` — pins the load-bearing assumption of gating at translate time. Node `args` may still carry unresolved `=`-expressions when the pass runs, so a tool whose classification depends on its arguments could be gated wrongly in either direction. None is reachable today (`WORKFLOW_TOOL_NAMESPACES` excludes `composio`); this fails the moment that stops being true, rather than letting a call slip the gate silently. Same stance as `web_search_is_still_a_priced_call`.
- `src/workflows/gated_tool_call_test.rs` — end-to-end on the real path (real graph, real `run_workflow`, real translation, real `WorkflowToolInvoker`, real exec-security, real on-disk journal; nothing stubbed — there is no model in this graph):
  - the gated node pauses, **the shell side effect does not happen**, and a card is on the Approvals page naming workflow, node, run, tool and reason;
  - **the same call executes when the policy does not gate it** — without this, every other assertion is also satisfied by a change that simply broke `tool_call` nodes;
  - the parked card produces a continuation whose `approvals` array names the node, so approving it can actually resume.

The e2e company gates under `full` + `always_approve` rather than `supervised`, deliberately: it is the stronger claim, and it keeps exec-security out of the way (`supervised` sets `require_approval_for_medium_risk`, and a test that cannot tell those two refusals apart proves nothing about this change).

**Revert-and-check.** The fix was reverted (`apply_tool_call_gates` made an unconditional no-op — the pre-#460 behaviour) and the new tests re-run. **5 of the 11 failed**, which is the intended result, and the split is worth stating rather than rounding up to "they all fail":

*Fail with the fix reverted — these pin the defect:*
- `a_consequential_call_gates_under_supervised`
- `always_approve_gates_a_call_the_tier_would_allow`
- `an_authored_opt_out_cannot_remove_a_policy_gate`
- `a_policy_gated_tool_call_node_parks_instead_of_running`
- `the_parked_card_produces_a_continuation_that_approves_the_node`

*Pass with the fix reverted, by design — these are controls, not defect tests, and each exists to catch a change that over-gates:* `full_autonomy_leaves_the_graph_untouched`, `a_plain_read_and_a_metered_read_do_not_gate`, `other_node_kinds_are_never_gated`, `a_slugless_tool_call_is_left_alone`, `the_same_call_executes_when_the_policy_does_not_gate_it`, and `every_reachable_workflow_tool_is_classified_by_name_alone` (a guard on `consequence.rs`, independent of this code). A control that failed under revert would mean it was testing the wrong thing.

All four pre-existing #395 tests also pass under the revert, confirming this change does not quietly take over their behaviour.

**Not verified here:** the full approve→continuation→execute round trip through `resume_from_effect` against a live `CompanyRuntime`. That path is #395's and is unchanged by this PR; what is new is the *card*, and the third test pins that the resume path reads it.

### Cross-reference

#338's criterion "a run that would send, publish, pay or delete stops for approval regardless of mode" is unreachable on the `tool_call` path until this lands — this PR is what makes that one honest.

## Documentation

Module docs carry the reasoning: `src/workflows/gate.rs` documents why the gate is not in the invoker, why this is not #561, and every deviation above. `gate_effect`'s doc records why the new payload keys sit outside the dedupe identity.
