### PR TITLE
overview: draw the graph's tool and workflow rings from the host instead of inventing them (#601)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -519,6 +519,32 @@ export interface TeamMemberDto {
   budgetSetBy?: string;
   /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
   budgetSetAtMillis?: number;
+  /**
+   * This teammate's tool grants (issue #601) — the **same** three lists, from
+   * the same host-side constructor, that `GET .../team/{agentId}` serves.
+   *
+   * On the list because the overview graph draws a ring of each teammate's
+   * tools and is built from the roster read: without this it would have to
+   * fetch every agent's detail on page load, and it invented a tool shelf
+   * instead. Read `effective` and nothing else when the question is "what does
+   * this agent hold" — see {@link AgentToolsDto} for why `requested` alone
+   * inverts the answer.
+   *
+   * **Optional on the type, not on the wire.** A host predating #601 sends no
+   * such field; `undefined` means "this host cannot say", which is a different
+   * statement from an empty `effective` ("holds nothing") and must not be
+   * collapsed into it.
+   */
+  tools?: AgentToolsDto;
+  /**
+   * The desks this teammate sits on (issue #601), same shape as the detail
+   * read. Desks are the company's real grouping, so these are what the
+   * overview graph draws its department pillars from.
+   *
+   * **Optional on the type, not on the wire**, same rule as `tools`: absent
+   * means the host does not answer, empty means "on no desk".
+   */
+  desks?: AgentDeskDto[];
 }
 
 /**

--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -3,7 +3,10 @@
 // generic, company-agnostic roster the operator can edit. Either way, agents
 // are user-definable here.
 
-import type { TeamMemberDto } from "@/api/types";
+import type { AgentDeskDto, TeamMemberDto } from "@/api/types";
+
+/** A desk a teammate sits on, as the roster read reports it. */
+export type TeamMemberDesk = AgentDeskDto;
 
 export interface TeamMember {
   id: string;
@@ -39,6 +42,26 @@ export interface TeamMember {
   budgetSetBy?: string;
   /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
   budgetSetAtMillis?: number;
+  /**
+   * The tool grants this teammate **actually holds** — its own `[[agent]].tools`
+   * line narrowed by the company's `[tools].allow`, resolved by the host
+   * (issue #601).
+   *
+   * The `effective` list and only that: the agent detail view shows the same
+   * one, from the same server-side function the harness builds the agent with,
+   * so the two surfaces cannot disagree about a teammate. Empty means either
+   * "holds nothing" or "this host does not report grants" — both draw no tools,
+   * and neither is a licence to invent some.
+   */
+  effectiveTools: string[];
+  /**
+   * The desks this teammate sits on, host order (manifest desks first, then
+   * operator-created ones). Empty means it sits on none.
+   *
+   * This is the company's real grouping axis, and the overview graph's
+   * department pillars are drawn from it.
+   */
+  desks: TeamMemberDesk[];
 }
 
 const TONE_KEYS = ["sky", "violet", "amber", "emerald", "rose", "cyan", "indigo", "teal"];
@@ -78,6 +101,11 @@ export function fromDto(dto: TeamMemberDto): TeamMember {
     // which the card renders differently from "an admin set this".
     budgetSetBy: dto.budgetSetBy,
     budgetSetAtMillis: dto.budgetSetAtMillis,
+    // A host predating issue #601 sends neither, and an empty list is the
+    // honest reading of that: it draws no tools and no desk rather than a
+    // guess at either.
+    effectiveTools: dto.tools?.effective ?? [],
+    desks: dto.desks ?? [],
   };
 }
 
@@ -116,6 +144,10 @@ function member(name: string, role: string, description: string): TeamMember {
     description,
     tone: toneFor(name),
     inboxEnabled: false,
+    // A console-invented teammate exists on no host, so it holds no grant and
+    // sits on no desk. Stated, not guessed.
+    effectiveTools: [],
+    desks: [],
   };
 }
 
@@ -162,6 +194,10 @@ export function newMember(fields: { name: string; role: string; description: str
     description: fields.description.trim(),
     tone: toneFor(memberId),
     inboxEnabled: false,
+    // Same as `member` above: nothing on a host has granted this teammate
+    // anything or seated it anywhere yet.
+    effectiveTools: [],
+    desks: [],
   };
 }
 

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -1,4 +1,5 @@
-import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useCallback, useEffect, useMemo, useState } from "react";
+import { RefreshCw } from "lucide-react";
 
 import { listPeople, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
@@ -22,7 +23,7 @@ interface Props {
   company: string | null;
 }
 
-/** Everything the graph is drawn from, fetched once per company. */
+/** Everything the graph is drawn from — a snapshot, taken on demand. */
 interface Sources {
   tasks: Task[];
   team: TeamMember[];
@@ -40,6 +41,8 @@ interface Sources {
   memories: MemoryEntry[];
   /** The company's saved workflow graphs, whole — nodes and edges, not names. */
   workflows: WorkflowGraph[];
+  /** When this snapshot was taken (epoch millis); `null` before the first read. */
+  fetchedAt: number | null;
 }
 
 const EMPTY: Sources = {
@@ -49,6 +52,7 @@ const EMPTY: Sources = {
   people: [],
   memories: [],
   workflows: [],
+  fetchedAt: null,
 };
 
 /**
@@ -67,12 +71,27 @@ const EMPTY: Sources = {
  * The one thing this console decides for itself is which pillar a workflow
  * hangs off, because the host scopes a flow to the company rather than to a
  * desk — see `DERIVED_NOTICE` in `kg/adapter.ts`.
+ *
+ * ## Why this is a snapshot with a button rather than a live view
+ *
+ * One paint of this page is five reads — the board, the roster, the desks, the
+ * people, the memory — plus the workflow list and one more read per saved
+ * workflow. On a timer that is a standing cost per open tab, for a picture that
+ * changes when an operator does something rather than on the clock. So the page
+ * fetches once and **says** it fetched once, with a control that re-reads on
+ * demand: the staleness is answered out loud instead of by omission, and an
+ * operator is never reading an old wheel with no way to notice.
  */
 export function Overview({ client, company }: Props) {
   const [sources, setSources] = useState<Sources>(EMPTY);
+  // Bumped by the refresh control; re-runs the read below and nothing else.
+  const [reload, setReload] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const refresh = useCallback(() => setReload((n) => n + 1), []);
 
   useEffect(() => {
     let live = true;
+    setLoading(true);
     void (async () => {
       const [tasks, roster, desks, people, memories, flowList] = await Promise.all([
         listTasks(client, company).catch(() => [] as Task[]),
@@ -121,12 +140,14 @@ export function Overview({ client, company }: Props) {
         people,
         memories,
         workflows,
+        fetchedAt: Date.now(),
       });
+      setLoading(false);
     })();
     return () => {
       live = false;
     };
-  }, [client, company]);
+  }, [client, company, reload]);
 
   const adapted = useMemo(
     () =>
@@ -165,6 +186,30 @@ export function Overview({ client, company }: Props) {
       // the page now, so the graph is what gets spotlighted.
       data-tour="overview-graph"
     >
+      {/* The snapshot line: what the page is, when it was taken, and the way to
+          take another. The graph is not live, and says so rather than leaving an
+          operator to assume a stale wheel is the current company. */}
+      <div className="absolute right-3 top-3 z-10 flex items-center gap-1.5 rounded-md border bg-background/90 px-2 py-1 text-[11px] text-muted-foreground shadow-sm backdrop-blur">
+        <span className="truncate">
+          {sources.fetchedAt === null
+            ? "Loading…"
+            : `Snapshot ${new Date(sources.fetchedAt).toLocaleTimeString([], {
+                hour: "2-digit",
+                minute: "2-digit",
+              })}`}
+        </span>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={loading}
+          title="This page is a snapshot, not a live view. Re-read the company."
+          aria-label="Refresh the graph"
+          className="inline-flex items-center gap-1 rounded px-1 py-0.5 hover:bg-muted disabled:opacity-50"
+        >
+          <RefreshCw className={`size-3 ${loading ? "animate-spin" : ""}`} aria-hidden />
+          Refresh
+        </button>
+      </div>
       <Suspense
         fallback={
           <div className="grid h-full place-items-center text-sm text-muted-foreground">

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -5,6 +5,7 @@ import type { OpenCompanyClient } from "@/api/client";
 import { listMemory, type MemoryEntry } from "@/api/memory";
 import { listTasks, type Task } from "@/api/tasks";
 import type { DeskDto } from "@/api/types";
+import { getWorkflow, listWorkflows, type WorkflowGraph } from "@/api/workflows";
 import { fromDto, starterTeam, type TeamMember } from "@/lib/team";
 import { adapt, buildMemoryGraph } from "./overview/kg/adapter";
 import { buildKnowledgeGraph } from "./overview/kg/model";
@@ -37,6 +38,8 @@ interface Sources {
   desks: DeskDto[];
   people: Person[];
   memories: MemoryEntry[];
+  /** The company's saved workflow graphs, whole — nodes and edges, not names. */
+  workflows: WorkflowGraph[];
 }
 
 const EMPTY: Sources = {
@@ -45,6 +48,7 @@ const EMPTY: Sources = {
   desks: [],
   people: [],
   memories: [],
+  workflows: [],
 };
 
 /**
@@ -55,12 +59,14 @@ const EMPTY: Sources = {
  * the jobs hang off each pillar, the teammate who does each job sits above it,
  * and their tools are the outer ring.
  *
- * The pillars are **declared**: they are the company's own desks (issue #486),
- * not the keyword-matched guess that used to stand there. So is the outer ring:
- * the tools are the grants the host resolved for each teammate (issue #601),
- * not a deal from the company's catalogue. What is still derived is the
- * workflow templates — there is no flow API. See `DERIVED_NOTICE` in
- * `kg/adapter.ts`; it is the standing caveat on what remains.
+ * Every ring is **declared** now: the pillars are the company's own desks
+ * (issue #486), the outer ring is the grants the host resolved for each
+ * teammate, and the flows are its saved workflow graphs with their own stages
+ * (issue #601). Nothing here is keyword-matched, dealt out or templated.
+ *
+ * The one thing this console decides for itself is which pillar a workflow
+ * hangs off, because the host scopes a flow to the company rather than to a
+ * desk — see `DERIVED_NOTICE` in `kg/adapter.ts`.
  */
 export function Overview({ client, company }: Props) {
   const [sources, setSources] = useState<Sources>(EMPTY);
@@ -68,7 +74,7 @@ export function Overview({ client, company }: Props) {
   useEffect(() => {
     let live = true;
     void (async () => {
-      const [tasks, roster, desks, people, memories] = await Promise.all([
+      const [tasks, roster, desks, people, memories, flowList] = await Promise.all([
         listTasks(client, company).catch(() => [] as Task[]),
         client.listTeam(company).catch(() => null),
         // Ring 1 (issue #486). Best-effort: see `Sources.desks`.
@@ -80,7 +86,32 @@ export function Overview({ client, company }: Props) {
         // surface draws no constellation rather than a seeded one — the graph
         // must never claim the company remembers something it doesn't.
         listMemory(client, company).catch(() => [] as MemoryEntry[]),
+        // Ring 2 (issue #601). Summaries only — see the graph reads below.
+        listWorkflows(client, company).catch(() => []),
       ]);
+      if (!live) return;
+
+      // `listWorkflows` answers with `{id,name,description,editable,enabled}`
+      // and no nodes or edges, so the stages ring needs one graph read per
+      // workflow. That is bounded by how many flows the company has saved — not
+      // an N+1 over the roster — and they go out together.
+      const workflows = await Promise.all(
+        flowList.map((summary) =>
+          getWorkflow(client, company, summary.id).catch(
+            // A name-only entry has no saved graph to fetch (and a read can
+            // simply fail). The company still declares the flow, so it is drawn
+            // with no stages rather than dropped: a flow missing from the wheel
+            // would be a quieter lie than one drawn empty.
+            (): WorkflowGraph => ({
+              id: summary.id,
+              name: summary.name,
+              description: summary.description,
+              nodes: [],
+              edges: [],
+            }),
+          ),
+        ),
+      );
       if (!live) return;
 
       setSources({
@@ -89,6 +120,7 @@ export function Overview({ client, company }: Props) {
         desks,
         people,
         memories,
+        workflows,
       });
     })();
     return () => {
@@ -103,6 +135,7 @@ export function Overview({ client, company }: Props) {
         desks: sources.desks,
         tasks: sources.tasks,
         people: sources.people,
+        workflows: sources.workflows,
         ownedBy,
       }),
     [sources],

--- a/frontend/src/views/Overview.tsx
+++ b/frontend/src/views/Overview.tsx
@@ -1,13 +1,10 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
-import { TriangleAlert } from "lucide-react";
 
 import { listPeople, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
-import { discoverMcpTools, listMcpServers } from "@/api/mcp";
 import { listMemory, type MemoryEntry } from "@/api/memory";
-import { listSkills, type Skill } from "@/api/skills";
 import { listTasks, type Task } from "@/api/tasks";
-import { ApiError, type DeskDto, type McpServer, type McpToolInfo } from "@/api/types";
+import type { DeskDto } from "@/api/types";
 import { fromDto, starterTeam, type TeamMember } from "@/lib/team";
 import { adapt, buildMemoryGraph } from "./overview/kg/adapter";
 import { buildKnowledgeGraph } from "./overview/kg/model";
@@ -39,21 +36,7 @@ interface Sources {
    */
   desks: DeskDto[];
   people: Person[];
-  skills: Skill[];
   memories: MemoryEntry[];
-  servers: McpServer[];
-  /** Server **name** → the tools it advertises. `name` is this API's server key. */
-  toolsByServer: Record<string, McpToolInfo[]>;
-  /**
-   * The MCP read failed for a reason that is not "this host has no MCP".
-   *
-   * Kept apart from an empty `servers` on purpose. A company with no tool
-   * servers and a company whose tool servers we could not reach draw the same
-   * toolless graph, and only one of those is a true statement about the
-   * company — collapsing them is how an outage comes to look like an empty
-   * configuration. The notice below is the difference.
-   */
-  mcpUnreadable: boolean;
 }
 
 const EMPTY: Sources = {
@@ -61,27 +44,8 @@ const EMPTY: Sources = {
   team: starterTeam(),
   desks: [],
   people: [],
-  skills: [],
   memories: [],
-  servers: [],
-  toolsByServer: {},
-  mcpUnreadable: false,
 };
-
-/**
- * Whether a server is worth asking for its tool list.
- *
- * Tool discovery opens a live connection to the remote server, so this skips
- * the ones already known not to answer: disabled, or last probed as broken /
- * missing its credential. A server never probed is asked once — we cannot know
- * it works without trying, and refusing to ask would leave a working server's
- * tools off the graph forever.
- */
-function worthAsking(server: McpServer): boolean {
-  if (!server.enabled) return false;
-  const status = server.health?.status;
-  return status !== "error" && status !== "needs_config";
-}
 
 /**
  * The command centre: the company's knowledge graph, and nothing else.
@@ -92,10 +56,11 @@ function worthAsking(server: McpServer): boolean {
  * and their tools are the outer ring.
  *
  * The pillars are **declared**: they are the company's own desks (issue #486),
- * not the keyword-matched guess that used to stand there. What is still derived
- * is the tool assignments and the workflow templates — there is no per-agent
- * tool list and no flow API. See `DERIVED_NOTICE` in `kg/adapter.ts`; it is the
- * standing caveat on what remains.
+ * not the keyword-matched guess that used to stand there. So is the outer ring:
+ * the tools are the grants the host resolved for each teammate (issue #601),
+ * not a deal from the company's catalogue. What is still derived is the
+ * workflow templates — there is no flow API. See `DERIVED_NOTICE` in
+ * `kg/adapter.ts`; it is the standing caveat on what remains.
  */
 export function Overview({ client, company }: Props) {
   const [sources, setSources] = useState<Sources>(EMPTY);
@@ -103,7 +68,7 @@ export function Overview({ client, company }: Props) {
   useEffect(() => {
     let live = true;
     void (async () => {
-      const [tasks, roster, desks, people, skills, memories, mcp] = await Promise.all([
+      const [tasks, roster, desks, people, memories] = await Promise.all([
         listTasks(client, company).catch(() => [] as Task[]),
         client.listTeam(company).catch(() => null),
         // Ring 1 (issue #486). Best-effort: see `Sources.desks`.
@@ -111,42 +76,11 @@ export function Overview({ client, company }: Props) {
         // Only an admin may list people; a member just gets no humans on the
         // graph, which is the right amount of information for them to have.
         listPeople(client, company).catch(() => [] as Person[]),
-        listSkills(client, company).catch(() => [] as Skill[]),
         // The company's real durable memory (issue #36). A host without the
         // surface draws no constellation rather than a seeded one — the graph
         // must never claim the company remembers something it doesn't.
         listMemory(client, company).catch(() => [] as MemoryEntry[]),
-        // `.../mcp/servers` answers with a bare array of servers. It used to be
-        // read through a client helper that promised a `{ servers }` wrapper no
-        // host has ever sent, so `mcp.servers` was `undefined` and filtering it
-        // threw — on every host that mounts the route, which is all of them
-        // (issue #407). The wrapper only looked survivable because the failure
-        // path handed back a hand-built `{ servers: [] }`: the tab rendered
-        // exactly when MCP was unreachable, and threw when it worked.
-        listMcpServers(client, company).then(
-          (servers) => ({ servers: servers ?? [], unreadable: false }),
-          (error: unknown) => ({
-            servers: [] as McpServer[],
-            // A host with no MCP surface answers 404. That is a company with no
-            // tool servers — a fact, not a failure, and not worth a warning.
-            // Anything else (offline, 5xx, a body we couldn't parse) means we
-            // genuinely do not know, which is what the notice says.
-            unreadable: !(error instanceof ApiError && error.status === 404),
-          }),
-        ),
       ]);
-      if (!live) return;
-
-      const toolLists = await Promise.all(
-        mcp.servers.filter(worthAsking).map((s) =>
-          discoverMcpTools(client, company, s.name)
-            .then((tools) => [s.name, tools ?? []] as const)
-            // A host built without the MCP client answers `not_wired`, and a
-            // server can simply be down. Neither is worth failing the graph
-            // over: that server contributes no tools and the rest still draw.
-            .catch(() => [s.name, [] as McpToolInfo[]] as const),
-        ),
-      );
       if (!live) return;
 
       setSources({
@@ -154,11 +88,7 @@ export function Overview({ client, company }: Props) {
         team: roster?.length ? roster.map(fromDto) : starterTeam(),
         desks,
         people,
-        skills,
         memories,
-        servers: mcp.servers,
-        toolsByServer: Object.fromEntries(toolLists),
-        mcpUnreadable: mcp.unreadable,
       });
     })();
     return () => {
@@ -173,9 +103,6 @@ export function Overview({ client, company }: Props) {
         desks: sources.desks,
         tasks: sources.tasks,
         people: sources.people,
-        skills: sources.skills,
-        servers: sources.servers,
-        toolsByServer: sources.toolsByServer,
         ownedBy,
       }),
     [sources],
@@ -205,22 +132,6 @@ export function Overview({ client, company }: Props) {
       // the page now, so the graph is what gets spotlighted.
       data-tour="overview-graph"
     >
-      {/* An unreadable MCP surface and a company with no tool servers draw the
-          same toolless graph. Saying which one this is turns "this company has
-          no tools" from an assertion the page cannot support into a question
-          the operator knows to go and check. */}
-      {sources.mcpUnreadable && (
-        <p
-          role="status"
-          className="pointer-events-none absolute left-1/2 top-3 z-10 flex max-w-[calc(100%-1.5rem)] -translate-x-1/2 items-center gap-1.5 rounded-md border bg-background/90 px-2.5 py-1.5 text-xs text-muted-foreground shadow-sm backdrop-blur"
-        >
-          <TriangleAlert className="size-3.5 shrink-0" aria-hidden />
-          <span className="min-w-0 truncate">
-            Couldn&apos;t read this company&apos;s MCP tool servers — tools may be missing from
-            the graph.
-          </span>
-        </p>
-      )}
       <Suspense
         fallback={
           <div className="grid h-full place-items-center text-sm text-muted-foreground">

--- a/frontend/src/views/overview/README.md
+++ b/frontend/src/views/overview/README.md
@@ -11,10 +11,10 @@ Five concentric rings, read outward from the centre:
 | Ring | What | Where it comes from |
 |---|---|---|
 | 0 | the company, drawn as its memory constellation | `lib/memory.ts` (local store) |
-| 1 | departments (pillars) | **derived** — see below |
-| 2 | the jobs on each pillar, and the workflows it runs | `…/tasks` grouped through their assignee; workflows **derived** |
-| 3 | the teammate who does each job, each workflow stage, and the humans | `…/team` matched by `task.assignee`; humans from `…/users`; stages **derived** |
-| 4 | that teammate's tools | **derived** — see below |
+| 1 | departments (pillars) | `…/desks` — the company's real desks |
+| 2 | the jobs on each pillar, and the workflows it runs | `…/tasks` grouped through their assignee; `…/workflows` for the flows |
+| 3 | the teammate who does each job, each workflow stage, and the humans | `…/team` matched by `task.assignee`; humans from `…/users`; stages are the saved graph's nodes |
+| 4 | that teammate's tools | `…/team` — the grants the host resolved for that agent |
 
 Rings 2 and 3 each carry two kinds. A workflow sits beside the SOP tasks
 because both are work a department runs; a workflow's stages sit beside the
@@ -30,33 +30,58 @@ Panning is an offset on top of whatever the camera is framing, not a separate
 mode: the shot still tracks its subject, just off-centre by the amount you
 dragged, and re-framing (selecting a node, opening the core) resets it.
 
-## The derived rings — read this before trusting the org chart
+## What is derived — read this before trusting the org chart
 
-**Ring 1 is no longer one of them.** Departments are the company's **desks**
-(issue #486) — a `[[group_chat]]` in the manifest, or an operator-created
-overlay desk. That is the one place the company declares how it is organised,
-and it is the same source the Company org chart reads. `assignDepartment` and
-its keyword table are gone.
+**One thing, and it is not a ring.** Everything the graph draws is now a value
+the company declared. What this console still decides for itself is **where a
+workflow hangs on the wheel**: the host scopes a flow to the *company*, and
+nothing links a flow to a desk, so a flow is drawn on the desk of the first
+teammate it runs through. That is a real relationship read as a placement it was
+never declared to be. `DERIVED_NOTICE` in `kg/adapter.ts` is the standing
+caveat, and the legend chip reads "flow placement".
 
-What is still invented by `kg/adapter.ts`:
+Three rings used to be invented, and were deleted as the host grew the reads
+they were standing in for:
 
-- **Tool assignments** are a deterministic deal from the company-wide tool list,
-  because `[tools] allow` is company-wide and `[[agent]]` has no `tools` field.
-- **Workflows and their stages** are templates, because the console has no flow
-  API; the Workflows canvas draws a single hard-coded sample. One routine is
-  dealt to each desk **by position**, wrapping, and its stages are dealt
-  round-robin across that desk's agents. Nothing ties a routine to what the desk
-  actually does — the console does not know.
+- **Ring 1, departments** — `assignDepartment` keyword-matched a role string into
+  one of five hardcoded buckets, falling back to Operations. Departments are the
+  company's **desks** now (issue #486): a `[[group_chat]]` in the manifest or an
+  operator-created overlay desk, the same source the Company org chart reads.
+- **Ring 4, tools** — `assignTools` dealt each teammate a slice of the
+  company-wide `[tools] allow` list, positionally. A teammate's tools are the
+  grants the host resolved for it (issue #601), carried on the roster read from
+  the same server-side constructor the agent detail card uses, so the graph and
+  the card cannot disagree about who holds what.
+- **Ring 2, workflows and their stages** — `WORKFLOW_ROUTINES` dealt one made-up
+  routine per desk by position, and `model.ts` dealt its stages round-robin
+  across that desk's agents. A workflow is one of the company's saved graphs
+  now, its stages are that graph's nodes in run order, and a stage hands off
+  only to the agent the flow itself names.
 
-Both are deterministic, so nothing jumps between renders — but neither is
-something the company declared. `DERIVED_NOTICE` in `kg/adapter.ts` is the
-standing caveat. When `[[agent]]` grows `tools` (issue #363), delete
-`assignTools` and read it straight through.
+A tool node is labelled with the grant **verbatim** — `mcp:*`, `workspace.*`,
+`*`. It is the literal string in `company.toml`, which is what an operator greps
+for; title-casing produced labels that appear nowhere in the company's config.
+
+The console deliberately does **not** intersect a grant against the tool names
+discovered from MCP servers. Deciding what a glob covers is the host's
+`grant_matches`, and a second copy here is exactly the drift issue #264 forbids.
+
+## Freshness
+
+The page is a **snapshot**, not a live view, and says so: a "Snapshot HH:MM" chip
+sits top-right with a Refresh control that re-reads on demand.
+
+There is no polling, on purpose. One paint is five reads — board, roster, desks,
+people, memory — plus the workflow list and one graph read per saved workflow.
+On a timer that is a standing cost for every open tab, for a picture that changes
+when an operator does something rather than on the clock. The workflow reads are
+bounded by how many flows the company has saved, not by roster size, so this is
+not an N+1. What was never defensible was staying silent about the staleness.
 
 ### Who the graph does not place
 
-Ring 1 can only place somebody the company seats. Two kinds of teammate it
-cannot, and the graph says so rather than guessing:
+Ring 1 can only place somebody the company seats. Three things it cannot, and
+the graph says so rather than guessing:
 
 - **A teammate on no desk.** They are on the roster and nowhere in the
   structure, so they hang off the company core in a sector of their own, with no
@@ -68,13 +93,19 @@ cannot, and the graph says so rather than guessing:
   spreading humans across *invented* buckets was self-consistent fiction, but
   spreading them across *real desks* would assert a membership the desk's own
   member list contradicts.
+- **A workflow that runs through nobody seated** — a pure trigger/HTTP routine,
+  one whose agents all sit on no desk, or one the host lists with no saved graph
+  behind it. It hangs off the core too. Unlike the board cards above it is *not*
+  dropped: the company really does declare the flow, so it is drawn stageless
+  rather than going missing with no error anywhere.
 
 An empty declared desk draws no pillar: `buildKnowledgeGraph` only draws a
 department somebody claims. That is pre-existing behaviour, not a decision this
 made.
 
-Everything else is real: a card's assignee, a skill's category, the tools a
-connected MCP server advertises, and who can sign in.
+Everything else is real: a card's assignee, the desks that seat each teammate,
+the grants the host resolved for each agent, the nodes of each saved workflow,
+and who can sign in.
 
 ## Files
 

--- a/frontend/src/views/overview/kg/KnowledgeGraph.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeGraph.tsx
@@ -1502,10 +1502,15 @@ export function KnowledgeGraph({
           graph's persistent, low-weight chrome, so it is where an operator
           reading the wheel is already looking to learn how to read it. The
           full sentence lives in the title — the strip is crowded enough
-          without seven kind-labels wrapping around a whole caveat. */}
+          without seven kind-labels wrapping around a whole caveat.
+
+          It used to read "derived data", covering three whole invented rings.
+          Since issue #601 the notice names the one thing left: where a flow
+          sits on the wheel. Departments, tools and stages are the company's own
+          answers now, so claiming otherwise here would understate them. */}
       <span className="flex items-center gap-1 border-l border-os-border pl-3 font-mono text-[9.5px] text-os-dim" title={DERIVED_NOTICE}>
         <Info className="h-3 w-3 shrink-0" strokeWidth={2} />
-        derived data
+        flow placement
       </span>
     </div>
   );

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -329,13 +329,13 @@ export function adapt(input: AdaptInput): Adapted {
   // reading here (see `DERIVED_NOTICE`): a flow hangs off the desk of the first
   // teammate it runs through.
   //
-  // A flow that runs through nobody seated — a pure trigger/HTTP routine, or one
-  // whose agents are all on no desk — comes out `UNPLACED` and therefore is not
-  // drawn, because ring 2 hangs off ring 1 and there is no pillar there. That is
-  // a real flow missing from the wheel, and it is the same trade `#602` already
-  // made for an unplaced teammate's board card just above: the alternative is
-  // asserting a desk the company never tied the flow to. Seat one of its agents
-  // and the flow appears.
+  // A flow that runs through nobody seated — a pure trigger/HTTP routine, one
+  // whose agents are all on no desk, or one the host lists with no saved graph
+  // behind it — comes out `UNPLACED`. Unlike an unplaced teammate's board card,
+  // which is dropped above, the flow is still drawn: `model.ts` hangs it off the
+  // company core, the same answer it gives an unplaced worker. The company
+  // really does declare the flow, so the choice is between drawing it somewhere
+  // honest and hiding it, not between two placements.
   const deskOfAgent = new Map(agents.map((a) => [a.id, a.departmentId]));
   const workflows: Workflow[] = input.workflows.map((graph) => {
     const stages = orderStages(graph);

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -5,14 +5,18 @@
 // ## What is real, and what is not
 //
 // The graph reads `company → department → SOP task → the worker who does it →
-// that worker's tools`. This host serves all but one of those edges:
+// that worker's tools`. Every one of those is a value the host answers for:
 //
-// | Edge                  | Source                             | Real? |
-// |-----------------------|------------------------------------|-------|
-// | task → worker         | `task.assignee` on the board       | yes   |
-// | teammate → department | `GET {scope}/desks`                | yes   |
-// | worker → tools        | its resolved grants (`GET …/team`) | yes   |
-// | department → workflow | nothing (no flow API yet)          | **derived** |
+// | Edge                  | Source                                        |
+// |-----------------------|-----------------------------------------------|
+// | task → worker         | `task.assignee` on the board                  |
+// | teammate → department | the desk that seats it (`GET {scope}/desks`)  |
+// | worker → tools        | its resolved grants (`GET …/team`)            |
+// | workflow → stages     | the saved graph's nodes (`GET …/workflows/…`) |
+// | stage → worker        | the `agent` node's own agent id               |
+//
+// The one thing left that is this console's reading rather than the company's
+// declaration is **where a workflow hangs on the wheel** — see `DERIVED_NOTICE`.
 //
 // Ring 1 used to be invented too: `assignDepartment` keyword-matched a role
 // string into one of five hardcoded buckets, falling back to Operations. It is
@@ -33,25 +37,36 @@
 // constructor the per-agent detail read uses, so the graph and the agent card
 // cannot disagree about who holds what (the rule issue #264 established).
 //
-// One derived edge is left, and it is a placeholder: there is no flow API, so
-// the routines below are templates. `DERIVED_NOTICE` is the standing caveat.
-// When it lands upstream, delete `WORKFLOW_ROUTINES` and read the real value
-// straight through.
+// Workflows were the last invention: `WORKFLOW_ROUTINES` dealt one made-up
+// routine per desk by position, and `model.ts` dealt its stages round-robin
+// across that desk's agents. Both are gone (issue #601). A workflow is one of
+// the company's saved graphs, its stages are that graph's nodes in run order,
+// and a stage hands off to the agent the flow itself names.
 
 import type { Person as HostPerson } from "@/api/auth";
 import type { Task } from "@/api/tasks";
 import type { MemoryEntry } from "@/api/memory";
 import type { DeskDto } from "@/api/types";
+import type { WorkflowGraph } from "@/api/workflows";
 import type { TeamMember } from "@/lib/team";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import type { BrainGraphEdge, BrainGraphNode, MemoryGraph } from "./memory-core";
 import { distillMemoryGraph } from "./memory-core";
 import { isOpen } from "../pulse";
-import type { Agent, Department, Person, SopTask, Workflow } from "./schemas";
+import type { Agent, Department, Person, SopTask, Workflow, WorkflowStage } from "./schemas";
 
-/** Shown wherever the derived structure is on screen. */
+/**
+ * The one caveat left on this surface.
+ *
+ * Everything the graph draws is something the company declared — except which
+ * pillar a workflow hangs off, because the host scopes a flow to the *company*
+ * and nothing links a flow to a desk. It is drawn on the desk of the first
+ * teammate it runs through, which is a real relationship (that teammate really
+ * does perform that stage, and really does sit on that desk) read as a
+ * placement it was never declared to be.
+ */
 export const DERIVED_NOTICE =
-  "Workflows are placeholders — this company doesn't declare them. Departments are its real desks and tools are the grants the host resolved; anyone on no desk is shown unplaced.";
+  "A workflow is drawn on the desk of the first teammate it runs through — the company scopes flows to itself, not to a desk. Everything else on this graph is declared.";
 
 /**
  * The department a worker gets when the company declares no desk for them.
@@ -121,56 +136,64 @@ export function deskOfMember(id: string, desks: DeskDto[]): string {
 }
 
 /**
- * One standing routine per desk.
+ * A saved workflow graph, written out as an ordered list of stages.
  *
- * **Derived, and now visibly so.** The console has no flow API — the Workflows
- * canvas draws a single hard-coded sample — so these are plausible routines
- * rather than anything the company declared. They exist to show the shape a
- * real flow will take on the graph: a desk runs a flow, and the flow passes
- * through several of that desk's agents in turn.
+ * The nodes are sorted into run order (Kahn's algorithm over the graph's own
+ * edges, ties broken by declared order) rather than taken as declared: the file
+ * lists nodes, the edges say what follows what, and a flow read out of order is
+ * a flow described wrongly. A cycle — or a node no edge reaches — cannot be
+ * ordered that way, so anything left over is appended in declared order rather
+ * than dropped.
  *
- * These used to be pinned to the five invented departments by id, which read as
- * if each area had been given its own considered routine. With ring 1 drawn
- * from real desks (issue #486) that pinning is gone: a routine is dealt to a
- * desk **by position**, wrapping when there are more desks than routines. The
- * arbitrariness is the honest part — the console does not know what a desk
- * called "Front of house" actually runs, and pretending otherwise was the
- * dodge. Kept only because deleting them would empty two of the five rings
- * before there is anything to put back; deleting them here is #363's job, not
- * this one's.
+ * `agentId` rides along from the graph's own `agent` nodes, so the "who performs
+ * this stage" edge is the flow's own answer rather than a deal across a desk.
  */
-const WORKFLOW_ROUTINES: { slug: string; name: string; summary: string; stages: string[] }[] = [
-  {
-    slug: "discovery",
-    name: "Discovery loop",
-    summary: "Turn a raw request into a specced, prioritised piece of work.",
-    stages: ["Intake", "Research", "Spec", "Prioritise"],
-  },
-  {
-    slug: "delivery",
-    name: "Ship it",
-    summary: "Take a spec through build, review, and release.",
-    stages: ["Plan", "Build", "Review", "Release"],
-  },
-  {
-    slug: "brand",
-    name: "Make it look right",
-    summary: "Draft, critique, and hand off the visuals for a piece of work.",
-    stages: ["Brief", "Draft", "Critique", "Hand off"],
-  },
-  {
-    slug: "campaign",
-    name: "Campaign run",
-    summary: "Angle to published post, with the numbers read back after.",
-    stages: ["Angle", "Write", "Publish", "Measure"],
-  },
-  {
-    slug: "triage",
-    name: "Inbound triage",
-    summary: "Sort what arrives, answer it, and escalate what needs a person.",
-    stages: ["Receive", "Sort", "Answer", "Escalate"],
-  },
-];
+export function orderStages(graph: Pick<WorkflowGraph, "nodes" | "edges">): WorkflowStage[] {
+  const rank = new Map(graph.nodes.map((n, i) => [n.id, i]));
+  const indegree = new Map(graph.nodes.map((n) => [n.id, 0]));
+  const next = new Map<string, string[]>();
+  // Deduplicated: two edges between the same pair would raise the in-degree
+  // twice and strand the target forever.
+  const seen = new Set<string>();
+  for (const edge of graph.edges) {
+    if (!rank.has(edge.from) || !rank.has(edge.to)) continue;
+    const key = `${edge.from}\u001f${edge.to}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    indegree.set(edge.to, (indegree.get(edge.to) ?? 0) + 1);
+    next.set(edge.from, [...(next.get(edge.from) ?? []), edge.to]);
+  }
+
+  const ready = graph.nodes.filter((n) => indegree.get(n.id) === 0).map((n) => n.id);
+  const order: string[] = [];
+  const placed = new Set<string>();
+  while (ready.length) {
+    // Lowest declared index first, so a fan-out reads in file order and the
+    // same graph always produces the same list.
+    ready.sort((a, b) => (rank.get(a) ?? 0) - (rank.get(b) ?? 0));
+    const id = ready.shift()!;
+    if (placed.has(id)) continue;
+    placed.add(id);
+    order.push(id);
+    for (const to of next.get(id) ?? []) {
+      const left = (indegree.get(to) ?? 0) - 1;
+      indegree.set(to, left);
+      if (left === 0) ready.push(to);
+    }
+  }
+  for (const node of graph.nodes) if (!placed.has(node.id)) order.push(node.id);
+
+  const byId = new Map(graph.nodes.map((n) => [n.id, n]));
+  return order.map((id) => {
+    const node = byId.get(id)!;
+    return {
+      name: node.name,
+      // Only an `agent` node names a teammate; every other kind performs no
+      // agent's work and must not be attached to one.
+      ...(node.kind === "agent" && node.agent ? { agentId: node.agent } : {}),
+    };
+  });
+}
 
 // `assignHumanDepartment` was deleted with `assignDepartment` (issue #486),
 // and the reason is worth keeping: it did not merely stay derived, it got
@@ -197,6 +220,13 @@ export interface AdaptInput {
    */
   desks: DeskDto[];
   tasks: Task[];
+  /**
+   * The company's saved workflow graphs, whole — nodes and edges, not just
+   * names. The list read serves summaries only, so the caller fetches each
+   * graph; see `Overview.tsx` for why that is bounded and what a flow with no
+   * saved graph falls back to.
+   */
+  workflows: WorkflowGraph[];
   /** The humans who can sign in to this company. */
   people: HostPerson[];
   /** Matches a board card to a roster member; the one real assignment edge. */
@@ -295,20 +325,29 @@ export function adapt(input: AdaptInput): Adapted {
     tools: [],
   }));
 
-  // A flow only makes sense where its desk has agents to run it, and every
-  // drawn desk has some by construction. The routine is dealt by the desk's
-  // position, wrapping — see `WORKFLOW_ROUTINES` for why that arbitrariness is
-  // deliberate. The id is desk-scoped so two desks sharing a routine still get
-  // two distinct `flow:` nodes.
-  const workflows: Workflow[] = departments.map((d, i) => {
-    const routine = WORKFLOW_ROUTINES[i % WORKFLOW_ROUTINES.length];
+  // Every workflow the company has saved, written out. Placement is the one
+  // reading here (see `DERIVED_NOTICE`): a flow hangs off the desk of the first
+  // teammate it runs through.
+  //
+  // A flow that runs through nobody seated — a pure trigger/HTTP routine, or one
+  // whose agents are all on no desk — comes out `UNPLACED` and therefore is not
+  // drawn, because ring 2 hangs off ring 1 and there is no pillar there. That is
+  // a real flow missing from the wheel, and it is the same trade `#602` already
+  // made for an unplaced teammate's board card just above: the alternative is
+  // asserting a desk the company never tied the flow to. Seat one of its agents
+  // and the flow appears.
+  const deskOfAgent = new Map(agents.map((a) => [a.id, a.departmentId]));
+  const workflows: Workflow[] = input.workflows.map((graph) => {
+    const stages = orderStages(graph);
+    const firstSeated = stages
+      .map((stage) => (stage.agentId ? deskOfAgent.get(stage.agentId) : undefined))
+      .find((desk) => desk !== undefined && desk !== UNPLACED);
     return {
-      id: `${d.id}-${routine.slug}`,
-      departmentId: d.id,
-      name: routine.name,
-      summary: routine.summary,
-      stages: routine.stages,
-      agentIds: agents.filter((a) => a.departmentId === d.id).map((a) => a.id),
+      id: graph.id,
+      departmentId: firstSeated ?? UNPLACED,
+      name: graph.name,
+      summary: graph.description ?? "",
+      stages,
     };
   });
 

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -5,16 +5,14 @@
 // ## What is real, and what is not
 //
 // The graph reads `company → department → SOP task → the worker who does it →
-// that worker's tools`. This host serves only some of those edges:
+// that worker's tools`. This host serves all but one of those edges:
 //
-// | Edge                | Source                        | Real? |
-// |---------------------|-------------------------------|-------|
-// | task → worker       | `task.assignee` on the board  | yes   |
-// | category → skill    | `skill.category`              | yes   |
-// | server → tool       | what the server advertises    | yes   |
-// | teammate → department | `GET {scope}/desks`         | yes   |
-// | worker → tools      | nothing (`[tools] allow` is company-wide) | **derived** |
-// | department → workflow | nothing (no flow API yet)   | **derived** |
+// | Edge                  | Source                             | Real? |
+// |-----------------------|------------------------------------|-------|
+// | task → worker         | `task.assignee` on the board       | yes   |
+// | teammate → department | `GET {scope}/desks`                | yes   |
+// | worker → tools        | its resolved grants (`GET …/team`) | yes   |
+// | department → workflow | nothing (no flow API yet)          | **derived** |
 //
 // Ring 1 used to be invented too: `assignDepartment` keyword-matched a role
 // string into one of five hardcoded buckets, falling back to Operations. It is
@@ -27,16 +25,23 @@
 // let it dodge: **what about somebody the company declares no desk for?** They
 // are not placed — see `UNPLACED`. Nothing here invents a position for anyone.
 //
-// The two remaining derived edges are placeholders: there is no per-agent tool
-// list and no flow API. `DERIVED_NOTICE` is the standing caveat. As each lands
-// upstream, delete the matching helper (or `WORKFLOW_TEMPLATES`) and read the
-// real value straight through.
+// The per-agent tool list used to be derived too: `assignTools` dealt each
+// teammate a slice of the company-wide `[tools] allow` list, because the roster
+// **list** carried no grants and fetching every agent's detail on page load was
+// worse. That DTO gap is closed (issue #601) — a roster row now carries the
+// grants the host resolved for that teammate, from the same server-side
+// constructor the per-agent detail read uses, so the graph and the agent card
+// cannot disagree about who holds what (the rule issue #264 established).
+//
+// One derived edge is left, and it is a placeholder: there is no flow API, so
+// the routines below are templates. `DERIVED_NOTICE` is the standing caveat.
+// When it lands upstream, delete `WORKFLOW_ROUTINES` and read the real value
+// straight through.
 
 import type { Person as HostPerson } from "@/api/auth";
-import type { Skill } from "@/api/skills";
 import type { Task } from "@/api/tasks";
 import type { MemoryEntry } from "@/api/memory";
-import type { DeskDto, McpServer, McpToolInfo } from "@/api/types";
+import type { DeskDto } from "@/api/types";
 import type { TeamMember } from "@/lib/team";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import type { BrainGraphEdge, BrainGraphNode, MemoryGraph } from "./memory-core";
@@ -46,7 +51,7 @@ import type { Agent, Department, Person, SopTask, Workflow } from "./schemas";
 
 /** Shown wherever the derived structure is on screen. */
 export const DERIVED_NOTICE =
-  "Workflows and tool assignments are placeholders — this company doesn't declare them. Departments are its real desks; anyone on no desk is shown unplaced.";
+  "Workflows are placeholders — this company doesn't declare them. Departments are its real desks and tools are the grants the host resolved; anyone on no desk is shown unplaced.";
 
 /**
  * The department a worker gets when the company declares no desk for them.
@@ -113,22 +118,6 @@ export function deskDepartments(desks: DeskDto[]): Department[] {
 export function deskOfMember(id: string, desks: DeskDto[]): string {
   const desk = desks.find((d) => d.members.includes(id));
   return desk ? departmentIdOfDesk(desk.id) : UNPLACED;
-}
-
-/**
- * Which tools a teammate uses.
- *
- * **Derived.** The host knows the company's tools but not who reaches for
- * which, so each teammate is given the tools of their department's slice — a
- * deterministic deal from the company-wide list, not a record of anything.
- */
-// (member is not consulted: the assignment is positional, not personal)
-export function assignTools(index: number, tools: string[]): string[] {
-  if (tools.length === 0) return [];
-  const take = Math.min(3, Math.max(1, Math.ceil(tools.length / 3)));
-  return Array.from({ length: take }, (_, k) => tools[(index * 2 + k) % tools.length]).filter(
-    (tool, k, all) => all.indexOf(tool) === k,
-  );
 }
 
 /**
@@ -208,10 +197,6 @@ export interface AdaptInput {
    */
   desks: DeskDto[];
   tasks: Task[];
-  skills: Skill[];
-  servers: McpServer[];
-  /** Keyed by server **name** — the key `.../mcp/servers` identifies a server by. */
-  toolsByServer: Record<string, McpToolInfo[]>;
   /** The humans who can sign in to this company. */
   people: HostPerson[];
   /** Matches a board card to a roster member; the one real assignment edge. */
@@ -230,26 +215,7 @@ export interface Adapted {
 
 /** Shape the host's data into the graph's org model. */
 export function adapt(input: AdaptInput): Adapted {
-  const toolLabels: Record<string, string> = {};
-  const toolSlugs: string[] = [];
-
-  // Only active skills are tools an agent can actually reach for; a disabled
-  // one is installed but off, so it does not belong on anyone's tool shelf.
-  for (const skill of input.skills) {
-    if (!skill.enabled) continue;
-    const slug = `skill-${skill.id}`;
-    toolLabels[slug] = skill.name;
-    toolSlugs.push(slug);
-  }
-  for (const server of input.servers) {
-    for (const tool of input.toolsByServer[server.name] ?? []) {
-      const slug = `mcp-${server.name}-${tool.name}`;
-      toolLabels[slug] = tool.name;
-      toolSlugs.push(slug);
-    }
-  }
-
-  const agents: Agent[] = input.members.map((member, i) => ({
+  const agents: Agent[] = input.members.map((member) => ({
     id: member.id,
     departmentId: deskOfMember(member.id, input.desks),
     name: member.name,
@@ -258,10 +224,22 @@ export function adapt(input: AdaptInput): Adapted {
     tier: "worker",
     description: member.description,
     model: "—",
-    tools: assignTools(i, toolSlugs),
+    // What the host says this teammate actually holds, straight through: its
+    // own `[[agent]].tools` line narrowed by the company's `[tools] allow`,
+    // resolved server-side. The agent detail card renders the same list from
+    // the same resolution, which is the whole point of issue #601.
+    tools: member.effectiveTools,
     parentId: null,
     instance: "builtin",
   }));
+
+  // A tool slug is a grant glob now — the literal `[tools] allow` entry, like
+  // `composio`, `mcp:*` or `workspace.*` — so it is its own best label. The map
+  // is kept because the detail card takes one, and mapping each grant to itself
+  // is what stops the card title-casing `workspace.*` into something an
+  // operator cannot grep for.
+  const toolLabels: Record<string, string> = {};
+  for (const agent of agents) for (const grant of agent.tools) toolLabels[grant] = grant;
 
   // A board card becomes an SOP task owned by the teammate it is assigned to —
   // the one edge here that the host actually records. Cards nobody owns are

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -152,14 +152,12 @@ export function orderStages(graph: Pick<WorkflowGraph, "nodes" | "edges">): Work
   const rank = new Map(graph.nodes.map((n, i) => [n.id, i]));
   const indegree = new Map(graph.nodes.map((n) => [n.id, 0]));
   const next = new Map<string, string[]>();
-  // Deduplicated: two edges between the same pair would raise the in-degree
-  // twice and strand the target forever.
-  const seen = new Set<string>();
+  // A repeated edge needs no special case: it raises the target's in-degree
+  // twice and is then followed twice, so the two cancel and the target is
+  // still released exactly once. An edge naming a node this graph does not
+  // contain is skipped, so it can never hold a real node back.
   for (const edge of graph.edges) {
     if (!rank.has(edge.from) || !rank.has(edge.to)) continue;
-    const key = `${edge.from}\u001f${edge.to}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
     indegree.set(edge.to, (indegree.get(edge.to) ?? 0) + 1);
     next.set(edge.from, [...(next.get(edge.from) ?? []), edge.to]);
   }

--- a/frontend/src/views/overview/kg/agent-wiki.ts
+++ b/frontend/src/views/overview/kg/agent-wiki.ts
@@ -3,24 +3,37 @@
 /**
  * The detail card shown when you click a tool on the graph.
  *
- * A tool here is one of two things, and its slug says which: a skill this
- * company has defined (`skill-<id>`), or a single tool advertised by a
- * connected MCP server (`mcp-<serverId>-<toolName>`). Nothing else is invented
- * — the card states what the console actually knows, which is where the tool
- * comes from and who reaches for it.
+ * A tool on the outer ring is a **tool-grant glob**: one entry of what the host
+ * says an agent actually holds, resolved from that agent's own `[[agent]].tools`
+ * line against the company's `[tools] allow` ceiling (issue #601). `composio`,
+ * `mcp:*`, `workspace.*` and the catch-all `*` are all grants; so is anything
+ * else an operator wrote into that list.
+ *
+ * It used to be one of two records instead — a skill this company defined
+ * (`skill-<id>`) or a single tool advertised by a connected MCP server
+ * (`mcp-<serverId>-<toolName>`) — because the ring was dealt out of the
+ * company's catalogue rather than read from the agent. Those slugs no longer
+ * reach this card.
+ *
+ * The slug is therefore the truest label there is: it is the literal string in
+ * `company.toml`, which is what an operator greps for when they want to change
+ * it. Nothing here invents a friendlier name for it.
  */
 
-const SKILL_PREFIX = 'skill-';
-const MCP_PREFIX = 'mcp-';
+/** Grant spellings that name the MCP tool namespace, which the card flags. */
+const MCP_PREFIXES = ['mcp_', 'mcp:', 'mcp.', 'mcp-'];
+
+/** The grant that holds everything the company allows. */
+const CATCH_ALL = '*';
 
 export type ToolWiki = {
   slug: string;
   name: string;
-  /** True when the tool is served by an MCP server rather than defined here. */
+  /** True when the grant names the MCP tool namespace. */
   mcp: boolean;
-  /** Human-readable origin: `MCP server`, `skill`, or a plain tool. */
+  /** Human-readable origin. */
   kind: string;
-  /** Where this tool is managed in the console. */
+  /** Where this grant is managed. */
   path: string;
   summary: string;
   usedBy: string[];
@@ -34,18 +47,28 @@ export function prettifySlug(slug: string): string {
     .join(' ');
 }
 
-/** Whether a slug names a tool served by an MCP server. */
+/**
+ * Whether a grant names the MCP tool namespace.
+ *
+ * Matched on the namespace rather than one exact string, because a grant may be
+ * the bare family (`mcp`), a glob over it (`mcp:*`), or a single tool inside it
+ * (`mcp_registry_list_tools`).
+ *
+ * This is a **display** hint only — it decides whether the card shows an MCP
+ * mark. It is deliberately not a membership test: deciding which tools a grant
+ * actually covers is the host's `grant_matches`, and re-implementing that here
+ * would be the second copy issue #264 exists to prevent.
+ */
 export function isMcpSlug(slug: string): boolean {
-  return slug.startsWith(MCP_PREFIX);
+  return slug === 'mcp' || MCP_PREFIXES.some((p) => slug.startsWith(p));
 }
 
 /**
  * Build a tool's card.
  *
- * `labels` is the adapter's slug → display-name map, built from the skill and
- * MCP records themselves; without it the slug is prettified, which reads badly
- * for an MCP tool (`mcp-fs-1-read_file` → `Mcp Fs 1 Read_file`) and is only a
- * last resort.
+ * `labels` is the adapter's slug → display-name map, which for a grant maps the
+ * slug to itself so the card shows the literal `company.toml` entry. The
+ * prettified fallback is only reached for a slug no adapter described.
  */
 export function buildToolWiki(
   slug: string,
@@ -53,20 +76,20 @@ export function buildToolWiki(
   labels: Record<string, string> = {},
 ): ToolWiki {
   const mcp = isMcpSlug(slug);
-  const skill = slug.startsWith(SKILL_PREFIX);
   const name = labels[slug] ?? prettifySlug(slug);
 
   return {
     slug,
     name,
     mcp,
-    kind: mcp ? 'MCP server' : skill ? 'skill' : 'tool',
-    path: mcp ? 'Settings → MCP Servers' : skill ? 'Skills' : '—',
-    summary: mcp
-      ? `${name} — served by one of this company's connected MCP servers.`
-      : skill
-        ? `${name} — a skill defined for this company.`
-        : `${name} — available to this company.`,
+    kind: 'tool grant',
+    path: 'company.toml → [tools] allow',
+    summary:
+      slug === CATCH_ALL
+        ? 'Every tool this company allows — the catch-all grant.'
+        : mcp
+          ? `${name} — a grant over tools served by this company's MCP servers.`
+          : `${name} — a tool family this company grants.`,
     usedBy,
   };
 }

--- a/frontend/src/views/overview/kg/model.ts
+++ b/frontend/src/views/overview/kg/model.ts
@@ -66,14 +66,6 @@ export function orderGraphDepartments<T>(items: T[], deptIdOf: (item: T) => stri
   return [...items].sort((a, b) => rank(a) - rank(b) || deptIdOf(a).localeCompare(deptIdOf(b)));
 }
 
-/** 'design-review' → 'Design Review' */
-function prettify(slug: string): string {
-  return slug
-    .split(/[-_]/)
-    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}
-
 /** Graph node id for a task's worker: agents are `emp:`, humans are `person:`. */
 export function workerNodeId(kind: SopTask['assigneeKind'], assigneeId: string): string {
   return kind === 'agent' ? `emp:${assigneeId}` : `person:${assigneeId}`;
@@ -216,14 +208,20 @@ export function buildKnowledgeGraph(
 
   // Software tools (outer ring) — one node per (tool, department-that-uses-it)
   // for shared tools, a single node otherwise.
+  //
+  // Labelled with the slug verbatim: a slug here is a tool-grant glob, which is
+  // the literal string in the company's `[tools] allow` list. Title-casing it
+  // turned `mcp:*` into "Mcp " and `workspace.*` into something that appears
+  // nowhere in the company's own config, so an operator reading the wheel could
+  // not grep for what they were looking at (issue #601).
   for (const slug of [...deptsOfTool.keys()].sort()) {
     const depts = [...deptsOfTool.get(slug)!].sort();
     if (depts.length > 1) {
       for (const deptId of depts) {
-        nodes.push({ id: `tool:${slug}@${deptId}`, kind: 'tool', label: prettify(slug), ring: RING.tool });
+        nodes.push({ id: `tool:${slug}@${deptId}`, kind: 'tool', label: slug, ring: RING.tool });
       }
     } else {
-      nodes.push({ id: `tool:${slug}`, kind: 'tool', label: prettify(slug), ring: RING.tool });
+      nodes.push({ id: `tool:${slug}`, kind: 'tool', label: slug, ring: RING.tool });
     }
   }
 

--- a/frontend/src/views/overview/kg/model.ts
+++ b/frontend/src/views/overview/kg/model.ts
@@ -136,8 +136,8 @@ export function buildKnowledgeGraph(
   }
 
   // Workflows (ring 2) — the multi-step routines a department runs. Unlike an
-  // SOP task, a flow passes through several workers, so it draws one `runs`
-  // edge per agent it touches.
+  // SOP task, which one worker owns outright, a flow passes through several, so
+  // it draws one `runs` edge per stage that names an agent.
   const agentIds = new Set(agents.map((a) => a.id));
   for (const f of workflows) {
     if (!drawn.has(f.departmentId)) continue;
@@ -146,18 +146,26 @@ export function buildKnowledgeGraph(
 
     // Each stage is its own node, chained to the next so the flow reads as a
     // sequence rather than a bag, and handed to the agent who performs it.
-    const runners = f.agentIds.filter((id) => agentIds.has(id));
+    //
+    // That last edge is drawn ONLY where the stage names an agent. The saved
+    // graph says which of its nodes is an `agent` node and which roster
+    // teammate it runs as, so there is nothing to deal out: a `trigger` or an
+    // `http_request` stage is performed by no teammate, and drawing a line from
+    // it to one would be a claim the company never made. This used to be a
+    // round-robin across the department's agents, which gave every stage a
+    // performer and got the performer wrong (issue #601).
     let prevStep: string | null = null;
     f.stages.forEach((stage, i) => {
       const stepId = `step:${f.id}:${i}`;
-      nodes.push({ id: stepId, kind: 'step', label: stage, ring: RING.step });
+      nodes.push({ id: stepId, kind: 'step', label: stage.name, ring: RING.step });
       edges.push({ source: `flow:${f.id}`, target: stepId, kind: 'stage' });
       if (prevStep) edges.push({ source: prevStep, target: stepId, kind: 'next' });
       prevStep = stepId;
-      // Stages are dealt round-robin across the department's agents: the flow
-      // knows its order, not who owns which step.
-      if (runners.length) {
-        edges.push({ source: stepId, target: `emp:${runners[i % runners.length]}`, kind: 'runs' });
+      // A stage may name an agent the roster no longer carries (a graph saved
+      // before a teammate was deleted); `forceLink` throws on an edge to a node
+      // that was never created, so the membership check is load-bearing.
+      if (stage.agentId && agentIds.has(stage.agentId)) {
+        edges.push({ source: stepId, target: `emp:${stage.agentId}`, kind: 'runs' });
       }
     });
   }

--- a/frontend/src/views/overview/kg/model.ts
+++ b/frontend/src/views/overview/kg/model.ts
@@ -140,9 +140,18 @@ export function buildKnowledgeGraph(
   // it draws one `runs` edge per stage that names an agent.
   const agentIds = new Set(agents.map((a) => a.id));
   for (const f of workflows) {
-    if (!drawn.has(f.departmentId)) continue;
     nodes.push({ id: `flow:${f.id}`, kind: 'workflow', label: f.name, ring: RING.workflow });
-    edges.push({ source: `team:${f.departmentId}`, target: `flow:${f.id}`, kind: 'flow' });
+    // A flow the adapter could not place — it runs through nobody on a desk, or
+    // it is a company flow with no saved graph at all — hangs off the core
+    // instead of a pillar, exactly as an unplaced worker does just below. The
+    // company really does declare this flow, so dropping it would be the
+    // quieter lie: it draws, stageless if that is all we know, rather than
+    // going missing with no error anywhere.
+    edges.push(
+      drawn.has(f.departmentId)
+        ? { source: `team:${f.departmentId}`, target: `flow:${f.id}`, kind: 'flow' }
+        : { source: SELF_ID, target: `flow:${f.id}`, kind: 'flow' },
+    );
 
     // Each stage is its own node, chained to the next so the flow reads as a
     // sequence rather than a bag, and handed to the agent who performs it.

--- a/frontend/src/views/overview/kg/schemas.ts
+++ b/frontend/src/views/overview/kg/schemas.ts
@@ -4,8 +4,9 @@
 //
 // The graph, its layout, and its detail cards were written against a five-ring
 // org model — departments, written-out SOP tasks, the one worker who does each,
-// and that worker's tools. This console's host does not serve that model, so
-// `adapter.ts` derives it; these are the types both sides agree on.
+// and that worker's tools. `adapter.ts` maps the host's own shapes (desks,
+// resolved tool grants, saved workflow graphs, board cards) onto it; these are
+// the types both sides agree on.
 
 export type AgentStatus = "active" | "idle" | "paused";
 export type AgentTier = "lead" | "worker";
@@ -41,16 +42,26 @@ export interface Person {
   tools: string[];
 }
 
+/**
+ * One step of a workflow: a node of the company's saved graph.
+ *
+ * `agentId` is set only on the graph's `agent` nodes — the flow itself names
+ * who performs that step, so nothing here has to guess. A `trigger`, an
+ * `http_request` or an `output` node performs no agent's work and carries none.
+ */
+export interface WorkflowStage {
+  name: string;
+  agentId?: string;
+}
+
 export interface Workflow {
   id: string;
   departmentId: string;
   name: string;
   /** One line on what the flow does. */
   summary: string;
-  /** The stage names, in order — the flow written out. */
-  stages: string[];
-  /** Agent ids the flow runs through. */
-  agentIds: string[];
+  /** The stages, in run order — the flow written out. */
+  stages: WorkflowStage[];
 }
 
 export type SopAssigneeKind = "agent" | "person";

--- a/frontend/test/unit/chat-channels.test.ts
+++ b/frontend/test/unit/chat-channels.test.ts
@@ -25,6 +25,8 @@ function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): Te
     description: "",
     tone: "sky",
     inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
     ...over,
   };
 }

--- a/frontend/test/unit/overview-graph.test.ts
+++ b/frontend/test/unit/overview-graph.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, it } from "vitest";
+
+import type { Person as HostPerson } from "@/api/auth";
+import type { WorkflowGraph } from "@/api/workflows";
+import type { DeskDto } from "@/api/types";
+import type { TeamMember } from "@/lib/team";
+import { adapt, DERIVED_NOTICE, orderStages, UNPLACED } from "@/views/overview/kg/adapter";
+import { buildKnowledgeGraph, SELF_ID } from "@/views/overview/kg/model";
+import { ownedBy } from "@/views/overview/pulse";
+
+/**
+ * The outer rings of the overview graph, drawn from the host rather than from a
+ * plausible story (issue #601).
+ *
+ * Ring 1 is covered by `overview-ring1.test.ts`; this file is about the three
+ * rings that were still invented after it: a teammate's tools, the company's
+ * workflows, and which teammate performs a stage.
+ *
+ * Every assertion here exists because the honest value and the invented one
+ * were indistinguishable on screen. A tool shelf dealt out of the company-wide
+ * allow-list and one templated routine per desk drew a clean, convincing wheel;
+ * it just described a company that does not exist, which is why it stayed wrong
+ * long enough to need an issue.
+ */
+
+function member(over: Partial<TeamMember> & Pick<TeamMember, "id" | "name">): TeamMember {
+  return {
+    role: "Engineer",
+    description: "",
+    tone: "sky",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+function desk(id: string, name: string, members: string[] = []): DeskDto {
+  return { id, name, members };
+}
+
+function flow(over: Partial<WorkflowGraph> & Pick<WorkflowGraph, "id" | "name">): WorkflowGraph {
+  return { nodes: [], edges: [], ...over };
+}
+
+function person(id: string, email: string, role: "admin" | "member"): HostPerson {
+  return {
+    id,
+    email,
+    role,
+    status: "active",
+    hasPassword: true,
+    mustChangePassword: false,
+    createdAtMillis: 0,
+  };
+}
+
+const BASE = { tasks: [], people: [] as HostPerson[], workflows: [], ownedBy };
+
+describe("a teammate's tools", () => {
+  it("are the grants the host resolved, verbatim", () => {
+    const { agents } = adapt({
+      ...BASE,
+      members: [
+        member({ id: "ada", name: "Ada", effectiveTools: ["workspace.read", "composio"] }),
+      ],
+      desks: [desk("eng", "Engineering", ["ada"])],
+    });
+
+    // Not a slice, not a deal, not a reordering: the same list, in the same
+    // order, that `GET .../team/{id}` shows on the agent's own card.
+    expect(agents[0].tools).toEqual(["workspace.read", "composio"]);
+  });
+
+  it("are empty when the host granted none, rather than filled from somewhere", () => {
+    const { agents, toolLabels } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada", effectiveTools: [] })],
+      desks: [],
+    });
+
+    expect(agents[0].tools).toEqual([]);
+    expect(toolLabels).toEqual({});
+  });
+
+  it("label themselves with the literal grant, so an operator can grep for it", () => {
+    const { toolLabels } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada", effectiveTools: ["workspace.*", "*"] })],
+      desks: [],
+    });
+
+    expect(toolLabels).toEqual({ "workspace.*": "workspace.*", "*": "*" });
+  });
+
+  it("reach the graph as the grant glob, not a title-cased rewrite of it", () => {
+    const { agents, departments } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada", effectiveTools: ["mcp:*", "workspace.read"] })],
+      desks: [desk("eng", "Engineering", ["ada"])],
+    });
+    const graph = buildKnowledgeGraph(agents, departments);
+
+    // The pre-fix UI showed things like "Mcp Deepwiki Read Wiki Contents"; the
+    // truth is `mcp:*`, and it is the string in the company's `[tools] allow`.
+    const labels = graph.nodes.filter((n) => n.kind === "tool").map((n) => n.label);
+    expect(labels.sort()).toEqual(["mcp:*", "workspace.read"]);
+  });
+
+  it("never reach a human — the host resolves grants per agent", () => {
+    const { people } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada", effectiveTools: ["composio"] })],
+      desks: [],
+      people: [person("u1", "sam@example.com", "admin")],
+    });
+
+    expect(people[0].tools).toEqual([]);
+  });
+});
+
+describe("orderStages", () => {
+  it("reads the flow in edge order, not declaration order", () => {
+    const stages = orderStages({
+      nodes: [
+        { id: "c", kind: "output", name: "Report" },
+        { id: "a", kind: "trigger", name: "Every morning" },
+        { id: "b", kind: "agent", name: "Draft", agent: "ada" },
+      ],
+      edges: [
+        { from: "a", to: "b" },
+        { from: "b", to: "c" },
+      ],
+    });
+
+    expect(stages.map((s) => s.name)).toEqual(["Every morning", "Draft", "Report"]);
+  });
+
+  it("names the agent the flow itself names, and nobody else", () => {
+    const stages = orderStages({
+      nodes: [
+        { id: "a", kind: "trigger", name: "Every morning" },
+        { id: "b", kind: "agent", name: "Draft", agent: "ada" },
+        // An `agent` field on a non-agent node is not a performer.
+        { id: "c", kind: "http_request", name: "Post it", agent: "grace" },
+      ],
+      edges: [
+        { from: "a", to: "b" },
+        { from: "b", to: "c" },
+      ],
+    });
+
+    expect(stages.map((s) => s.agentId)).toEqual([undefined, "ada", undefined]);
+  });
+
+  it("breaks a fan-out tie by declared order, so the same graph always reads the same", () => {
+    const stages = orderStages({
+      nodes: [
+        { id: "root", kind: "trigger", name: "Start" },
+        { id: "x", kind: "agent", name: "X", agent: "ada" },
+        { id: "y", kind: "agent", name: "Y", agent: "grace" },
+      ],
+      edges: [
+        { from: "root", to: "y" },
+        { from: "root", to: "x" },
+      ],
+    });
+
+    expect(stages.map((s) => s.name)).toEqual(["Start", "X", "Y"]);
+  });
+
+  it("keeps every node when the graph has a cycle", () => {
+    const stages = orderStages({
+      nodes: [
+        { id: "a", kind: "agent", name: "A" },
+        { id: "b", kind: "agent", name: "B" },
+      ],
+      edges: [
+        { from: "a", to: "b" },
+        { from: "b", to: "a" },
+      ],
+    });
+
+    expect(stages.map((s) => s.name).sort()).toEqual(["A", "B"]);
+  });
+
+  // Documents behaviour rather than guarding a guard: a repeated edge balances
+  // out (in-degree raised twice, followed twice), so this passes with or
+  // without any explicit de-duplication. It is here because a saved graph can
+  // carry the same edge twice and the stage list must not gain or lose a step.
+  it("is not confused by a repeated edge", () => {
+    const stages = orderStages({
+      nodes: [
+        { id: "a", kind: "trigger", name: "A" },
+        { id: "b", kind: "agent", name: "B" },
+      ],
+      edges: [
+        { from: "a", to: "b" },
+        { from: "a", to: "b" },
+      ],
+    });
+
+    expect(stages.map((s) => s.name)).toEqual(["A", "B"]);
+  });
+});
+
+describe("workflows", () => {
+  it("are the company's saved graphs, not templates", () => {
+    const { workflows } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada" })],
+      desks: [desk("eng", "Engineering", ["ada"])],
+      workflows: [
+        flow({
+          id: "wf-nightly",
+          name: "Nightly digest",
+          description: "Summarise the day.",
+          nodes: [
+            { id: "t", kind: "trigger", name: "22:00 UTC" },
+            { id: "w", kind: "agent", name: "Write it", agent: "ada" },
+          ],
+          edges: [{ from: "t", to: "w" }],
+        }),
+      ],
+    });
+
+    expect(workflows).toHaveLength(1);
+    expect(workflows[0].name).toBe("Nightly digest");
+    expect(workflows[0].summary).toBe("Summarise the day.");
+    expect(workflows[0].stages.map((s) => s.name)).toEqual(["22:00 UTC", "Write it"]);
+    // Placement — the one thing this console decides. `ada` sits on `eng`.
+    expect(workflows[0].departmentId).toBe("desk:eng");
+  });
+
+  it("draws no flow ring at all for a company that has saved none", () => {
+    // The templates guaranteed a flow per desk, so this ring could never be
+    // empty and an operator could never tell "no flows" from "not read".
+    const { workflows } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada" })],
+      desks: [desk("eng", "Engineering", ["ada"])],
+    });
+
+    expect(workflows).toEqual([]);
+  });
+
+  it("is unplaced when it runs through nobody seated", () => {
+    const { workflows } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada" })],
+      desks: [],
+      workflows: [
+        flow({
+          id: "wf-ping",
+          name: "Ping",
+          nodes: [{ id: "h", kind: "http_request", name: "Call the API" }],
+        }),
+      ],
+    });
+
+    expect(workflows[0].departmentId).toBe(UNPLACED);
+  });
+
+  it("still draws a flow it could not place, hanging it off the core", () => {
+    // A flow the host lists with no saved graph behind it falls back to an
+    // empty stub, which names no agent and so cannot be placed. It must still
+    // appear: the company declares it, and a flow missing from the wheel with
+    // no error anywhere is the quieter lie.
+    const { agents, departments, workflows } = adapt({
+      ...BASE,
+      members: [member({ id: "ada", name: "Ada" })],
+      desks: [desk("eng", "Engineering", ["ada"])],
+      workflows: [flow({ id: "wf-stub", name: "Unreadable flow" })],
+    });
+    const graph = buildKnowledgeGraph(agents, departments, [], [], workflows);
+
+    expect(graph.nodes.some((n) => n.id === "flow:wf-stub")).toBe(true);
+    expect(graph.edges).toContainEqual({
+      source: SELF_ID,
+      target: "flow:wf-stub",
+      kind: "flow",
+    });
+    // Drawn stageless rather than given invented steps.
+    expect(graph.nodes.filter((n) => n.kind === "step")).toEqual([]);
+  });
+
+  it("draws a stage only to the teammate the flow names", () => {
+    const { agents, departments, workflows } = adapt({
+      ...BASE,
+      members: [
+        member({ id: "ada", name: "Ada" }),
+        member({ id: "grace", name: "Grace" }),
+      ],
+      desks: [desk("eng", "Engineering", ["ada", "grace"])],
+      workflows: [
+        flow({
+          id: "wf",
+          name: "Flow",
+          nodes: [
+            { id: "t", kind: "trigger", name: "Start" },
+            { id: "d", kind: "agent", name: "Draft", agent: "ada" },
+            // Names a teammate the roster does not carry: no edge, rather than
+            // a link to a node that was never created.
+            { id: "g", kind: "agent", name: "Ghost step", agent: "nobody" },
+          ],
+          edges: [
+            { from: "t", to: "d" },
+            { from: "d", to: "g" },
+          ],
+        }),
+      ],
+    });
+    const graph = buildKnowledgeGraph(agents, departments, [], [], workflows);
+
+    // Under the old round-robin every stage got an edge, dealt across the
+    // department — including the two the flow never handed to anyone, and
+    // `grace` collected one purely by being on the same desk.
+    const runs = graph.edges.filter((e) => e.kind === "runs");
+    expect(runs).toEqual([{ source: "step:wf:1", target: "emp:ada", kind: "runs" }]);
+    expect(runs.some((e) => e.target === "emp:grace")).toBe(false);
+  });
+});
+
+describe("DERIVED_NOTICE", () => {
+  it("names flow placement and no longer claims departments or tools are invented", () => {
+    expect(DERIVED_NOTICE).toMatch(/workflow/i);
+    // The acceptance criterion for #601, asserted rather than assumed: the
+    // notice must not still be telling operators that rings the host now
+    // answers for are placeholders.
+    expect(DERIVED_NOTICE).not.toMatch(/placeholder/i);
+    expect(DERIVED_NOTICE).not.toMatch(/tool assignments/i);
+    expect(DERIVED_NOTICE).not.toMatch(/templates/i);
+  });
+});

--- a/frontend/test/unit/overview-ring1.test.ts
+++ b/frontend/test/unit/overview-ring1.test.ts
@@ -30,7 +30,19 @@ import { ownedBy } from "@/views/overview/pulse";
  */
 
 function member(id: string, role: string, name = id): TeamMember {
-  return { id, name, role, description: "", tone: "a", inboxEnabled: false };
+  // `effectiveTools` and `desks` are what the roster read now carries for every
+  // teammate (issue #601). Empty here on purpose: these cases are about ring 1,
+  // and a teammate holding no grants must still be placed by their desk.
+  return {
+    id,
+    name,
+    role,
+    description: "",
+    tone: "a",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+  };
 }
 
 /**

--- a/frontend/test/unit/overview-ring1.test.ts
+++ b/frontend/test/unit/overview-ring1.test.ts
@@ -78,6 +78,9 @@ const BASE = {
   servers: [],
   toolsByServer: {},
   people: [] as HostPerson[],
+  // The company's saved flows (issue #601). None by default: these cases are
+  // about ring 1, and a company with no flows must still draw its desks.
+  workflows: [],
   ownedBy,
 };
 
@@ -192,18 +195,39 @@ describe("nobody is given a position the company did not declare", () => {
 });
 
 describe("the workflow ring survives desks replacing the hardcoded departments", () => {
-  it("hangs one routine off every drawn desk", () => {
-    // The templates used to be pinned to `dept-product`, `dept-engineering` and
-    // friends. Those ids no longer exist, so a template keyed to them matches
-    // no desk and the whole ring vanishes without an error.
-    const { workflows, departments } = adapt({ ...BASE, members: ROSTER, desks: DESKS });
-    expect(workflows).toHaveLength(departments.length);
-    expect(workflows.map((f) => f.departmentId).sort()).toEqual(
-      departments.map((d) => d.id).sort(),
-    );
-    // Desk-scoped ids: two desks dealt the same routine still get two nodes.
-    expect(new Set(workflows.map((f) => f.id)).size).toBe(workflows.length);
-    for (const f of workflows) expect(f.agentIds.length).toBeGreaterThan(0);
+  // This case used to assert "hangs one routine off every drawn desk": one
+  // templated routine was dealt to each desk by position, so the count of flows
+  // was the count of desks and every flow carried an `agentIds` list. Issue #601
+  // deleted the templates — a workflow is one of the company's saved graphs now,
+  // so a company with no saved flows draws no flow ring, and `agentIds` is gone
+  // with the round-robin that consumed it.
+  //
+  // The concern the case was written for still holds and is what is checked
+  // here: when ring 1 changed under it, the flow ring must not silently empty.
+  it("hangs a saved flow off the desk of the teammate it runs through", () => {
+    const { workflows, departments } = adapt({
+      ...BASE,
+      members: ROSTER,
+      desks: DESKS,
+      workflows: [
+        {
+          id: "wf-nightly",
+          name: "Nightly digest",
+          // `hedy` is seated on Engineering by the desk, not by her job title.
+          nodes: [
+            { id: "t", kind: "trigger", name: "22:00 UTC" },
+            { id: "w", kind: "agent", name: "Write it", agent: "hedy" },
+          ],
+          edges: [{ from: "t", to: "w" }],
+        },
+      ],
+    });
+
+    expect(workflows).toHaveLength(1);
+    expect(workflows[0].departmentId).toBe("desk:engineering");
+    // And it landed on a desk that is actually drawn, so the flow is reachable
+    // on the wheel rather than pointing at a pillar nobody built.
+    expect(departments.map((d) => d.id)).toContain(workflows[0].departmentId);
   });
 });
 

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -79,6 +79,26 @@ struct TeamMemberDto {
     role: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    /// This teammate's tool grants, in the **same shape and from the same
+    /// constructor** as `GET …/team/{agent_id}` (issue #601).
+    ///
+    /// Carried on the list because the overview knowledge graph draws one ring
+    /// per teammate's tools and had no way to learn them: the detail read
+    /// answered per agent, so drawing a whole roster meant N+1 fetches on page
+    /// load, and the graph invented a tool shelf instead — dealing each
+    /// teammate a slice of `[tools].allow` while the detail card beside it
+    /// rendered the real grant. One list read now answers for the roster.
+    ///
+    /// `companyAllow` repeats on every row, which is the payload cost of
+    /// mirroring the detail shape exactly rather than inventing a leaner
+    /// parallel one. It is worth paying: an **empty `requested` means the
+    /// company's standard grant**, not "no tools", and a row that dropped the
+    /// ceiling would leave a client no way to say which it was looking at.
+    tools: super::team_agent::AgentToolsDto,
+    /// The desks this teammate sits on, resolved through the same helper the
+    /// detail read uses (issue #601). Desks are the company's real grouping —
+    /// the overview graph draws its department pillars from these.
+    desks: Vec<super::team_agent::AgentDeskDto>,
     /// Whether this teammate has an enabled inbox, so the Team page's toggle
     /// renders the host's real state instead of a client-side guess.
     inbox_enabled: bool,
@@ -273,6 +293,14 @@ fn member_row(
         name,
         role,
         description,
+        // Both through `team_agent`'s constructors, never recomputed here: the
+        // roster list and the detail read must not be able to disagree about
+        // the same teammate (issues #264, #601).
+        tools: super::team_agent::agent_tools(
+            &record.manifest.tools.allow,
+            super::team_agent::requested_grants(record, agent_id),
+        ),
+        desks: super::team_agent::desks_for(record, agent_id),
         inbox_enabled,
         budget_usd_daily: cap,
         // Paired with the cap: no cap, no spend row.
@@ -385,11 +413,22 @@ async fn add_member(
         .save(&record)
         .await
         .map_err(|e| ApiError(e).into_response())?;
+    // A brand-new overlay teammate has no `[[agent]].tools` line, so it holds
+    // the company's standard grant, and it sits on no desk until somebody adds
+    // it to one. Resolved through the shared constructors rather than written
+    // out here, so this response cannot drift from the two reads (issue #601).
+    let tools = super::team_agent::agent_tools(
+        &record.manifest.tools.allow,
+        super::team_agent::requested_grants(&record, &agent.id),
+    );
+    let desks = super::team_agent::desks_for(&record, &agent.id);
     Ok(Json(TeamMemberDto {
         id: agent.id,
         name: Some(agent.name),
         role: agent.role,
         description: agent.description,
+        tools,
+        desks,
         // A brand-new teammate has no inbox until the toggle writes one.
         inbox_enabled: false,
         budget_usd_daily: body.budget_usd_daily,

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -147,6 +147,10 @@ pub(super) struct AgentDetailDto {
 
 /// An agent's tool grants at all three levels, so the resolution is legible
 /// rather than asserted.
+///
+/// Built **only** through [`agent_tools`], so every surface that renders an
+/// agent's tools renders the same list — see that function for why that is a
+/// rule rather than a convenience.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(super) struct AgentToolsDto {
@@ -169,6 +173,45 @@ pub(super) struct AgentDeskDto {
     /// Whether this agent is the desk's lead — the first effective member, who
     /// receives a `delegate_to_desk` hand-off.
     lead: bool,
+}
+
+/// The tool globs an agent *asks* for, resolved identically for every reader.
+///
+/// A manifest teammate's `[[agent]].tools` line; an **empty** list for an
+/// overlay teammate, which mirrors `harness::overlay_agent_to_manifest` — and
+/// which means "the company's standard grant", not "no tools".
+///
+/// Its callers have already established that `agent_id` is on the roster, so a
+/// miss here can only be the overlay half.
+pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<String> {
+    record
+        .manifest
+        .agents
+        .iter()
+        .find(|agent| agent.id == agent_id)
+        .map(|agent| agent.tools.clone())
+        .unwrap_or_default()
+}
+
+/// One agent's grants at all three levels — the single constructor for
+/// [`AgentToolsDto`].
+///
+/// `effective` comes from
+/// [`agent_effective_grants`](crate::runtime::builder::agent_effective_grants),
+/// the same function the harness builds the agent with, for the reason the
+/// module docs give. This function exists so the **roster list** and the
+/// **detail read** cannot answer that question differently either (issue
+/// #601): the overview graph reads the list and used to invent a tool shelf by
+/// dealing slices of `[tools].allow`, so the graph and the detail card beside
+/// it disagreed about the same agent. Sharing the constructor makes that
+/// disagreement unrepresentable rather than merely fixed once.
+pub(super) fn agent_tools(company_allow: &[String], requested: Vec<String>) -> AgentToolsDto {
+    let effective = agent_effective_grants(company_allow, &requested);
+    AgentToolsDto {
+        requested,
+        company_allow: company_allow.to_vec(),
+        effective,
+    }
 }
 
 /// The `PATCH` body. Every field is optional, and an absent field is left
@@ -325,7 +368,7 @@ async fn detail(
     let manifest_agent = record.manifest.agents.iter().find(|a| a.id == agent_id);
     let overlay_agent = record.overlay_agents.iter().find(|a| a.id == agent_id);
 
-    let (source, name, role, description, tier, requested) = match (manifest_agent, overlay_agent) {
+    let (source, name, role, description, tier) = match (manifest_agent, overlay_agent) {
         // A manifest agent wins an id collision, exactly as `build_roster`
         // resolves one: the version-controlled roster is authoritative.
         (Some(agent), _) => (
@@ -334,18 +377,17 @@ async fn detail(
             agent.role.clone(),
             agent.description.clone(),
             agent.tier.clone(),
-            agent.tools.clone(),
         ),
         (None, Some(agent)) => (
             AgentSource::Overlay,
             Some(agent.name.clone()),
             agent.role.clone(),
             agent.description.clone(),
-            // An overlay teammate has no manifest row, so no tier and no
-            // per-agent tool line: it holds the company's standard grant. This
-            // mirrors `harness::overlay_agent_to_manifest` exactly.
+            // An overlay teammate has no manifest row, so no tier — and, in
+            // `requested_grants` below, no per-agent tool line either: it holds
+            // the company's standard grant, mirroring
+            // `harness::overlay_agent_to_manifest`.
             None,
-            Vec::new(),
         ),
         (None, None) => {
             return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
@@ -353,9 +395,6 @@ async fn detail(
             ))));
         }
     };
-
-    let company_allow = record.manifest.tools.allow.clone();
-    let effective = agent_effective_grants(&company_allow, &requested);
 
     let cap = record.effective_budget(agent_id);
     let attribution = record.budget_override(agent_id);
@@ -386,11 +425,10 @@ async fn detail(
         },
         tier,
         is_orchestrator: crate::company::orchestrator_id(&record.manifest.agents) == Some(agent_id),
-        tools: AgentToolsDto {
-            requested,
-            company_allow,
-            effective,
-        },
+        tools: agent_tools(
+            &record.manifest.tools.allow,
+            requested_grants(record, agent_id),
+        ),
         desks: desks_for(record, agent_id),
         inbox_enabled,
         budget_usd_daily: cap,
@@ -407,7 +445,11 @@ async fn detail(
 /// rather than by reading the declared member lists, so an operator-added
 /// membership and an operator-set lead order are both reflected — the same
 /// answer the Desks page and the harness `desk_lead` resolver give.
-fn desks_for(record: &CompanyRecord, agent_id: &str) -> Vec<AgentDeskDto> {
+///
+/// Shared with `GET {scope}/team` (issue #601) for the same anti-drift reason
+/// as [`agent_tools`]: desks are the overview graph's departments now, so the
+/// roster list and this read have to agree on which desks a teammate sits on.
+pub(super) fn desks_for(record: &CompanyRecord, agent_id: &str) -> Vec<AgentDeskDto> {
     let declared = record
         .manifest
         .group_chats

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -777,6 +777,149 @@ members = ["writer", "ceo"]
         );
     }
 
+    /// Issue #601: the roster **list** answers for tools and desks too, with
+    /// the same values as the detail read.
+    ///
+    /// The overview graph is drawn from the list, so before this it had no way
+    /// to learn either without an N+1 fetch — and invented both instead, while
+    /// the detail card beside it rendered the real thing. The equality is the
+    /// contract; anything less lets the two surfaces disagree again.
+    #[tokio::test]
+    async fn the_roster_list_carries_the_same_tools_and_desks_as_the_detail_read() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        // An overlay teammate too, so the agreement is checked on both halves
+        // of the merged roster rather than only on the manifest half.
+        let jamie = add_overlay(&state, "Jamie", "Growth").await;
+
+        let (status, roster) = send(&state, "GET", "/api/v1/company/team", None).await;
+        assert_eq!(status, StatusCode::OK, "{roster}");
+        let rows = roster.as_array().unwrap();
+        assert_eq!(rows.len(), 4, "{roster}");
+
+        for row in rows {
+            let id = row["id"].as_str().unwrap();
+            let (_, detail) = get_agent(&state, id).await;
+            assert_eq!(
+                row["tools"], detail["tools"],
+                "the graph reads the list and the card reads the detail; they \
+                 must not disagree about {id}"
+            );
+            assert_eq!(row["desks"], detail["desks"], "desks disagree for {id}");
+        }
+
+        let row_of = |id: &str| {
+            rows.iter()
+                .find(|row| row["id"] == id)
+                .unwrap_or_else(|| panic!("{id} missing from {roster}"))
+                .clone()
+        };
+
+        // …and the shared values are the *right* ones, so a shared-but-wrong
+        // constructor cannot pass on agreement alone.
+        let ceo = row_of("ceo");
+        assert_eq!(
+            strings(&ceo["tools"]["effective"]),
+            vec!["workspace.read"],
+            "a request the company never allowed is not a grant: {ceo}"
+        );
+        let writer = row_of("writer");
+        assert!(
+            strings(&writer["tools"]["requested"]).is_empty(),
+            "{writer}"
+        );
+        assert_eq!(
+            strings(&writer["tools"]["effective"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "an agent that lists no tools holds the whole allow-list: {writer}"
+        );
+        assert_eq!(
+            strings(&writer["tools"]["companyAllow"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "the ceiling rides along, so a reader can tell an empty request \
+             from an empty grant: {writer}"
+        );
+
+        // Desks, which are the graph's departments now: declared membership,
+        // the lead flag off the effective order, and a stated empty list.
+        let writer_desks = writer["desks"].as_array().unwrap();
+        assert_eq!(writer_desks.len(), 1, "{writer}");
+        assert_eq!(writer_desks[0]["id"], "content", "{writer}");
+        assert_eq!(writer_desks[0]["name"], "Content desk", "{writer}");
+        assert_eq!(writer_desks[0]["lead"], true, "{writer}");
+        assert_eq!(ceo["desks"].as_array().unwrap()[0]["lead"], false, "{ceo}");
+        assert!(
+            row_of("hermit")["desks"].as_array().unwrap().is_empty(),
+            "a teammate on no desk says so with an empty list rather than by \
+             omitting the key: {roster}"
+        );
+        assert!(
+            row_of(&jamie)["desks"].as_array().unwrap().is_empty(),
+            "{roster}"
+        );
+    }
+
+    /// An operator-added desk membership reaches the list, not just the detail
+    /// read — otherwise the graph's pillars would go stale the moment somebody
+    /// moved a teammate.
+    #[tokio::test]
+    async fn a_desk_change_shows_up_on_the_roster_list() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, _) = send(
+            &state,
+            "POST",
+            "/api/v1/company/desks/content/members",
+            Some(json!({"agent_id": "hermit"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, roster) = send(&state, "GET", "/api/v1/company/team", None).await;
+        let hermit = roster
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|row| row["id"] == "hermit")
+            .unwrap()
+            .clone();
+        let desks = hermit["desks"].as_array().unwrap();
+        assert_eq!(desks.len(), 1, "{hermit}");
+        assert_eq!(desks[0]["id"], "content", "{hermit}");
+    }
+
+    /// A teammate created through the console reads back with the grant it
+    /// actually holds, so the card the console renders from the POST response
+    /// says the same thing the next list read will.
+    #[tokio::test]
+    async fn a_new_overlay_teammate_is_created_with_the_standard_grant() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Robin", "role": "Support"})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert_eq!(
+            strings(&created["tools"]["effective"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "{created}"
+        );
+        assert!(
+            created["desks"].as_array().unwrap().is_empty(),
+            "nobody has put it on a desk yet: {created}"
+        );
+
+        let (_, detail) = get_agent(&state, created["id"].as_str().unwrap()).await;
+        assert_eq!(created["tools"], detail["tools"], "{created} vs {detail}");
+        assert_eq!(created["desks"], detail["desks"], "{created} vs {detail}");
+    }
+
     // --- The edit half ------------------------------------------------------
 
     /// The issue's "write-once per member", gone: a console-defined teammate can


### PR DESCRIPTION
## Summary

The Overview knowledge graph invented three of its five rings. #602 landed ring 1 — pillars are now the company's real desks. This does the rest, and gives the console a host answer to read instead of a guess.

- **Ring 4 (tools)** was `assignTools`: a deterministic deal of the company-wide `[tools] allow` across teammates by index. Every agent showed a plausible tool list and no agent showed its own. It is now each teammate's **effective grants**, resolved host-side.
- **The workflow ring** was `WORKFLOW_TEMPLATES`: a hardcoded set of routines dealt to desks by position. A company with one real flow drew several fictional ones. It is now the company's actual workflows, with actual stages.
- **Stage → agent** was a round-robin living in `kg/model.ts`, not in the adapter. Deleting the templates alone would have left that invention standing, so a stage now carries the agent the flow names and draws a `runs` edge only to it.

The enabling change is on the host: the roster list already knew each teammate's grants and desks, but `GET {scope}/team` did not carry them, so the console had nothing to read and guessed. Both list and detail now build that answer through **one constructor**, resolving through `agent_effective_grants` — the console cannot show a grant the harness would not honour (#264).

### What is still derived, and why

**Flow placement.** The host scopes a workflow to the *company*; nothing links a flow to a desk. A flow is drawn on the desk of the first teammate it runs through — that placement is this console's reading, not a declared fact, and `DERIVED_NOTICE` says so on screen. Every *value* on the ring (name, summary, stage names, which agent performs which stage) is real. The notice shrinks; it does not empty.

### Relationship to other issues

- **#602 / #486** — ring 1. Merged first; this builds on it and does not revisit its design. Teammates on no desk stay **unplaced** (no pillar, own sector off the core); an earlier revision of this branch drew a "No desk" pillar and that approach was dropped in favour of #602's. Its ring-1 tests are untouched and still pass.
- **#363** (@senamakel) — names `assignTools` as its own. #602's body already argued #363's scope shrinks once desks are read; this deletes `assignTools` outright, so what remains for #363 is the manifest-declaration question, not the display one. Flagging rather than assuming.

## API Or Behavior Changes

**Host — additive only.** `TeamMemberDto` on `GET {scope}/team` gains `tools` (`requested` / `companyAllow` / `effective`) and `desks`. Both are built by the same constructors the single-agent read uses; nothing is recomputed in a second place. No new endpoint, no removed field.

**Console:**

1. A teammate's tool ring is their real effective grants, labelled with the grant **verbatim** (`mcp:*`, `workspace.read`) rather than title-cased prose. Grants are globs from `[tools] allow`, not skill ids or MCP tool names — the previous ring showed strings like a title-cased MCP tool name that corresponded to no grant the host would honour.
2. The workflow ring is the company's real workflows. `listWorkflows` returns summaries only (`id,name,description,editable,enabled`), so drawing stages needs one graph read per workflow — bounded by declared workflow count, not an N+1 over the roster. A workflow that lists but has no saved graph draws as a stub with no stages rather than vanishing.
3. **Three reads are removed from this page**: `listSkills`, `listMcpServers`, and the per-server `discoverMcpTools`. Once the ring shows grant globs, none of them feed anything. This also stops the Overview opening live MCP connections on every page load, and removes its "couldn't read MCP servers" banner. Grants are deliberately **not** intersected against discovered MCP tool names in the console — that would be a second implementation of the host's `grant_matches`, which is the drift #264 exists to prevent.
4. The page states that it is a snapshot: a "Snapshot HH:MM" chip and a Refresh control, with a tooltip saying outright that it is not a live view. No polling is added. One paint is several reads plus one per saved workflow, and this picture changes when an operator does something rather than on the clock; the indefensible part was the silence, not the staleness.

## Tests

New: `frontend/test/unit/overview-graph.test.ts` (16 cases) covering real grants on ring 4, workflows built from saved graphs, stage→agent edges, stage ordering, and the unplaceable-flow fallback.

Every case has a negative control — the fix reverted, the specific test watched to fail, then restored. Reverts run: tools forced to `[]`; the tool label put back through `toUpperCase()`; the stage edge restored to a round-robin; the unplaced-flow `continue` restored; stage order forced to declared order; `DERIVED_NOTICE` re-given its "placeholders" wording.

**One control did not fail, and is reported rather than dressed up.** Removing the edge de-duplication in `orderStages` left the repeated-edge case passing. On inspection the guard was dead and its comment asserted a failure mode the algorithm does not have: a duplicate edge raises the target's in-degree twice *and* is followed twice, so the decrements cancel and the target is released exactly once either way. The guard is deleted in its own commit and that test is marked in-file as documenting behaviour, not as evidence.

**One of #602's ring-1 cases had to change.** `hangs one routine off every drawn desk` asserted `workflows.length === departments.length` and read `f.agentIds` — both properties of the templates this PR deletes. It is rewritten to preserve the concern it was written for (the flow ring must not silently empty when ring 1 changes) as `hangs a saved flow off the desk of the teammate it runs through`. The other 13 cases are untouched; 14/14 pass. `tree-layout.ts`, the `UNPLACED` sentinel and the desk-reading code are untouched.

Gates, all run on the final tree:

```
npm run typecheck        clean
npm run typecheck:unit   clean
npm run typecheck:e2e    clean
npx vitest run           28 files, 305 passed
npm run build            built in 3.92s
cargo fmt --all -- --check          clean
cargo clippy --all-targets -D warns no warnings
cargo test --lib server::           614 passed; 0 failed; 1 ignored
```

`typecheck:unit` and `typecheck:e2e` are load-bearing here, not decoration: `test/unit` and `test/e2e` are standalone `tsc -p` projects that `npm run typecheck` does not cover, and widening `TeamMember` broke the unit project while vitest stayed green.

**Verified on a running host**, not only in unit tests. Booted the branch against the `e2e_harness` company and walked the graph: two pillars with the CEO and the operator unplaced (#602's design intact); Writer showing `composio` / `mcp:*` / `workspace` and the CEO showing `workspace.read` — the manifest's actual per-agent grants, which the old shared-pool deal could not have produced; and one real flow with its real stages, replacing the fabricated routine the previous build drew.

**Not verified:** Playwright e2e was not run (needs a live host in CI).

## Documentation

- `frontend/src/views/overview/README.md` — the derived-rings section now describes what actually remains derived after this change.
- `DERIVED_NOTICE` (the on-screen legend caveat) names only flow placement.
- `Overview`'s module docblock records the snapshot-vs-poll decision and its reasoning.

Closes #601
