### PR TITLE
feat(workflows): plan→workflow operator UI — Stage 2 (#580)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -7,6 +7,7 @@
 //     and calls use `/api/v1/companies/{id}/*`.
 
 import type { ConsoleConfig } from "../config";
+import type { TaskDeliverable } from "./tasks";
 import { defaultTransport } from "./transport";
 import type { StreamHandlers, Transport, TransportResponse } from "./transport";
 import {
@@ -240,10 +241,21 @@ export class OpenCompanyClient {
      * id — callers strip the `h` prefix with `toHostMessageId` first.
      */
     parent?: string | null,
+    /**
+     * The once-vs-workflow choice for the card this line opens (issue #580).
+     * Only `"workflow"` reaches the wire: `"once"` (and the default) is sent as
+     * *nothing at all*, so an ordinary message keeps the exact body shape it had
+     * before #580 — the same omitted-field compatibility rule the deliverable
+     * field follows everywhere (see `CreateTask.deliverable`).
+     */
+    deliverable?: TaskDeliverable,
   ): Promise<ChatResponse> {
-    const body: { text: string; chat?: string; parent?: string } = { text };
+    const body: { text: string; chat?: string; parent?: string; deliverable?: TaskDeliverable } = {
+      text,
+    };
     if (chat) body.chat = chat;
     if (parent) body.parent = parent;
+    if (deliverable === "workflow") body.deliverable = deliverable;
     return this.request<ChatResponse>("POST", `${this.scope(company)}/chat`, body);
   }
 

--- a/frontend/src/lib/task-edit.ts
+++ b/frontend/src/lib/task-edit.ts
@@ -1,0 +1,35 @@
+// The edit-dialog's field diff, pulled out of the component so it is a pure,
+// unit-testable function (issue #580 adds the deliverable arm to it).
+//
+// A `PatchTask` is applied field-by-field on the host, and every field it
+// *receives* is re-validated — `assignee` included, which re-runs
+// `assignee::resolve` against the current roster. Sending the whole seeded draft
+// therefore made a card uneditable the moment its stored assignee left the
+// roster: renaming the title resubmitted the stale assignee, which came back
+// `Unknown`, and the save failed with a `400` about a field the operator never
+// touched. Diffing means an untouched field is never re-validated.
+
+import type { PatchTask, Task } from "@/api/tasks";
+
+/**
+ * The fields the operator actually changed, and only those.
+ *
+ * `deliverable` is normalized on both sides — absent means `"once"` (issue
+ * #580) — so an untouched control emits no patch and a card with no stored value
+ * does not diff `"once"` against `undefined` and patch a field nobody touched;
+ * flipping the choice sends exactly `{ deliverable }`.
+ */
+export function computeTaskPatch(draft: PatchTask, current: Task): PatchTask {
+  const patch: PatchTask = {};
+  if ((draft.title ?? "") !== current.title) patch.title = draft.title ?? "";
+  if ((draft.note ?? "") !== (current.note ?? "")) patch.note = draft.note ?? "";
+  if (draft.column !== undefined && draft.column !== current.column) patch.column = draft.column;
+  if (draft.priority !== undefined && draft.priority !== current.priority) {
+    patch.priority = draft.priority;
+  }
+  if ((draft.assignee ?? "") !== current.assignee) patch.assignee = draft.assignee ?? "";
+  if ((draft.deliverable ?? "once") !== (current.deliverable ?? "once")) {
+    patch.deliverable = draft.deliverable ?? "once";
+  }
+  return patch;
+}

--- a/frontend/src/lib/task-workflow-proposal.ts
+++ b/frontend/src/lib/task-workflow-proposal.ts
@@ -1,0 +1,84 @@
+// Issue #580: turn a card's STORED workflow proposal into the same reviewable
+// diff the copilot's proposal card renders (#415).
+//
+// The builder pass (`src/harness/workflow_build.rs`) settles a `workflow`-card
+// to In Review carrying a `TaskWorkflowProposal` whose `ops` is NOT a
+// `ProposalOp[]` — it is the camelCase authoring graph the host rebuilds from,
+// a `WorkflowGraphSpec` `{ id, name, description?, nodes[], edges[] }` (see
+// `src/company/workflow_create.rs`). This module converts that spec into the
+// add-only op list #415 already knows how to validate and diff, then runs it
+// through the exact same pure functions — so the operator reviews a proposed
+// workflow with the machinery that already exists rather than a second one.
+//
+// ## Everything renders "added"
+//
+// A built proposal is a brand-new graph, so it is diffed against the empty
+// graph: every step and every connection is an addition, with each step's whole
+// payload (`kind`, `schedule`, `requiresApproval`, `destination`, …) shown — the
+// same guarantee #415 makes about a proposed new node, and for the same reason:
+// a scheduled auto-approving node must not reach Apply off a row that showed
+// only a name.
+//
+// ## It refuses rather than crashes
+//
+// `ops` is opaque on the client and comes from a model-authored graph, so this
+// is defensive: a spec that is not an object, lists no steps, reuses a step id,
+// connects to a step that is not there, or carries a field the diff cannot
+// render comes back as a stated `reason` (the panel shows it and withholds
+// Apply), never as a thrown error. The refusals are `validateProposal`'s own —
+// the host stays the authority on whether Apply actually succeeds.
+
+import {
+  applyProposal,
+  diffGraphs,
+  validateProposal,
+  type GraphDiff,
+} from "@/api/workflow-proposal";
+import type { WorkflowGraph } from "@/api/workflows";
+
+/** The graph a built proposal is diffed against: nothing, so all of it is new. */
+const EMPTY_GRAPH: WorkflowGraph = { id: "", name: "", nodes: [], edges: [] };
+
+/** Either the all-added diff, or the one sentence to show instead of Apply. */
+export type TaskProposalDiff = { diff: GraphDiff } | { reason: string };
+
+/**
+ * Convert a stored `TaskWorkflowProposal.ops` (a `WorkflowGraphSpec`) into the
+ * reviewable diff, or a reason it cannot be shown.
+ *
+ * The spec's `nodes` become `addNode` ops and its `edges` become `addEdge` ops,
+ * in that order so an edge may reference a node the same spec adds. The
+ * assembled op list is handed to {@link validateProposal} against the empty
+ * graph — which is the single place that decides a duplicate id, an edge to an
+ * absent step, or an unrenderable field is a refusal — and, if it passes,
+ * applied and diffed by the same pure functions the copilot uses.
+ */
+export function taskProposalDiff(ops: unknown): TaskProposalDiff {
+  if (!ops || typeof ops !== "object" || Array.isArray(ops)) {
+    return { reason: "This proposal's workflow could not be read." };
+  }
+  const spec = ops as { nodes?: unknown; edges?: unknown; summary?: unknown };
+  const nodes = Array.isArray(spec.nodes) ? spec.nodes : [];
+  const edges = Array.isArray(spec.edges) ? spec.edges : [];
+
+  // The shape `validateProposal` reads: a non-empty summary and an op list. The
+  // summary is a placeholder — the panel leads with the proposal's own summary,
+  // not this — it exists only to satisfy the shape check, which is right to
+  // refuse a summary-less copilot proposal but has no bearing on a built one.
+  const candidate = {
+    summary: "workflow",
+    ops: [
+      ...nodes.map((node) => ({ op: "addNode", node })),
+      ...edges.map((edge) => ({
+        op: "addEdge",
+        ...(edge && typeof edge === "object" && !Array.isArray(edge) ? edge : {}),
+      })),
+    ],
+  };
+
+  const validated = validateProposal(candidate, EMPTY_GRAPH);
+  if ("reason" in validated) return { reason: validated.reason };
+
+  const proposal = { ...validated, basedOnVersion: EMPTY_GRAPH.version };
+  return { diff: diffGraphs(EMPTY_GRAPH, applyProposal(EMPTY_GRAPH, proposal)) };
+}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -13,6 +13,7 @@ import { toast } from "sonner";
 
 import { listPeople, me as fetchMe, type Person } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
+import type { TaskDeliverable } from "@/api/tasks";
 import { setInboxEnabled } from "@/api/inbox";
 import {
   ApiError,
@@ -580,7 +581,7 @@ export function ChatView({
    * cannot resolve — the row's own actions are disabled in that window, so this
    * is the belt to that brace.
    */
-  async function send(text: string, parentId?: string) {
+  async function send(text: string, deliverable?: TaskDeliverable, parentId?: string) {
     if (sending) return;
     const target = active.id;
     const chatId = activeThreadId;
@@ -593,7 +594,13 @@ export function ChatView({
     // below — two bubbles for one turn.
     if (chatId) onSendStart?.(chatId);
     try {
-      const reply = await client.chat(text, company, chatId, toHostMessageId(parentId));
+      const reply = await client.chat(
+        text,
+        company,
+        chatId,
+        toHostMessageId(parentId),
+        deliverable,
+      );
       const replies = reply.responses.length
         ? reply.responses.map((r) =>
             makeMessage("company", r.text, {
@@ -838,7 +845,11 @@ export function ChatView({
             <MessageComposer
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
-              onSend={(text) => void send(text)}
+              onSend={(text, deliverable) => void send(text, deliverable)}
+              // Only the company-channel composer offers "do it once" vs "build
+              // me the workflow" (issue #580): a channel line can open a board
+              // card, so the once-vs-workflow choice belongs at that prompt box.
+              deliverableChoice={active.kind === "channel"}
             />
           </div>
 
@@ -848,7 +859,7 @@ export function ChatView({
               parent={parent}
               replies={threadReplies}
               sending={sending}
-              onSend={(text) => void send(text, parent.id)}
+              onSend={(text) => void send(text, undefined, parent.id)}
               onClose={() => setOpenThreadId(null)}
             />
           )}

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -41,6 +41,7 @@ import {
   StickyNote,
   Trash2,
   UserCog,
+  Workflow,
   Wrench,
 } from "lucide-react";
 
@@ -115,6 +116,7 @@ import { ArtifactsTab } from "./ArtifactsTab";
 import { TaskPlanBrief, tallyPrerequisites } from "./TaskPlanBrief";
 import { AssigneeSelect } from "./AssigneeSelect";
 import { TaskEditDialog } from "./TaskEditDialog";
+import { TaskWorkflowProposalPanel } from "./TaskWorkflowProposalPanel";
 
 /** How often to re-poll the detail while the screen is open (visibility-gated). */
 const POLL_MS = 4000;
@@ -494,6 +496,20 @@ export function TaskDetailView({
 
             <AwaitingApprovalRow approvals={detail.approvals} now={now} />
 
+            {/* Issue #580: the built workflow awaiting approval, shown only while
+                the card sits In Review with a proposal. Apply creates the
+                workflow and moves the card to Done (#339 link); reject returns
+                it to To-do. */}
+            {detail.task.column === "in_review" && detail.task.workflowProposal && (
+              <TaskWorkflowProposalPanel
+                client={client}
+                company={company}
+                task={detail.task}
+                onSaved={onSaved}
+                onReload={load}
+              />
+            )}
+
             <Tabs value={tab} onValueChange={(next) => setTab(String(next))}>
               <TabsList>
                 <TabsTrigger value="timeline">Timeline</TabsTrigger>
@@ -646,6 +662,17 @@ function DetailHeader({
             {columnLabel(task.column)}
           </Badge>
         </span>
+        {/* Issue #580: this card builds a reusable workflow rather than doing
+            the work once. Stated on the detail header the same as the board
+            card's chip, so the deliverable reads the same from either surface. */}
+        {task.deliverable === "workflow" && (
+          <span className="inline-flex items-center gap-1.5">
+            <Badge variant="outline" className="gap-1 font-normal">
+              <Workflow className="size-3" aria-hidden />
+              Workflow
+            </Badge>
+          </span>
+        )}
         {task.assignee && (
           <span className="inline-flex items-center gap-1.5">
             <span

--- a/frontend/src/views/TaskEditDialog.tsx
+++ b/frontend/src/views/TaskEditDialog.tsx
@@ -6,7 +6,13 @@
 import { useEffect, useState } from "react";
 import { Loader2, Trash2 } from "lucide-react";
 
-import { deleteTask, patchTask, type PatchTask, type Task } from "@/api/tasks";
+import {
+  deleteTask,
+  patchTask,
+  type PatchTask,
+  type Task,
+  type TaskDeliverable,
+} from "@/api/tasks";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   AlertDialog,
@@ -38,11 +44,31 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { computeTaskPatch } from "@/lib/task-edit";
 import { TASK_COLUMNS } from "@/lib/tasks-sample";
 import { toast } from "sonner";
 import { AssigneeSelect } from "./AssigneeSelect";
 
 const PRIORITIES = ["low", "medium", "high"] as const;
+
+/** The once-vs-workflow options, in review order (issue #580). */
+const DELIVERABLES: { value: TaskDeliverable; label: string }[] = [
+  { value: "once", label: "Do it once" },
+  { value: "workflow", label: "Build me the workflow" },
+];
+
+/**
+ * The columns where the deliverable can still be flipped (issue #580).
+ *
+ * Once a card leaves To-do/Planning the choice is settled: the builder pass
+ * fires on the drag into In Progress, so changing once-vs-workflow afterwards
+ * cannot rebuild what already ran. The control is disabled there rather than
+ * hidden — an honest "locked" reads better than a field that silently vanishes —
+ * but this is a **UI-honesty** guard, not enforcement: the host is the authority
+ * on whether a late patch is accepted, and the untouched-field diff below means
+ * a save that does not touch the deliverable never sends it anyway.
+ */
+const DELIVERABLE_EDITABLE = new Set(["todo", "planning"]);
 
 /**
  * Edit a card (or delete it). Open when `task` is non-null; `onClose` fires on
@@ -76,40 +102,21 @@ export function TaskEditDialog({
         column: task.column,
         priority: task.priority,
         assignee: task.assignee,
+        // Absent means `"once"` on the wire, so the control is seeded with the
+        // normalized value and a card with no stored deliverable edits as the
+        // one-off it is (issue #580).
+        deliverable: task.deliverable ?? "once",
       });
     }
   }, [task]);
 
   if (!task) return null;
 
-  /**
-   * The fields the operator actually changed, and only those.
-   *
-   * A `PatchTask` is applied field-by-field on the host, and every field it
-   * *receives* is re-validated — `assignee` included, which re-runs
-   * `assignee::resolve` against the current roster. Sending the whole seeded
-   * draft therefore made a card uneditable the moment its stored assignee left
-   * the roster (a teammate removed, a desk deleted): renaming the title
-   * resubmitted the stale assignee, which came back `Unknown`, and the save
-   * failed with a `400` about a field the operator never touched. Diffing means
-   * an untouched field is never re-validated, so the only assignee the host is
-   * ever asked to resolve is one just picked from the roster.
-   */
-  function changedFields(current: Task): PatchTask {
-    const patch: PatchTask = {};
-    if ((draft.title ?? "") !== current.title) patch.title = draft.title ?? "";
-    if ((draft.note ?? "") !== (current.note ?? "")) patch.note = draft.note ?? "";
-    if (draft.column !== undefined && draft.column !== current.column) patch.column = draft.column;
-    if (draft.priority !== undefined && draft.priority !== current.priority) {
-      patch.priority = draft.priority;
-    }
-    if ((draft.assignee ?? "") !== current.assignee) patch.assignee = draft.assignee ?? "";
-    return patch;
-  }
-
   async function save() {
     if (!task) return;
-    const patch = changedFields(task);
+    // Only the fields the operator actually touched (issue #263's roster-safety
+    // diff, extended with #580's deliverable). See `computeTaskPatch`.
+    const patch = computeTaskPatch(draft, task);
     if (Object.keys(patch).length === 0) {
       // Nothing to write. Saying so beats a round-trip that reports "Saved."
       // for an edit that never happened.
@@ -241,6 +248,34 @@ export function TaskEditDialog({
                 onChange={(next) => setDraft((d) => ({ ...d, assignee: next }))}
               />
             </div>
+          </div>
+
+          <div className="grid gap-1.5">
+            <Label htmlFor="task-deliverable">Deliverable</Label>
+            <Select
+              value={draft.deliverable ?? task.deliverable ?? "once"}
+              onValueChange={(v) =>
+                setDraft((d) => ({ ...d, deliverable: (v as TaskDeliverable) ?? undefined }))
+              }
+              disabled={!DELIVERABLE_EDITABLE.has(task.column)}
+            >
+              <SelectTrigger id="task-deliverable" data-testid="edit-deliverable">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {DELIVERABLES.map((d) => (
+                  <SelectItem key={d.value} value={d.value}>
+                    {d.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {!DELIVERABLE_EDITABLE.has(task.column) && (
+              <p className="text-[11px] text-muted-foreground">
+                Locked once work starts — the workflow is built when a card enters In progress, so
+                this can only be changed while it&apos;s still in To-do or Planning.
+              </p>
+            )}
           </div>
         </div>
 

--- a/frontend/src/views/TaskWorkflowProposalPanel.tsx
+++ b/frontend/src/views/TaskWorkflowProposalPanel.tsx
@@ -1,0 +1,186 @@
+// Issue #580: the In-Review panel where an operator approves (or rejects) the
+// workflow a builder pass proposed for a `workflow`-deliverable card.
+//
+// The road to #339's Done link. A card whose deliverable is `workflow`, dragged
+// into In Progress, has the builder pass turn its plan into a proposed graph and
+// settle it here — In Review, carrying a `TaskWorkflowProposal`. This panel is
+// where a person reads that proposal and decides:
+//
+// * **Apply** runs the one workflow-authoring path host-side
+//   (`POST …/workflow-proposal/apply`): it rebuilds the graph from the STORED
+//   proposal, validates it exactly as a hand-authored create, links the card to
+//   the created workflow, and returns it moved to Done — where #339's existing
+//   output link opens the new workflow. A refused create (a name taken since, a
+//   teammate off the roster) comes back rejected and the card stays In Review
+//   with its proposal intact; the host's own message is shown verbatim.
+// * **Reject** clears the proposal and returns the card to To-do (decision D2c),
+//   keeping its `workflow` deliverable so dragging it back builds again.
+//
+// The diff is the #415 renderer, fed by the {@link taskProposalDiff} adapter —
+// the same review an operator gets for a copilot's edit, so a built workflow is
+// approved with machinery that already exists. When the adapter cannot render
+// the stored graph, Apply is withheld (the host would refuse it too) and the
+// reason is shown; Reject stays available so a card is never stuck.
+
+import { useMemo, useState } from "react";
+import { AlertTriangle, Check, Loader2, Workflow, X } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { applyWorkflowProposal, rejectWorkflowProposal, type Task } from "@/api/tasks";
+import { ApiError } from "@/api/types";
+import type { GraphDiff } from "@/api/workflow-proposal";
+import { taskProposalDiff } from "@/lib/task-workflow-proposal";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ProposalDiff } from "@/views/workflows/ProposalDiff";
+
+function generatedAt(atMillis: number): string {
+  return new Date(atMillis).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+export function TaskWorkflowProposalPanel({
+  client,
+  company,
+  task,
+  onSaved,
+  onReload,
+}: {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** The In-Review card. The caller guarantees `task.workflowProposal` is set. */
+  task: Task;
+  /** Hand the settled card back to the board/detail for reconciliation. */
+  onSaved: (t: Task) => void;
+  /** Re-read the detail after a settle, so its poll picks up the new state. */
+  onReload: () => Promise<void> | void;
+}) {
+  const proposal = task.workflowProposal!;
+  const result = useMemo(() => taskProposalDiff(proposal.ops), [proposal.ops]);
+  const [busy, setBusy] = useState<null | "apply" | "reject">(null);
+  // Component-local so the parent's 4s detail poll cannot wipe it: a refused
+  // Apply leaves the card In Review, the panel stays mounted, and the host's
+  // reason must persist until the operator acts rather than blinking out on the
+  // next re-render.
+  const [error, setError] = useState<string | null>(null);
+
+  const refused = "reason" in result;
+
+  async function apply() {
+    setBusy("apply");
+    setError(null);
+    try {
+      const saved = await applyWorkflowProposal(client, company, task.id);
+      onSaved(saved);
+      await onReload();
+      toast.success("Workflow created — the card is done.");
+    } catch (e) {
+      // The host's refusal, verbatim: a name taken since the pass ran, a
+      // teammate no longer on the roster. The card stays In Review with its
+      // proposal, so this is a state to recover from, not a dead end.
+      setError(
+        e instanceof ApiError
+          ? e.message
+          : e instanceof Error
+            ? e.message
+            : "The workflow could not be created.",
+      );
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  async function reject() {
+    setBusy("reject");
+    setError(null);
+    try {
+      const saved = await rejectWorkflowProposal(client, company, task.id);
+      onSaved(saved);
+      await onReload();
+      toast.success("Proposal rejected — the card is back in To-do.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "The proposal could not be rejected.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  return (
+    <div
+      className="rounded-xl border bg-card p-4"
+      data-testid="task-workflow-proposal"
+    >
+      <div className="flex items-start gap-2">
+        <Workflow className="mt-0.5 size-4 shrink-0 text-muted-foreground" aria-hidden />
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold leading-snug">{proposal.summary}</p>
+          <p className="mt-0.5 text-[11px] text-muted-foreground">
+            Proposed workflow · built {generatedAt(proposal.generatedAtMillis)}
+          </p>
+        </div>
+      </div>
+
+      {refused ? (
+        // The adapter could not render the stored graph, which is what the host
+        // would refuse on Apply too — so Apply is withheld rather than offered
+        // and rejected. Reject stays, so the card is never stuck.
+        <Alert className="mt-3 py-1.5">
+          <AlertTriangle className="size-3.5" />
+          <AlertDescription className="text-[11px] leading-snug">
+            <span className="font-medium text-foreground">Apply withheld.</span>{" "}
+            {(result as { reason: string }).reason} You can still reject it to send the card back to
+            To-do and have the workflow built again.
+          </AlertDescription>
+        </Alert>
+      ) : (
+        <div className="mt-2 text-[11px] leading-snug">
+          <ProposalDiff diff={(result as { diff: GraphDiff }).diff} />
+        </div>
+      )}
+
+      {error && (
+        <Alert variant="destructive" className="mt-3 py-1.5" data-testid="task-workflow-proposal-error">
+          <AlertTriangle className="size-3.5" />
+          <AlertDescription className="text-[11px] leading-snug">{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="mt-3 flex items-center gap-2">
+        {!refused && (
+          <Button
+            size="sm"
+            className="h-8"
+            disabled={busy !== null}
+            onClick={() => void apply()}
+            data-testid="task-workflow-proposal-apply"
+          >
+            {busy === "apply" ? (
+              <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+            ) : (
+              <Check className="mr-1.5 size-3.5" />
+            )}
+            Approve &amp; create
+          </Button>
+        )}
+        <Button
+          size="sm"
+          variant="outline"
+          className="h-8"
+          disabled={busy !== null}
+          onClick={() => void reject()}
+          data-testid="task-workflow-proposal-reject"
+        >
+          {busy === "reject" ? (
+            <Loader2 className="mr-1.5 size-3.5 animate-spin" />
+          ) : (
+            <X className="mr-1.5 size-3.5" />
+          )}
+          Reject
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -16,7 +16,9 @@ import {
   createTask,
   listTasks,
   patchTask,
+  type CreateTask,
   type Task,
+  type TaskDeliverable,
   type TaskPlan,
 } from "@/api/tasks";
 import type { OpenCompanyClient } from "@/api/client";
@@ -32,6 +34,13 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
@@ -611,6 +620,12 @@ function TaskItem({
           <span className="truncate text-xs text-muted-foreground">{task.assignee}</span>
         </div>
       )}
+      {task.deliverable === "workflow" && (
+        <div className="mt-2 inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] text-muted-foreground">
+          <ListTree className="size-3 shrink-0" />
+          Workflow
+        </div>
+      )}
       {task.plan && <PlanBadgeRow plan={task.plan} />}
       {SHOWS_OUTPUT_LINK.has(task.column) && <OutputLinkRow task={task} />}
       {task.column === "paused" && (
@@ -779,6 +794,20 @@ export function derivePromptCard(prompt: string): { title: string; note?: string
 }
 
 /**
+ * The once-vs-workflow options, in review order (issue #580). Shared by the
+ * create dialog here and the edit dialog, so the two pickers can never offer a
+ * different vocabulary than the wire's {@link TaskDeliverable}.
+ */
+export const DELIVERABLE_OPTIONS: { value: TaskDeliverable; label: string; hint: string }[] = [
+  { value: "once", label: "Do it once", hint: "A one-off result." },
+  {
+    value: "workflow",
+    label: "Build me the workflow",
+    hint: "A reusable workflow you can open, edit and re-run.",
+  },
+];
+
+/**
  * New work enters the board through one prompt box (issue #301).
  *
  * Title/Note/Priority/Assignee used to be collected up front. They are not gone,
@@ -788,6 +817,12 @@ export function derivePromptCard(prompt: string): { title: string; note?: string
  * decides where the card lands — the same spend gate the transcript's "Add to
  * board" relies on, keeping the human drag into In progress the only thing that
  * spends an agent turn.
+ *
+ * The one field it does collect beyond the prompt is the deliverable (issue
+ * #580): once versus workflow is a decision about *what kind of thing* the card
+ * produces, not a default the host can pick, so the operator states it here. It
+ * still lands in To-do like any card — the builder pass fires only on the drag
+ * into In progress.
  */
 function CreateTaskDialog({
   open,
@@ -803,10 +838,14 @@ function CreateTaskDialog({
   company: string | null;
 }) {
   const [prompt, setPrompt] = useState("");
+  const [deliverable, setDeliverable] = useState<TaskDeliverable>("once");
   const [busy, setBusy] = useState(false);
 
   useEffect(() => {
-    if (open) setPrompt("");
+    if (open) {
+      setPrompt("");
+      setDeliverable("once");
+    }
   }, [open]);
 
   if (!open) return null;
@@ -816,7 +855,12 @@ function CreateTaskDialog({
     if (!title) return;
     setBusy(true);
     try {
-      const created = await createTask(client, company, { title, note });
+      const body: CreateTask = { title, note };
+      // Only `"workflow"` reaches the wire; `"once"` is the host default and is
+      // sent as nothing, so a one-off card's body is byte-identical to a
+      // pre-#580 one.
+      if (deliverable === "workflow") body.deliverable = "workflow";
+      const created = await createTask(client, company, body);
       onCreated(created);
       toast.success("Task created.");
     } catch (e) {
@@ -850,6 +894,28 @@ function CreateTaskDialog({
             onChange={(e) => setPrompt(e.target.value)}
             placeholder="Describe the work. The first line becomes the card's title."
           />
+        </div>
+
+        <div className="grid gap-1.5">
+          <Label htmlFor="new-deliverable">Deliverable</Label>
+          <Select
+            value={deliverable}
+            onValueChange={(v) => setDeliverable((v as TaskDeliverable) ?? "once")}
+          >
+            <SelectTrigger id="new-deliverable" data-testid="create-deliverable">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {DELIVERABLE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value}>
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-[11px] text-muted-foreground">
+            {DELIVERABLE_OPTIONS.find((o) => o.value === deliverable)?.hint}
+          </p>
         </div>
 
         <DialogFooter>

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -11,15 +11,25 @@ import {
   Strikethrough,
 } from "lucide-react";
 
+import type { TaskDeliverable } from "@/api/tasks";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface Props {
   placeholder: string;
   disabled?: boolean;
-  onSend: (text: string) => void;
+  onSend: (text: string, deliverable?: TaskDeliverable) => void;
   /** Compact form, for the narrower thread panel. */
   compact?: boolean;
+  /**
+   * Show the once-vs-workflow control (issue #580), opt-in per composer.
+   *
+   * Only the company-channel composer asks for it — a channel line can open a
+   * board card, so "do it once" versus "build me the workflow" belongs there.
+   * The thread and copilot composers never carry it, so their `onSend` stays a
+   * plain `(text)` and their wire shape is unchanged.
+   */
+  deliverableChoice?: boolean;
 }
 
 /** The markdown a toolbar button wraps the selection in. */
@@ -38,15 +48,26 @@ const WRAPS = [
  * with the draft up to a cap before scrolling. Enter sends; Shift+Enter breaks
  * the line, which is the convention every chat client shares.
  */
-export function MessageComposer({ placeholder, disabled, onSend, compact }: Props) {
+export function MessageComposer({
+  placeholder,
+  disabled,
+  onSend,
+  compact,
+  deliverableChoice,
+}: Props) {
   const [draft, setDraft] = useState("");
+  // The once-vs-workflow choice for the NEXT line only. It resets to "once"
+  // after every send so a workflow request never silently carries into the
+  // ordinary message after it — each build is an explicit, per-line decision.
+  const [deliverable, setDeliverable] = useState<TaskDeliverable>("once");
   const input = useRef<HTMLTextAreaElement>(null);
 
   function send() {
     const text = draft.trim();
     if (!text || disabled) return;
     setDraft("");
-    onSend(text);
+    onSend(text, deliverableChoice ? deliverable : undefined);
+    setDeliverable("once");
   }
 
   function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
@@ -131,6 +152,36 @@ export function MessageComposer({ placeholder, disabled, onSend, compact }: Prop
         />
 
         <div className="flex items-center gap-0.5 px-2 pb-1.5">
+          {deliverableChoice && !compact && (
+            <div
+              className="mr-1 flex items-center gap-0.5 rounded-lg border p-0.5"
+              role="group"
+              aria-label="What this should produce"
+            >
+              {(
+                [
+                  { value: "once", label: "Do it once" },
+                  { value: "workflow", label: "Build me the workflow" },
+                ] as const
+              ).map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={deliverable === option.value}
+                  onClick={() => setDeliverable(option.value)}
+                  data-testid={`composer-deliverable-${option.value}`}
+                  className={cn(
+                    "rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
+                    deliverable === option.value
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  {option.label}
+                </button>
+              ))}
+            </div>
+          )}
           <Button
             variant="ghost"
             size="icon"

--- a/frontend/src/views/workflows/ProposalCard.tsx
+++ b/frontend/src/views/workflows/ProposalCard.tsx
@@ -11,12 +11,13 @@
 // writes nothing at all: the card greys out and stays in the transcript so a
 // later question can refer to what was turned down.
 
-import { AlertTriangle, ArrowRight, Check, Loader2, Minus, Plus, X } from "lucide-react";
+import { AlertTriangle, Check, Loader2, X } from "lucide-react";
 
-import type { GraphDiff, NodeChange } from "@/api/workflow-proposal";
+import type { GraphDiff } from "@/api/workflow-proposal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { ProposalDiff } from "./ProposalDiff";
 
 /** Where a proposal has got to. Only `pending` can write anything. */
 export type ProposalState = "pending" | "applying" | "applied" | "dismissed";
@@ -67,33 +68,7 @@ export function ProposalCard({
         {state === "dismissed" && <span className="shrink-0 text-muted-foreground">Dismissed</span>}
       </div>
 
-      <ul className="mt-2 space-y-1">
-        {diff.nodes.map((node) => (
-          <li key={`n-${node.id}`}>
-            <NodeLine node={node} />
-          </li>
-        ))}
-        {diff.edges.map((edge) => (
-          <li
-            key={`e-${edge.change}-${edge.from}-${edge.to}`}
-            className="flex items-center gap-1 text-muted-foreground"
-          >
-            {edge.change === "added" ? (
-              <Plus className="size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
-            ) : (
-              <Minus className="size-3 shrink-0 text-destructive" />
-            )}
-            <span className="font-mono">{edge.from}</span>
-            <ArrowRight className="size-3 shrink-0" aria-hidden />
-            <span className="font-mono">{edge.to}</span>
-          </li>
-        ))}
-        {diff.nodes.length === 0 && diff.edges.length === 0 && (
-          <li className="text-muted-foreground">
-            This would change nothing about the workflow as it stands.
-          </li>
-        )}
-      </ul>
+      <ProposalDiff diff={diff} />
 
       {blocked && !settled && (
         <Alert className="mt-2 py-1.5">
@@ -139,66 +114,5 @@ export function ProposalCard({
         </div>
       )}
     </div>
-  );
-}
-
-/** One step's line: added, removed, or changed with the fields that moved. */
-function NodeLine({ node }: { node: NodeChange }) {
-  if (node.change === "added") {
-    return (
-      <span className="block text-muted-foreground">
-        <span className="flex items-start gap-1">
-          <Plus className="mt-px size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
-          <span>
-            new step <span className="font-mono">{node.id}</span>{" "}
-            <span className="text-foreground">{node.name}</span>
-          </span>
-        </span>
-        {/* A new step's whole payload, not just its name: its kind, and any
-            schedule, config or approval flag it arrives with, each of which
-            changes what the workflow does. Reviewing a name and applying a
-            scheduled auto-approving node is the gap this closes. */}
-        <span className="mt-0.5 ml-4 block space-y-0.5">
-          {node.fields.map((field) => (
-            <span key={field.field} className="block">
-              <span className="font-medium text-foreground">{field.field}</span>:{" "}
-              <span className="text-foreground">{field.after}</span>
-            </span>
-          ))}
-        </span>
-      </span>
-    );
-  }
-  if (node.change === "removed") {
-    return (
-      <span className="flex items-start gap-1 text-muted-foreground">
-        <Minus className="mt-px size-3 shrink-0 text-destructive" />
-        <span>
-          remove <span className="font-mono">{node.id}</span>{" "}
-          <span className="text-foreground">{node.name}</span>
-        </span>
-      </span>
-    );
-  }
-  return (
-    <span className="block text-muted-foreground">
-      <span className="flex items-start gap-1">
-        <ArrowRight className="mt-px size-3 shrink-0" aria-hidden />
-        <span>
-          <span className="font-mono">{node.id}</span>{" "}
-          <span className="text-foreground">{node.name}</span>
-        </span>
-      </span>
-      <span className="mt-0.5 ml-4 block space-y-0.5">
-        {node.fields.map((field) => (
-          <span key={field.field} className="block">
-            <span className="font-medium text-foreground">{field.field}</span>:{" "}
-            <span className="line-through">{field.before}</span>{" "}
-            <ArrowRight className="inline size-3 align-[-2px]" aria-hidden />{" "}
-            <span className="text-foreground">{field.after}</span>
-          </span>
-        ))}
-      </span>
-    </span>
   );
 }

--- a/frontend/src/views/workflows/ProposalDiff.tsx
+++ b/frontend/src/views/workflows/ProposalDiff.tsx
@@ -1,0 +1,107 @@
+// The reviewable diff, shared by the copilot's proposal card (#415) and the
+// task's In-Review workflow panel (#580).
+//
+// This is the list `ProposalCard` used to render inline, lifted out verbatim so
+// both surfaces show a change the same way — step by step and connection by
+// connection, computed from the candidate graph rather than a model's op list —
+// without either forking the renderer. A change nobody proposed cannot appear
+// in it, and an op that changes nothing shows as nothing. It renders nothing but
+// the diff: the shell, the buttons and the settled/blocked states stay with
+// whichever surface owns them.
+
+import { ArrowRight, Minus, Plus } from "lucide-react";
+
+import type { GraphDiff, NodeChange } from "@/api/workflow-proposal";
+
+export function ProposalDiff({ diff }: { diff: GraphDiff }) {
+  return (
+    <ul className="mt-2 space-y-1">
+      {diff.nodes.map((node) => (
+        <li key={`n-${node.id}`}>
+          <NodeLine node={node} />
+        </li>
+      ))}
+      {diff.edges.map((edge) => (
+        <li
+          key={`e-${edge.change}-${edge.from}-${edge.to}`}
+          className="flex items-center gap-1 text-muted-foreground"
+        >
+          {edge.change === "added" ? (
+            <Plus className="size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          ) : (
+            <Minus className="size-3 shrink-0 text-destructive" />
+          )}
+          <span className="font-mono">{edge.from}</span>
+          <ArrowRight className="size-3 shrink-0" aria-hidden />
+          <span className="font-mono">{edge.to}</span>
+        </li>
+      ))}
+      {diff.nodes.length === 0 && diff.edges.length === 0 && (
+        <li className="text-muted-foreground">
+          This would change nothing about the workflow as it stands.
+        </li>
+      )}
+    </ul>
+  );
+}
+
+/** One step's line: added, removed, or changed with the fields that moved. */
+function NodeLine({ node }: { node: NodeChange }) {
+  if (node.change === "added") {
+    return (
+      <span className="block text-muted-foreground">
+        <span className="flex items-start gap-1">
+          <Plus className="mt-px size-3 shrink-0 text-emerald-600 dark:text-emerald-400" />
+          <span>
+            new step <span className="font-mono">{node.id}</span>{" "}
+            <span className="text-foreground">{node.name}</span>
+          </span>
+        </span>
+        {/* A new step's whole payload, not just its name: its kind, and any
+            schedule, config or approval flag it arrives with, each of which
+            changes what the workflow does. Reviewing a name and applying a
+            scheduled auto-approving node is the gap this closes. */}
+        <span className="mt-0.5 ml-4 block space-y-0.5">
+          {node.fields.map((field) => (
+            <span key={field.field} className="block">
+              <span className="font-medium text-foreground">{field.field}</span>:{" "}
+              <span className="text-foreground">{field.after}</span>
+            </span>
+          ))}
+        </span>
+      </span>
+    );
+  }
+  if (node.change === "removed") {
+    return (
+      <span className="flex items-start gap-1 text-muted-foreground">
+        <Minus className="mt-px size-3 shrink-0 text-destructive" />
+        <span>
+          remove <span className="font-mono">{node.id}</span>{" "}
+          <span className="text-foreground">{node.name}</span>
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span className="block text-muted-foreground">
+      <span className="flex items-start gap-1">
+        <ArrowRight className="mt-px size-3 shrink-0" aria-hidden />
+        <span>
+          <span className="font-mono">{node.id}</span>{" "}
+          <span className="text-foreground">{node.name}</span>
+        </span>
+      </span>
+      <span className="mt-0.5 ml-4 block space-y-0.5">
+        {node.fields.map((field) => (
+          <span key={field.field} className="block">
+            <span className="font-medium text-foreground">{field.field}</span>:{" "}
+            <span className="line-through">{field.before}</span>{" "}
+            <ArrowRight className="inline size-3 align-[-2px]" aria-hidden />{" "}
+            <span className="text-foreground">{field.after}</span>
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}

--- a/frontend/test/unit/task-workflow-proposal.test.ts
+++ b/frontend/test/unit/task-workflow-proposal.test.ts
@@ -1,0 +1,236 @@
+import { describe, expect, it } from "vitest";
+
+import { OpenCompanyClient } from "@/api/client";
+import type { PatchTask, Task } from "@/api/tasks";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { computeTaskPatch } from "@/lib/task-edit";
+import { taskProposalDiff } from "@/lib/task-workflow-proposal";
+
+/**
+ * Issue #580 (Stage 2, frontend). Three decidable-without-a-host contracts:
+ *
+ * 1. the adapter that turns a card's STORED workflow proposal (a camelCase
+ *    `WorkflowGraphSpec`) into the #415 review diff, or a stated refusal;
+ * 2. the chat wire — a once-vs-workflow line omits `deliverable` for once and
+ *    carries `"workflow"` when chosen, so an ordinary message is byte-identical
+ *    to a pre-#580 one;
+ * 3. the edit-dialog diff's deliverable arm — an untouched control emits no
+ *    patch, a flip emits exactly `{ deliverable }`.
+ */
+
+// ---------------------------------------------------------------------------
+// 1. taskProposalDiff — the ops→diff adapter
+// ---------------------------------------------------------------------------
+
+/** A realistic built proposal: the camelCase graph the host stores on the card. */
+function spec() {
+  return {
+    id: "weekly_summary",
+    name: "Weekly summary",
+    description: "Posts a weekly summary of dev activity.",
+    nodes: [
+      { id: "cron", kind: "trigger", name: "Weekly", schedule: "0 9 * * 1" },
+      { id: "gather", kind: "agent", name: "Gather", agent: "analyst" },
+      {
+        id: "post",
+        kind: "output",
+        name: "Post",
+        destination: { kind: "owner" },
+        requiresApproval: true,
+      },
+    ],
+    edges: [
+      { from: "cron", to: "gather" },
+      { from: "gather", to: "post" },
+    ],
+  };
+}
+
+describe("taskProposalDiff", () => {
+  it("renders a realistic spec as an all-added diff with field payloads and edges", () => {
+    const result = taskProposalDiff(spec());
+    if ("reason" in result) throw new Error(`expected a diff, got: ${result.reason}`);
+    const { diff } = result;
+
+    // Every step is an addition — the proposal is a brand-new graph.
+    expect(diff.nodes.map((n) => n.id).sort()).toEqual(["cron", "gather", "post"]);
+    expect(diff.nodes.every((n) => n.change === "added")).toBe(true);
+
+    // A new step carries its whole payload, not just its name (the #415
+    // guarantee): the trigger's schedule and the output's approval flag are
+    // reviewable rather than applied unseen.
+    const cron = diff.nodes.find((n) => n.id === "cron")!;
+    const cronFields = Object.fromEntries(cron.fields.map((f) => [f.field, f.after]));
+    expect(cronFields).toMatchObject({ kind: "trigger", schedule: "0 9 * * 1" });
+
+    const post = diff.nodes.find((n) => n.id === "post")!;
+    const postFields = Object.fromEntries(post.fields.map((f) => [f.field, f.after]));
+    expect(postFields).toMatchObject({ kind: "output", requiresApproval: "true" });
+
+    // Both connections show as added.
+    expect(diff.edges).toEqual([
+      { from: "cron", to: "gather", change: "added" },
+      { from: "gather", to: "post", change: "added" },
+    ]);
+  });
+
+  it("refuses a spec with no steps rather than showing an empty diff", () => {
+    const result = taskProposalDiff({ id: "x", name: "Y", nodes: [], edges: [] });
+    expect(result).toHaveProperty("reason");
+  });
+
+  it("refuses a spec that reuses a step id", () => {
+    const bad = {
+      ...spec(),
+      nodes: [
+        { id: "gather", kind: "agent", name: "Gather" },
+        { id: "gather", kind: "output", name: "Duplicate" },
+      ],
+      edges: [],
+    };
+    const result = taskProposalDiff(bad);
+    expect(result).toMatchObject({ reason: expect.stringContaining("gather") });
+  });
+
+  it("refuses an edge to a step that is not there", () => {
+    const bad = {
+      ...spec(),
+      nodes: [{ id: "gather", kind: "agent", name: "Gather" }],
+      edges: [{ from: "gather", to: "ghost" }],
+    };
+    const result = taskProposalDiff(bad);
+    expect(result).toHaveProperty("reason");
+  });
+
+  it("refuses a step carrying a field the diff cannot render", () => {
+    const bad = {
+      ...spec(),
+      nodes: [{ id: "gather", kind: "agent", name: "Gather", sudo: true }],
+      edges: [],
+    };
+    const result = taskProposalDiff(bad);
+    expect(result).toMatchObject({ reason: expect.stringContaining("sudo") });
+  });
+
+  it("refuses a non-object ops payload without crashing", () => {
+    for (const junk of [null, undefined, "nope", 42, [1, 2, 3]]) {
+      const result = taskProposalDiff(junk);
+      expect(result).toHaveProperty("reason");
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. the chat wire — deliverable is omitted for once, carried for workflow
+// ---------------------------------------------------------------------------
+
+/** Records every request body so the test can read what reached the wire. */
+class RecordingTransport implements Transport {
+  readonly seen: TransportRequest[] = [];
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    this.seen.push(req);
+    return {
+      status: 200,
+      statusText: "",
+      url: req.url,
+      text: '{"responses":[]}',
+      header: () => null,
+    };
+  }
+  subscribe(_url: string, _handlers: StreamHandlers): () => void {
+    return () => {};
+  }
+}
+
+function bodyOf(req: TransportRequest): Record<string, unknown> {
+  return req.body ? (JSON.parse(req.body) as Record<string, unknown>) : {};
+}
+
+describe("client.chat deliverable", () => {
+  function clientOn(t: Transport) {
+    return new OpenCompanyClient({ baseUrl: "", company: null, operatorToken: null }, t);
+  }
+
+  it("omits deliverable for an ordinary (once) message, keeping the pre-#580 shape", async () => {
+    const t = new RecordingTransport();
+    await clientOn(t).chat("just a message");
+    const body = bodyOf(t.seen[0]);
+    expect(body).toEqual({ text: "just a message" });
+    expect("deliverable" in body).toBe(false);
+  });
+
+  it("omits deliverable when the choice is explicitly once", async () => {
+    const t = new RecordingTransport();
+    await clientOn(t).chat("do it once", null, null, null, "once");
+    expect("deliverable" in bodyOf(t.seen[0])).toBe(false);
+  });
+
+  it("carries deliverable:'workflow' when the operator chose to build one", async () => {
+    const t = new RecordingTransport();
+    await clientOn(t).chat("build me a weekly summary workflow", null, "main", null, "workflow");
+    const body = bodyOf(t.seen[0]);
+    expect(body.deliverable).toBe("workflow");
+    // The other fields still ride the same body — the deliverable is additive.
+    expect(body.chat).toBe("main");
+    expect(body.text).toBe("build me a weekly summary workflow");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. the edit-dialog diff — deliverable normalization
+// ---------------------------------------------------------------------------
+
+function task(overrides: Partial<Task> = {}): Task {
+  return {
+    id: "t1",
+    title: "Weekly summary",
+    column: "todo",
+    priority: "medium",
+    assignee: "",
+    updatedAt: 0,
+    ...overrides,
+  };
+}
+
+/** The fully-seeded draft the dialog builds when a card opens (absent → once). */
+function seededDraft(current: Task): PatchTask {
+  return {
+    title: current.title,
+    note: current.note ?? "",
+    column: current.column,
+    priority: current.priority,
+    assignee: current.assignee,
+    deliverable: current.deliverable ?? "once",
+  };
+}
+
+describe("computeTaskPatch deliverable", () => {
+  it("emits no patch when the untouched draft matches the card", () => {
+    const current = task({ deliverable: "workflow" });
+    expect(computeTaskPatch(seededDraft(current), current)).toEqual({});
+  });
+
+  it("does not patch deliverable for a card with no stored value left untouched", () => {
+    // task.deliverable is absent (== once); the seeded draft is normalized to
+    // "once", so the two agree and nothing is sent.
+    const current = task();
+    expect("deliverable" in computeTaskPatch(seededDraft(current), current)).toBe(false);
+  });
+
+  it("patches exactly { deliverable } when flipped once → workflow", () => {
+    const current = task(); // no stored deliverable → normalized "once"
+    const draft = { ...seededDraft(current), deliverable: "workflow" as const };
+    expect(computeTaskPatch(draft, current)).toEqual({ deliverable: "workflow" });
+  });
+
+  it("patches exactly { deliverable } when flipped workflow → once", () => {
+    const current = task({ deliverable: "workflow" });
+    const draft = { ...seededDraft(current), deliverable: "once" as const };
+    expect(computeTaskPatch(draft, current)).toEqual({ deliverable: "once" });
+  });
+});


### PR DESCRIPTION
## Summary

Stage 2 of the spine (#580): the operator UI on top of the merged Stage-1 backend (#595). Stage 1 shipped the deliverable field, the builder pass that settles a workflow card to In Review with a stored proposal, and the apply/reject routes + clients — but nothing drove them. This adds the UI: choose the deliverable, see the proposed workflow as a diff, and apply or reject it. Frontend-only; no backend change.

- **Composer toggle** — "Do it once" / "Build me the workflow" on the company-channel composer; resets to once after each send (an explicit per-request choice, never a sticky route into the builder). Thread/copilot composers don't get it.
- **Card deliverable control** — Once/Workflow on the create dialog and the edit dialog (edit enabled only in To-do/Planning — a UI-honesty layer; the host accepts a patch later too), plus a "Workflow" chip on board cards + the detail header.
- **In Review op-diff panel** — when a card settles In Review with a proposal, render it as an everything-added diff (reusing #415's `validateProposal`/`applyProposal`/`diffGraphs` via a small spec→ops adapter). Apply → Done with the #339 workflow link; Reject → back to To-do. A proposal the diff can't render shows the reason and withholds Apply (Reject still offered).
- **Shared renderer, not forked** — the diff list is extracted from #415's `ProposalCard` into `ProposalDiff.tsx`; ProposalCard's props + testids are unchanged, so the copilot flow is byte-identical.

## API Or Behavior Changes

- `client.chat` sends `deliverable` only when `"workflow"` (ordinary messages unchanged). No new routes — apply/reject + deliverable create/patch all shipped in Stage 1.
- Deliverable is UI-editable only through Planning; stated as honesty, not enforcement (the host PATCHes in any column).

## Tests

- [x] `npm run typecheck` + `npm run typecheck:e2e` + `npm run build`
- [x] `npx vitest run` — **310 passed / 29 files**. New: adapter (realistic spec w/ fields + edges → all-added; empty/duplicate-id/absent-edge/non-object/out-of-UPDATABLE → reason, no crash), chat-wire (once omits, workflow carries), edit-dialog deliverable diff. Existing `workflow-proposal.test.ts` untouched — proves the ProposalDiff extraction is non-breaking.
- No cargo (no Rust touched).
- [ ] **Live-host end-to-end walk (UI-bound, required by author directive):** the orchestrator runs the full 8-step walk on a running console before this is called done — compose "build me the workflow" → Workflow chip + toggle reset; create/edit deliverable + lock after Planning; Planning→In Progress→In Review op-diff panel; Apply → Done + #339 link opens the workflow; second identical card → name-taken refusal inline (stays In Review); Reject → To-do; copilot ProposalCard regression.

## Documentation

N/A — no API/architecture change; the flow is documented by Stage 1's docs.

## Related

Advances #580 (Stage 2 of 2 — Stage 1 was #595). Reuses #415 (proposal renderer) + #339 (Done link) + #276 (disarm, via the merged apply path). Disjoint from #596 (run inspection) and #612/#627 (node approval gates).