### PR TITLE
feat(scheduler): durable cross-replica fire claims + restart catch-up (#241)

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -31,6 +31,9 @@ use crate::ports::{
     SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore,
     WorkspaceStore,
 };
+// Separate line (#241) so this addition is a pure append, not a reflow of the
+// grouped import that sibling store-seam branches (#274, #596) also edit.
+use crate::ports::ScheduleFireStore;
 
 /// The board column a task must enter to be dispatched to its assignee. Read
 /// from the task port (#205) so this edge and the write boundary that validates
@@ -124,6 +127,8 @@ pub struct OpsStores {
     pub artifacts: Arc<dyn ArtifactStore>,
     /// First-class records of each task attempt: status, trace, cost (#242).
     pub runs: Arc<dyn RunStore>,
+    /// Durable cross-replica scheduler fire claims (#241).
+    pub schedule_fires: Arc<dyn ScheduleFireStore>,
     /// The usage meter (written by the WS4 cost hook, read by WS5).
     pub usage: Arc<dyn UsageMeter>,
     /// Operator deltas over the company's skills.
@@ -769,6 +774,13 @@ impl CompanyRuntime {
     /// with its status, step trace and cost.
     pub fn runs(&self) -> &Arc<dyn RunStore> {
         &self.ops.runs
+    }
+
+    /// This company's durable scheduler fire claims (#241): one row per
+    /// `(schedule, minute)` the schedulers use to dedup fires across replicas and
+    /// restarts.
+    pub fn schedule_fires(&self) -> &Arc<dyn ScheduleFireStore> {
+        &self.ops.schedule_fires
     }
 
     /// This company's usage meter (written by the cost hook, read by WS5).

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -20,6 +20,7 @@ pub mod inbox;
 pub mod login_codes;
 pub mod memory;
 pub mod runs;
+pub mod schedule_fires;
 pub mod secrets;
 pub mod sessions;
 pub mod skills_state;
@@ -51,6 +52,7 @@ pub use runs::{
     NewRun, RunFilter, RunOutcome, RunRecord, RunStatus, RunStepRecord, RunStore,
     reap_orphaned_runs,
 };
+pub use schedule_fires::ScheduleFireStore;
 pub use secrets::SecretStore;
 pub use sessions::{SessionKind, SessionRecord, SessionStore};
 pub use skills_state::{SkillSource, SkillState, SkillStateStore};
@@ -98,6 +100,7 @@ mod test {
         _sessions: &dyn crate::ports::sessions::SessionStore,
         _login_codes: &dyn crate::ports::login_codes::LoginCodeStore,
         _runs: &dyn crate::ports::runs::RunStore,
+        _schedule_fires: &dyn crate::ports::schedule_fires::ScheduleFireStore,
         _workflow_runner: &dyn crate::ports::workflow_runner::WorkflowRunner,
     ) {
     }

--- a/src/ports/schedule_fires.rs
+++ b/src/ports/schedule_fires.rs
@@ -1,0 +1,113 @@
+//! The [`ScheduleFireStore`] port: a durable, cross-replica claim on one
+//! schedule's fire instant.
+//!
+//! Both schedulers — [`CompanyScheduler`](crate::runtime::CompanyScheduler) for
+//! manifest `[[schedule]]` crons and
+//! [`WorkflowScheduler`](crate::runtime::WorkflowScheduler) for saved-workflow
+//! triggers — used to dedup fires purely in process memory (a
+//! `HashMap<_, u64>` of the last minute each schedule fired). That map cannot
+//! survive a restart and cannot see a second replica, so a schedule whose fire
+//! instant fell during a deploy was silently dropped, and two hosted replicas of
+//! one tenant both fired every schedule. This port is the durable record those
+//! two failures needed and never had.
+//!
+//! ## One row per (company, schedule, minute)
+//!
+//! The unit of the claim is the exact UTC epoch minute both ticks already
+//! compute (`minute = now / MINUTE_MS`), so no new time math is introduced and
+//! two processes whose clocks agree within a minute compute the *same* key. The
+//! composite key is `(company_id, schedule_id, scheduled_for)`; the winning
+//! caller is whoever inserts that row first, decided by the backend's own
+//! uniqueness primitive:
+//!
+//! * **sqlite** — `INSERT OR IGNORE` into a table with
+//!   `PRIMARY KEY (company_id, schedule_id, scheduled_for)`; rows-affected picks
+//!   the winner.
+//! * **mongodb** — `insert_one` against a unique compound index; an `E11000`
+//!   duplicate-key means lost. This is the arbiter that actually matters, since
+//!   hosted replicas share the tenant database.
+//! * **fs** — an `OpenOptions::create_new` (`O_EXCL`) marker file. Declared
+//!   single-node-only: `O_EXCL` is not trustworthy on NFS, and hosted
+//!   deployments run mongodb.
+//!
+//! A claim is **terminal** — there is no lease and no release. Awaited *before*
+//! any side effect, it gives at-most-once firing: the loser skips with zero side
+//! effects, and a cycle that fails *after* a won claim burns that instant rather
+//! than risking a double external effect (a second email, a second task, more
+//! token spend). Because the key is the minute itself, a burned instant cannot
+//! wedge a schedule — the next minute is a fresh key.
+//!
+//! ## Schedule identity is restart-stable and path-safe
+//!
+//! `schedule_id` is a caller-minted string, never a positional index:
+//!
+//! * workflow crons use `"workflow-<workflow_id>"`;
+//! * manifest schedules use `"manifest-" + hex(sha256(cron + "\n" + prompt))`
+//!   truncated to 16 hex chars, so reordering the manifest does not reassign a
+//!   schedule's identity and two identical `(cron, prompt)` entries collapse to
+//!   one fire.
+//!
+//! The hyphen prefixes (no colon) keep the id readable in a log line. The fs
+//! backend hashes the id again before letting it address the filesystem, so an
+//! id the store did not mint can never become a path component (the same rule
+//! [`Bundle::runs_jsonl`](crate::store::paths) documents for run ids).
+//!
+//! ## Retention
+//!
+//! [`latest_fire`](ScheduleFireStore::latest_fire) is the restart catch-up
+//! anchor (the most recent minute this schedule is known to have fired), and
+//! [`prune_fires_before`](ScheduleFireStore::prune_fires_before) bounds growth —
+//! a `* * * * *` schedule writes 1440 rows a day. The maintenance tick prunes at
+//! a cutoff that sits *outside* the catch-up window, so the anchor can never be
+//! pruned out from under a catch-up.
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// Durable per-company claims that one schedule fired at one UTC epoch minute.
+///
+/// Company A's claims MUST be invisible to company B, exactly like every other
+/// per-company port. The three methods are storage verbs only: the schedulers
+/// own the claim *policy* (claim before side effect, fail closed on error, one
+/// bounded catch-up), and a backend only ever sees "insert this key if absent",
+/// "what is the max minute for this schedule", "delete minutes below this
+/// cutoff".
+#[async_trait]
+pub trait ScheduleFireStore: Send + Sync {
+    /// Atomically records that `schedule_id` fired at epoch `minute` for
+    /// `company`, if no peer has already recorded it.
+    ///
+    /// Returns `Ok(true)` when *this* caller inserted the row (it won the race
+    /// and may proceed to fire), `Ok(false)` when the row already existed (a
+    /// peer — another replica, or this process before a restart — already
+    /// claimed the instant, so the caller must skip with zero side effects).
+    ///
+    /// The atomicity MUST come from the backend's own uniqueness primitive
+    /// (`INSERT OR IGNORE`, a unique index, `O_EXCL`), never from an in-process
+    /// lock: an in-process lock cannot see the second replica this port exists
+    /// to arbitrate against.
+    ///
+    /// `claimed_at_ms` (wall-clock at insert) may be stored alongside for
+    /// debugging, but it is not part of the key and no caller reads it back.
+    async fn claim_fire(&self, company: &CompanyId, schedule_id: &str, minute: u64)
+    -> Result<bool>;
+
+    /// The highest `minute` ever claimed for `(company, schedule_id)`, or `None`
+    /// when the schedule has never fired.
+    ///
+    /// This is the restart catch-up anchor. `None` (a fresh install) means "no
+    /// anchor", which the schedulers read as "no catch-up" — a company that has
+    /// never fired a schedule has nothing to make up.
+    async fn latest_fire(&self, company: &CompanyId, schedule_id: &str) -> Result<Option<u64>>;
+
+    /// Removes every claim row for `company` whose `minute` is strictly less
+    /// than `cutoff_minute`, returning how many rows were removed.
+    ///
+    /// Called from the maintenance tick with a cutoff far enough in the past
+    /// that a catch-up anchor is never eligible (see
+    /// [`PRUNE_CUTOFF_MINUTES`](crate::runtime::PRUNE_CUTOFF_MINUTES) vs
+    /// [`CATCHUP_WINDOW_MINUTES`](crate::runtime::CATCHUP_WINDOW_MINUTES)).
+    async fn prune_fires_before(&self, company: &CompanyId, cutoff_minute: u64) -> Result<usize>;
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -44,6 +44,9 @@ use crate::ports::{
     FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore, SessionStore,
     SkillStateStore, TaskStore, ToolProvider, UsageMeter, UserStore, WorkspaceStore,
 };
+// Separate line (#241) so this addition is a pure append, not a reflow of the
+// grouped import that sibling store-seam branches (#274, #596) also edit.
+use crate::ports::ScheduleFireStore;
 use crate::runtime::board_events::BoardAnnouncer;
 use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::handover::RuntimeHandover;
@@ -223,6 +226,7 @@ pub struct RuntimeBuilder {
     facts: Option<Arc<dyn FactStore>>,
     artifacts: Option<Arc<dyn ArtifactStore>>,
     runs: Option<Arc<dyn RunStore>>,
+    schedule_fires: Option<Arc<dyn ScheduleFireStore>>,
     usage: Option<Arc<dyn UsageMeter>>,
     skills: Option<Arc<dyn SkillStateStore>>,
     users: Option<Arc<dyn UserStore>>,
@@ -313,6 +317,7 @@ impl RuntimeBuilder {
             facts: None,
             artifacts: None,
             runs: None,
+            schedule_fires: None,
             usage: None,
             skills: None,
             users: None,
@@ -420,6 +425,7 @@ impl RuntimeBuilder {
         self.facts = Some(handles.facts.clone());
         self.artifacts = Some(handles.artifacts.clone());
         self.runs = Some(handles.runs.clone());
+        self.schedule_fires = Some(handles.schedule_fires.clone());
         self.usage = Some(handles.usage.clone());
         self.skills = Some(handles.skills.clone());
         self.users = Some(handles.users.clone());
@@ -489,6 +495,12 @@ impl RuntimeBuilder {
     /// Swaps the task-run store (default: fs-backed).
     pub fn with_runs(mut self, runs: Arc<dyn RunStore>) -> Self {
         self.runs = Some(runs);
+        self
+    }
+
+    /// Swaps the scheduler fire-claim store (default: fs-backed).
+    pub fn with_schedule_fires(mut self, schedule_fires: Arc<dyn ScheduleFireStore>) -> Self {
+        self.schedule_fires = Some(schedule_fires);
         self
     }
 
@@ -817,6 +829,7 @@ impl RuntimeBuilder {
                 facts: self.facts.unwrap_or_else(|| fs_ops.clone()),
                 artifacts: self.artifacts.unwrap_or_else(|| fs_ops.clone()),
                 runs: self.runs.unwrap_or_else(|| fs_ops.clone()),
+                schedule_fires: self.schedule_fires.unwrap_or_else(|| fs_ops.clone()),
                 usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
                 skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
                 users: self.users.unwrap_or_else(|| fs_ops.clone()),

--- a/src/runtime/cron.rs
+++ b/src/runtime/cron.rs
@@ -137,6 +137,31 @@ impl CronExpr {
         None
     }
 
+    /// The most recent epoch **minute** strictly before `before_minute` that
+    /// satisfies this schedule, scanning back at most `limit` minutes; `None`
+    /// when no match falls inside that window.
+    ///
+    /// The bounded reverse mirror of [`next_after`](Self::next_after), working in
+    /// epoch minutes (`unix_millis / 60_000`) rather than [`CivilTime`] because
+    /// its one caller — the restart catch-up (issue #241) — compares against the
+    /// `latest_fire` anchor, which is a minute. The `limit` bound is what keeps a
+    /// long downtime from walking the schedule back years: the catch-up passes a
+    /// one-week window, so at most `limit` minutes are probed and the scan is
+    /// `O(limit)`, never unbounded. Purely arithmetic — no wall clock.
+    pub fn prev_match_before(&self, before_minute: u64, limit: u64) -> Option<u64> {
+        let mut minute = before_minute;
+        for _ in 0..limit {
+            if minute == 0 {
+                break; // epoch floor: nothing before minute 0
+            }
+            minute -= 1;
+            if self.matches(&CivilTime::from_unix_millis(minute * MINUTE_MS)) {
+                return Some(minute);
+            }
+        }
+        None
+    }
+
     /// A plain-English gloss of this schedule, or `None` when the shape is
     /// gnarlier than a one-liner can honestly state.
     ///
@@ -581,6 +606,47 @@ mod test {
         let next = weekly.next_after(&at(2026, 7, 10, 9, 0)).unwrap();
         assert_eq!((next.year, next.month, next.day), (2026, 7, 13));
         assert_eq!((next.hour, next.minute), (9, 0));
+    }
+
+    /// The epoch minute of a UTC civil minute, the unit `prev_match_before`
+    /// speaks in.
+    fn minute_of(year: i64, month: u32, day: u32, hour: u32, minute: u32) -> u64 {
+        ((days_from_civil(year, month, day) as u64) * DAY_MS
+            + (hour as u64) * 3_600_000
+            + (minute as u64) * MINUTE_MS)
+            / MINUTE_MS
+    }
+
+    #[test]
+    fn prev_match_before_finds_the_preceding_tick() {
+        let expr = CronExpr::parse("*/15 * * * *").unwrap();
+        // Strictly before :07 the previous quarter-hour is :00.
+        let from = minute_of(2026, 7, 10, 9, 7);
+        assert_eq!(
+            expr.prev_match_before(from, 60),
+            Some(minute_of(2026, 7, 10, 9, 0))
+        );
+        // Strictly before an exact match (:15) returns the one before it (:00),
+        // never :15 itself — the scan is exclusive of `before_minute`.
+        let on_match = minute_of(2026, 7, 10, 9, 15);
+        assert_eq!(
+            expr.prev_match_before(on_match, 60),
+            Some(minute_of(2026, 7, 10, 9, 0))
+        );
+    }
+
+    #[test]
+    fn prev_match_before_respects_the_window_bound() {
+        // Weekly Monday 09:00. From the following Wednesday the previous fire is
+        // ~2 days back (2880 minutes).
+        let weekly = CronExpr::parse("0 9 * * MON").unwrap();
+        let wednesday = minute_of(2026, 7, 15, 9, 0);
+        let monday = minute_of(2026, 7, 13, 9, 0);
+        // A window that reaches the Monday finds it…
+        assert_eq!(weekly.prev_match_before(wednesday, 10_080), Some(monday));
+        // …but a window too short to reach it finds nothing rather than walking
+        // further back.
+        assert_eq!(weekly.prev_match_before(wednesday, 60), None);
     }
 
     #[test]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -112,7 +112,10 @@ pub use handover::RuntimeHandover;
 pub use rebuild::{BootInputs, RebuildRequest, RuntimeRebuilder, rebuild_company};
 pub use registry::CompanyRegistry;
 pub use run_supervisor::{RunGuard, RunSupervisor};
-pub use scheduler::{Clock, CompanyScheduler, FakeClock, SystemClock};
+pub use scheduler::{
+    CATCHUP_WINDOW_MINUTES, Clock, CompanyScheduler, FakeClock, PRUNE_CUTOFF_MINUTES, SystemClock,
+    missed_instant,
+};
 pub use tools::StubToolProvider;
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
 pub use workflow_outcome::{

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -32,6 +32,66 @@ use crate::runtime::cron::{CivilTime, CronExpr};
 /// Milliseconds in one minute.
 pub(crate) const MINUTE_MS: u64 = 60_000;
 
+/// How far back a restart catch-up (issue #241) will reach to make up a single
+/// missed fire: seven days, in minutes.
+///
+/// Bounded on purpose. Buzz's `scheduled_workflow_fires` never replays a missed
+/// fire at all; unbounded replay would stampede token-burning cycles after a
+/// long outage. One catch-up per schedule per boot, within this window, is the
+/// middle path — it fixes the headline "a weekly run fell during the deploy and
+/// vanished" defect without turning a fortnight of downtime into a fortnight of
+/// backlog.
+pub const CATCHUP_WINDOW_MINUTES: u64 = 7 * 24 * 60;
+
+/// How old a claim row must be before the maintenance tick prunes it: fourteen
+/// days, in minutes.
+///
+/// Deliberately **larger** than [`CATCHUP_WINDOW_MINUTES`] and documented right
+/// beside it: the catch-up anchor is the newest claimed minute, and it may be up
+/// to a catch-up window old. Pruning at a cutoff inside that window could delete
+/// the anchor out from under a booting replica, re-arming a fire that already
+/// happened. Keeping the cutoff strictly past the window makes that impossible
+/// by construction. A `* * * * *` schedule writes 1440 rows a day, so the prune
+/// is what bounds growth.
+pub const PRUNE_CUTOFF_MINUTES: u64 = 14 * 24 * 60;
+
+// Compile-time guarantee of the retention invariant: the prune cutoff must sit
+// strictly outside the catch-up window, or a prune could delete the anchor a
+// booting replica still needs. Enforced here so a future edit to either constant
+// that violated it would fail the build, not a test.
+const _: () = assert!(PRUNE_CUTOFF_MINUTES > CATCHUP_WINDOW_MINUTES);
+
+/// The single catch-up instant to fire for a schedule at boot, or `None`.
+///
+/// The one place the "fire at most one missed occurrence" rule lives, shared by
+/// both schedulers so they cannot drift. Given the schedule's matcher, the
+/// `anchor` (the newest minute it is known to have fired, from
+/// [`latest_fire`](crate::ports::ScheduleFireStore::latest_fire)), the current
+/// `now_minute`, and a `window`:
+///
+/// * **No anchor** (`None`, a fresh install) yields `None`: a schedule that has
+///   never fired has nothing to make up.
+/// * Otherwise the answer is the most recent occurrence strictly between the
+///   anchor and now — `anchor < missed < now_minute` — within `window` minutes,
+///   or `None` when the last occurrence was already the anchor (nothing was
+///   missed) or falls outside the window.
+///
+/// It returns the *original* scheduled minute, so a caller claims the fire at
+/// that minute and simultaneously-booting replicas still race one row.
+pub fn missed_instant(
+    expr: &CronExpr,
+    anchor: Option<u64>,
+    now_minute: u64,
+    window: u64,
+) -> Option<u64> {
+    let anchor = anchor?;
+    // The most recent match strictly before now, bounded by the window.
+    let missed = expr.prev_match_before(now_minute, window)?;
+    // Only a match *after* the anchor was actually missed; one at or before it
+    // was already fired (the anchor is the last claimed minute).
+    (missed > anchor).then_some(missed)
+}
+
 /// A source of the current wall-clock time, in unix epoch milliseconds.
 ///
 /// Injected so the scheduler never reads a real clock in tests.
@@ -82,6 +142,37 @@ struct ParsedSchedule {
     expr: CronExpr,
     cron: String,
     prompt: String,
+    /// Restart-stable, content-derived identity for the durable fire claim
+    /// (issue #241). See [`manifest_schedule_id`].
+    id: String,
+}
+
+/// The durable [`ScheduleFireStore`](crate::ports::ScheduleFireStore) identity
+/// for a manifest `[[schedule]]`: `"manifest-"` plus the first 16 hex chars of
+/// `sha256(cron + "\n" + prompt)`.
+///
+/// Content-derived rather than the schedule's Vec index, which is what the
+/// in-memory dedup keyed on before #241 — reordering the manifest silently
+/// reassigned a schedule's identity and could double-fire or drop one. Two
+/// schedules with the same `(cron, prompt)` now collapse to one id, so they
+/// share one fire per minute; that is a deliberate, documented behaviour change
+/// (a manifest that wants two truly distinct fires must differ in cron or
+/// prompt). The `\n` separator keeps `("a", "bc")` and `("ab", "c")` distinct.
+/// The `manifest-` prefix (a hyphen, never a colon) stays readable in a log line
+/// and path-safe for the fs backend.
+pub(crate) fn manifest_schedule_id(cron: &str, prompt: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(cron.as_bytes());
+    hasher.update(b"\n");
+    hasher.update(prompt.as_bytes());
+    let digest = hasher.finalize();
+    let mut hex = String::with_capacity(16);
+    for byte in digest.iter().take(8) {
+        use std::fmt::Write;
+        let _ = write!(hex, "{byte:02x}");
+    }
+    format!("manifest-{hex}")
 }
 
 /// Drives the cron schedules of a single [`CompanyRuntime`].
@@ -115,6 +206,10 @@ impl CompanyScheduler {
                 expr: CronExpr::parse(&schedule.cron)?,
                 cron: schedule.cron.clone(),
                 prompt: schedule.prompt.clone(),
+                // Computed once, here, so identity is stable for the life of the
+                // scheduler and independent of the schedule's position in the
+                // manifest.
+                id: manifest_schedule_id(&schedule.cron, &schedule.prompt),
             });
         }
         Ok(Self {
@@ -178,6 +273,7 @@ impl CompanyScheduler {
         let now = self.clock.now_millis();
         let minute = now / MINUTE_MS;
         let civil = CivilTime::from_unix_millis(now);
+        let store = runtime.schedule_fires().clone();
 
         let mut fired = 0;
         for (idx, schedule) in self.schedules.iter().enumerate() {
@@ -185,16 +281,110 @@ impl CompanyScheduler {
                 continue;
             }
             if self.last_fired.get(&idx) == Some(&minute) {
-                continue; // already fired this minute
+                continue; // already fired this minute (cheap in-process first pass)
             }
+            // The in-process map is only a first-pass filter; the durable claim
+            // below is the authority. Set it before the claim so a transiently
+            // failing store is not re-hit on every tick within this minute.
             self.last_fired.insert(idx, minute);
-            runtime
-                .run_cycle(vec![CompanyEvent::ScheduleFired {
-                    cron: schedule.cron.clone(),
-                    prompt: schedule.prompt.clone(),
-                }])
-                .await?;
-            fired += 1;
+            match store.claim_fire(runtime.id(), &schedule.id, minute).await {
+                // Won the claim: this is the one process/replica that fires.
+                Ok(true) => {
+                    runtime
+                        .run_cycle(vec![CompanyEvent::ScheduleFired {
+                            cron: schedule.cron.clone(),
+                            prompt: schedule.prompt.clone(),
+                        }])
+                        .await?;
+                    fired += 1;
+                }
+                // A peer — another replica, or this process before a restart —
+                // already claimed this minute. Skip with ZERO side effects.
+                Ok(false) => {}
+                // Fail closed: a claim store that cannot answer must not fire
+                // unclaimed, or it reintroduces the cross-replica double-fire
+                // this claim exists to prevent. Skip this minute and warn.
+                Err(err) => {
+                    tracing::warn!(
+                        company = %runtime.id(),
+                        schedule = %schedule.id,
+                        %err,
+                        "scheduler: could not claim a fire; skipping this minute (fail closed)"
+                    );
+                }
+            }
+        }
+        Ok(fired)
+    }
+
+    /// Fires at most one missed occurrence per schedule at boot (issue #241).
+    ///
+    /// The restart half of the durability fix: a schedule whose fire instant fell
+    /// while the process was down would otherwise be dropped with nothing to say
+    /// so. For each schedule this reads the [`latest_fire`] anchor, asks
+    /// [`missed_instant`] for the single most-recent missed occurrence inside the
+    /// catch-up window, and claims it **at its original minute** — so two replicas
+    /// booting at once still race one claim and only one fires it. A fresh install
+    /// (no anchor) makes up nothing. A claim-store read failure fails closed
+    /// (skip), for the same reason [`tick`](Self::tick) does.
+    ///
+    /// Run once, from [`spawn`](Self::spawn), before the steady-state loop.
+    ///
+    /// [`latest_fire`]: crate::ports::ScheduleFireStore::latest_fire
+    pub async fn catch_up(&self) -> Result<usize> {
+        if self.schedules.is_empty() {
+            return Ok(0);
+        }
+        let runtime = self.runtime();
+        if runtime.ensure_running().await.is_err() {
+            return Ok(0);
+        }
+        let now_minute = self.clock.now_millis() / MINUTE_MS;
+        let store = runtime.schedule_fires().clone();
+        let mut fired = 0;
+        for schedule in &self.schedules {
+            let anchor = match store.latest_fire(runtime.id(), &schedule.id).await {
+                Ok(anchor) => anchor,
+                Err(err) => {
+                    tracing::warn!(
+                        company = %runtime.id(),
+                        schedule = %schedule.id,
+                        %err,
+                        "scheduler: could not read catch-up anchor; skipping catch-up (fail closed)"
+                    );
+                    continue;
+                }
+            };
+            let Some(missed) =
+                missed_instant(&schedule.expr, anchor, now_minute, CATCHUP_WINDOW_MINUTES)
+            else {
+                continue;
+            };
+            match store.claim_fire(runtime.id(), &schedule.id, missed).await {
+                Ok(true) => {
+                    runtime
+                        .run_cycle(vec![CompanyEvent::ScheduleFired {
+                            cron: schedule.cron.clone(),
+                            prompt: schedule.prompt.clone(),
+                        }])
+                        .await?;
+                    fired += 1;
+                    tracing::info!(
+                        company = %runtime.id(),
+                        schedule = %schedule.id,
+                        missed_minute = missed,
+                        "scheduler: fired one catch-up for a schedule missed during downtime"
+                    );
+                }
+                // A simultaneously-booting replica claimed the catch-up first.
+                Ok(false) => {}
+                Err(err) => tracing::warn!(
+                    company = %runtime.id(),
+                    schedule = %schedule.id,
+                    %err,
+                    "scheduler: could not claim catch-up fire; skipping (fail closed)"
+                ),
+            }
         }
         Ok(fired)
     }
@@ -212,6 +402,23 @@ impl CompanyScheduler {
         let runtime = self.runtime();
         let expired = runtime.sweep_expired_approvals().await?;
         runtime.sweep_expired_grants().await?;
+        // Issue #241: bound the fire-claim log's growth on the same tick. The
+        // cutoff sits a full week past the catch-up window (PRUNE_CUTOFF_MINUTES
+        // > CATCHUP_WINDOW_MINUTES), so an anchor a booting replica still needs
+        // is never eligible. Best-effort — a prune failure must not abort the
+        // approval sweeps it shares a tick with.
+        let cutoff = (self.clock.now_millis() / MINUTE_MS).saturating_sub(PRUNE_CUTOFF_MINUTES);
+        if let Err(err) = runtime
+            .schedule_fires()
+            .prune_fires_before(runtime.id(), cutoff)
+            .await
+        {
+            tracing::warn!(
+                company = %runtime.id(),
+                %err,
+                "scheduler: pruning old fire claims failed"
+            );
+        }
         Ok(expired)
     }
 
@@ -220,6 +427,12 @@ impl CompanyScheduler {
     /// shared `shutdown` so the scheduler stops cleanly when the server does.
     pub fn spawn(mut self, shutdown: Arc<Notify>) -> JoinHandle<()> {
         tokio::spawn(async move {
+            // Issue #241: make up at most one missed fire per schedule that fell
+            // during downtime, BEFORE entering the steady-state loop, so a weekly
+            // run whose instant landed inside the last deploy still happens.
+            if let Err(err) = self.catch_up().await {
+                tracing::warn!(company = %self.runtime.id(), %err, "scheduled catch-up failed");
+            }
             // The `Notified` future is built ONCE and pinned across iterations,
             // not rebuilt inside the `select!`. Boot signals with
             // `notify_waiters()`, which wakes only the waiters registered at
@@ -739,5 +952,234 @@ mod test {
         assert_eq!(millis_to_next_minute(1), MINUTE_MS - 1);
         assert_eq!(millis_to_next_minute(MINUTE_MS - 1), 1);
         assert_eq!(millis_to_next_minute(MINUTE_MS), MINUTE_MS);
+    }
+
+    // --- issue #241: durable claims + restart catch-up ---------------------
+
+    use crate::error::OpenCompanyError;
+    use crate::ports::schedule_fires::ScheduleFireStore;
+    use crate::ports::types::CompanyId;
+
+    /// ScheduleFired events actually written to a runtime's log. A claim loser,
+    /// and a fail-closed skip, must leave this at whatever it was — the "zero
+    /// side effects" invariant, read from the durable trail.
+    async fn fired_count(rt: &CompanyRuntime) -> usize {
+        rt.events
+            .read_from(rt.id(), EventSeq::new(0), 1024)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|e| matches!(e.event, CompanyEvent::ScheduleFired { .. }))
+            .count()
+    }
+
+    /// A claim store whose every method errors, for the fail-closed path.
+    struct ErroringFires;
+
+    #[async_trait]
+    impl ScheduleFireStore for ErroringFires {
+        async fn claim_fire(&self, _c: &CompanyId, _s: &str, _m: u64) -> Result<bool> {
+            Err(OpenCompanyError::Store("claim store is down".into()))
+        }
+        async fn latest_fire(&self, _c: &CompanyId, _s: &str) -> Result<Option<u64>> {
+            Err(OpenCompanyError::Store("claim store is down".into()))
+        }
+        async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> Result<usize> {
+            Err(OpenCompanyError::Store("claim store is down".into()))
+        }
+    }
+
+    #[test]
+    fn manifest_schedule_id_is_stable_and_order_independent() {
+        let a = manifest_schedule_id("0 9 * * MON", "standup");
+        let b = manifest_schedule_id("0 9 * * MON", "standup");
+        assert_eq!(a, b, "same (cron, prompt) → same id, whatever the position");
+        assert!(a.starts_with("manifest-"), "{a}");
+        // A different prompt or cron is a different schedule.
+        assert_ne!(a, manifest_schedule_id("0 9 * * MON", "other"));
+        assert_ne!(a, manifest_schedule_id("0 10 * * MON", "standup"));
+        // The `\n` separator keeps ("a","bc") and ("ab","c") distinct.
+        assert_ne!(
+            manifest_schedule_id("a", "bc"),
+            manifest_schedule_id("ab", "c")
+        );
+    }
+
+    #[test]
+    fn missed_instant_rules() {
+        let expr = CronExpr::parse("0 9 * * MON").unwrap();
+        let minute = |ms: u64| ms / MINUTE_MS;
+        let m0 = minute(millis_at(2026, 7, 6, 9, 0)); // a Monday 09:00
+        let m2 = minute(millis_at(2026, 7, 20, 9, 0)); // two Mondays later
+        let now = minute(millis_at(2026, 7, 20, 9, 5)); // just after m2
+
+        // Fresh install (no anchor) makes up nothing.
+        assert_eq!(
+            missed_instant(&expr, None, now, CATCHUP_WINDOW_MINUTES),
+            None
+        );
+        // Downtime spanning the two intervening Mondays, anchor at m0 → exactly
+        // the MOST RECENT missed one (m2), never the older intermediates.
+        assert_eq!(
+            missed_instant(&expr, Some(m0), now, CATCHUP_WINDOW_MINUTES),
+            Some(m2)
+        );
+        // Anchor already at the most recent match → nothing was missed.
+        assert_eq!(
+            missed_instant(&expr, Some(m2), now, CATCHUP_WINDOW_MINUTES),
+            None
+        );
+        // Beyond the window: too small a window cannot reach even m2.
+        assert_eq!(missed_instant(&expr, Some(m0), now, 1), None);
+    }
+
+    /// Two independent schedulers over one durable store — a second replica, or a
+    /// restarted process — fire exactly once between them, and the loser writes
+    /// nothing.
+    #[tokio::test]
+    async fn two_schedulers_over_one_store_fire_once() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut a = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
+        let mut b = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        let first = a.tick().await.unwrap();
+        let second = b.tick().await.unwrap();
+        assert_eq!(first + second, 1, "exactly one replica fires the minute");
+        assert_eq!(
+            fired_count(&rt).await,
+            1,
+            "the loser leaves no ScheduleFired behind"
+        );
+    }
+
+    /// A claim store that errors fails **closed**: the fire is skipped, not fired
+    /// unclaimed, so the double-fire the claim prevents cannot sneak back in.
+    #[tokio::test]
+    async fn a_failing_claim_store_fires_nothing() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .with_schedule_fires(Arc::new(ErroringFires))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        assert_eq!(scheduler.tick().await.unwrap(), 0, "fail-closed: no fire");
+        assert_eq!(fired_count(&rt).await, 0);
+    }
+
+    /// Downtime spanning several occurrences produces exactly one catch-up (the
+    /// most recent), and a second boot finds it already claimed.
+    #[tokio::test]
+    async fn catch_up_fires_one_missed_instant_then_none_left() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        // Anchor at the oldest of three Mondays; "now" just after the newest.
+        let sid = manifest_schedule_id("0 9 * * MON", "weekly standup");
+        let anchor = millis_at(2026, 7, 6, 9, 0) / MINUTE_MS;
+        assert!(
+            rt.schedule_fires()
+                .claim_fire(rt.id(), &sid, anchor)
+                .await
+                .unwrap()
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            1,
+            "one catch-up for the most recent missed Monday"
+        );
+        assert_eq!(fired_count(&rt).await, 1);
+        // The catch-up claimed the ORIGINAL minute, so the anchor advanced to it.
+        assert_eq!(
+            rt.schedule_fires()
+                .latest_fire(rt.id(), &sid)
+                .await
+                .unwrap(),
+            Some(millis_at(2026, 7, 20, 9, 0) / MINUTE_MS)
+        );
+        // Idempotent: a second boot finds the catch-up already made.
+        assert_eq!(scheduler.catch_up().await.unwrap(), 0);
+        assert_eq!(fired_count(&rt).await, 1);
+    }
+
+    /// A fresh install — no anchor row anywhere — makes up nothing at boot.
+    #[tokio::test]
+    async fn catch_up_on_a_fresh_install_fires_nothing() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        assert_eq!(scheduler.catch_up().await.unwrap(), 0);
+        assert_eq!(fired_count(&rt).await, 0);
+    }
+
+    /// Two replicas booting at once race the catch-up claim: one fires it, the
+    /// other loses.
+    #[tokio::test]
+    async fn racing_catch_up_fires_once() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let sid = manifest_schedule_id("0 9 * * MON", "weekly standup");
+        let anchor = millis_at(2026, 7, 6, 9, 0) / MINUTE_MS;
+        rt.schedule_fires()
+            .claim_fire(rt.id(), &sid, anchor)
+            .await
+            .unwrap();
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let a = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
+        let b = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        let fa = a.catch_up().await.unwrap();
+        let fb = b.catch_up().await.unwrap();
+        assert_eq!(fa + fb, 1, "only one booting replica fires the catch-up");
+        assert_eq!(fired_count(&rt).await, 1);
     }
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -85,8 +85,12 @@ use crate::company::{WorkflowFile, list_workflows_union};
 use crate::ports::types::CompanyId;
 use crate::ports::{DeliveryReport, DeliveryStatus};
 use crate::runtime::CompanyRegistry;
+use crate::runtime::WorkflowSpawn;
 use crate::runtime::cron::{CivilTime, CronExpr};
-use crate::runtime::scheduler::{Clock, MINUTE_MS, millis_to_next_minute};
+use crate::runtime::scheduler::{
+    CATCHUP_WINDOW_MINUTES, Clock, MINUTE_MS, PRUNE_CUTOFF_MINUTES, millis_to_next_minute,
+    missed_instant,
+};
 
 /// Identifies one schedulable workflow: which company, which graph.
 type WorkflowKey = (CompanyId, String);
@@ -154,6 +158,13 @@ pub struct WorkflowScheduler {
     /// is once a minute forever, so the warning is latched here and re-armed
     /// only when the situation changes — see [`note_unwired`](Self::note_unwired).
     warned_unwired: HashSet<CompanyId>,
+    /// Workflows this scheduler has already run its one restart catch-up check
+    /// for (issue #241). Keyed per `(company, workflow)` and checked the FIRST
+    /// time each is seen — not once globally — so a tenant provisioned after boot
+    /// and a workflow created at runtime each get their catch-up when they first
+    /// appear, rather than being missed by a boot-only pass. Swept when a company
+    /// leaves the registry, like [`warned_unwired`](Self::warned_unwired).
+    caught_up: HashSet<WorkflowKey>,
     /// How many unwired-company warnings have been emitted, so a test can assert
     /// the latch actually suppresses the repeat.
     #[cfg(test)]
@@ -169,6 +180,7 @@ impl WorkflowScheduler {
             last_fired: HashMap::new(),
             in_flight: Arc::new(Mutex::new(HashSet::new())),
             warned_unwired: HashSet::new(),
+            caught_up: HashSet::new(),
             #[cfg(test)]
             unwired_warnings: 0,
         }
@@ -232,6 +244,11 @@ impl WorkflowScheduler {
         let now = self.clock.now_millis();
         let minute = now / MINUTE_MS;
         let civil = CivilTime::from_unix_millis(now);
+        // Issue #241: prune stale fire claims once a day, on the 00:00 UTC tick,
+        // per visited company. Once daily rather than every tick keeps a
+        // `* * * * *` schedule's 1440-rows-a-day log bounded without a delete on
+        // every minute.
+        let prune_due = civil.hour == 0 && civil.minute == 0;
 
         let mut fired = 0;
         for company in self.registry.list() {
@@ -241,6 +258,20 @@ impl WorkflowScheduler {
             // Not accepting work: paused or archived.
             if runtime.ensure_running().await.is_err() {
                 continue;
+            }
+            // The cutoff sits a full week past the catch-up window
+            // (PRUNE_CUTOFF_MINUTES > CATCHUP_WINDOW_MINUTES), so an anchor a
+            // booting replica still needs is never eligible. Best-effort — a
+            // prune failure must not stop this company's schedules from firing.
+            if prune_due {
+                let cutoff = minute.saturating_sub(PRUNE_CUTOFF_MINUTES);
+                if let Err(err) = runtime
+                    .schedule_fires()
+                    .prune_fires_before(&company, cutoff)
+                    .await
+                {
+                    tracing::warn!(%company, %err, "workflow scheduler: pruning old fire claims failed");
+                }
             }
             // The record's runtime-authored graph bodies, and the ids the
             // operator has switched off (issue #276) — both off the SAME load, so
@@ -326,20 +357,92 @@ impl WorkflowScheduler {
             // have failed to say so.
             let spawn = crate::runtime::WorkflowSpawn::new(&runtime, runner);
 
+            // The durable fire-claim store for this company (issue #241),
+            // reached through the runtime resolved this tick.
+            let store = runtime.schedule_fires().clone();
+
             for (file, cron, expr) in scheduled {
+                let key = (company.clone(), file.id.clone());
+                // The restart-stable durable identity for this workflow's cron.
+                let schedule_id = workflow_schedule_id(&file.id);
+
+                // First-sight restart catch-up (issue #241). The FIRST time this
+                // scheduler sees a (company, workflow), make up at most one fire
+                // that fell during downtime — covering a tenant provisioned after
+                // boot and a workflow created at runtime, neither of which a
+                // boot-only pass would reach. A disabled workflow never gets here
+                // (filtered above), so a paused schedule is never caught up.
+                if self.caught_up.insert(key.clone()) {
+                    match store.latest_fire(&company, &schedule_id).await {
+                        Ok(anchor) => {
+                            if let Some(missed) =
+                                missed_instant(&expr, anchor, minute, CATCHUP_WINDOW_MINUTES)
+                            {
+                                // Hold the overlap slot across the catch-up run so
+                                // a same-minute steady-state fire below suppresses
+                                // WITHOUT claiming (the minute is suppressed, not
+                                // burned) rather than running a second copy.
+                                if let Some(claim) = self.claim(&key) {
+                                    match store.claim_fire(&company, &schedule_id, missed).await {
+                                        Ok(true) => {
+                                            let input = json!({
+                                                "request": format!("Scheduled run (cron `{cron}`)"),
+                                                "scheduled": true,
+                                                "cron": cron.clone(),
+                                                // The ORIGINAL missed minute, not
+                                                // now — the run is a make-up of it.
+                                                "firedAtMs": missed * MINUTE_MS,
+                                                "catchUp": true,
+                                            });
+                                            tracing::info!(
+                                                %company,
+                                                workflow = %file.id,
+                                                schedule = %cron,
+                                                missed_minute = missed,
+                                                "workflow scheduler: firing one catch-up for a schedule missed during downtime"
+                                            );
+                                            spawn_scheduled_run(
+                                                &spawn,
+                                                claim,
+                                                company.clone(),
+                                                file.clone(),
+                                                input,
+                                            );
+                                            fired += 1;
+                                        }
+                                        // A simultaneously-booting replica claimed
+                                        // the catch-up first: release the slot.
+                                        Ok(false) => drop(claim),
+                                        Err(err) => {
+                                            drop(claim);
+                                            tracing::warn!(%company, workflow = %file.id, %err, "workflow scheduler: could not claim catch-up fire; skipping (fail closed)");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        // Fail closed: without a trustworthy anchor we cannot tell
+                        // a missed fire from an already-made one.
+                        Err(err) => {
+                            tracing::warn!(%company, workflow = %file.id, %err, "workflow scheduler: could not read catch-up anchor; skipping catch-up (fail closed)");
+                        }
+                    }
+                }
+
                 if !expr.matches(&civil) {
                     continue;
                 }
 
-                let key = (company.clone(), file.id.clone());
                 if self.last_fired.get(&key) == Some(&minute) {
-                    continue; // already fired this minute
+                    continue; // already fired this minute (in-process first pass)
                 }
                 self.last_fired.insert(key.clone(), minute);
 
-                // Overlap guard: a previous scheduled run still executing keeps
-                // this fire from stacking a second copy on top of it. Manual
-                // runs go through the run route and are unaffected.
+                // Overlap guard, checked BEFORE the durable claim: a previous
+                // scheduled run still executing suppresses this fire WITHOUT
+                // claiming the minute, so a slow run's own next tick is suppressed
+                // rather than burned. Manual runs go through the run route and are
+                // unaffected.
                 let Some(claim) = self.claim(&key) else {
                     tracing::info!(
                         %company,
@@ -350,179 +453,37 @@ impl WorkflowScheduler {
                     continue;
                 };
 
+                // Durable cross-replica claim (issue #241): the authority the
+                // in-process `last_fired` map only approximates. Awaited before
+                // the run spawns, so a loser produces zero side effects.
+                match store.claim_fire(&company, &schedule_id, minute).await {
+                    // Won: this replica fires.
+                    Ok(true) => {}
+                    // A peer already fired this minute: release the overlap slot
+                    // and skip with zero side effects.
+                    Ok(false) => {
+                        drop(claim);
+                        continue;
+                    }
+                    // Fail closed: never fire unclaimed, or the cross-replica
+                    // double-fire this claim exists to prevent comes back.
+                    Err(err) => {
+                        drop(claim);
+                        tracing::warn!(%company, workflow = %file.id, %err, "workflow scheduler: could not claim a fire; skipping this minute (fail closed)");
+                        continue;
+                    }
+                }
+
                 let input = json!({
                     // `request` is what `run_request_text` reads, so every agent
                     // turn in the run knows it was started by a schedule rather
                     // than by an operator typing a topic.
                     "request": format!("Scheduled run (cron `{cron}`)"),
                     "scheduled": true,
-                    "cron": cron,
+                    "cron": cron.clone(),
                     "firedAtMs": now,
                 });
-
-                let workflow = file;
-                // Cloned BEFORE the spawn: the task outlives this loop
-                // iteration (and this borrow of `runtime`), so everything it
-                // needs has to be moved in rather than reached for from inside.
-                // The clone carries the company id, the event log (issue #228 —
-                // what turns a scheduled run's outcome from a host-stdout line
-                // into something the tenant's own console reads back), the run
-                // supervisor (issue #383 — what puts a Cancel button on a cron
-                // fire nobody chose the timing of) and the runner.
-                let spawn = spawn.clone();
-                // A FRESH TASK PER FIRE IS CORRECT HERE, and is not a hole in
-                // the `WORKFLOW_DEPTH` re-entry guard
-                // (`crate::workflows::runner`). That guard is a task-local
-                // counting one *causal chain*: a run, the agent turns inside
-                // it, and the tools those turns call all stay on one task, so a
-                // workflow that reaches back into itself is bounded. A
-                // scheduled fire starts no such chain — it is a new root, at
-                // depth 0, exactly like an operator clicking Run — so spawning
-                // it here is the same as any other entry point. What would
-                // break the guard is spawning *inside* an existing run's chain,
-                // which would reset the depth mid-chain; this scheduler never
-                // runs inside a run. Spawning also keeps one slow agent run
-                // from starving every other company's schedule on the tick
-                // loop.
-                tokio::spawn(async move {
-                    // Held for the whole run so the slot is released on EVERY
-                    // exit path, including an unwind. Releasing after the
-                    // `await` instead would leak the claim when the runner
-                    // panics — and a leaked claim is permanent, because nothing
-                    // else ever removes it, so one panic would retire that
-                    // schedule for the life of the process with no log line.
-                    let _claim = claim;
-                    let (company, workflow_id) = key;
-                    // Issue #440: through the shared primitive, which owns both
-                    // halves this used to copy — the supervisor-minted run id
-                    // (issue #383: it is the address the console's Cancel button
-                    // sends to, and #371: the id the run's progress events and
-                    // its outcome share, including on the error arm where the
-                    // runner hands back nothing that could carry one) and the
-                    // `record_run_finished` on BOTH arms (issue #228), with the
-                    // run guard held across the journal write.
-                    //
-                    // The handle is **awaited**, not dropped. The claim above is
-                    // this scheduler's own overlap guard and has to outlive the
-                    // run, and the delivery-log sweep below needs the outcome.
-                    // Both remain the scheduler's job; what is shared is only
-                    // how a run is started and recorded.
-                    // Issue #542: a scheduled run is always for real — `false`.
-                    let (_run_id, handle) = spawn.spawn(workflow, input, true, false);
-                    match handle.await {
-                        Ok(Ok(run)) => {
-                            // A manual run hands `deliveries` back in the HTTP
-                            // response and the console renders it. A scheduled
-                            // run has no response and nobody watching, so
-                            // without this the exact case the operator most
-                            // needs to know about — the owner summary that did
-                            // NOT go out — would be the quietest thing the
-                            // system does.
-                            let counts = DeliveryCounts::of(&run.deliveries);
-                            // One line per undelivered report: a count alone
-                            // says something is wrong without saying what to
-                            // fix, and `reason` is the part that names the
-                            // failure class.
-                            for report in &run.deliveries {
-                                if report.status == DeliveryStatus::Sent {
-                                    continue;
-                                }
-                                // A parked report is not a failure and must not
-                                // be logged as one — it is a card waiting in
-                                // the approvals queue. Say where to go, at
-                                // info, and move on.
-                                if report.status == DeliveryStatus::Pending {
-                                    tracing::info!(
-                                        %company,
-                                        workflow = %workflow_id,
-                                        node = %report.node,
-                                        kind = %report.kind,
-                                        // Same reason as the warn below: never
-                                        // the recipient's address in a host log.
-                                        target_configured = report.target.is_some(),
-                                        "workflow scheduler: a scheduled run's report is parked for operator approval — see the Approvals view"
-                                    );
-                                    continue;
-                                }
-                                tracing::warn!(
-                                    %company,
-                                    workflow = %workflow_id,
-                                    node = %report.node,
-                                    kind = %report.kind,
-                                    // NOT the target itself: for an `email`
-                                    // destination that is the recipient's
-                                    // address, and this line goes to host
-                                    // stdout — which on a hosted tenant is us,
-                                    // not the operator. Whether one resolved is
-                                    // the part with diagnostic value anyway.
-                                    target_configured = report.target.is_some(),
-                                    status = ?report.status,
-                                    // The classification, NOT `report.detail`.
-                                    // `detail` interpolates the transport's own
-                                    // words on the failure arms, and a mail
-                                    // transport quotes the mailbox it refused —
-                                    // so logging it walks the recipient address
-                                    // onto host stdout through the back door
-                                    // that scrubbing `target` left open (issue
-                                    // #248). `reason` says the same thing about
-                                    // what failed, out of a closed set that
-                                    // cannot carry transport text; the operator
-                                    // still gets the full `detail` on the run
-                                    // response and in the run history their own
-                                    // console reads back.
-                                    reason = %report.reason,
-                                    "workflow scheduler: a scheduled run's report was NOT delivered"
-                                );
-                            }
-                            tracing::info!(
-                                %company,
-                                workflow = %workflow_id,
-                                pending_approvals = run.pending_approvals.len(),
-                                sent = counts.sent,
-                                // Awaiting a human, not a fix — counted apart
-                                // from `undelivered` for exactly that reason.
-                                pending_approval = counts.pending,
-                                skipped = counts.skipped,
-                                denied = counts.denied,
-                                failed = counts.failed,
-                                // The one number worth alerting on, so a log
-                                // query need not sum the three refusal kinds.
-                                undelivered = counts.undelivered(),
-                                "workflow scheduler: scheduled run finished"
-                            );
-                            // The operator-facing half — the journaled
-                            // `WorkflowRunFinished` the tenant's own console
-                            // reads back — was written by `spawn` before this
-                            // handle resolved (issue #228). The log lines above
-                            // stay exactly as they are: they are the platform
-                            // team's diagnostic on host stdout, which on a
-                            // hosted tenant is emphatically not the operator.
-                        }
-                        Ok(Err(err)) => {
-                            tracing::warn!(
-                                %company,
-                                workflow = %workflow_id,
-                                %err,
-                                "workflow scheduler: scheduled run failed"
-                            );
-                        }
-                        // The run task itself came apart — a panic inside the
-                        // runner, which unwinds in the spawned task rather than
-                        // here. Nothing was journaled for it (the outcome write
-                        // lives in that task), so this line is the only trace
-                        // there is, and it must not be silent. The claim still
-                        // releases: it is held by this task's guard.
-                        Err(err) => {
-                            tracing::error!(
-                                %company,
-                                workflow = %workflow_id,
-                                %err,
-                                "workflow scheduler: a scheduled run's task did not complete; its \
-                                 outcome was never recorded"
-                            );
-                        }
-                    }
-                });
+                spawn_scheduled_run(&spawn, claim, company.clone(), file, input);
                 fired += 1;
             }
         }
@@ -544,6 +505,15 @@ impl WorkflowScheduler {
         let registry = &self.registry;
         self.warned_unwired
             .retain(|company| registry.get(company).is_some());
+        // The catch-up latch is keyed per (company, workflow); a company archived
+        // out of the registry is never visited again, so its entries would be
+        // orphaned forever. Swept here beside the others. (A deleted-but-company-
+        // still-present workflow leaves one stale entry, harmless: it is only a
+        // "have I run catch-up for this" bit and a re-created workflow of the same
+        // id is a first sight again only after this sweep — acceptable, since a
+        // re-created workflow's anchor is whatever it last durably fired.)
+        self.caught_up
+            .retain(|(company, _)| registry.get(company).is_some());
 
         fired
     }
@@ -666,6 +636,165 @@ fn lock_in_flight(
     in_flight
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+/// The durable [`ScheduleFireStore`](crate::ports::ScheduleFireStore) identity
+/// for a saved workflow's cron trigger: `"workflow-<workflow_id>"` (issue #241).
+///
+/// The natural `(company, workflow)` identity, so it survives a restart and does
+/// not depend on any positional index. The `workflow-` prefix (a hyphen, never a
+/// colon) keeps it readable in a log line; the fs backend hashes it before it
+/// can address the filesystem, so a console-chosen `<workflow_id>` is safe.
+fn workflow_schedule_id(workflow_id: &str) -> String {
+    format!("workflow-{workflow_id}")
+}
+
+/// Spawns one scheduled run on its own task, holding `claim` for the run's whole
+/// lifetime and logging its delivery outcome.
+///
+/// Shared by the steady-state fire path and the restart catch-up (issue #241),
+/// so both start a run and record it the one way [`WorkflowSpawn`] owns (issues
+/// #228 / #383 / #440); the callers differ only in the `firedAtMs` / `catchUp`
+/// they stamp into `input`.
+///
+/// A FRESH TASK PER FIRE IS CORRECT HERE, and is not a hole in the
+/// `WORKFLOW_DEPTH` re-entry guard (`crate::workflows::runner`). That guard is a
+/// task-local counting one *causal chain*: a run, its agent turns, and the tools
+/// those turns call all stay on one task, so a workflow that reaches back into
+/// itself is bounded. A scheduled fire starts no such chain — it is a new root,
+/// at depth 0, exactly like an operator clicking Run. Spawning also keeps one
+/// slow agent run from starving every other company's schedule on the tick loop.
+fn spawn_scheduled_run(
+    spawn: &WorkflowSpawn,
+    claim: Claim,
+    company: CompanyId,
+    workflow: WorkflowFile,
+    input: serde_json::Value,
+) {
+    // Cloned before the spawn: the task outlives the tick's borrow of `runtime`,
+    // so everything it needs is moved in. The clone carries the company id, the
+    // event log (issue #228 — what turns a scheduled run's outcome from a
+    // host-stdout line into something the tenant's own console reads back), the
+    // run supervisor (issue #383 — the Cancel button on a cron fire nobody chose
+    // the timing of) and the runner.
+    let spawn = spawn.clone();
+    tokio::spawn(async move {
+        // Held for the whole run so the slot is released on EVERY exit path,
+        // including an unwind. Releasing after the `await` instead would leak the
+        // claim when the runner panics — and a leaked claim is permanent, because
+        // nothing else ever removes it, so one panic would retire that schedule
+        // for the life of the process with no log line.
+        let _claim = claim;
+        let workflow_id = workflow.id.clone();
+        // Issue #440: through the shared primitive, which owns the
+        // supervisor-minted run id (#383/#371) and the `record_run_finished` on
+        // BOTH arms (#228), with the run guard held across the journal write. The
+        // handle is **awaited**, not dropped: the claim is this scheduler's own
+        // overlap guard and has to outlive the run, and the delivery-log sweep
+        // below needs the outcome.
+        // Issue #542: a scheduled run is always for real — `false`.
+        let (_run_id, handle) = spawn.spawn(workflow, input, true, false);
+        match handle.await {
+            Ok(Ok(run)) => {
+                // A manual run hands `deliveries` back in the HTTP response and
+                // the console renders it. A scheduled run has no response and
+                // nobody watching, so without this the exact case the operator
+                // most needs to know about — the owner summary that did NOT go
+                // out — would be the quietest thing the system does.
+                let counts = DeliveryCounts::of(&run.deliveries);
+                for report in &run.deliveries {
+                    if report.status == DeliveryStatus::Sent {
+                        continue;
+                    }
+                    // A parked report is not a failure and must not be logged as
+                    // one — it is a card waiting in the approvals queue. Say where
+                    // to go, at info, and move on.
+                    if report.status == DeliveryStatus::Pending {
+                        tracing::info!(
+                            %company,
+                            workflow = %workflow_id,
+                            node = %report.node,
+                            kind = %report.kind,
+                            // Same reason as the warn below: never the recipient's
+                            // address in a host log.
+                            target_configured = report.target.is_some(),
+                            "workflow scheduler: a scheduled run's report is parked for operator approval — see the Approvals view"
+                        );
+                        continue;
+                    }
+                    tracing::warn!(
+                        %company,
+                        workflow = %workflow_id,
+                        node = %report.node,
+                        kind = %report.kind,
+                        // NOT the target itself: for an `email` destination that
+                        // is the recipient's address, and this line goes to host
+                        // stdout — which on a hosted tenant is us, not the
+                        // operator. Whether one resolved is the part with
+                        // diagnostic value anyway.
+                        target_configured = report.target.is_some(),
+                        status = ?report.status,
+                        // The classification, NOT `report.detail`. `detail`
+                        // interpolates the transport's own words on the failure
+                        // arms, and a mail transport quotes the mailbox it refused
+                        // — so logging it walks the recipient address onto host
+                        // stdout through the back door that scrubbing `target`
+                        // left open (issue #248). `reason` says the same thing
+                        // about what failed, out of a closed set that cannot carry
+                        // transport text; the operator still gets the full
+                        // `detail` on the run response and in the run history
+                        // their own console reads back.
+                        reason = %report.reason,
+                        "workflow scheduler: a scheduled run's report was NOT delivered"
+                    );
+                }
+                tracing::info!(
+                    %company,
+                    workflow = %workflow_id,
+                    pending_approvals = run.pending_approvals.len(),
+                    sent = counts.sent,
+                    // Awaiting a human, not a fix — counted apart from
+                    // `undelivered` for exactly that reason.
+                    pending_approval = counts.pending,
+                    skipped = counts.skipped,
+                    denied = counts.denied,
+                    failed = counts.failed,
+                    // The one number worth alerting on, so a log query need not
+                    // sum the three refusal kinds.
+                    undelivered = counts.undelivered(),
+                    "workflow scheduler: scheduled run finished"
+                );
+                // The operator-facing half — the journaled `WorkflowRunFinished`
+                // the tenant's own console reads back — was written by `spawn`
+                // before this handle resolved (issue #228). The log lines above
+                // stay exactly as they are: they are the platform team's
+                // diagnostic on host stdout, which on a hosted tenant is
+                // emphatically not the operator.
+            }
+            Ok(Err(err)) => {
+                tracing::warn!(
+                    %company,
+                    workflow = %workflow_id,
+                    %err,
+                    "workflow scheduler: scheduled run failed"
+                );
+            }
+            // The run task itself came apart — a panic inside the runner, which
+            // unwinds in the spawned task rather than here. Nothing was journaled
+            // for it (the outcome write lives in that task), so this line is the
+            // only trace there is, and it must not be silent. The claim still
+            // releases: it is held by this task's guard.
+            Err(err) => {
+                tracing::error!(
+                    %company,
+                    workflow = %workflow_id,
+                    %err,
+                    "workflow scheduler: a scheduled run's task did not complete; its outcome was \
+                     never recorded"
+                );
+            }
+        }
+    });
 }
 
 /// The cron a graph's trigger schedules itself on, if any.
@@ -2572,5 +2701,235 @@ to = "done"
             "the paused workflow must be the one that did not run"
         );
         drain(&scheduler).await;
+    }
+
+    // --- issue #241: durable claims + restart catch-up ---------------------
+
+    /// The anchor minute of a UTC civil minute, the unit the claim store speaks.
+    fn minute_at(year: i64, month: u32, day: u32, hour: u32, minute: u32) -> u64 {
+        millis_at(year, month, day, hour, minute) / MINUTE_MS
+    }
+
+    /// Two independent schedulers over one durable store — a second replica —
+    /// fire a matching minute exactly once between them.
+    #[tokio::test]
+    async fn two_schedulers_over_one_store_fire_once() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        // Monday 2026-07-13 09:00 — the schedule matches.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut a = WorkflowScheduler::new(registry.clone(), clock.clone());
+        let mut b = WorkflowScheduler::new(registry, clock);
+
+        assert_eq!(a.tick().await, 1, "the first replica wins the claim");
+        assert_eq!(
+            b.tick().await,
+            0,
+            "the second replica loses and fires nothing"
+        );
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        assert_eq!(started.lock().unwrap().len(), 1, "one run in total");
+    }
+
+    /// The FIRST time a scheduler sees a scheduled workflow, it makes up one fire
+    /// missed during downtime — at the original missed minute, marked `catchUp`.
+    #[tokio::test]
+    async fn first_sight_catch_up_fires_one_missed_run() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        // Anchor two Mondays back; the most recent missed Monday is 2026-07-13.
+        let anchor = minute_at(2026, 7, 6, 9, 0);
+        runtime
+            .schedule_fires()
+            .claim_fire(&company, "workflow-digest", anchor)
+            .await
+            .unwrap();
+
+        // "Now" is a Tuesday, so the CURRENT minute never matches — isolating the
+        // catch-up as the only possible fire.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+        assert_eq!(scheduler.tick().await, 1, "one catch-up fires");
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+
+        let run = started.lock().unwrap()[0].clone();
+        assert_eq!(run.workflow, "digest");
+        assert_eq!(run.input["catchUp"], true);
+        assert_eq!(
+            run.input["firedAtMs"],
+            minute_at(2026, 7, 13, 9, 0) * MINUTE_MS,
+            "the make-up run carries the ORIGINAL missed minute, not now"
+        );
+        // The catch-up claimed that minute, so the anchor advanced to it.
+        assert_eq!(
+            runtime
+                .schedule_fires()
+                .latest_fire(&company, "workflow-digest")
+                .await
+                .unwrap(),
+            Some(minute_at(2026, 7, 13, 9, 0))
+        );
+    }
+
+    /// A switched-off workflow (#276) gets NO catch-up: it is filtered before the
+    /// catch-up check, so its anchor is never touched.
+    #[tokio::test]
+    async fn a_disabled_workflow_gets_no_catch_up() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        set_enabled(&registry, "acme", "digest", false).await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        let anchor = minute_at(2026, 7, 6, 9, 0);
+        runtime
+            .schedule_fires()
+            .claim_fire(&company, "workflow-digest", anchor)
+            .await
+            .unwrap();
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock);
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "a paused schedule makes up nothing"
+        );
+        // The anchor is untouched: no catch-up claim was written.
+        assert_eq!(
+            runtime
+                .schedule_fires()
+                .latest_fire(&company, "workflow-digest")
+                .await
+                .unwrap(),
+            Some(anchor)
+        );
+        assert!(started.lock().unwrap().is_empty());
+    }
+
+    /// A previous scheduled run still in flight suppresses the next minute's fire
+    /// WITHOUT claiming it — the minute is suppressed (a slow run's own next
+    /// tick), not burned, so a peer could still fire it.
+    #[tokio::test]
+    async fn an_in_flight_run_suppresses_the_next_minute_without_claiming_it() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let gate = Arc::new(Semaphore::new(0));
+        let (runner, started, _completed) = RecordingRunner::gated(gate.clone());
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 13, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry, clock.clone());
+
+        // Minute M fires and the run parks (gated), holding the in-flight slot.
+        assert_eq!(scheduler.tick().await, 1);
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        let m = minute_at(2026, 7, 13, 9, 0);
+        assert_eq!(
+            runtime
+                .schedule_fires()
+                .latest_fire(&company, "workflow-digest")
+                .await
+                .unwrap(),
+            Some(m)
+        );
+
+        // Minute M+1: the still-in-flight run suppresses this fire. Crucially the
+        // durable claim is NOT taken, so the anchor stays at M — the minute is
+        // suppressed, not burned.
+        clock.set(millis_at(2026, 7, 13, 9, 1));
+        assert_eq!(scheduler.tick().await, 0);
+        assert_eq!(
+            runtime
+                .schedule_fires()
+                .latest_fire(&company, "workflow-digest")
+                .await
+                .unwrap(),
+            Some(m),
+            "a suppressed minute must NOT be claimed"
+        );
+
+        // Let the parked run finish so the test tears down cleanly.
+        gate.add_permits(1);
+        drain(&scheduler).await;
+    }
+
+    /// A company provisioned AFTER boot still gets its catch-up: the check is
+    /// per-(company, workflow) first-sight, not a one-shot boot pass.
+    #[tokio::test]
+    async fn a_late_provisioned_company_gets_its_catch_up_on_first_sight() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+
+        // The scheduler starts over an EMPTY registry — nothing to do yet.
+        let registry = CompanyRegistry::new();
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+        assert_eq!(scheduler.tick().await, 0, "empty registry fires nothing");
+
+        // Provision a company with a missed schedule, after boot.
+        let late = company_with_overlays(
+            &home,
+            "late",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let company = CompanyId::new("late");
+        let runtime = late.get(&company).unwrap();
+        runtime
+            .schedule_fires()
+            .claim_fire(&company, "workflow-digest", minute_at(2026, 7, 6, 9, 0))
+            .await
+            .unwrap();
+        registry.insert(company, runtime);
+
+        // Next tick sees the company for the first time and makes up its fire.
+        assert_eq!(
+            scheduler.tick().await,
+            1,
+            "the late company gets its catch-up"
+        );
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        assert_eq!(started.lock().unwrap()[0].input["catchUp"], true);
     }
 }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2513,3 +2513,145 @@ pub async fn assert_run_reaper(runs: Arc<dyn crate::ports::runs::RunStore>) {
             .is_empty()
     );
 }
+
+// ---------------------------------------------------------------------------
+// ScheduleFireStore (issue #241)
+// ---------------------------------------------------------------------------
+//
+// Imports for this suite are function-local rather than added to the module
+// header, keeping it a pure append to a file edited concurrently on other
+// branches.
+
+/// Asserts the
+/// [`ScheduleFireStore`](crate::ports::schedule_fires::ScheduleFireStore)
+/// contract: a claim is won exactly once; keys are isolated per minute, per
+/// schedule and per company; `latest_fire` is the max claimed minute (never the
+/// last written); pruning removes only rows strictly below the cutoff and never
+/// the anchor; and N concurrent claimers of one key produce exactly one winner —
+/// the cross-replica race the whole port exists to arbitrate.
+pub async fn assert_schedule_fire_store(
+    fires: Arc<dyn crate::ports::schedule_fires::ScheduleFireStore>,
+) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    // -- first claim wins, a repeat loses -----------------------------------
+
+    assert!(
+        fires.claim_fire(&alpha, "workflow-a", 100).await.unwrap(),
+        "the first claim on a key wins"
+    );
+    assert!(
+        !fires.claim_fire(&alpha, "workflow-a", 100).await.unwrap(),
+        "a second claim on the same key loses"
+    );
+
+    // -- keys are distinct per minute, per schedule, per company ------------
+
+    assert!(
+        fires.claim_fire(&alpha, "workflow-a", 101).await.unwrap(),
+        "a different minute is a different claim"
+    );
+    assert!(
+        fires.claim_fire(&alpha, "workflow-b", 100).await.unwrap(),
+        "a different schedule at the same minute is a different claim"
+    );
+    assert!(
+        fires.claim_fire(&beta, "workflow-a", 100).await.unwrap(),
+        "another company claiming the same key does not collide"
+    );
+
+    // -- latest_fire is the max claimed minute, or None ---------------------
+
+    assert_eq!(
+        fires.latest_fire(&alpha, "workflow-a").await.unwrap(),
+        Some(101),
+        "the anchor is the highest claimed minute"
+    );
+    assert_eq!(
+        fires.latest_fire(&alpha, "workflow-b").await.unwrap(),
+        Some(100)
+    );
+    assert_eq!(
+        fires.latest_fire(&beta, "workflow-a").await.unwrap(),
+        Some(100),
+        "company A's rows are invisible to company B's anchor"
+    );
+    assert_eq!(
+        fires.latest_fire(&alpha, "never").await.unwrap(),
+        None,
+        "a schedule that never fired has no anchor"
+    );
+
+    // Claiming an OLDER minute after a newer one does not move the anchor down:
+    // it is a max, not a last-write.
+    assert!(fires.claim_fire(&alpha, "workflow-a", 50).await.unwrap());
+    assert_eq!(
+        fires.latest_fire(&alpha, "workflow-a").await.unwrap(),
+        Some(101)
+    );
+
+    // -- prune removes only rows strictly below the cutoff, never the anchor -
+    //
+    // Prune is COMPANY-wide across every schedule, not per schedule. alpha holds
+    // workflow-a {50, 100, 101} and workflow-b {100}. Pruning below 101 drops
+    // workflow-a's 50 and 100 and workflow-b's 100 — three rows — and keeps
+    // workflow-a's 101, exactly the anchor-preservation invariant the 14-day
+    // cutoff / 7-day window gap guarantees in production.
+    let removed = fires.prune_fires_before(&alpha, 101).await.unwrap();
+    assert_eq!(
+        removed, 3,
+        "prune removes every row below the cutoff, across all schedules"
+    );
+    assert_eq!(
+        fires.latest_fire(&alpha, "workflow-a").await.unwrap(),
+        Some(101),
+        "the newest row survives a prune whose cutoff equals it"
+    );
+    assert_eq!(
+        fires.latest_fire(&alpha, "workflow-b").await.unwrap(),
+        None,
+        "a schedule whose only row fell below the cutoff has no anchor left"
+    );
+    // A pruned minute no longer exists, so it can be claimed again.
+    assert!(
+        fires.claim_fire(&alpha, "workflow-a", 100).await.unwrap(),
+        "a pruned minute can be re-claimed"
+    );
+    // Prune is per-company: beta's row is untouched.
+    assert_eq!(
+        fires.latest_fire(&beta, "workflow-a").await.unwrap(),
+        Some(100)
+    );
+    // A cutoff below everything removes nothing.
+    assert_eq!(fires.prune_fires_before(&alpha, 0).await.unwrap(), 0);
+
+    // -- N concurrent claimers of one key: exactly one winner ---------------
+    //
+    // Spawned tasks, so the claims genuinely contend rather than serialising on
+    // one await. This is the property hosted replicas depend on: two processes
+    // ticking the same minute must not both fire.
+    const N: usize = 16;
+    let key_minute = 777_u64;
+    let mut set = tokio::task::JoinSet::new();
+    for _ in 0..N {
+        let fires = fires.clone();
+        let company = alpha.clone();
+        set.spawn(async move {
+            fires
+                .claim_fire(&company, "race", key_minute)
+                .await
+                .unwrap()
+        });
+    }
+    let mut winners = 0;
+    while let Some(res) = set.join_next().await {
+        if res.unwrap() {
+            winners += 1;
+        }
+    }
+    assert_eq!(
+        winners, 1,
+        "exactly one of {N} concurrent claimers may win the key"
+    );
+}

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -613,6 +613,149 @@ impl RunStore for FsOps {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduleFireStore (issue #241)
+// ---------------------------------------------------------------------------
+//
+// Function-local imports keep this a pure append to a file edited concurrently
+// on other branches (#274, #596).
+
+/// The filesystem-safe directory component for `schedule_id`: its lowercase-hex
+/// SHA-256. Hashing means an id the store did not mint (a `workflow-<id>` whose
+/// `<id>` a console author chose) can never become a path component — the rule
+/// [`Bundle::runs_jsonl`] documents for run ids.
+fn hashed_schedule_component(schedule_id: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(schedule_id.as_bytes());
+    let mut out = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        use std::fmt::Write;
+        // Infallible: writing to a String never fails.
+        let _ = write!(out, "{byte:02x}");
+    }
+    out
+}
+
+#[async_trait]
+impl crate::ports::schedule_fires::ScheduleFireStore for FsOps {
+    async fn claim_fire(
+        &self,
+        company: &CompanyId,
+        schedule_id: &str,
+        minute: u64,
+    ) -> Result<bool> {
+        let dir = self
+            .bundle(company)
+            .schedule_fires_dir()
+            .join(hashed_schedule_component(schedule_id));
+        let marker = dir.join(minute.to_string());
+        // `create_new` is `O_EXCL`: the OS refuses to open the file if it
+        // already exists, so the *first* caller to reach an unclaimed minute is
+        // the only one whose open succeeds. That is the whole claim — no lock,
+        // no read-then-write window. Single-node only: `O_EXCL` is not
+        // trustworthy on NFS, which is why the hosted path runs mongodb.
+        let claimed_at = now_millis();
+        tokio::task::spawn_blocking(move || {
+            use std::io::Write;
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                return Err(io_err(&dir, e));
+            }
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&marker)
+            {
+                Ok(mut file) => {
+                    // The claimed-at stamp is debug only, never part of the key;
+                    // a write failure here does not un-claim the instant, so it
+                    // is deliberately not propagated as a lost claim.
+                    let _ = file.write_all(claimed_at.to_string().as_bytes());
+                    Ok(true)
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(false),
+                Err(e) => Err(io_err(&marker, e)),
+            }
+        })
+        .await
+        .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+    }
+
+    async fn latest_fire(&self, company: &CompanyId, schedule_id: &str) -> Result<Option<u64>> {
+        let dir = self
+            .bundle(company)
+            .schedule_fires_dir()
+            .join(hashed_schedule_component(schedule_id));
+        tokio::task::spawn_blocking(move || {
+            let entries = match std::fs::read_dir(&dir) {
+                Ok(entries) => entries,
+                // No directory means the schedule has never fired — the fresh
+                // install case, which is "no anchor", not an error.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(e) => return Err(io_err(&dir, e)),
+            };
+            let mut max: Option<u64> = None;
+            for entry in entries {
+                let entry = entry.map_err(|e| io_err(&dir, e))?;
+                // A marker filename that does not parse as a minute is not one of
+                // ours; skip it rather than failing the read.
+                if let Some(minute) = entry
+                    .file_name()
+                    .to_str()
+                    .and_then(|name| name.parse::<u64>().ok())
+                {
+                    max = Some(max.map_or(minute, |m| m.max(minute)));
+                }
+            }
+            Ok(max)
+        })
+        .await
+        .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+    }
+
+    async fn prune_fires_before(&self, company: &CompanyId, cutoff_minute: u64) -> Result<usize> {
+        let root = self.bundle(company).schedule_fires_dir();
+        tokio::task::spawn_blocking(move || {
+            let schedules = match std::fs::read_dir(&root) {
+                Ok(entries) => entries,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+                Err(e) => return Err(io_err(&root, e)),
+            };
+            let mut removed = 0usize;
+            for schedule in schedules {
+                let schedule_dir = schedule.map_err(|e| io_err(&root, e))?.path();
+                let markers = match std::fs::read_dir(&schedule_dir) {
+                    Ok(entries) => entries,
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                    Err(e) => return Err(io_err(&schedule_dir, e)),
+                };
+                for marker in markers {
+                    let marker = marker.map_err(|e| io_err(&schedule_dir, e))?;
+                    let Some(minute) = marker
+                        .file_name()
+                        .to_str()
+                        .and_then(|name| name.parse::<u64>().ok())
+                    else {
+                        continue;
+                    };
+                    if minute < cutoff_minute {
+                        let path = marker.path();
+                        match std::fs::remove_file(&path) {
+                            Ok(()) => removed += 1,
+                            // A racing prune already removed it — not our removal
+                            // to count, but not an error either.
+                            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                            Err(e) => return Err(io_err(&path, e)),
+                        }
+                    }
+                }
+            }
+            Ok(removed)
+        })
+        .await
+        .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -1145,6 +1288,40 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_run_reaper(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_schedule_fire_store() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_schedule_fire_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    /// A fresh `FsOps` over the same root sees a prior instance's claims (issue
+    /// #241): the durable record is on disk, so the anchor survives the process
+    /// restart that motivated the whole port. Proves the fs backend's marker
+    /// files are read back, not just written.
+    #[tokio::test]
+    async fn schedule_fire_claim_survives_a_new_fsops_over_the_same_root() {
+        use crate::ports::schedule_fires::ScheduleFireStore;
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let company = crate::ports::types::CompanyId::new("acme");
+
+        let first = FsOps::new(&root);
+        assert!(first.claim_fire(&company, "workflow-x", 42).await.unwrap());
+
+        // A brand-new store over the same root — the shape a restart produces.
+        let second = FsOps::new(&root);
+        assert!(
+            !second.claim_fire(&company, "workflow-x", 42).await.unwrap(),
+            "a restart must see the earlier claim and lose the repeat"
+        );
+        assert_eq!(
+            second.latest_fire(&company, "workflow-x").await.unwrap(),
+            Some(42),
+            "the anchor is durable across a new instance"
+        );
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -211,6 +211,17 @@ impl MongoStore {
             .create_index(unique(doc! {"company_id": 1}))
             .await
             .map_err(mongo_err)?;
+        // Issue #241: the cross-replica arbiter. This unique compound index is
+        // what turns two replicas racing one schedule minute into one winning
+        // `insert_one` and one `E11000` — the case that actually matters, since
+        // hosted replicas share the tenant database. Created outside the array
+        // above so adding it does not disturb that array's fixed length.
+        self.collection("schedule_fires")
+            .create_index(unique(
+                doc! {"company_id": 1, "schedule_id": 1, "scheduled_for": 1},
+            ))
+            .await
+            .map_err(mongo_err)?;
         Ok(())
     }
 
@@ -1638,6 +1649,69 @@ impl crate::ports::runs::RunStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduleFireStore (issue #241)
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::schedule_fires::ScheduleFireStore for MongoStore {
+    async fn claim_fire(
+        &self,
+        company: &CompanyId,
+        schedule_id: &str,
+        minute: u64,
+    ) -> Result<bool> {
+        // A plain `insert_one` against the unique `(company_id, schedule_id,
+        // scheduled_for)` index. Success means this caller won the race; an
+        // `E11000` duplicate-key means a peer — another replica, or this process
+        // before a restart — already claimed the instant, so the caller lost and
+        // must skip. Every OTHER driver error propagates: a claim store that
+        // cannot answer must fail closed at the scheduler, never be read as a win.
+        let result = self
+            .collection("schedule_fires")
+            .insert_one(doc! {
+                "company_id": company.as_ref(),
+                "schedule_id": schedule_id,
+                "scheduled_for": minute as i64,
+                "claimed_at_ms": now_millis() as i64,
+            })
+            .await;
+        match result {
+            Ok(_) => Ok(true),
+            Err(e) if is_duplicate_key(&e) => Ok(false),
+            Err(e) => Err(mongo_err(e)),
+        }
+    }
+
+    async fn latest_fire(&self, company: &CompanyId, schedule_id: &str) -> Result<Option<u64>> {
+        // The single newest row for this schedule, straight off the compound
+        // index — no aggregation needed. A schedule that never fired matches
+        // nothing and yields `None`, the no-anchor case.
+        let found = self
+            .collection("schedule_fires")
+            .find_one(doc! {"company_id": company.as_ref(), "schedule_id": schedule_id})
+            .sort(doc! {"scheduled_for": -1})
+            .await
+            .map_err(mongo_err)?;
+        match found {
+            Some(doc) => Ok(Some(get_i64(&doc, "scheduled_for")? as u64)),
+            None => Ok(None),
+        }
+    }
+
+    async fn prune_fires_before(&self, company: &CompanyId, cutoff_minute: u64) -> Result<usize> {
+        let result = self
+            .collection("schedule_fires")
+            .delete_many(doc! {
+                "company_id": company.as_ref(),
+                "scheduled_for": {"$lt": cutoff_minute as i64},
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(result.deleted_count as usize)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -2268,6 +2342,13 @@ mod test {
     async fn conformance_run_reaper() {
         let Some(s) = store().await else { return };
         conformance::assert_run_reaper(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_schedule_fire_store() {
+        let Some(s) = store().await else { return };
+        conformance::assert_schedule_fire_store(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -324,6 +324,19 @@ impl Bundle {
         self.dir.join("run-steps.jsonl")
     }
 
+    /// The per-company schedule-fire claim subdirectory
+    /// (`schedule_fires/<hashed-schedule-id>/<minute>`, one empty-ish marker
+    /// file per claimed instant; #241).
+    ///
+    /// A directory of `O_EXCL` marker files rather than a JSONL log: the claim's
+    /// whole value is that `create_new` is atomic, so the *existence* of the
+    /// file is the claim. The schedule-id component is hashed before it becomes a
+    /// path so an id the store did not mint can never address the filesystem —
+    /// the same rule [`runs_jsonl`](Self::runs_jsonl) states for run ids.
+    pub fn schedule_fires_dir(&self) -> PathBuf {
+        self.dir.join("schedule_fires")
+    }
+
     /// Path to the human user directory (`users.json`, the full set as a JSON
     /// array).
     pub fn users_json(&self) -> PathBuf {

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -25,6 +25,7 @@ use crate::ports::inbox::InboxStore;
 use crate::ports::login_codes::LoginCodeStore;
 use crate::ports::memory::MemoryStore;
 use crate::ports::runs::RunStore;
+use crate::ports::schedule_fires::ScheduleFireStore;
 use crate::ports::secrets::SecretStore;
 use crate::ports::sessions::SessionStore;
 use crate::ports::skills_state::SkillStateStore;
@@ -148,6 +149,8 @@ pub struct StorageHandles {
     pub artifacts: Arc<dyn ArtifactStore>,
     /// First-class task-run records and their step traces (#242).
     pub runs: Arc<dyn RunStore>,
+    /// Durable cross-replica scheduler fire claims (#241).
+    pub schedule_fires: Arc<dyn ScheduleFireStore>,
     pub usage: Arc<dyn UsageMeter>,
     pub skills: Arc<dyn SkillStateStore>,
     pub users: Arc<dyn UserStore>,
@@ -402,6 +405,7 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         facts: store.clone(),
         artifacts: store.clone(),
         runs: store.clone(),
+        schedule_fires: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),
@@ -439,6 +443,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         facts: store.clone(),
         artifacts: store.clone(),
         runs: store.clone(),
+        schedule_fires: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
         users: store.clone(),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -227,6 +227,15 @@ CREATE UNIQUE INDEX IF NOT EXISTS login_codes_hash
     ON login_codes (company_id, code_hash);
 CREATE INDEX IF NOT EXISTS login_codes_email
     ON login_codes (company_id, email);
+CREATE TABLE IF NOT EXISTS schedule_fires (
+    company_id    TEXT NOT NULL,
+    schedule_id   TEXT NOT NULL,
+    scheduled_for INTEGER NOT NULL,
+    claimed_at_ms INTEGER NOT NULL,
+    PRIMARY KEY (company_id, schedule_id, scheduled_for)
+);
+CREATE INDEX IF NOT EXISTS schedule_fires_by_schedule
+    ON schedule_fires (company_id, schedule_id, scheduled_for);
 "#;
 
 /// Maps a `rusqlite` failure onto the crate error type without a bare `?` on
@@ -1846,6 +1855,69 @@ impl crate::ports::runs::RunStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// ScheduleFireStore (issue #241)
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::schedule_fires::ScheduleFireStore for SqliteStore {
+    async fn claim_fire(
+        &self,
+        company: &CompanyId,
+        schedule_id: &str,
+        minute: u64,
+    ) -> Result<bool> {
+        let conn = self.conn();
+        // `INSERT OR IGNORE` against the `(company_id, schedule_id,
+        // scheduled_for)` primary key: the row lands for the first caller and is
+        // silently skipped for every later one. `changes()` (rows-affected) is
+        // therefore exactly "did I win the claim" — 1 = won, 0 = a peer already
+        // held it.
+        let changed = conn
+            .execute(
+                "INSERT OR IGNORE INTO schedule_fires \
+                 (company_id, schedule_id, scheduled_for, claimed_at_ms) \
+                 VALUES (?1, ?2, ?3, ?4)",
+                params![
+                    company.as_ref(),
+                    schedule_id,
+                    minute as i64,
+                    now_millis() as i64,
+                ],
+            )
+            .map_err(sql_err)?;
+        Ok(changed == 1)
+    }
+
+    async fn latest_fire(&self, company: &CompanyId, schedule_id: &str) -> Result<Option<u64>> {
+        let conn = self.conn();
+        // `MAX(scheduled_for)` over one schedule; a company that never fired it
+        // returns SQL `NULL`, mapped to `None` — the no-anchor / fresh-install
+        // case the schedulers read as "no catch-up".
+        let max: Option<i64> = conn
+            .query_row(
+                "SELECT MAX(scheduled_for) FROM schedule_fires \
+                 WHERE company_id = ?1 AND schedule_id = ?2",
+                params![company.as_ref(), schedule_id],
+                |r| r.get(0),
+            )
+            .map_err(sql_err)?;
+        Ok(max.map(|m| m as u64))
+    }
+
+    async fn prune_fires_before(&self, company: &CompanyId, cutoff_minute: u64) -> Result<usize> {
+        let conn = self.conn();
+        let removed = conn
+            .execute(
+                "DELETE FROM schedule_fires \
+                 WHERE company_id = ?1 AND scheduled_for < ?2",
+                params![company.as_ref(), cutoff_minute as i64],
+            )
+            .map_err(sql_err)?;
+        Ok(removed)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -2407,6 +2479,36 @@ mod test {
     #[tokio::test]
     async fn conformance_run_reaper() {
         conformance::assert_run_reaper(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_schedule_fire_store() {
+        conformance::assert_schedule_fire_store(store()).await;
+    }
+
+    /// A fire claim written to a file-backed database survives a reopen (issue
+    /// #241) — the restart durability the whole port exists for.
+    #[tokio::test]
+    async fn schedule_fire_claim_survives_reopen() {
+        use crate::ports::schedule_fires::ScheduleFireStore;
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("company.db");
+        let id = CompanyId::new("acme");
+        {
+            let s = SqliteStore::open(&path).unwrap();
+            assert!(s.claim_fire(&id, "workflow-x", 42).await.unwrap());
+        }
+        // A fresh handle over the same file loses the repeat and reads the anchor.
+        let s = SqliteStore::open(&path).unwrap();
+        assert!(
+            !s.claim_fire(&id, "workflow-x", 42).await.unwrap(),
+            "a reopened database must see the earlier claim and lose the repeat"
+        );
+        assert_eq!(
+            s.latest_fire(&id, "workflow-x").await.unwrap(),
+            Some(42),
+            "the anchor is durable across a reopen"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Both schedulers deduped fires purely in process memory (`last_fired: HashMap`), so a restart across a fire instant silently dropped that occurrence (the module doc conceded "missed runs are skipped, never caught up") and two hosted replicas of one tenant both fired every schedule. This makes the dedup durable: before firing, a scheduler atomically **claims** `(schedule_id, minute)` in a new `ScheduleFireStore`; the winner fires, losers skip. Cross-replica safety lives in the backend's own uniqueness primitive (Mongo unique index / SQLite `PRIMARY KEY`), never in-process locking. Adds bounded restart catch-up (at most one make-up fire per schedule, within a 7-day window) and fixes a latent bug where manifest `[[schedule]]` identity was the Vec index (reorder reassigned identity) by deriving a content-hash id.

## API Or Behavior Changes

- New `ScheduleFireStore` port (`claim_fire`/`latest_fire`/`prune_fires_before`), fs/sqlite/mongo impls + conformance, wired through the storage seam like `runs`.
- **At-most-once by design, fail-closed:** the claim is awaited before any side effect; a claim-store error skips + warns (never fires unclaimed); a crash between claim and fire burns that one instant (per-minute keys mean no schedule can wedge). Deliberate — a duplicate LLM cycle / email / token spend is worse than a rare drop.
- **fs backend is single-node-only** (O_EXCL, untrustworthy on NFS); hosted replicas run Mongo, where the unique index is the arbiter.
- Behavior change: two *identical* `(cron, prompt)` manifest schedules now collapse to one fire (content-derived identity).
- Retention: `PRUNE_CUTOFF (14d) > CATCHUP_WINDOW (7d)` (compile-time invariant assert) so the catch-up anchor is never pruned out from under it.
- No `CompanyEvent` change — catch-up reuses the existing `ScheduleFired`/`WorkflowSpawn` path.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features openhuman,tinycortex`)
- [x] `cargo build --all-targets` (`cargo check --all-features` — sqlite + mongo impls compile)
- [x] `cargo test` — default **1836 passed / 0 failed**; gated 0 failures. Conformance (first-wins/dup-loses, per-minute/schedule/company isolation, latest_fire=max, company-wide prune, **N-concurrent-claim → exactly one true**); reopen durability (sqlite + fs); scheduler suite (two-replicas-one-store → one fire + loser zero side effects, restart no-refire, catch-up within/beyond/fresh/raced/3-occurrence→one, fail-closed, manifest-reorder identity stability, in-flight-suppress-without-claim, disabled-no-catchup, late-company first-sight); `prev_match_before` units; prune invariant. All time-injected (`FakeClock`) — no wall-clock sleeps.

## Documentation

Port-doc + inline design docs (atomicity contract, at-most-once, fs caveat). Owner re-verification (`saved_by` at fire time) is a **deferred follow-up** the issue itself scopes out — will open a tracking issue on merge.

## Related

Closes #241. Shares the storage-registration seam additively with #274 (#626) + #596 (distinct names `ScheduleFireStore`/`schedule_fires`; union-built before the second merges).