### PR TITLE
approvals: tell the operator when a turn's approval requests were dropped

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1972,7 +1972,9 @@ impl HarnessBrain {
             );
         }
 
-        let notice = drained.overflow_notice(cap);
+        // No `cap` argument: the drain carries the one it was taken against, so
+        // the sentence cannot name a limit this turn was not held to.
+        let notice = drained.overflow_notice();
         for request in drained.requests {
             match host.park_effect(request.effect).await {
                 Ok(approval_id) => log::info!(

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -5620,7 +5620,7 @@ members = ["eng1", "eng2"]
             None,
         )
         .with_requests(requests.clone());
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = crate::policy::test_support::composio_send_args();
         let request = ToolPolicyRequest::new(
             "composio_execute",
             args.clone(),
@@ -5856,7 +5856,14 @@ members = ["eng1", "eng2"]
         let log: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
         let requests = crate::harness::policy::ApprovalRequestQueue::default();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        // Issue #470: a real catalogued send, with the action's own parameters
+        // under `arguments` where the tool's schema puts them — so the
+        // re-dispatch path this test covers carries a call the classifier can
+        // actually read.
+        let args = crate::policy::test_support::composio_args_with(
+            crate::policy::test_support::COMPOSIO_SEND_SLUG,
+            serde_json::json!({ "to": "a@b.test" }),
+        );
         requests
             .grants()
             .grant(crate::runtime::grants::GrantedCall {

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1956,12 +1956,24 @@ impl HarnessBrain {
     /// already-computed operator reply along with it. That is precisely the
     /// silent-disappearance failure this issue exists to fix, so each failure is
     /// logged at `error` and the drain continues.
-    async fn park_approval_requests(&self, host: &dyn CycleHost) -> Result<()> {
-        for request in self
-            .deps
-            .approval_requests
-            .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN)
-        {
+    async fn park_approval_requests(&self, host: &dyn CycleHost) -> Result<Option<String>> {
+        let cap = crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
+        let drained = self.deps.approval_requests.drain(cap);
+
+        // Issue #561: the overflow used to end here, silently. The queue entries
+        // are already gone and the turn is over, so a log line is the only trace
+        // — and a log line is not something an operator reads. Kept loud for the
+        // operator's sake *and* returned, so the cycle can say it out loud.
+        if drained.discarded > 0 {
+            log::warn!(
+                "[harness::brain] {} gated tool call(s) past the per-turn cap of {cap} were \
+                 discarded and will not reach the operator",
+                drained.discarded
+            );
+        }
+
+        let notice = drained.overflow_notice(cap);
+        for request in drained.requests {
             match host.park_effect(request.effect).await {
                 Ok(approval_id) => log::info!(
                     "[harness::brain] parked '{}' for operator approval (id={approval_id}): {}",
@@ -1977,7 +1989,7 @@ impl HarnessBrain {
                 ),
             }
         }
-        Ok(())
+        Ok(notice)
     }
 
     /// Executes one drained delegation from the orchestrator's turn.
@@ -2294,7 +2306,23 @@ impl Brain for HarnessBrain {
         // Issue #172: every approval-gated tool call this cycle's turns hit is
         // parked on the host's gate now, so it shows up on the operator's
         // Approvals page instead of only being narrated away in chat.
-        self.park_approval_requests(host).await?;
+        //
+        // Issue #561: and if the turn gated more calls than one turn may raise,
+        // the operator is told so here rather than discovering it as silence.
+        // Pushed as its own bubble instead of appended to the reply above,
+        // because the reply is the agent's answer and this is the system saying
+        // the agent was cut off — and because a turn whose only outcome was
+        // overflow has no reply to append to.
+        if let Some(notice) = self.park_approval_requests(host).await? {
+            channel_responses.push(OutboundMessage {
+                message_id: None,
+                task_id: None,
+                channel: "operator".to_string(),
+                text: notice,
+                steps: Vec::new(),
+                reply_to: None,
+            });
+        }
 
         // The runtime requires at least one channel response per cycle.
         if channel_responses.is_empty() {
@@ -5683,6 +5711,99 @@ members = ["eng1", "eng2"]
             .await
             .expect("second drain");
         assert_eq!(host.parked().len(), 1, "parked once, not twice");
+    }
+
+    /// Issue #561: a turn that gates more calls than one turn may raise tells
+    /// the operator so, with the count.
+    ///
+    /// The cap itself is not the bug and is not touched here. The bug is that
+    /// exceeding it was **silent**: the operator saw eight cards and had no way
+    /// to learn that five more gated calls had happened, been refused, and been
+    /// dropped. Eight cards and no notice is indistinguishable from "eight is
+    /// all there was".
+    #[tokio::test]
+    async fn a_turn_that_overflows_the_cap_tells_the_operator_how_many_were_dropped() {
+        use crate::harness::policy::{ApprovalRequest, ApprovalRequestQueue};
+        use crate::ports::types::EffectGroup;
+
+        let cap = crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
+        let over = 5;
+
+        let dir = tempfile::tempdir().unwrap();
+        let requests = ApprovalRequestQueue::default();
+        let brain = brain_with_approval_queue(dir.path(), requests.clone());
+        for i in 0..(cap + over) {
+            requests.push(ApprovalRequest {
+                tool: "composio_execute".to_string(),
+                reason: "supervised".to_string(),
+                effect: Effect {
+                    kind: "composio_execute".to_string(),
+                    group: EffectGroup::Send,
+                    amount_usd: None,
+                    established_thread: false,
+                    first_time_counterparty: false,
+                    // Distinct payloads, or `push` would dedupe them and the
+                    // queue would never reach the cap in the first place.
+                    payload: crate::policy::test_support::composio_unclassified_args_numbered(i),
+                    agent: None,
+                    run_id: None,
+                },
+            });
+        }
+
+        let host = ParkingHost::default();
+        let notice = brain
+            .park_approval_requests(&host)
+            .await
+            .expect("drain")
+            .expect("an overflowing turn has something to tell the operator");
+
+        assert_eq!(host.parked().len(), cap, "the cap still holds");
+        assert!(
+            notice.contains(&over.to_string()),
+            "the operator is told HOW MANY were dropped, not just that some were: {notice}"
+        );
+        assert!(
+            notice.contains(&cap.to_string()),
+            "…and what the limit was, so the number means something: {notice}"
+        );
+    }
+
+    /// The ordinary turn stays quiet. A notice on every cycle would train the
+    /// operator to scroll past the one that matters.
+    #[tokio::test]
+    async fn a_turn_within_the_cap_raises_no_notice() {
+        use crate::harness::policy::{ApprovalRequest, ApprovalRequestQueue};
+        use crate::ports::types::EffectGroup;
+
+        let dir = tempfile::tempdir().unwrap();
+        let requests = ApprovalRequestQueue::default();
+        let brain = brain_with_approval_queue(dir.path(), requests.clone());
+        requests.push(ApprovalRequest {
+            tool: "composio_execute".to_string(),
+            reason: "supervised".to_string(),
+            effect: Effect {
+                kind: "composio_execute".to_string(),
+                group: EffectGroup::Send,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: crate::policy::test_support::composio_send_args(),
+                agent: None,
+                run_id: None,
+            },
+        });
+
+        let host = ParkingHost::default();
+        assert!(
+            brain
+                .park_approval_requests(&host)
+                .await
+                .expect("drain")
+                .is_none(),
+            "one request, a cap of 8: nothing was dropped and nothing is said"
+        );
+        assert_eq!(host.parked().len(), 1, "and the request itself still parks");
     }
 
     /// A host that fails to park the *first* effect it is handed, then behaves.

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -185,9 +185,37 @@ pub struct DrainedRequests {
     pub requests: Vec<ApprovalRequest>,
     /// How many were dropped for exceeding the cap. Zero on the ordinary path.
     pub discarded: usize,
+    /// The cap this drain was taken against.
+    ///
+    /// Kept rather than asked for again, so the notice cannot be rendered
+    /// against a different number than the one that did the discarding. A
+    /// caller holding a `DrainedRequests` from `drain(8)` could otherwise write
+    /// `overflow_notice(20)` and hand the operator a confidently-worded, wrong
+    /// sentence — the same shape of defect as the invisible discard this type
+    /// exists to fix, one level up. Private because the only honest value is
+    /// the one [`ApprovalRequestQueue::drain`] already had in hand.
+    cap: usize,
 }
 
 impl DrainedRequests {
+    /// A drain result, for callers that build one directly (tests, and any
+    /// future producer that is not the queue).
+    ///
+    /// Takes `cap` because rendering the notice needs it, and takes it *here*
+    /// so it arrives with the count it belongs to rather than at the sentence.
+    pub fn new(requests: Vec<ApprovalRequest>, discarded: usize, cap: usize) -> Self {
+        Self {
+            requests,
+            discarded,
+            cap,
+        }
+    }
+
+    /// The cap this drain was taken against.
+    pub fn cap(&self) -> usize {
+        self.cap
+    }
+
     /// The operator-facing sentence for a turn that overflowed the cap, or
     /// `None` when nothing was dropped.
     ///
@@ -199,9 +227,10 @@ impl DrainedRequests {
     /// discarded" alone invites the reading that the calls happened and only the
     /// records were lost; they did not happen, they were refused, and the only
     /// way to get them is to ask the agent again.
-    pub fn overflow_notice(&self, cap: usize) -> Option<String> {
+    pub fn overflow_notice(&self) -> Option<String> {
         (self.discarded > 0).then(|| {
             let n = self.discarded;
+            let cap = self.cap;
             let calls = if n == 1 { "call" } else { "calls" };
             let them = if n == 1 { "it" } else { "them" };
             format!(
@@ -254,6 +283,11 @@ impl ApprovalRequestQueue {
     /// caller that wants only the requests writes `.requests` and is at least
     /// choosing to; it can no longer happen by not knowing there was a second
     /// number.
+    ///
+    /// `cap` travels into the result rather than being asked for again when the
+    /// notice is rendered: the count and the number that produced it are then
+    /// one value, and a caller cannot pair a drain of eight with a sentence
+    /// that claims the limit is twenty.
     pub fn drain(&self, cap: usize) -> DrainedRequests {
         let mut guard = self.inner.lock().expect("approval request queue");
         let take = guard.len().min(cap);
@@ -263,6 +297,7 @@ impl ApprovalRequestQueue {
         DrainedRequests {
             requests,
             discarded,
+            cap,
         }
     }
 
@@ -1704,7 +1739,7 @@ mod tests {
             "12 gated calls, a cap of 8, so 4 were dropped"
         );
         let notice = drained
-            .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
+            .overflow_notice()
             .expect("an overflowing drain has something to tell the operator");
         assert!(
             notice.contains('4'),
@@ -1733,11 +1768,7 @@ mod tests {
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN - 1);
         assert_eq!(drained.discarded, 0);
-        assert!(
-            drained
-                .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
-                .is_none()
-        );
+        assert!(drained.overflow_notice().is_none());
     }
 
     /// Exactly at the cap is not an overflow. An off-by-one here would cry wolf
@@ -1756,25 +1787,49 @@ mod tests {
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(drained.discarded, 0);
-        assert!(
-            drained
-                .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
-                .is_none()
-        );
+        assert!(drained.overflow_notice().is_none());
     }
 
     /// One dropped request reads as one, not as "1 calls".
     #[test]
     fn the_overflow_notice_is_singular_for_a_single_dropped_request() {
-        let drained = DrainedRequests {
-            requests: Vec::new(),
-            discarded: 1,
-        };
-        let notice = drained
-            .overflow_notice(8)
-            .expect("one is still an overflow");
+        let drained = DrainedRequests::new(Vec::new(), 1, 8);
+        let notice = drained.overflow_notice().expect("one is still an overflow");
         assert!(notice.contains("1 further gated tool call "), "{notice}");
         assert!(!notice.contains("calls"), "{notice}");
+    }
+
+    /// The notice names the cap the drain was actually taken against, not one a
+    /// caller supplied later.
+    ///
+    /// `discarded` was always captured at drain time while `cap` arrived at the
+    /// sentence, so `drain(8)` followed by `overflow_notice(20)` produced a
+    /// confidently-worded, wrong number for the operator — the same class of
+    /// defect as the invisible discard #561 fixes. Storing it makes that
+    /// unrepresentable, and this pins that the stored value is the one used.
+    #[tokio::test]
+    async fn the_notice_quotes_the_cap_the_drain_was_taken_against() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        for i in 0..5 {
+            let _ = p
+                .check(&request(
+                    "composio_execute",
+                    composio_unclassified_args_numbered(i),
+                ))
+                .await;
+        }
+        let drained = queue.drain(3);
+        assert_eq!(drained.cap(), 3);
+        assert_eq!(drained.discarded, 2);
+        let notice = drained.overflow_notice().expect("2 were dropped");
+        assert!(
+            notice.contains("at most 3"),
+            "the sentence must quote the cap that did the discarding: {notice}"
+        );
+        assert!(
+            !notice.contains(&MAX_APPROVAL_REQUESTS_PER_TURN.to_string()),
+            "and not the constant the call site happened to have in scope: {notice}"
+        );
     }
 
     // --- Redeeming a grant (issue #243) --------------------------------------

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1484,6 +1484,66 @@ mod tests {
         );
     }
 
+    /// Issue #559, at the gate an agent actually hits: a Composio read runs
+    /// under `supervised` instead of parking, and nothing is queued for a
+    /// human — while a send on the same tool still parks.
+    ///
+    /// This is the behaviour the issue is about. `a_composio_read_and_a_
+    /// composio_send_are_classified_differently` above pins what the two calls
+    /// *are*; this pins what the desk *does* with them, which is the part an
+    /// operator notices when every page of a mailbox raises a card.
+    #[tokio::test]
+    async fn a_composio_read_runs_under_supervision_without_parking() {
+        let (p, queue) = queued_policy("supervised", &[]);
+
+        assert_eq!(
+            p.check(&request("composio_execute", composio_read_args()))
+                .await,
+            ToolPolicyDecision::Allow,
+            "reading a connected account changes nothing and costs nothing"
+        );
+        assert_eq!(
+            queue.queued(),
+            0,
+            "no card was raised, so no human was interrupted"
+        );
+
+        // Paging the same list is not a second decision, because there was
+        // never a first one. This is the symptom the issue opens with.
+        for _ in 0..5 {
+            let _ = p
+                .check(&request("composio_execute", composio_read_args()))
+                .await;
+        }
+        assert_eq!(queue.queued(), 0);
+
+        // The send half is untouched: same tool, same desk, still parks.
+        assert!(matches!(
+            p.check(&request("composio_execute", composio_send_args()))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(queue.queued(), 1);
+    }
+
+    /// A `readonly` desk still denies the read. That tier's contract is that
+    /// nothing outside the company is reached at all — #559 moves the read out
+    /// of the parking bucket, not out of the reaching-outward one.
+    #[tokio::test]
+    async fn a_readonly_desk_still_denies_a_composio_read() {
+        let p = policy("readonly", &[], None);
+        assert!(matches!(
+            p.check(&request("composio_execute", composio_read_args()))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+        assert!(matches!(
+            p.check(&request("composio_execute", composio_send_args()))
+                .await,
+            ToolPolicyDecision::Deny { .. }
+        ));
+    }
+
     /// `always_approve` parks regardless of tier — including under `full` — so
     /// that arm has to record its request too.
     #[tokio::test]
@@ -2896,11 +2956,25 @@ mod tests {
         );
     }
 
-    /// Issue #457, through the real admission path. Re-classifying the live
-    /// action (the test above) separates a read from a send; it cannot separate
-    /// one provider's read from another's, because both are reads under the same
-    /// tool name for the same teammate. The card said "read from GitHub" and the
-    /// grant has to mean that.
+    /// Issue #457's scope check, pinned **directly** rather than through
+    /// `check()`.
+    ///
+    /// It used to run through the real admission path, asserting that a grant
+    /// scoped to `github` admitted a GitHub read and re-parked a Gmail one.
+    /// Issue #559 made that unobservable from `check()`, and the honest thing
+    /// is to say so rather than relax the assertion until it passes:
+    ///
+    /// * under `supervised` a catalogue read no longer parks at all, so it is
+    ///   allowed by the tier long before the scope is consulted;
+    /// * under `readonly` the brake at step 1 denies every external effect
+    ///   *above* the grant checks, so the scope is not consulted there either;
+    /// * under `full` everything is allowed.
+    ///
+    /// So `standing_grant_allows` is still correct and still worth pinning —
+    /// this test does that — but no tier currently routes a Composio read to
+    /// it. See the note in the PR for #559; the issue's claim that
+    /// `Standing::Grantable` "still governs `readonly`" does not hold against
+    /// the ordering in `check()`.
     #[tokio::test]
     async fn a_grant_scoped_to_one_provider_does_not_admit_another_providers_read() {
         let queue = ApprovalRequestQueue::default();
@@ -2916,41 +2990,47 @@ mod tests {
         ));
 
         // A *different* GitHub read: the operator consented to the provider, so
-        // this is inside the sentence and must keep running. Scoping by action
-        // slug instead would have re-parked here and made the grant worthless.
-        assert_eq!(
-            p.check(&request(
+        // this is inside the sentence. Scoping by action slug instead would
+        // have refused here and made the grant worthless.
+        assert!(
+            p.standing_grant_allows(
                 "composio_execute",
-                serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" })
-            ))
-            .await,
-            ToolPolicyDecision::Allow
+                &composio_args("GITHUB_LIST_PULL_REQUESTS")
+            ),
+            "the operator consented to a provider, not to one action slug"
         );
 
         // A mailbox read. Also a catalogue read, also grantable, also `ops`,
-        // also `composio_execute` — every check upstream of the scope says yes.
+        // also `composio_execute` — every check upstream of the scope says yes,
+        // and the scope is the one thing that says no.
         assert!(
-            matches!(
-                p.check(&request(
-                    "composio_execute",
-                    serde_json::json!({ "tool": "GMAIL_FETCH_EMAILS" })
-                ))
-                .await,
-                ToolPolicyDecision::RequireApproval { .. }
-            ),
+            !p.standing_grant_allows("composio_execute", &composio_args("GMAIL_FETCH_EMAILS")),
             "'read from GitHub' is not consent to read the company's mail"
         );
 
-        // An action the catalogue cannot place has no scope to compare, so the
-        // scoped grant refuses it and it parks — unknown is a send, here too.
+        // An action the catalogue cannot place carries no scope, so a scoped
+        // grant refuses it — unknown is a send, here too.
+        assert!(
+            !p.standing_grant_allows("composio_execute", &composio_unclassified_args()),
+            "an unplaceable action has no scope for a scoped grant to admit"
+        );
+
+        // Through the real gate, the unknown action still parks: it is a send,
+        // so the tier does not wave it through and the scoped grant will not
+        // admit it either. This half of the original test survives #559
+        // unchanged, because only the *read* branch moved.
         assert!(matches!(
-            p.check(&request(
-                "composio_execute",
-                serde_json::json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" })
-            ))
-            .await,
+            p.check(&request("composio_execute", composio_unclassified_args()))
+                .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
+
+        // Deliberately NOT asserting `check(read) == Allow` here. It would pass
+        // whether or not #559 landed — this policy holds a standing grant that
+        // admits a GitHub read at step 2b, so the tier never gets a say, and
+        // the assertion would prove nothing while looking like it proved the
+        // change. `a_composio_read_runs_under_supervision_without_parking` is
+        // the test for that, and it uses a policy with no grant at all.
 
         assert_eq!(
             grants.standing_count(),

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -172,6 +172,48 @@ pub struct ApprovalRequestQueue {
     grants: GrantSet,
 }
 
+/// What one cycle-end drain took, and what it threw away (issue #561).
+///
+/// Two numbers rather than one, because the second one is the one an operator
+/// needs and never got: `requests` is what they will be asked about, and
+/// `discarded` is how many gated calls this turn made that they will **not** be
+/// asked about and cannot discover any other way — the queue entries are gone
+/// and the turn that produced them is over.
+#[derive(Debug, Default)]
+pub struct DrainedRequests {
+    /// The requests to park, oldest first, at most `cap` of them.
+    pub requests: Vec<ApprovalRequest>,
+    /// How many were dropped for exceeding the cap. Zero on the ordinary path.
+    pub discarded: usize,
+}
+
+impl DrainedRequests {
+    /// The operator-facing sentence for a turn that overflowed the cap, or
+    /// `None` when nothing was dropped.
+    ///
+    /// Lives here rather than at the call site so the chat drain and any future
+    /// consumer word it the same way, and so the count and the sentence cannot
+    /// drift apart.
+    ///
+    /// It deliberately says what the operator must do about it. "Requests were
+    /// discarded" alone invites the reading that the calls happened and only the
+    /// records were lost; they did not happen, they were refused, and the only
+    /// way to get them is to ask the agent again.
+    pub fn overflow_notice(&self, cap: usize) -> Option<String> {
+        (self.discarded > 0).then(|| {
+            let n = self.discarded;
+            let calls = if n == 1 { "call" } else { "calls" };
+            let them = if n == 1 { "it" } else { "them" };
+            format!(
+                "Heads up: {n} further gated tool {calls} from this turn were not raised for \
+                 approval. A single turn can raise at most {cap}, and {n} more needed your \
+                 sign-off than that. They were **not** run and they are **not** on the \
+                 Approvals page — ask the agent again to get {them} back."
+            )
+        })
+    }
+}
+
 impl ApprovalRequestQueue {
     /// Records a gated call, ignoring one already queued for the same tool and
     /// arguments.
@@ -197,12 +239,31 @@ impl ApprovalRequestQueue {
 
     /// Drains up to `cap` queued requests (FIFO) and discards the rest, so one
     /// turn can never flood the operator's queue.
-    pub fn drain(&self, cap: usize) -> Vec<ApprovalRequest> {
+    ///
+    /// # Why this returns a struct rather than a `Vec`
+    ///
+    /// The discard is the whole point of the cap and it used to be invisible:
+    /// this method dropped the overflow on the floor and handed back a `Vec`
+    /// that looked exactly like a complete one. A caller could not tell a turn
+    /// that parked everything from a turn that parked eight of thirteen, so the
+    /// operator was shown eight cards and no indication that five more calls had
+    /// been gated — a queue that quietly truncates reads as "nothing else needed
+    /// approving", which is the opposite of true (issue #561).
+    ///
+    /// Returning [`DrainedRequests`] makes the overflow part of the value. A
+    /// caller that wants only the requests writes `.requests` and is at least
+    /// choosing to; it can no longer happen by not knowing there was a second
+    /// number.
+    pub fn drain(&self, cap: usize) -> DrainedRequests {
         let mut guard = self.inner.lock().expect("approval request queue");
         let take = guard.len().min(cap);
-        let drained: Vec<ApprovalRequest> = guard.drain(..take).collect();
+        let requests: Vec<ApprovalRequest> = guard.drain(..take).collect();
+        let discarded = guard.len();
         guard.clear();
-        drained
+        DrainedRequests {
+            requests,
+            discarded,
+        }
     }
 
     /// Splits off every request queued **at or after** `from`, leaving the ones
@@ -1412,7 +1473,7 @@ mod tests {
             ToolPolicyDecision::RequireApproval { .. }
         ));
 
-        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN).requests;
         assert_eq!(queued.len(), 1, "the gated call was recorded");
         assert_eq!(queued[0].tool, "composio_execute");
         assert_eq!(queued[0].effect.kind, "composio_execute");
@@ -1474,7 +1535,7 @@ mod tests {
         // group asserted above is the one the operator's card is built from.
         let (p, queue) = queued_policy("supervised", &[]);
         let _ = p.check(&request("composio_execute", send.clone())).await;
-        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN).requests;
         assert_eq!(queued.len(), 1);
         assert_eq!(queued[0].effect.group, EffectGroup::Send);
         assert_eq!(
@@ -1557,7 +1618,7 @@ mod tests {
             .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
-        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN).requests;
         assert_eq!(queued.len(), 1);
         assert_eq!(queued[0].effect.kind, "payment.send");
         assert_eq!(queued[0].effect.amount_usd, Some(40.0));
@@ -1633,8 +1694,87 @@ mod tests {
                 .await;
         }
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
-        assert_eq!(drained.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
         assert_eq!(queue.queued(), 0, "the overflow is discarded, not carried");
+
+        // Issue #561: and the drain says how many it threw away, rather than
+        // handing back a `Vec` indistinguishable from a complete one.
+        assert_eq!(
+            drained.discarded, 4,
+            "12 gated calls, a cap of 8, so 4 were dropped"
+        );
+        let notice = drained
+            .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
+            .expect("an overflowing drain has something to tell the operator");
+        assert!(
+            notice.contains('4'),
+            "the count is in the sentence: {notice}"
+        );
+        assert!(
+            notice.contains("not** run") || notice.contains("not run"),
+            "the operator must not read this as 'the calls happened, the records \
+             were lost': {notice}"
+        );
+    }
+
+    /// The ordinary path says nothing. A notice on every turn would train the
+    /// operator to ignore the one that matters.
+    #[tokio::test]
+    async fn a_drain_under_the_cap_reports_no_overflow() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        for i in 0..(MAX_APPROVAL_REQUESTS_PER_TURN - 1) {
+            let _ = p
+                .check(&request(
+                    "composio_execute",
+                    composio_unclassified_args_numbered(i),
+                ))
+                .await;
+        }
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN - 1);
+        assert_eq!(drained.discarded, 0);
+        assert!(
+            drained
+                .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
+                .is_none()
+        );
+    }
+
+    /// Exactly at the cap is not an overflow. An off-by-one here would cry wolf
+    /// on the commonest boundary case.
+    #[tokio::test]
+    async fn a_drain_exactly_at_the_cap_reports_no_overflow() {
+        let (p, queue) = queued_policy("supervised", &[]);
+        for i in 0..MAX_APPROVAL_REQUESTS_PER_TURN {
+            let _ = p
+                .check(&request(
+                    "composio_execute",
+                    composio_unclassified_args_numbered(i),
+                ))
+                .await;
+        }
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(drained.requests.len(), MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(drained.discarded, 0);
+        assert!(
+            drained
+                .overflow_notice(MAX_APPROVAL_REQUESTS_PER_TURN)
+                .is_none()
+        );
+    }
+
+    /// One dropped request reads as one, not as "1 calls".
+    #[test]
+    fn the_overflow_notice_is_singular_for_a_single_dropped_request() {
+        let drained = DrainedRequests {
+            requests: Vec::new(),
+            discarded: 1,
+        };
+        let notice = drained
+            .overflow_notice(8)
+            .expect("one is still an overflow");
+        assert!(notice.contains("1 further gated tool call "), "{notice}");
+        assert!(!notice.contains("calls"), "{notice}");
     }
 
     // --- Redeeming a grant (issue #243) --------------------------------------
@@ -1923,7 +2063,7 @@ mod tests {
 
         assert_eq!(queue.stamp_run(boundary, "run-1"), 2);
 
-        let drained = queue.drain(10);
+        let drained = queue.drain(10).requests;
         assert_eq!(drained.len(), 3);
         assert_eq!(
             drained[0].effect.run_id, None,
@@ -1984,7 +2124,7 @@ mod tests {
             "the chat cycle's entry is still queued for its own drain"
         );
         assert_eq!(
-            queue.drain(10)[0].tool,
+            queue.drain(10).requests[0].tool,
             "chat.thing",
             "…and it is the same entry, not a survivor of a clear-and-rebuild"
         );

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -950,6 +950,15 @@ mod tests {
     use super::*;
     use oh::agent::tool_policy::{ToolCallContext, ToolPolicyRequest};
 
+    // Issue #470: the `composio_execute` fixtures are built here, from the same
+    // key the classifier reads, so a call in a test reaches the same catalogue
+    // lookup a call in production does.
+    use crate::policy::test_support::{
+        COMPOSIO_OTHER_SEND_SLUG, COMPOSIO_READ_SLUG, COMPOSIO_SEND_SLUG, composio_args,
+        composio_read_args, composio_send_args, composio_unclassified_args,
+        composio_unclassified_args_numbered,
+    };
+
     fn policy(mode: &str, always: &[&str], auto_under: Option<f64>) -> ApprovalPolicy {
         let p = Policy {
             mode: mode.to_string(),
@@ -1397,7 +1406,7 @@ mod tests {
     #[tokio::test]
     async fn require_approval_records_the_request_to_park() {
         let (p, queue) = queued_policy("supervised", &[]);
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         assert!(matches!(
             p.check(&request("composio_execute", args.clone())).await,
             ToolPolicyDecision::RequireApproval { .. }
@@ -1413,6 +1422,65 @@ mod tests {
             queued[0].reason.contains("supervised"),
             "the operator-facing reason rides along: {}",
             queued[0].reason
+        );
+    }
+
+    /// Issue #470, at the layer that projects a blocked call onto the effect
+    /// the operator's card is built from.
+    ///
+    /// The fixtures above used to name their action under a key nothing reads,
+    /// so every Composio test in this module classified through the
+    /// unknown-is-a-send fallback and none of them ever reached the catalogue.
+    /// Read and send came out identical, and a regression in the split would
+    /// have failed nothing here. This asserts they come out different, and
+    /// asserts the classification rather than the parking decision — so it
+    /// stays honest across issue #559, which changes whether a read parks but
+    /// not what it is.
+    #[tokio::test]
+    async fn a_composio_read_and_a_composio_send_are_classified_differently() {
+        let read = composio_read_args();
+        let send = composio_send_args();
+
+        assert_eq!(
+            classify_group("composio_execute", &read),
+            EffectGroup::Other,
+            "`{COMPOSIO_READ_SLUG}` is tagged `Read` in the vendored catalogue; \
+             if this fails the lookup is not being reached"
+        );
+        assert!(
+            grantable("composio_execute", &read),
+            "a read scoped to one connected account is what a standing grant \
+             can honestly describe"
+        );
+
+        assert_eq!(
+            classify_group("composio_execute", &send),
+            EffectGroup::Send,
+            "`{COMPOSIO_SEND_SLUG}` is tagged `Write`"
+        );
+        assert!(!grantable("composio_execute", &send));
+
+        // The cautious fallback still has its own coverage, and still says
+        // send — but now because the catalogue was asked and had no answer,
+        // not because the classifier never saw an action at all.
+        let unknown = composio_unclassified_args();
+        assert_eq!(
+            classify_group("composio_execute", &unknown),
+            EffectGroup::Send
+        );
+        assert!(!grantable("composio_execute", &unknown));
+
+        // And the split survives the round trip through the park queue: the
+        // group asserted above is the one the operator's card is built from.
+        let (p, queue) = queued_policy("supervised", &[]);
+        let _ = p.check(&request("composio_execute", send.clone())).await;
+        let queued = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        assert_eq!(queued.len(), 1);
+        assert_eq!(queued[0].effect.group, EffectGroup::Send);
+        assert_eq!(
+            queued[0].effect.payload, send,
+            "the card shows the arguments the agent actually sent, action key \
+             included"
         );
     }
 
@@ -1467,23 +1535,32 @@ mod tests {
     #[tokio::test]
     async fn a_retried_call_is_recorded_once() {
         let (p, queue) = queued_policy("supervised", &[]);
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         for _ in 0..3 {
             let _ = p.check(&request("composio_execute", args.clone())).await;
         }
         assert_eq!(queue.queued(), 1, "the same call parks once");
 
-        // A different call to the same tool is a distinct request.
+        // A different call to the same tool is a distinct request. Another
+        // catalogued send, so the second call is classified rather than merely
+        // unrecognised.
         let _ = p
             .check(&request(
                 "composio_execute",
-                serde_json::json!({ "tool_slug": "SLACK_POST" }),
+                composio_args(COMPOSIO_OTHER_SEND_SLUG),
             ))
             .await;
         assert_eq!(queue.queued(), 2);
     }
 
     /// The drain is capped, so a runaway turn can't flood the operator's queue.
+    ///
+    /// The slugs here are deliberately uncatalogued (issue #470): this test
+    /// wants many calls the queue treats as distinct and is indifferent to what
+    /// any of them classify as, so naming real actions would only invite a
+    /// reader to think the classification mattered. They do still land under
+    /// the real action key, so each one reaches the catalogue lookup and misses
+    /// it — the honest fallback, rather than a call carrying no action at all.
     #[tokio::test]
     async fn the_drain_is_capped_and_empties_the_queue() {
         let (p, queue) = queued_policy("supervised", &[]);
@@ -1491,7 +1568,7 @@ mod tests {
             let _ = p
                 .check(&request(
                     "composio_execute",
-                    serde_json::json!({ "tool_slug": format!("TOOL_{i}") }),
+                    composio_unclassified_args_numbered(i),
                 ))
                 .await;
         }
@@ -1538,7 +1615,7 @@ mod tests {
     #[tokio::test]
     async fn a_granted_call_is_allowed_once_and_then_parks_again() {
         let (p, grants) = granting_policy("supervised", &[], "finance");
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         grants.grant(granted("finance", "composio_execute", args.clone()));
 
         assert_eq!(
@@ -1593,7 +1670,7 @@ mod tests {
     #[tokio::test]
     async fn a_grant_does_not_travel_to_another_agent() {
         let (marketing, grants) = granting_policy("supervised", &[], "marketing");
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         // The grant belongs to `finance`.
         grants.grant(granted("finance", "composio_execute", args.clone()));
 
@@ -1727,7 +1804,7 @@ mod tests {
     fn grants_survive_a_queue_clear() {
         let queue = ApprovalRequestQueue::default();
         let grants = queue.grants();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" });
+        let args = composio_send_args();
         grants.grant(crate::runtime::grants::GrantedCall {
             approval_id: crate::ports::types::ApprovalId::new("appr-1"),
             agent: "finance".into(),

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -148,7 +148,13 @@ pub const COMPOSIO_EXECUTE: &str = "composio_execute";
 
 /// The argument key `composio_execute` carries the action slug under, on the
 /// wire and in both this crate's tool and openhuman's.
-const COMPOSIO_ACTION_KEY: &str = "tool";
+///
+/// `pub(crate)` so the test fixtures in
+/// [`crate::policy::test_support`] build their arguments from the same constant
+/// this classifier reads. Issue #470: fixtures across five modules hard-coded a
+/// key of their own, the two drifted apart, and every one of those tests
+/// silently stopped reaching the catalogue lookup it claimed to cover.
+pub(crate) const COMPOSIO_ACTION_KEY: &str = "tool";
 
 /// Every tool this crate can wire onto an agent, and what it can reach.
 ///

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -68,6 +68,8 @@ use crate::ports::types::EffectGroup;
 ///   #238): it changes nothing but the backend bills per request, and parking
 ///   it would be worse than useless — openhuman resolves a `RequireApproval`
 ///   inline, so a parked search is a search that never happens.
+///   [`ExternalRead`](Self::ExternalRead) is the fourth (issue #559), for the
+///   same reason with the billing removed.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Reach {
     /// Nothing changes and nothing is spent. Runs in every mode, `readonly`
@@ -76,6 +78,18 @@ pub enum Reach {
     /// Nothing changes, but the call is billed. Runs under `supervised`,
     /// denied under `readonly`.
     Money,
+    /// A third party's own data is read with the company's connected
+    /// credential. Nothing changes anywhere and nothing is billed, but the
+    /// account being read is not the company's own — so `supervised` allows it
+    /// and `readonly` still denies it (issue #559).
+    ///
+    /// Distinct from [`Money`](Self::Money) rather than folded into it, and the
+    /// reason is [`costs_money`](Self::costs_money): that predicate feeds the
+    /// daily spend cap, so reusing `Money` here would bill an operator for
+    /// every page of every mailbox they read. Distinct from
+    /// [`Nothing`](Self::Nothing) because a `readonly` desk reaching into a
+    /// counterparty's account is exactly what that tier promises not to do.
+    ExternalRead,
     /// State changes, a counterparty is reached, arbitrary code runs, an
     /// arbitrary address is reached, or operator-owned guidance is overwritten.
     /// Parks under `supervised`, denied under `readonly`.
@@ -410,13 +424,22 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
         return send;
     };
     if composio_action_is_read(slug) {
-        // A read still reaches a third-party account, so `readonly` denies it
-        // and `supervised` parks it the first time. What changes is that the
-        // operator now has something to say other than yes-again: the card
-        // offers a standing scope, and the reads stop asking for its duration.
+        // A read reaches a third-party account, so `readonly` denies it — but
+        // it changes nothing and is billed for nothing, so `supervised` lets it
+        // through (issue #559).
+        //
+        // It used to be `Reach::Consequence`, which parks. The intent was that
+        // the operator consent once and grant a standing scope; the effect was
+        // that checking a mailbox interrupted a person, refused the call and
+        // dead-ended the turn — per page, per list. A first-time park is not a
+        // cheap price for a read, it is the whole cost.
+        //
+        // `Standing::Grantable` stays. It stops mattering for `supervised` now
+        // that nothing parks there, but it still governs `readonly` and any
+        // tier added later.
         Consequence {
             group: EffectGroup::Other,
-            reach: Reach::Consequence,
+            reach: Reach::ExternalRead,
             standing: Standing::Grantable,
         }
     } else {
@@ -646,8 +669,10 @@ mod tests {
         );
         assert_eq!(read.group, EffectGroup::Other);
         assert_eq!(read.standing, Standing::Grantable);
-        // …and it still parks the first time, because it does reach GitHub.
-        assert_eq!(read.reach, Reach::Consequence);
+        // …and since issue #559 it does not park: it reaches GitHub, so
+        // `readonly` still denies it, but it changes nothing and costs nothing,
+        // so `supervised` runs it.
+        assert_eq!(read.reach, Reach::ExternalRead);
 
         let send = consequence_of(COMPOSIO_EXECUTE, &json!({ "tool": "GMAIL_SEND_EMAIL" }));
         assert_eq!(send.group, EffectGroup::Send);
@@ -776,6 +801,100 @@ mod tests {
             // They mutate, so `readonly` must still deny and `supervised` must
             // still park the first call.
             assert!(verdict.reach.parks_under_supervision(), "`{tool}`");
+        }
+    }
+
+    /// Issue #559, every acceptance criterion in one place — the four verdicts
+    /// `ExternalRead` has to give, and the one it must not.
+    ///
+    /// The three predicates are the whole of the behaviour: `Reach` is never
+    /// matched exhaustively outside this module, so adding a variant changes
+    /// nothing anywhere until one of these answers differently.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn a_composio_read_runs_under_supervision_and_is_still_denied_under_readonly() {
+        use crate::policy::test_support::{COMPOSIO_READ_SLUG, composio_read_args};
+
+        let read = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
+        assert_eq!(
+            read.reach,
+            Reach::ExternalRead,
+            "`{COMPOSIO_READ_SLUG}` is tagged `Read` in the vendored catalogue"
+        );
+
+        // 1. Under `supervised` it runs, instead of costing the operator a card.
+        assert!(
+            !read.reach.parks_under_supervision(),
+            "reading a mailbox must not interrupt a person"
+        );
+        // 2. Under `readonly` it is still denied: that tier's contract is that
+        //    nothing outside the company is reached at all.
+        assert!(read.reach.denied_under_readonly());
+        // 3. And it is NOT spend. This is the criterion that rules out reusing
+        //    `Reach::Money`, whose `costs_money()` feeds the daily cap — every
+        //    page of every mailbox would have counted against it.
+        assert!(
+            !read.reach.costs_money(),
+            "a read is not billed; folding it into `Money` would bill it"
+        );
+        assert_ne!(read.group, EffectGroup::Spend);
+
+        // 4. The standing answer is unchanged — it stops mattering for
+        //    `supervised` now that nothing parks there, but still governs
+        //    `readonly` and any tier added later.
+        assert_eq!(read.standing, Standing::Grantable);
+        assert_eq!(read.group, EffectGroup::Other);
+    }
+
+    /// The other half of #559: only the **read** branch moved.
+    ///
+    /// The `send` binding is shared by the missing-key path and the non-read
+    /// path, so these hold structurally — but nothing stops a later edit from
+    /// touching that shared binding, which is the whole reason to assert them.
+    #[test]
+    fn a_composio_send_and_every_unclassifiable_call_still_park() {
+        use crate::policy::test_support::{composio_send_args, composio_unclassified_args};
+
+        let cases: [(&str, serde_json::Value); 6] = [
+            ("a catalogued send", composio_send_args()),
+            ("an uncatalogued action", composio_unclassified_args()),
+            (
+                "an unrecognised slug in a real toolkit",
+                json!({ "tool": "GITHUB_INVENT_A_NEW_VERB" }),
+            ),
+            ("a non-string `tool`", json!({ "tool": 7 })),
+            ("an empty slug", json!({ "tool": "" })),
+            ("a missing `tool` key", json!({ "arguments": { "q": "x" } })),
+        ];
+
+        for (what, args) in cases {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(verdict.reach, Reach::Consequence, "{what}: {args}");
+            assert!(
+                verdict.reach.parks_under_supervision(),
+                "{what} must still park: {args}"
+            );
+            assert!(verdict.reach.denied_under_readonly(), "{what}: {args}");
+            assert_eq!(verdict.group, EffectGroup::Send, "{what}: {args}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{what}: {args}");
+        }
+    }
+
+    /// `ExternalRead` must not leak into the spend cap from any other tool.
+    ///
+    /// `web_search_is_still_a_priced_call` pins the `Money`→`Spend` direction;
+    /// this pins that no *declared* tool picked up the new variant by accident,
+    /// so the only thing carrying it is the Composio read branch.
+    #[test]
+    fn no_declared_tool_claims_the_external_read_bucket() {
+        let args = json!({});
+        for tool in declared_tools() {
+            assert_ne!(
+                consequence_of(tool, &args).reach,
+                Reach::ExternalRead,
+                "`{tool}` is a declared tool; `ExternalRead` is for the Composio \
+                 read branch, which is classified from its arguments"
+            );
         }
     }
 

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -414,14 +414,35 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
 /// might do anything, so it parks and it cannot be granted standing. Same for a
 /// slug whose toolkit has no catalogue, a missing or non-string `tool`
 /// argument, and — in a build without the harness compiled in — every slug.
+///
+/// ## Two different reasons for the same verdict
+///
+/// "The catalogue has never heard of this slug" and "these arguments carry no
+/// slug at all" both end in a send, and that is right — but only one of them is
+/// a caller bug. Issue #470 survived for as long as it did precisely because
+/// the two were indistinguishable from outside: fixtures named their action
+/// under a key nothing reads, every call fell through to the fallback, and the
+/// verdicts still looked plausible. The verdict stays cautious either way; the
+/// second case now says so in the log, via [`ActionKeyMiss`], so a caller
+/// building the wrong argument shape is visible rather than silently safe.
 fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     let send = Consequence {
         group: EffectGroup::Send,
         reach: Reach::Consequence,
         standing: Standing::PerCall,
     };
-    let Some(slug) = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()) else {
-        return send;
+    let slug = match composio_action_slug(args) {
+        Ok(slug) => slug,
+        Err(miss) => {
+            tracing::warn!(
+                "[policy] a '{COMPOSIO_EXECUTE}' call carries no readable \
+                 '{COMPOSIO_ACTION_KEY}' argument ({}); classifying it as a send, which is \
+                 the cautious answer but not the one the catalogue would have given — the \
+                 caller is building an argument shape the tool's own schema rejects",
+                miss.describe()
+            );
+            return send;
+        }
     };
     if composio_action_is_read(slug) {
         // A read reaches a third-party account, so `readonly` denies it — but
@@ -445,6 +466,57 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
     } else {
         send
     }
+}
+
+/// Why a `composio_execute` call carries no action slug this classifier can
+/// read (issue #470).
+///
+/// Every variant classifies as a send, so this changes no verdict. It exists so
+/// the log line can say *which* shape arrived: a caller that omits the key, one
+/// that sends a number where a slug belongs, and one naming an action the
+/// catalogue has never heard of are three different mistakes, and only the last
+/// is a legitimate call to an unclassified action.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ActionKeyMiss {
+    /// The arguments are not a JSON object at all.
+    NotAnObject,
+    /// An object, but with no [`COMPOSIO_ACTION_KEY`] property — the shape the
+    /// `tool_slug` fixtures of #470 had.
+    KeyAbsent,
+    /// The key is present but not a string.
+    NotAString,
+    /// The key is present and a string, but empty, so no lookup can succeed.
+    Empty,
+}
+
+impl ActionKeyMiss {
+    /// A short phrase for the log line, in the caller's terms.
+    pub(crate) fn describe(self) -> &'static str {
+        match self {
+            Self::NotAnObject => "the arguments are not an object",
+            Self::KeyAbsent => "the key is absent",
+            Self::NotAString => "the key is present but not a string",
+            Self::Empty => "the key is present but empty",
+        }
+    }
+}
+
+/// The action slug in a `composio_execute` call's arguments, or why there
+/// isn't one.
+pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, ActionKeyMiss> {
+    let Some(object) = args.as_object() else {
+        return Err(ActionKeyMiss::NotAnObject);
+    };
+    let Some(value) = object.get(COMPOSIO_ACTION_KEY) else {
+        return Err(ActionKeyMiss::KeyAbsent);
+    };
+    let Some(slug) = value.as_str() else {
+        return Err(ActionKeyMiss::NotAString);
+    };
+    if slug.trim().is_empty() {
+        return Err(ActionKeyMiss::Empty);
+    }
+    Ok(slug)
 }
 
 /// Which slice of a tool one standing grant is confined to (issue #457).
@@ -476,7 +548,10 @@ pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String>
     if !tool.eq_ignore_ascii_case(COMPOSIO_EXECUTE) {
         return None;
     }
-    let slug = args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str())?;
+    // Same reader as the classifier, so a call it could not read a slug out of
+    // cannot resolve a toolkit here either — a scoped grant refuses to admit
+    // `None`, which is the safe direction.
+    let slug = composio_action_slug(args).ok()?;
     composio_toolkit_of(slug)
 }
 
@@ -700,6 +775,62 @@ mod tests {
                 "an unclassifiable action must read as a send: {args}"
             );
             assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// Same verdict, different reasons — and the reasons are now separable
+    /// (issue #470). A slug the catalogue cannot place is a legitimate call to
+    /// an unclassified action; an argument shape with no readable slug is a
+    /// caller bug that the send verdict would otherwise hide, which is exactly
+    /// how the `tool_slug` fixtures passed for as long as they did.
+    #[test]
+    fn a_missing_action_key_is_distinguishable_from_an_unknown_action() {
+        assert_eq!(
+            composio_action_slug(&json!({ "tool": "NOTAREALTOOLKIT_LIST_THINGS" })),
+            Ok("NOTAREALTOOLKIT_LIST_THINGS"),
+            "an uncatalogued slug is still a slug — the catalogue, not this reader, \
+             is what declines it"
+        );
+        for (args, expected) in [
+            (
+                json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+                ActionKeyMiss::KeyAbsent,
+            ),
+            (
+                json!({ "arguments": { "owner": "acme" } }),
+                ActionKeyMiss::KeyAbsent,
+            ),
+            (json!({}), ActionKeyMiss::KeyAbsent),
+            (json!({ "tool": 7 }), ActionKeyMiss::NotAString),
+            (json!({ "tool": null }), ActionKeyMiss::NotAString),
+            (json!({ "tool": "" }), ActionKeyMiss::Empty),
+            (json!({ "tool": "   " }), ActionKeyMiss::Empty),
+            (json!("GMAIL_SEND_EMAIL"), ActionKeyMiss::NotAnObject),
+            (json!(null), ActionKeyMiss::NotAnObject),
+        ] {
+            assert_eq!(composio_action_slug(&args), Err(expected), "{args}");
+            // …and the verdict is unchanged by any of it: the log line is the
+            // only thing that differs, so this can never loosen a decision.
+            assert_eq!(
+                consequence_of(COMPOSIO_EXECUTE, &args).group,
+                EffectGroup::Send,
+                "{args}"
+            );
+        }
+    }
+
+    /// A grant scope is read through the same reader, so a call whose slug the
+    /// classifier could not find cannot resolve a toolkit either — `None`, and
+    /// a scoped grant refuses to admit `None`.
+    #[test]
+    fn an_unreadable_action_key_resolves_no_grant_scope() {
+        for args in [
+            json!({ "tool_slug": "GITHUB_LIST_PULL_REQUESTS" }),
+            json!({ "tool": "" }),
+            json!({ "tool": 7 }),
+            json!({}),
+        ] {
+            assert_eq!(standing_scope_of(COMPOSIO_EXECUTE, &args), None, "{args}");
         }
     }
 

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -455,9 +455,22 @@ fn composio_execute_consequence(args: &serde_json::Value) -> Consequence {
         // dead-ended the turn — per page, per list. A first-time park is not a
         // cheap price for a read, it is the whole cost.
         //
-        // `Standing::Grantable` stays. It stops mattering for `supervised` now
-        // that nothing parks there, but it still governs `readonly` and any
-        // tier added later.
+        // `Standing::Grantable` stays — but not for the reason the issue gives.
+        // It does **not** govern `readonly`: that brake denies off
+        // `Reach::denied_under_readonly` before any grant is consulted
+        // (`harness::policy::check`, "readonly outranks a grant"), and it never
+        // reads `Standing` at all. Under `supervised` nothing parks here now,
+        // so the admission path this used to feed is unreachable for a
+        // catalogue read in every tier that exists today.
+        //
+        // What it still governs is the **mint** side: a standing grant may only
+        // be minted for a grantable call
+        // (`Effect::may_be_granted_standing`, and the re-check in
+        // `standing_grant_allows`), and a Composio *send* arriving under this
+        // same tool name must never be mintable. It is also the field any
+        // unattended tier has to read to tell a read it may run from a send it
+        // may not — the `auto` tier proposed in #560 derives exactly that line.
+        // Removing it would make both of those decisions unrepresentable.
         Consequence {
             group: EffectGroup::Other,
             reach: Reach::ExternalRead,

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -14,5 +14,12 @@
 pub mod consequence;
 pub mod gate;
 
+/// Shared `composio_execute` call fixtures (issue #470). Test-only, and
+/// deliberately here rather than in any one test module: the key they build
+/// their arguments under is the classifier's own constant, which is what stops
+/// a fixture and the code under test from drifting apart again.
+#[cfg(test)]
+pub(crate) mod test_support;
+
 pub use consequence::{Consequence, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};

--- a/src/policy/test_support.rs
+++ b/src/policy/test_support.rs
@@ -212,9 +212,9 @@ mod tests {
         let verdict = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
         assert_eq!(verdict.group, EffectGroup::Other);
         assert_eq!(verdict.standing, Standing::Grantable);
-        // Today a read still parks under `supervised`. Issue #559 moves this
-        // off `Consequence`; the two assertions above are what stay put.
-        assert_eq!(verdict.reach, Reach::Consequence);
+        // Issue #559 moved the read off `Consequence`, which is what parks. The
+        // two assertions above are the ones that did not move.
+        assert_eq!(verdict.reach, Reach::ExternalRead);
     }
 
     /// And the other lane, stated rather than left to be discovered: without

--- a/src/policy/test_support.rs
+++ b/src/policy/test_support.rs
@@ -1,0 +1,230 @@
+//! Shared `composio_execute` call fixtures for the approval tests (issue #470).
+//!
+//! # Why this module exists
+//!
+//! `composio_execute` carries every Composio action under one tool name, so the
+//! approval verdict is a property of the **action slug in its arguments**. The
+//! tool's own schema declares that slug under `"tool"`
+//! (`required: ["tool"]`, `additionalProperties: false`, see
+//! [`crate::harness::composio`]), and
+//! [`consequence_of`](crate::policy::consequence::consequence_of) reads it back
+//! under [`COMPOSIO_ACTION_KEY`].
+//!
+//! Fixtures in five modules used to hard-code a key of their own — `tool_slug`
+//! — which neither side accepts. Every one of them was therefore a call with
+//! **no recognisable action**: the classifier could not find a slug, fell
+//! through to the cautious "unknown is a send" verdict, and the test passed
+//! without ever reaching the catalogue lookup it was credited with exercising.
+//! The assertions were right; the inputs never arrived. A regression in the
+//! read/send split would not have failed one of them.
+//!
+//! # What keeps it from drifting again
+//!
+//! [`composio_args`] builds the key from [`COMPOSIO_ACTION_KEY`] itself rather
+//! than from a literal, so a fixture cannot disagree with the classifier: the
+//! two now read the same constant. Renaming the wire key moves both together.
+//!
+//! # Choosing a slug
+//!
+//! The slugs below are real entries in the vendored provider catalogue, so they
+//! exercise the lookup rather than the fallback. Do not invent a plausible-
+//! looking slug for a fixture that is meant to classify — an uncatalogued slug
+//! reads as a send, which is often the verdict the test expected anyway, and
+//! that is exactly how #470 stayed invisible. When a test genuinely wants an
+//! action nobody has classified, reach for
+//! [`COMPOSIO_UNCLASSIFIED_SLUG`] and say so in its name.
+//!
+//! # A note on the two lanes
+//!
+//! The catalogue is vendored with openhuman and linked in only under that
+//! feature. Without it [`composio_action_is_read`] answers `false` for
+//! everything, so [`composio_read_args`] classifies as a **send** in the
+//! default build. That is deliberate and pinned below in both directions — a
+//! test that asserts the read verdict must be `#[cfg(feature = "openhuman")]`.
+//!
+//! [`composio_action_is_read`]: crate::policy::consequence
+//! [`COMPOSIO_ACTION_KEY`]: crate::policy::consequence::COMPOSIO_ACTION_KEY
+
+use serde_json::Value;
+
+use crate::policy::consequence::COMPOSIO_ACTION_KEY;
+
+/// A Composio action the vendored catalogue tags `Write`: sending mail.
+///
+/// Classifies as [`EffectGroup::Send`](crate::ports::types::EffectGroup::Send)
+/// with [`Standing::PerCall`](crate::policy::Standing::PerCall) — and does so
+/// through the catalogue, not through the unknown-slug fallback.
+pub(crate) const COMPOSIO_SEND_SLUG: &str = "GMAIL_SEND_EMAIL";
+
+/// A second catalogued `Write`, on a different toolkit.
+///
+/// For tests that need two calls the queue must treat as distinct without
+/// either of them being unclassifiable.
+pub(crate) const COMPOSIO_OTHER_SEND_SLUG: &str = "SLACK_POST_MESSAGE_TO_CHANNEL";
+
+/// A Composio action the vendored catalogue tags `Read`: listing a repository's
+/// pull requests.
+///
+/// Classifies as [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other)
+/// with [`Standing::Grantable`](crate::policy::Standing::Grantable) — **under
+/// the `openhuman` feature only**. See the lane note in the module docs.
+pub(crate) const COMPOSIO_READ_SLUG: &str = "GITHUB_LIST_PULL_REQUESTS";
+
+/// An action slug whose toolkit the catalogue has never heard of.
+///
+/// The cautious fallback deserves its own coverage, so this exists to be
+/// requested deliberately and named as such at the call site — never as the
+/// accidental result of a typo'd key.
+pub(crate) const COMPOSIO_UNCLASSIFIED_SLUG: &str = "NOTAREALTOOLKIT_DO_SOMETHING";
+
+/// A `composio_execute` argument object naming `slug`, keyed the way the tool
+/// and the classifier both key it.
+pub(crate) fn composio_args(slug: &str) -> Value {
+    let mut args = serde_json::Map::new();
+    args.insert(COMPOSIO_ACTION_KEY.to_string(), Value::String(slug.into()));
+    Value::Object(args)
+}
+
+/// [`composio_args`], plus the action's own parameters under `"arguments"` —
+/// the only other property the tool's schema admits.
+pub(crate) fn composio_args_with(slug: &str, arguments: Value) -> Value {
+    let mut args = composio_args(slug);
+    args["arguments"] = arguments;
+    args
+}
+
+/// A call the catalogue classifies as a send.
+pub(crate) fn composio_send_args() -> Value {
+    composio_args(COMPOSIO_SEND_SLUG)
+}
+
+/// A call the catalogue classifies as a read — under the `openhuman` feature.
+pub(crate) fn composio_read_args() -> Value {
+    composio_args(COMPOSIO_READ_SLUG)
+}
+
+/// A call naming an action the catalogue cannot place, so it reads as a send
+/// through the cautious fallback rather than through the lookup.
+pub(crate) fn composio_unclassified_args() -> Value {
+    composio_args(COMPOSIO_UNCLASSIFIED_SLUG)
+}
+
+/// The `i`th of a run of distinct, deliberately uncatalogued calls.
+///
+/// For the over-cap tests, whose point is the *number* of parked requests: they
+/// need many calls the queue treats as distinct and care nothing for what any
+/// of them classify as. The slug still lands under the real key, so these
+/// reach the catalogue lookup and miss it — an honest fallback rather than a
+/// call with no action at all.
+pub(crate) fn composio_unclassified_args_numbered(i: usize) -> Value {
+    composio_args(&format!("NOTAREALTOOLKIT_ACTION_{i}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::Standing;
+    #[cfg(feature = "openhuman")]
+    use crate::policy::consequence::Reach;
+    use crate::policy::consequence::{COMPOSIO_EXECUTE, consequence_of};
+    use crate::ports::types::EffectGroup;
+
+    /// The guarantee the whole module exists for: a fixture reaches the
+    /// classifier's action key. Asserted against the constant *and* against the
+    /// literal, because agreeing with `COMPOSIO_ACTION_KEY` while both drift off
+    /// the tool's declared schema would reproduce #470 with the helper in place.
+    #[test]
+    fn a_fixture_names_its_action_under_the_key_the_tool_declares() {
+        let args = composio_send_args();
+        assert_eq!(
+            args.get(COMPOSIO_ACTION_KEY).and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG)
+        );
+        assert_eq!(
+            args.get("tool").and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG),
+            "`tool` is what `composio_execute`'s schema requires; if this fails \
+             the wire key moved and the tool's schema has to move with it"
+        );
+        assert!(
+            args.get("tool_slug").is_none(),
+            "the key #470 was about must not come back"
+        );
+    }
+
+    /// The action's own parameters ride under `arguments`, which is the only
+    /// other property the tool's schema admits — a fixture that spread them at
+    /// the top level would be rejected by `additionalProperties: false`.
+    #[test]
+    fn action_parameters_ride_under_arguments() {
+        let args = composio_args_with(COMPOSIO_SEND_SLUG, serde_json::json!({ "to": "a@b.test" }));
+        assert_eq!(
+            args.get("tool").and_then(|v| v.as_str()),
+            Some(COMPOSIO_SEND_SLUG)
+        );
+        assert_eq!(args["arguments"]["to"], "a@b.test");
+        assert_eq!(
+            args.as_object().map(|o| o.len()),
+            Some(2),
+            "`tool` and `arguments` are the whole of the declared schema"
+        );
+    }
+
+    /// The send fixture is a send *through the catalogue*. True in both lanes,
+    /// but for different reasons — which is why the read fixture below is
+    /// pinned separately per lane.
+    #[test]
+    fn the_send_fixture_classifies_as_a_send() {
+        for args in [
+            composio_send_args(),
+            composio_args(COMPOSIO_OTHER_SEND_SLUG),
+        ] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(verdict.group, EffectGroup::Send, "{args}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// The fixture the fallback tests want: an action nobody has classified,
+    /// asked for on purpose. Same verdict in both lanes.
+    #[test]
+    fn the_unclassified_fixture_falls_back_to_a_send() {
+        for args in [
+            composio_unclassified_args(),
+            composio_unclassified_args_numbered(0),
+            composio_unclassified_args_numbered(7),
+        ] {
+            let verdict = consequence_of(COMPOSIO_EXECUTE, &args);
+            assert_eq!(verdict.group, EffectGroup::Send, "{args}");
+            assert_eq!(verdict.standing, Standing::PerCall, "{args}");
+        }
+    }
+
+    /// The one that #470 was really about: with the catalogue linked in, the
+    /// read fixture is classified as a read — by the lookup, not by luck.
+    ///
+    /// This is the assertion the old `tool_slug` fixtures could not have made.
+    /// Break the catalogue lookup and this fails, which is the property the
+    /// negative control in #559 is built on.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_read_fixture_classifies_as_a_read() {
+        let verdict = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
+        assert_eq!(verdict.group, EffectGroup::Other);
+        assert_eq!(verdict.standing, Standing::Grantable);
+        // Today a read still parks under `supervised`. Issue #559 moves this
+        // off `Consequence`; the two assertions above are what stay put.
+        assert_eq!(verdict.reach, Reach::Consequence);
+    }
+
+    /// And the other lane, stated rather than left to be discovered: without
+    /// the harness feature the catalogue is not linked in, so the read fixture
+    /// classifies as a send. A test that wants the read verdict must be gated.
+    #[test]
+    #[cfg(not(feature = "openhuman"))]
+    fn without_the_catalogue_the_read_fixture_is_a_send() {
+        let verdict = consequence_of(COMPOSIO_EXECUTE, &composio_read_args());
+        assert_eq!(verdict.group, EffectGroup::Send);
+        assert_eq!(verdict.standing, Standing::PerCall);
+    }
+}

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2760,7 +2760,12 @@ mod test {
     #[tokio::test]
     async fn approving_a_harness_tool_call_mints_a_grant_instead_of_executing() {
         let home_dir = tmp_home();
-        let args = serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL", "to": "a@b.test" });
+        // Issue #470: a catalogued send, keyed the way `composio_execute`'s
+        // schema keys it, with the action's parameters under `arguments`.
+        let args = crate::policy::test_support::composio_args_with(
+            crate::policy::test_support::COMPOSIO_SEND_SLUG,
+            serde_json::json!({ "to": "a@b.test" }),
+        );
         let (rt, id) = park_one(
             home_dir.path().to_path_buf(),
             harness_effect("finance", "composio_execute", args.clone()),
@@ -3204,7 +3209,7 @@ mod test {
             amount_usd: None,
             established_thread: false,
             first_time_counterparty: false,
-            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            payload: crate::policy::test_support::composio_send_args(),
             agent: None,
             run_id: None,
         };

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -1988,7 +1988,7 @@ mod test {
             approval_id: ApprovalId::new(id),
             agent: "finance".into(),
             tool: "composio_execute".into(),
-            args: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            args: crate::policy::test_support::composio_send_args(),
             at_millis,
             origin_thread: None,
         }
@@ -2021,7 +2021,7 @@ mod test {
         assert_eq!(replayed[0].tool, "composio_execute");
         assert_eq!(
             replayed[0].args,
-            serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            crate::policy::test_support::composio_send_args(),
             "the exact arguments the operator approved survive the restart"
         );
     }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3675,6 +3675,12 @@ mod test {
     /// makes approving it mint a single-use grant rather than execute it
     /// (issue #243) — which is the whole reason a lost continuation hurts: the
     /// grant is spent on a turn that never happens.
+    ///
+    /// The payload names an action the vendored catalogue tags `Write`, so
+    /// `consequence_of` classifies it as a send on its merits. Until issue #470
+    /// it named the slug under `tool_slug`, a key neither the tool nor the
+    /// classifier reads — so it was a call with no action at all, and it
+    /// reached the per-call verdict through the unknown-slug fallback instead.
     fn gated_tool_call() -> crate::ports::types::Effect {
         crate::ports::types::Effect {
             kind: "composio_execute".into(),
@@ -3682,7 +3688,7 @@ mod test {
             amount_usd: None,
             established_thread: false,
             first_time_counterparty: false,
-            payload: serde_json::json!({ "tool_slug": "GMAIL_SEND_EMAIL" }),
+            payload: crate::policy::test_support::composio_send_args(),
             agent: Some("ceo".into()),
             run_id: None,
         }
@@ -3690,11 +3696,11 @@ mod test {
 
     /// A tool call an operator MAY grant a standing permission for (issue
     /// #431), which `gated_tool_call` deliberately is not: its Composio payload
-    /// names no action slug, so `consequence_of` cannot classify it as a read
-    /// and it stays a per-call decision. `file_write` is declared grantable in
-    /// `src/policy/consequence.rs` and carries an agent, so it satisfies both
-    /// halves of `check_broadly_grantable` — it mutates, but only the agent's
-    /// own sandboxed workspace.
+    /// names an action the catalogue tags `Write`, so `consequence_of` reads it
+    /// as a send and it stays a per-call decision. `file_write` is declared
+    /// grantable in `src/policy/consequence.rs` and carries an agent, so it
+    /// satisfies both halves of `check_broadly_grantable` — it mutates, but
+    /// only the agent's own sandboxed workspace.
     fn grantable_tool_call() -> crate::ports::types::Effect {
         crate::ports::types::Effect {
             kind: "file_write".into(),
@@ -5295,9 +5301,16 @@ mod test {
             for event in &req.events {
                 match event {
                     CompanyEvent::OperatorMessage { .. } => {
+                        // Deliberately uncatalogued slugs (issue #470): this
+                        // brain exists to park a *number* of distinct calls and
+                        // is indifferent to how any of them classify. They
+                        // still land under the real action key, so each reaches
+                        // the catalogue lookup and misses it, rather than
+                        // carrying no action for the classifier to find.
                         for i in 0..self.parks {
                             let mut effect = gated_tool_call();
-                            effect.payload = serde_json::json!({ "tool_slug": format!("T{i}") });
+                            effect.payload =
+                                crate::policy::test_support::composio_unclassified_args_numbered(i);
                             host.park_effect(effect).await?;
                         }
                     }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -426,6 +426,13 @@ impl HarnessAgentRunner {
         if requests.len() > cap {
             // Bounded exactly as the cycle drain is: a model that keeps
             // re-trying a blocked tool must not be able to flood the queue.
+            //
+            // Issue #638: the chat path now *tells* the operator when it
+            // discards (#561, `DrainedRequests::overflow_notice`); this one
+            // still only logs. Less bad than the chat path was — the count
+            // exists somewhere — but a log line is not the operator learning
+            // anything. Fixing it needs a surface a run can speak on, which is
+            // why it is tracked separately rather than done here.
             tracing::warn!(
                 company = %self.company,
                 run_id = %self.run_id,


### PR DESCRIPTION
## Summary

Partially addresses #561 — the **"also worth fixing regardless"** item, chat path only.
The headline fix (option 3, suspend/resume in openhuman's turn loop) is not attempted here
and is not opencompany work.

`MAX_APPROVAL_REQUESTS_PER_TURN` is 8. Everything a turn gates past that was **discarded
silently**: `ApprovalRequestQueue::drain` took the first 8, called `guard.clear()` on the
rest, and returned a `Vec` indistinguishable from a complete one. The operator saw eight
cards and had no way to learn that five more calls had been gated, refused, and dropped.
Eight cards and no notice reads as "eight is all there was", which is the opposite of
true.

Now the operator is told, with the count, on their own channel.

### What changed

- **`drain` returns `DrainedRequests { requests, discarded }`** instead of a bare `Vec`
  (`src/harness/policy.rs`). This is the load-bearing part. The overflow is now *in the
  value*, so a caller cannot drop it by not knowing there was a second number — it has to
  write `.requests` and choose to. The compiler enumerated all seven call sites when the
  type changed, which is exactly the property this issue is about: your scoping comment
  called this "the kind of split that gets half-fixed".
- **`DrainedRequests::overflow_notice(cap)`** — the operator-facing sentence, or `None`.
  It lives next to the count so the two cannot drift, and it says what the operator has to
  *do*: the calls were **not** run and are **not** on the Approvals page, so the agent has
  to be asked again. "Requests were discarded" alone invites the reading that the calls
  happened and only the records were lost.
- **`HarnessBrain::park_approval_requests` returns `Option<String>`** and `run_cycle`
  pushes it as its own operator bubble. Its own bubble rather than appended to the agent's
  reply, because the reply is the agent's answer and this is the system saying the agent
  was cut off — and a turn whose only outcome was overflow has no reply to append to.
  Still logged at `warn` as well; a log is for us, the bubble is for them.

The cap itself is untouched. Whether 8 is the right number is a separate question and this
PR does not answer it.

## The workflow half is NOT fixed here, deliberately

`MAX_APPROVAL_REQUESTS_PER_TURN` has a second consumer: **`src/workflows/caps/mod.rs:425`**,
the workflow node park path. **I did not touch it** — that file belongs to the in-flight
work on #460 and editing it would collide.

Being precise about what is left, because "half-fixed and implied whole" is the failure
mode this issue exists to name:

* The workflow path is **not** as bad as the chat path was. It already emits a
  `tracing::warn!` carrying `discarded = requests.len() - cap`, so the drop is at least in
  the logs today.
* It is **still not fixed**, because a log line is not the operator learning anything. The
  gap this PR closes for chat — the person who needed to know is told — remains open for
  workflow runs.
* The fix there is small and now has a home: `caps/mod.rs` builds its own `requests` vec
  and takes `.take(cap)`, so it can construct a `DrainedRequests` (or just call
  `overflow_notice`) and route the sentence wherever a workflow run surfaces operator
  notices. The wording helper is deliberately on the type rather than inlined at my call
  site so that path can reuse it verbatim.

Suggested follow-up: a one-line-ish change on the workflow path once #460's PR lands, so
the two paths tell the operator the same thing in the same words.

## API Or Behavior Changes

**API:** `ApprovalRequestQueue::drain` now returns `DrainedRequests` rather than
`Vec<ApprovalRequest>`. Callers take `.requests`. New public type `DrainedRequests` with
`overflow_notice`. `HarnessBrain::park_approval_requests` (private) returns
`Option<String>`.

**Behaviour:** a cycle that gates more calls than the per-turn cap now emits one extra
operator bubble naming how many were dropped and what the cap was. A cycle within the cap
is byte-identical to before.

## Tests

All exit-code gated via unpiped redirect.

- [x] `cargo fmt --all -- --check` — EXIT:0.
- [x] `cargo clippy --all-targets -- -D warnings` — EXIT:0 (default lane). Gated lane in
      CI's exact form, `--locked --no-deps --features openhuman,tinycortex --all-targets`
      — EXIT:0.
- [x] `cargo build --all-targets` — covered by the two clippy runs, which build all
      targets in both lanes. Narrower than a full `build` (no codegen), broader in feature
      coverage.
- [x] `cargo test` — `cargo test --lib` default lane **1834 passed / 0 failed**;
      `cargo test --features openhuman,tinycortex --lib` gated lane **2748 passed / 0
      failed**. Integration targets not re-run on this branch (library-only diff); they
      ran green on the parent, PR #603.

### Negative controls

Two, because the fix has two halves that fail in opposite directions.

**A — restore the silent discard** (`let discarded = 0;` in `drain`). EXIT:101, **2
failed**:

```
harness::brain::tests::a_turn_that_overflows_the_cap_tells_the_operator_how_many_were_dropped
harness::policy::tests::the_drain_is_capped_and_empties_the_queue
```

**B — make the notice fire when nothing was dropped** (`self.discarded >= 0`). EXIT:101,
**15 failed** — the four boundary tests below, plus **11 pre-existing brain tests** that
would break if an extra bubble appeared on an ordinary cycle:

```
harness::policy::tests::a_drain_under_the_cap_reports_no_overflow
harness::policy::tests::a_drain_exactly_at_the_cap_reports_no_overflow
harness::brain::tests::a_turn_within_the_cap_raises_no_notice
…plus operator_message_gets_an_agent_reply, no_events_still_acknowledges, and 9 more
```

Both restored; green again (2748 passed, EXIT:0).

**Coverage I am not claiming.** One new test —
`the_overflow_notice_is_singular_for_a_single_dropped_request` — fails under neither
control, because both controls target the count and the gating rather than the wording. It
is a formatting assertion and would fail if the pluralisation broke; I am flagging it
rather than implying the controls cover all six new tests.

## Documentation

`DrainedRequests` and the rewritten `drain` doc explain why the return type changed and
what the second number is for. No user-facing docs affected — though the new operator
bubble is user-visible text, and reviewers should read its wording as copy, not just as
code.
