### PR TITLE
feat(workflows): revision history and rollback for an edited workflow (#274)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -37,6 +37,7 @@ event vocabulary those traits carry moved to [`events.md`](events.md)
 | `SkillStateStore` | [ports-console.md](ports-console.md#skillstatestore) | installed-skill state overlay |
 | `InboxStore` | [ports-console.md](ports-console.md#inboxstore) | per-teammate email inboxes |
 | `RunStore` | [ports-runs.md](ports-runs.md#runstore) | one attempt at a task, and its trace |
+| `WorkflowRevisionStore` | [`src/ports/workflow_revisions.rs`](../../../src/ports/workflow_revisions.rs) | a bounded per-workflow edit-history ring for rollback (issue #274) |
 
 ## Assembly
 
@@ -74,3 +75,28 @@ the multi-tenant platform case with the same type.
 | `SecretStore` | fs (encrypted at rest) | OS keychain, operator-supplied |
 | `TaskStore`, `WorkspaceStore`, `FactStore`, `UsageMeter`, `SkillStateStore`, `InboxStore` | fs bundle | sqlite, mongodb |
 | `UserStore`, `SessionStore`, `LoginCodeStore` | fs bundle | sqlite, mongodb |
+| `ArtifactStore`, `RunStore`, `WorkflowRevisionStore` | fs bundle (JSONL) | sqlite, mongodb |
+
+### `WorkflowRevisionStore` (issue #274)
+
+A workflow's overlay body is replaced whole on every `PUT …/workflows/{wid}`.
+This port keeps the graph each edit replaced, so an edit that drops a node or
+mangles a cron is recoverable. It is its **own** store rather than a field on
+`CompanyRecord` because the record is loaded and saved whole on every write — a
+snapshot ring riding that hot path would bloat every unrelated company save.
+
+- **Capture** happens inside `update_company_workflow`, under the per-company
+  write lock, immediately before the overlay body is overwritten and **before**
+  the record save — the one race-free instant, and push-first so a failed push
+  loses nothing. A byte-identical re-save captures nothing.
+- **Bounded** to `MAX_WORKFLOW_REVISIONS` (20) per workflow; the prune rides the
+  push, atomically where the backend allows.
+- **Rollback** (`rollback_company_workflow`) restores a snapshot *through the
+  ordinary update path*, so it re-validates against the current record, is itself
+  undoable, honours the version token, and inherits the #276 disarm.
+- **Ids are minted**, not content hashes: the workflow's version token is already
+  a content hash, so an A→B→A edit would otherwise collide two distinct
+  snapshots.
+- Routes: `GET …/workflows/{wid}/revisions` (metadata only — no graph bodies),
+  `POST …/workflows/{wid}/revisions/{rev}/restore`. A workflow delete cascades
+  its revisions away.

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -570,6 +570,87 @@ export function setWorkflowEnabled(
 }
 
 /**
+ * One entry in a workflow's edit history (issue #274) — **metadata only**.
+ *
+ * The graph body is deliberately absent: the history list is a chooser, and the
+ * body arrives (and is applied to the canvas) only when
+ * {@link restoreWorkflowRevision} actually restores one. `version` is the same
+ * opaque token {@link getWorkflow} hands out, so the console can tell which
+ * snapshot matches the graph it currently holds.
+ */
+export interface WorkflowRevision {
+  /** Stable id of the snapshot, used to address it for a restore. */
+  id: string;
+  /** The workflow's display name at the moment the snapshot was captured. */
+  name: string;
+  /** The opaque version token of the snapshotted body. Never parse it. */
+  version: string;
+  /** Epoch-millis the snapshot was captured. */
+  createdAtMillis: number;
+}
+
+/** The `GET …/workflows/{wid}/revisions` response. */
+interface WorkflowRevisionsResponse {
+  revisions: WorkflowRevision[];
+}
+
+/**
+ * Lists one workflow's edit history (issue #274), **newest first**.
+ *
+ * Each `PUT` that actually changed the graph left the prior body here, bounded
+ * to the most recent 20. A workflow that was never edited — or a seed-defined
+ * one that cannot be edited from the console — resolves to an empty list rather
+ * than an error: "no history" is a normal state the History panel renders as
+ * empty, not a failure.
+ *
+ * Returns metadata only (see {@link WorkflowRevision}); the graph body is
+ * fetched by {@link restoreWorkflowRevision} when an operator picks one.
+ */
+export async function listWorkflowRevisions(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+): Promise<WorkflowRevision[]> {
+  const res = await client.get<WorkflowRevisionsResponse>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}/revisions`,
+  );
+  return res.revisions;
+}
+
+/**
+ * Restores a workflow to one of its captured revisions (issue #274), returning
+ * the restored graph with a **fresh** `version`.
+ *
+ * A restore is an ordinary edit whose new body is an old one, so it inherits
+ * everything {@link updateWorkflow} guarantees: the revision is re-validated
+ * against the *current* company (a snapshot naming a since-removed teammate is a
+ * `400`, not a broken restore), the body it replaces is itself snapshotted (so a
+ * restore is undoable), and a restored schedule lands **switched off** pending
+ * review (issue #276) — read `enabled` on the result to reflect that.
+ *
+ * Pass `expectedVersion` — the `version` of the graph the operator was looking
+ * at — to make the restore conditional. On a `409` the graph moved underneath
+ * them: **reload and let them re-choose, do not retry** without the token, which
+ * is the silent-overwrite the guard exists to prevent. Other rejections carry
+ * the host's prosumer-language message: `404` for an unknown workflow or
+ * revision, `409` for a source-defined / body-less workflow or a name collision.
+ */
+export function restoreWorkflowRevision(
+  client: OpenCompanyClient,
+  company: string | null,
+  wid: string,
+  revisionId: string,
+  expectedVersion?: string,
+): Promise<WorkflowGraph> {
+  return client.post<WorkflowGraph>(
+    `${client.scopeFor(company)}/workflows/${encodeURIComponent(wid)}/revisions/${encodeURIComponent(
+      revisionId,
+    )}/restore`,
+    expectedVersion ? { expectedVersion } : {},
+  );
+}
+
+/**
  * The node kinds the form creator's palette offers.
  *
  * The first six author from a bare form — `trigger` starts the graph, `agent`

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -14,18 +14,21 @@
 // second one would drift the moment either side grew a field.
 
 import { useEffect, useId, useState } from "react";
-import { Plus, Trash2 } from "lucide-react";
+import { History, Plus, RotateCcw, Trash2 } from "lucide-react";
 
 import {
   CREATABLE_NODE_KINDS,
   DESTINATION_KINDS,
   createWorkflow,
+  listWorkflowRevisions,
   listWorkflows,
+  restoreWorkflowRevision,
   updateWorkflow,
   type WorkflowDestination,
   type WorkflowEdge,
   type WorkflowGraph,
   type WorkflowNode,
+  type WorkflowRevision,
   type WorkflowSummary,
 } from "@/api/workflows";
 import {
@@ -387,6 +390,17 @@ export function WorkflowCreateDialog({
    * is inline, scoped to the control that caused it, and never blocks Save on
    * its own — `validate()` remains the gate. */
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
+  // Issue #274: the edit history panel (edit mode only). It fetches lazily — the
+  // first time an operator expands it — so opening the dialog to make an edit
+  // costs no extra request unless they actually want to look back.
+  const [historyOpen, setHistoryOpen] = useState(false);
+  const [revisions, setRevisions] = useState<WorkflowRevision[]>([]);
+  const [revisionsLoaded, setRevisionsLoaded] = useState(false);
+  const [revisionsLoading, setRevisionsLoading] = useState(false);
+  const [revisionsError, setRevisionsError] = useState<string | null>(null);
+  /** The revision currently being restored, so its row can show a spinner and
+   * every Restore button disables while one restore is in flight. */
+  const [restoringId, setRestoringId] = useState<string | null>(null);
   const formId = useId();
 
   // Reload the roster (for the agent-node picker) and reset the draft each
@@ -410,6 +424,14 @@ export function WorkflowCreateDialog({
     setEdges(workflow ? draftEdges(workflow) : []);
     setError(null);
     setFieldErrors({});
+    // Issue #274: a fresh open (or a re-hydrate after a restore) must not carry
+    // the previous graph's history. It re-loads on the next expand, and against
+    // the freshly-restored body's version token.
+    setHistoryOpen(false);
+    setRevisions([]);
+    setRevisionsLoaded(false);
+    setRevisionsError(null);
+    setRestoringId(null);
     let live = true;
     (async () => {
       try {
@@ -607,6 +629,77 @@ export function WorkflowCreateDialog({
       if (e.from === e.to) return "An edge can't loop a node back to itself.";
     }
     return null;
+  }
+
+  // Issue #274: fetch this workflow's edit history. Called on first expand and
+  // again after a restore, so the list reflects the snapshot the restore just
+  // captured. A host predating #274 has no such route; the panel degrades to
+  // "no revisions" rather than throwing.
+  async function loadRevisions() {
+    if (!workflow) return;
+    setRevisionsLoading(true);
+    setRevisionsError(null);
+    try {
+      const rows = await listWorkflowRevisions(client, company, workflow.id);
+      setRevisions(rows);
+      setRevisionsLoaded(true);
+    } catch (e) {
+      setRevisionsError(
+        e instanceof Error ? e.message : "could not load the edit history",
+      );
+    } finally {
+      setRevisionsLoading(false);
+    }
+  }
+
+  function toggleHistory() {
+    const next = !historyOpen;
+    setHistoryOpen(next);
+    // Lazy: only fetch the first time it opens (or after a reset cleared it).
+    if (next && !revisionsLoaded && !revisionsLoading) void loadRevisions();
+  }
+
+  // Issue #274: restore one snapshot. A confirm names the undoability, because a
+  // restore overwrites the live graph — but the body it replaces is itself
+  // snapshotted, so the operator can walk it back. On success the dialog
+  // re-hydrates from the returned graph exactly as a save does (via `onSaved`),
+  // so the canvas shows the restored body and the next edit carries its fresh
+  // token; the history list is then refreshed to include the pre-restore body.
+  async function restore(rev: WorkflowRevision) {
+    if (!workflow || restoringId) return;
+    const ok = window.confirm(
+      `Restore "${rev.name}"? This replaces the current graph. The version you have now ` +
+        `is saved to history first, so you can restore back to it.`,
+    );
+    if (!ok) return;
+    setRestoringId(rev.id);
+    setRevisionsError(null);
+    try {
+      const restored = await restoreWorkflowRevision(
+        client,
+        company,
+        workflow.id,
+        rev.id,
+        // Condition on the graph the operator is looking at, so a concurrent
+        // edit is a 409 rather than a silent clobber.
+        workflow.version,
+      );
+      onSaved?.(restored);
+      // The parent updates `workflow`, which re-hydrates this dialog and resets
+      // the history state; re-fetch so the panel (if still open) reflects the
+      // snapshot the restore just captured.
+      await loadRevisions();
+    } catch (e) {
+      // 409 (moved under us) / 400 (invalid against the current graph) / 404 —
+      // surface the host's prosumer-language message in the panel. A 409 also
+      // rides out to the view's persistent reload banner, same as a save.
+      setRevisionsError(
+        e instanceof Error ? e.message : "could not restore this revision",
+      );
+      if (e instanceof ApiError && e.status === 409) onConflict?.(e.message);
+    } finally {
+      setRestoringId(null);
+    }
   }
 
   async function submit() {
@@ -838,6 +931,73 @@ export function WorkflowCreateDialog({
           <Alert variant="destructive">
             <AlertDescription>{error}</AlertDescription>
           </Alert>
+        )}
+
+        {/* Issue #274: the edit-history panel. Edit mode only — a workflow being
+            created has nothing to look back on. */}
+        {editing && (
+          <div className="rounded-lg border">
+            <button
+              type="button"
+              onClick={toggleHistory}
+              className="flex w-full items-center justify-between gap-2 px-3 py-2 text-sm font-medium"
+              aria-expanded={historyOpen}
+              data-testid="workflow-history-toggle"
+            >
+              <span className="flex items-center gap-2">
+                <History className="size-4" />
+                History
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {historyOpen ? "Hide" : "Show"}
+              </span>
+            </button>
+            {historyOpen && (
+              <div className="border-t px-3 py-2">
+                {revisionsLoading && (
+                  <p className="py-2 text-center text-xs text-muted-foreground">
+                    Loading history…
+                  </p>
+                )}
+                {revisionsError && (
+                  <Alert variant="destructive" className="my-2">
+                    <AlertDescription>{revisionsError}</AlertDescription>
+                  </Alert>
+                )}
+                {!revisionsLoading && !revisionsError && revisions.length === 0 && (
+                  <p className="py-2 text-center text-xs text-muted-foreground">
+                    No earlier versions yet — every edit you save will show up here.
+                  </p>
+                )}
+                <ul className="divide-y">
+                  {revisions.map((rev) => (
+                    <li
+                      key={rev.id}
+                      className="flex items-center justify-between gap-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-sm">{rev.name}</p>
+                        <p className="text-[11px] text-muted-foreground">
+                          {relativeTime(rev.createdAtMillis)}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void restore(rev)}
+                        disabled={restoringId !== null || submitting}
+                        aria-label={`Restore ${rev.name}`}
+                      >
+                        <RotateCcw className="mr-1 size-3.5" />
+                        {restoringId === rev.id ? "Restoring…" : "Restore"}
+                      </Button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+          </div>
         )}
 
         <DialogFooter>
@@ -1155,6 +1315,23 @@ function ScheduleField({
       )}
     </div>
   );
+}
+
+/**
+ * A compact "how long ago" label for a revision row (issue #274). Coarse on
+ * purpose — the history list wants "2h ago", not a timestamp — and it falls back
+ * to a locale date past a week so an old snapshot reads as a real date.
+ */
+function relativeTime(millis: number): string {
+  const secs = Math.max(0, Math.round((Date.now() - millis) / 1000));
+  if (secs < 60) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  return new Date(millis).toLocaleDateString();
 }
 
 function EdgeRow({

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -75,13 +75,15 @@ pub use workflow_file::{
 // Crate-internal only: the workflow creator (issue #69) builds a `RawWorkflow`
 // from its request body, renders it to TOML, and re-parses it through
 // `parse_workflow` above for validation before writing to disk.
-pub(crate) use workflow_file::{RawEdge, RawNode, RawWorkflow, render_workflow};
+pub(crate) use workflow_file::{
+    RawEdge, RawNode, RawWorkflow, raw_workflow_from_toml, render_workflow,
+};
 // Crate-internal only: the shared validated-persist core (issue #112) both the
 // REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.
 // Ungated: the REST route is in the default build, so gating this behind
 // `openhuman` is what let the two surfaces drift apart (issue #168).
 pub(crate) use workflow_create::{
-    create_company_workflow, delete_company_workflow, seed_file_exists,
+    create_company_workflow, delete_company_workflow, rollback_company_workflow, seed_file_exists,
     set_company_workflow_enabled, update_company_workflow, workflow_version,
 };
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -29,7 +29,7 @@ use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
     EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore,
     SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore,
-    WorkspaceStore,
+    WorkflowRevisionStore, WorkspaceStore,
 };
 
 /// The board column a task must enter to be dispatched to its assignee. Read
@@ -124,6 +124,8 @@ pub struct OpsStores {
     pub artifacts: Arc<dyn ArtifactStore>,
     /// First-class records of each task attempt: status, trace, cost (#242).
     pub runs: Arc<dyn RunStore>,
+    /// Per-workflow edit history, for rollback of an edited workflow (#274).
+    pub workflow_revisions: Arc<dyn WorkflowRevisionStore>,
     /// The usage meter (written by the WS4 cost hook, read by WS5).
     pub usage: Arc<dyn UsageMeter>,
     /// Operator deltas over the company's skills.
@@ -769,6 +771,12 @@ impl CompanyRuntime {
     /// with its status, step trace and cost.
     pub fn runs(&self) -> &Arc<dyn RunStore> {
         &self.ops.runs
+    }
+
+    /// This company's per-workflow edit history (#274), the snapshot ring a
+    /// workflow rollback reads and writes.
+    pub fn workflow_revisions(&self) -> &Arc<dyn WorkflowRevisionStore> {
+        &self.ops.workflow_revisions
     }
 
     /// This company's usage meter (written by the cost hook, read by WS5).

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -84,10 +84,16 @@
 //!
 //! ## What is deliberately not here
 //!
-//! * **No revision history.** OpenHuman keeps a bounded snapshot ring in a
-//!   dedicated `flow_revisions` table; our overlay bodies live inside
-//!   `CompanyRecord`, which is loaded and saved *whole* on every write, so a ring
-//!   per workflow would bloat that hot path. It needs its own store surface.
+//! * **Revision history lives in its own store (issue #274).** OpenHuman keeps a
+//!   bounded snapshot ring in a dedicated `flow_revisions` table; our overlay
+//!   bodies live inside `CompanyRecord`, which is loaded and saved *whole* on
+//!   every write, so a ring per workflow would bloat that hot path. It therefore
+//!   got its own [`WorkflowRevisionStore`](crate::ports::WorkflowRevisionStore)
+//!   port plus three backends rather than a field on the record.
+//!   [`update_company_workflow`] captures the prior body into it under the write
+//!   lock, and [`rollback_company_workflow`] restores one *through this same
+//!   update path* — so a rollback re-validates against the current record and is
+//!   itself undoable. Diffing/merging revisions stays out of scope.
 //! * **No run-history reaping.** Past runs are
 //!   [`WorkflowRunFinished`](CompanyEvent::WorkflowRunFinished) entries on the
 //!   company's single append-only journal, interleaved with chat and audit. What
@@ -146,15 +152,18 @@ use std::sync::Arc;
 use sha2::{Digest, Sha256};
 
 use crate::company::{
-    RawNode, RawWorkflow, WorkflowFile, list_workflows_union, parse_workflow, render_workflow,
+    RawNode, RawWorkflow, WorkflowFile, list_workflows_union, parse_workflow,
+    raw_workflow_from_toml, render_workflow,
 };
 use crate::error::{OpenCompanyError, Result};
 use crate::ports::CompanyStore;
 use crate::ports::events::EventLog;
+use crate::ports::now_millis;
 use crate::ports::store::company_write_lock;
 use crate::ports::types::{
     CompanyEvent, CompanyId, CompanyRecord, OverlayWorkflow, WorkflowEnabledReason,
 };
+use crate::ports::workflow_revisions::{WorkflowRevisionRecord, WorkflowRevisionStore};
 use crate::server::ops::language;
 
 /// Max nodes a freshly authored graph may declare. A larger graph is refused
@@ -707,6 +716,7 @@ pub(crate) async fn update_company_workflow(
     company: &CompanyId,
     source_dir: Option<&Path>,
     store: &Arc<dyn CompanyStore>,
+    revisions: &Arc<dyn WorkflowRevisionStore>,
     events: Option<&Arc<dyn EventLog>>,
     draft: RawWorkflow,
     expected_version: Option<&str>,
@@ -787,6 +797,31 @@ pub(crate) async fn update_company_workflow(
         .is_some();
     let disarmed = file.trigger_schedule().is_some() && !armed_before;
 
+    // Issue #274: snapshot the body we are about to overwrite, so the edit is
+    // undoable. Captured HERE — inside the write lock, holding the prior TOML —
+    // because this is the only instant a snapshot is race-free (the same reason
+    // OpenHuman's `flow_revisions` insert rides inside the guarded UPDATE).
+    //
+    // Ordering is load-bearing: push the revision BEFORE `store.save`. A failed
+    // push aborts the edit and the prior body is still the live one, so nothing
+    // is lost — which is the exact failure this feature exists to prevent.
+    // Save-first would risk overwriting the body and then losing its only copy.
+    //
+    // Deduped against a no-op save: when the new TOML is byte-identical to the
+    // prior, there is nothing to lose — the version token already defines those
+    // two as the same graph — so no snapshot is taken.
+    let prior_toml = record.overlay_workflows[index].toml.clone();
+    if prior_toml != toml_src {
+        // Name from the prior parsed body; fall back to the id when it no longer
+        // parses (a corrupt body still deserves a recoverable snapshot).
+        let prior_name = parse_workflow(&prior_toml)
+            .map(|f| f.name)
+            .unwrap_or_else(|_| file.id.clone());
+        let revision =
+            WorkflowRevisionRecord::new(file.id.clone(), prior_name, prior_toml, now_millis());
+        revisions.push_revision(company, &revision).await?;
+    }
+
     // Replace in place: same slot, same order, so the picker doesn't reshuffle.
     record.overlay_workflows[index] = OverlayWorkflow {
         id: file.id.clone(),
@@ -841,6 +876,76 @@ pub(crate) async fn update_company_workflow(
     }
 
     Ok(file)
+}
+
+/// Restores a workflow to one of its captured revisions (issue #274), returning
+/// the parsed [`WorkflowFile`] the union read path will now serve.
+///
+/// A rollback is **not** a special write path — it is an ordinary edit whose new
+/// body happens to be an old one. It loads the revision (scoped to `wid`, so one
+/// workflow's snapshot can never be restored onto another), converts its stored
+/// TOML back into a draft, and routes it through
+/// [`update_company_workflow`] unchanged. That reuse is deliberate and buys four
+/// properties for free:
+///
+/// * **Re-validation against the *current* record.** A revision that named a
+///   teammate who has since been removed is a `400`, not a broken restore — the
+///   same roster/tool check every edit passes.
+/// * **The rollback is itself undoable.** `update_company_workflow` snapshots the
+///   *current* body before overwriting it, so restoring A over B captures B — a
+///   rollback can be rolled back.
+/// * **Optimistic concurrency.** `expected_version`, when supplied, is the token
+///   of the body being replaced; a stale one is a `409`, so a rollback cannot
+///   silently clobber a concurrent edit.
+/// * **The #276 disarm.** If the restored graph carries a schedule the live one
+///   lacked, it lands switched **off** — a restored cron cannot fire before
+///   anyone has reviewed it.
+///
+/// Statuses: `400` (the revision is invalid against the current record), `404`
+/// (unknown `wid` or unknown `rev_id`), `409` (seed-backed / body-less `wid`, a
+/// stale token, or a name collision).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn rollback_company_workflow(
+    company: &CompanyId,
+    source_dir: Option<&Path>,
+    store: &Arc<dyn CompanyStore>,
+    revisions: &Arc<dyn WorkflowRevisionStore>,
+    events: Option<&Arc<dyn EventLog>>,
+    wid: &str,
+    rev_id: &str,
+    expected_version: Option<&str>,
+) -> Result<WorkflowFile> {
+    if !is_safe_workflow_id(wid) {
+        return Err(OpenCompanyError::InvalidRequest(
+            language::WORKFLOW_ID_INVALID.to_string(),
+        ));
+    }
+
+    // Load the snapshot, scoped to this workflow. Unknown wid or unknown rev both
+    // read as "nothing to restore" → 404.
+    let revision = revisions
+        .get_revision(company, wid, rev_id)
+        .await?
+        .ok_or_else(|| {
+            OpenCompanyError::CompanyNotFound(format!("workflow {wid} revision {rev_id}"))
+        })?;
+
+    // Convert the captured body back into an editable draft and pin its id to
+    // `wid`: a rollback restores a workflow **in place**, never renames it, and a
+    // hand-mangled revision body must not be able to retarget another workflow.
+    let mut draft = raw_workflow_from_toml(&revision.toml)?;
+    draft.id = wid.to_string();
+
+    update_company_workflow(
+        company,
+        source_dir,
+        store,
+        revisions,
+        events,
+        draft,
+        expected_version,
+    )
+    .await
 }
 
 /// Switches a workflow on or off without touching its graph (issue #276).
@@ -983,6 +1088,7 @@ pub(crate) async fn delete_company_workflow(
     company: &CompanyId,
     source_dir: Option<&Path>,
     store: &Arc<dyn CompanyStore>,
+    revisions: &Arc<dyn WorkflowRevisionStore>,
     events: Option<&Arc<dyn EventLog>>,
     wid: &str,
     expected_version: Option<&str>,
@@ -1021,6 +1127,21 @@ pub(crate) async fn delete_company_workflow(
     store.save(&record).await?;
 
     drop(_lock);
+
+    // Issue #274: cascade the workflow's revision history away with it, so a
+    // removed workflow leaves no orphaned snapshots behind. Best-effort in the
+    // same sense as the audit journal below: the workflow is already gone by the
+    // time this runs, so a failure is logged rather than rolling the delete back
+    // (and a leftover ring is harmless — a re-created id starts its own history,
+    // and nothing reads another workflow's rows).
+    if let Err(err) = revisions.delete_revisions(company, wid).await {
+        tracing::warn!(
+            company = %company,
+            workflow = %wid,
+            error = %err,
+            "workflow deleted but its revision history could not be cleared"
+        );
+    }
 
     if let Some(log) = events
         && let Err(err) = log
@@ -1172,6 +1293,86 @@ mod tests {
         fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
             Box::pin(stream::empty())
         }
+    }
+
+    /// An in-memory [`WorkflowRevisionStore`] so the capture, prune, cascade and
+    /// rollback behaviour can be asserted without a real backend. Pruning to the
+    /// cap is applied on push, mirroring the durable backends.
+    #[derive(Default)]
+    struct MemRevisions {
+        rows: StdMutex<Vec<WorkflowRevisionRecord>>,
+    }
+
+    #[async_trait]
+    impl WorkflowRevisionStore for MemRevisions {
+        async fn push_revision(
+            &self,
+            _company: &CompanyId,
+            revision: &WorkflowRevisionRecord,
+        ) -> Result<()> {
+            use crate::ports::workflow_revisions::{MAX_WORKFLOW_REVISIONS, sort_newest_first};
+            let mut rows = self.rows.lock().unwrap();
+            rows.push(revision.clone());
+            let mut mine: Vec<WorkflowRevisionRecord> = rows
+                .iter()
+                .filter(|r| r.workflow_id == revision.workflow_id)
+                .cloned()
+                .collect();
+            if mine.len() > MAX_WORKFLOW_REVISIONS {
+                sort_newest_first(&mut mine);
+                let keep: std::collections::HashSet<String> = mine
+                    .into_iter()
+                    .take(MAX_WORKFLOW_REVISIONS)
+                    .map(|r| r.id)
+                    .collect();
+                rows.retain(|r| r.workflow_id != revision.workflow_id || keep.contains(&r.id));
+            }
+            Ok(())
+        }
+        async fn list_revisions(
+            &self,
+            _company: &CompanyId,
+            workflow_id: &str,
+        ) -> Result<Vec<WorkflowRevisionRecord>> {
+            use crate::ports::workflow_revisions::sort_newest_first;
+            let mut mine: Vec<WorkflowRevisionRecord> = self
+                .rows
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|r| r.workflow_id == workflow_id)
+                .cloned()
+                .collect();
+            sort_newest_first(&mut mine);
+            Ok(mine)
+        }
+        async fn get_revision(
+            &self,
+            _company: &CompanyId,
+            workflow_id: &str,
+            revision_id: &str,
+        ) -> Result<Option<WorkflowRevisionRecord>> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .iter()
+                .find(|r| r.workflow_id == workflow_id && r.id == revision_id)
+                .cloned())
+        }
+        async fn delete_revisions(&self, _company: &CompanyId, workflow_id: &str) -> Result<u64> {
+            let mut rows = self.rows.lock().unwrap();
+            let before = rows.len();
+            rows.retain(|r| r.workflow_id != workflow_id);
+            Ok((before - rows.len()) as u64)
+        }
+    }
+
+    /// A throwaway revision store for tests that do not assert on revision
+    /// capture — the common case. Tests that DO assert capture/prune/rollback
+    /// hold their own `Arc<MemRevisions>` so they can read it back.
+    fn revs() -> Arc<dyn WorkflowRevisionStore> {
+        Arc::new(MemRevisions::default())
     }
 
     // --- fixtures ------------------------------------------------------------
@@ -1783,6 +1984,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             Some(&log_dyn),
             draft,
             Some(&version),
@@ -1850,16 +2052,17 @@ to = "done"
         // Someone else edits first, unconditionally.
         let mut theirs = valid_draft("greeter", "Greeter");
         theirs.description = Some("Theirs landed first.".to_string());
-        update_company_workflow(&company, None, &store, None, theirs, None)
+        update_company_workflow(&company, None, &store, &revs(), None, theirs, None)
             .await
             .expect("first writer wins");
 
         // Our stale token is now wrong.
         let mut ours = valid_draft("greeter", "Greeter");
         ours.description = Some("Ours would clobber.".to_string());
-        let err = update_company_workflow(&company, None, &store, None, ours, Some(&stale))
-            .await
-            .expect_err("stale version must be refused");
+        let err =
+            update_company_workflow(&company, None, &store, &revs(), None, ours, Some(&stale))
+                .await
+                .expect_err("stale version must be refused");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
 
         // And the other writer's edit is intact — the refusal is not partial.
@@ -1879,7 +2082,7 @@ to = "done"
 
         let mut once = valid_draft("greeter", "Greeter");
         once.description = Some("One.".to_string());
-        update_company_workflow(&company, None, &store, None, once, Some(&first))
+        update_company_workflow(&company, None, &store, &revs(), None, once, Some(&first))
             .await
             .expect("first conditional write");
 
@@ -1889,7 +2092,7 @@ to = "done"
 
         let mut twice = valid_draft("greeter", "Greeter");
         twice.description = Some("Two.".to_string());
-        update_company_workflow(&company, None, &store, None, twice, Some(&second))
+        update_company_workflow(&company, None, &store, &revs(), None, twice, Some(&second))
             .await
             .expect("refreshed token is accepted");
     }
@@ -1901,7 +2104,7 @@ to = "done"
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
         let mut draft = valid_draft("greeter", "Greeter");
         draft.description = Some("No token needed.".to_string());
-        update_company_workflow(&company, None, &store, None, draft, None)
+        update_company_workflow(&company, None, &store, &revs(), None, draft, None)
             .await
             .expect("unconditional write");
     }
@@ -1913,7 +2116,7 @@ to = "done"
         let (store, version) = with_one_workflow(&company, "greeter", "Greeter").await;
         let mut draft = valid_draft("greeter", "  greeter  ");
         draft.description = Some("Same name, different case and padding.".to_string());
-        update_company_workflow(&company, None, &store, None, draft, Some(&version))
+        update_company_workflow(&company, None, &store, &revs(), None, draft, Some(&version))
             .await
             .expect("own name must not conflict with itself");
     }
@@ -1931,6 +2134,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             None,
             valid_draft("greeter", "OTHER"),
             None,
@@ -1949,7 +2153,7 @@ to = "done"
         // Zero triggers.
         let mut no_trigger = valid_draft("greeter", "Greeter");
         no_trigger.nodes[0].kind = "output".to_string();
-        let err = update_company_workflow(&company, None, &store, None, no_trigger, None)
+        let err = update_company_workflow(&company, None, &store, &revs(), None, no_trigger, None)
             .await
             .expect_err("no trigger");
         assert!(err.to_string().contains("exactly one `trigger`"), "{err}");
@@ -1957,7 +2161,7 @@ to = "done"
         // Off-roster teammate.
         let mut ghost = valid_draft("greeter", "Greeter");
         ghost.nodes[1].agent = Some("ghost".to_string());
-        let err = update_company_workflow(&company, None, &store, None, ghost, None)
+        let err = update_company_workflow(&company, None, &store, &revs(), None, ghost, None)
             .await
             .expect_err("off-roster teammate");
         assert!(
@@ -1994,6 +2198,7 @@ to = "done"
             &company,
             Some(dir.path()),
             &store,
+            &revs(),
             None,
             valid_draft("seeded", "Seeded flow"),
             None,
@@ -2012,6 +2217,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             None,
             valid_draft("ghost", "Ghost"),
             None,
@@ -2037,6 +2243,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             None,
             valid_draft("legacy", "Legacy"),
             None,
@@ -2062,7 +2269,7 @@ to = "done"
 
         let mut draft = valid_draft("a", "Alpha");
         draft.description = Some("Edited.".to_string());
-        update_company_workflow(&company, None, &store, None, draft, None)
+        update_company_workflow(&company, None, &store, &revs(), None, draft, None)
             .await
             .expect("edit the first");
 
@@ -2088,6 +2295,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             Some(&log_dyn),
             "greeter",
             Some(&version),
@@ -2133,7 +2341,7 @@ to = "done"
     async fn a_deleted_workflow_has_nothing_left_for_the_boot_merge_to_re_enable() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        delete_company_workflow(&company, None, &store, None, "greeter", None)
+        delete_company_workflow(&company, None, &store, &revs(), None, "greeter", None)
             .await
             .expect("deletes");
 
@@ -2157,13 +2365,21 @@ to = "done"
 
         let mut theirs = valid_draft("greeter", "Greeter");
         theirs.description = Some("Edited after you loaded it.".to_string());
-        update_company_workflow(&company, None, &store, None, theirs, None)
+        update_company_workflow(&company, None, &store, &revs(), None, theirs, None)
             .await
             .expect("someone edits first");
 
-        let err = delete_company_workflow(&company, None, &store, None, "greeter", Some(&stale))
-            .await
-            .expect_err("stale delete must be refused");
+        let err = delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            None,
+            "greeter",
+            Some(&stale),
+        )
+        .await
+        .expect_err("stale delete must be refused");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
 
         let record = store.load(&company).await.unwrap().unwrap();
@@ -2186,9 +2402,17 @@ to = "done"
             manifest_with_assistant(),
         )));
 
-        let err = delete_company_workflow(&company, Some(dir.path()), &store, None, "seeded", None)
-            .await
-            .expect_err("a source-defined workflow is not deletable");
+        let err = delete_company_workflow(
+            &company,
+            Some(dir.path()),
+            &store,
+            &revs(),
+            None,
+            "seeded",
+            None,
+        )
+        .await
+        .expect_err("a source-defined workflow is not deletable");
         assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
         assert!(err.to_string().contains("source tree"), "{err}");
         // And the seed file is untouched — this path never writes to the tree.
@@ -2199,7 +2423,7 @@ to = "done"
     async fn deleting_an_unknown_workflow_is_not_found() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        let err = delete_company_workflow(&company, None, &store, None, "ghost", None)
+        let err = delete_company_workflow(&company, None, &store, &revs(), None, "ghost", None)
             .await
             .expect_err("unknown id");
         assert!(
@@ -2212,9 +2436,10 @@ to = "done"
     async fn deleting_a_traversal_id_is_invalid() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        let err = delete_company_workflow(&company, None, &store, None, "../secrets", None)
-            .await
-            .expect_err("traversal id");
+        let err =
+            delete_company_workflow(&company, None, &store, &revs(), None, "../secrets", None)
+                .await
+                .expect_err("traversal id");
         assert!(
             matches!(err, OpenCompanyError::InvalidRequest(_)),
             "{err:?}"
@@ -2236,7 +2461,7 @@ to = "done"
                 .expect("seed");
         }
 
-        delete_company_workflow(&company, None, &store, None, "b", None)
+        delete_company_workflow(&company, None, &store, &revs(), None, "b", None)
             .await
             .expect("deletes the middle one");
 
@@ -2263,7 +2488,7 @@ to = "done"
         rec.manifest.workflows.enabled.push("greeter".to_string());
         let store = store_of(MemStore::failing(rec));
 
-        delete_company_workflow(&company, None, &store, None, "greeter", None)
+        delete_company_workflow(&company, None, &store, &revs(), None, "greeter", None)
             .await
             .expect_err("save fails");
 
@@ -2521,6 +2746,7 @@ to = "done"
             &company,
             None,
             &store,
+            &revs(),
             None,
             tool_call_draft("wf", "WF", Some("totally_bogus")),
             None,
@@ -2770,6 +2996,7 @@ to = "done"
             &company,
             Some(dir.path()),
             &store,
+            &revs(),
             Some(&log_dyn),
             scheduled_draft("greeter", "Greeter", "0 8 * * *"),
             None,
@@ -2826,6 +3053,7 @@ to = "done"
             &company,
             Some(dir.path()),
             &store,
+            &revs(),
             Some(&log_dyn),
             scheduled_draft("digest", "Digest", "0 3 * * *"),
             None,
@@ -2874,6 +3102,7 @@ to = "done"
             &company,
             Some(dir.path()),
             &store,
+            &revs(),
             Some(&log_dyn),
             valid_draft("digest", "Digest"),
             None,
@@ -3087,6 +3316,7 @@ to = "done"
             &company,
             Some(dir.path()),
             &store,
+            &revs(),
             None,
             valid_draft("seeded", "Seeded flow"),
             None,
@@ -3113,6 +3343,348 @@ to = "done"
         assert!(
             saved.overlay_workflows.is_empty(),
             "pausing must not materialize an overlay body for a seed graph"
+        );
+    }
+
+    // --- issue #274: revision capture + rollback -----------------------------
+
+    /// The overlay TOML currently stored for `wid`.
+    async fn current_toml(store: &Arc<dyn CompanyStore>, company: &CompanyId, wid: &str) -> String {
+        store
+            .load(company)
+            .await
+            .unwrap()
+            .unwrap()
+            .overlay_workflows
+            .into_iter()
+            .find(|w| w.id == wid)
+            .expect("overlay body exists")
+            .toml
+    }
+
+    /// Creates `greeter`, then returns `(store, revisions, body_a)` ready to edit.
+    async fn seeded_greeter() -> (Arc<dyn CompanyStore>, Arc<MemRevisions>, String) {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            valid_draft("greeter", "Greeter"),
+        )
+        .await
+        .expect("create");
+        let body_a = current_toml(&store, &company, "greeter").await;
+        (store, Arc::new(MemRevisions::default()), body_a)
+    }
+
+    #[tokio::test]
+    async fn update_snapshots_the_prior_body_exactly_once() {
+        let company = CompanyId::new("acme");
+        let (store, revs, body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // Edit the description so the rendered body differs from A.
+        let mut edit = valid_draft("greeter", "Greeter");
+        edit.description = Some("edited once".to_string());
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None)
+            .await
+            .expect("update");
+
+        let history = revs.list_revisions(&company, "greeter").await.unwrap();
+        assert_eq!(history.len(), 1, "one edit captures one snapshot");
+        assert_eq!(
+            history[0].toml, body_a,
+            "the snapshot must hold the prior body byte-for-byte"
+        );
+        assert_eq!(history[0].workflow_id, "greeter");
+        assert_eq!(history[0].name, "Greeter");
+    }
+
+    #[tokio::test]
+    async fn a_byte_identical_resave_snapshots_nothing() {
+        let company = CompanyId::new("acme");
+        let (store, revs, _body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // Re-save the exact same graph: the rendered body is byte-identical, so
+        // there is nothing to lose and no snapshot is taken.
+        update_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            valid_draft("greeter", "Greeter"),
+            None,
+        )
+        .await
+        .expect("no-op resave");
+        assert!(
+            revs.list_revisions(&company, "greeter")
+                .await
+                .unwrap()
+                .is_empty(),
+            "a byte-identical re-save must not snapshot"
+        );
+    }
+
+    #[tokio::test]
+    async fn the_ring_prunes_the_oldest_past_the_cap() {
+        use crate::ports::workflow_revisions::MAX_WORKFLOW_REVISIONS;
+        let company = CompanyId::new("acme");
+        let (store, revs, _body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // MAX+1 distinct edits capture MAX+1 prior bodies; the ring keeps MAX.
+        for i in 0..=MAX_WORKFLOW_REVISIONS {
+            let mut edit = valid_draft("greeter", "Greeter");
+            edit.description = Some(format!("edit {i}"));
+            update_company_workflow(&company, None, &store, &revs_dyn, None, edit, None)
+                .await
+                .expect("update");
+        }
+        let history = revs.list_revisions(&company, "greeter").await.unwrap();
+        assert_eq!(
+            history.len(),
+            MAX_WORKFLOW_REVISIONS,
+            "the ring is capped at MAX_WORKFLOW_REVISIONS"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_restores_the_body_and_is_itself_undoable() {
+        let company = CompanyId::new("acme");
+        let (store, revs, body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // A → edit → B. One revision now holds A.
+        let mut edit_b = valid_draft("greeter", "Greeter");
+        edit_b.description = Some("this is B".to_string());
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+            .await
+            .expect("edit to B");
+        let body_b = current_toml(&store, &company, "greeter").await;
+        let rev_a = revs.list_revisions(&company, "greeter").await.unwrap()[0]
+            .id
+            .clone();
+
+        // Restore A: the live body becomes A again, and B is captured as the new
+        // newest revision — so the rollback can itself be rolled back.
+        let restored = rollback_company_workflow(
+            &company, None, &store, &revs_dyn, None, "greeter", &rev_a, None,
+        )
+        .await
+        .expect("rollback to A");
+        assert_eq!(restored.description.as_deref(), Some("A tiny graph."));
+        assert_eq!(current_toml(&store, &company, "greeter").await, body_a);
+
+        let history = revs.list_revisions(&company, "greeter").await.unwrap();
+        assert_eq!(
+            history.len(),
+            2,
+            "the restore captured the body it replaced"
+        );
+        assert_eq!(history[0].toml, body_b, "B is the newest snapshot now");
+
+        // …and restoring that B snapshot puts B back.
+        let rev_b = history[0].id.clone();
+        rollback_company_workflow(
+            &company, None, &store, &revs_dyn, None, "greeter", &rev_b, None,
+        )
+        .await
+        .expect("rollback the rollback");
+        assert_eq!(current_toml(&store, &company, "greeter").await, body_b);
+    }
+
+    #[tokio::test]
+    async fn rollback_of_a_revision_naming_a_removed_teammate_is_400_and_leaves_current() {
+        let company = CompanyId::new("acme");
+        let (store, revs, _body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // Edit to capture a revision (which still names `assistant`), then set B.
+        let mut edit_b = valid_draft("greeter", "Greeter");
+        edit_b.description = Some("B, assistant still valid here".to_string());
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+            .await
+            .expect("edit to B");
+        let body_b = current_toml(&store, &company, "greeter").await;
+        let rev_a = revs.list_revisions(&company, "greeter").await.unwrap()[0]
+            .id
+            .clone();
+
+        // Remove `assistant` from the roster: the captured revision now names a
+        // teammate the current record does not know about.
+        let mut rec = store.load(&company).await.unwrap().unwrap();
+        rec.manifest = toml::from_str("[company]\nname = \"Acme\"\n").unwrap();
+        store.save(&rec).await.unwrap();
+
+        let err = rollback_company_workflow(
+            &company, None, &store, &revs_dyn, None, "greeter", &rev_a, None,
+        )
+        .await
+        .expect_err("a revision naming a removed teammate must not restore");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        // The current body is untouched — a rejected rollback writes nothing.
+        assert_eq!(current_toml(&store, &company, "greeter").await, body_b);
+    }
+
+    #[tokio::test]
+    async fn rollback_with_a_stale_expected_version_is_409_and_writes_nothing() {
+        let company = CompanyId::new("acme");
+        let (store, revs, body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        let mut edit_b = valid_draft("greeter", "Greeter");
+        edit_b.description = Some("B".to_string());
+        update_company_workflow(&company, None, &store, &revs_dyn, None, edit_b, None)
+            .await
+            .expect("edit to B");
+        let body_b = current_toml(&store, &company, "greeter").await;
+        let rev_a = revs.list_revisions(&company, "greeter").await.unwrap()[0]
+            .id
+            .clone();
+
+        let err = rollback_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            "greeter",
+            &rev_a,
+            Some("deadbeef-not-the-current-token"),
+        )
+        .await
+        .expect_err("a stale token must refuse the restore");
+        assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+        assert_eq!(
+            current_toml(&store, &company, "greeter").await,
+            body_b,
+            "a 409 must leave the live body unchanged"
+        );
+
+        // The response token of a successful restore is the hash of the restored
+        // body — echo the CURRENT token and the restore lands.
+        let current = workflow_version(&body_b);
+        let restored = rollback_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            "greeter",
+            &rev_a,
+            Some(&current),
+        )
+        .await
+        .expect("the current token lets the restore through");
+        // The restored live body is the captured A body, and the token the write
+        // response carries is that body's hash.
+        let restored_toml = current_toml(&store, &company, "greeter").await;
+        assert_eq!(restored_toml, body_a, "restoring A puts A back verbatim");
+        assert_eq!(restored.id, "greeter");
+        assert_eq!(
+            workflow_version(&restored_toml),
+            workflow_version(&body_a),
+            "the response token is the restored body's hash"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_disarms_a_restored_schedule() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let revs: Arc<MemRevisions> = Arc::new(MemRevisions::default());
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+
+        // A scheduled workflow lands disarmed on create (issue #276); arm it, so
+        // the "restored cron re-arms" hazard is real to test.
+        let mut scheduled = valid_draft("greeter", "Greeter");
+        scheduled.nodes[0].schedule = Some("0 9 * * *".to_string());
+        create_company_workflow(&company, None, &store, None, scheduled)
+            .await
+            .expect("create scheduled");
+        set_company_workflow_enabled(&company, None, &store, None, "greeter", true)
+            .await
+            .expect("arm it");
+
+        // Edit the schedule away — the workflow stays armed (removal never
+        // disarms), and the scheduled body is captured as a revision.
+        let mut unscheduled = valid_draft("greeter", "Greeter");
+        unscheduled.description = Some("no schedule now".to_string());
+        update_company_workflow(&company, None, &store, &revs_dyn, None, unscheduled, None)
+            .await
+            .expect("remove schedule");
+        assert!(
+            store
+                .load(&company)
+                .await
+                .unwrap()
+                .unwrap()
+                .workflow_enabled("greeter"),
+            "removing a schedule must not disarm"
+        );
+        let rev_scheduled = revs.list_revisions(&company, "greeter").await.unwrap()[0]
+            .id
+            .clone();
+
+        // Restoring the scheduled body re-introduces a cron the live graph lacked
+        // → it lands switched off pending review.
+        rollback_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            "greeter",
+            &rev_scheduled,
+            None,
+        )
+        .await
+        .expect("restore scheduled body");
+        assert!(
+            !store
+                .load(&company)
+                .await
+                .unwrap()
+                .unwrap()
+                .workflow_enabled("greeter"),
+            "a restored schedule must land disarmed (issue #276)"
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_unknown_revision_is_not_found() {
+        let company = CompanyId::new("acme");
+        let (store, revs, _body_a) = seeded_greeter().await;
+        let revs_dyn: Arc<dyn WorkflowRevisionStore> = revs.clone();
+        let err = rollback_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs_dyn,
+            None,
+            "greeter",
+            "no-such-rev",
+            None,
+        )
+        .await
+        .expect_err("unknown revision");
+        assert!(
+            matches!(err, OpenCompanyError::CompanyNotFound(_)),
+            "{err:?}"
         );
     }
 }

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -346,6 +346,22 @@ pub(crate) fn render_workflow(raw: &RawWorkflow) -> Result<String> {
     })
 }
 
+/// Parses stored workflow TOML back into an editable [`RawWorkflow`] draft — the
+/// inverse of [`render_workflow`], and the seam a rollback (issue #274) uses to
+/// re-feed a captured revision through the ordinary update path.
+///
+/// `RawWorkflow` is the same serde shape both directions (it is what
+/// [`render_workflow`] emits and what [`parse_workflow`] validates), so a body
+/// that was persisted through the create/update path round-trips here verbatim.
+/// A parse failure is an [`InvalidRequest`](OpenCompanyError::InvalidRequest)
+/// (400) rather than the 500 a malformed on-disk file gets, because the only
+/// caller feeds it straight back into the validating update path.
+pub(crate) fn raw_workflow_from_toml(toml_src: &str) -> Result<RawWorkflow> {
+    toml::from_str(toml_src).map_err(|err| {
+        OpenCompanyError::InvalidRequest(format!("workflow revision is unreadable: {err}"))
+    })
+}
+
 /// Parses one workflow graph from TOML source, validating it in full.
 ///
 /// Unknown keys are tolerated. On a validation failure every problem is

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -29,6 +29,7 @@ pub mod tools;
 pub mod types;
 pub mod usage;
 pub mod users;
+pub mod workflow_revisions;
 pub mod workflow_runner;
 pub mod workspace;
 
@@ -60,6 +61,9 @@ pub use tools::ToolProvider;
 pub use types::*;
 pub use usage::{SampleKind, UsageMeter, UsageSample};
 pub use users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore, normalize_email};
+pub use workflow_revisions::{
+    MAX_WORKFLOW_REVISIONS, WorkflowRevisionRecord, WorkflowRevisionStore,
+};
 pub use workflow_runner::{
     DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowRun, WorkflowRunContext,
     WorkflowRunNodeRow, WorkflowRunner,
@@ -98,6 +102,7 @@ mod test {
         _sessions: &dyn crate::ports::sessions::SessionStore,
         _login_codes: &dyn crate::ports::login_codes::LoginCodeStore,
         _runs: &dyn crate::ports::runs::RunStore,
+        _workflow_revisions: &dyn crate::ports::workflow_revisions::WorkflowRevisionStore,
         _workflow_runner: &dyn crate::ports::workflow_runner::WorkflowRunner,
     ) {
     }

--- a/src/ports/workflow_revisions.rs
+++ b/src/ports/workflow_revisions.rs
@@ -1,0 +1,205 @@
+//! The [`WorkflowRevisionStore`] port: a bounded snapshot ring per edited
+//! workflow (issue #274).
+//!
+//! Issue #259 made a saved workflow *replaceable* (`PUT …/workflows/{wid}`),
+//! guarded by an optimistic-concurrency token — but it did not keep the graph it
+//! replaced. An edit that drops a node or mangles a cron was unrecoverable
+//! except by re-authoring from memory. This port keeps the prior body.
+//!
+//! ## Why its own store, not a field on the record
+//!
+//! Overlay workflow bodies live on
+//! [`CompanyRecord`](crate::ports::types::CompanyRecord), which is loaded and
+//! saved **whole** on every write. A 20-snapshot ring per workflow riding that
+//! hot path would bloat every unrelated company save. So revisions get their own
+//! durable surface — a port plus the three backends — exactly the shape the
+//! issue calls for, mirroring OpenHuman's dedicated `flow_revisions` table.
+//!
+//! ## The capture moment
+//!
+//! A snapshot can only be taken race-free at the one instant the update path
+//! already holds the prior TOML under the per-company write lock — immediately
+//! before it overwrites the overlay body. [`push_revision`](WorkflowRevisionStore::push_revision)
+//! is therefore called *there*, and **before** the record save, so a failed push
+//! aborts the edit and nothing is lost (save-first would risk the exact data
+//! loss this port fixes).
+//!
+//! ## Minted ids, not content hashes
+//!
+//! A revision's id is [`generate_id`]-minted, deliberately **not** a hash of its
+//! body. The workflow's version token *is* a content hash, so an A → B → A edit
+//! sequence produces two revisions with identical bodies — a hash id would
+//! collide them and lose one. A minted id keeps every distinct snapshot
+//! addressable even when two share a body.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::ports::generate_id;
+use crate::ports::types::CompanyId;
+
+/// How many snapshots a single workflow keeps. Older ones are pruned on each new
+/// capture, so a hot, frequently-edited workflow cannot grow unbounded. Mirrors
+/// OpenHuman's `MAX_REVISIONS_PER_FLOW`.
+pub const MAX_WORKFLOW_REVISIONS: usize = 20;
+
+/// One immutable snapshot of a workflow graph as it stood before an edit
+/// replaced it.
+///
+/// The body is stored as the exact overlay TOML that was persisted — the same
+/// string [`workflow_version`](crate::company::workflow_version) hashes — so a
+/// rollback re-feeds it through the ordinary update path and gets the identical
+/// re-validation a hand-authored edit does.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRevisionRecord {
+    /// Stable, **minted** id within the company (see the module docs for why it
+    /// is not a content hash).
+    pub id: String,
+    /// The workflow this snapshot belongs to. All of a workflow's revisions
+    /// share this, and it is what [`list_revisions`](WorkflowRevisionStore::list_revisions)
+    /// and [`delete_revisions`](WorkflowRevisionStore::delete_revisions) scope on.
+    pub workflow_id: String,
+    /// The workflow's display name at snapshot time, for the history list. Falls
+    /// back to the workflow id when the captured body no longer parsed.
+    pub name: String,
+    /// The overlay TOML exactly as it was stored before the edit — the whole
+    /// point of the record.
+    pub toml: String,
+    /// Epoch-millis the snapshot was captured.
+    pub created_at_millis: u64,
+}
+
+impl WorkflowRevisionRecord {
+    /// Builds a revision with a freshly minted id and the given capture time.
+    pub fn new(
+        workflow_id: impl Into<String>,
+        name: impl Into<String>,
+        toml: impl Into<String>,
+        at_millis: u64,
+    ) -> Self {
+        Self {
+            id: generate_id(),
+            workflow_id: workflow_id.into(),
+            name: name.into(),
+            toml: toml.into(),
+            created_at_millis: at_millis,
+        }
+    }
+}
+
+/// The canonical [`list_revisions`](WorkflowRevisionStore::list_revisions)
+/// ordering: newest first, by `created_at_millis` descending, ties broken by
+/// `id` descending.
+///
+/// Shared by every backend rather than left to each one's natural order, because
+/// the conformance suite asserts an exact sequence and two revisions captured in
+/// the same millisecond are the common case (a burst of edits), not the exotic
+/// one — a timestamp-only sort would make the suite pass or fail on scheduler
+/// luck. Minted ids sort in mint order, so the tie-break is itself newest-first.
+pub fn sort_newest_first(revisions: &mut [WorkflowRevisionRecord]) {
+    revisions.sort_by(|a, b| {
+        b.created_at_millis
+            .cmp(&a.created_at_millis)
+            .then_with(|| b.id.cmp(&a.id))
+    });
+}
+
+/// Bounded, per-workflow revision history. Company A's revisions MUST be
+/// invisible to company B, and one workflow's revisions MUST be invisible to
+/// another's.
+#[async_trait]
+pub trait WorkflowRevisionStore: Send + Sync {
+    /// Records a snapshot and prunes the workflow's history down to
+    /// [`MAX_WORKFLOW_REVISIONS`], **atomically** where the backend can (one
+    /// SQLite/Mongo transaction; under the fs per-path lock otherwise).
+    ///
+    /// The prune is part of the write on purpose: a caller must never see a
+    /// 21-deep ring, and doing it here keeps the cap a property of the port
+    /// rather than of every writer remembering to trim.
+    async fn push_revision(
+        &self,
+        company: &CompanyId,
+        revision: &WorkflowRevisionRecord,
+    ) -> Result<()>;
+
+    /// Lists one workflow's revisions, **newest first** (see
+    /// [`sort_newest_first`]).
+    async fn list_revisions(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+    ) -> Result<Vec<WorkflowRevisionRecord>>;
+
+    /// Fetches one revision by id, scoped to its workflow, or `None`.
+    ///
+    /// Scoped to `workflow_id` so a rollback cannot restore one workflow's body
+    /// onto another by naming a revision id that belongs elsewhere.
+    async fn get_revision(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<WorkflowRevisionRecord>>;
+
+    /// Drops every revision of a workflow; returns how many were removed. The
+    /// delete cascade a workflow deletion runs so a removed workflow leaves no
+    /// orphaned history behind.
+    async fn delete_revisions(&self, company: &CompanyId, workflow_id: &str) -> Result<u64>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn new_mints_a_distinct_id_each_time() {
+        let a = WorkflowRevisionRecord::new("wf", "Greeter", "id = \"wf\"", 1);
+        let b = WorkflowRevisionRecord::new("wf", "Greeter", "id = \"wf\"", 1);
+        assert_ne!(a.id, b.id, "identical bodies must still get distinct ids");
+        assert_eq!(a.workflow_id, "wf");
+        assert_eq!(a.toml, "id = \"wf\"");
+    }
+
+    #[test]
+    fn a_record_round_trips_as_camel_case_json() {
+        let rev = WorkflowRevisionRecord::new("wf", "Greeter", "id = \"wf\"", 7);
+        let json = serde_json::to_string(&rev).unwrap();
+        assert!(json.contains("\"workflowId\""), "{json}");
+        assert!(json.contains("\"createdAtMillis\""), "{json}");
+        assert_eq!(rev, serde_json::from_str(&json).unwrap());
+    }
+
+    #[test]
+    fn sort_is_newest_first_with_id_tiebreak() {
+        // Three revisions, two sharing a millisecond — the burst-of-edits case.
+        let mut revs = vec![
+            WorkflowRevisionRecord {
+                id: "a".to_string(),
+                workflow_id: "wf".to_string(),
+                name: "n".to_string(),
+                toml: String::new(),
+                created_at_millis: 10,
+            },
+            WorkflowRevisionRecord {
+                id: "c".to_string(),
+                workflow_id: "wf".to_string(),
+                name: "n".to_string(),
+                toml: String::new(),
+                created_at_millis: 20,
+            },
+            WorkflowRevisionRecord {
+                id: "b".to_string(),
+                workflow_id: "wf".to_string(),
+                name: "n".to_string(),
+                toml: String::new(),
+                created_at_millis: 20,
+            },
+        ];
+        sort_newest_first(&mut revs);
+        let ids: Vec<&str> = revs.iter().map(|r| r.id.as_str()).collect();
+        // 20/c and 20/b outrank 10/a; within the tick the higher id wins.
+        assert_eq!(ids, ["c", "b", "a"]);
+    }
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -42,7 +42,8 @@ use crate::ports::types::{
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
     FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore, SessionStore,
-    SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
+    SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkflowRevisionStore,
+    WorkspaceStore,
 };
 use crate::runtime::board_events::BoardAnnouncer;
 use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
@@ -223,6 +224,7 @@ pub struct RuntimeBuilder {
     facts: Option<Arc<dyn FactStore>>,
     artifacts: Option<Arc<dyn ArtifactStore>>,
     runs: Option<Arc<dyn RunStore>>,
+    workflow_revisions: Option<Arc<dyn WorkflowRevisionStore>>,
     usage: Option<Arc<dyn UsageMeter>>,
     skills: Option<Arc<dyn SkillStateStore>>,
     users: Option<Arc<dyn UserStore>>,
@@ -313,6 +315,7 @@ impl RuntimeBuilder {
             facts: None,
             artifacts: None,
             runs: None,
+            workflow_revisions: None,
             usage: None,
             skills: None,
             users: None,
@@ -420,6 +423,7 @@ impl RuntimeBuilder {
         self.facts = Some(handles.facts.clone());
         self.artifacts = Some(handles.artifacts.clone());
         self.runs = Some(handles.runs.clone());
+        self.workflow_revisions = Some(handles.workflow_revisions.clone());
         self.usage = Some(handles.usage.clone());
         self.skills = Some(handles.skills.clone());
         self.users = Some(handles.users.clone());
@@ -489,6 +493,15 @@ impl RuntimeBuilder {
     /// Swaps the task-run store (default: fs-backed).
     pub fn with_runs(mut self, runs: Arc<dyn RunStore>) -> Self {
         self.runs = Some(runs);
+        self
+    }
+
+    /// Swaps the workflow-revision store (default: fs-backed).
+    pub fn with_workflow_revisions(
+        mut self,
+        workflow_revisions: Arc<dyn WorkflowRevisionStore>,
+    ) -> Self {
+        self.workflow_revisions = Some(workflow_revisions);
         self
     }
 
@@ -817,6 +830,7 @@ impl RuntimeBuilder {
                 facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
                 artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
                 runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
+                workflow_revisions: self.workflow_revisions.unwrap_or_else(|| fs_ops.clone()),
                 usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
                 skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
                 users: self.users.unwrap_or_else(|| fs_ops.clone()),

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -85,8 +85,8 @@ use crate::AppState;
 use crate::company::{
     RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowEdgeDef, WorkflowFile,
     WorkflowNodeDef, WorkflowRetryDef, create_company_workflow, delete_company_workflow,
-    list_workflows_union, load_workflow_union, seed_file_exists, set_company_workflow_enabled,
-    update_company_workflow, workflow_version,
+    list_workflows_union, load_workflow_union, rollback_company_workflow, seed_file_exists,
+    set_company_workflow_enabled, update_company_workflow, workflow_version,
 };
 use crate::error::OpenCompanyError;
 use crate::ports::types::{
@@ -150,6 +150,19 @@ pub fn router() -> Router<AppState> {
         .merge(scoped(
             "/workflows/{wid}/enabled",
             put(set_workflow_enabled),
+        ))
+        // Issue #274: the edit history of one workflow, and the restore of one of
+        // its snapshots. Both hang off `{wid}` after a further static segment
+        // (`revisions`), so they cannot collide with the dynamic `{wid}` reads
+        // above — they are strictly more specific — and they carry zero overlap
+        // with the `…/runs*` family, which lives on a different static prefix.
+        .merge(scoped(
+            "/workflows/{wid}/revisions",
+            get(list_workflow_revisions),
+        ))
+        .merge(scoped(
+            "/workflows/{wid}/revisions/{rev}/restore",
+            post(restore_workflow_revision),
         ))
 }
 
@@ -724,6 +737,7 @@ async fn update_workflow(
         company.id(),
         company.runtime.source_dir(),
         company.runtime.store(),
+        company.runtime.workflow_revisions(),
         Some(company.runtime.events()),
         draft,
         expected.as_deref(),
@@ -773,6 +787,7 @@ async fn delete_workflow(
         company.id(),
         company.runtime.source_dir(),
         company.runtime.store(),
+        company.runtime.workflow_revisions(),
         Some(company.runtime.events()),
         &wid,
         query.expected_version.as_deref(),
@@ -846,6 +861,135 @@ async fn set_workflow_enabled(
         .flatten();
     let enabled = !disabled.iter().any(|id| id == &wid);
     Ok(Json(WorkflowGraph::new(file, editable, version, enabled)))
+}
+
+// ---------------------------------------------------------------------------
+// Revision history + rollback (issue #274)
+// ---------------------------------------------------------------------------
+
+/// One revision as the console's history panel renders it — **metadata only**.
+///
+/// The graph body is deliberately absent: the list is a chooser, and shipping a
+/// full graph per row would make the history read as heavy as N graph reads for
+/// no benefit. The restore route fetches (and returns) the body when an operator
+/// actually picks one. `version` is the same opaque token
+/// `GET …/workflows/{wid}` hands out for the current body, so a console can tell
+/// which revision matches what it is looking at.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct RevisionSummary {
+    id: String,
+    name: String,
+    version: String,
+    created_at_millis: u64,
+}
+
+/// The `GET …/workflows/{wid}/revisions` response: the snapshots, newest first.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRevisionsResponse {
+    revisions: Vec<RevisionSummary>,
+}
+
+/// `GET …/workflows/{wid}/revisions` — one workflow's edit history (issue #274),
+/// newest first, **metadata only** (no graph bodies — see [`RevisionSummary`]).
+///
+/// A workflow with no history (never edited, or seed-backed) answers `200` with
+/// an empty list rather than a `404`: "no revisions" is a normal state the
+/// console renders as an empty panel, not an error. A malformed `wid` is a `404`
+/// like every other read here.
+async fn list_workflow_revisions(
+    company: ScopedCompany,
+    Path(WorkflowPath { wid }): Path<WorkflowPath>,
+) -> Result<Json<WorkflowRevisionsResponse>, ApiError> {
+    if !safe_wid(&wid) {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
+    let rows = company
+        .runtime
+        .workflow_revisions()
+        .list_revisions(company.id(), &wid)
+        .await
+        .map_err(ApiError)?;
+    let revisions = rows
+        .into_iter()
+        .map(|r| RevisionSummary {
+            id: r.id,
+            name: r.name,
+            // The token the current-graph read would hand out for this body, so
+            // the console can correlate a row with what it currently holds.
+            version: workflow_version(&r.toml),
+            created_at_millis: r.created_at_millis,
+        })
+        .collect();
+    Ok(Json(WorkflowRevisionsResponse { revisions }))
+}
+
+/// The sub-resource path on the restore route: the workflow id and the revision
+/// id. The scope `id` is consumed by the extractor.
+#[derive(Debug, Deserialize)]
+struct RevisionPath {
+    wid: String,
+    rev: String,
+}
+
+/// The `POST …/workflows/{wid}/revisions/{rev}/restore` body: the optional
+/// concurrency token of the graph being replaced.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RestoreRevisionBody {
+    /// The token from the `GET`/`PUT` the operator was looking at when they hit
+    /// Restore. Omit for an unconditional restore; the console always sends it,
+    /// and on a `409` should reload rather than retry — the graph moved under it.
+    #[serde(default)]
+    expected_version: Option<String>,
+}
+
+/// `POST …/workflows/{wid}/revisions/{rev}/restore` — roll a workflow back to a
+/// captured revision (issue #274), returning the restored [`WorkflowGraph`] with
+/// a fresh version token.
+///
+/// This is an ordinary edit whose new body is an old one, so it routes through
+/// the same [`rollback_company_workflow`] → [`update_company_workflow`] path a
+/// `PUT` does and inherits every one of its guarantees: re-validation against
+/// the *current* record, a snapshot of the body it replaces (so the restore is
+/// itself undoable), the optimistic-concurrency token, and the #276 disarm of a
+/// restored schedule.
+///
+/// Statuses: `200` (restored), `400` (the revision is invalid against the
+/// current record — e.g. it names a since-removed teammate), `404` (unknown
+/// `wid` or unknown `rev`), `409` (seed-backed / body-less `wid`, a stale
+/// `expectedVersion`, or a name collision).
+async fn restore_workflow_revision(
+    company: ScopedCompany,
+    Path(RevisionPath { wid, rev }): Path<RevisionPath>,
+    body: Option<Json<RestoreRevisionBody>>,
+) -> Result<Json<WorkflowGraph>, ApiError> {
+    if !safe_wid(&wid) {
+        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+            "workflow {wid}"
+        ))));
+    }
+    let expected = body.and_then(|Json(b)| b.expected_version);
+    let file = rollback_company_workflow(
+        company.id(),
+        company.runtime.source_dir(),
+        company.runtime.store(),
+        company.runtime.workflow_revisions(),
+        Some(company.runtime.events()),
+        &wid,
+        &rev,
+        expected.as_deref(),
+    )
+    .await
+    .map_err(ApiError)?;
+    // The response carries the restored graph plus its NEW token — a restore is a
+    // write, so the console holds a valid token for the next edit without a
+    // follow-up read (and can see the #276 disarm on `enabled` if the restored
+    // graph re-introduced a schedule).
+    Ok(Json(graph_with_version(&company, file).await?))
 }
 
 /// Whether `wid` is a single safe on-disk filename stem — no path separators,
@@ -3357,6 +3501,181 @@ mod tests {
                 .unwrap();
             let items = json_body(response).await;
             assert_eq!(items.as_array().unwrap().len(), 1, "{items}");
+        }
+
+        // ── Issue #274: revision history + rollback at the HTTP boundary ────
+
+        /// Edits `greeter` once (adding a schedule) so exactly one revision — the
+        /// original, schedule-less body — is captured, and returns the token of
+        /// the now-current (scheduled) graph.
+        async fn create_then_edit_greeter(state: &AppState) -> String {
+            let version = create_greeter(state).await;
+            let response = router(state.clone())
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(edited_body(Some(&version))),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            json_body(response).await["version"]
+                .as_str()
+                .expect("new token")
+                .to_string()
+        }
+
+        /// `GET …/revisions` returns metadata only — id, name, version,
+        /// createdAtMillis — and never a graph body. Leaking the TOML/nodes here
+        /// would make the list as heavy as N graph reads and expose the raw
+        /// stored body the console never asked for.
+        #[tokio::test]
+        async fn revisions_list_is_metadata_only_and_newest_first() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_then_edit_greeter(&state).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/greeter/revisions",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = json_body(response).await;
+            let revs = body["revisions"].as_array().expect("revisions array");
+            assert_eq!(revs.len(), 1, "one edit captured one revision: {body}");
+            let row = &revs[0];
+            assert!(row["id"].is_string());
+            assert_eq!(row["name"], "Greeter");
+            assert!(row["version"].is_string());
+            assert!(row["createdAtMillis"].is_number());
+            // No graph body leaks into the list.
+            assert!(row.get("nodes").is_none(), "metadata only: {row}");
+            assert!(row.get("edges").is_none(), "metadata only: {row}");
+            assert!(
+                row.get("toml").is_none(),
+                "the raw body must never leak: {row}"
+            );
+        }
+
+        /// `POST …/revisions/{rev}/restore` reverts the live graph to the
+        /// snapshot and answers with the restored body + a fresh token. The
+        /// captured revision was the schedule-less original, so the restore
+        /// removes the schedule the edit added.
+        #[tokio::test]
+        async fn restore_reverts_the_live_graph() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_then_edit_greeter(&state).await;
+
+            // Discover the revision id from the list.
+            let list = json_body(
+                router(state.clone())
+                    .oneshot(request(
+                        "GET",
+                        "/api/v1/company/workflows/greeter/revisions",
+                        None,
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            let rev_id = list["revisions"][0]["id"].as_str().unwrap().to_string();
+
+            // Restore it (unconditionally — no expectedVersion).
+            let response = router(state.clone())
+                .oneshot(request(
+                    "POST",
+                    &format!("/api/v1/company/workflows/greeter/revisions/{rev_id}/restore"),
+                    Some(serde_json::json!({})),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let restored = json_body(response).await;
+            // The schedule the edit introduced is gone — the original is back.
+            assert!(
+                restored["nodes"][0].get("schedule").is_none(),
+                "restore should drop the edit's schedule: {restored}"
+            );
+            assert!(
+                restored["version"].is_string(),
+                "restore returns a fresh token"
+            );
+
+            // A fresh read agrees, and the restore itself was captured, so the
+            // history now holds two snapshots (the original + the scheduled body
+            // the restore replaced).
+            let graph = json_body(
+                router(state.clone())
+                    .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert!(graph["nodes"][0].get("schedule").is_none(), "{graph}");
+            let list = json_body(
+                router(state)
+                    .oneshot(request(
+                        "GET",
+                        "/api/v1/company/workflows/greeter/revisions",
+                        None,
+                    ))
+                    .await
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(
+                list["revisions"].as_array().unwrap().len(),
+                2,
+                "the restore captured the body it replaced: {list}"
+            );
+        }
+
+        /// Restoring a revision id that does not exist is a clean `404`.
+        #[tokio::test]
+        async fn restore_unknown_revision_is_not_found() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_then_edit_greeter(&state).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "POST",
+                    "/api/v1/company/workflows/greeter/revisions/no-such-rev/restore",
+                    Some(serde_json::json!({})),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        }
+
+        /// A workflow that was never edited has an empty history — `200 []`, not
+        /// a `404`.
+        #[tokio::test]
+        async fn revisions_of_an_unedited_workflow_are_empty() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+            create_greeter(&state).await;
+
+            let response = router(state)
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/greeter/revisions",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = json_body(response).await;
+            assert_eq!(body["revisions"].as_array().unwrap().len(), 0, "{body}");
         }
 
         /// **The silent-overwrite guard.** Two consoles hold the same graph; one

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -34,6 +34,9 @@ use crate::ports::types::{
 };
 use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
 use crate::ports::users::{InviteRecord, UserRecord, UserRole, UserStatus, UserStore};
+use crate::ports::workflow_revisions::{
+    MAX_WORKFLOW_REVISIONS, WorkflowRevisionRecord, WorkflowRevisionStore,
+};
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
 /// A minimal valid manifest used to seed [`CompanyRecord`]s in the suite.
@@ -1573,6 +1576,198 @@ pub async fn assert_artifact_store(artifacts: Arc<dyn ArtifactStore>) {
     assert!(!artifacts.delete(&alpha, "a1").await.unwrap());
     assert_eq!(artifacts.list(&alpha, None).await.unwrap().len(), 3);
     assert_eq!(artifacts.list(&beta, None).await.unwrap().len(), 1);
+}
+
+/// Asserts the [`WorkflowRevisionStore`] contract (issue #274): per-company and
+/// per-workflow isolation, newest-first order, prune-to-cap inside the push, a
+/// verbatim body round-trip, and the delete cascade.
+///
+/// The prune assertion is the load-bearing one: a backend that grew the ring
+/// unbounded, or that pruned the *newest* rows instead of the oldest, would
+/// still pass a naive "push then read back" check while defeating the whole
+/// point of a bounded history.
+pub async fn assert_workflow_revision_store(revisions: Arc<dyn WorkflowRevisionStore>) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    // A helper that pins the capture time, so ordering is asserted against a
+    // known sequence rather than the wall clock.
+    let rev = |workflow_id: &str, name: &str, toml: &str, at: u64| {
+        let mut r = WorkflowRevisionRecord::new(workflow_id, name, toml, at);
+        // Force a distinct, ordered id so the tie-break is deterministic even
+        // when two share a millisecond.
+        r.id = format!("{workflow_id}-{at:04}");
+        r
+    };
+
+    // Two revisions of `greeter`, plus one of a sibling workflow, plus one under
+    // company beta that must never leak into alpha.
+    let first = rev(
+        "greeter",
+        "Greeter v1",
+        "id = \"greeter\"\nname = \"Greeter v1\"",
+        10,
+    );
+    let second = rev(
+        "greeter",
+        "Greeter v2",
+        "id = \"greeter\"\nname = \"Greeter v2\"",
+        20,
+    );
+    revisions.push_revision(&alpha, &first).await.unwrap();
+    revisions.push_revision(&alpha, &second).await.unwrap();
+    revisions
+        .push_revision(&alpha, &rev("digest", "Digest", "id = \"digest\"", 15))
+        .await
+        .unwrap();
+    revisions
+        .push_revision(&beta, &rev("greeter", "Other", "id = \"greeter\"", 99))
+        .await
+        .unwrap();
+
+    // Isolation by company AND by workflow.
+    let alpha_greeter = revisions.list_revisions(&alpha, "greeter").await.unwrap();
+    assert_eq!(alpha_greeter.len(), 2, "only greeter's two snapshots");
+    assert_eq!(
+        revisions
+            .list_revisions(&alpha, "digest")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        revisions
+            .list_revisions(&beta, "greeter")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Newest first, and the body round-trips verbatim.
+    assert_eq!(alpha_greeter[0].id, second.id, "newest snapshot leads");
+    assert_eq!(alpha_greeter[1].id, first.id);
+    assert_eq!(
+        alpha_greeter[0].toml, second.toml,
+        "the captured TOML must survive byte-for-byte"
+    );
+
+    // get_revision is workflow-scoped: greeter's id is invisible under digest.
+    assert!(
+        revisions
+            .get_revision(&alpha, "greeter", &first.id)
+            .await
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        revisions
+            .get_revision(&alpha, "digest", &first.id)
+            .await
+            .unwrap()
+            .is_none(),
+        "a revision id must not resolve under the wrong workflow"
+    );
+    assert!(
+        revisions
+            .get_revision(&alpha, "greeter", "nope")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // Prune-to-cap: push MAX+5 distinct snapshots of a fresh workflow and prove
+    // the ring holds exactly MAX, keeping the newest and dropping the oldest.
+    for i in 0..(MAX_WORKFLOW_REVISIONS as u64 + 5) {
+        revisions
+            .push_revision(
+                &alpha,
+                &rev(
+                    "ring",
+                    &format!("v{i}"),
+                    &format!("id = \"ring\" # {i}"),
+                    1000 + i,
+                ),
+            )
+            .await
+            .unwrap();
+    }
+    let ring = revisions.list_revisions(&alpha, "ring").await.unwrap();
+    assert_eq!(
+        ring.len(),
+        MAX_WORKFLOW_REVISIONS,
+        "the ring must be capped at MAX_WORKFLOW_REVISIONS"
+    );
+    assert_eq!(
+        ring[0].created_at_millis,
+        1000 + MAX_WORKFLOW_REVISIONS as u64 + 4,
+        "the newest snapshot survives the prune"
+    );
+    assert_eq!(
+        ring[ring.len() - 1].created_at_millis,
+        1000 + 5,
+        "the oldest kept is exactly MAX back from the newest — older ones pruned"
+    );
+
+    // The prune must not have touched the sibling workflows or company beta.
+    assert_eq!(
+        revisions
+            .list_revisions(&alpha, "greeter")
+            .await
+            .unwrap()
+            .len(),
+        2
+    );
+    assert_eq!(
+        revisions
+            .list_revisions(&beta, "greeter")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+
+    // Delete cascade: drops exactly one workflow's history, reports the count,
+    // and is a no-op the second time.
+    let removed = revisions.delete_revisions(&alpha, "greeter").await.unwrap();
+    assert_eq!(removed, 2, "both greeter snapshots removed");
+    assert!(
+        revisions
+            .list_revisions(&alpha, "greeter")
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert_eq!(
+        revisions.delete_revisions(&alpha, "greeter").await.unwrap(),
+        0
+    );
+    // Siblings and beta untouched by the cascade.
+    assert_eq!(
+        revisions
+            .list_revisions(&alpha, "digest")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+    assert_eq!(
+        revisions
+            .list_revisions(&alpha, "ring")
+            .await
+            .unwrap()
+            .len(),
+        MAX_WORKFLOW_REVISIONS
+    );
+    assert_eq!(
+        revisions
+            .list_revisions(&beta, "greeter")
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
 }
 
 /// Asserts the [`FactStore`] contract: isolation, query/kind filtering, upsert,

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -36,6 +36,10 @@ use crate::ports::tasks::{TaskRecord, TaskStore};
 use crate::ports::types::CompanyId;
 use crate::ports::usage::{UsageMeter, UsageSample, retention_cutoff};
 use crate::ports::users::{InviteRecord, UserRecord, UserStore};
+use crate::ports::workflow_revisions::{
+    MAX_WORKFLOW_REVISIONS, WorkflowRevisionRecord, WorkflowRevisionStore,
+    sort_newest_first as sort_revisions_newest_first,
+};
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 use crate::store::fs::{append_line, io_err, path_lock, read_jsonl, read_optional, write_atomic};
 use crate::store::paths::Bundle;
@@ -507,6 +511,93 @@ impl ArtifactStore for FsOps {
         rewrite_jsonl(&path, &artifacts).await?;
         Ok(true)
     }
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowRevisionStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl WorkflowRevisionStore for FsOps {
+    async fn push_revision(
+        &self,
+        company: &CompanyId,
+        revision: &WorkflowRevisionRecord,
+    ) -> Result<()> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.workflow_revisions_jsonl();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut all = read_jsonl::<WorkflowRevisionRecord>(&path).await?;
+        all.push(revision.clone());
+        // Prune-to-cap for THIS workflow only, inside the lock so a reader never
+        // sees a 21-deep ring. Other workflows' snapshots are untouched.
+        prune_workflow_revisions(&mut all, &revision.workflow_id);
+        rewrite_jsonl(&path, &all).await
+    }
+
+    async fn list_revisions(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+    ) -> Result<Vec<WorkflowRevisionRecord>> {
+        let mut revs =
+            read_jsonl::<WorkflowRevisionRecord>(&self.bundle(company).workflow_revisions_jsonl())
+                .await?;
+        revs.retain(|r| r.workflow_id == workflow_id);
+        sort_revisions_newest_first(&mut revs);
+        Ok(revs)
+    }
+
+    async fn get_revision(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<WorkflowRevisionRecord>> {
+        let revs =
+            read_jsonl::<WorkflowRevisionRecord>(&self.bundle(company).workflow_revisions_jsonl())
+                .await?;
+        Ok(revs
+            .into_iter()
+            .find(|r| r.workflow_id == workflow_id && r.id == revision_id))
+    }
+
+    async fn delete_revisions(&self, company: &CompanyId, workflow_id: &str) -> Result<u64> {
+        let path = self.bundle(company).workflow_revisions_jsonl();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut revs = read_jsonl::<WorkflowRevisionRecord>(&path).await?;
+        let before = revs.len();
+        revs.retain(|r| r.workflow_id != workflow_id);
+        let removed = (before - revs.len()) as u64;
+        if removed > 0 {
+            rewrite_jsonl(&path, &revs).await?;
+        }
+        Ok(removed)
+    }
+}
+
+/// Trims `all` so the workflow named by `workflow_id` keeps at most
+/// [`MAX_WORKFLOW_REVISIONS`] of its newest snapshots, leaving every other
+/// workflow's rows in place and in their original file order.
+fn prune_workflow_revisions(all: &mut Vec<WorkflowRevisionRecord>, workflow_id: &str) {
+    let mut mine: Vec<WorkflowRevisionRecord> = all
+        .iter()
+        .filter(|r| r.workflow_id == workflow_id)
+        .cloned()
+        .collect();
+    if mine.len() <= MAX_WORKFLOW_REVISIONS {
+        return;
+    }
+    sort_revisions_newest_first(&mut mine);
+    let keep: HashSet<String> = mine
+        .into_iter()
+        .take(MAX_WORKFLOW_REVISIONS)
+        .map(|r| r.id)
+        .collect();
+    all.retain(|r| r.workflow_id != workflow_id || keep.contains(&r.id));
 }
 
 // ---------------------------------------------------------------------------
@@ -1138,6 +1229,13 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_run_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_workflow_revision_store() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_workflow_revision_store(Arc::new(FsOps::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/migrate.rs
+++ b/src/store/migrate.rs
@@ -124,6 +124,7 @@ const BUNDLE_FILES: &[&str] = &[
     "tasks.json",
     "facts.jsonl",
     "artifacts.jsonl",
+    "workflow-revisions.jsonl",
     "users.json",
     "user-invites.json",
     "user-sessions.json",

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -146,7 +146,7 @@ impl MongoStore {
         // Not every index can be unique: a user holds many sessions, and an
         // address may have several login codes over time.
         let nonunique = |keys: Document| IndexModel::builder().keys(keys).build();
-        let plans: [(&str, IndexModel); 28] = [
+        let plans: [(&str, IndexModel); 30] = [
             ("companies", unique(doc! {"company_id": 1})),
             ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
             ("events", unique(doc! {"company_id": 1, "seq": 1})),
@@ -199,6 +199,16 @@ impl MongoStore {
             (
                 "run_steps",
                 unique(doc! {"company_id": 1, "run_id": 1, "step_seq": 1}),
+            ),
+            // Issue #274: one row per snapshot; the compound index backs both the
+            // per-workflow list (newest-first) and the prune.
+            (
+                "workflow_revisions",
+                unique(doc! {"company_id": 1, "revision_id": 1}),
+            ),
+            (
+                "workflow_revisions",
+                nonunique(doc! {"company_id": 1, "workflow_id": 1, "created_ms": -1}),
             ),
         ];
         for (name, index) in plans {
@@ -1457,6 +1467,108 @@ impl crate::ports::artifacts::ArtifactStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// WorkflowRevisionStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::workflow_revisions::WorkflowRevisionStore for MongoStore {
+    async fn push_revision(
+        &self,
+        company: &CompanyId,
+        revision: &crate::ports::workflow_revisions::WorkflowRevisionRecord,
+    ) -> Result<()> {
+        use crate::ports::workflow_revisions::MAX_WORKFLOW_REVISIONS;
+        let coll = self.collection("workflow_revisions");
+        coll.insert_one(doc! {
+            "company_id": company.as_ref(),
+            "revision_id": &revision.id,
+            "workflow_id": &revision.workflow_id,
+            "revision_json": serde_json::to_string(revision)?,
+            "created_ms": revision.created_at_millis as i64,
+        })
+        .await
+        .map_err(mongo_err)?;
+
+        // Prune to the cap: collect this workflow's revision ids newest-first and
+        // delete everything past `MAX`. Two statements rather than one because
+        // MongoDB has no "delete all but the newest N" operator; the compound
+        // index keeps the read cheap, and an interleaved second push only ever
+        // trims further, never resurrects a pruned row.
+        let mut cursor = coll
+            .find(doc! {"company_id": company.as_ref(), "workflow_id": &revision.workflow_id})
+            .sort(doc! {"created_ms": -1, "revision_id": -1})
+            .await
+            .map_err(mongo_err)?;
+        let mut ids: Vec<String> = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            ids.push(get_str(&doc, "revision_id")?);
+        }
+        if ids.len() > MAX_WORKFLOW_REVISIONS {
+            let stale: Vec<&String> = ids.iter().skip(MAX_WORKFLOW_REVISIONS).collect();
+            coll.delete_many(doc! {
+                "company_id": company.as_ref(),
+                "workflow_id": &revision.workflow_id,
+                "revision_id": {"$in": stale},
+            })
+            .await
+            .map_err(mongo_err)?;
+        }
+        Ok(())
+    }
+
+    async fn list_revisions(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+    ) -> Result<Vec<crate::ports::workflow_revisions::WorkflowRevisionRecord>> {
+        let mut cursor = self
+            .collection("workflow_revisions")
+            .find(doc! {"company_id": company.as_ref(), "workflow_id": workflow_id})
+            .sort(doc! {"created_ms": -1, "revision_id": -1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(serde_json::from_str(&get_str(&doc, "revision_json")?)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_revision(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<crate::ports::workflow_revisions::WorkflowRevisionRecord>> {
+        let found = self
+            .collection("workflow_revisions")
+            .find_one(doc! {
+                "company_id": company.as_ref(),
+                "workflow_id": workflow_id,
+                "revision_id": revision_id,
+            })
+            .await
+            .map_err(mongo_err)?;
+        match found {
+            Some(doc) => Ok(Some(serde_json::from_str(&get_str(
+                &doc,
+                "revision_json",
+            )?)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_revisions(&self, company: &CompanyId, workflow_id: &str) -> Result<u64> {
+        let res = self
+            .collection("workflow_revisions")
+            .delete_many(doc! {"company_id": company.as_ref(), "workflow_id": workflow_id})
+            .await
+            .map_err(mongo_err)?;
+        Ok(res.deleted_count)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // RunStore
 // ---------------------------------------------------------------------------
 
@@ -2261,6 +2373,13 @@ mod test {
     async fn conformance_run_store() {
         let Some(s) = store().await else { return };
         conformance::assert_run_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_workflow_revision_store() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workflow_revision_store(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -299,6 +299,16 @@ impl Bundle {
         self.dir.join("artifacts.jsonl")
     }
 
+    /// Path to the per-workflow revision ring (`workflow-revisions.jsonl`, one
+    /// [`WorkflowRevisionRecord`] per line, append-then-prune to the cap; issue
+    /// #274). Not last-write-wins: every distinct snapshot is its own immutable
+    /// line, keyed by its minted `id`.
+    ///
+    /// [`WorkflowRevisionRecord`]: crate::ports::workflow_revisions::WorkflowRevisionRecord
+    pub fn workflow_revisions_jsonl(&self) -> PathBuf {
+        self.dir.join("workflow-revisions.jsonl")
+    }
+
     /// Path to the task-run log (`runs.jsonl`, one [`RunRecord`] per line;
     /// last-write-wins per id).
     ///

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -33,6 +33,7 @@ use crate::ports::tasks::TaskStore;
 use crate::ports::types::CompanyId;
 use crate::ports::usage::UsageMeter;
 use crate::ports::users::UserStore;
+use crate::ports::workflow_revisions::WorkflowRevisionStore;
 use crate::ports::workspace::WorkspaceStore;
 
 /// Which storage backend hosts the durable ports.
@@ -148,6 +149,8 @@ pub struct StorageHandles {
     pub artifacts: Arc<dyn ArtifactStore>,
     /// First-class task-run records and their step traces (#242).
     pub runs: Arc<dyn RunStore>,
+    /// Per-workflow edit history for rollback (#274).
+    pub workflow_revisions: Arc<dyn WorkflowRevisionStore>,
     pub usage: Arc<dyn UsageMeter>,
     pub skills: Arc<dyn SkillStateStore>,
     pub users: Arc<dyn UserStore>,
@@ -402,6 +405,7 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         facts: store.clone(),
         artifacts: store.clone(),
         runs: store.clone(),
+        workflow_revisions: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),
@@ -439,6 +443,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         facts: store.clone(),
         artifacts: store.clone(),
         runs: store.clone(),
+        workflow_revisions: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -159,6 +159,16 @@ CREATE TABLE IF NOT EXISTS run_steps (
     step_json  TEXT NOT NULL,
     PRIMARY KEY (company_id, run_id, step_seq)
 );
+CREATE TABLE IF NOT EXISTS workflow_revisions (
+    company_id    TEXT NOT NULL,
+    id            TEXT NOT NULL,
+    workflow_id   TEXT NOT NULL,
+    revision_json TEXT NOT NULL,
+    created_ms    INTEGER NOT NULL,
+    PRIMARY KEY (company_id, id)
+);
+CREATE INDEX IF NOT EXISTS workflow_revisions_by_workflow
+    ON workflow_revisions (company_id, workflow_id, created_ms);
 CREATE TABLE IF NOT EXISTS usage_samples (
     company_id TEXT NOT NULL,
     seq        INTEGER NOT NULL,
@@ -1628,6 +1638,116 @@ impl crate::ports::artifacts::ArtifactStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// WorkflowRevisionStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::workflow_revisions::WorkflowRevisionStore for SqliteStore {
+    async fn push_revision(
+        &self,
+        company: &CompanyId,
+        revision: &crate::ports::workflow_revisions::WorkflowRevisionRecord,
+    ) -> Result<()> {
+        use crate::ports::workflow_revisions::MAX_WORKFLOW_REVISIONS;
+        let json = serde_json::to_string(revision)?;
+        let mut guard = self.conn();
+        // Insert + prune in ONE transaction, so a reader never observes a
+        // 21-deep ring. The prune keeps the newest `MAX` rows for THIS workflow
+        // (by `created_ms DESC, id DESC`, matching `sort_newest_first`) and
+        // deletes the rest — the same shape OpenHuman's `flow_revisions` prune
+        // uses.
+        let tx = guard.transaction().map_err(sql_err)?;
+        tx.execute(
+            "INSERT INTO workflow_revisions (company_id, id, workflow_id, revision_json, created_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5)",
+            params![
+                company.as_ref(),
+                revision.id,
+                revision.workflow_id,
+                json,
+                revision.created_at_millis as i64,
+            ],
+        )
+        .map_err(sql_err)?;
+        tx.execute(
+            "DELETE FROM workflow_revisions \
+             WHERE company_id = ?1 AND workflow_id = ?2 AND id NOT IN (\
+                 SELECT id FROM workflow_revisions \
+                 WHERE company_id = ?1 AND workflow_id = ?2 \
+                 ORDER BY created_ms DESC, id DESC LIMIT ?3)",
+            params![
+                company.as_ref(),
+                revision.workflow_id,
+                MAX_WORKFLOW_REVISIONS as i64,
+            ],
+        )
+        .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn list_revisions(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+    ) -> Result<Vec<crate::ports::workflow_revisions::WorkflowRevisionRecord>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT revision_json FROM workflow_revisions \
+                 WHERE company_id = ?1 AND workflow_id = ?2 \
+                 ORDER BY created_ms DESC, id DESC",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref(), workflow_id], |r| {
+                r.get::<_, String>(0)
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(serde_json::from_str(&row.map_err(sql_err)?)?);
+        }
+        Ok(out)
+    }
+
+    async fn get_revision(
+        &self,
+        company: &CompanyId,
+        workflow_id: &str,
+        revision_id: &str,
+    ) -> Result<Option<crate::ports::workflow_revisions::WorkflowRevisionRecord>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT revision_json FROM workflow_revisions \
+                 WHERE company_id = ?1 AND workflow_id = ?2 AND id = ?3",
+            )
+            .map_err(sql_err)?;
+        let mut rows = stmt
+            .query_map(params![company.as_ref(), workflow_id, revision_id], |r| {
+                r.get::<_, String>(0)
+            })
+            .map_err(sql_err)?;
+        match rows.next() {
+            Some(row) => Ok(Some(serde_json::from_str(&row.map_err(sql_err)?)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn delete_revisions(&self, company: &CompanyId, workflow_id: &str) -> Result<u64> {
+        let conn = self.conn();
+        let n = conn
+            .execute(
+                "DELETE FROM workflow_revisions WHERE company_id = ?1 AND workflow_id = ?2",
+                params![company.as_ref(), workflow_id],
+            )
+            .map_err(sql_err)?;
+        Ok(n as u64)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // RunStore
 // ---------------------------------------------------------------------------
 
@@ -2311,6 +2431,11 @@ mod test {
     async fn conformance_fact_store() {
         conformance::assert_fact_store(store()).await;
         conformance::assert_artifact_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_workflow_revision_store() {
+        conformance::assert_workflow_revision_store(store()).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Editing a saved workflow (`PUT …/workflows/{wid}`, #259) overwrote the prior graph with nothing kept — a dropped node or mangled cron was unrecoverable except by re-authoring. This adds edit history + rollback, ported from OpenHuman's `flow_revisions`: on every edit the prior graph is snapshotted into a dedicated revision store **inside the guarded write** (push-before-save), the newest 20 distinct versions are kept, and the editor gets a History panel with one-click Restore.

Restore is itself a guarded edit through the same `create`/`update` path: it re-validates against the *current* company (a revision naming a since-removed agent → 400, not a broken restore), **snapshots the current body first so rollback is undoable**, honours the optimistic version token (stale → 409), and inherits #276's disarm (a restored cron lands disabled until a human enables it). Byte-identical re-saves don't consume a slot.

## API Or Behavior Changes

- New `WorkflowRevisionStore` port (fs/sqlite/mongo impls + conformance), wired through the storage seam like `runs`/`artifacts`. `MAX_WORKFLOW_REVISIONS = 20`.
- New routes: `GET {scope}/workflows/{wid}/revisions` (metadata only — no graph body / no TOML leak, newest-first) and `POST {scope}/workflows/{wid}/revisions/{rev}/restore` (`{expectedVersion?}` → 200 `WorkflowGraph` | 400 invalid-vs-current | 404 unknown | 409 stale/seed-backed/name-clash).
- `delete_company_workflow` cascades `delete_revisions`. Seed-file-backed workflows are never overlay-edited, so their history is legitimately empty and restore 409s with the existing "edit the source file" message.
- No engine change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features openhuman,tinycortex`)
- [x] `cargo build --all-targets` (`cargo check --all-features` — proves the feature-gated sqlite + mongo impls)
- [x] `cargo test` — default **1825 passed / 0 failed**; gated **2752 / 0**. New: store conformance (roundtrip/order/prune-at-MAX+5/isolation-by-company-and-wid/cascade); capture-on-update (byte-exact prior, byte-identical→none, ring prunes at cap); rollback roundtrip (A→edit→restore A, restore-of-rollback, removed-agent→400 leaves current, restored cron disarmed, stale token→409 writes nothing, token = restored body hash); route shape (metadata-only, 404 unknown rev, empty→`200 []`)
- [x] frontend `npm run typecheck` + `npm run build`
- [ ] **Manual edit-dialog walk (UI-bound, pending a live host):** edit a workflow twice → History shows prior versions newest-first (metadata only) → Restore reverts the canvas and gains a new top row (the pre-restore body) → a restored cron shows disarmed → race a 2nd tab for the 409 reload UX.

## Documentation

`docs/spec/runtime/ports.md` — new port table entry + a #274 section.

## Related

Closes #274. Ports OpenHuman's `flow_revisions`. Builds on #259 (replace) + #276 (disarm). Shares the storage-registration seam additively with #241 + #596 (distinct names; union-built before the second merges).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added workflow edit history with newest-first revision listings.
  - Added the ability to restore previous workflow versions with confirmation and conflict checks.
  - Restored workflows undergo normal validation and version handling.
  - Revision history is automatically captured during edits and removed when workflows are deleted.
  - History is capped at 20 revisions per workflow.
- **Documentation**
  - Documented workflow revision storage and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->