### PR TITLE
fix(tasks): remove the card's Approvals tab, keep the waiting signal (#468)

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -328,25 +328,25 @@ export type TaskApprovalStatus = "pending" | "approved" | "denied" | "expired";
  * Distinct from an `approval` {@link TimelineEntry}, which can only describe a
  * *resolution*: an approval still parked has no resolution event, so it cannot
  * reach the timeline at all, and it is the row that matters most — the card is
- * stopped behind it. Carries no payload; the Approvals page is where a sign-off
- * is read in full and decided.
+ * stopped behind it.
+ *
+ * **Three fields on purpose (#468).** This used to back an Approvals tab on the
+ * task card. That tab is gone — approvals are decided in one place, and a
+ * second half-surface beside it could not decide anything. All the card does
+ * now is say *that* it is waiting and for how long, linking to the Approvals
+ * page, so this type carries only what that line reads. `kind`,
+ * `resolvedAtMillis` and `waitedMillis` went with the tab; the park to resolve
+ * span is still on the `approval` {@link TimelineEntry}.
  */
 export interface TaskApproval {
   /** The approval's id, the same one the Approvals page resolves against. */
   id: string;
-  /** The parked effect's dotted kind, e.g. `payment.send`. */
-  kind: string;
-  /** Epoch-millis the effect parked. Rows are ordered by this, oldest first. */
+  /**
+   * Epoch-millis the effect parked. Rows are ordered by this, oldest first, and
+   * the card measures "waiting for N" from the oldest pending one.
+   */
   atMillis: number;
   status: TaskApprovalStatus;
-  /** Epoch-millis the resolution landed; absent while pending. */
-  resolvedAtMillis?: number;
-  /**
-   * The park to resolve span. Absent while pending, where the console runs that
-   * clock itself from `atMillis`, and for an approval whose park instant the
-   * host cannot recover.
-  */
-  waitedMillis?: number;
 }
 
 /**

--- a/frontend/src/lib/task-approvals.ts
+++ b/frontend/src/lib/task-approvals.ts
@@ -1,0 +1,54 @@
+import type { TaskApproval } from "@/api/tasks";
+
+/**
+ * What the task card says about approvals (issue #468).
+ *
+ * `null` when the card is not waiting on anything — the caller renders nothing
+ * at all rather than a "no approvals" line, which is the clutter the removed
+ * Approvals tab was made of.
+ */
+export interface PendingApprovalWait {
+  /** How many of this task's approvals are still parked. */
+  count: number;
+  /** Epoch-millis the *oldest* parked one arrived. */
+  since: number;
+  /** How long the card has been stopped, measured to the caller's clock. */
+  waited: number;
+}
+
+/**
+ * Derives the card's one approval line from this task's approvals.
+ *
+ * Lives here rather than inline in the view for the reason every other
+ * derivation in `lib/` does: getting it wrong produces a card that looks
+ * completely normal while saying the wrong thing. A card that reports the
+ * *newest* park reads as freshly blocked no matter how long it has actually sat
+ * there, and nothing about the rendering would look broken.
+ *
+ * Three decisions worth stating, because each is a way this could be silently
+ * wrong:
+ *
+ * - **Only `pending` counts.** `approved`, `denied` and `expired` are
+ *   resolutions; they are already on the timeline with their own waited span,
+ *   and counting them here would rebuild the removed tab one row at a time.
+ * - **The oldest park wins**, not the newest. It is how long this card has
+ *   really been stopped. With the newest, a second effect parking behind the
+ *   first would reset a clock that should be climbing.
+ * - **`waited` is clamped at zero.** `atMillis` comes from the host and `now`
+ *   from the browser; a clock skew of a few seconds must not render "waiting
+ *   for -3s".
+ */
+export function pendingApprovalWait(
+  approvals: readonly TaskApproval[],
+  now: number,
+): PendingApprovalWait | null {
+  let count = 0;
+  let since = Number.POSITIVE_INFINITY;
+  for (const a of approvals) {
+    if (a.status !== "pending") continue;
+    count += 1;
+    if (a.atMillis < since) since = a.atMillis;
+  }
+  if (count === 0) return null;
+  return { count, since, waited: Math.max(0, now - since) };
+}

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -59,7 +59,6 @@ import {
   type SteerAction,
   type Task,
   type TaskApproval,
-  type TaskApprovalStatus,
   type TaskDetail,
   type TaskPlan,
   type TimelineEntry,
@@ -81,6 +80,7 @@ import {
 } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { hasFocus, type TaskFocus } from "@/lib/task-output";
+import { pendingApprovalWait } from "@/lib/task-approvals";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -492,6 +492,8 @@ export function TaskDetailView({
 
             <LineageRail lineage={detail.lineage} onNavigate={onNavigate} />
 
+            <AwaitingApprovalRow approvals={detail.approvals} now={now} />
+
             <Tabs value={tab} onValueChange={(next) => setTab(String(next))}>
               <TabsList>
                 <TabsTrigger value="timeline">Timeline</TabsTrigger>
@@ -526,7 +528,6 @@ export function TaskDetailView({
                     })()}
                   </TabsTrigger>
                 )}
-                <TabsTrigger value="approvals">Approvals</TabsTrigger>
                 <TabsTrigger value="artifacts">Artifacts</TabsTrigger>
                 <TabsTrigger value="discussion">Discussion</TabsTrigger>
               </TabsList>
@@ -554,10 +555,6 @@ export function TaskDetailView({
                   <TaskPlanBrief plan={detail.task.plan} />
                 </TabsContent>
               )}
-
-              <TabsContent value="approvals" className="mt-4">
-                <ApprovalsTab approvals={detail.approvals} now={now} />
-              </TabsContent>
 
               <TabsContent value="artifacts" className="mt-4">
                 <ArtifactsTab
@@ -1787,94 +1784,53 @@ function RunDrawer({
   );
 }
 
-/** What each status reads as on a row, and how it is coloured (#333). */
-const APPROVAL_STATUS: Record<TaskApprovalStatus, { label: string; className: string }> = {
-  pending: {
-    label: "Waiting on you",
-    className: "text-amber-700 dark:text-amber-400",
-  },
-  approved: { label: "Approved", className: "text-emerald-600 dark:text-emerald-400" },
-  denied: { label: "Declined", className: "text-muted-foreground" },
-  expired: { label: "Expired (auto-declined)", className: "text-muted-foreground" },
-};
-
 /**
- * The Approvals tab (#333): this task's own sign-offs, oldest first — ordered
- * by when each was *asked for*, not when it was answered, so a still-parked row
- * sits in the run where it arose rather than being pinned to the bottom.
+ * The card's one line about approvals (#468).
  *
- * It reads `detail.approvals`, not the timeline. Filtering the timeline for
- * `kind === "approval"` could only ever find *resolutions*, and only ones that
- * fell inside the run window, so the tab was empty for every task that had an
- * approval actually waiting on a human.
+ * This replaces an Approvals tab that listed every sign-off this task ever
+ * asked for. The tab was removed because it could not do the one thing an
+ * operator wanted from it — decide. Approvals are resolved in exactly one
+ * place, and a second surface beside that one was a maintenance cost that only
+ * ever ended in a link.
+ *
+ * What could not be removed with it is the *signal*. A card stalled behind a
+ * sign-off has to say so, or the screen that exists to answer "why is this
+ * stuck" silently stops answering it — trading a bad surface for a worse
+ * silence. So: one row, only when something is actually pending, saying what is
+ * being waited on and for how long, and linking to where it gets decided.
+ *
+ * Deliberately says nothing about *decided* approvals. Those are resolutions,
+ * they are already on the timeline as `approval` entries with their own waited
+ * span, and repeating them here would rebuild the tab one row at a time.
+ *
+ * Renders nothing when nothing is pending — an always-present "no approvals"
+ * line is the clutter the tab was removed for.
  */
-function ApprovalsTab({ approvals, now }: { approvals: TaskApproval[]; now: number }) {
+function AwaitingApprovalRow({ approvals, now }: { approvals: TaskApproval[]; now: number }) {
+  const pending = pendingApprovalWait(approvals, now);
+  if (!pending) return null;
+  const { waited } = pending;
+
   return (
-    <div className="space-y-3">
-      <p className="text-xs text-muted-foreground">
-        Sign-offs this task asked for, still waiting or already decided. Each wait is measured from
-        the moment the effect actually parked.
-      </p>
-      {approvals.length === 0 ? (
-        <EmptyState
-          title="No approvals for this task"
-          body="Anything this task parks for your sign-off will appear here."
-        />
-      ) : (
-        <ol className="space-y-1.5">
-          {approvals.map((a) => {
-            const status = APPROVAL_STATUS[a.status] ?? APPROVAL_STATUS.pending;
-            const pending = a.status === "pending";
-            // A pending row has no resolution to measure against, so its wait
-            // runs to the polled clock instead.
-            const waited = pending ? Math.max(0, now - a.atMillis) : a.waitedMillis;
-            return (
-              <li
-                key={a.id}
-                className="flex items-center gap-2 rounded-lg border bg-card px-3 py-2 text-xs"
-              >
-                {pending ? (
-                  <Hourglass className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
-                ) : (
-                  <ShieldCheck className="size-3.5 shrink-0 text-muted-foreground" />
-                )}
-                <span className="min-w-0 flex-1 truncate font-medium">{a.kind}</span>
-                {/*
-                 * A pending row is the one thing on this tab the operator can
-                 * act on, and the tab itself cannot approve or deny — so the
-                 * status doubles as the way out, to the Approvals page where
-                 * the decision lives. Decided rows have nothing to go to.
-                 */}
-                {pending ? (
-                  <a
-                    href="#/approvals"
-                    className={cn(
-                      "shrink-0 text-[11px] underline-offset-2 hover:underline",
-                      status.className,
-                    )}
-                    aria-label={`${status.label} — review ${a.kind} on the Approvals page`}
-                    title="Review this on the Approvals page"
-                  >
-                    {status.label}
-                  </a>
-                ) : (
-                  <span className={cn("shrink-0 text-[11px]", status.className)}>
-                    {status.label}
-                  </span>
-                )}
-                {waited !== undefined && (
-                  <span className="shrink-0 text-[11px] tabular-nums text-amber-700 dark:text-amber-400">
-                    {pending ? "waiting" : "waited"} {formatDuration(waited)}
-                  </span>
-                )}
-                <span className="shrink-0 text-[11px] tabular-nums text-muted-foreground">
-                  {timeOf(a.atMillis)}
-                </span>
-              </li>
-            );
-          })}
-        </ol>
-      )}
+    <div className="flex items-center gap-2 rounded-lg border border-amber-300/60 bg-amber-50 px-3 py-2 text-xs dark:border-amber-400/30 dark:bg-amber-950/30">
+      <Hourglass className="size-3.5 shrink-0 text-amber-600 dark:text-amber-400" />
+      <span className="min-w-0 flex-1 text-amber-800 dark:text-amber-300">
+        {pending.count === 1
+          ? "Waiting on an approval"
+          : `Waiting on ${pending.count} approvals`}{" "}
+        <span className="tabular-nums">for {formatDuration(waited)}</span>
+      </span>
+      <a
+        href="#/approvals"
+        className="shrink-0 font-medium text-amber-800 underline-offset-2 hover:underline dark:text-amber-300"
+        aria-label={
+          pending.count === 1
+            ? "Review this task's pending approval on the Approvals page"
+            : `Review this task's ${pending.count} pending approvals on the Approvals page`
+        }
+      >
+        Review
+      </a>
     </div>
   );
 }

--- a/frontend/test/unit/task-approvals.test.ts
+++ b/frontend/test/unit/task-approvals.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+
+import { pendingApprovalWait } from "@/lib/task-approvals";
+import type { TaskApproval, TaskApprovalStatus } from "@/api/tasks";
+
+/**
+ * The task card's one approval line (issue #468).
+ *
+ * #468 removed the card's Approvals tab, which could list every sign-off but
+ * could not decide any of them. What had to survive the removal is the
+ * *signal*: a card stalled behind an approval must still say so, or the screen
+ * that exists to answer "why is this stuck" quietly stops answering it.
+ *
+ * This derivation is the whole of that signal, which is why it is tested rather
+ * than left inline — each way it can be wrong produces a card that looks
+ * entirely normal while misreporting.
+ */
+
+function approval(over: Partial<TaskApproval> = {}): TaskApproval {
+  return { id: "appr-1", atMillis: 1_000, status: "pending", ...over };
+}
+
+describe("pendingApprovalWait", () => {
+  it("reports nothing when the task has no approvals at all", () => {
+    expect(pendingApprovalWait([], 5_000)).toBeNull();
+  });
+
+  /**
+   * The removed tab rendered a "No approvals for this task" empty state on
+   * every card that never parked one. Returning `null` rather than a zero
+   * count is what lets the caller render nothing instead of reintroducing it.
+   */
+  it.each<TaskApprovalStatus>(["approved", "denied", "expired"])(
+    "reports nothing when the only approval is %s",
+    (status) => {
+      expect(pendingApprovalWait([approval({ status })], 5_000)).toBeNull();
+    },
+  );
+
+  it("reports a single pending approval and how long it has waited", () => {
+    const wait = pendingApprovalWait([approval({ atMillis: 1_000 })], 4_500);
+    expect(wait).toEqual({ count: 1, since: 1_000, waited: 3_500 });
+  });
+
+  /**
+   * The one that matters most. A card with two parked effects has been stopped
+   * since the *first* of them; measuring from the newest would reset a clock
+   * that should be climbing, every time another effect parks behind it — and
+   * the card would look freshly blocked no matter how long it had really sat.
+   */
+  it("measures from the oldest park, not the newest", () => {
+    const wait = pendingApprovalWait(
+      [
+        approval({ id: "new", atMillis: 9_000 }),
+        approval({ id: "old", atMillis: 2_000 }),
+        approval({ id: "mid", atMillis: 5_000 }),
+      ],
+      10_000,
+    );
+    expect(wait).toEqual({ count: 3, since: 2_000, waited: 8_000 });
+  });
+
+  it("counts only the pending ones when the task has a mixed history", () => {
+    const wait = pendingApprovalWait(
+      [
+        // Resolved long before the pending one, and must not be what the
+        // clock is measured from.
+        approval({ id: "done", atMillis: 100, status: "approved" }),
+        approval({ id: "gone", atMillis: 200, status: "expired" }),
+        approval({ id: "live", atMillis: 6_000, status: "pending" }),
+      ],
+      6_750,
+    );
+    expect(wait).toEqual({ count: 1, since: 6_000, waited: 750 });
+  });
+
+  /**
+   * `atMillis` is the host's clock and `now` is the browser's. A few seconds of
+   * skew is ordinary and must not render as "waiting for -3s".
+   */
+  it("clamps a negative wait to zero when the browser clock lags the host", () => {
+    const wait = pendingApprovalWait([approval({ atMillis: 10_000 })], 7_000);
+    expect(wait).toEqual({ count: 1, since: 10_000, waited: 0 });
+  });
+});

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -487,35 +487,42 @@ pub(crate) struct TimelineEntry {
 
 /// One approval that belongs to this task (issue #333).
 ///
-/// The Approvals tab's row. Distinct from the `approval` [`TimelineEntry`],
-/// which can only ever describe a *resolution* — an approval still parked has
-/// no `ApprovalResolved` event, so it cannot reach the timeline at all, and
-/// that is exactly the row an operator opening this screen needs: the one
-/// waiting on them right now.
+/// Distinct from the `approval` [`TimelineEntry`], which can only ever describe
+/// a *resolution* — an approval still parked has no `ApprovalResolved` event,
+/// so it cannot reach the timeline at all, and that is exactly the one the card
+/// needs to report: the sign-off a task is stalled on right now.
 ///
-/// Carries no payload. The parked effect can hold a recipient, a body or an
-/// amount, and this response is not the place to widen what a task read
-/// exposes — the Approvals page resolves the sign-off, and this is only the
-/// task's view of what it asked for.
+/// **Deliberately three fields (issue #468).** This used to back an Approvals
+/// tab on the task card that listed every sign-off with its kind and its
+/// park→resolve span. That tab is gone: approvals are decided in one place, and
+/// a second half-surface beside it was a maintenance cost with no payoff. What
+/// replaced it is a single "waiting on approval" line linking to the Approvals
+/// page, so this projection now carries what that line needs and stops there —
+/// whether anything is pending, and since when. `id` stays because it is the
+/// discriminator that makes "which approvals belong to which card" testable,
+/// which is #333's actual behaviour and outlives the tab.
+///
+/// Dropped with the tab: `kind`, `resolvedAtMillis`, `waitedMillis`. The
+/// park→resolve arithmetic is unchanged and still observable on the `approval`
+/// [`TimelineEntry`], which carries its own `waitedMillis`.
+///
+/// Still carries no payload, and the reason has changed. It used to be that a
+/// task read was the wrong place to widen exposure. That argument does not hold
+/// — `GET …/approvals` already returns the payload to any company member — so
+/// the honest reason is simply that this line does not need one. Whether
+/// membership is the right boundary for that sibling route is asked separately
+/// in issue #618 and is not decided here.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct TaskApproval {
     /// The approval's id — the same one the Approvals page resolves against.
     pub(crate) id: String,
-    /// The parked effect's dotted kind, e.g. `payment.send`.
-    pub(crate) kind: String,
-    /// Epoch-millis the effect parked.
+    /// Epoch-millis the effect parked. The card measures "waiting for N" from
+    /// here against its own clock, which is why a pending row needs no
+    /// server-side span.
     pub(crate) at_millis: u64,
     /// `pending`, `approved`, `denied`, or `expired`.
     pub(crate) status: String,
-    /// Epoch-millis the resolution landed. Absent while pending.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) resolved_at_millis: Option<u64>,
-    /// The park → resolve span. Absent while pending (the console runs that
-    /// clock itself from `atMillis`) and for an approval whose park instant the
-    /// journal cannot recover.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) waited_millis: Option<u64>,
 }
 
 /// One irreversible effect this task already executed (issue #351).
@@ -1051,11 +1058,8 @@ async fn assemble_detail_with_cursor(
 
     approvals.extend(pending.into_iter().map(|a| TaskApproval {
         id: a.id.as_ref().to_string(),
-        kind: a.kind,
         at_millis: a.at_millis,
         status: "pending".to_string(),
-        resolved_at_millis: None,
-        waited_millis: None,
     }));
     approvals.sort_by(|a, b| a.at_millis.cmp(&b.at_millis).then_with(|| a.id.cmp(&b.id)));
 
@@ -1562,18 +1566,14 @@ fn fold_page(
                 fold.approvals.push(TaskApproval {
                     id: approval_id.as_ref().to_string(),
                     // An origin is missing only for a park this journal never
-                    // saw. The row still belongs on the tab; it just cannot say
-                    // what the effect was.
-                    kind: origin
-                        .map_or_else(|| "unknown".to_string(), |origin| origin.kind.clone()),
+                    // saw; fall back to the resolution instant so the row still
+                    // sorts sanely among its siblings.
                     at_millis: origin.map_or(ev.at_millis, |origin| origin.at_millis),
                     status: if expired {
                         "expired".to_string()
                     } else {
                         crate::brain::medulla::effects::verdict_word(*verdict).to_string()
                     },
-                    resolved_at_millis: Some(ev.at_millis),
-                    waited_millis: waited,
                 });
                 Some(("approval", label, None, waited))
             }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -4863,12 +4863,15 @@ async fn a_parked_approval_appears_on_its_own_task() {
     assert_eq!(approvals.len(), 1, "{approvals:?}");
     assert_eq!(approvals[0]["id"], "appr-mine");
     assert_eq!(approvals[0]["status"], "pending");
-    assert_eq!(approvals[0]["kind"], "filing.submit");
     assert_eq!(approvals[0]["atMillis"].as_u64().unwrap(), parked_at);
-    assert!(
-        approvals[0].get("resolvedAtMillis").is_none(),
-        "a pending approval has not resolved",
-    );
+    // #468 shrank this projection to what the card's one waiting line reads.
+    // `kind`, `resolvedAtMillis` and `waitedMillis` left with the Approvals tab.
+    for gone in ["kind", "resolvedAtMillis", "waitedMillis"] {
+        assert!(
+            approvals[0].get(gone).is_none(),
+            "`{gone}` was dropped with the Approvals tab (#468)",
+        );
+    }
     // The timeline is untouched — a parked approval still has no event.
     assert!(
         body["timeline"]
@@ -5042,13 +5045,23 @@ async fn a_resolved_approval_reports_its_verdict_and_wait_on_the_tab() {
     assert_eq!(approvals.len(), 1, "{approvals:?}");
     let row = &approvals[0];
     assert_eq!(row["status"], "denied");
-    // The row is anchored at the *park*, so the tab reads in the order things
+    // The row is anchored at the *park*, so approvals read in the order things
     // were asked rather than the order they were answered.
     assert_eq!(row["atMillis"].as_u64().unwrap(), parked_at);
-    let resolved_at = row["resolvedAtMillis"].as_u64().unwrap();
+    // The park→resolve span moved off this row with the Approvals tab (#468).
+    // It is unchanged, and still asserted here — on the `approval` timeline
+    // entry, which is where it now lives. Dropping the assertion along with the
+    // field would have quietly retired the arithmetic's only coverage.
+    let entry = body["timeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["kind"] == "approval")
+        .expect("a resolved approval reaches the timeline");
+    let resolved_at = entry["atMillis"].as_u64().unwrap();
     assert!(resolved_at > parked_at);
     assert_eq!(
-        row["waitedMillis"].as_u64().unwrap(),
+        entry["waitedMillis"].as_u64().unwrap(),
         resolved_at - parked_at,
     );
     // Nothing is parked any more, so the card is not still waiting.
@@ -5302,9 +5315,17 @@ async fn a_pre_333_approval_falls_back_to_the_run_window() {
     assert_eq!(approvals.len(), 1, "{approvals:?}");
     assert_eq!(approvals[0]["id"], "appr-legacy");
     assert_eq!(approvals[0]["status"], "approved");
-    let resolved_at = approvals[0]["resolvedAtMillis"].as_u64().unwrap();
+    // As above (#468): the span lives on the timeline entry now, and the legacy
+    // clamping behaviour is asserted there rather than dropped.
+    let entry = body["timeline"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|e| e["kind"] == "approval")
+        .expect("a resolved approval reaches the timeline");
+    let resolved_at = entry["atMillis"].as_u64().unwrap();
     assert_eq!(
-        approvals[0]["waitedMillis"].as_u64().unwrap(),
+        entry["waitedMillis"].as_u64().unwrap(),
         resolved_at.saturating_sub(dispatched_at + 5),
         "the resolved legacy row keeps the original park-to-resolve wait",
     );


### PR DESCRIPTION
## Summary

Closes #468.

**The issue body is superseded.** @oxoxDev's decision comment (2026-08-11 09:02) answered the exposure question in a way that dissolved the issue rather than unblocking it, and a body rewrite was promised but has not landed — the body still describes widening the projection so the tab can render the shared card. I worked from the comment. If the body is rewritten before this merges, it should read as below.

What changed:

1. **Removed the Approvals tab** from the task detail card.
2. **Kept the signal** — one line, present only when something is actually pending, saying how many approvals the card is stopped behind and for how long, linking to the Approvals page.
3. **`TaskApproval` shrank** from six fields to three (`id`, `atMillis`, `status`), rather than growing.
4. The **"all approval surfaces render one shared component" goal is closed as not pursued** — there is one approval surface now, so there is nothing to share.

## Problem

The tab rendered each approval as a bare tool name. It could not approve or deny — every pending row was a link out to the Approvals page — and it showed none of what a decision needs. The original plan was to widen the projection so it could render the shared card. The decision instead was that approvals do not belong on the task card at all: they are resolved in exactly one place, and a second half-surface beside that one is a maintenance cost whose best case is still a link.

The thing that could **not** be removed with it is the *signal*. The card is where someone goes to ask "why is this stuck". Deleting the tab and saying nothing would trade one bad surface for a worse silence.

## Solution

### The one line

`AwaitingApprovalRow` sits above the tab strip, so it is visible whichever tab is open — the point is that a stalled card announces it, not that you can go find it. It renders **nothing** when nothing is pending; an always-present "no approvals" line is exactly the clutter the tab was made of.

The derivation is in `frontend/src/lib/task-approvals.ts` rather than inline, for the reason the other `lib/` derivations are: every way it can be wrong produces a card that looks completely normal while misreporting. Three decisions, each pinned by a test:

- **Only `pending` counts.** The rest are resolutions; they are already on the timeline with their own waited span, and counting them here rebuilds the tab one row at a time.
- **Measured from the oldest park, not the newest.** With the newest, a second effect parking behind the first resets a clock that should be climbing, and the card reads as freshly blocked no matter how long it has really sat.
- **`waited` clamps at zero.** `atMillis` is the host's clock, `now` is the browser's; ordinary skew must not render "waiting for -3s".

### The projection shrink, and the one thing I deliberately kept

Six fields to three. `kind`, `resolvedAtMillis` and `waitedMillis` went with the tab. `id` stays: it is the discriminator that makes "which approvals belong to which card" testable, which is #333's behaviour and outlives the tab — three existing tests identify rows by it.

**The park→resolve arithmetic is unchanged and still asserted.** Two tests existed to pin it (the run-window clamping, and the pre-#333 legacy row). Deleting `waitedMillis` would have deleted their assertion point and quietly retired the only coverage of that arithmetic while looking like a tidy-up. Instead both now assert on the `approval` **timeline entry**, which carries its own `waitedMillis` and always did. Same numbers, same clamping, different observable.

### A coupling worth making visible now

The status line reads `detail.approvals` from the **task detail** route, not from `GET …/approvals`. Both are gated on company membership alone. I filed #618 asking whether membership is the intended boundary for the payload-bearing approvals route — and if that route were ever role-gated, **this line would keep working while the "Review" link it points at would show a Member an empty page.** Not designing around a gate that does not exist; recording the coupling so it cannot be found later by breaking it.

## API Or Behavior Changes

- **Removed**: the Approvals tab on the task detail card, and its `ApprovalsTab` component and `APPROVAL_STATUS` map.
- **Added**: a "Waiting on N approvals for X" row above the tab strip, shown only while something is pending, linking to `#/approvals`.
- **Wire change**: `GET /tasks/{task_id}` — each entry of `approvals[]` now carries `id`, `atMillis`, `status` only. `kind`, `resolvedAtMillis` and `waitedMillis` are gone. The console is the only consumer and is updated in the same commit; the `approval` timeline entry is unchanged.
- Nothing about how approvals are *decided* changes. This PR touches no approval resolution path.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs this lane: `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, exit 0. (`--no-deps` matters: without it the command fails on two pre-existing `large_enum_variant` lints in `vendor/tinyagents`. CI passes it — `ci.yml:434`.)
- [x] `cargo build --all-targets` — **not run as `build`**; ran `cargo check --features openhuman,tinycortex --all-targets`, exit 0. Gated lane, covers `examples/`, which default features skip.
- [x] `cargo test` — **not run bare**; ran `cargo test --features openhuman,tinycortex`: **2705 passed, 0 failed**. Default features skip about a third of the crate.

Console, all four commands CI's `Console` job runs:

- `npm run typecheck`, `npm run typecheck:e2e`, `npm run typecheck:unit` — all exit 0.
- `npm test` — 8 new tests pass. **The suite has 38 pre-existing failures** in `tour-resume`, `desktop-bridge` and `connection-registry`, all `window.localStorage.clear is not a function`. Confirmed pre-existing by stashing this diff and re-running: baseline **38 failed / 237 passed**, with this diff **38 failed / 245 passed** — same failures, my 8 on top. It looks like a local jsdom/environment difference; I am making no claim about CI, which is authoritative.

New: `frontend/test/unit/task-approvals.test.ts`, 8 cases — empty, each of the three non-pending statuses, single pending, oldest-of-many, mixed history, and negative-skew clamping.

**Revert-and-check, run on both sides rather than reasoned about:**

- *Frontend*: changing the derivation to measure from the newest park fails exactly one test — `measures from the oldest park, not the newest` — with `expected { count: 3, since: 9000, waited: 1000 } to deeply equal { count: 3, since: 2000, waited: 8000 }`. The other seven still pass, so it fails for the intended reason rather than because everything broke.
- *Backend*: restoring `kind` to the DTO fails `a_parked_approval_appears_on_its_own_task` with `` `kind` was dropped with the Approvals tab (#468) ``.

## Documentation

No doc change needed — `grep -rn "read_workspace_state\|Approvals tab" docs/` finds nothing; the tab's rationale lived in doc comments, which are rewritten in place on both `TaskApproval` definitions. The now-stale "carries no payload because a task read is the wrong place to widen exposure" comment is replaced: that argument does not hold (the sibling route already returns the payload to any member), so the honest reason is recorded instead — this line does not need one — with a pointer to #618 for the question it raises.
