### PR TITLE
feat(skills): say that teammates read skills rather than run them (#569)

### DIFF
--- a/frontend/src/lib/skills.ts
+++ b/frontend/src/lib/skills.ts
@@ -14,3 +14,38 @@ export const CATEGORY_STYLES: Record<SkillCategory, string> = {
   Content: "border-emerald-500/30 bg-emerald-500/10 text-emerald-600 dark:text-emerald-400",
   Finance: "border-rose-500/30 bg-rose-500/10 text-rose-600 dark:text-rose-400",
 };
+
+// What a skill actually is to a teammate (issue #569).
+//
+// A desk agent can list, describe and read an installed skill, and can never run
+// one: `dispatched_belt_excludes_every_deferred_family` pins `run_skill`,
+// `skill_run`, `run_workflow` and `await_workflow` off every dispatched belt,
+// and only the orchestrator is handed `RunWorkflowTool`. That is deliberate —
+// the upstream runner reaches for a global config and bypasses the harness's
+// metering — but the tab was built from the vocabulary of switching a capability
+// on (install / enable / disable), so an operator reasonably read "enabled" as
+// "a teammate will now do this", and nothing on the screen disagreed until they
+// tried it and watched nothing happen.
+//
+// The copy lives here rather than inline in the view so the claim is one string
+// with one test on it. What must not regress is the *claim*, not its layout.
+
+/**
+ * The Skills tab's standing statement of what installing and enabling a skill
+ * does. Says the two things the screen otherwise implies the opposite of:
+ * teammates **read** skills, and **running** one is the orchestrator's job.
+ */
+export const SKILLS_READ_ONLY_NOTE =
+  "Skills are reference material your teammates read — playbooks they follow, not buttons they press. " +
+  "Enabling one puts it in front of every teammate; executing a saved workflow stays the orchestrator's job.";
+
+/**
+ * What an installed skill's on/off state means for the company's teammates.
+ *
+ * Deliberately phrased as reach ("can read it") rather than capability ("can use
+ * it"): the switch decides whether a skill is visible to a desk agent, and never
+ * whether one can execute it.
+ */
+export function skillReachLabel(enabled: boolean): string {
+  return enabled ? "Teammates can read this" : "Hidden from teammates";
+}

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -19,7 +19,11 @@ export const SETTINGS_PAGES = [
   { id: "people", label: "People", icon: UserCog, hint: "Who can sign in, and as what" },
   { id: "connections", label: "Connections", icon: Plug, hint: "Third-party accounts" },
   { id: "mcp", label: "MCP Servers", icon: Blocks, hint: "Tool servers and their tools" },
-  { id: "skills", label: "Skills", icon: Sparkles, hint: "What this company knows how to do" },
+  // "What this company knows how to do" read as capability the company performs
+  // — the implication issue #569 exists to remove, set here *before* the tab
+  // gets a chance to correct it. The siblings describe their content; so does
+  // this now.
+  { id: "skills", label: "Skills", icon: Sparkles, hint: "Playbooks your teammates read" },
   { id: "usage", label: "Usage", icon: ChartColumnBig, hint: "What this company is spending" },
 ] as const satisfies readonly { id: string; label: string; icon: LucideIcon; hint: string }[];
 

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -438,7 +438,13 @@ function AddSkillDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Add a skill</DialogTitle>
-          <DialogDescription>Describe a capability your company should have.</DialogDescription>
+          {/* Not "a capability your company should have" (issue #569): this is
+              where an operator authors one, so it is the earliest point the
+              console can frame a skill as the playbook a teammate reads rather
+              than as something the company will carry out. */}
+          <DialogDescription>
+            Describe a playbook your teammates should follow — what to do, and when.
+          </DialogDescription>
         </DialogHeader>
         <div className="grid gap-2">
           <Label htmlFor="skill-name">Name</Label>

--- a/frontend/src/views/SkillsView.tsx
+++ b/frontend/src/views/SkillsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Download, Loader2, Plus, Search, Sparkles, Trash2 } from "lucide-react";
+import { BookOpen, Check, Download, Loader2, Plus, Search, Sparkles, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -39,7 +39,12 @@ import { Switch } from "@/components/ui/switch";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { CATEGORY_STYLES, type SkillCategory } from "@/lib/skills";
+import {
+  CATEGORY_STYLES,
+  SKILLS_READ_ONLY_NOTE,
+  type SkillCategory,
+  skillReachLabel,
+} from "@/lib/skills";
 
 interface Props {
   client: OpenCompanyClient;
@@ -176,13 +181,24 @@ export function SkillsView({ client, company }: Props) {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold tracking-tight">Skills</h2>
             <p className="text-sm text-muted-foreground">
-              Capabilities your company can use. Enable, install from the registry, or add your own.
+              Playbooks your teammates read. Enable, install from the registry, or add your own.
             </p>
           </div>
           <Button onClick={() => setAddOpen(true)}>
             <Plus className="size-4" /> Add skill
           </Button>
         </div>
+
+        {/* Issue #569: what install / enable actually buy. A desk agent can list,
+            describe and read a skill and can never run one — deliberate, and
+            pinned by `dispatched_belt_excludes_every_deferred_family` — but this
+            screen's vocabulary is the vocabulary of switching a capability on,
+            so without saying it the operator learns the difference by asking a
+            teammate to do something and watching nothing happen. */}
+        <Alert data-testid="skills-read-only-note">
+          <BookOpen className="size-4" />
+          <AlertDescription>{SKILLS_READ_ONLY_NOTE}</AlertDescription>
+        </Alert>
 
         {error && (
           <Alert variant="destructive">
@@ -304,6 +320,11 @@ function InstalledCard({
               {skill.category}
             </Badge>
             <span className="text-xs text-muted-foreground capitalize">{skill.source}</span>
+            {/* What the switch above decides, in the terms it actually decides
+                them: reach, not capability (issue #569). */}
+            <span data-testid="skill-reach" className="text-xs text-muted-foreground">
+              · {skillReachLabel(skill.enabled)}
+            </span>
           </div>
           {skill.source !== "company" && (
             <Button

--- a/frontend/test/e2e/skills-registry.spec.ts
+++ b/frontend/test/e2e/skills-registry.spec.ts
@@ -47,6 +47,15 @@ test("registry tab lists the live server registry, not a hardcoded array", async
   // names a view, so it would silently canonicalize to Overview.
   await page.goto("/#/settings/skills");
   await dismissOnboarding(page);
+
+  // Issue #569: the tab states what installing one of these buys. A desk agent
+  // reads a skill and can never run it, and this screen's install / enable
+  // vocabulary implies the opposite — so the statement has to be on the page an
+  // operator browses the library from, not only on the installed list.
+  const note = page.getByTestId("skills-read-only-note");
+  await expect(note).toBeVisible();
+  await expect(note).toContainText("orchestrator");
+
   await page.getByRole("tab", { name: "Registry" }).click();
 
   const cards = page.getByTestId("registry-card");

--- a/frontend/test/unit/skills-read-only.test.ts
+++ b/frontend/test/unit/skills-read-only.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import { SKILLS_READ_ONLY_NOTE, skillReachLabel } from "@/lib/skills";
+
+/**
+ * The Skills tab's honesty about what a skill is (issue #569).
+ *
+ * A desk agent lists, describes and reads an installed skill and can never run
+ * one — `dispatched_belt_excludes_every_deferred_family` keeps `run_skill`,
+ * `skill_run`, `run_workflow` and `await_workflow` off every dispatched belt,
+ * and only the orchestrator holds `RunWorkflowTool`. The behaviour is intended;
+ * the bug was that the console said nothing, while offering install / enable /
+ * disable — the vocabulary of turning a capability on.
+ *
+ * These assert the *claim*, not the layout: that the note names reading and the
+ * orchestrator, and that neither it nor the per-card line tells an operator a
+ * teammate will execute anything. A future copy edit is free to move words
+ * around; it is not free to quietly put the promise back.
+ */
+
+describe("SKILLS_READ_ONLY_NOTE", () => {
+  it("says teammates read skills", () => {
+    expect(SKILLS_READ_ONLY_NOTE).toMatch(/\bread\b/i);
+  });
+
+  it("names the orchestrator as what executes a workflow", () => {
+    expect(SKILLS_READ_ONLY_NOTE).toMatch(/orchestrator/i);
+  });
+
+  it("never promises that enabling a skill makes a teammate run it", () => {
+    // The exact shape of the old implication: enabling/installing framed as
+    // handing a teammate something it will carry out.
+    expect(SKILLS_READ_ONLY_NOTE).not.toMatch(/teammates? (can|will) (run|execute|use)/i);
+    expect(SKILLS_READ_ONLY_NOTE).not.toMatch(/agents? (can|will) (run|execute)/i);
+  });
+});
+
+describe("skillReachLabel", () => {
+  it("describes an enabled skill as readable, not as runnable", () => {
+    const label = skillReachLabel(true);
+    expect(label).toMatch(/read/i);
+    expect(label).not.toMatch(/run|execute/i);
+  });
+
+  it("describes a disabled skill as out of a teammate's sight", () => {
+    expect(skillReachLabel(false)).toMatch(/hidden/i);
+  });
+
+  it("distinguishes the two states", () => {
+    expect(skillReachLabel(true)).not.toBe(skillReachLabel(false));
+  });
+});


### PR DESCRIPTION
## Summary

Closes #569 (finding #4 of the MCP/Skills console↔harness epic #565).

The Skills tab offers **install / enable / disable** — the vocabulary of switching a capability on — for something a desk agent can only ever *read*. `dispatched_belt_excludes_every_deferred_family` keeps `run_skill`, `skill_run`, `run_workflow` and `await_workflow` off every dispatched belt, and only the orchestrator is handed `RunWorkflowTool`, because that tool reaches for the global `Config::load_or_init()` and bypasses the harness's metering.

The behaviour is deliberate and stays exactly as it is. What changes is that the console now says so, instead of leaving the operator to discover it by asking a teammate to use an installed skill and watching nothing happen.

## What the tab says now

- **A standing note** above the tabs: skills are reference material teammates read — playbooks they follow, not buttons they press — and executing a saved workflow stays the orchestrator's job.
- **The subtitle** drops "Capabilities your company can use" for "Playbooks your teammates read".
- **Per installed card**, one line describing what the switch actually decides: *reach*, not capability — "Teammates can read this" / "Hidden from teammates".
- **The two entry points into the tab**, which is where the old framing did most of the work: the Settings rail advertised the page as "What this company knows how to do" — read *before* the tab can correct it — and the Add-skill dialog asked the operator to "describe a capability your company should have" at the exact moment they author one. Both now describe the playbook a teammate reads, in the register of their siblings ("Tool servers and their tools", "Third-party accounts").

## Why the copy lives in `lib/skills.ts`

So the claim is one string with one test on it. `frontend/test/unit/skills-read-only.test.ts` asserts the **claim**, not the layout: the note names reading and names the orchestrator, and neither it nor the per-card line tells an operator that a teammate will run anything (`/teammates? (can|will) (run|execute|use)/i` and friends must not match). A future copy edit is free to move words around; it is not free to quietly put the promise back.

## What is deliberately not here

The issue's second candidate — wiring skill execution for desk agents behind the metering seam — is upstream-shaped and unchanged here. **No harness change at all**: `dispatched_belt_excludes_every_deferred_family` is untouched, and so is the skills-liveness ordering (deltas fetched and fingerprinted before the fast-path staleness check) the issue asks any change here to keep intact.

The e2e spec also asserts the note is visible on the page an operator browses the library from, with the orchestrator named — a real browser against a live host rather than the unit test's word-level check alone.

## Verification

`tsc -b --noEmit`, `tsc -p tsconfig.unit.json`, `tsc -p tsconfig.e2e.json`, `vitest run` (303 passed, 29 files — 6 new), and `npm run build` (the production console build). Frontend-only; no Rust touched, so no cargo lane is affected.

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
