### PR TITLE
feat(mcp): surface which agents can reach each MCP server (#568)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -751,6 +751,14 @@ export interface McpServer {
   timeoutSecs: number;
   /** Whether an outbound credential is stored — never the credential itself. */
   authConfigured: boolean;
+  /**
+   * Ids of the company's agents whose effective tool grants cover this server —
+   * who can actually call it (issue #568). An empty array means no teammate can
+   * reach it, a probable misconfiguration the console flags loudly. Optional
+   * only for forward-compat with an older backend that does not send the field;
+   * `undefined` (unknown) is treated differently from `[]` (known-empty).
+   */
+  reachableBy?: string[];
   /** The last recorded (scrubbed) probe outcome, when the server has been probed. */
   health?: McpHealth;
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -753,9 +753,12 @@ export interface McpServer {
   authConfigured: boolean;
   /**
    * Ids of the company's agents whose effective tool grants cover this server —
-   * who can actually call it (issue #568). An empty array means no teammate can
-   * reach it, a probable misconfiguration the console flags loudly. Optional
-   * only for forward-compat with an older backend that does not send the field;
+   * who can actually call it (issue #568). On an **enabled** server an empty
+   * array means no teammate can reach it, a probable misconfiguration the
+   * console flags loudly. A **disabled** server is always empty (the harness
+   * hands out no tool for it whatever the grants say), so the console reads the
+   * empty case against `enabled` and stays quiet there. Optional only for
+   * forward-compat with an older backend that does not send the field;
    * `undefined` (unknown) is treated differently from `[]` (known-empty).
    */
   reachableBy?: string[];

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -444,6 +444,30 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                         </span>
                       </div>
                       <p className="truncate text-xs text-muted-foreground">{server.endpoint}</p>
+                      {/* Reachability (issue #568): who can actually call this server. A
+                          healthy server no agent reaches is almost always a misconfiguration,
+                          so the empty case is flagged loudly rather than shown as a blank list. */}
+                      {server.reachableBy !== undefined &&
+                        (server.reachableBy.length === 0 ? (
+                          <p
+                            data-testid="mcp-reachability-none"
+                            className="flex items-start gap-1.5 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs font-medium text-destructive"
+                          >
+                            <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                            <span>
+                              No agent can reach this server — no teammate&apos;s tool grants cover{" "}
+                              <code className="font-mono">mcp:{server.name}</code>. Widen a company or
+                              per-agent tool grant, or this server is unused.
+                            </span>
+                          </p>
+                        ) : (
+                          <p data-testid="mcp-reachability" className="text-xs text-muted-foreground">
+                            Reachable by:{" "}
+                            <span className="font-medium text-foreground">
+                              {server.reachableBy.join(", ")}
+                            </span>
+                          </p>
+                        ))}
                       {health && health.status !== "ok" && health.message && (
                         <p className="text-xs text-muted-foreground">{health.message}</p>
                       )}

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -444,10 +444,14 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                         </span>
                       </div>
                       <p className="truncate text-xs text-muted-foreground">{server.endpoint}</p>
-                      {/* Reachability (issue #568): who can actually call this server. A
-                          healthy server no agent reaches is almost always a misconfiguration,
-                          so the empty case is flagged loudly rather than shown as a blank list. */}
+                      {/* Reachability (issue #568): who can actually call this server. An
+                          enabled server no agent reaches is almost always a misconfiguration,
+                          so that empty case is flagged loudly rather than shown as a blank list.
+                          A disabled server is empty by construction — the harness hands out no
+                          tool for it whatever the grants say — so the loud state is scoped to
+                          enabled servers; flagging an off server would cry wolf on intent. */}
                       {server.reachableBy !== undefined &&
+                        server.enabled &&
                         (server.reachableBy.length === 0 ? (
                           <p
                             data-testid="mcp-reachability-none"

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -36,7 +36,7 @@ use crate::error::OpenCompanyError;
 use crate::harness::mcp_probe::{
     McpFailure, McpFailureQueue, classify_mcp_error, operator_message, scrub, strip_endpoint,
 };
-use crate::runtime::tools::grant_matches;
+use crate::runtime::tools::{grant_matches, grants_cover_server};
 
 /// Builds a registry from a set of decls, keeping only the enabled ones.
 ///
@@ -86,14 +86,6 @@ pub fn registry_for_agent(
     } else {
         Some(Arc::new(registry))
     }
-}
-
-/// Whether an agent's effective `grants` cover the MCP server named `name`,
-/// using the same glob semantics as every other tool grant (`mcp:*` = all,
-/// `mcp:notion` = exact).
-fn grants_cover_server(grants: &[String], name: &str) -> bool {
-    let want = format!("mcp:{name}");
-    grants.iter().any(|grant| grant_matches(grant, &want))
 }
 
 /// Whether `agent`'s tool grants reach the MCP server named `name`, using the

--- a/src/runtime/tools.rs
+++ b/src/runtime/tools.rs
@@ -89,6 +89,19 @@ pub(crate) fn grant_matches(grant: &str, tool: &str) -> bool {
     grant == tool
 }
 
+/// Whether an agent's effective tool `grants` cover the MCP server named `name`,
+/// using the same glob semantics as every other grant (`mcp:*` grants all,
+/// `mcp:notion` is exact). The single primitive read by both the harness's
+/// per-agent registry assembly (`registry_for_agent`) and the console's
+/// reachability view (issue #568), so the two can never disagree about which
+/// agents reach a server. `grants` are the *effective* grants — resolve them
+/// with [`agent_effective_grants`](crate::runtime::builder::agent_effective_grants)
+/// first, never the raw per-agent `tools`.
+pub(crate) fn grants_cover_server(grants: &[String], name: &str) -> bool {
+    let want = format!("mcp:{name}");
+    grants.iter().any(|grant| grant_matches(grant, &want))
+}
+
 #[async_trait]
 impl ToolProvider for StubToolProvider {
     async fn catalog(&self, _company: &CompanyId) -> Result<Vec<ToolSpec>> {

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -76,9 +76,12 @@ struct McpServerDto {
     /// through the shared
     /// [`grants_cover_server`](crate::runtime::tools::grants_cover_server), so the
     /// console cannot disagree with the harness about reachability. **An empty
-    /// list is meaningful**: a live, healthy server no teammate can reach is
-    /// almost always a misconfiguration, and the console flags it rather than
-    /// showing an empty list silently. Always serialized (even when empty).
+    /// list is meaningful**: an *enabled*, healthy server no teammate can reach
+    /// is almost always a misconfiguration, and the console flags it rather than
+    /// showing an empty list silently. A **disabled** server is always empty —
+    /// the harness hands out no tool for it whatever the grants say — so the
+    /// console reads the empty case against `enabled` and stays quiet there.
+    /// Always serialized (even when empty).
     reachable_by: Vec<String>,
     /// The last recorded probe outcome (scrubbed), or `None` when never probed.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -289,13 +292,22 @@ fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)> {
     grants
 }
 
-/// The ids of the agents whose effective `grants` reach the server `name`
-/// (issue #568), read through the shared [`grants_cover_server`] so this agrees
-/// with the harness registry. Empty ⇒ no teammate can reach the server.
-fn reachers_of(roster_grants: &[(String, Vec<String>)], name: &str) -> Vec<String> {
+/// The ids of the agents whose effective `grants` reach `decl` (issue #568),
+/// read through the shared [`grants_cover_server`] so this agrees with the
+/// harness registry. Empty ⇒ no teammate can reach the server.
+///
+/// A **disabled** server reaches nobody regardless of grants: `registry_for_agent`
+/// filters on `decl.enabled && grants_cover_server(..)`, so an agent granted
+/// `mcp:<slug>` still gets no such tool while the server is off. Mirroring both
+/// halves of that filter here is what keeps the console from claiming a
+/// reachability the harness does not hand out.
+fn reachers_of(roster_grants: &[(String, Vec<String>)], decl: &mcp::McpServerDecl) -> Vec<String> {
+    if !decl.enabled {
+        return Vec::new();
+    }
     roster_grants
         .iter()
-        .filter(|(_, grants)| grants_cover_server(grants, name))
+        .filter(|(_, grants)| grants_cover_server(grants, &decl.name))
         .map(|(id, _)| id.clone())
         .collect()
 }
@@ -323,11 +335,7 @@ async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>,
         let health = load_health(runtime.id(), &decl.name, runtime.secrets().as_ref())
             .await
             .map_err(ApiError)?;
-        out.push(dto_from_decl(
-            decl,
-            reachers_of(&grants, &decl.name),
-            health,
-        ));
+        out.push(dto_from_decl(decl, reachers_of(&grants, decl), health));
     }
     Ok(Json(out))
 }
@@ -550,7 +558,7 @@ async fn mutation_response(
     let reachable_by = record
         .as_ref()
         .map(roster_grants)
-        .map(|grants| reachers_of(&grants, name))
+        .map(|grants| reachers_of(&grants, decl))
         .unwrap_or_default();
     let health = load_health(runtime.id(), name, runtime.secrets().as_ref())
         .await

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -29,6 +29,9 @@ use crate::company::mcp::{
 };
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
+use crate::ports::types::CompanyRecord;
+use crate::runtime::builder::agent_effective_grants;
+use crate::runtime::tools::grants_cover_server;
 use crate::server::error::ApiError;
 use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
@@ -66,6 +69,16 @@ struct McpServerDto {
     timeout_secs: u64,
     /// Whether an outbound credential is stored — never the credential itself.
     auth_configured: bool,
+    /// The ids of the company's agents whose effective tool grants cover this
+    /// server — who can actually call it (issue #568). Computed over the same
+    /// roster the harness builds (manifest agents + promoted overlay teammates),
+    /// through the shared
+    /// [`grants_cover_server`](crate::runtime::tools::grants_cover_server), so the
+    /// console cannot disagree with the harness about reachability. **An empty
+    /// list is meaningful**: a live, healthy server no teammate can reach is
+    /// almost always a misconfiguration, and the console flags it rather than
+    /// showing an empty list silently. Always serialized (even when empty).
+    reachable_by: Vec<String>,
     /// The last recorded probe outcome (scrubbed), or `None` when never probed.
     #[serde(skip_serializing_if = "Option::is_none")]
     health: Option<McpHealth>,
@@ -215,9 +228,13 @@ async fn manifest_servers(runtime: &CompanyRuntime) -> Result<Vec<McpServer>, Ap
 }
 
 /// Projects an effective decl (already merged + auth-resolved) to the console
-/// DTO, reducing the resolved credential to a boolean and attaching the last
-/// (scrubbed) probe health.
-fn dto_from_decl(decl: &mcp::McpServerDecl, health: Option<McpHealth>) -> McpServerDto {
+/// DTO, reducing the resolved credential to a boolean, listing the agents that
+/// can reach it (issue #568), and attaching the last (scrubbed) probe health.
+fn dto_from_decl(
+    decl: &mcp::McpServerDecl,
+    reachable_by: Vec<String>,
+    health: Option<McpHealth>,
+) -> McpServerDto {
     McpServerDto {
         name: decl.name.clone(),
         endpoint: decl.endpoint.clone(),
@@ -228,24 +245,88 @@ fn dto_from_decl(decl: &mcp::McpServerDecl, health: Option<McpHealth>) -> McpSer
         disallowed_tools: decl.disallowed_tools.clone(),
         timeout_secs: decl.timeout_secs,
         auth_configured: decl.auth.is_configured(),
+        reachable_by,
         health,
     }
+}
+
+/// Every roster agent's *effective* tool grants (issue #568), as
+/// `(agent_id, grants)`. The roster is exactly what the harness builds in
+/// `build_roster`: the manifest agents (each with its own `tools` narrowed by
+/// the company `allow`), plus the promoted overlay teammates. An overlay
+/// teammate has no manifest `tools` row, so it inherits the full company `allow`
+/// — the standard grant `overlay_agent_to_manifest` gives it — and an overlay id
+/// already claimed by a manifest agent is skipped, both mirroring the harness so
+/// console reachability equals what an agent is actually granted.
+fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)> {
+    let allow = &record.manifest.tools.allow;
+    let mut grants: Vec<(String, Vec<String>)> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|agent| {
+            (
+                agent.id.clone(),
+                agent_effective_grants(allow, &agent.tools),
+            )
+        })
+        .collect();
+    let manifest_ids: std::collections::HashSet<&str> = record
+        .manifest
+        .agents
+        .iter()
+        .map(|agent| agent.id.as_str())
+        .collect();
+    for overlay in &record.overlay_agents {
+        if manifest_ids.contains(overlay.id.as_str()) {
+            continue;
+        }
+        // No manifest tools row → the company's standard grant (empty `tools`
+        // ⇒ inherit `allow`), matching `overlay_agent_to_manifest`.
+        grants.push((overlay.id.clone(), agent_effective_grants(allow, &[])));
+    }
+    grants
+}
+
+/// The ids of the agents whose effective `grants` reach the server `name`
+/// (issue #568), read through the shared [`grants_cover_server`] so this agrees
+/// with the harness registry. Empty ⇒ no teammate can reach the server.
+fn reachers_of(roster_grants: &[(String, Vec<String>)], name: &str) -> Vec<String> {
+    roster_grants
+        .iter()
+        .filter(|(_, grants)| grants_cover_server(grants, name))
+        .map(|(id, _)| id.clone())
+        .collect()
 }
 
 /// `GET …/mcp/servers` — the company's effective MCP servers, each with its last
 /// recorded (scrubbed) probe health.
 async fn list_servers(company: ScopedCompany) -> Result<Json<Vec<McpServerDto>>, ApiError> {
     let runtime = company.runtime.as_ref();
-    let manifest = manifest_servers(runtime).await?;
+    // One record load feeds both the manifest servers (merged into the effective
+    // set) and the roster used for reachability (issue #568), rather than loading
+    // it twice.
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let manifest = record
+        .as_ref()
+        .map(|r| r.manifest.mcp_servers.clone())
+        .unwrap_or_default();
     let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
+    // Resolve every agent's effective grants once, then ask per server who is
+    // covered — the wildcard-heavy work happens N(agents) times, not N×M.
+    let grants = record.as_ref().map(roster_grants).unwrap_or_default();
     let mut out = Vec::with_capacity(decls.len());
     for decl in &decls {
         let health = load_health(runtime.id(), &decl.name, runtime.secrets().as_ref())
             .await
             .map_err(ApiError)?;
-        out.push(dto_from_decl(decl, health));
+        out.push(dto_from_decl(
+            decl,
+            reachers_of(&grants, &decl.name),
+            health,
+        ));
     }
     Ok(Json(out))
 }
@@ -450,7 +531,13 @@ async fn mutation_response(
     // DTO so the response and a later `GET` agree.
     let test = probe_and_persist(runtime, name).await;
 
-    let manifest = manifest_servers(runtime).await?;
+    // One record load: the manifest servers merged into the effective set, and
+    // the roster the mutated server's reachability is computed against (#568).
+    let record = runtime.store().load(runtime.id()).await.map_err(ApiError)?;
+    let manifest = record
+        .as_ref()
+        .map(|r| r.manifest.mcp_servers.clone())
+        .unwrap_or_default();
     let decls = resolve_effective(runtime.id(), &manifest, runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
@@ -459,11 +546,16 @@ async fn mutation_response(
             "`{name}` not found"
         )))
     })?;
+    let reachable_by = record
+        .as_ref()
+        .map(roster_grants)
+        .map(|grants| reachers_of(&grants, name))
+        .unwrap_or_default();
     let health = load_health(runtime.id(), name, runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
     Ok(Json(MutationResponse {
-        server: dto_from_decl(decl, health),
+        server: dto_from_decl(decl, reachable_by, health),
         note: REBUILD_NOTE.to_string(),
         test,
         warning,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2388,6 +2388,45 @@ async fn state_with_manifest(home: &std::path::Path, manifest: CompanyManifest) 
     state
 }
 
+/// Like [`state_with_manifest`], but seeds operator-added overlay teammates too,
+/// so a test can assert MCP reachability over the full runtime roster — manifest
+/// agents plus overlay agents — the way `build_roster` composes it (issue #568).
+async fn state_with_manifest_and_overlays(
+    home: &std::path::Path,
+    manifest: CompanyManifest,
+    overlay_agents: Vec<crate::ports::types::OverlayAgent>,
+) -> AppState {
+    use crate::ports::CompanyStore;
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new("acme");
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents,
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default());
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+    state
+}
+
 #[tokio::test]
 async fn mcp_servers_crud_round_trips_and_token_is_write_only() {
     let home_dir = home();
@@ -2503,6 +2542,104 @@ async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(updated["server"]["source"], "manifest");
     assert_eq!(updated["server"]["enabled"], false);
+}
+
+/// Issue #568: each listed server carries the ids of the agents whose *effective*
+/// grants reach it — over the full runtime roster, manifest agents plus overlay
+/// teammates. With a company `allow = ["*"]`, an agent that declares no `tools`
+/// (and every overlay teammate, which has no tools row) inherits the wildcard and
+/// reaches everything; an agent that narrows itself to `mcp:notion` reaches only
+/// that server.
+#[tokio::test]
+async fn mcp_reachability_lists_reaching_agents_including_overlay() {
+    let manifest: CompanyManifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[tools]\nallow = [\"*\"]\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\ntools = [\"mcp:notion\"]\n\
+         [[agent]]\nid = \"eng\"\nrole = \"Engineer\"\n[policy]\nmode = \"full\"\n\
+         [[mcp_server]]\nname = \"notion\"\nendpoint = \"https://notion.example/mcp\"\n\
+         [[mcp_server]]\nname = \"linear\"\nendpoint = \"https://linear.example/mcp\"\n",
+    )
+    .unwrap();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let overlay = crate::ports::types::OverlayAgent {
+        id: "helper".to_string(),
+        name: "Helper".to_string(),
+        role: "Assistant".to_string(),
+        description: None,
+    };
+    let state = state_with_manifest_and_overlays(&home, manifest, vec![overlay]).await;
+
+    let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let reach = |name: &str| -> Vec<String> {
+        let row = list
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == name)
+            .unwrap_or_else(|| panic!("server `{name}` is listed"));
+        let mut ids: Vec<String> = row["reachableBy"]
+            .as_array()
+            .expect("reachableBy serializes as an array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect();
+        ids.sort();
+        ids
+    };
+
+    // notion: the narrowed ceo, the wildcard-inheriting eng, and the overlay.
+    assert_eq!(reach("notion"), vec!["ceo", "eng", "helper"]);
+    // linear: only the wildcard holders — ceo scoped itself out of it.
+    assert_eq!(
+        reach("linear"),
+        vec!["eng", "helper"],
+        "ceo narrowed to mcp:notion, so it cannot reach linear"
+    );
+}
+
+/// Issue #568: a server no agent's grants cover comes back with an **empty**
+/// `reachableBy` — the signal the console flags loudly rather than showing a
+/// healthy server that is silently unreachable. Here a narrow company
+/// `allow = ["mcp:docs"]` reaches `docs` but never `notion`.
+#[tokio::test]
+async fn mcp_reachability_flags_a_server_no_agent_can_reach() {
+    let manifest: CompanyManifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[tools]\nallow = [\"mcp:docs\"]\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\ntools = [\"mcp:docs\"]\n[policy]\nmode = \"full\"\n\
+         [[mcp_server]]\nname = \"docs\"\nendpoint = \"https://docs.example/mcp\"\n\
+         [[mcp_server]]\nname = \"notion\"\nendpoint = \"https://notion.example/mcp\"\n",
+    )
+    .unwrap();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_manifest(&home, manifest).await;
+
+    let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let row = |name: &str| {
+        list.as_array()
+            .unwrap()
+            .iter()
+            .find(|s| s["name"] == name)
+            .unwrap_or_else(|| panic!("server `{name}` is listed"))
+            .clone()
+    };
+    assert_eq!(
+        row("docs")["reachableBy"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["ceo"],
+        "the company allow covers mcp:docs for the one agent"
+    );
+    assert!(
+        row("notion")["reachableBy"].as_array().unwrap().is_empty(),
+        "no agent's grants cover mcp:notion — the flagged zero case"
+    );
 }
 
 /// Without the `openhuman` feature there is no MCP transport, so live discovery

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2542,6 +2542,12 @@ async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(updated["server"]["source"], "manifest");
     assert_eq!(updated["server"]["enabled"], false);
+    // The mutating response carries reachability too (issue #568), so the console
+    // reflects who can reach the server right after an edit, not only on reload.
+    assert!(
+        updated["server"]["reachableBy"].is_array(),
+        "a mutating response also carries reachableBy"
+    );
 }
 
 /// Issue #568: each listed server carries the ids of the agents whose *effective*

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2661,6 +2661,62 @@ async fn mcp_reachability_flags_a_server_no_agent_can_reach() {
     );
 }
 
+/// Issue #568: a **disabled** server reaches nobody, however wide the grants.
+/// `registry_for_agent` filters on `decl.enabled && grants_cover_server(..)`, so
+/// an agent holding `mcp:docs` is handed no such tool while the server is off —
+/// reporting it as reachable would be the console/harness disagreement this
+/// feature exists to remove. Asserted on both readers: the mutating response
+/// that turns the server off, and the later list.
+#[tokio::test]
+async fn mcp_reachability_is_empty_for_a_disabled_server() {
+    let manifest: CompanyManifest = toml::from_str(
+        "[company]\nname = \"Acme\"\n[tools]\nallow = [\"*\"]\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\ntools = [\"mcp:docs\"]\n[policy]\nmode = \"full\"\n\
+         [[mcp_server]]\nname = \"docs\"\nendpoint = \"https://docs.example/mcp\"\n",
+    )
+    .unwrap();
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_manifest(&home, manifest).await;
+
+    let reach = |body: &serde_json::Value| -> Vec<String> {
+        body["reachableBy"]
+            .as_array()
+            .expect("reachableBy serializes as an array")
+            .iter()
+            .map(|v| v.as_str().unwrap().to_string())
+            .collect()
+    };
+
+    // Enabled: the one agent's grant covers it.
+    let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(reach(&list[0]), vec!["ceo".to_string()]);
+
+    // Disabling it empties reachability in the mutating response itself.
+    let (status, updated) = send(
+        &state,
+        "PUT",
+        "/api/v1/company/mcp/servers/docs",
+        Some(json!({ "enabled": false })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["server"]["enabled"], false);
+    assert!(
+        reach(&updated["server"]).is_empty(),
+        "a disabled server is handed to no agent, so it is reachable by none"
+    );
+
+    // And the list agrees on the next read — the grant is unchanged, the server is off.
+    let (_, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
+    assert_eq!(list[0]["enabled"], false);
+    assert!(
+        reach(&list[0]).is_empty(),
+        "the list reader applies the same enabled filter as the harness"
+    );
+}
+
 /// Without the `openhuman` feature there is no MCP transport, so live discovery
 /// is "not wired". (Under the feature it would attempt a real network call.)
 #[cfg(not(feature = "openhuman"))]


### PR DESCRIPTION
## Summary

Closes #568 (finding #3 of the MCP/Skills console↔harness epic #565).

The MCP console showed a server's health and tool count but never **who could actually call it**. An agent reaches `mcp:<slug>` only when its effective grants cover it, so the moment a company narrows grants per agent, a server can be live, healthy, and reachable by nobody — silently, with no error anywhere in the chain (such an agent does not even get `mcp_list_servers`).

`GET .../mcp/servers` (and every mutating response) now carries **`reachableBy`**: the ids of the agents whose effective grants cover the server. The console renders it per row and **flags the empty case loudly**, because a healthy server no teammate can reach is almost always a misconfiguration rather than an intent.

## The design decision worth challenging

Reachability is computed over the **same roster the harness builds** — manifest agents **plus** promoted overlay teammates — using the **exact** machinery the harness registry uses, so the console cannot disagree with what an agent is actually granted (the thesis of #565):

- `agent_effective_grants` for each agent's effective grants (already shared with the team-agent console route).
- `grants_cover_server` for the `mcp:<slug>` match.

`grants_cover_server` **moves** from `harness::mcp` (which is `#[cfg(feature = "openhuman")]`) to `runtime::tools`, beside `grant_matches`. The console route ships in the **default build** and cannot import a harness symbol; relocating the primitive — rather than reimplementing the two-line check — keeps one matcher read by both the registry and the console (the "one validator" rule the codebase already follows). The registry path is unchanged.

### Overlay teammates are included, deliberately

`build_roster` grants tools to manifest agents **and** overlay teammates (an overlay has no `tools` row, so it inherits the company `allow`). Iterating only `manifest.agents` would let the loud zero-state **falsely fire** when an overlay agent actually reaches the server — the exact console/harness disagreement #565 is about. `roster_grants` mirrors `build_roster` exactly, including skipping an overlay id already claimed by a manifest agent.

### One note on the issue text

The issue says `agent_effective_grants` is "already shared between the harness and the console capability route." Accurate, but that console reader is the **team-agent detail route**, not an MCP route — this PR makes the MCP list route a new reader. No change to the approach; recording it for the next reader.

## API / behavior changes

- `McpServerDto` gains `reachableBy: string[]` — **always serialized, even when empty** (the empty array is the load-bearing signal). Additive; existing fields unchanged.
- A **disabled** server is reachable by nobody, whatever the grants say: `registry_for_agent` filters on `decl.enabled && grants_cover_server(..)`, so `reachers_of` mirrors both halves of that filter. The console scopes its loud zero-state to enabled servers — a disabled server is empty by construction, and flagging it would cry wolf on intent.
- No route or signature changes. `list_servers` and `mutation_response` load the company record once and derive both the manifest servers and the roster from it — not an extra load.

## Tests

- `mcp_reachability_lists_reaching_agents_including_overlay` — with `allow = ["*"]`, a narrowed agent (`tools = ["mcp:notion"]`) reaches only that server, while a no-tools agent and an overlay teammate inherit the wildcard and reach everything.
- `mcp_reachability_flags_a_server_no_agent_can_reach` — a narrow company `allow` leaves a manifest server with an **empty** `reachableBy` (the flagged zero case).
- Both run in the **default build**, exercising the relocation: the route reads `grants_cover_server` with no `openhuman` feature.

Verified locally: `cargo test --lib` (default **and** `--features openhuman,tinycortex`), `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, `tsc -b --noEmit`, `cargo fmt --all -- --check` — all clean.

## Depends on #554 — merge it first

#554 (`feat(mcp): install-wide default MCP servers`) also edits `McpServerDto`, `list_servers`, and the frontend `McpServer` type, and changes `resolve_effective` from 3 to 4 args. This PR is written against `main`; the agreed order (see #554/#598) is **#554 → this**. Once #554 merges I will follow up — adopting the 4-arg `resolve_effective` and the `source: "default"` servers, which flow through the reachability loop for free.

`main` has since been merged in (not rebased, to keep the review history readable). The one conflict was in `src/server/ops/mcp.rs`: #598 renamed `REBUILD_NOTE` to `NEXT_TURN_NOTE` while this branch added the `reachable_by` argument to `dto_from_decl` — both kept.

Closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP server listings now show which agents can access each server.
  * Displays a clear warning when no agents have permission to reach a server.
  * Reachability information is included in server creation and update responses.

* **Bug Fixes**
  * Reachability now accurately reflects narrowed, wildcard, and overlay-agent tool permissions.

* **Tests**
  * Added coverage for reachable, unreachable, and permission-specific MCP server scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
