### PR TITLE
docs(data-root): answer the hosted overlap question — a tenant rollout cannot overlap

### DIFF
--- a/docs/spec/runtime/data-root.md
+++ b/docs/spec/runtime/data-root.md
@@ -60,23 +60,38 @@ share regardless.
 
 ### Hosted deployments: the overlap window
 
-**Open question for the platform.** In hosted mode the manager runs each tenant
-as a container over `OPENCOMPANY_DATA_DIR=/data`. If a rollout ever has the new
-pod running while the old one is still alive over the same volume, the new pod
-now **fails to boot** with a configuration error where it previously started and
-silently raced.
+**Answered — a tenant rollout cannot overlap**
+(`opencompany-microservice`#15). In hosted mode the manager runs each tenant as
+a container over `OPENCOMPANY_DATA_DIR=/data`, and the question was whether a
+rollout ever has the new pod running while the old one still holds the volume —
+which since this lock exists means the new pod fails to boot where it
+previously started and silently raced.
 
-Refusing is the correct behaviour — the alternative is two writers over one
-journal — but it changes what a deploy does, so it needs a decision rather than
-a discovery:
+It does not, and by construction rather than by configuration. A tenant is a
+**StatefulSet at one replica**, and a StatefulSet has no `maxSurge`: pod
+`opencompany-0` is deleted and fully terminated before its replacement is
+created, so at most one pod ever holds the claim. The one path that rolls
+tenants — `kubectl rollout restart statefulset -A -l app=opencompany` in the
+platform's deploy workflow — goes through exactly that sequence. A
+`Deployment` would have been the dangerous shape: its default rolling update
+surges one extra pod even at one replica.
 
-- If the manager already uses a `Recreate`-style strategy (old pod terminated
-  before the new one starts), nothing needs to change.
-- If it uses a rolling strategy with overlap, either the strategy or the
-  readiness gate has to account for a boot that legitimately refuses.
+Two things changed on the platform side anyway, because the invariant was
+incidental and the failure was illegible:
 
-Whoever owns `opencompany-manager` should confirm which it is before this
-reaches a tenant.
+- The manifest builder now states the no-surge strategy explicitly instead of
+  inheriting the API server's default, with a test that fails if the tenant
+  workload ever becomes a `Deployment` or grows a second replica.
+- A refused boot is now reported as the refusal. The manager's startup gate
+  polls `/healthz` and used to report only "did not become healthy before
+  timeout", which reads the same for a lock refusal and a slow image pull. The
+  tenant container runs with `terminationMessagePolicy:
+  FallbackToLogsOnError`, so the message above reaches the pod status, and the
+  manager reads it back into the error it returns.
+
+What remains genuinely outside the rollout path — a pod force-deleted while
+its node was unreachable, or a volume mounted by hand — is the case this lock
+was written for, and it now surfaces as the message naming the directory.
 
 ## Running two hosts side by side
 


### PR DESCRIPTION
`docs/spec/runtime/data-root.md` carried the lock's one open question: whether the platform's tenant rollout ever runs a new pod over a `/data` the old one still holds — which since #536 turns a silent race into a failed boot.

**It does not.** A tenant is a StatefulSet at one replica, and a StatefulSet has no `maxSurge`: `opencompany-0` is deleted and fully terminated before its replacement is created. The one path that rolls tenants (`kubectl rollout restart statefulset -A -l app=opencompany`, in the platform's deploy workflow) goes through exactly that sequence. A `Deployment` would have been the dangerous shape — its default rolling update surges an extra pod even at one replica.

This replaces the open question with the answer, and records the two things that changed on the platform side anyway:

- the manifest builder now states the no-surge strategy explicitly instead of inheriting the API server's default, with a test that fails if the tenant workload ever becomes a `Deployment` or grows a second replica;
- a refused boot is now reported as the refusal — the manager's startup gate used to say only "did not become healthy before timeout", which reads the same for a lock refusal and a slow image pull. The tenant container runs with `terminationMessagePolicy: FallbackToLogsOnError`, so the message this lock emits reaches the pod status and the manager reads it back.

Docs only — no code in this repo changes.

Answers tinyhumansai/opencompany-microservice#15; platform side is tinyhumansai/opencompany-microservice#16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)