### PR TITLE
fix(ops): report and probe the inference endpoint requests actually reach (#597)

### DIFF
--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -497,11 +497,14 @@ async fn test_config(company: ScopedCompany) -> Response {
         Ok(m) => m,
         Err(err) => return err.into_response(),
     };
-    let decl =
-        match resolve_effective(runtime.id(), &manifest, None, runtime.secrets().as_ref()).await {
-            Ok(d) => d,
-            Err(err) => return ApiError(err).into_response(),
-        };
+    let secrets = runtime.secrets().as_ref();
+    // Gate on *tenant* config, with no platform default: the button probes what
+    // the company configured, so "nothing configured" stays a 409 instead of
+    // quietly probing the platform brain on the operator's behalf.
+    let decl = match resolve_effective(runtime.id(), &manifest, None, secrets).await {
+        Ok(d) => d,
+        Err(err) => return ApiError(err).into_response(),
+    };
     match decl {
         None => (
             StatusCode::CONFLICT,
@@ -512,23 +515,45 @@ async fn test_config(company: ScopedCompany) -> Response {
             })),
         )
             .into_response(),
-        Some(decl) => match crate::harness::provider::probe(&decl).await {
-            Ok(()) => Json(serde_json::json!({
-                "ok": true,
-                "provider": decl.provider,
-                "note": "Reached the provider and got a reply.",
-            }))
-            .into_response(),
-            Err(err) => (
-                StatusCode::BAD_GATEWAY,
-                Json(serde_json::json!({
-                    "ok": false,
-                    "error": format!("Inference probe failed: {err}"),
-                    "code": "probe_failed",
-                })),
-            )
+        Some(tenant) => {
+            // Probe with the platform default in place. A `managed` config
+            // inherits both the platform endpoint and its credential, so
+            // resolving without it aimed the probe at the built-in production
+            // URL carrying no bearer at all — a staging tenant whose routing is
+            // perfectly fine would be told its provider is unreachable, on the
+            // same card that was already misreporting the URL (issue #597).
+            let decl = match platform_default(&crate::app::config::ProcessEnv) {
+                None => tenant,
+                Some(platform) => {
+                    match resolve_effective(runtime.id(), &manifest, Some(&platform), secrets).await
+                    {
+                        // Adding the platform default can only add a source,
+                        // never remove the one that just resolved — fall back to
+                        // it rather than inventing an error path for a case that
+                        // cannot happen.
+                        Ok(d) => d.unwrap_or(tenant),
+                        Err(err) => return ApiError(err).into_response(),
+                    }
+                }
+            };
+            match crate::harness::provider::probe(&decl).await {
+                Ok(()) => Json(serde_json::json!({
+                    "ok": true,
+                    "provider": decl.provider,
+                    "note": "Reached the provider and got a reply.",
+                }))
                 .into_response(),
-        },
+                Err(err) => (
+                    StatusCode::BAD_GATEWAY,
+                    Json(serde_json::json!({
+                        "ok": false,
+                        "error": format!("Inference probe failed: {err}"),
+                        "code": "probe_failed",
+                    })),
+                )
+                    .into_response(),
+            }
+        }
     }
 }
 
@@ -758,6 +783,22 @@ mod tests {
             .unwrap();
         assert_eq!(dto.base_url, inference::OPENROUTER_BASE_URL);
         assert_eq!(dto.source, "manifest");
+    }
+
+    /// The probe's gate stays keyed on *tenant* config. Pointing a deployment at
+    /// a platform endpoint gives the probe somewhere real to aim, but it must not
+    /// turn "nothing configured" into a live probe of the platform brain — that
+    /// 409 is the honest answer to "test my provider" from a company that has
+    /// not named one.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn probing_an_unconfigured_company_stays_not_configured() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+
+        let (status, body, _) = send(&state, "POST", "/api/v1/company/inference/test", None).await;
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert_eq!(body["code"], "not_configured");
     }
 
     #[cfg(feature = "openhuman")]

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -27,9 +27,10 @@ use axum::{Json, response::Response};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
+use crate::app::config::EnvSource;
 use crate::company::Inference;
 use crate::company::inference::{
-    self, InferenceSource, RuntimeInference, clear_runtime_config, resolve_effective,
+    self, EnvDefault, InferenceSource, RuntimeInference, clear_runtime_config, resolve_effective,
     save_runtime_config, store_key, validate_runtime,
 };
 use crate::company::runtime::CompanyRuntime;
@@ -79,7 +80,11 @@ struct InferenceStatusDto {
     provider: String,
     /// The stable telemetry slug (`managed` / `openrouter` / `byok` / `ollama`).
     slug: String,
-    /// Resolved OpenAI-compatible base URL.
+    /// Resolved OpenAI-compatible base URL — the endpoint requests actually
+    /// travel to, including the platform default this deployment was pointed at
+    /// with `OPENCOMPANY_INFERENCE_URL`. A `managed` provider inherits that
+    /// endpoint, so resolving this without the platform default printed the
+    /// built-in production constant on every staging tenant (issue #597).
     base_url: String,
     /// Abstract-tier → concrete model id.
     models: BTreeMap<String, String>,
@@ -253,14 +258,85 @@ pub(crate) async fn runner_gap_for(runtime: &CompanyRuntime) -> RunnerGap {
     RunnerGap::NotWired
 }
 
-/// Resolves the effective status DTO. The ops layer resolves *tenant* config
-/// only (no env default), so a company with nothing configured reports the
-/// managed default rather than a synthesized env decl.
+/// This deployment's platform-injected managed default — the same
+/// `(base_url, credential)` pair the harness routes on
+/// ([`harness_inference_from_env`](crate::harness::provider::harness_inference_from_env)),
+/// read from the environment and never from a tenant secret.
+///
+/// `None` off the `openhuman` feature, and `None` when no managed credential
+/// resolves — which is exactly when the harness resolves no env default either.
+/// Deriving it from that one function rather than reading
+/// `OPENCOMPANY_INFERENCE_URL` directly is what keeps display and routing
+/// honest in both directions: a bare URL with no credential routes nowhere, so
+/// the card must not advertise it as the endpoint in use.
+fn platform_default(env: &dyn EnvSource) -> Option<EnvDefault> {
+    #[cfg(feature = "openhuman")]
+    {
+        crate::harness::provider::harness_inference_from_env(env).map(|(config, _)| EnvDefault {
+            base_url: config.base_url,
+            credential: config.credential,
+        })
+    }
+    #[cfg(not(feature = "openhuman"))]
+    {
+        let _ = env;
+        None
+    }
+}
+
+/// Resolves the effective status DTO against the real process environment.
 async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto, ApiError> {
+    effective_status_with(
+        runtime,
+        platform_default(&crate::app::config::ProcessEnv).as_ref(),
+    )
+    .await
+}
+
+/// [`effective_status`] against an explicit platform default, so the resolution
+/// is testable without touching the process environment.
+///
+/// Two resolves, deliberately, because the card answers two different questions
+/// (issue #597):
+///
+/// - **What did the tenant configure?** — resolved with no env default, and the
+///   only thing `source`, `keyConfigured` and `restartRequired` may see. A
+///   platform endpoint is not tenant config: reporting it as `source: "default"`
+///   would move the badge, reporting the platform token as `keyConfigured` would
+///   tell an operator a key they never set is stored (and that blanking the
+///   field "keeps" it), and feeding it to [`restart_pending`] would strand a
+///   company behind a restart that changes nothing. That is the intent the old
+///   `None` argument was protecting, and it survives here intact.
+/// - **Where do requests actually go?** — resolved *with* the platform default,
+///   and used for `baseUrl` alone. `managed` inherits the platform endpoint, so
+///   without it every non-production tenant rendered the built-in production
+///   constant: both the `None` arm below and any tenant whose own config names
+///   `managed` without its own `base_url`.
+async fn effective_status_with(
+    runtime: &CompanyRuntime,
+    platform: Option<&EnvDefault>,
+) -> Result<InferenceStatusDto, ApiError> {
     let manifest = manifest_inference(runtime).await?;
-    let decl = resolve_effective(runtime.id(), &manifest, None, runtime.secrets().as_ref())
+    let secrets = runtime.secrets().as_ref();
+    let decl = resolve_effective(runtime.id(), &manifest, None, secrets)
         .await
         .map_err(ApiError)?;
+    let base_url = match platform {
+        // Re-resolve with the platform default in place rather than
+        // reconstructing `resolve_endpoint`'s precedence here — the tenant's own
+        // `base_url` still outranks it, and only the `managed` kind inherits it.
+        Some(platform) => resolve_effective(runtime.id(), &manifest, Some(platform), secrets)
+            .await
+            .map_err(ApiError)?
+            .map_or_else(|| inference::MANAGED_BASE_URL.to_string(), |d| d.base_url),
+        // No platform endpoint on this deployment: nothing to inherit, so the
+        // tenant resolve already holds the whole answer and the second read is
+        // skipped.
+        None => decl.as_ref().map_or_else(
+            || inference::MANAGED_BASE_URL.to_string(),
+            |d| d.base_url.clone(),
+        ),
+    };
     // What the company actually booted onto, not what the config implies.
     let cognition = runtime.cognition();
     let restart_required = restart_pending(runtime, decl.is_some());
@@ -268,7 +344,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
         Some(d) => InferenceStatusDto {
             provider: d.provider.clone(),
             slug: d.telemetry_slug().to_string(),
-            base_url: d.base_url.clone(),
+            base_url,
             models: d.models.clone(),
             source: source_label(d.source).to_string(),
             key_configured: d.key_configured(),
@@ -279,7 +355,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<InferenceStatusDto
         None => InferenceStatusDto {
             provider: "managed".to_string(),
             slug: "managed".to_string(),
-            base_url: inference::MANAGED_BASE_URL.to_string(),
+            base_url,
             models: BTreeMap::new(),
             source: "managed".to_string(),
             key_configured: false,
@@ -471,6 +547,8 @@ mod tests {
     use serde_json::{Value, json};
     use tower::ServiceExt;
 
+    use super::*;
+
     use crate::company::CompanyManifest;
     use crate::ports::types::{CompanyId, CompanyRecord};
     use crate::runtime::RuntimeBuilder;
@@ -491,14 +569,13 @@ mod tests {
         toml::from_str("[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n").unwrap()
     }
 
-    async fn state_with_company(home: &std::path::Path) -> AppState {
+    /// Commits `manifest` as `id`'s record — what `manifest_inference` reads.
+    async fn save_record(home: &std::path::Path, id: &CompanyId, manifest: &CompanyManifest) {
         use crate::ports::CompanyStore;
-        let store = FsCompanyStore::new(home.to_path_buf());
-        let id = CompanyId::new("acme");
-        store
+        FsCompanyStore::new(home.to_path_buf())
             .save(&CompanyRecord {
                 id: id.clone(),
-                manifest: manifest(),
+                manifest: manifest.clone(),
                 ledger: Vec::new(),
                 lifecycle: "running".to_string(),
                 overlay_agents: Vec::new(),
@@ -512,6 +589,11 @@ mod tests {
             })
             .await
             .unwrap();
+    }
+
+    async fn state_with_company(home: &std::path::Path) -> AppState {
+        let id = CompanyId::new("acme");
+        save_record(home, &id, &manifest()).await;
         let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
             .with_id(id.clone())
             .build()
@@ -550,6 +632,153 @@ mod tests {
             serde_json::from_slice(&bytes).unwrap_or(Value::Null)
         };
         (status, value, raw)
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #597 — the card must report the endpoint requests actually reach,
+    // not the built-in production constant.
+    // ---------------------------------------------------------------------
+
+    /// Where a staging deployment is pointed with `OPENCOMPANY_INFERENCE_URL`.
+    const STAGING_URL: &str = "https://staging-api.tinyhumans.ai/openai/v1";
+
+    /// The platform default a staging tenant is injected with.
+    fn staging_platform() -> EnvDefault {
+        EnvDefault {
+            base_url: STAGING_URL.to_string(),
+            credential: crate::company::credentials::Credential::from_value(
+                "platform-token".to_string(),
+            ),
+        }
+    }
+
+    /// A built runtime whose committed manifest is `manifest_toml`.
+    async fn runtime_with(home: &std::path::Path, manifest_toml: &str) -> CompanyRuntime {
+        let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+        let id = CompanyId::new("acme");
+        save_record(home, &id, &manifest).await;
+        RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id)
+            .build()
+            .await
+            .unwrap()
+    }
+
+    const NO_INFERENCE: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n";
+
+    #[tokio::test]
+    async fn unconfigured_company_reports_the_platform_url_not_the_built_in_default() {
+        let home_dir = home();
+        let runtime = runtime_with(home_dir.path(), NO_INFERENCE).await;
+
+        // No platform endpoint on this deployment — the built-in constant is
+        // still the only honest answer, and this arm must not regress.
+        let dto = effective_status_with(&runtime, None).await.unwrap();
+        assert_eq!(dto.base_url, inference::MANAGED_BASE_URL);
+
+        // Pointed at staging, the card follows — and *only* the URL moves.
+        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+            .await
+            .unwrap();
+        assert_eq!(dto.base_url, STAGING_URL);
+        assert_eq!(dto.provider, "managed");
+        assert_eq!(
+            dto.source, "managed",
+            "a platform endpoint is not tenant config"
+        );
+        assert!(
+            !dto.key_configured,
+            "the platform token is not a stored tenant key"
+        );
+        assert!(
+            !dto.restart_required,
+            "a platform endpoint strands no tenant config behind a restart"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_managed_manifest_also_inherits_the_platform_url() {
+        // The half of #597 the report did not cover: `resolve_endpoint` falls
+        // back to the built-in constant for *any* `managed` config that names no
+        // base URL of its own, so a tenant with `[inference] provider =
+        // "managed"` printed the production URL too — under a `manifest` badge
+        // rather than the `managed` one the report reproduced.
+        let home_dir = home();
+        let runtime = runtime_with(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [inference]\nprovider = \"managed\"\n",
+        )
+        .await;
+
+        let dto = effective_status_with(&runtime, None).await.unwrap();
+        assert_eq!(dto.base_url, inference::MANAGED_BASE_URL);
+
+        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+            .await
+            .unwrap();
+        assert_eq!(dto.base_url, STAGING_URL);
+        assert_eq!(dto.source, "manifest");
+        assert!(
+            !dto.key_configured,
+            "the platform token must not read as a tenant key on a managed manifest"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_explicit_tenant_base_url_outranks_the_platform_default() {
+        let home_dir = home();
+        let runtime = runtime_with(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [inference]\nprovider = \"managed\"\nbase_url = \"https://byo.example/v1\"\n",
+        )
+        .await;
+
+        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+            .await
+            .unwrap();
+        assert_eq!(dto.base_url, "https://byo.example/v1");
+    }
+
+    #[tokio::test]
+    async fn a_non_managed_provider_ignores_the_platform_default() {
+        // Only `managed` inherits the platform endpoint; every other kind uses
+        // its own resolved URL verbatim.
+        let home_dir = home();
+        let runtime = runtime_with(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [inference]\nprovider = \"openrouter\"\n",
+        )
+        .await;
+
+        let dto = effective_status_with(&runtime, Some(&staging_platform()))
+            .await
+            .unwrap();
+        assert_eq!(dto.base_url, inference::OPENROUTER_BASE_URL);
+        assert_eq!(dto.source, "manifest");
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[test]
+    fn platform_default_follows_the_injected_inference_url() {
+        use crate::app::config::MapEnv;
+
+        let env = MapEnv::new([
+            ("TINYHUMANS_API_KEY", "platform-key"),
+            ("OPENCOMPANY_INFERENCE_URL", STAGING_URL),
+        ]);
+        assert_eq!(
+            platform_default(&env).map(|d| d.base_url),
+            Some(STAGING_URL.to_string())
+        );
+
+        // A URL with no credential resolves to nothing — the same answer the
+        // harness gives, so the card never advertises an endpoint that would
+        // route nowhere.
+        let bare = MapEnv::new([("OPENCOMPANY_INFERENCE_URL", STAGING_URL)]);
+        assert!(platform_default(&bare).is_none());
     }
 
     #[tokio::test]

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -263,12 +263,22 @@ pub(crate) async fn runner_gap_for(runtime: &CompanyRuntime) -> RunnerGap {
 /// ([`harness_inference_from_env`](crate::harness::provider::harness_inference_from_env)),
 /// read from the environment and never from a tenant secret.
 ///
-/// `None` off the `openhuman` feature, and `None` when no managed credential
-/// resolves — which is exactly when the harness resolves no env default either.
-/// Deriving it from that one function rather than reading
-/// `OPENCOMPANY_INFERENCE_URL` directly is what keeps display and routing
-/// honest in both directions: a bare URL with no credential routes nowhere, so
-/// the card must not advertise it as the endpoint in use.
+/// `None` when no managed credential resolves — which is exactly when the
+/// harness resolves no env default either. Deriving it from that one function
+/// rather than reading `OPENCOMPANY_INFERENCE_URL` directly is what keeps
+/// display and routing honest in both directions: a bare URL with no credential
+/// routes nowhere, so the card must not advertise it as the endpoint in use.
+///
+/// Also `None` off the `openhuman` feature, which is a shipped configuration
+/// (`Dockerfile`'s `FEATURES` arg defaults to empty, and `deploy/README.md`
+/// suggests sets like `medulla tinyplace sqlite`) — but not a gap. Nothing
+/// outside `src/harness/` reads `OPENCOMPANY_INFERENCE_URL`, so in such a build
+/// there is no injected endpoint for the card to misreport: the built-in
+/// constant is the only inference endpoint that exists, and the company is on
+/// the echo or hosted brain, which `cognition` reports on its own. The medulla
+/// hosted path talks to `DEFAULT_API_URL` over its own socket protocol rather
+/// than an OpenAI-compatible surface, so it is not an endpoint `baseUrl`
+/// describes either.
 fn platform_default(env: &dyn EnvSource) -> Option<EnvDefault> {
     #[cfg(feature = "openhuman")]
     {
@@ -691,6 +701,9 @@ mod tests {
 
     const NO_INFERENCE: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n";
 
+    const MANAGED_MANIFEST: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [inference]\nprovider = \"managed\"\n";
+
     #[tokio::test]
     async fn unconfigured_company_reports_the_platform_url_not_the_built_in_default() {
         let home_dir = home();
@@ -729,12 +742,7 @@ mod tests {
         // "managed"` printed the production URL too — under a `manifest` badge
         // rather than the `managed` one the report reproduced.
         let home_dir = home();
-        let runtime = runtime_with(
-            home_dir.path(),
-            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
-             [inference]\nprovider = \"managed\"\n",
-        )
-        .await;
+        let runtime = runtime_with(home_dir.path(), MANAGED_MANIFEST).await;
 
         let dto = effective_status_with(&runtime, None).await.unwrap();
         assert_eq!(dto.base_url, inference::MANAGED_BASE_URL);
@@ -748,6 +756,51 @@ mod tests {
             !dto.key_configured,
             "the platform token must not read as a tenant key on a managed manifest"
         );
+    }
+
+    /// Three inputs converge on `keyConfigured`, and exactly one of them must
+    /// never feed it. Today the tenant sources are a manifest `api_key_secret`
+    /// and a console `PUT`; #634 makes the console path the ordinary way an
+    /// admin sets the key on `managed`, which is precisely the provider that
+    /// inherits the platform credential. So the field has to keep answering
+    /// "did the *tenant* store a credential" and never "is there a credential",
+    /// on the one company where both are true at once.
+    ///
+    /// Pinned here rather than left to review: without it the distinction this
+    /// PR's two-resolve split exists to preserve is enforced by nothing.
+    #[tokio::test]
+    async fn a_platform_token_never_reads_as_a_console_set_key() {
+        let home_dir = home();
+        let runtime = runtime_with(home_dir.path(), MANAGED_MANIFEST).await;
+        let platform = staging_platform();
+
+        // The platform credential is doing the outbound work, and the card still
+        // says no key is configured — because none of it is the tenant's.
+        let dto = effective_status_with(&runtime, Some(&platform))
+            .await
+            .unwrap();
+        assert!(
+            !dto.key_configured,
+            "the platform token is not a stored tenant key"
+        );
+        assert_eq!(dto.base_url, STAGING_URL);
+
+        // An admin sets one from the console — the write #634's screen performs.
+        inference::store_key(runtime.id(), runtime.secrets().as_ref(), "sk-console-set")
+            .await
+            .unwrap();
+
+        let dto = effective_status_with(&runtime, Some(&platform))
+            .await
+            .unwrap();
+        assert!(
+            dto.key_configured,
+            "a console-set key must read as configured even on managed"
+        );
+        // Same company, same injected platform default, opposite answer — and the
+        // endpoint is unmoved either way: paying for your own agents on the
+        // managed brain does not take you off it.
+        assert_eq!(dto.base_url, STAGING_URL);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #597.

## What was wrong

Two resolvers, only one env-aware. **Routing** (`resolve_endpoint`, `src/company/inference.rs:180`) treats `managed` as the platform brain and inherits `env_default.base_url`, which comes from `hosted_endpoint_from_env` reading `OPENCOMPANY_INFERENCE_URL` — outbound calls followed the env correctly all along. **Display** (`effective_status`, `src/server/ops/inference.rs`) passed `None` into that slot, so resolution fell through to the hardcoded `MANAGED_BASE_URL`. The card contradicted the traffic, and no configuration could change what it printed.

Two things the issue does not cover, both fixed here:

**It is not only the unconfigured arm.** The report reproduced `source: "managed"` and points at the `None` arm's hardcoded constant. But `resolve_endpoint` falls back to the same constant for *any* `managed` config that names no `base_url` of its own — so a tenant with `[inference] provider = "managed"` in `company.toml`, or a console override set to managed, printed the production URL too, under a `manifest`/`runtime` badge. Fixing only the `None` arm would have left most of the surface wrong.

**`POST /inference/test` had the same defect** (second commit). It resolved with `None` as well, so for a `managed` config the probe got the hardcoded production base URL *and* `Credential::None` — it fired at the wrong host with no bearer. A staging tenant whose routing is fine was told its provider is unreachable. That is a wrong verdict on the same card, not just a wrong label. It is a separate commit for reviewability, **not as a ship option** — see *Merge order* below.

## Approach

The issue's option 1, but applied literally it breaks three other fields: passing the env default straight into `resolve_effective` makes step 3 synthesize a decl, which moves `source` from `managed` to `default`, flips `keyConfigured` to true (the console then renders a "key set" badge and an "API key (leave blank to keep)" hint for a key the operator never set), and feeds `decl.is_some()` into `restart_pending`, telling operators to restart for config that does not exist. The `None` was protecting something real — it was just protecting the URL too.

So the resolution is split. Tenant config resolves with no env default and stays the only input to `source`, `keyConfigured` and `restartRequired`; the base URL alone resolves with the platform default in place. That default is derived from `harness_inference_from_env` — the same function the harness routes on — rather than from reading `OPENCOMPANY_INFERENCE_URL` directly, because a URL with no credential resolves to `None` there. The card therefore never advertises an endpoint that would route nowhere.

Option 2 (`platformBaseUrl` / `baseUrlSource`) was considered and skipped: the existing `source` field already separates "this is your tenant config" from "this is the platform default", so the extra field would restate it.

## On the web-search aside

`search_backend_from_env`'s hardcoded default is a *routing* default that `OPENCOMPANY_SEARCH_BACKEND_URL` overrides correctly, the same way inference routing already did. No ops surface renders it — `capabilities.rs:187` reports only a bool. There is no display bug to fix there, so nothing changed.

## Merge order and the `keyConfigured` invariant

**Do not partially merge this.** The probe commit is split out so the two changes can be read apart, not so the second can be dropped. Dropping it would leave the card worse than today rather than better: `baseUrl` would render the correct staging endpoint while `POST /inference/test` still fires at the hardcoded production host with `Credential::None` and reports the provider unreachable. Two adjacent fields contradicting each other is harder for an operator to reason about than both being wrong in the same direction.

**Order against #634: this PR first, then #634 rebases on it.** They are textually adjacent but semantically independent — #634 touches `src/server/ops/inference.rs` only to extend the module doc header and add `managed_key_can_be_set_rotated_and_cleared`; the backend already preferred a stored key over `EnvDefault` on `managed`, and the `inference-key-conflict` guard it retires is frontend-only. So neither changes behaviour the other depends on, and the conflict is a mechanical one in the test module.

The invariant is worth more than the ordering, so it is pinned here rather than deferred to whichever lands second: `a_platform_token_never_reads_as_a_console_set_key` drives one company with one injected platform default to both answers — no tenant key reads `keyConfigured: false` while the platform token does the outbound work, a console-set key reads `true`, and the resolved endpoint stays the platform's either way. #634's new source then arrives against a test that already separates the three.

## API change

`baseUrl` on `GET /api/v1/company/inference` now reports the platform endpoint when one is injected. Every other field is byte-identical. No frontend change needed — the console already renders whatever `baseUrl` holds.

## Tests

Five new tests: the unconfigured arm follows the platform URL while `source`/`keyConfigured`/`restartRequired` stay put; a `managed` manifest inherits it too; an explicit tenant `base_url` still outranks it; a non-managed provider ignores it; and `platform_default` follows `OPENCOMPANY_INFERENCE_URL` but resolves to nothing without a credential. Plus one pinning the probe's 409 gate. I verified they are not vacuous by reverting the fix — the two fix-specific ones fail, the over-reach guards stay green.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test                                    # 1813 passed
```

The `openhuman` lane cannot build on the pinned `stable` (1.93.0): `libsqlite3-sys 0.38.1`'s build script uses unstable `cfg_select!`. That is pre-existing and unrelated — it dies in a third-party build script before `opencompany` compiles. Verified on the installed 1.96.1 instead, which is the only way to exercise `platform_default` and the probe:

```
cargo +1.96.1 clippy -p opencompany --features openhuman --all-targets --no-deps -- -D warnings
cargo +1.96.1 test --features openhuman --lib server::ops::inference   # 16 passed
```

(`--no-deps` because vendored `tinyagents` trips `large_enum_variant` on 1.96 — also pre-existing, also unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
