### PR TITLE
feat(mcp): tell operators when a build cannot run the servers it manages (#567)

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -105,6 +105,35 @@ Discovery is gated on the `openhuman` feature (the MCP transport lives there);
 without it the route reports `not_wired` and the console falls back to the
 declared tool lists. Every mutating response carries a `note` reminder.
 
+## Which builds can honour a server (issue #567)
+
+The management routes above are **ungated** — they ship in every build. The
+agent-side bridge is not: `registry_for_agent` is pushed onto a teammate's belt
+behind `#[cfg(feature = "mcp")]`. Three configurations, only one of which the
+routes alone distinguish:
+
+| Build | CRUD | Discovery / probe | Agent tools |
+|-------|------|-------------------|-------------|
+| default (no `openhuman`) | works | `not_wired` | none — no harness |
+| `openhuman`, no `mcp` | works | **works for real** | **none** |
+| `openhuman` + `mcp` | works | works | yes |
+
+The middle row is the one worth stating outright: every read on the screen
+answers correctly, so a healthy badge and a live tool list sit above a server no
+teammate can call. The console cannot infer this — an empty tool belt is not
+visible over HTTP — so `GET …/capabilities` carries **`mcpInBuild`**
+(`cfg!(feature = "mcp")`, alongside `mediaInBuild` / `composioInBuild` /
+`searchInBuild`), and `McpServersSection` renders a stated degraded state when it
+is explicitly `false`. A host that omits the field is *unknown*, never
+"absent" — an older build must not be reported as broken.
+
+Writes stay open on every build deliberately. A manifest can declare servers for
+a deployment that runs elsewhere with the feature, and configuration entered
+before the capability arrives survives the rebuild; refusing the write would turn
+that into a hard error while fixing nothing an operator can act on. Staging
+builds with `mcp` (`TENANT_FEATURES` in `deploy-staging.yml`); the default
+`docker-compose` build does not.
+
 ## Console surface
 
 One component reads these routes —

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -866,6 +866,15 @@ export interface CapabilityStatusDto {
   searchCredentialConfigured?: boolean;
   /** The company's daily `web_search` call ceiling. */
   searchDailyCallCap?: number;
+  /**
+   * Whether the agent-side MCP bridge is compiled into this build (issue #567).
+   * Not a grant question like the flags above: the `/mcp/servers` management
+   * routes ship in every build, so without this an operator can add a server,
+   * store a token and watch it probe healthy on a deployment that hands agents
+   * no MCP tool at all. `undefined` is **unknown** (an older host that does not
+   * send the field) and must never be rendered as "absent".
+   */
+  mcpInBuild?: boolean;
 }
 
 /** One day's token totals in the usage series (`GET .../usage`). */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -756,9 +756,10 @@ export interface McpServer {
 }
 
 /**
- * A mutating MCP response: the resulting server, a rebuild reminder, the live
- * probe result (absent on a non-`openhuman` host), and any non-blocking
- * endpoint advisory.
+ * A mutating MCP response: the resulting server, the host's pickup note (since
+ * issue #566 that is next-turn pickup with no restart, not a rebuild reminder),
+ * the live probe result (absent on a non-`openhuman` host), and any
+ * non-blocking endpoint advisory.
  */
 export interface McpMutationResponse {
   server: McpServer;

--- a/frontend/src/lib/mcp-bridge.ts
+++ b/frontend/src/lib/mcp-bridge.ts
@@ -1,0 +1,40 @@
+// Whether this deployment can actually run the MCP servers its console manages
+// (issue #567).
+//
+// The `/mcp/servers` management routes ship in every build; the agent-side
+// registry is pushed onto a teammate's tool belt behind the `mcp` Cargo feature.
+// So a build without it accepts a server, stores its token and reports it
+// healthy — and no agent ever receives a single tool from it. The console has to
+// state that, because every other reading on the screen looks correct: on a
+// build with the harness but without the bridge, live tool discovery and health
+// probes answer for real.
+//
+// The three-state answer matters more than it looks. `mcpInBuild` is optional on
+// the wire: a host predating the field sends nothing, and rendering that silence
+// as "no agent can use these" would be a fresh lie in the other direction. Only
+// an explicit `false` is absence.
+
+import type { CapabilityStatusDto } from "@/api/types";
+
+/**
+ * What this build can do with MCP servers.
+ *
+ * - `present` — the bridge is compiled in; managed servers reach agents.
+ * - `absent` — the host said the bridge is missing; servers are configuration
+ *   this deployment cannot honour.
+ * - `unknown` — the host did not say (an older build, or the capability read
+ *   failed). Claim nothing.
+ */
+export type McpBridgeState = "present" | "absent" | "unknown";
+
+/**
+ * Reads the MCP bridge's build state off the capability status.
+ *
+ * A missing status (the read failed, or the host has no `…/capabilities`
+ * surface) and a status without the field are both `unknown` — the console
+ * degrades to saying nothing rather than to an accusation it cannot support.
+ */
+export function mcpBridgeState(status: CapabilityStatusDto | null | undefined): McpBridgeState {
+  if (!status || typeof status.mcpInBuild !== "boolean") return "unknown";
+  return status.mcpInBuild ? "present" : "absent";
+}

--- a/frontend/src/lib/mcp-bridge.ts
+++ b/frontend/src/lib/mcp-bridge.ts
@@ -38,3 +38,24 @@ export function mcpBridgeState(status: CapabilityStatusDto | null | undefined): 
   if (!status || typeof status.mcpInBuild !== "boolean") return "unknown";
   return status.mcpInBuild ? "present" : "absent";
 }
+
+/**
+ * What to tell the operator after a server is added.
+ *
+ * The success path is where the old claim did its damage: a banner stating that
+ * no agent can use tool servers here is worth nothing if the confirmation
+ * toast, fired at the moment the operator acts, still promises that agents pick
+ * the server up. On a build with no bridge the add genuinely succeeded — the
+ * server is stored, and it survives the rebuild that adds the feature — so this
+ * says that, rather than dressing a success up as a failure.
+ *
+ * `unknown` gets the ordinary message: the host has not said the bridge is
+ * missing, and the pickup promise is the host's own (`NEXT_TURN_NOTE`, since
+ * issue #566 — the console said "next rebuild" for a while after the runtime
+ * stopped needing one).
+ */
+export function mcpAddedMessage(name: string, bridge: McpBridgeState): string {
+  return bridge === "absent"
+    ? `Added ${name}. It is stored, but no agent can call it until this deployment is rebuilt with the MCP bridge.`
+    : `Added ${name}. Agents pick it up on their next turn.`;
+}

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -25,7 +25,7 @@ import {
   updateMcpServer,
 } from "@/api/mcp";
 import { ApiError, type McpHealth, type McpServer, type McpToolInfo } from "@/api/types";
-import { type McpBridgeState, mcpBridgeState } from "@/lib/mcp-bridge";
+import { type McpBridgeState, mcpAddedMessage, mcpBridgeState } from "@/lib/mcp-bridge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -209,7 +209,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
       } else if (res.warning) {
         setAddError(res.warning);
       } else {
-        toast.success(`Added ${name.trim()}. Agents pick it up on the next rebuild.`);
+        // The success path has to agree with the banner (issue #567): a toast
+        // promising pickup, fired at the moment the operator acts, undoes a
+        // statement sitting a few pixels above it.
+        toast.success(mcpAddedMessage(name.trim(), bridge));
       }
       setName("");
       setEndpoint("");

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -25,6 +25,7 @@ import {
   updateMcpServer,
 } from "@/api/mcp";
 import { ApiError, type McpHealth, type McpServer, type McpToolInfo } from "@/api/types";
+import { type McpBridgeState, mcpBridgeState } from "@/lib/mcp-bridge";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -76,6 +77,9 @@ interface Props {
  */
 export function McpServersSection({ client, company, canManage, chrome = "inline" }: Props) {
   const [load, setLoad] = useState<McpLoad>("loading");
+  // Whether the agent-side MCP bridge is compiled into this host (issue #567).
+  // Starts `unknown` so nothing is claimed before the capability read lands.
+  const [bridge, setBridge] = useState<McpBridgeState>("unknown");
   const [servers, setServers] = useState<McpServer[]>([]);
   const [busy, setBusy] = useState<string | null>(null);
   const [tools, setTools] = useState<Record<string, ToolsState>>({});
@@ -136,6 +140,27 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     setLoad("loading");
     void refresh();
   }, [refresh]);
+
+  // Whether this build can actually run what this screen manages (issue #567).
+  // Read separately from the server list, and deliberately not fatal to it: the
+  // list is the screen's job, the build state is a caption on it, so a host that
+  // cannot answer the capability read still gets a working MCP tab — it just
+  // gets no claim about the bridge.
+  useEffect(() => {
+    let alive = true;
+    client
+      .capabilityStatus(company)
+      .then((status) => {
+        if (alive) setBridge(mcpBridgeState(status));
+      })
+      // A host with no `…/capabilities` surface 404s. Unknown, not absent.
+      .catch(() => {
+        if (alive) setBridge("unknown");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [client, company]);
 
   // Cancel any in-flight sign-in polls when the view unmounts so their timers
   // don't fire against a torn-down component, and tell a poll that is currently
@@ -352,6 +377,23 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
         Remote MCP tool servers your agents can call. Add an HTTP endpoint and (optionally) a token —
         the token is stored securely and never shown again.
       </p>
+
+      {/* Issue #567: this screen's routes ship in every build, the agent-side
+          bridge does not. Said before the list rather than per row, because it
+          is a fact about the deployment and not about any one server — and said
+          only on an explicit `false`, never on a host that stayed silent. */}
+      {bridge === "absent" && (
+        <Alert data-testid="mcp-bridge-absent">
+          <AlertTriangle className="size-4" />
+          <AlertTitle>No agent can use tool servers in this deployment</AlertTitle>
+          <AlertDescription>
+            The MCP bridge isn&apos;t compiled into this build, so servers added here are stored and
+            can be probed, but no teammate ever receives their tools. The configuration survives —
+            rebuild this deployment with the <code className="font-mono">mcp</code> feature and the
+            servers below start reaching agents on the next turn.
+          </AlertDescription>
+        </Alert>
+      )}
 
       {load === "error" ? (
         // Not an empty list: an empty list is a company with no tool servers,

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from "@playwright/test";
 
+import { LIVE_BRAIN } from "./capabilities";
+
 /**
  * Issue #414 — Settings, MCP Servers must render the servers the host actually
  * serves.
@@ -56,6 +58,19 @@ test("Settings MCP lists the company's servers instead of crashing on open", asy
   await expect(manifest).toBeVisible();
   await expect(manifest).toContainText("manifest");
   await expect(manifest).toContainText("https://mcp.deepwiki.com/mcp");
+
+  // Issue #567: the screen states what this deployment can do with these
+  // servers. Asserted from both sides, because the failure being fixed is a
+  // console that reads identically on a host that honours a server and one that
+  // never can — the default-feature host behind this lane has no `mcp` bridge
+  // and must say so; the live-brain lane compiles it in and must stay quiet.
+  const bridgeAbsent = page.getByTestId("mcp-bridge-absent");
+  if (LIVE_BRAIN) {
+    await expect(bridgeAbsent).toHaveCount(0);
+  } else {
+    await expect(bridgeAbsent).toBeVisible();
+    await expect(bridgeAbsent).toContainText("no teammate ever receives their tools");
+  }
 
   // The page must not be one that renders and throws. `.length` of `undefined`
   // was the exact crash; any uncaught error here is a failure regardless.

--- a/frontend/test/unit/mcp-bridge.test.ts
+++ b/frontend/test/unit/mcp-bridge.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { mcpBridgeState } from "@/lib/mcp-bridge";
+import { mcpAddedMessage, mcpBridgeState } from "@/lib/mcp-bridge";
 import type { CapabilityStatusDto } from "@/api/types";
 
 /**
@@ -43,5 +43,36 @@ describe("mcpBridgeState", () => {
     // the bridge is missing — the same silence as omitting it.
     const malformed = { configured: false, mcpInBuild: null } as unknown as CapabilityStatusDto;
     expect(mcpBridgeState(malformed)).toBe("unknown");
+  });
+});
+
+/**
+ * The add-success message, which is where the screen's other claim used to
+ * live: "Agents pick it up on the next rebuild" — fired at the moment the
+ * operator acts, and false twice over on a build with no bridge (nothing picks
+ * it up, and since #566 a rebuild is not how pickup happens either).
+ */
+describe("mcpAddedMessage", () => {
+  it("confirms the add without promising pickup when the bridge is missing", () => {
+    const message = mcpAddedMessage("notion", "absent");
+    expect(message).toContain("notion");
+    // Still a success: the server IS stored, and survives the rebuild that adds
+    // the feature. Saying otherwise would report a working add as a failure.
+    expect(message).toMatch(/stored/i);
+    expect(message).not.toMatch(/agents pick it up/i);
+  });
+
+  it("promises next-turn pickup when the bridge is present", () => {
+    const message = mcpAddedMessage("notion", "present");
+    expect(message).toMatch(/next turn/i);
+    // #566: pickup no longer needs a restart, and the console said it did long
+    // after the host stopped saying so.
+    expect(message).not.toMatch(/rebuild|restart/i);
+  });
+
+  it("treats an unanswering host as ordinary, not as broken", () => {
+    // Unknown is not absence: claiming no agent can use the server, on a host
+    // that never said so, is the same class of lie in the other direction.
+    expect(mcpAddedMessage("notion", "unknown")).toBe(mcpAddedMessage("notion", "present"));
   });
 });

--- a/frontend/test/unit/mcp-bridge.test.ts
+++ b/frontend/test/unit/mcp-bridge.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { mcpBridgeState } from "@/lib/mcp-bridge";
+import type { CapabilityStatusDto } from "@/api/types";
+
+/**
+ * The MCP tab's build-state signal (issue #567).
+ *
+ * The management routes are ungated, so an operator on a build without the `mcp`
+ * feature adds a server, stores a token, watches it probe healthy — and no agent
+ * ever receives a tool from it. What makes this worth a test rather than an
+ * inline ternary is the third state: `mcpInBuild` is optional on the wire, and
+ * treating a host that never sends it as "the bridge is missing" would replace
+ * one false claim with another, on every older host.
+ */
+
+function status(over: Partial<CapabilityStatusDto> = {}): CapabilityStatusDto {
+  return { configured: false, ...over };
+}
+
+describe("mcpBridgeState", () => {
+  it("reads an explicit true as the bridge being present", () => {
+    expect(mcpBridgeState(status({ mcpInBuild: true }))).toBe("present");
+  });
+
+  it("reads an explicit false as the bridge being absent", () => {
+    expect(mcpBridgeState(status({ mcpInBuild: false }))).toBe("absent");
+  });
+
+  it("says nothing when the host omits the field", () => {
+    // An older host that predates the flag. Rendering this as "absent" would
+    // tell every such operator their servers are dead when they may be fine.
+    expect(mcpBridgeState(status())).toBe("unknown");
+  });
+
+  it("says nothing when the capability read failed", () => {
+    expect(mcpBridgeState(null)).toBe("unknown");
+    expect(mcpBridgeState(undefined)).toBe("unknown");
+  });
+
+  it("does not treat a non-boolean as an answer", () => {
+    // A host that sends `null` (or any other shape) for the field has not said
+    // the bridge is missing — the same silence as omitting it.
+    const malformed = { configured: false, mcpInBuild: null } as unknown as CapabilityStatusDto;
+    expect(mcpBridgeState(malformed)).toBe("unknown");
+  });
+});

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -94,6 +94,18 @@ struct CapabilityStatusDto {
     /// (`[tools].search_daily_calls`, else the built-in default). Reaching it
     /// makes the tool refuse loudly rather than return an empty result set.
     search_daily_call_cap: u32,
+    /// Whether the agent-side MCP bridge is compiled into this build (issue
+    /// #567). Unlike media/composio/search this is **not** a grant question: the
+    /// `/mcp/servers` management routes ship in every build, so an operator can
+    /// add a server, store a token and watch it probe healthy on a build that
+    /// hands agents no MCP tool at all — `registry_for_agent` is pushed onto the
+    /// belt behind `#[cfg(feature = "mcp")]`. The most misleading case is a
+    /// build with `openhuman` but without `mcp`: live tool discovery and health
+    /// probes answer for real (they ride the harness feature), so every read in
+    /// the console looks correct while no agent can call the server. `false`
+    /// lets the MCP surfaces state that plainly instead of the operator finding
+    /// out by asking an agent and watching nothing happen.
+    mcp_in_build: bool,
 }
 
 /// One tier's budget row.
@@ -173,6 +185,7 @@ fn unconfigured(flags: OptInFlags) -> CapabilityStatusDto {
         search_in_build: cfg!(feature = "openhuman"),
         search_credential_configured: search_credential_configured(),
         search_daily_call_cap: flags.search_daily_call_cap,
+        mcp_in_build: cfg!(feature = "mcp"),
     }
 }
 
@@ -294,6 +307,7 @@ async fn effective_status(runtime: &CompanyRuntime) -> Result<CapabilityStatusDt
         search_in_build: cfg!(feature = "openhuman"),
         search_credential_configured: search_credential_configured(),
         search_daily_call_cap: flags.search_daily_call_cap,
+        mcp_in_build: cfg!(feature = "mcp"),
     })
 }
 
@@ -503,6 +517,71 @@ mod tests {
             crate::company::DEFAULT_SEARCH_DAILY_CALLS,
             "an unset cap reports the built-in default: {dto2}"
         );
+    }
+
+    /// Issue #567: the MCP bridge's build state travels on every response, with
+    /// a `[plan]` and without one. The `/mcp/servers` management routes ship in
+    /// every build while the agent-side registry is pushed onto the belt behind
+    /// `#[cfg(feature = "mcp")]`, so without this flag a console cannot tell a
+    /// deployment that will honour a server from one that never can — the
+    /// operator finds out by asking an agent and watching nothing happen.
+    ///
+    /// Asserted on **both** response paths deliberately: the DTO is built in two
+    /// places (`unconfigured` and the configured branch), so a flag added to one
+    /// alone would report honestly for a company with no plan and lie to every
+    /// company that has one.
+    #[tokio::test]
+    async fn reports_whether_the_mcp_bridge_is_in_this_build() {
+        let unplanned_dir = home();
+        let unplanned = unplanned_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &unplanned,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"*\"]\n",
+        )
+        .await;
+        let (status, dto) = get_capabilities(&state).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(dto["configured"], false);
+        assert_eq!(
+            dto["mcpInBuild"],
+            cfg!(feature = "mcp"),
+            "the unconfigured response states the bridge's build state: {dto}"
+        );
+
+        let planned_dir = home();
+        let planned = planned_dir.path().to_path_buf();
+        let state2 = state_with_manifest(
+            &planned,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[plan]\nname = \"starter\"\n",
+        )
+        .await;
+        let (_, dto2) = get_capabilities(&state2).await;
+        assert_eq!(dto2["configured"], true, "{dto2}");
+        assert_eq!(
+            dto2["mcpInBuild"],
+            cfg!(feature = "mcp"),
+            "a configured plan reports the same build state: {dto2}"
+        );
+
+        // The without-feature path is the one the console must not misreport:
+        // pinned as a literal so the honest answer cannot regress into a
+        // vacuously-true comparison against the same `cfg!`.
+        #[cfg(not(feature = "mcp"))]
+        {
+            assert_eq!(
+                dto["mcpInBuild"], false,
+                "a build without the bridge must say so: {dto}"
+            );
+            assert_eq!(dto2["mcpInBuild"], false, "{dto2}");
+        }
+        #[cfg(feature = "mcp")]
+        {
+            assert_eq!(
+                dto["mcpInBuild"], true,
+                "a build with the bridge must say so: {dto}"
+            );
+            assert_eq!(dto2["mcpInBuild"], true, "{dto2}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes #567 (finding #2 of the MCP/Skills console↔harness epic #565).

The `/mcp/servers` management routes ship in **every** build. The agent-side bridge does not — `registry_for_agent` is pushed onto a teammate's belt behind `#[cfg(feature = "mcp")]` (`src/harness/build.rs`). An operator can add a server, store a token, watch `authConfigured` turn true, and no agent ever receives a tool from it.

## The case the issue misses, and why the existing honest route doesn't cover it

| Build | CRUD | Discovery / probe | Agent tools |
|-------|------|-------------------|-------------|
| default (no `openhuman`) | works | `not_wired` | none — no harness at all |
| `openhuman`, no `mcp` | works | **works for real** | **none** |
| `openhuman` + `mcp` | works | works | yes |

The issue names `GET …/mcp/servers/{name}/tools` as "the one route that answers honestly". It is honest about **`openhuman`**, not about `mcp`: `harness/mcp.rs` compiles without the `mcp` feature, so on the middle row discovery and health probes answer for real and *every* reading on the screen looks correct while the belt is empty. That row is the one an operator cannot diagnose from the console at all.

Also confirmed, since the issue asks: staging **does** build with `mcp` (`TENANT_FEATURES` in `deploy-staging.yml`), so this is latent there and live for the default `docker-compose` build. And the combination is not un-built by CI — `ci.yml` runs `cargo test --features openhuman,mcp,telegram --lib harness::build::tests` plus `Check (--all-features)`.

## The change — option (1), reported as a capability

`GET …/capabilities` gains **`mcpInBuild`** = `cfg!(feature = "mcp")`, beside the `mediaInBuild` / `composioInBuild` / `searchInBuild` flags that already answer exactly this question for the other optional surfaces. `McpServersSection` reads it and states the degraded case above the list.

**Not on the list route**, which the issue suggested: `GET …/mcp/servers` answers a *bare array*, pinned by `expectList` / `mcp-wire.test.ts` after #414 — wrapping it to carry a flag would reintroduce the very shape that crashed that page.

**Absence is only ever an explicit `false`.** `mcpBridgeState` returns `unknown` for a host that omits the field, for a non-boolean, and for a failed capability read; `unknown` renders nothing. Reporting an older build as broken would be a fresh lie in the other direction. The capability read is also deliberately non-fatal to the list — a host that cannot answer it still gets a working MCP tab, just no claim about the bridge.

## Option (2) — refusing the write — is deliberately not implemented

The issue offers it as "defensible" alongside (1). It shouldn't be: a manifest can legitimately declare servers for a deployment that runs elsewhere with the feature, configuration entered before the capability arrives survives the rebuild, and the default-build test suite adds servers over HTTP throughout. Refusing the write turns a config-ahead-of-deploy flow into a hard error while fixing nothing an operator can act on.

## API / behavior changes

- `CapabilityStatusDto` gains `mcpInBuild: bool` — always serialized, on **both** construction paths (`unconfigured` and the configured branch). Additive; no route, signature or existing field changes.
- No change on a build with `mcp`: the banner is scoped to an explicit `false`.
- The **add-success toast** now comes from `mcpAddedMessage(name, bridge)`. A banner is worth nothing while the success path fires `Added <name>. Agents pick it up on the next rebuild.` at the moment the operator acts, so without the bridge it confirms the add and says the server is stored but uncallable until the deployment is rebuilt with it — still a success, because the add did succeed and the configuration survives that rebuild. An unanswering host gets the ordinary message: unknown is not absence.
- That pickup promise was also **stale on every build**: since #566 the host answers `NEXT_TURN_NOTE` (next-turn pickup, no restart) while the console still said "next rebuild" — in the toast and in the `McpMutationResponse` doc comment. Both now match the host. This is the one place a build *with* `mcp` sees a wording change; shipping a known-false string seemed worse than the letter of "no change in behaviour".

## Tests

- `reports_whether_the_mcp_bridge_is_in_this_build` — asserts the flag on both response paths (a flag added to one alone would report honestly for a company with no plan and lie to every company that has one), and pins the without-feature answer as a literal rather than a vacuous comparison against the same `cfg!`. Runs in the default build **and** under `--features mcp`, so both answers are exercised.
- `frontend/test/unit/mcp-bridge.test.ts` — the three-state predicate, including the two silences (field omitted, read failed) that must not render as "absent"; and the add message, pinning that the bridge-absent case never promises pickup, the present case never says "rebuild"/"restart", and `unknown` reads exactly like `present`.
- `frontend/test/e2e/mcp.spec.ts` — asserts from both sides on a real host: the default-feature lane's binary has no bridge and must show the banner; the `Console E2E (live brain)` lane builds `openhuman,tinycortex,mcp` and must not.

## Verification

`cargo fmt --all -- --check`, `cargo test --locked --lib` (1810 passed), `cargo clippy --locked --all-targets -- -D warnings`, `cargo test --locked --features mcp --lib server::ops::capabilities` (7 passed), `tsc -b --noEmit`, `tsc -p tsconfig.unit.json`, `tsc -p tsconfig.e2e.json`, `vitest run` (305 passed), and `npm run build` (the production console build).

## Note for the reviewer

`docs/modules/mcp.md` gains a "Which builds can honour a server" section. Its existing "Pool-staleness caveat" still says mid-session edits reach agents only on "practically, a company restart" — the claim #566 / #598 removed from the UI. Left untouched here to keep this diff to one concern; worth a follow-up.

Closes #567

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capability-aware MCP support across builds.
  * MCP settings now clearly indicate when agent-side tools are unavailable in the current build.
  * Added live status reporting to distinguish available, unavailable, and unknown MCP bridge states.
  * MCP server setup messages now explain when changes will be picked up on the next turn.

* **Documentation**
  * Documented MCP availability across build configurations, including discovery, management, and agent tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->