### PR TITLE
feat(connections): broker providers through the company's own TinyHumans credential (#586)

### DIFF
--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -43,8 +43,9 @@ Supporting docs:
   hand over → swap), so a first-time inference config needs no restart
 - [api.md](api.md) — HTTP routes and auth
 - [credentials.md](credentials.md) — the company's own TinyHumans key: the one
-  seam every brokered surface resolves through, and why rotating it reaches all
-  of them
+  seam a brokered surface resolves through (Composio today), why rotating it
+  reaches every surface wired to it, and which surfaces are deliberately outside
+  it
 - [config.md](config.md) — configuration and the one-key story
 - [users.md](users.md) — human collaborators: magic-link/password sign-in,
   sessions, invites, and chat attribution

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -42,6 +42,9 @@ Supporting docs:
 - [rebuild.md](rebuild.md) — replacing a registered runtime in place (quiesce →
   hand over → swap), so a first-time inference config needs no restart
 - [api.md](api.md) — HTTP routes and auth
+- [credentials.md](credentials.md) — the company's own TinyHumans key: the one
+  seam every brokered surface resolves through, and why rotating it reaches all
+  of them
 - [config.md](config.md) — configuration and the one-key story
 - [users.md](users.md) — human collaborators: magic-link/password sign-in,
   sessions, invites, and chat attribution

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -291,6 +291,8 @@ dependency-inverted behind a trait; when the relevant seam is absent the write
 route `404`s with `{"code":"not_wired"}`.
 
 ```text
+GET    …/credential                         whether the company has its own key + which tier it presents
+PUT    …/credential                         set / rotate / clear the company's TinyHumans key  [admin]
 PUT    …/domain                             set the custom domain
 POST   …/domain/verify                       server-side DNS check
 PUT    …/smtp                               store SMTP credentials (secret store)
@@ -299,6 +301,13 @@ POST   …/connections/{provider}/start        begin OAuth (returns authorize UR
 POST   …/connections/{provider}/disconnect   drop stored OAuth tokens               [feature: oauth]
 GET    /api/v1/oauth/callback                OAuth redirect target (unscoped; state carries the company)  [feature: oauth]
 ```
+
+`…/credential` is the company's **one** TinyHumans key, and every surface the
+platform brokers on its behalf presents it — so a company with a key set
+connects a provider with no per-tenant provider app and no second token. The
+resolution order, the rotation guarantee, why it is not the inference key, and
+what it deliberately does not cover are in
+[`credentials.md`](credentials.md).
 
 ### The OAuth callback always redirects
 

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -302,12 +302,10 @@ POST   …/connections/{provider}/disconnect   drop stored OAuth tokens         
 GET    /api/v1/oauth/callback                OAuth redirect target (unscoped; state carries the company)  [feature: oauth]
 ```
 
-`…/credential` is the company's **one** TinyHumans key, and every surface the
-platform brokers on its behalf presents it — so a company with a key set
-connects a provider with no per-tenant provider app and no second token. The
-resolution order, the rotation guarantee, why it is not the inference key, and
-what it deliberately does not cover are in
-[`credentials.md`](credentials.md).
+`…/credential` is the company's **one** TinyHumans key, presented by every
+surface wired to it (**Composio today**) — see
+[`credentials.md`](credentials.md) for the resolution order, the rotation
+guarantee, and which surfaces are deliberately outside it.
 
 ### The OAuth callback always redirects
 

--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -50,6 +50,16 @@ account, so its full order is `composio/token` → company key → instance
 identity → none. What no surface may do is resolve a *company* identity some
 other way.
 
+That composed order is itself derived **once**, in
+`company::composio::resolve_credential` — not in the harness. The agent-facing
+`TenantComposio::resolve` builds its config from it, and the console's
+`GET …/composio` reports its `source`, so the tier an operator is shown cannot
+disagree with the identity the agents actually present. It lives in the
+always-compiled `company::` module rather than the feature-gated `harness::`
+one precisely so both callers can share it in every build; a console route that
+restated the precedence instead would keep confidently reporting a tier after
+the resolver stopped honouring it.
+
 ## Rotation
 
 The rotation guarantee — "rotating the company key does not silently leave one

--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -44,6 +44,38 @@ resolved. Most specific first:
    degraded state rather than offering a picker that cannot work. An absent
    credential means "no tools", never a borrowed identity.
 
+### An unreadable store is not "no key"
+
+A `SecretStore` read error **propagates** rather than falling through to the next
+tier. The tempting shortcut is to map it to "nothing stored" so a transient
+hiccup cannot brick a roster build — right about availability, wrong about
+attribution.
+
+A connection lives on the backend keyed by the account the bearer resolves to.
+If an unreadable store silently resolved a company that *has* a key to the
+instance's identity, any connection established in that window would belong to
+the instance's account. When the store recovered, resolution would return the
+company key, the bearer would resolve to a different entity, and the connection
+made under the fallback would no longer be the one the company sees — the same
+"connect Gmail" click producing a different owner depending on store health at
+that instant, with no signal either way.
+
+Availability-degrade and identity-degrade are different decisions, and only the
+first is safe to make silently. So each caller answers the error in the way its
+own surface can afford:
+
+- **The roster build** (`TenantComposio::resolve`) logs a warning and withholds
+  the tools for that cycle. Fail closed: an *unknown* credential must no more
+  mean a borrowed identity than an absent one does. The company loses Composio
+  for a cycle and gets it back on the next.
+- **The console planes** (`GET …/composio`, `GET …/credential`) surface the
+  failure instead of reporting a confident "not configured" for a company that
+  may well have a key.
+- **`POST …/composio/authorize`** — the call that actually *establishes* a
+  connection — refuses outright. It resolves the credential itself rather than
+  through the roster path, precisely so a store error stays distinguishable from
+  "nothing configured" and cannot be guessed past.
+
 A surface may prepend its **own** escape hatch above that seam. Composio keeps
 its BYO `composio/token` for a company that insists on using its own Composio
 account, so its full order is `composio/token` → company key → instance
@@ -78,6 +110,15 @@ Two mechanics make it land without a restart:
   and hashing its value would rebuild every agent's roster on that schedule. A
   company key is rotated by a person, on purpose, and a new value really is a
   new identity.
+
+**The fingerprint is internal and must stay internal.** It is a value-derived
+hash of a live credential, which makes it a cheap confirmation oracle for anyone
+who can read it: given a guess at the key, you can confirm it. It lives only in
+`HarnessPool`'s in-memory `RwLock<HashMap<CompanyId, u64>>` and is compared for
+equality — no `tracing` call renders it, no DTO serializes it, and no journal
+event carries it. Do not log it, return it from a route, or put it in an event,
+even for debugging; if a rebuild needs explaining, log *that the identity
+changed*, never the hash.
 
 ## Write-only, and admin-only
 

--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -1,0 +1,121 @@
+# The company credential
+
+How a company proves who it is to the surfaces the platform brokers on its
+behalf (issue #586). The routes are listed in
+[`api.md`](api.md#credential-bearing-surfaces-feature-gated); this is the model
+behind them.
+
+## One key per company
+
+A company belongs to one owner. Its admin sets **one** TinyHumans key through
+`PUT …/credential`, and everything the platform backend brokers for the company
+rides it. Membership in the company is what grants access to it.
+
+Composio is the first consumer, and it is the one that shows why this works: the
+backend derives the Composio entity from whatever bearer it is handed, and a
+TinyHumans key is a bearer it recognises. So the key **authorizes Composio
+directly** — there is no provisioning step that trades it for a second token,
+and no per-tenant provider application to register with Google, Slack or GitHub.
+A company with a key set connects Gmail by clicking Connect.
+
+## Where a connection lives
+
+On the backend, keyed by the account the bearer resolves to — under this model,
+the company's owning account. Nothing about a connection is scoped to the member
+who made it, and nothing new is stored on the instance.
+
+That is what makes "connect Gmail once, every teammate's agents can use it" true:
+every agent in the company resolves the *same* credential from the *company's*
+store, so the backend resolves one entity for all of them. It is a property of
+the resolution, not a feature layered on top of it.
+
+## Resolution — one seam
+
+`company::company_key::resolve` is the only place a company identity is
+resolved. Most specific first:
+
+1. **The company's own key** — `tinyhumans/key` in its `SecretStore`, set by an
+   admin through the console.
+2. **This instance's platform identity** — `TinyhumansTokenSource`: a projected,
+   audience-bound pod token the cluster rotates in place, else a static
+   `TINYHUMANS_API_KEY`. Unchanged behaviour for a tenant whose admin set
+   nothing.
+3. **Nothing** ⇒ fail closed. No tools are wired, and the read planes report the
+   degraded state rather than offering a picker that cannot work. An absent
+   credential means "no tools", never a borrowed identity.
+
+A surface may prepend its **own** escape hatch above that seam. Composio keeps
+its BYO `composio/token` for a company that insists on using its own Composio
+account, so its full order is `composio/token` → company key → instance
+identity → none. What no surface may do is resolve a *company* identity some
+other way.
+
+## Rotation
+
+The rotation guarantee — "rotating the company key does not silently leave one
+brokered surface on the old credential" — is structural rather than a
+convention. Because every brokered surface calls the one resolver, there is no
+second resolution that could drift, and no surface that could forget to re-read.
+
+Two mechanics make it land without a restart:
+
+- The key is read **live** from the secret store on every resolution, so a set /
+  rotate / clear takes effect on the next cycle.
+- The resolved credential contributes its **value** to the harness roster
+  fingerprint (`Credential::hash_identity`), so a rotation rebuilds the tool
+  roster. This is deliberately different from the projected platform token,
+  which contributes its *path*: the cluster rotates that one every few minutes
+  and hashing its value would rebuild every agent's roster on that schedule. A
+  company key is rotated by a person, on purpose, and a new value really is a
+  new identity.
+
+## Write-only, and admin-only
+
+The key is sent on the `key` field, stored, and never echoed. No read route
+returns it; `GET …/credential` carries `configured` plus `source` — one of
+`company` / `attested` / `static` / `none`, the same vocabulary `GET …/composio`
+and the connections read plane already use. `Credential`'s `Debug` redacts it,
+and the Composio tools feed whatever value they resolve to the scrubber as a
+known secret, so it cannot survive into agent-visible output.
+
+`PUT` requires an admin. This key is the identity every one of the company's
+agents presents **and** the account they all spend against, so setting it is a
+decision made for the company rather than a member's own — the same reasoning
+that made `PUT …/composio/token` admin-only in issue #403. Both a set and a
+clear are journaled as `ToolAccessChanged`, told apart from each other, and
+attributed to whoever made the change.
+
+## Not the inference key
+
+`inference/key` is a different thing and must stay a different slot. It holds
+whatever credential the company's *declared provider* wants — an OpenRouter
+`sk-or-…`, a raw BYOK token, an `openai_compatible` key. It is provider-scoped,
+not an identity, and handing it to the TinyHumans backend would present one
+vendor's credential to another. The two coincide only when the declared provider
+is `managed`, and even then they are the same value for different reasons.
+
+## What this does not cover
+
+- **The native OAuth catalog.** `…/connections/{provider}/start` still resolves
+  through `HostConnectRoutes` — a stored provider token, else a *projected*
+  instance identity, else this host's own registered provider application. That
+  precedence is unchanged, so `source: "company"` never appears on a native-only
+  provider. That path is entangled with the inert-catalog question in #396 and is
+  left alone deliberately rather than papered over.
+- **Chat inference and embeddings.** Both still resolve from the environment via
+  `hosted_endpoint_from_env`. Moving them onto this seam is issue #585; when it
+  lands they inherit the rotation guarantee by construction, because the seam is
+  already here.
+- **Media generation and `web_search`.** Deliberately environment-only: those run
+  on the *platform's* managed credential, never a company-controlled one.
+
+## Known limits, recorded deliberately
+
+- **No per-member attribution.** Spend arrives as one account, so which member
+  burned what is not answerable. Per-agent `budget_usd_daily` caps still work;
+  per-person accounting does not exist and is not in scope.
+- **Removing someone from the roster stops future access**, but nothing already
+  spent is separable.
+- **Two companies pasting the same key share one entity.** That cannot be
+  prevented client-side; it is a deployment caveat, the same one the BYO Composio
+  token already carries.

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -19,10 +19,15 @@ import type { OpenCompanyClient } from "./client";
  * Where this company's Composio credential comes from.
  *
  * - `attested` — the instance's own platform identity; nothing is stored here.
- * - `static` — a token this company pasted, or a static instance key.
+ * - `company` — this company's **own** TinyHumans credential, set by its admin
+ *   (issue #586). The backend derives the Composio entity from it, so a company
+ *   with a key set connects providers as itself with no Composio token and no
+ *   per-tenant provider app. Rotating that one key moves every brokered surface
+ *   at once — see `api/credential.ts`.
+ * - `static` — a Composio token this company pasted, or a static instance key.
  * - `none` — no credential can be obtained, so agents get no Composio tools.
  */
-export type ComposioCredentialSource = "attested" | "static" | "none";
+export type ComposioCredentialSource = "attested" | "company" | "static" | "none";
 
 /**
  * One provider in the catalog the host offers, with the backend's own display

--- a/frontend/src/api/credential.ts
+++ b/frontend/src/api/credential.ts
@@ -1,0 +1,75 @@
+// The company's own TinyHumans credential (issue #586): the one key its admin
+// sets on this tenant, and the identity every surface the platform brokers
+// presents on the company's behalf.
+//
+// Set it once and Composio rides it — no separate Composio token, no per-tenant
+// provider app to register. Rotate it and every brokered surface moves together,
+// because they all resolve through one seam on the host rather than each keeping
+// its own copy.
+//
+// WRITE-ONLY, like every other credential the console handles: the key goes out
+// on `PUT .../credential`, lands in the host's secret store, and is never
+// returned. The read shape carries only `configured` plus the non-secret tier
+// name. Standalone functions over the shared client (mirrors `api/composio.ts`).
+//
+// NOT the same thing as the inference key in `api/inference.ts`. That one holds
+// whatever the company's *declared provider* wants — an OpenRouter key, a raw
+// BYOK token — so it is provider-scoped, not an identity, and handing it to the
+// TinyHumans backend would present one vendor's credential to another.
+
+import type { OpenCompanyClient } from "./client";
+
+/**
+ * Which identity this company's brokered calls present right now.
+ *
+ * - `company` — this company's own key. What setting one buys you.
+ * - `attested` / `static` — no company key set, so calls fall back to the
+ *   instance's platform identity.
+ * - `none` — neither, so providers cannot be connected or used at all. The
+ *   honest degraded state, and the one the picker must not paper over.
+ */
+export type CompanyCredentialSource = "company" | "attested" | "static" | "none";
+
+/** The company's credential status. Never carries the key. */
+export interface CompanyCredentialStatus {
+  /**
+   * Whether this company has its **own** key stored. `false` does not mean no
+   * credential — read {@link source} for what calls actually present.
+   */
+  configured: boolean;
+  /** Which identity a brokered call presents right now. */
+  source: CompanyCredentialSource;
+  /**
+   * The consequence of setting this key, or the degraded state when nothing can
+   * be presented. Rendered verbatim: the host words it, so the console cannot
+   * drift from what the host actually does.
+   */
+  notice: string;
+}
+
+/** A mutating response: the resulting status plus a plain-language note. */
+export interface CompanyCredentialMutation {
+  status: CompanyCredentialStatus;
+  note: string;
+}
+
+/** Whether this company has its own credential, and which identity it presents. */
+export function getCompanyCredential(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<CompanyCredentialStatus> {
+  return client.get<CompanyCredentialStatus>(`${client.scopeFor(company)}/credential`);
+}
+
+/**
+ * Set / rotate / clear the company's TinyHumans credential. A non-empty value
+ * sets or rotates it; an empty string clears it, falling back to the instance's
+ * platform identity where there is one. Admin-only — a member gets a 403.
+ */
+export function setCompanyCredential(
+  client: OpenCompanyClient,
+  company: string | null,
+  key: string,
+): Promise<CompanyCredentialMutation> {
+  return client.put<CompanyCredentialMutation>(`${client.scopeFor(company)}/credential`, { key });
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -723,11 +723,15 @@ export interface InboxMessageDto {
  * - `attested` — this instance carries a platform-minted identity, so
  *   connections are the platform's to run. Nothing to register here, and the
  *   console offers no local Connect.
+ * - `company` — this company's own TinyHumans credential (issue #586). Reported
+ *   by the Composio plane, which brokers through it. The native OAuth catalog
+ *   does **not** route through the company key today, so this value does not
+ *   appear on a native-only provider — see `api/credential.ts`.
  * - `static` — a token this company already stored, or this host's own
  *   registered provider application (the self-hosted hatch). Connect works.
  * - `none` — neither, so no Connect can succeed on this host.
  */
-export type ConnectionCredentialSource = "attested" | "static" | "none";
+export type ConnectionCredentialSource = "attested" | "company" | "static" | "none";
 
 /**
  * One third-party connection's state, from `GET .../connections`.

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -28,6 +28,7 @@ import { cn } from "@/lib/utils";
 import { armTourResume } from "@/tour/state";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { McpServersSection } from "@/views/connections/McpServersSection";
+import { CompanyCredentialCard } from "@/views/connections/CompanyCredentialCard";
 import { ComposioSection } from "@/views/connections/ComposioSection";
 import { ChannelsSection } from "./connections/ChannelsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
@@ -55,6 +56,9 @@ export function ConnectionsView({ client, company }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [states, setStates] = useState<Record<string, ConnectionState>>({});
   const [busy, setBusy] = useState<string | null>(null);
+  // Bumped when the company credential changes, to remount the sections whose
+  // reported tier is downstream of it (issue #586).
+  const [credentialGeneration, setCredentialGeneration] = useState(0);
   // Whether this viewer may change what the company connects through (issue
   // #403). A connection belongs to the company, so changing one is an admin's
   // call; reading the page is everyone's.
@@ -361,7 +365,26 @@ export function ConnectionsView({ client, company }: Props) {
 
         <InferenceSection client={client} company={company} canManage={canManage} />
 
-        <ComposioSection client={client} company={company} canManage={canManage} />
+        {/* The general answer sits above the Composio-specific one: this key
+            authorizes every brokered surface, and the Composio token below is
+            the escape hatch (issue #586). */}
+        <CompanyCredentialCard
+          client={client}
+          company={company}
+          canManage={canManage}
+          onChanged={() => setCredentialGeneration((n) => n + 1)}
+        />
+
+        {/* Remounted on a credential change so its status is re-read: the tier
+            it reports (`company` vs `attested` vs `none`) is downstream of the
+            key that was just set, and a stale badge would tell the operator
+            their change did not land. */}
+        <ComposioSection
+          key={credentialGeneration}
+          client={client}
+          company={company}
+          canManage={canManage}
+        />
 
         <ChannelsSection client={client} company={company} canManage={canManage} />
 

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -147,7 +147,13 @@ export function ConnectionsView({ client, company }: Props) {
     return () => {
       live = false;
     };
-  }, [client, company]);
+    // `credentialGeneration` is load-bearing, not decoration: this probe feeds
+    // `reach.hasCredential` and `attested`, both of which are downstream of the
+    // company credential. Setting a key flips `credentialSource` from `none` to
+    // `company`, and without a re-probe the grid would keep every tile on the
+    // "no credential" route while the Composio section right below it correctly
+    // reported the opposite (issue #586).
+  }, [client, company, credentialGeneration]);
 
   useEffect(() => {
     const timers = pollTimers.current;

--- a/frontend/src/views/connections/CompanyCredentialCard.tsx
+++ b/frontend/src/views/connections/CompanyCredentialCard.tsx
@@ -8,6 +8,7 @@ import {
   setCompanyCredential,
   type CompanyCredentialStatus,
 } from "@/api/credential";
+import { ApiError } from "@/api/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -32,8 +33,8 @@ interface Props {
 /**
  * The company's own TinyHumans credential (issue #586).
  *
- * One key, set once by the admin, and every surface the platform brokers rides
- * it — Composio today, whatever the backend fronts next. This is what replaces
+ * One key, set once by the admin, and every surface wired to it presents it —
+ * Composio today, whatever is wired next. This is what replaces
  * per-tenant provider apps and per-surface tokens: a company with a key set can
  * connect a provider without registering anything, and a provider connected
  * that way belongs to the company rather than to the member who connected it.
@@ -47,7 +48,8 @@ interface Props {
  * had to receive.
  */
 export function CompanyCredentialCard({ client, company, canManage, onChanged }: Props) {
-  const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
+  const [load, setLoad] = useState<"loading" | "ready" | "unavailable" | "error">("loading");
+  const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<CompanyCredentialStatus | null>(null);
   const [key, setKey] = useState("");
   const [busy, setBusy] = useState<"save" | "clear" | null>(null);
@@ -55,11 +57,25 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
   const refresh = useCallback(async () => {
     try {
       setStatus(await getCompanyCredential(client, company));
+      setError(null);
       setLoad("ready");
-    } catch {
-      // A host predating this route simply 404s. Render nothing rather than an
-      // error: the console still works, this company just has no such plane.
-      setLoad("unavailable");
+    } catch (err) {
+      // Only a genuinely absent route hides the card. A host predating this
+      // plane 404s, and rendering nothing is right there — the console still
+      // works, this company just has no such surface.
+      //
+      // Anything else must NOT be swallowed. The status route now surfaces a
+      // secret-store read failure as a 5xx rather than reporting a confident
+      // "not configured" (see `company_key::resolve`), and hiding the card on
+      // that would throw away the very distinction that fix exists to draw:
+      // the operator would see no credential UI at all and conclude the feature
+      // is absent, rather than that the host could not answer.
+      if (err instanceof ApiError && err.status === 404) {
+        setLoad("unavailable");
+        return;
+      }
+      setError(err instanceof ApiError ? err.message : "Couldn't read the company credential.");
+      setLoad("error");
     }
   }, [client, company]);
 
@@ -79,9 +95,16 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
         description: result.note,
       });
       onChanged?.();
-    } catch {
+    } catch (err) {
+      // Show the host's own reason when it sent one — an admin-only refusal or a
+      // store failure says something specific, and replacing it with a generic
+      // "couldn't save" throws away the only actionable part.
       toast.error(
-        mode === "save" ? "Couldn't save the credential." : "Couldn't clear the credential.",
+        err instanceof ApiError
+          ? err.message
+          : mode === "save"
+          ? "Couldn't save the credential."
+          : "Couldn't clear the credential.",
       );
     } finally {
       setBusy(null);
@@ -111,6 +134,18 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
 
       {load === "loading" ? (
         <Skeleton className="h-32 rounded-xl" />
+      ) : load === "error" ? (
+        // Say the host could not answer. Rendering the card's "Not set" state
+        // here would be a confident claim built on no data.
+        <Card>
+          <CardContent className="py-4">
+            <p className="text-xs text-muted-foreground">
+              {error ?? "Couldn't read the company credential."}{" "}
+              This is not the same as having none set — the host could not answer, so the current
+              credential is unknown.
+            </p>
+          </CardContent>
+        </Card>
       ) : (
         <Card>
           <CardContent className="space-y-4 py-4">

--- a/frontend/src/views/connections/CompanyCredentialCard.tsx
+++ b/frontend/src/views/connections/CompanyCredentialCard.tsx
@@ -104,6 +104,9 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
         <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
           Company credential
         </h3>
+        <span className="text-xs text-muted-foreground">
+          for connecting providers — not the model key
+        </span>
       </div>
 
       {load === "loading" ? (
@@ -137,13 +140,14 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
               <>
                 <div className="space-y-1">
                   <Label htmlFor="company-credential" className="text-xs">
-                    TinyHumans API key {configured ? "— set (paste a new value to rotate)" : ""}
+                    TinyHumans account key{" "}
+                    {configured ? "— set (paste a new value to rotate)" : ""}
                   </Label>
                   <Input
                     id="company-credential"
                     type="password"
                     autoComplete="off"
-                    placeholder="paste this company's TinyHumans API key"
+                    placeholder="paste this company's TinyHumans account key"
                     value={key}
                     onChange={(e) => setKey(e.target.value)}
                   />

--- a/frontend/src/views/connections/CompanyCredentialCard.tsx
+++ b/frontend/src/views/connections/CompanyCredentialCard.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { KeyRound, Loader2, Save, ShieldCheck, Trash2, Wallet } from "lucide-react";
 import { toast } from "sonner";
 
@@ -54,12 +54,25 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
   const [key, setKey] = useState("");
   const [busy, setBusy] = useState<"save" | "clear" | null>(null);
 
+  // Discards the result of a request whose company is no longer the one on
+  // screen. `refresh` re-runs when `company` changes, but nothing cancels the
+  // request already in flight, so two responses can land out of order and the
+  // later `setStatus` be the *earlier* company's. On this card that is
+  // decision-shaped rather than cosmetic: an admin who reads "configured" for a
+  // company that in fact has no key will not set one. Same generation guard
+  // `ComposioSection` uses next door.
+  const requestGeneration = useRef(0);
+
   const refresh = useCallback(async () => {
+    const generation = ++requestGeneration.current;
     try {
-      setStatus(await getCompanyCredential(client, company));
+      const next = await getCompanyCredential(client, company);
+      if (generation !== requestGeneration.current) return;
+      setStatus(next);
       setError(null);
       setLoad("ready");
     } catch (err) {
+      if (generation !== requestGeneration.current) return;
       // Only a genuinely absent route hides the card. A host predating this
       // plane 404s, and rendering nothing is right there — the console still
       // works, this company just has no such surface.
@@ -87,13 +100,20 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
 
   async function write(value: string, mode: "save" | "clear") {
     setBusy(mode);
+    const generation = ++requestGeneration.current;
     try {
       const result = await setCompanyCredential(client, company, value);
-      setStatus(result.status);
-      setKey("");
+      // The toast is unconditional: the write really did land, and an admin who
+      // navigated away mid-request is still owed that fact. What is conditional
+      // is the *state* — `result.status` describes the company that was on
+      // screen when the write started, so painting it after a switch would put
+      // one company's credential state under another's name.
       toast.success(mode === "save" ? "Credential saved." : "Credential cleared.", {
         description: result.note,
       });
+      if (generation !== requestGeneration.current) return;
+      setStatus(result.status);
+      setKey("");
       onChanged?.();
     } catch (err) {
       // Show the host's own reason when it sent one — an admin-only refusal or a

--- a/frontend/src/views/connections/CompanyCredentialCard.tsx
+++ b/frontend/src/views/connections/CompanyCredentialCard.tsx
@@ -1,0 +1,187 @@
+import { useCallback, useEffect, useState } from "react";
+import { KeyRound, Loader2, Save, ShieldCheck, Trash2, Wallet } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  getCompanyCredential,
+  setCompanyCredential,
+  type CompanyCredentialStatus,
+} from "@/api/credential";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /**
+   * Whether the signed-in operator may change the company's credential. Admins
+   * only (issue #403's discipline): this key is the identity every one of the
+   * company's agents presents, and it is the company's wallet. A member still
+   * sees the status — that is what tells them why their agents can reach Gmail
+   * — but not a field inviting them to paste a credential the host will refuse.
+   */
+  canManage: boolean;
+  /** Called after a successful write, so sibling sections re-read their status. */
+  onChanged?: () => void;
+}
+
+/**
+ * The company's own TinyHumans credential (issue #586).
+ *
+ * One key, set once by the admin, and every surface the platform brokers rides
+ * it — Composio today, whatever the backend fronts next. This is what replaces
+ * per-tenant provider apps and per-surface tokens: a company with a key set can
+ * connect a provider without registering anything, and a provider connected
+ * that way belongs to the company rather than to the member who connected it.
+ *
+ * Sits **above** the Composio section deliberately. It is the general answer;
+ * the Composio token below it is the escape hatch for a company that insists on
+ * its own Composio account.
+ *
+ * Write-only: the key is sent and never returned, so the field is always empty
+ * on load and "set" is reported by a flag, never by a masked value we would have
+ * had to receive.
+ */
+export function CompanyCredentialCard({ client, company, canManage, onChanged }: Props) {
+  const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
+  const [status, setStatus] = useState<CompanyCredentialStatus | null>(null);
+  const [key, setKey] = useState("");
+  const [busy, setBusy] = useState<"save" | "clear" | null>(null);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await getCompanyCredential(client, company));
+      setLoad("ready");
+    } catch {
+      // A host predating this route simply 404s. Render nothing rather than an
+      // error: the console still works, this company just has no such plane.
+      setLoad("unavailable");
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    setLoad("loading");
+    setKey("");
+    void refresh();
+  }, [refresh]);
+
+  async function write(value: string, mode: "save" | "clear") {
+    setBusy(mode);
+    try {
+      const result = await setCompanyCredential(client, company, value);
+      setStatus(result.status);
+      setKey("");
+      toast.success(mode === "save" ? "Credential saved." : "Credential cleared.", {
+        description: result.note,
+      });
+      onChanged?.();
+    } catch {
+      toast.error(
+        mode === "save" ? "Couldn't save the credential." : "Couldn't clear the credential.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  if (load === "unavailable") return null;
+
+  const configured = status?.configured === true;
+  // No company key, but the instance carries an identity of its own — calls
+  // still work, they are just attributed to the instance rather than to this
+  // company. Worth saying, because "not configured" alone reads as broken.
+  const instanceFallback =
+    !configured && (status?.source === "attested" || status?.source === "static");
+
+  return (
+    <section className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Wallet className="size-4 text-muted-foreground" />
+        <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+          Company credential
+        </h3>
+      </div>
+
+      {load === "loading" ? (
+        <Skeleton className="h-32 rounded-xl" />
+      ) : (
+        <Card>
+          <CardContent className="space-y-4 py-4">
+            <div className="flex flex-wrap items-center gap-2">
+              {configured ? (
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                  <ShieldCheck className="size-3" /> Set — providers connect as this company
+                </span>
+              ) : instanceFallback ? (
+                <span className="text-xs text-muted-foreground">
+                  Not set — using this instance&apos;s identity
+                </span>
+              ) : (
+                <span className="text-xs text-muted-foreground">Not set</span>
+              )}
+            </div>
+
+            {/* The host words the consequence, so the console cannot drift from
+                what the host actually does. */}
+            {status && (
+              <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                {status.notice}
+              </p>
+            )}
+
+            {canManage && (
+              <>
+                <div className="space-y-1">
+                  <Label htmlFor="company-credential" className="text-xs">
+                    TinyHumans API key {configured ? "— set (paste a new value to rotate)" : ""}
+                  </Label>
+                  <Input
+                    id="company-credential"
+                    type="password"
+                    autoComplete="off"
+                    placeholder="paste this company's TinyHumans API key"
+                    value={key}
+                    onChange={(e) => setKey(e.target.value)}
+                  />
+                </div>
+
+                <div className="flex items-center gap-2">
+                  <Button
+                    disabled={busy !== null || !key.trim()}
+                    onClick={() => void write(key.trim(), "save")}
+                  >
+                    {busy === "save" ? (
+                      <Loader2 className="size-4 animate-spin" />
+                    ) : (
+                      <Save className="size-4" />
+                    )}
+                    {configured ? "Rotate key" : "Save key"}
+                  </Button>
+                  {configured && (
+                    <Button
+                      variant="outline"
+                      disabled={busy !== null}
+                      onClick={() => void write("", "clear")}
+                    >
+                      {busy === "clear" ? (
+                        <Loader2 className="size-4 animate-spin" />
+                      ) : (
+                        <Trash2 className="size-4" />
+                      )}
+                      Clear
+                    </Button>
+                  )}
+                  <KeyRound className="ml-auto size-4 text-muted-foreground" />
+                </div>
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/views/connections/CompanyCredentialCard.tsx
+++ b/frontend/src/views/connections/CompanyCredentialCard.tsx
@@ -171,7 +171,7 @@ export function CompanyCredentialCard({ client, company, canManage, onChanged }:
           <CardContent className="space-y-4 py-4">
             <div className="flex flex-wrap items-center gap-2">
               {configured ? (
-                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                   <ShieldCheck className="size-3" /> Set — providers connect as this company
                 </span>
               ) : instanceFallback ? (

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -103,7 +103,11 @@ interface Props {
  *    - `attested` (hosted) — the instance already holds a platform identity, so
  *      there is nothing to paste and nothing stored here. A company that wants
  *      to use its OWN Composio account can still override.
- *    - `static` — a token this company pasted, or a static instance key.
+ *    - `company` (issue #586) — this company's own TinyHumans credential, set
+ *      by its admin. Composio is brokered through it, so there is nothing to
+ *      paste here either: the one key already authorizes this. The override
+ *      still exists for a company that wants its own Composio account.
+ *    - `static` — a Composio token this company pasted, or a static instance key.
  *    - `none` — no credential can be obtained, so there is nothing to authorize
  *      against and agents get no Composio tools.
  * 2. **Which providers are connected**, via a per-provider OAuth "Sign in" list
@@ -308,6 +312,10 @@ export function ComposioSection({ client, company, canManage }: Props) {
   if (load === "unavailable") return null;
 
   const attested = status?.credentialSource === "attested";
+  // The company's own key already authorizes Composio (issue #586), so this
+  // reads like `attested` everywhere the question is "is there anything to
+  // paste?" — the difference is whose identity it is, which the copy states.
+  const companyKey = status?.credentialSource === "company";
   const byoToken = status?.credentialSource === "static";
   // No credential of any tier: there is nothing to authorize a provider against.
   const noCredential = status?.credentialSource === "none";
@@ -323,7 +331,10 @@ export function ComposioSection({ client, company, canManage }: Props) {
   // status line above ("token set" / "linked via cluster identity"), which is
   // what tells them why their agents can reach Gmail; what they do not get is a
   // field that invites them to paste a credential the host will refuse.
-  const showTokenCard = canManage && (!attested || showOverride || byoToken);
+  // A company already brokered through its own key is in the same position as an
+  // attested one: the paste card is a deliberate override, not the way in.
+  const credentialed = attested || companyKey;
+  const showTokenCard = canManage && (!credentialed || showOverride || byoToken);
 
   return (
     <section className="space-y-3">
@@ -338,6 +349,8 @@ export function ComposioSection({ client, company, canManage }: Props) {
           ? "Your agents reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
           : attested
           ? "Give your agents Gmail, Slack & GitHub via Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Sign in per provider below."
+          : companyKey
+          ? "Give your agents Gmail, Slack & GitHub via Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Sign in per provider below; every agent in the company can then use what you connect."
           : "Give your agents Gmail, Slack & GitHub via Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then sign in per provider below. A change takes effect on the next turn, no restart."}
       </p>
 
@@ -353,6 +366,10 @@ export function ComposioSection({ client, company, canManage }: Props) {
               {attested ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                   <ShieldCheck className="size-3" /> Linked via cluster identity — nothing stored
+                </span>
+              ) : companyKey ? (
+                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                  <ShieldCheck className="size-3" /> Linked via this company&apos;s own credential
                 </span>
               ) : byoToken ? (
                 <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
@@ -378,8 +395,10 @@ export function ComposioSection({ client, company, canManage }: Props) {
                 <p className="text-xs font-medium text-muted-foreground">Sign in per provider</p>
                 {noCredential && (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    No Composio credential is available for this company yet, so there is nothing to
-                    authorize against. Paste a token below first.
+                    No credential is available for this company yet, so there is nothing to
+                    authorize against. Set the company&apos;s TinyHumans credential — one key
+                    authorizes every provider the platform brokers — or paste a Composio token
+                    below to use a Composio account of your own.
                   </p>
                 )}
                 {degraded ? (

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -393,12 +393,15 @@ export function ComposioSection({ client, company, canManage }: Props) {
             <Card>
               <CardContent className="space-y-2 py-4">
                 <p className="text-xs font-medium text-muted-foreground">Sign in per provider</p>
+                {/* Branches on `canManage` like the intro above it. A member has
+                    neither the credential field nor the paste card, so telling
+                    them to "set the credential or paste a token below" points at
+                    controls that are not on their screen. */}
                 {noCredential && (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    No credential is available for this company yet, so there is nothing to
-                    authorize against. Set the company&apos;s TinyHumans credential — one key
-                    authorizes every provider the platform brokers — or paste a Composio token
-                    below to use a Composio account of your own.
+                    {canManage
+                      ? "No credential is available for this company yet, so there is nothing to authorize against. Set the company's TinyHumans credential — one key authorizes the providers the platform brokers — or paste a Composio token below to use a Composio account of your own."
+                      : "No credential is available for this company yet, so there is nothing to authorize against. An admin has to set the company's credential before providers can be connected."}
                   </p>
                 )}
                 {degraded ? (
@@ -611,7 +614,12 @@ export function ComposioSection({ client, company, canManage }: Props) {
             </Card>
           )}
 
-          {canManage && attested && !showTokenCard && (
+          {/* Gated on `credentialed`, not `attested`: a company brokered through
+              its own TinyHumans key is equally "already credentialled", so it
+              equally needs a way back to the BYO card. Gating this on `attested`
+              alone left a company-key admin with the paste card hidden and no
+              control to reveal it — the override became unreachable. */}
+          {canManage && credentialed && !showTokenCard && (
             <Button variant="outline" size="sm" onClick={() => setShowOverride(true)}>
               <KeyRound className="size-4" />
               Use your own Composio account instead
@@ -621,13 +629,25 @@ export function ComposioSection({ client, company, canManage }: Props) {
           {showTokenCard && (
             <Card>
               <CardContent className="space-y-4 py-4">
-                {attested && (
+                {/* The explainer has to name what the token would displace,
+                    and that differs by tier: an attested company falls back to
+                    the pod's cluster identity, a company-key one falls back to
+                    its own credential. Saying "cluster identity" to the latter
+                    would describe a fallback it does not have. */}
+                {companyKey ? (
+                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                    Optional. This company&apos;s own TinyHumans credential already authorizes
+                    Composio. A token set here replaces it for Composio only — use it when the
+                    company has a separate Composio account. Clear it to go back to the company
+                    credential.
+                  </p>
+                ) : attested ? (
                   <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
                     Optional. A token set here overrides the instance identity for this company only
                     — use it when the company has its own Composio account. Clear it to go back to
                     the cluster identity.
                   </p>
-                )}
+                ) : null}
                 <div className="space-y-1">
                   <Label htmlFor="composio-token" className="text-xs">
                     Composio token {byoToken ? "— set (paste a new value to rotate)" : ""}

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -368,7 +368,7 @@ export function ComposioSection({ client, company, canManage }: Props) {
                   <ShieldCheck className="size-3" /> Linked via cluster identity — nothing stored
                 </span>
               ) : companyKey ? (
-                <span className="inline-flex items-center gap-1 text-xs text-emerald-600 dark:text-emerald-400">
+                <span className="inline-flex items-center gap-1 text-xs text-status-done-text">
                   <ShieldCheck className="size-3" /> Linked via this company&apos;s own credential
                 </span>
               ) : byoToken ? (

--- a/src/app/doctor.rs
+++ b/src/app/doctor.rs
@@ -131,6 +131,11 @@ pub fn report(cfg: &RuntimeConfig, prov: &ConfigProvenance) -> DoctorReport {
         layer: match source {
             crate::company::CredentialSource::Attested => prov.layer("tinyhumans_token_file"),
             crate::company::CredentialSource::Static => prov.layer("tinyhumans_credential"),
+            // The doctor reports the *instance's* tier, resolved from process
+            // config. A company key is per-company state in a secret store, so
+            // it can never win here — and if it somehow did, no config layer
+            // named it, which is exactly what `None` says.
+            crate::company::CredentialSource::Company => None,
             crate::company::CredentialSource::None => None,
         }
         .unwrap_or(ConfigLayer::Default)

--- a/src/company/company_key.rs
+++ b/src/company/company_key.rs
@@ -76,23 +76,23 @@ pub async fn store_key(company: &CompanyId, secrets: &dyn SecretStore, key: &str
 /// thing the read planes ever surface about it.
 pub async fn key_configured(company: &CompanyId, secrets: &dyn SecretStore) -> Result<bool> {
     Ok(matches!(
-        load(company, secrets).await,
+        load(company, secrets).await?,
         Credential::Company(_)
     ))
 }
 
-/// The company's own key as a [`Credential`], or [`Credential::None`] when unset,
-/// blank, or unreadable.
+/// The company's own key as a [`Credential`], or [`Credential::None`] when unset
+/// or blank.
 ///
-/// A secret-store read error degrades to `None` rather than bubbling: a
-/// transient store hiccup must fall through to the instance identity for that
-/// cycle, not brick a roster build. Mirrors the same choice in
-/// [`TenantComposio::resolve`](crate::harness::composio::TenantComposio::resolve).
-pub async fn load(company: &CompanyId, secrets: &dyn SecretStore) -> Credential {
-    match secrets.get(company, KEY_KEY).await {
-        Ok(Some(SecretValue(key))) => Credential::from_company_key(key),
-        _ => Credential::None,
-    }
+/// A store read error **propagates**. It is tempting to map it to `None` —
+/// "degrade rather than brick a roster build" — but `None` here does not mean
+/// "no credential", it means *fall through to the instance identity*, and those
+/// are different answers to different questions. See [`resolve`].
+pub async fn load(company: &CompanyId, secrets: &dyn SecretStore) -> Result<Credential> {
+    Ok(match secrets.get(company, KEY_KEY).await? {
+        Some(SecretValue(key)) => Credential::from_company_key(key),
+        None => Credential::None,
+    })
 }
 
 /// The credential a brokered call presents for this company — **the** seam.
@@ -100,16 +100,36 @@ pub async fn load(company: &CompanyId, secrets: &dyn SecretStore) -> Credential 
 /// The company's own key wins; failing that this instance's platform identity;
 /// failing that [`Credential::None`], which every caller treats as fail-closed.
 /// See the module docs for why there is exactly one of these.
+///
+/// ## Why a store error is not a fallthrough
+///
+/// An unreadable store means *we do not know who this company is*. Treating that
+/// as "no key set" would silently resolve a company that **has** a key to the
+/// instance's identity — and because a provider connection lives on the backend
+/// keyed by the account the bearer resolves to, a connection established in that
+/// window would belong to the instance's account rather than the company's. When
+/// the store recovered, resolution would return the company key, the bearer would
+/// resolve to a different entity, and the connection made under the fallback
+/// would no longer be the one the company sees. The same "connect Gmail" click
+/// would produce a different owner depending on store health at that instant,
+/// with no signal in either direction.
+///
+/// Availability-degrade and identity-degrade are different decisions, and only
+/// the first is safe to make silently. So the error propagates, and each caller
+/// answers it in the way its own surface can afford: the roster build withholds
+/// the tools for that cycle (fail closed — an unknown credential must never mean
+/// a borrowed identity, exactly as an absent one must not), while the console
+/// planes surface the failure instead of reporting a confident "not configured".
 pub async fn resolve(
     company: &CompanyId,
     secrets: &dyn SecretStore,
     token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
-) -> Credential {
-    match (load(company, secrets).await, token_source) {
+) -> Result<Credential> {
+    Ok(match (load(company, secrets).await?, token_source) {
         (company_key @ Credential::Company(_), _) => company_key,
         (_, Some(source)) => Credential::from_source(source),
         (_, None) => Credential::None,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -166,7 +186,7 @@ mod tests {
 
         // Nothing set: the tenant borrows the instance's identity, exactly as
         // it did before this seam existed.
-        let credential = resolve(&company, &secrets, Some(source())).await;
+        let credential = resolve(&company, &secrets, Some(source())).await.unwrap();
         assert_eq!(credential.source(), CredentialSource::Static);
         assert_eq!(
             credential.current().await.unwrap().as_deref(),
@@ -177,7 +197,7 @@ mod tests {
         store_key(&company, &secrets, "th_company_key")
             .await
             .unwrap();
-        let credential = resolve(&company, &secrets, Some(source())).await;
+        let credential = resolve(&company, &secrets, Some(source())).await.unwrap();
         assert_eq!(credential.source(), CredentialSource::Company);
         assert_eq!(
             credential.current().await.unwrap().as_deref(),
@@ -189,7 +209,7 @@ mod tests {
     async fn no_key_and_no_instance_identity_fails_closed() {
         let company = CompanyId::new("acme");
         let secrets = MemSecrets::default();
-        let credential = resolve(&company, &secrets, None).await;
+        let credential = resolve(&company, &secrets, None).await.unwrap();
         assert_eq!(credential.source(), CredentialSource::None);
         assert!(!credential.configured());
     }
@@ -208,7 +228,10 @@ mod tests {
         store_key(&company, &secrets, "").await.unwrap();
         assert!(!key_configured(&company, &secrets).await.unwrap());
         assert_eq!(
-            resolve(&company, &secrets, Some(source())).await.source(),
+            resolve(&company, &secrets, Some(source()))
+                .await
+                .unwrap()
+                .source(),
             CredentialSource::Static
         );
     }
@@ -220,21 +243,48 @@ mod tests {
         store_key(&company, &secrets, "   ").await.unwrap();
         assert!(!key_configured(&company, &secrets).await.unwrap());
         assert_eq!(
-            resolve(&company, &secrets, None).await.source(),
+            resolve(&company, &secrets, None).await.unwrap().source(),
             CredentialSource::None
         );
     }
 
-    /// A store read that fails must degrade to the instance identity for that
-    /// cycle, never bubble into the roster build.
+    /// A store read that fails must **not** silently resolve to the instance
+    /// identity.
+    ///
+    /// The tempting reading is "degrade rather than brick the roster build", and
+    /// that is the right instinct about availability — but it is the wrong
+    /// answer about attribution. A connection lives on the backend keyed by the
+    /// account the bearer resolves to, so a company that *has* a key silently
+    /// borrowing the instance's identity during a hiccup would attribute its
+    /// Gmail to the wrong account, and the operator would get no signal in
+    /// either direction. The error surfaces here; each caller then decides what
+    /// its own surface can afford.
     #[tokio::test]
-    async fn an_unreadable_store_degrades_to_the_instance_identity() {
+    async fn an_unreadable_store_never_borrows_another_identity() {
         let company = CompanyId::new("acme");
-        assert!(!key_configured(&company, &BrokenSecrets).await.unwrap());
-        let credential = resolve(&company, &BrokenSecrets, Some(source())).await;
-        assert!(credential.configured());
+
+        assert!(
+            key_configured(&company, &BrokenSecrets).await.is_err(),
+            "an unreadable store is not the same answer as `not configured`"
+        );
+        assert!(
+            resolve(&company, &BrokenSecrets, Some(source()))
+                .await
+                .is_err(),
+            "an unreadable store must never resolve to the instance identity"
+        );
+
+        // And an *absent* key still falls through as it always did — the two
+        // cases are now distinguishable, which is the whole point.
+        let secrets = MemSecrets::default();
         assert_eq!(
-            credential.current().await.unwrap().as_deref(),
+            resolve(&company, &secrets, Some(source()))
+                .await
+                .unwrap()
+                .current()
+                .await
+                .unwrap()
+                .as_deref(),
             Some("instance-identity")
         );
     }
@@ -254,10 +304,10 @@ mod tests {
         let company = CompanyId::new("acme");
         let secrets = MemSecrets::default();
         store_key(&company, &secrets, "key-a").await.unwrap();
-        let before = identity_of(&resolve(&company, &secrets, Some(source())).await);
+        let before = identity_of(&resolve(&company, &secrets, Some(source())).await.unwrap());
 
         store_key(&company, &secrets, "key-b").await.unwrap();
-        let after = identity_of(&resolve(&company, &secrets, Some(source())).await);
+        let after = identity_of(&resolve(&company, &secrets, Some(source())).await.unwrap());
         assert_ne!(
             before, after,
             "a rotated company key must rebuild the roster"
@@ -278,7 +328,7 @@ mod tests {
         store_key(&company, &secrets, "th_super_secret")
             .await
             .unwrap();
-        let credential = resolve(&company, &secrets, None).await;
+        let credential = resolve(&company, &secrets, None).await.unwrap();
         let rendered = format!("{credential:?}");
         assert!(!rendered.contains("th_super_secret"), "{rendered}");
         assert!(rendered.contains("<redacted>"), "{rendered}");

--- a/src/company/company_key.rs
+++ b/src/company/company_key.rs
@@ -1,0 +1,286 @@
+//! The company's own TinyHumans credential — the one key its admin sets on the
+//! tenant, and the identity every **brokered** surface presents (issue #586).
+//!
+//! ## What this is, and what it is not
+//!
+//! A company belongs to one owner. The admin sets one TinyHumans key here, and
+//! everything the platform backend brokers on the company's behalf rides it:
+//! Composio today, whatever else the backend fronts tomorrow. Membership in the
+//! company is what grants access to it.
+//!
+//! It is deliberately **not** [`inference::KEY_KEY`](crate::company::inference)
+//! . That slot holds whatever credential the company's *declared provider*
+//! wants — an OpenRouter `sk-or-…`, a raw BYOK key, an `openai_compatible`
+//! token. It is provider-scoped, not an identity. Handing it to the TinyHumans
+//! backend would present one vendor's credential to another. The two coincide
+//! only when the declared provider is `managed`, and even then they are the same
+//! *value* for different reasons. One slot per meaning.
+//!
+//! ## Precedence
+//!
+//! [`resolve`] is the single seam. Most specific first:
+//!
+//! 1. **The company's own key**, stored here — set, rotated and cleared by an
+//!    admin through the console, write-only, never read back.
+//! 2. **This instance's platform identity** —
+//!    [`TinyhumansTokenSource`](crate::company::credentials::TinyhumansTokenSource),
+//!    the projected, audience-bound token a hosted pod carries. Unchanged
+//!    behaviour for a tenant whose admin has set nothing.
+//! 3. **Nothing** ⇒ [`Credential::None`], and the caller fails closed.
+//!
+//! Every brokered surface resolving through *this one function* is what makes
+//! the rotation guarantee true by construction: there is no second resolution to
+//! drift, so a key set in the console cannot reach one surface and miss another.
+//! A surface may prepend its own escape-hatch tier ahead of this (Composio keeps
+//! its BYO `composio/token` — see
+//! [`harness::composio`](crate::harness::composio)), but nothing may resolve a
+//! *company* identity any other way.
+//!
+//! ## Write-only
+//!
+//! The value is never returned by any read route. [`key_configured`] answers the
+//! only question the console needs, and [`Credential`]'s `Debug` redacts what it
+//! holds.
+//!
+//! ## Freshness
+//!
+//! Read live from the [`SecretStore`] on every resolution, so a console set /
+//! rotate / clear takes effect on the next cycle with no restart. The resolved
+//! credential contributes its **value** to the roster fingerprint
+//! ([`Credential::hash_identity`]), so a rotation rebuilds the tool roster
+//! rather than leaving agents on the previous identity.
+
+use crate::Result;
+use crate::company::credentials::{Credential, TinyhumansTokenSource};
+use crate::ports::SecretStore;
+use crate::ports::types::{CompanyId, SecretValue};
+
+/// The canonical per-company TinyHumans credential key. Write-only via the
+/// console; the value is the raw key string.
+///
+/// Namespaced `tinyhumans/` rather than under any one consumer, because it is
+/// not any one consumer's key — see the module docs on why this is not
+/// `inference/key`.
+pub const KEY_KEY: &str = "tinyhumans/key";
+
+/// Store (or rotate / clear) the company's TinyHumans credential. A non-empty
+/// value rotates it; an empty string clears it. Write-only — never read back
+/// over the API.
+pub async fn store_key(company: &CompanyId, secrets: &dyn SecretStore, key: &str) -> Result<()> {
+    secrets
+        .set(company, KEY_KEY, SecretValue(key.trim().to_string()))
+        .await
+}
+
+/// Whether a non-empty company key is stored — never the key itself. The only
+/// thing the read planes ever surface about it.
+pub async fn key_configured(company: &CompanyId, secrets: &dyn SecretStore) -> Result<bool> {
+    Ok(matches!(
+        load(company, secrets).await,
+        Credential::Company(_)
+    ))
+}
+
+/// The company's own key as a [`Credential`], or [`Credential::None`] when unset,
+/// blank, or unreadable.
+///
+/// A secret-store read error degrades to `None` rather than bubbling: a
+/// transient store hiccup must fall through to the instance identity for that
+/// cycle, not brick a roster build. Mirrors the same choice in
+/// [`TenantComposio::resolve`](crate::harness::composio::TenantComposio::resolve).
+pub async fn load(company: &CompanyId, secrets: &dyn SecretStore) -> Credential {
+    match secrets.get(company, KEY_KEY).await {
+        Ok(Some(SecretValue(key))) => Credential::from_company_key(key),
+        _ => Credential::None,
+    }
+}
+
+/// The credential a brokered call presents for this company — **the** seam.
+///
+/// The company's own key wins; failing that this instance's platform identity;
+/// failing that [`Credential::None`], which every caller treats as fail-closed.
+/// See the module docs for why there is exactly one of these.
+pub async fn resolve(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
+) -> Credential {
+    match (load(company, secrets).await, token_source) {
+        (company_key @ Credential::Company(_), _) => company_key,
+        (_, Some(source)) => Credential::from_source(source),
+        (_, None) => Credential::None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::company::credentials::CredentialSource;
+    use std::collections::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    use async_trait::async_trait;
+
+    #[derive(Default)]
+    struct MemSecrets {
+        map: Mutex<HashMap<String, String>>,
+    }
+
+    #[async_trait]
+    impl SecretStore for MemSecrets {
+        async fn get(&self, _c: &CompanyId, key: &str) -> Result<Option<SecretValue>> {
+            Ok(self
+                .map
+                .lock()
+                .unwrap()
+                .get(key)
+                .map(|v| SecretValue(v.clone())))
+        }
+        async fn set(&self, _c: &CompanyId, key: &str, value: SecretValue) -> Result<()> {
+            self.map.lock().unwrap().insert(key.to_string(), value.0);
+            Ok(())
+        }
+    }
+
+    /// A store whose reads always fail — the transient-hiccup case.
+    struct BrokenSecrets;
+
+    #[async_trait]
+    impl SecretStore for BrokenSecrets {
+        async fn get(&self, _c: &CompanyId, _key: &str) -> Result<Option<SecretValue>> {
+            Err(crate::error::OpenCompanyError::Store("boom".into()))
+        }
+        async fn set(&self, _c: &CompanyId, _key: &str, _value: SecretValue) -> Result<()> {
+            Err(crate::error::OpenCompanyError::Store("boom".into()))
+        }
+    }
+
+    fn source() -> Arc<TinyhumansTokenSource> {
+        Arc::new(TinyhumansTokenSource::static_key("instance-identity"))
+    }
+
+    #[tokio::test]
+    async fn the_company_key_outranks_the_instance_identity() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+
+        // Nothing set: the tenant borrows the instance's identity, exactly as
+        // it did before this seam existed.
+        let credential = resolve(&company, &secrets, Some(source())).await;
+        assert_eq!(credential.source(), CredentialSource::Static);
+        assert_eq!(
+            credential.current().await.unwrap().as_deref(),
+            Some("instance-identity")
+        );
+
+        // Admin sets the company's own key: every brokered call now presents it.
+        store_key(&company, &secrets, "th_company_key")
+            .await
+            .unwrap();
+        let credential = resolve(&company, &secrets, Some(source())).await;
+        assert_eq!(credential.source(), CredentialSource::Company);
+        assert_eq!(
+            credential.current().await.unwrap().as_deref(),
+            Some("th_company_key")
+        );
+    }
+
+    #[tokio::test]
+    async fn no_key_and_no_instance_identity_fails_closed() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        let credential = resolve(&company, &secrets, None).await;
+        assert_eq!(credential.source(), CredentialSource::None);
+        assert!(!credential.configured());
+    }
+
+    #[tokio::test]
+    async fn clearing_the_key_falls_back_rather_than_stranding_the_company() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "th_company_key")
+            .await
+            .unwrap();
+        assert!(key_configured(&company, &secrets).await.unwrap());
+
+        // An empty value is a clear. The store has no delete, so this is how
+        // "unset" reads back.
+        store_key(&company, &secrets, "").await.unwrap();
+        assert!(!key_configured(&company, &secrets).await.unwrap());
+        assert_eq!(
+            resolve(&company, &secrets, Some(source())).await.source(),
+            CredentialSource::Static
+        );
+    }
+
+    #[tokio::test]
+    async fn a_blank_key_is_not_configuration() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "   ").await.unwrap();
+        assert!(!key_configured(&company, &secrets).await.unwrap());
+        assert_eq!(
+            resolve(&company, &secrets, None).await.source(),
+            CredentialSource::None
+        );
+    }
+
+    /// A store read that fails must degrade to the instance identity for that
+    /// cycle, never bubble into the roster build.
+    #[tokio::test]
+    async fn an_unreadable_store_degrades_to_the_instance_identity() {
+        let company = CompanyId::new("acme");
+        assert!(!key_configured(&company, &BrokenSecrets).await.unwrap());
+        let credential = resolve(&company, &BrokenSecrets, Some(source())).await;
+        assert!(credential.configured());
+        assert_eq!(
+            credential.current().await.unwrap().as_deref(),
+            Some("instance-identity")
+        );
+    }
+
+    /// The rotation contract (issue #586 acceptance): a rotated company key is a
+    /// new identity, so anything fingerprinting the credential rebuilds.
+    #[tokio::test]
+    async fn rotating_the_key_moves_the_fingerprint() {
+        use std::hash::Hasher;
+
+        let identity_of = |credential: &Credential| {
+            let mut hasher = std::collections::hash_map::DefaultHasher::new();
+            credential.hash_identity(&mut hasher);
+            hasher.finish()
+        };
+
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "key-a").await.unwrap();
+        let before = identity_of(&resolve(&company, &secrets, Some(source())).await);
+
+        store_key(&company, &secrets, "key-b").await.unwrap();
+        let after = identity_of(&resolve(&company, &secrets, Some(source())).await);
+        assert_ne!(
+            before, after,
+            "a rotated company key must rebuild the roster"
+        );
+
+        // And a company key is never confused with an identically-valued
+        // per-provider token pasted into some other slot.
+        assert_ne!(
+            identity_of(&Credential::from_company_key("key-b")),
+            identity_of(&Credential::from_value("key-b"))
+        );
+    }
+
+    #[tokio::test]
+    async fn the_key_is_write_only_in_every_rendering() {
+        let company = CompanyId::new("acme");
+        let secrets = MemSecrets::default();
+        store_key(&company, &secrets, "th_super_secret")
+            .await
+            .unwrap();
+        let credential = resolve(&company, &secrets, None).await;
+        let rendered = format!("{credential:?}");
+        assert!(!rendered.contains("th_super_secret"), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+    }
+}

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -10,9 +10,13 @@
 //! closed), never a borrowed identity. Only the backend URL may be overridden
 //! from the environment.
 
+use std::sync::Arc;
+
 use serde::Serialize;
 
 use crate::Result;
+use crate::company::company_key;
+use crate::company::credentials::{Credential, TinyhumansTokenSource};
 use crate::ports::SecretStore;
 use crate::ports::types::{CompanyId, SecretValue};
 
@@ -67,6 +71,46 @@ pub async fn store_token(
     secrets
         .set(company, TOKEN_KEY, SecretValue(token.trim().to_string()))
         .await
+}
+
+/// The credential this company's Composio calls present, or [`Credential::None`]
+/// when none can be obtained at all.
+///
+/// The **one** derivation of that answer, and the reason it lives here rather
+/// than in the feature-gated harness: both callers need it in every build.
+/// [`TenantComposio::resolve`](crate::harness::composio::TenantComposio::resolve)
+/// builds the agent-facing config from it, and the console status route
+/// ([`ops::composio`](crate::server::ops::composio)) reports its
+/// [`source`](Credential::source) — so the tier the console shows an operator
+/// cannot disagree with the identity the agents actually present. Two functions
+/// that merely *mirrored* each other's precedence would drift the first time a
+/// tier was added to one of them, which is exactly the failure issue #586 exists
+/// to remove.
+///
+/// Precedence: the company's own Composio token ([`TOKEN_KEY`], the BYO escape
+/// hatch) wins; otherwise the shared brokered-credential seam
+/// [`company_key::resolve`] answers — the company's own TinyHumans key, else this
+/// instance's platform identity, else nothing.
+///
+/// A secret-store read error degrades to the next tier rather than bubbling: a
+/// transient hiccup must not brick a roster build.
+pub async fn resolve_credential(
+    company: &CompanyId,
+    secrets: &dyn SecretStore,
+    token_source: Option<Arc<TinyhumansTokenSource>>,
+) -> Credential {
+    let byo = match secrets.get(company, TOKEN_KEY).await {
+        Ok(Some(SecretValue(token))) => Credential::from_value(token),
+        _ => Credential::None,
+    };
+    match byo {
+        // The company's own Composio token always wins.
+        byo @ Credential::Value(_) => byo,
+        // Everything else is the shared seam's answer, so a rotated company key
+        // reaches Composio the same cycle it reaches every other brokered
+        // surface.
+        _ => company_key::resolve(company, secrets, token_source).await,
+    }
 }
 
 /// Whether a non-empty per-tenant token is stored — never the token itself.

--- a/src/company/composio.rs
+++ b/src/company/composio.rs
@@ -92,25 +92,26 @@ pub async fn store_token(
 /// [`company_key::resolve`] answers — the company's own TinyHumans key, else this
 /// instance's platform identity, else nothing.
 ///
-/// A secret-store read error degrades to the next tier rather than bubbling: a
-/// transient hiccup must not brick a roster build.
+/// A store read error **propagates** rather than degrading to the next tier —
+/// see [`company_key::resolve`] for why an unreadable store must not silently
+/// change which account a call is attributed to.
 pub async fn resolve_credential(
     company: &CompanyId,
     secrets: &dyn SecretStore,
     token_source: Option<Arc<TinyhumansTokenSource>>,
-) -> Credential {
-    let byo = match secrets.get(company, TOKEN_KEY).await {
-        Ok(Some(SecretValue(token))) => Credential::from_value(token),
-        _ => Credential::None,
+) -> Result<Credential> {
+    let byo = match secrets.get(company, TOKEN_KEY).await? {
+        Some(SecretValue(token)) => Credential::from_value(token),
+        None => Credential::None,
     };
-    match byo {
+    Ok(match byo {
         // The company's own Composio token always wins.
         byo @ Credential::Value(_) => byo,
         // Everything else is the shared seam's answer, so a rotated company key
         // reaches Composio the same cycle it reaches every other brokered
         // surface.
-        _ => company_key::resolve(company, secrets, token_source).await,
-    }
+        _ => company_key::resolve(company, secrets, token_source).await?,
+    })
 }
 
 /// Whether a non-empty per-tenant token is stored — never the token itself.

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -120,18 +120,24 @@ pub enum CredentialSource {
     /// The pod presents a platform-minted, audience-bound identity. Nothing is
     /// stored on this instance.
     Attested,
+    /// The **company's own** TinyHumans credential — the one key its admin set
+    /// on this tenant (issue #586). Distinct from [`Self::Static`]: this is the
+    /// company's platform identity, so every surface the backend brokers rides
+    /// it, and rotating it reaches all of them at once.
+    Company,
     /// A static key/token is configured — the docker-development path, or a
-    /// per-company token an operator pasted in.
+    /// per-provider token an operator pasted in as an escape hatch.
     Static,
     /// No credential can be obtained at all.
     None,
 }
 
 impl CredentialSource {
-    /// The stable wire spelling (`attested` / `static` / `none`).
+    /// The stable wire spelling (`attested` / `company` / `static` / `none`).
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Attested => "attested",
+            Self::Company => "company",
             Self::Static => "static",
             Self::None => "none",
         }
@@ -378,9 +384,15 @@ pub enum Credential {
     /// No credential — omit the bearer entirely (e.g. a keyless local Ollama).
     #[default]
     None,
-    /// A value held in memory: a per-company token an operator pasted into the
+    /// A value held in memory: a per-provider token an operator pasted into the
     /// secret store, or a BYOK key. A changed value is a changed identity.
     Value(String),
+    /// The **company's own** TinyHumans credential, read from its secret store
+    /// (issue #586). Behaves like [`Self::Value`] on the request path — it is a
+    /// held string, and a changed value is a changed identity — but reports
+    /// itself as [`CredentialSource::Company`] so the console can say *whose*
+    /// identity a brokered call presents rather than only that one exists.
+    Company(String),
     /// A platform token source. Read per request; the value it yields rotates
     /// while the identity behind it does not.
     Source(std::sync::Arc<TinyhumansTokenSource>),
@@ -394,6 +406,18 @@ impl Credential {
             Self::None
         } else {
             Self::Value(value)
+        }
+    }
+
+    /// The company's own TinyHumans credential, treating blank as "not
+    /// configured". The seam every brokered surface resolves through — see
+    /// [`company_key`](crate::company::company_key).
+    pub fn from_company_key(value: impl Into<String>) -> Self {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Self::None
+        } else {
+            Self::Company(value)
         }
     }
 
@@ -413,6 +437,7 @@ impl Credential {
         match self {
             Self::None => CredentialSource::None,
             Self::Value(_) => CredentialSource::Static,
+            Self::Company(_) => CredentialSource::Company,
             Self::Source(source) => source.credential_source(),
         }
     }
@@ -423,7 +448,7 @@ impl Credential {
     pub async fn current(&self) -> Result<Option<String>> {
         let token = match self {
             Self::None => return Ok(None),
-            Self::Value(value) => value.clone(),
+            Self::Value(value) | Self::Company(value) => value.clone(),
             Self::Source(source) => source.current().await?,
         };
         let token = token.trim().to_string();
@@ -453,6 +478,15 @@ impl Credential {
                 2u8.hash(hasher);
                 source.hash_identity(hasher);
             }
+            // Hashed by **value**, like `Value`: the company key is a static
+            // credential its admin rotates deliberately, not one the cluster
+            // rotates on a timer, so a new value really is a new identity and
+            // the roster must rebuild. That is what makes a console rotation
+            // reach every brokered surface on the next cycle (issue #586).
+            Self::Company(value) => {
+                3u8.hash(hasher);
+                value.hash(hasher);
+            }
         }
     }
 }
@@ -462,6 +496,7 @@ impl std::fmt::Debug for Credential {
         match self {
             Self::None => f.write_str("Credential(<unset>)"),
             Self::Value(_) => f.write_str("Credential(<redacted>)"),
+            Self::Company(_) => f.write_str("Credential(company <redacted>)"),
             Self::Source(source) => write!(f, "Credential({})", source.describe()),
         }
     }

--- a/src/company/credentials.rs
+++ b/src/company/credentials.rs
@@ -410,8 +410,8 @@ impl Credential {
     }
 
     /// The company's own TinyHumans credential, treating blank as "not
-    /// configured". The seam every brokered surface resolves through — see
-    /// [`company_key`](crate::company::company_key).
+    /// configured". The seam a brokered surface resolves its company identity
+    /// through — see [`company_key`](crate::company::company_key).
     pub fn from_company_key(value: impl Into<String>) -> Self {
         let value = value.into();
         if value.trim().is_empty() {
@@ -482,7 +482,8 @@ impl Credential {
             // credential its admin rotates deliberately, not one the cluster
             // rotates on a timer, so a new value really is a new identity and
             // the roster must rebuild. That is what makes a console rotation
-            // reach every brokered surface on the next cycle (issue #586).
+            // reach every surface wired to this credential on the next cycle —
+            // Composio today (issue #586).
             Self::Company(value) => {
                 3u8.hash(hasher);
                 value.hash(hasher);

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -9,6 +9,7 @@
 /// Always compiled — the console's workspace and artifact routes reach it in
 /// every build, and only the publish drain's half is behind `openhuman`.
 pub mod artifact_mirror;
+pub mod company_key;
 pub mod composio;
 #[cfg(test)]
 mod content_test;

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -10,21 +10,41 @@
 //! and that resolution happens **server-side** here — never from agent input and
 //! never from manifest free-text.
 //!
-//! Two sources, in strict precedence:
+//! Three sources, in strict precedence:
 //!
-//! 1. **The company's own token**, stored in its [`SecretStore`] under
+//! 1. **The company's own Composio token**, stored in its [`SecretStore`] under
 //!    [`TOKEN_KEY`] by the console. A company that brings its own Composio
-//!    identity keeps it, always.
-//! 2. **This instance's platform identity** — the
+//!    identity keeps it, always. This is the self-hosting escape hatch, not a
+//!    deployment mode.
+//! 2. **The company's own TinyHumans credential** —
+//!    [`company_key`](crate::company::company_key), the one key its admin set on
+//!    this tenant. The backend derives the Composio entity from whatever bearer
+//!    it is handed, and a TinyHumans key is a bearer it recognises, so no
+//!    separate Composio token and no per-tenant provider app is needed to
+//!    connect a provider (issue #586).
+//! 3. **This instance's platform identity** — the
 //!    [`TinyhumansTokenSource`](crate::company::credentials::TinyhumansTokenSource)
 //!    the runtime authenticates with everywhere else. On the hosted platform that
 //!    is a projected, audience-bound token the cluster rotates in place, so it is
 //!    read **per call**, never captured when the roster is built.
 //!
-//! With neither, resolution yields `None` and no tools are wired (fail closed) —
-//! an absent credential must mean "no tools", never a borrowed identity. Two
-//! companies pasting the *same* token would share one entity; that cannot be
-//! prevented client-side and is documented as a deployment caveat.
+//! Tiers 2 and 3 are not resolved here: they are
+//! [`company_key::resolve`](crate::company::company_key::resolve), the one seam
+//! every brokered surface shares. That is what makes rotating the company key
+//! reach all of them rather than whichever remembered to re-read.
+//!
+//! With none of the three, resolution yields `None` and no tools are wired (fail
+//! closed) — an absent credential must mean "no tools", never a borrowed
+//! identity. Two companies pasting the *same* token would share one entity; that
+//! cannot be prevented client-side and is documented as a deployment caveat.
+//!
+//! ## One connection, every agent
+//!
+//! Nothing here is scoped to the member who connected a provider. The credential
+//! is resolved from the *company's* store, every agent in the company resolves
+//! the same one, and the backend derives one entity from it — so a provider
+//! connected once is usable by every agent in the company, which is the
+//! behaviour issue #586 asks for.
 //!
 //! ## Rotation must not churn the roster
 //!
@@ -54,6 +74,7 @@
 
 use std::sync::Arc;
 
+use crate::company::company_key;
 use crate::company::credentials::{Credential, TinyhumansTokenSource};
 use crate::ports::SecretStore;
 use crate::ports::types::{CompanyId, SecretValue};
@@ -107,21 +128,23 @@ impl TenantComposio {
     /// Resolve a per-tenant Composio config, or `None` (fail closed) when no
     /// credential can be obtained at all.
     ///
-    /// Precedence: the company's **own** token under [`TOKEN_KEY`] in the secret
-    /// store wins; otherwise this instance's platform identity (`token_source`)
-    /// is used. A company that pasted its own Composio token therefore keeps it
-    /// even on the hosted platform, and a company that pasted nothing borrows no
-    /// one else's identity — it presents the identity of the instance it runs in,
-    /// which the backend resolves to that instance's owner.
+    /// Precedence: the company's **own Composio** token under [`TOKEN_KEY`] wins
+    /// — a company that pasted one keeps it even on the hosted platform. Failing
+    /// that, the shared brokered-credential seam
+    /// [`company_key::resolve`](crate::company::company_key::resolve) answers:
+    /// the company's own TinyHumans key, else this instance's platform identity.
+    /// A company that pasted nothing borrows no one else's identity — it presents
+    /// its own key if it has one, otherwise the identity of the instance it runs
+    /// in, which the backend resolves to that instance's owner.
     ///
     /// The URL resolves from [`COMPOSIO_BACKEND_URL_ENV`], then the tenant API
     /// base [`TINYHUMANS_API_URL_ENV`], then [`DEFAULT_BACKEND_URL`] — see
     /// [`backend_url_or_default`]. `toolkits` is the manifest allowlist, threaded
     /// through unchanged.
     ///
-    /// A secret-store read error degrades to the token source (and, failing that,
-    /// to `None`) rather than bubbling — a transient store hiccup must not brick
-    /// the roster build.
+    /// A secret-store read error degrades to the next tier (and, failing all of
+    /// them, to `None`) rather than bubbling — a transient store hiccup must not
+    /// brick the roster build.
     pub async fn resolve(
         company: &CompanyId,
         secrets: &dyn SecretStore,
@@ -130,15 +153,20 @@ impl TenantComposio {
         api_url_env: Option<String>,
         token_source: Option<Arc<TinyhumansTokenSource>>,
     ) -> Option<Self> {
-        let stored = match secrets.get(company, TOKEN_KEY).await {
+        let byo = match secrets.get(company, TOKEN_KEY).await {
             Ok(Some(SecretValue(token))) => Credential::from_value(token),
             _ => Credential::None,
         };
-        let credential = match (stored, token_source) {
-            // The company's own token always wins.
-            (stored @ Credential::Value(_), _) => stored,
-            (_, Some(source)) => Credential::from_source(source),
-            (_, None) => return None,
+        let credential = match byo {
+            // The company's own Composio token always wins.
+            byo @ Credential::Value(_) => byo,
+            // Everything else is the shared seam's answer, so a rotated company
+            // key reaches Composio the same cycle it reaches every other
+            // brokered surface.
+            _ => match company_key::resolve(company, secrets, token_source).await {
+                Credential::None => return None,
+                credential => credential,
+            },
         };
         Some(Self::new(
             backend_url_or_default(backend_url_env, api_url_env),
@@ -1210,6 +1238,130 @@ mod tests {
         assert_eq!(staged.backend_url, "https://staging-api.tinyhumans.ai");
 
         unsafe { std::env::remove_var("TINYHUMANS_API_KEY") };
+    }
+
+    /// Issue #586: the company's own TinyHumans key sits between its pasted
+    /// Composio token and the instance's identity, and it is enough on its own —
+    /// a company with a key set connects providers with no Composio token and no
+    /// per-tenant provider app.
+    #[tokio::test]
+    async fn the_company_key_credentials_composio_between_a_byo_token_and_the_instance() {
+        use crate::company::company_key;
+        use crate::company::credentials::CredentialSource;
+        use crate::ports::SecretStore;
+        use crate::ports::types::{CompanyId, SecretValue};
+        use crate::store::FsSecretStore;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-companykey-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
+        let company = CompanyId::new("acme");
+        let source = || Arc::new(TinyhumansTokenSource::static_key("platform-identity"));
+
+        company_key::store_key(&company, &secrets, "th_company_key")
+            .await
+            .unwrap();
+
+        // With no instance identity at all, the company key alone credentials
+        // Composio — the case this issue exists to fix, since a pod with no
+        // projected token previously had to fall back to a pasted token.
+        let resolved = TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, None)
+            .await
+            .expect("the company key resolves without any instance identity");
+        assert_eq!(token_of(&resolved).await.as_deref(), Some("th_company_key"));
+        assert_eq!(resolved.credential().source(), CredentialSource::Company);
+
+        // And it outranks the instance's identity: the company acts as itself,
+        // not as the pod it happens to run in.
+        let resolved =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
+                .await
+                .expect("resolves");
+        assert_eq!(token_of(&resolved).await.as_deref(), Some("th_company_key"));
+
+        // A pasted Composio token still outranks it — the BYO hatch survives.
+        secrets
+            .set(&company, TOKEN_KEY, SecretValue("byo-composio".to_string()))
+            .await
+            .unwrap();
+        let resolved =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
+                .await
+                .expect("resolves");
+        assert_eq!(token_of(&resolved).await.as_deref(), Some("byo-composio"));
+        assert_eq!(resolved.credential().source(), CredentialSource::Static);
+
+        // Clearing the BYO token falls back to the company key, not to the
+        // instance — clearing one tier must not silently re-borrow another.
+        secrets
+            .set(&company, TOKEN_KEY, SecretValue(String::new()))
+            .await
+            .unwrap();
+        let resolved =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
+                .await
+                .expect("resolves");
+        assert_eq!(token_of(&resolved).await.as_deref(), Some("th_company_key"));
+
+        // Clearing the company key too falls all the way back to the instance.
+        company_key::store_key(&company, &secrets, "")
+            .await
+            .unwrap();
+        let resolved =
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, Some(source()))
+                .await
+                .expect("resolves");
+        assert_eq!(
+            token_of(&resolved).await.as_deref(),
+            Some("platform-identity")
+        );
+    }
+
+    /// The rotation guarantee (issue #586 acceptance): rotating the company key
+    /// moves the roster fingerprint, so agents cannot be left on the previous
+    /// credential after a console rotation.
+    #[tokio::test]
+    async fn rotating_the_company_key_moves_the_composio_fingerprint() {
+        use crate::company::company_key;
+        use crate::ports::types::CompanyId;
+        use crate::store::FsSecretStore;
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-composio-rotate-")
+            .tempdir()
+            .expect("tempdir");
+        let secrets = FsSecretStore::new(dir.path());
+        let company = CompanyId::new("acme");
+
+        let resolve = async || {
+            TenantComposio::resolve(&company, &secrets, Vec::new(), None, None, None).await
+        };
+
+        company_key::store_key(&company, &secrets, "key-a")
+            .await
+            .unwrap();
+        let before = TenantComposio::fingerprint(&resolve().await);
+
+        company_key::store_key(&company, &secrets, "key-b")
+            .await
+            .unwrap();
+        let after = TenantComposio::fingerprint(&resolve().await);
+        assert_ne!(
+            before, after,
+            "a rotated company key must rebuild the roster, or agents keep the old credential"
+        );
+
+        // And clearing it is a change too — the roster must drop the tools.
+        company_key::store_key(&company, &secrets, "")
+            .await
+            .unwrap();
+        assert_eq!(
+            TenantComposio::fingerprint(&resolve().await),
+            TenantComposio::fingerprint(&None),
+            "a cleared credential resolves to nothing, so no tools are wired"
+        );
     }
 
     /// The bearer a config would present right now.

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -198,8 +198,10 @@ impl TenantComposio {
     ///
     /// The credential contributes its **identity**, not its bytes: a projected
     /// platform token rotates every few minutes, and hashing the value would
-    /// rebuild the whole roster on that schedule. A pasted per-company token does
-    /// contribute its value, since changing it is a real identity change.
+    /// rebuild the whole roster on that schedule. A pasted per-company token —
+    /// and the company's own TinyHumans key — does contribute its value, since
+    /// an admin changing either is a real identity change and must reach the
+    /// agents on the next cycle.
     pub fn fingerprint(config: &Option<TenantComposio>) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -30,8 +30,10 @@
 //!
 //! Tiers 2 and 3 are not resolved here: they are
 //! [`company_key::resolve`](crate::company::company_key::resolve), the one seam
-//! every brokered surface shares. That is what makes rotating the company key
-//! reach all of them rather than whichever remembered to re-read.
+//! a brokered surface resolves a company identity through. That is what makes
+//! rotating the company key reach every surface wired to it rather than
+//! whichever remembered to re-read — Composio today, with inference and
+//! embeddings still on the environment until #585.
 //!
 //! With none of the three, resolution yields `None` and no tools are wired (fail
 //! closed) — an absent credential must mean "no tools", never a borrowed

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -74,16 +74,16 @@
 
 use std::sync::Arc;
 
-use crate::company::company_key;
 use crate::company::credentials::{Credential, TinyhumansTokenSource};
 use crate::ports::SecretStore;
-use crate::ports::types::{CompanyId, SecretValue};
+use crate::ports::types::CompanyId;
 
 // The credential key + backend routing live in the always-compiled
 // `company::composio` module (so the console read/write plane can manage the
 // token in the default build); re-exported here for the harness call sites.
 pub use crate::company::composio::{
     COMPOSIO_BACKEND_URL_ENV, TINYHUMANS_API_URL_ENV, TOKEN_KEY, backend_url_or_default,
+    resolve_credential,
 };
 
 /// A per-tenant Composio configuration: the backend URL, how the outbound bearer
@@ -153,26 +153,14 @@ impl TenantComposio {
         api_url_env: Option<String>,
         token_source: Option<Arc<TinyhumansTokenSource>>,
     ) -> Option<Self> {
-        let byo = match secrets.get(company, TOKEN_KEY).await {
-            Ok(Some(SecretValue(token))) => Credential::from_value(token),
-            _ => Credential::None,
-        };
-        let credential = match byo {
-            // The company's own Composio token always wins.
-            byo @ Credential::Value(_) => byo,
-            // Everything else is the shared seam's answer, so a rotated company
-            // key reaches Composio the same cycle it reaches every other
-            // brokered surface.
-            _ => match company_key::resolve(company, secrets, token_source).await {
-                Credential::None => return None,
-                credential => credential,
-            },
-        };
-        Some(Self::new(
-            backend_url_or_default(backend_url_env, api_url_env),
-            credential,
-            toolkits,
-        ))
+        match crate::company::composio::resolve_credential(company, secrets, token_source).await {
+            Credential::None => None,
+            credential => Some(Self::new(
+                backend_url_or_default(backend_url_env, api_url_env),
+                credential,
+                toolkits,
+            )),
+        }
     }
 
     /// The credential this config presents. Status and fingerprinting only —
@@ -1078,6 +1066,11 @@ mod live {
 mod tests {
     use super::*;
 
+    // Used by the resolver tests below; the module body itself resolves its
+    // credential through `company::composio::resolve_credential`.
+    use crate::company::company_key;
+    use crate::ports::types::SecretValue;
+
     // The three helper tests below follow their subjects behind the `composio`
     // feature: `toolkit_allowed` / `slug_toolkit` do not exist in an
     // `openhuman`-without-`composio` build.
@@ -1143,7 +1136,7 @@ mod tests {
     #[tokio::test]
     async fn resolve_prefers_the_stored_token_then_the_token_source_then_fails_closed() {
         use crate::ports::SecretStore;
-        use crate::ports::types::{CompanyId, SecretValue};
+        use crate::ports::types::CompanyId;
         use crate::store::FsSecretStore;
 
         let dir = tempfile::Builder::new()
@@ -1248,10 +1241,9 @@ mod tests {
     /// per-tenant provider app.
     #[tokio::test]
     async fn the_company_key_credentials_composio_between_a_byo_token_and_the_instance() {
-        use crate::company::company_key;
         use crate::company::credentials::CredentialSource;
         use crate::ports::SecretStore;
-        use crate::ports::types::{CompanyId, SecretValue};
+        use crate::ports::types::CompanyId;
         use crate::store::FsSecretStore;
 
         let dir = tempfile::Builder::new()
@@ -1326,7 +1318,6 @@ mod tests {
     /// credential after a console rotation.
     #[tokio::test]
     async fn rotating_the_company_key_moves_the_composio_fingerprint() {
-        use crate::company::company_key;
         use crate::ports::types::CompanyId;
         use crate::store::FsSecretStore;
 

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -142,9 +142,13 @@ impl TenantComposio {
     /// [`backend_url_or_default`]. `toolkits` is the manifest allowlist, threaded
     /// through unchanged.
     ///
-    /// A secret-store read error degrades to the next tier (and, failing all of
-    /// them, to `None`) rather than bubbling — a transient store hiccup must not
-    /// brick the roster build.
+    /// A secret-store read error yields `None` — **fail closed, no tools this
+    /// cycle** — rather than falling through to the instance identity. This is
+    /// the roster path, so it must not bubble and brick a build; but an *unknown*
+    /// credential must no more mean a borrowed identity than an absent one does.
+    /// A company whose store hiccups loses its Composio tools for a cycle and
+    /// gets them back on the next; it never quietly acts as somebody else. See
+    /// [`company_key::resolve`](crate::company::company_key::resolve).
     pub async fn resolve(
         company: &CompanyId,
         secrets: &dyn SecretStore,
@@ -153,7 +157,25 @@ impl TenantComposio {
         api_url_env: Option<String>,
         token_source: Option<Arc<TinyhumansTokenSource>>,
     ) -> Option<Self> {
-        match crate::company::composio::resolve_credential(company, secrets, token_source).await {
+        let credential = match crate::company::composio::resolve_credential(
+            company,
+            secrets,
+            token_source,
+        )
+        .await
+        {
+            Ok(credential) => credential,
+            Err(err) => {
+                tracing::warn!(
+                    company = %company,
+                    error = %err,
+                    "[composio] could not read this company's credential; withholding tools \
+                     for this cycle rather than presenting another identity"
+                );
+                return None;
+            }
+        };
+        match credential {
             Credential::None => None,
             credential => Some(Self::new(
                 backend_url_or_default(backend_url_env, api_url_env),
@@ -190,6 +212,13 @@ impl TenantComposio {
     /// and the company's own TinyHumans key — does contribute its value, since
     /// an admin changing either is a real identity change and must reach the
     /// agents on the next cycle.
+    ///
+    /// **Internal only — never log, serialize, or journal this.** Because it is
+    /// value-derived over a live credential, anyone who can read it can confirm
+    /// a guessed key against it: cheap to check, expensive to discover has been
+    /// leaking. It is compared for equality inside [`HarnessPool`] and goes
+    /// nowhere else. If a rebuild needs explaining, say that the identity
+    /// changed — not what it hashes to.
     pub fn fingerprint(config: &Option<TenantComposio>) -> u64 {
         use std::hash::{Hash, Hasher};
         let mut hasher = std::collections::hash_map::DefaultHasher::new();
@@ -1310,6 +1339,58 @@ mod tests {
         assert_eq!(
             token_of(&resolved).await.as_deref(),
             Some("platform-identity")
+        );
+    }
+
+    /// The roster path's half of the store-error contract: it must **fail
+    /// closed** — no tools this cycle — rather than fall through to the
+    /// instance identity or bubble and brick the build.
+    ///
+    /// Fewer tools for a cycle is recoverable and visible. Silently presenting
+    /// a different identity is neither: it would attribute whatever the agents
+    /// did in that window to the wrong account.
+    #[tokio::test]
+    async fn an_unreadable_store_withholds_tools_rather_than_borrowing_an_identity() {
+        use crate::ports::types::CompanyId;
+
+        struct BrokenSecrets;
+
+        #[async_trait::async_trait]
+        impl SecretStore for BrokenSecrets {
+            async fn get(
+                &self,
+                _c: &CompanyId,
+                _key: &str,
+            ) -> crate::Result<Option<crate::ports::types::SecretValue>> {
+                Err(crate::error::OpenCompanyError::Store("boom".into()))
+            }
+            async fn set(
+                &self,
+                _c: &CompanyId,
+                _key: &str,
+                _v: crate::ports::types::SecretValue,
+            ) -> crate::Result<()> {
+                Err(crate::error::OpenCompanyError::Store("boom".into()))
+            }
+        }
+
+        let company = CompanyId::new("acme");
+        let resolved = TenantComposio::resolve(
+            &company,
+            &BrokenSecrets,
+            Vec::new(),
+            None,
+            None,
+            // An instance identity IS available — and must still not be used,
+            // because we cannot tell whether this company has a key of its own.
+            Some(Arc::new(TinyhumansTokenSource::static_key(
+                "platform-identity",
+            ))),
+        )
+        .await;
+        assert!(
+            resolved.is_none(),
+            "an unreadable store must withhold the tools, not present the instance's identity"
         );
     }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -475,7 +475,17 @@ pub enum CompanyEvent {
     /// else.
     ToolAccessChanged {
         /// What changed, as a stable wire word: `credential_set`,
-        /// `credential_cleared`, or `provider_authorization_started`.
+        /// `credential_cleared`, `company_key_set`, `company_key_cleared`, or
+        /// `provider_authorization_started`.
+        ///
+        /// The `credential_*` pair is the **Composio** token
+        /// ([`ops::composio`](crate::server::ops::composio)); the `company_key_*`
+        /// pair is the company's own TinyHumans identity
+        /// ([`ops::company_key`](crate::server::ops::company_key), issue #586).
+        /// Two vocabularies rather than one because the changes have different
+        /// blast radii — swapping a Composio token repoints one integration,
+        /// rotating the company key repoints every surface wired to it — and an
+        /// audit reader has to be able to tell them apart.
         ///
         /// The last is deliberately *started*, not *completed*: Composio runs
         /// the OAuth on its own side with no callback here, so all this host

--- a/src/server/ops/company_key.rs
+++ b/src/server/ops/company_key.rs
@@ -1,0 +1,178 @@
+//! The company's own TinyHumans credential, over HTTP (issue #586): read whether
+//! one is set and which identity brokered calls currently present, and set /
+//! rotate / clear it.
+//!
+//! The credential itself is [`company_key`](crate::company::company_key); this
+//! is its console plane. **Write-only**: the key goes in through the `key`
+//! field, lands in the secret store, and is never echoed — the read shape
+//! carries only a `configured` boolean plus the non-secret tier name.
+//!
+//! **Admin-only** on the write, for the same reason
+//! [`ops::composio`](super::composio)'s token write is: this key is the identity
+//! every one of the company's agents presents to every surface the platform
+//! brokers, and it is the company's wallet — whoever sets it decides which
+//! account those agents act through and which account pays. That is a decision
+//! made *for* the company, not a member's own, and [`AdminScopedCompany`] is
+//! what says so in the signature.
+//!
+//! A set / rotate / clear takes effect on the agents' **next cycle** with no
+//! restart: every brokered surface re-resolves through
+//! [`company_key::resolve`](crate::company::company_key::resolve) and the roster
+//! fingerprint moves with the key's value.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::company_key::{key_configured, resolve, store_key};
+use crate::company::credentials::CredentialSource;
+use crate::company::runtime::CompanyRuntime;
+use crate::ports::types::CompanyEvent;
+use crate::server::error::ApiError;
+use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
+
+/// The reminder attached to every mutating response.
+const SWITCH_NOTE: &str = "Agents present the new credential on their next cycle — no restart \
+     needed. It reaches every surface the platform brokers at once.";
+
+/// What an admin most needs to understand before pasting: this key is the
+/// company's wallet, and membership in the company is what grants access to it.
+const CONSEQUENCE: &str = "This is the company's TinyHumans credential. Every member's agents act and spend through \
+     it, and every provider connected with it belongs to the company rather than to the person \
+     who connected it. Spend arrives as one account, so it cannot be attributed per member.";
+
+/// Said instead when nothing is configured and the instance carries no identity
+/// either — the honest degraded state, rather than a picker that will fail.
+const DEGRADED: &str = "No credential is set for this company and this instance carries no \
+     platform identity, so providers cannot be connected or used. Set the company's TinyHumans \
+     key to enable them.";
+
+/// Builds the company-credential route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/credential", get(get_status).put(set_key))
+}
+
+/// The company's credential status as the console renders it. **Never** carries
+/// the key — only whether one is stored and which tier a brokered call presents.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct CredentialStatusDto {
+    /// Whether this company has its **own** TinyHumans key stored. False does
+    /// not mean no credential — see `source`.
+    configured: bool,
+    /// Which identity a brokered call presents right now: `company` (this
+    /// company's own key), `attested` / `static` (this instance's platform
+    /// identity), or `none`.
+    source: CredentialSource,
+    /// The consequence of setting this key, stated plainly, or the degraded
+    /// state when nothing can be presented at all.
+    notice: String,
+}
+
+/// A mutating response: the resulting status plus the switch reminder.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct MutationResponse {
+    status: CredentialStatusDto,
+    note: String,
+}
+
+/// Set-key body. `key` is write-only intake (never returned): a non-empty value
+/// sets or rotates it, an explicit empty string clears it.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetKey {
+    key: String,
+}
+
+/// Resolves the credential status DTO for a company.
+///
+/// `source` comes from the **same** resolver the harness and the Composio routes
+/// use, so the console can never report a tier the agents are not actually on.
+async fn effective_status(runtime: &CompanyRuntime) -> Result<CredentialStatusDto, ApiError> {
+    let secrets = runtime.secrets();
+    let configured = key_configured(runtime.id(), secrets.as_ref())
+        .await
+        .map_err(ApiError)?;
+    let env = crate::app::config::ProcessEnv;
+    let source = resolve(
+        runtime.id(),
+        secrets.as_ref(),
+        crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
+    )
+    .await
+    .source();
+    Ok(CredentialStatusDto {
+        configured,
+        source,
+        notice: if source == CredentialSource::None {
+            DEGRADED.to_string()
+        } else {
+            CONSEQUENCE.to_string()
+        },
+    })
+}
+
+/// `GET …/credential` — whether this company has its own key, and which identity
+/// its brokered calls present.
+async fn get_status(company: ScopedCompany) -> Result<Json<CredentialStatusDto>, ApiError> {
+    Ok(Json(effective_status(company.runtime.as_ref()).await?))
+}
+
+/// `PUT …/credential` — set / rotate / clear the company's write-only TinyHumans
+/// credential. **Admin-only** — see the module docs.
+async fn set_key(
+    company: AdminScopedCompany,
+    Json(body): Json<SetKey>,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let runtime = company.runtime.as_ref();
+    store_key(runtime.id(), runtime.secrets().as_ref(), &body.key)
+        .await
+        .map_err(ApiError)?;
+    // The credential decides which account the backend resolves, so a change can
+    // change which Composio catalog this company gets. Drop the cached one
+    // rather than serving the previous account's answer for up to `CATALOG_TTL`.
+    super::composio::evict_catalog_cache(runtime);
+    // After the store, so the journal records a completed change. An empty value
+    // is a clear, not a set — worth telling apart in an audit trail, since one
+    // grants access and the other withdraws it.
+    let change = if body.key.trim().is_empty() {
+        "credential_cleared"
+    } else {
+        "credential_set"
+    };
+    journal(&company, change).await?;
+    Ok(Json(MutationResponse {
+        status: effective_status(runtime).await?,
+        note: SWITCH_NOTE.to_string(),
+    }))
+}
+
+/// Records who changed the company's credential (issue #403's discipline).
+///
+/// Propagates a journal failure rather than swallowing it, mirroring
+/// [`ops::composio`](super::composio): the point of this record is that a change
+/// to what the company's agents act through is never invisible, and an audit
+/// line that quietly fails to be written is the one failure mode that would
+/// defeat it.
+async fn journal(company: &AdminScopedCompany, change: &str) -> Result<(), ApiError> {
+    company
+        .runtime
+        .events()
+        .append(
+            company.id(),
+            CompanyEvent::ToolAccessChanged {
+                change: change.to_string(),
+                toolkit: None,
+                by: Some(company.actor()),
+            },
+        )
+        .await
+        .map_err(ApiError)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test;

--- a/src/server/ops/company_key.rs
+++ b/src/server/ops/company_key.rs
@@ -16,9 +16,11 @@
 //! what says so in the signature.
 //!
 //! A set / rotate / clear takes effect on the agents' **next cycle** with no
-//! restart: every brokered surface re-resolves through
+//! restart: every surface **wired to this credential** re-resolves through
 //! [`company_key::resolve`](crate::company::company_key::resolve) and the roster
-//! fingerprint moves with the key's value.
+//! fingerprint moves with the key's value. That is Composio today; inference and
+//! embeddings still resolve from the environment (#585), so "wired to it" is a
+//! smaller set than "brokered" until that lands.
 
 use axum::Json;
 use axum::Router;
@@ -34,8 +36,15 @@ use crate::server::error::ApiError;
 use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// The reminder attached to every mutating response.
+///
+/// Names Composio rather than claiming "every brokered surface". The seam is
+/// built so that any surface wired to it moves together, but Composio is the
+/// only one wired **today** — inference and embeddings still resolve from the
+/// environment (#585). Promising breadth the build does not have would be the
+/// same overclaim this PR removed from the status route.
 const SWITCH_NOTE: &str = "Agents present the new credential on their next cycle — no restart \
-     needed. It reaches every surface the platform brokers at once.";
+     needed. Composio picks it up at once, and any other surface wired to this credential moves \
+     with it.";
 
 /// What an admin most needs to understand before pasting: this key is the
 /// company's wallet, and membership in the company is what grants access to it.

--- a/src/server/ops/company_key.rs
+++ b/src/server/ops/company_key.rs
@@ -110,8 +110,17 @@ struct SetKey {
 
 /// Resolves the credential status DTO for a company.
 ///
-/// `source` comes from the **same** resolver the harness and the Composio routes
-/// use, so the console can never report a tier the agents are not actually on.
+/// `source` is the company's **TinyHumans identity**, straight from
+/// [`company_key::resolve`](crate::company::company_key::resolve): its own key,
+/// else this instance's platform identity, else nothing.
+///
+/// That is deliberately **not** the same answer `GET …/composio` gives. The
+/// Composio route prepends its BYO `composio/token` tier, so a company holding
+/// both reads `company` here and `static` there — and both are correct, because
+/// they answer different questions: this route reports whose identity the
+/// company *has*, the Composio one reports what a Composio call *presents*.
+/// Claiming parity between them would be wrong in exactly the case where the
+/// distinction matters.
 async fn effective_status(runtime: &CompanyRuntime) -> Result<CredentialStatusDto, ApiError> {
     let secrets = runtime.secrets();
     let configured = key_configured(runtime.id(), secrets.as_ref())
@@ -160,10 +169,18 @@ async fn set_key(
     // After the store, so the journal records a completed change. An empty value
     // is a clear, not a set — worth telling apart in an audit trail, since one
     // grants access and the other withdraws it.
+    //
+    // Namespaced `company_key_*` rather than reusing `ops::composio`'s
+    // `credential_set` / `credential_cleared`. Both routes append
+    // `ToolAccessChanged` to the same log, and with one shared vocabulary a
+    // reader could not tell "the admin rotated the company's identity" from
+    // "the admin swapped the Composio token" — two changes with different blast
+    // radii. An audit line that cannot name what changed is most of the way to
+    // not having one.
     let change = if body.key.trim().is_empty() {
-        "credential_cleared"
+        "company_key_cleared"
     } else {
-        "credential_set"
+        "company_key_set"
     };
     journal(&company, change).await?;
     Ok(Json(MutationResponse {

--- a/src/server/ops/company_key.rs
+++ b/src/server/ops/company_key.rs
@@ -39,15 +39,27 @@ const SWITCH_NOTE: &str = "Agents present the new credential on their next cycle
 
 /// What an admin most needs to understand before pasting: this key is the
 /// company's wallet, and membership in the company is what grants access to it.
-const CONSEQUENCE: &str = "This is the company's TinyHumans credential. Every member's agents act and spend through \
-     it, and every provider connected with it belongs to the company rather than to the person \
-     who connected it. Spend arrives as one account, so it cannot be attributed per member.";
+///
+/// The last sentence is load-bearing. The Connections screen renders this card
+/// next to the Inference one, both read "configured / not configured", and the
+/// two keys are different in kind — pasting one into the other's field is the
+/// exact mistake the `tinyhumans/key`-vs-`inference/key` split exists to
+/// prevent. An admin will not have read that reasoning in the module docs, so
+/// the card has to carry it. See [`company_key`](crate::company::company_key).
+const CONSEQUENCE: &str = "This is the company's TinyHumans account key — the identity the platform presents when it \
+     connects providers like Gmail or Slack on your behalf. Every member's agents act and spend \
+     through it, and a provider connected with it belongs to the company rather than to the \
+     person who connected it. Spend arrives as one account, so it cannot be attributed per \
+     member. It is not the model-provider key on the Inference card: that one is whatever your \
+     chosen provider issues (an OpenRouter key, or your own endpoint's), and the two are stored \
+     separately on purpose.";
 
 /// Said instead when nothing is configured and the instance carries no identity
 /// either — the honest degraded state, rather than a picker that will fail.
 const DEGRADED: &str = "No credential is set for this company and this instance carries no \
      platform identity, so providers cannot be connected or used. Set the company's TinyHumans \
-     key to enable them.";
+     account key to enable them — not the model-provider key from the Inference card, which is a \
+     different credential.";
 
 /// Builds the company-credential route fragment.
 pub fn router() -> Router<AppState> {
@@ -103,6 +115,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CredentialStatusDt
         crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
     .await
+    .map_err(ApiError)?
     .source();
     Ok(CredentialStatusDto {
         configured,

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -152,6 +152,13 @@ async fn the_key_round_trips_write_only_and_reports_the_company_tier() {
     let notice = resp["status"]["notice"].as_str().unwrap_or_default();
     assert!(notice.contains("spend"), "{notice}");
     assert!(notice.contains("company"), "{notice}");
+    // …and so is the distinction from the model-provider key. These two cards
+    // sit next to each other and both read "configured"; the copy is the only
+    // thing standing between an admin and pasting an OpenRouter key here.
+    assert!(
+        notice.contains("Inference card"),
+        "the notice must say which key this is NOT: {notice}"
+    );
 
     // GET reflects it and still never carries the key.
     let (_, dto, raw) = send(&state, "acme", "GET", "/api/v1/company/credential", None).await;

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -272,6 +272,56 @@ async fn a_pasted_composio_token_still_outranks_the_company_key() {
     assert_eq!(dto["credentialSource"], "company", "{dto}");
 }
 
+/// The two read planes answer **different questions**, and a company holding
+/// both credentials is where that stops being pedantry.
+///
+/// `GET …/credential` reports whose identity the company *has*; `GET …/composio`
+/// reports what a Composio call *presents*, which its BYO token overrides. Both
+/// are correct simultaneously, and any refactor that "unifies" them would have
+/// to break one of these two assertions.
+#[tokio::test]
+async fn the_credential_plane_and_the_composio_plane_may_honestly_disagree() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "disagree", GRANTED).await;
+
+    send(
+        &state,
+        "disagree",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+    send(
+        &state,
+        "disagree",
+        "PUT",
+        "/api/v1/company/composio/token",
+        Some(json!({ "token": "byo-composio-token" })),
+    )
+    .await;
+
+    let (_, credential, _) = send(
+        &state,
+        "disagree",
+        "GET",
+        "/api/v1/company/credential",
+        None,
+    )
+    .await;
+    let (_, composio, _) = send(&state, "disagree", "GET", "/api/v1/company/composio", None).await;
+
+    assert_eq!(
+        credential["source"], "company",
+        "the company's own identity is set, whatever Composio presents: {credential}"
+    );
+    assert_eq!(
+        composio["credentialSource"], "static",
+        "a Composio call presents the BYO token, whatever identity the company holds: {composio}"
+    );
+    assert_eq!(credential["configured"], true);
+}
+
 /// The write is admin-only, for the same reason the Composio token write is:
 /// this key repoints the company's entire brokered surface at whatever account
 /// the caller controls, and it is the company's wallet.
@@ -348,11 +398,21 @@ async fn setting_and_clearing_are_journaled_with_an_actor() {
         })
         .collect();
     assert!(
-        changes.contains(&("credential_set".to_string(), true)),
+        changes.contains(&("company_key_set".to_string(), true)),
         "a set must be journaled with who did it: {changes:?}"
     );
     assert!(
-        changes.contains(&("credential_cleared".to_string(), true)),
+        changes.contains(&("company_key_cleared".to_string(), true)),
         "a clear must be told apart from a set: {changes:?}"
+    );
+    // …and it must not borrow the Composio token's vocabulary. Both routes
+    // append `ToolAccessChanged` to one log, so if this route spoke
+    // `credential_set` an auditor could not tell a rotation of the company's
+    // whole identity from a swap of one integration's token.
+    assert!(
+        !changes
+            .iter()
+            .any(|(change, _)| change == "credential_set" || change == "credential_cleared"),
+        "no Composio write happened here, so no Composio audit word may appear: {changes:?}"
     );
 }

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -1,0 +1,351 @@
+//! Route tests for the company's TinyHumans credential (issue #586).
+
+use axum::body::{Body, to_bytes};
+use axum::http::{Request, StatusCode};
+use serde_json::{Value, json};
+use tower::ServiceExt;
+
+use crate::company::CompanyManifest;
+use crate::ports::types::{CompanyId, CompanyRecord};
+use crate::runtime::RuntimeBuilder;
+use crate::server::router;
+use crate::store::FsCompanyStore;
+use crate::{AppConfig, AppState};
+
+/// A value long and opaque enough that a leak would be unmistakable in a body.
+const KEY: &str = "th_company_credential_SECRET_do_not_echo_me";
+
+/// A company that grants Composio, so the status route has something to report
+/// a credential tier *for*.
+const GRANTED: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+     [tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n";
+
+fn home() -> tempfile::TempDir {
+    tempfile::Builder::new()
+        .prefix("oc-company-key-")
+        .tempdir()
+        .expect("tempdir")
+}
+
+async fn state_with_manifest(
+    home: &std::path::Path,
+    company: &str,
+    manifest_toml: &str,
+) -> AppState {
+    use crate::ports::CompanyStore;
+    let manifest: CompanyManifest = toml::from_str(manifest_toml).unwrap();
+    let store = FsCompanyStore::new(home.to_path_buf());
+    let id = CompanyId::new(company);
+    store
+        .save(&CompanyRecord {
+            id: id.clone(),
+            manifest: manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        })
+        .await
+        .unwrap();
+    let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+        .with_id(id.clone())
+        .build()
+        .await
+        .unwrap();
+    let state = AppState::new(AppConfig::default());
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    crate::server::test_support::seed_fixed_admin(&state, company).await;
+    state
+}
+
+async fn send_as(
+    state: &AppState,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+    cookie: String,
+) -> (StatusCode, Value, String) {
+    let request = Request::builder()
+        .method(method)
+        .uri(uri)
+        .header("cookie", cookie);
+    let request = match body {
+        Some(body) => request
+            .header("content-type", "application/json")
+            .body(Body::from(body.to_string()))
+            .unwrap(),
+        None => request.body(Body::empty()).unwrap(),
+    };
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let raw = String::from_utf8_lossy(&bytes).to_string();
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+    };
+    (status, value, raw)
+}
+
+async fn send(
+    state: &AppState,
+    company: &str,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> (StatusCode, Value, String) {
+    send_as(
+        state,
+        method,
+        uri,
+        body,
+        crate::server::test_support::fixed_cookie(company),
+    )
+    .await
+}
+
+/// The core round trip: an admin sets the key, the read plane reports it as the
+/// company's own identity, and the value never comes back out.
+#[tokio::test]
+async fn the_key_round_trips_write_only_and_reports_the_company_tier() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "acme", GRANTED).await;
+
+    // Nothing set, and the test process carries no platform identity: the
+    // honest degraded state, not a broken picker.
+    let (status, dto, raw) = send(&state, "acme", "GET", "/api/v1/company/credential", None).await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(dto["configured"], false);
+    assert_eq!(dto["source"], "none");
+    assert!(
+        dto["notice"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("cannot be connected"),
+        "the degraded state has to say what is unavailable: {dto}"
+    );
+    assert!(dto.get("key").is_none(), "status must never carry the key");
+
+    // Set it.
+    let (status, resp, raw) = send(
+        &state,
+        "acme",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{raw}");
+    assert_eq!(resp["status"]["configured"], true);
+    assert_eq!(resp["status"]["source"], "company");
+    assert!(!raw.contains(KEY), "PUT response leaked the key: {raw}");
+
+    // The consequence is stated, because it is the thing an admin most needs to
+    // understand before pasting.
+    let notice = resp["status"]["notice"].as_str().unwrap_or_default();
+    assert!(notice.contains("spend"), "{notice}");
+    assert!(notice.contains("company"), "{notice}");
+
+    // GET reflects it and still never carries the key.
+    let (_, dto, raw) = send(&state, "acme", "GET", "/api/v1/company/credential", None).await;
+    assert_eq!(dto["configured"], true);
+    assert_eq!(dto["source"], "company");
+    assert!(!raw.contains(KEY), "GET status leaked the key: {raw}");
+}
+
+/// Acceptance: a company with its key set can connect a provider without any
+/// per-tenant provider app — the Composio plane must see the company's own
+/// identity, with no Composio token pasted anywhere.
+#[tokio::test]
+async fn setting_the_key_credentials_composio_with_no_composio_token() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "brokered", GRANTED).await;
+
+    // No Composio token, no platform identity in this process → nothing.
+    let (_, dto, _) = send(&state, "brokered", "GET", "/api/v1/company/composio", None).await;
+    assert_eq!(dto["credentialSource"], "none");
+
+    send(
+        &state,
+        "brokered",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+
+    // The company key alone credentials Composio. This is the issue in one
+    // assertion: no `composio/token`, no provider app, still connectable.
+    let (_, dto, raw) = send(&state, "brokered", "GET", "/api/v1/company/composio", None).await;
+    assert_eq!(dto["credentialSource"], "company", "{raw}");
+    assert!(
+        !raw.contains(KEY),
+        "the Composio status leaked the key: {raw}"
+    );
+}
+
+/// Acceptance: clearing is real, and reverts to the honest degraded state
+/// rather than stranding the console on a stale "connected" claim.
+#[tokio::test]
+async fn clearing_the_key_reverts_to_the_degraded_state() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "cleared", GRANTED).await;
+    send(
+        &state,
+        "cleared",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+
+    let (_, resp, _) = send(
+        &state,
+        "cleared",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": "" })),
+    )
+    .await;
+    assert_eq!(resp["status"]["configured"], false);
+    assert_eq!(resp["status"]["source"], "none");
+
+    let (_, dto, _) = send(&state, "cleared", "GET", "/api/v1/company/composio", None).await;
+    assert_eq!(dto["credentialSource"], "none");
+}
+
+/// A company's own Composio token still outranks the company key — the BYO
+/// escape hatch is not taken away by this change.
+#[tokio::test]
+async fn a_pasted_composio_token_still_outranks_the_company_key() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "byo", GRANTED).await;
+    send(
+        &state,
+        "byo",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+    send(
+        &state,
+        "byo",
+        "PUT",
+        "/api/v1/company/composio/token",
+        Some(json!({ "token": "byo-composio-token" })),
+    )
+    .await;
+
+    let (_, dto, _) = send(&state, "byo", "GET", "/api/v1/company/composio", None).await;
+    assert_eq!(
+        dto["credentialSource"], "static",
+        "a company that pasted its own Composio token keeps it: {dto}"
+    );
+
+    // The company key is still stored — the two are separate slots, and
+    // clearing the Composio token falls back to the company's own identity
+    // rather than to nothing.
+    send(
+        &state,
+        "byo",
+        "PUT",
+        "/api/v1/company/composio/token",
+        Some(json!({ "token": "" })),
+    )
+    .await;
+    let (_, dto, _) = send(&state, "byo", "GET", "/api/v1/company/composio", None).await;
+    assert_eq!(dto["credentialSource"], "company", "{dto}");
+}
+
+/// The write is admin-only, for the same reason the Composio token write is:
+/// this key repoints the company's entire brokered surface at whatever account
+/// the caller controls, and it is the company's wallet.
+#[tokio::test]
+async fn a_member_cannot_set_the_companys_credential() {
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "acme", GRANTED).await;
+    let member =
+        crate::server::test_support::seed_session(&state, "acme", crate::ports::UserRole::Member)
+            .await;
+
+    let (status, body, raw) = send_as(
+        &state,
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+        member,
+    )
+    .await;
+    assert_eq!(status, StatusCode::FORBIDDEN, "{raw}");
+    assert_eq!(body["code"], "forbidden", "{body}");
+    assert!(
+        body["error"].as_str().unwrap_or_default().contains("admin"),
+        "the refusal has to say why: {body}"
+    );
+
+    // The refusal is real, not merely a different status.
+    let (_, dto, _) = send(&state, "acme", "GET", "/api/v1/company/credential", None).await;
+    assert_eq!(
+        dto["configured"], false,
+        "a refused write must not have stored anything: {dto}"
+    );
+}
+
+/// Setting the credential is journaled, so a change to what the company acts
+/// through is never invisible — and a clear is told apart from a set.
+#[tokio::test]
+async fn setting_and_clearing_are_journaled_with_an_actor() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let state = state_with_manifest(home_dir.path(), "audited", GRANTED).await;
+    send(
+        &state,
+        "audited",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": KEY })),
+    )
+    .await;
+    send(
+        &state,
+        "audited",
+        "PUT",
+        "/api/v1/company/credential",
+        Some(json!({ "key": "" })),
+    )
+    .await;
+
+    let id = CompanyId::new("audited");
+    let runtime = state.registry().get(&id).expect("registered");
+    let events = runtime
+        .events()
+        .read_from(&id, crate::ports::types::EventSeq::new(0), 200)
+        .await
+        .expect("events");
+    let changes: Vec<(String, bool)> = events
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            CompanyEvent::ToolAccessChanged { change, by, .. } => {
+                Some((change.clone(), by.is_some()))
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        changes.contains(&("credential_set".to_string(), true)),
+        "a set must be journaled with who did it: {changes:?}"
+    );
+    assert!(
+        changes.contains(&("credential_cleared".to_string(), true)),
+        "a clear must be told apart from a set: {changes:?}"
+    );
+}

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -356,14 +356,15 @@ struct ConnectionDto {
 async fn credential_source_for(
     runtime: &CompanyRuntime,
     token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
-) -> CredentialSource {
-    crate::company::composio::resolve_credential(
+) -> Result<CredentialSource, ApiError> {
+    Ok(crate::company::composio::resolve_credential(
         runtime.id(),
         runtime.secrets().as_ref(),
         token_source,
     )
     .await
-    .source()
+    .map_err(ApiError)?
+    .source())
 }
 
 /// Resolves the Composio status DTO for a company.
@@ -388,7 +389,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         runtime,
         TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
-    .await;
+    .await?;
     let (open_mode, effective) = effective_toolkits(runtime, &toolkits).await;
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
@@ -536,22 +537,32 @@ pub(crate) async fn resolve_tenant(
     let env = crate::app::config::ProcessEnv;
     let backend_env = env.get(crate::company::composio::COMPOSIO_BACKEND_URL_ENV);
     let api_env = env.get(crate::company::composio::TINYHUMANS_API_URL_ENV);
-    crate::harness::composio::TenantComposio::resolve(
+    // Resolved here rather than through `TenantComposio::resolve` so a store
+    // read failure stays distinguishable from "nothing configured". This is the
+    // path that *establishes* a connection, and a connection lives on the
+    // backend keyed by the account the bearer resolves to — so guessing here
+    // would attribute a company's Gmail to whichever identity happened to
+    // resolve during the outage. The roster path can afford to shrug and
+    // withhold tools; this one must say what went wrong and connect nothing.
+    let credential = crate::company::composio::resolve_credential(
         runtime.id(),
         runtime.secrets().as_ref(),
-        toolkits,
-        backend_env,
-        api_env,
         crate::company::TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
     )
     .await
-    .ok_or_else(|| {
-        ApiError(crate::error::OpenCompanyError::Conflict(
-            "no Composio credential is available for this company — this instance has no platform \
-             identity, so paste the company's Composio token first"
+    .map_err(ApiError)?;
+    if !credential.configured() {
+        return Err(ApiError(crate::error::OpenCompanyError::Conflict(
+            "no Composio credential is available for this company — set the company's TinyHumans \
+             credential, or paste its own Composio token"
                 .to_string(),
-        ))
-    })
+        )));
+    }
+    Ok(crate::harness::composio::TenantComposio::new(
+        backend_url_or_default(backend_env, api_env),
+        credential,
+        toolkits,
+    ))
 }
 
 #[cfg(feature = "composio")]
@@ -1115,12 +1126,16 @@ mod tests {
 
         // Nothing stored + a projected instance identity → attested.
         assert_eq!(
-            credential_source_for(&runtime, source_of(&projected)).await,
+            credential_source_for(&runtime, source_of(&projected))
+                .await
+                .unwrap(),
             CredentialSource::Attested
         );
         // Nothing stored at all → nothing obtainable, so no tools.
         assert_eq!(
-            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            credential_source_for(&runtime, source_of(&MapEnv::default()))
+                .await
+                .unwrap(),
             CredentialSource::None
         );
         // A static instance key is the static tier.
@@ -1132,7 +1147,8 @@ mod tests {
                     "th_static"
                 )]))
             )
-            .await,
+            .await
+            .unwrap(),
             CredentialSource::Static
         );
 
@@ -1143,13 +1159,17 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            credential_source_for(&runtime, source_of(&projected)).await,
+            credential_source_for(&runtime, source_of(&projected))
+                .await
+                .unwrap(),
             CredentialSource::Company
         );
         // …and is the whole credential when the instance carries none, which is
         // the case this issue exists to fix.
         assert_eq!(
-            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            credential_source_for(&runtime, source_of(&MapEnv::default()))
+                .await
+                .unwrap(),
             CredentialSource::Company
         );
 
@@ -1158,18 +1178,24 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(
-            credential_source_for(&runtime, source_of(&projected)).await,
+            credential_source_for(&runtime, source_of(&projected))
+                .await
+                .unwrap(),
             CredentialSource::Static
         );
         assert_eq!(
-            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            credential_source_for(&runtime, source_of(&MapEnv::default()))
+                .await
+                .unwrap(),
             CredentialSource::Static
         );
 
         // Clearing it falls back exactly one tier, not all the way to nothing.
         store_token(&id, secrets.as_ref(), "").await.unwrap();
         assert_eq!(
-            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            credential_source_for(&runtime, source_of(&MapEnv::default()))
+                .await
+                .unwrap(),
             CredentialSource::Company
         );
 

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -143,6 +143,18 @@ async fn open_mode_toolkits(runtime: &CompanyRuntime) -> OpenModeToolkits {
     OpenModeToolkits::from_outcome(outcome)
 }
 
+/// Drop this company's cached catalog.
+///
+/// Exposed because the catalog is a property of the **credential**, not of the
+/// Composio token alone: changing the company's TinyHumans key
+/// ([`ops::company_key`](super::company_key)) can change which account the
+/// backend resolves and therefore which catalog it serves. Both writes evict
+/// through here rather than each reaching into the cache with its own key
+/// derivation.
+pub(crate) fn evict_catalog_cache(runtime: &CompanyRuntime) {
+    composio_toolkits::cache().evict(&catalog_cache_key(runtime));
+}
+
 /// This company's catalog cache key. The backend URL is resolved the same way
 /// the status DTO resolves it, so a company repointed at a different backend
 /// does not read the old backend's catalog.
@@ -327,17 +339,23 @@ struct ConnectionDto {
 }
 
 /// Which tier a company's Composio credential comes from, mirroring the harness
-/// resolver's precedence: the company's **own** stored token wins, else this
-/// instance's platform identity, else nothing.
+/// resolver's precedence: the company's **own Composio** token wins, else its
+/// own TinyHumans key, else this instance's platform identity, else nothing.
 ///
-/// Takes the environment as a seam so the matrix is testable without mutating the
-/// process environment.
+/// `stored` and `company_key` are read by the caller rather than looked up here
+/// so the matrix stays a pure function of the two booleans plus the environment
+/// — testable without a secret store and without mutating the process
+/// environment.
 fn credential_source_for(
     stored: bool,
+    company_key: bool,
     env: &dyn crate::app::config::EnvSource,
 ) -> CredentialSource {
     if stored {
         return CredentialSource::Static;
+    }
+    if company_key {
+        return CredentialSource::Company;
     }
     TinyhumansTokenSource::from_env(env)
         .map(|source| source.credential_source())
@@ -359,6 +377,13 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
     let stored = token_configured(runtime.id(), runtime.secrets().as_ref())
         .await
         .map_err(ApiError)?;
+    // The company's own TinyHumans key is the tier between its pasted Composio
+    // token and this instance's identity — the whole point of issue #586 is that
+    // a company with a key set needs no Composio token of its own.
+    let company_key =
+        crate::company::company_key::key_configured(runtime.id(), runtime.secrets().as_ref())
+            .await
+            .map_err(ApiError)?;
     let env = crate::app::config::ProcessEnv;
     let (env_url, api_url) = {
         use crate::app::config::EnvSource;
@@ -367,7 +392,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
             env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
         )
     };
-    let credential_source = credential_source_for(stored, &env);
+    let credential_source = credential_source_for(stored, company_key, &env);
     let (open_mode, effective) = effective_toolkits(runtime, &toolkits).await;
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
@@ -410,7 +435,7 @@ async fn set_token(
     // cached one rather than serving the previous account's answer for up to
     // `CATALOG_TTL` — the response below re-reads the status, so the operator
     // sees the new list immediately.
-    composio_toolkits::cache().evict(&catalog_cache_key(runtime));
+    evict_catalog_cache(runtime);
     // After the store, so the journal records a completed change. An empty
     // value is a clear, not a set — the two are worth telling apart in an
     // audit trail, since one grants access and the other withdraws it.
@@ -1070,25 +1095,43 @@ mod tests {
 
         // Nothing stored + a projected instance identity → attested.
         assert_eq!(
-            credential_source_for(false, &projected),
+            credential_source_for(false, false, &projected),
             CredentialSource::Attested
         );
-        // The company's own token outranks the instance identity.
+        // The company's own Composio token outranks everything.
         assert_eq!(
-            credential_source_for(true, &projected),
+            credential_source_for(true, false, &projected),
             CredentialSource::Static
+        );
+        assert_eq!(
+            credential_source_for(true, true, &projected),
+            CredentialSource::Static
+        );
+        // The company's own TinyHumans key outranks the instance identity — a
+        // company with a key set connects providers as *itself*, not as the pod
+        // it happens to run in (issue #586).
+        assert_eq!(
+            credential_source_for(false, true, &projected),
+            CredentialSource::Company
+        );
+        // …and is the whole credential when the instance carries no identity,
+        // which is the case this issue exists to fix.
+        assert_eq!(
+            credential_source_for(false, true, &MapEnv::default()),
+            CredentialSource::Company
         );
         // A static instance key is the static tier too.
         assert_eq!(
             credential_source_for(
                 false,
+                false,
                 &MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")])
             ),
             CredentialSource::Static
         );
-        // Neither → nothing obtainable, so no tools.
+        // Nothing at any tier → nothing obtainable, so no tools.
         assert_eq!(
-            credential_source_for(false, &MapEnv::default()),
+            credential_source_for(false, false, &MapEnv::default()),
             CredentialSource::None
         );
 

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -66,9 +66,10 @@ use axum::routing::{get, post, put};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
-use crate::company::composio::{
-    CatalogEntry, backend_url_or_default, store_token, token_configured,
-};
+// `token_configured` is gone from this list deliberately: the status route no
+// longer re-derives the credential tier from booleans, it asks the resolver
+// (`resolve_credential`) — see `credential_source_for` below.
+use crate::company::composio::{CatalogEntry, backend_url_or_default, store_token};
 use crate::company::credentials::{CredentialSource, TinyhumansTokenSource};
 use crate::company::runtime::CompanyRuntime;
 use crate::ports::types::CompanyEvent;
@@ -340,26 +341,29 @@ struct ConnectionDto {
 
 /// Which tier a company's Composio credential comes from, mirroring the harness
 /// resolver's precedence: the company's **own Composio** token wins, else its
-/// own TinyHumans key, else this instance's platform identity, else nothing.
+/// Which tier a company's Composio credential comes from.
 ///
-/// `stored` and `company_key` are read by the caller rather than looked up here
-/// so the matrix stays a pure function of the two booleans plus the environment
-/// — testable without a secret store and without mutating the process
-/// environment.
-fn credential_source_for(
-    stored: bool,
-    company_key: bool,
-    env: &dyn crate::app::config::EnvSource,
+/// Asks the resolver itself rather than restating its precedence. The console
+/// must never be able to name a tier the agents are not on, and a second copy of
+/// the rule is a second place to forget to update — which is how a status route
+/// ends up confidently reporting a credential that no longer resolves.
+///
+/// Takes the instance identity already resolved, rather than an `&dyn
+/// EnvSource`: a trait object with no `Send + Sync` bound held across the await
+/// below makes the whole handler future non-`Send`, which axum rejects. Callers
+/// resolve it from whichever environment they mean, so the matrix stays testable
+/// without mutating the process environment.
+async fn credential_source_for(
+    runtime: &CompanyRuntime,
+    token_source: Option<std::sync::Arc<TinyhumansTokenSource>>,
 ) -> CredentialSource {
-    if stored {
-        return CredentialSource::Static;
-    }
-    if company_key {
-        return CredentialSource::Company;
-    }
-    TinyhumansTokenSource::from_env(env)
-        .map(|source| source.credential_source())
-        .unwrap_or(CredentialSource::None)
+    crate::company::composio::resolve_credential(
+        runtime.id(),
+        runtime.secrets().as_ref(),
+        token_source,
+    )
+    .await
+    .source()
 }
 
 /// Resolves the Composio status DTO for a company.
@@ -372,18 +376,6 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
         ),
         None => (false, Vec::new()),
     };
-    // Mirrors the harness resolver: this company's own token wins, else the
-    // instance's platform identity, else nothing.
-    let stored = token_configured(runtime.id(), runtime.secrets().as_ref())
-        .await
-        .map_err(ApiError)?;
-    // The company's own TinyHumans key is the tier between its pasted Composio
-    // token and this instance's identity — the whole point of issue #586 is that
-    // a company with a key set needs no Composio token of its own.
-    let company_key =
-        crate::company::company_key::key_configured(runtime.id(), runtime.secrets().as_ref())
-            .await
-            .map_err(ApiError)?;
     let env = crate::app::config::ProcessEnv;
     let (env_url, api_url) = {
         use crate::app::config::EnvSource;
@@ -392,7 +384,11 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<ComposioStatusDto,
             env.get(crate::company::composio::TINYHUMANS_API_URL_ENV),
         )
     };
-    let credential_source = credential_source_for(stored, company_key, &env);
+    let credential_source = credential_source_for(
+        runtime,
+        TinyhumansTokenSource::from_env(&env).map(std::sync::Arc::new),
+    )
+    .await;
     let (open_mode, effective) = effective_toolkits(runtime, &toolkits).await;
     Ok(ComposioStatusDto {
         in_build: cfg!(feature = "composio"),
@@ -1077,10 +1073,18 @@ mod tests {
 
     /// The hosted shape, driven through the env seam (no process mutation): a
     /// company that pasted nothing reads `attested` from the instance identity,
-    /// its own token still outranks that, and neither yields `none`.
-    #[test]
-    fn credential_source_matrix_follows_the_resolver_precedence() {
+    /// its own TinyHumans key outranks that, its own Composio token outranks
+    /// both, and with none of the three the answer is `none`.
+    ///
+    /// Drives the **real** resolver through a real secret store rather than a
+    /// restatement of its precedence. A pure function that merely mirrored the
+    /// rule would keep passing after the resolver lost a tier — which is exactly
+    /// what the negative control for issue #586 caught.
+    #[tokio::test]
+    async fn credential_source_matrix_follows_the_resolver_precedence() {
         use crate::app::config::MapEnv;
+        use crate::company::company_key;
+        use crate::company::composio::store_token;
 
         let dir = tempfile::Builder::new()
             .prefix("oc-dto-")
@@ -1093,46 +1097,80 @@ mod tests {
             path.display().to_string(),
         )]);
 
+        /// The instance identity a given environment resolves to.
+        fn source_of(
+            env: &dyn crate::app::config::EnvSource,
+        ) -> Option<std::sync::Arc<super::TinyhumansTokenSource>> {
+            super::TinyhumansTokenSource::from_env(env).map(std::sync::Arc::new)
+        }
+
+        let home_dir = home();
+        let state = state_with_manifest_id(home_dir.path(), "matrix", GRANTED).await;
+        let runtime = state
+            .registry()
+            .get(&CompanyId::new("matrix"))
+            .expect("registered");
+        let secrets = runtime.secrets();
+        let id = runtime.id().clone();
+
         // Nothing stored + a projected instance identity → attested.
         assert_eq!(
-            credential_source_for(false, false, &projected),
+            credential_source_for(&runtime, source_of(&projected)).await,
             CredentialSource::Attested
         );
-        // The company's own Composio token outranks everything.
+        // Nothing stored at all → nothing obtainable, so no tools.
         assert_eq!(
-            credential_source_for(true, false, &projected),
-            CredentialSource::Static
+            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            CredentialSource::None
         );
-        assert_eq!(
-            credential_source_for(true, true, &projected),
-            CredentialSource::Static
-        );
-        // The company's own TinyHumans key outranks the instance identity — a
-        // company with a key set connects providers as *itself*, not as the pod
-        // it happens to run in (issue #586).
-        assert_eq!(
-            credential_source_for(false, true, &projected),
-            CredentialSource::Company
-        );
-        // …and is the whole credential when the instance carries no identity,
-        // which is the case this issue exists to fix.
-        assert_eq!(
-            credential_source_for(false, true, &MapEnv::default()),
-            CredentialSource::Company
-        );
-        // A static instance key is the static tier too.
+        // A static instance key is the static tier.
         assert_eq!(
             credential_source_for(
-                false,
-                false,
-                &MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th_static")])
-            ),
+                &runtime,
+                source_of(&MapEnv::new([(
+                    crate::company::credentials::API_KEY_ENV,
+                    "th_static"
+                )]))
+            )
+            .await,
             CredentialSource::Static
         );
-        // Nothing at any tier → nothing obtainable, so no tools.
+
+        // The company's own TinyHumans key outranks the instance identity — a
+        // company with a key set connects providers as *itself*, not as the pod
+        // it happens to run in (issue #586)…
+        company_key::store_key(&id, secrets.as_ref(), "th_company")
+            .await
+            .unwrap();
         assert_eq!(
-            credential_source_for(false, false, &MapEnv::default()),
-            CredentialSource::None
+            credential_source_for(&runtime, source_of(&projected)).await,
+            CredentialSource::Company
+        );
+        // …and is the whole credential when the instance carries none, which is
+        // the case this issue exists to fix.
+        assert_eq!(
+            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            CredentialSource::Company
+        );
+
+        // The company's own Composio token outranks everything.
+        store_token(&id, secrets.as_ref(), "byo-composio")
+            .await
+            .unwrap();
+        assert_eq!(
+            credential_source_for(&runtime, source_of(&projected)).await,
+            CredentialSource::Static
+        );
+        assert_eq!(
+            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            CredentialSource::Static
+        );
+
+        // Clearing it falls back exactly one tier, not all the way to nothing.
+        store_token(&id, secrets.as_ref(), "").await.unwrap();
+        assert_eq!(
+            credential_source_for(&runtime, source_of(&MapEnv::default())).await,
+            CredentialSource::Company
         );
 
         std::fs::remove_dir_all(&dir).ok();

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -178,8 +178,22 @@ fn catalog_cache_key(runtime: &CompanyRuntime) -> String {
 async fn fetch_catalog(runtime: &CompanyRuntime) -> Result<Vec<CatalogEntry>, String> {
     // No credential of any tier means there is nothing to dial the backend
     // with. Say that, rather than spending the timeout to discover it.
-    let config = resolve_tenant(runtime).await.map_err(|_| {
-        "this company has no Composio credential yet, so the catalog cannot be read".to_string()
+    //
+    // But say only that when it is what happened. `resolve_tenant` answers
+    // `Conflict` for "nothing configured" and propagates anything else — a
+    // secret-store read failure among them. Collapsing every error into "no
+    // credential yet" would tell an operator whose store hiccupped that they
+    // never set a key, which is the confident-wrong-answer this credential work
+    // exists to remove (see `company_key::resolve`).
+    let config = resolve_tenant(runtime).await.map_err(|err| {
+        if matches!(err.0, crate::error::OpenCompanyError::Conflict(_)) {
+            "this company has no Composio credential yet, so the catalog cannot be read".to_string()
+        } else {
+            format!(
+                "this company's Composio credential could not be resolved: {}",
+                err.0
+            )
+        }
     })?;
     let fetch = crate::harness::composio::list_catalog_toolkits(&config);
     match tokio::time::timeout(composio_toolkits::FETCH_TIMEOUT, fetch).await {
@@ -339,8 +353,6 @@ struct ConnectionDto {
     connected: bool,
 }
 
-/// Which tier a company's Composio credential comes from, mirroring the harness
-/// resolver's precedence: the company's **own Composio** token wins, else its
 /// Which tier a company's Composio credential comes from.
 ///
 /// Asks the resolver itself rather than restating its precedence. The console

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -18,6 +18,7 @@
 pub mod artifacts;
 pub mod capabilities;
 pub mod channels;
+pub mod company_key;
 pub mod composio;
 pub mod composio_toolkits;
 pub mod connections_read;
@@ -153,6 +154,7 @@ pub fn router() -> Router<AppState> {
         .merge(capabilities::router())
         .merge(connections_read::router())
         .merge(channels::router())
+        .merge(company_key::router())
         .merge(composio::router())
         .merge(domain::router())
         .merge(finances::router())


### PR DESCRIPTION
## Summary

Closes #586.

A company's admin sets **one** TinyHumans key on the tenant, and every surface the
platform brokers on the company's behalf presents it. Composio is the first: the
backend derives the Composio entity from whatever bearer it is handed, and a
TinyHumans key is one it recognises — so a company with a key set connects Gmail
or Slack with **no Composio token pasted and no per-tenant provider app
registered**.

## What the issue got half-right

The issue says connections were "blocked on the tenant having no platform
identity to present." That blocker is already gone, and further than the issue
credits: `TenantComposio::resolve` has routed through the instance's platform
identity since #319's work landed, so a hosted pod already connects providers
with zero provider apps.

The real gap was narrower and sharper: **the company's own credential was not a
tier in any brokered surface's resolver, and there was no seam where one could
live.** Four independent credential resolutions existed and none consulted a
company-owned key —`hosted_endpoint_from_env` (env-only), `TenantComposio::resolve`
(`composio/token` → instance identity), the media/search resolvers (env-only by
design), and `HostConnectRoutes` (stored token → projected tier → host provider
app). Nothing fanned out, so acceptance criterion 3 — rotation reaching every
surface — failed by construction rather than by oversight.

### The trap worth flagging

The issue describes the admin's key as "the same one paying for inference," which
reads as *reuse `inference/key`*. **That would be a cross-vendor credential
leak.** `inference/key` is provider-scoped, not an identity: `resolve_effective`
hands it to whatever provider the company declared, so it may hold an OpenRouter
`sk-or-…` or a raw BYOK token — `validate_parts` even sniffs for those prefixes.
Presenting it to `api.tinyhumans.ai` would send one vendor's credential to
another. The two coincide only when the declared provider is `managed`. So the
company credential gets its own slot, and the module docs say why.

## The three decisions the issue asked for

1. **Does the key authorize Composio directly, or provision a separate token?**
   Directly. No provisioning dance — the platform-identity tier already proves a
   TinyHumans bearer works on `/agent-integrations/composio/*`.
2. **Where does a connection live?** On the backend, keyed by the account the
   bearer resolves to. No new local storage. Every agent resolves the *same*
   company credential, so "connect once, every teammate's agents can use it" is a
   property of the resolution rather than a feature layered on top.
3. **What happens on rotation?** One seam, read live per call, fingerprinted by
   identity. Because there is no second resolution to drift, a rotation cannot
   reach one brokered surface and miss another.

## The change

- **`src/company/company_key.rs`** — the single seam. `resolve` = company's own
  key (`tinyhumans/key`) → this instance's platform identity → fail closed. A
  store read error degrades to the next tier rather than bricking a roster build.
- **`Credential::Company` / `CredentialSource::Company`** — hashed by **value**,
  unlike the projected platform token which hashes by **path**. An admin rotates
  deliberately, so a new value is a new identity and the roster must rebuild; the
  cluster rotates the projected token every few minutes, and hashing *that* value
  would rebuild every agent's toolbelt on the platform's schedule.
- **Composio** resolves `composio/token` → company key → instance identity. The
  BYO hatch survives untouched, and clearing it falls back to the company key
  rather than silently re-borrowing the instance's identity.
- **`GET` / `PUT …/credential`** — write-only, admin-only (issue #403's
  discipline: this key is the identity every agent presents *and* the account
  they all spend against). A set and a clear are journaled separately and
  attributed. A credential change evicts the cached toolkit catalog, since the
  catalog is a property of the credential.
- **Console** — a Company credential card above the Composio section, the new
  tier rendered in the Composio status, and the degraded state reworded to name
  the company key instead of only offering a Composio token.

## API or behavior changes

- **New:** `GET …/credential` → `{configured, source, notice}`; `PUT …/credential`
  with `{key}` (empty string clears). Admin-only on the write.
- **`GET …/composio` `credentialSource` gains `"company"`.** The console unions
  (`ComposioCredentialSource`, `ConnectionCredentialSource`) are widened to match.
- **No behaviour change for a company that sets nothing.** With no company key the
  precedence is byte-for-byte what it was, which the existing resolver tests still
  assert unchanged.

## Deliberately out of scope, stated rather than papered over

- **The native OAuth catalog** keeps its own precedence, so `source: "company"`
  never appears on a native-only provider. Routing it through the company key
  entangles this with the inert-catalog question in #396.
- **Chat inference and embeddings** still resolve from the environment via
  `hosted_endpoint_from_env`. That is #585 — which now only has to *consume* this
  seam rather than build one, and inherits the rotation guarantee when it lands.

## Tests

New coverage: the resolver precedence matrix and its fail-closed arm, the
rotation-moves-the-fingerprint contract, the BYO-token-still-wins arm, the
clear-falls-back-one-tier-at-a-time arm, the write-only round trip, the
member-is-refused arm with a proof the refused write stored nothing, and the
journal's set-vs-clear distinction.

### The negative control found a real bug in the first draft

Deleting the company-key arm from the resolver was supposed to fail two tests.
It failed **one**. `setting_the_key_credentials_composio_with_no_composio_token`
kept passing, because `GET …/composio` re-derived the tier from two booleans
instead of asking the resolver — so the console would have gone on confidently
reporting `credentialSource: "company"` for a company whose agents were no
longer using the company key at all. A status route that can name a tier the
agents are not on is the same class of drift this issue exists to remove, and my
first draft shipped one.

Fixed in 74d7041: `resolve_credential` is now the single derivation, moved into
the always-compiled `company::composio` (not the feature-gated harness) so the
console and the harness can share it in every build. The matrix test now drives
the real resolver through a real secret store instead of restating its
precedence — the pure-function form was exactly what let the drift pass.

Re-run with the arm deleted, all three now fail as they should:
`setting_the_key_credentials_composio_with_no_composio_token`,
`credential_source_matrix_follows_the_resolver_precedence`, and
`the_company_key_credentials_composio_between_a_byo_token_and_the_instance`.
Restored, all green.

## Commands run locally

| Command | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo test` | 1822 passed, 1 ignored |
| `cargo clippy --no-deps -p opencompany --features openhuman,composio --all-targets -- -D warnings` | clean |
| `cargo test --features openhuman,composio` | 2698 passed, **1 pre-existing failure** |
| `npx tsc -b` (frontend) | clean |
| `npm test` (frontend) | 26 files, 275 passed |

**The one failure is pre-existing, not from this branch.**
`server::ops::composio::tests::an_admin_is_unaffected` expects `409` but gets
`502`: under `--features composio` the authorize handler dials the real
`https://api.tinyhumans.ai/agent-integrations/composio/authorize` and takes a
401. Verified by stashing this branch and re-running on a clean `upstream/main`,
where it fails identically. It only passes on a host without network access to
that backend.

Two environment notes for anyone reproducing: the `openhuman` feature does not
build on the repo's pinned `stable` (1.93 — `libsqlite3-sys 0.38.1` needs the
unstable `cfg_select`), and on 1.96.1 `cargo clippy --all-targets` fails inside
vendored `tinyagents` on `large_enum_variant`. Hence the `--no-deps -p opencompany`
form above for linting this crate's own code.

## Docs

`docs/spec/runtime/credentials.md` is new — the resolution order, the rotation
argument, the not-the-inference-key reasoning, the scope limits, and the recorded
known limits (no per-member attribution; two companies pasting the same key share
one entity). `docs/spec/runtime/api.md` links to it and lists the routes; adding
the section inline would have pushed that file to 524 lines, past the repo's
500-line rule, so it was split per `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added company-level TinyHumans credential management.
  - Authorized administrators can configure, rotate, or clear credentials from the Connections view.
  - Added credential status messaging, secure write-only handling, and success/error notifications.
  - Composio can use company credentials with clear status and fallback guidance.
  - Added API endpoints and documentation for credential configuration and behavior.

- **Bug Fixes**
  - Credential resolution now follows consistent precedence and fails closed when storage is unavailable.
  - Credential changes automatically refresh related connection and catalog status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->