### PR TITLE
fix(workflows): unbreak main — gate test asserted a reach #459 had already changed

### DIFF
--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -356,10 +356,17 @@ description = "Runs Acme."
     /// either would stop runs that have nothing to decide, and for `web_search`
     /// it would be worse than useless: consent for it happens once, at grant
     /// time, via an explicit `search` grant a `*` cannot confer.
+    ///
+    /// `file_read` rather than `read_workspace_state`, which reads like the
+    /// obvious choice and is not one: issue #459 moved it to
+    /// `Reach::Consequence` because it shells out to `git` in a directory the
+    /// agent can write a `.git/config` into. That is a deliberate stopgap with
+    /// its own revert condition (tinyhumansai/openhuman#5494), so the tool to
+    /// change here was the example, not the classification.
     #[tokio::test]
     async fn a_plain_read_and_a_metered_read_do_not_gate() {
         let mut g = graph(vec![
-            tool_node("read", "read_workspace_state"),
+            tool_node("read", "file_read"),
             tool_node("search", "web_search"),
         ]);
         let gated = apply_tool_call_gates(&mut g, &company("supervised", &[]), "wf", "run-1").await;


### PR DESCRIPTION
**`main` is red and has been since ~11:27 today.** Every run of the `Rust (openhuman, tinycortex)` lane fails on `workflows::gate::tests::a_plain_read_and_a_metered_read_do_not_gate`, so this blocks every open PR, not one. This is the smallest change that makes it green.

## What happened

Two PRs, each green against the `main` it branched from, that cannot both be right:

- **`c721e57` (#606, issue #459)** moved `read_workspace_state` from `Reach::Nothing` to `Reach::Consequence`. It shells out to `git status` / `git log` in `{root}/{company}/{agent}/workspace` — the directory `file_write` writes into — and the vendored `run_git` sets no `GIT_CONFIG_NOSYSTEM` and scrubs no environment, so a `.git/config` the agent authored decides what `core.fsmonitor` runs.
- **`afe2747` (issue #460)** added `src/workflows/gate.rs`, whose test uses `read_workspace_state` as its example of a pure workspace read that must *not* gate.

Merged together, the test asserts the opposite of the classification. Neither PR could have caught it in isolation — this is only visible in the merge, which is exactly the failure mode CI-on-`main` exists to catch and did.

## Why the test, and not the reach

Reverting `read_workspace_state` to `Reach::Nothing` would turn the lane green in one line, and it is the wrong line. That reach is a deliberate stopgap with its own revert condition recorded both in the code and upstream at `tinyhumansai/openhuman#5494`:

> Revert this to `Reach::Nothing` once a hardened `run_git` is vendored, and not before.

Undoing a security fix to keep a test assertion inverts which of the two is load-bearing. So the example changes: `file_read` is a genuine `Reach::Nothing` workspace read, and the test keeps its intent unchanged — a plain read and a metered read both pass the gate under `supervised`.

The doc comment now records why the obvious-looking tool is the wrong one, so the next person writing a "pure read" test does not reach for it again and rediscover this the same way.

## Scope

One test's fixture and its comment. No production code, no classification, no gate behaviour.

`every_reachable_workflow_tool_is_classified_by_name_alone` also names `read_workspace_state` and is deliberately left alone — it asserts that reach is stable across args, not what the reach is, so it holds either way.

## Verification

```
cargo fmt --all -- --check
cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
cargo test  --locked --features openhuman,tinycortex --tests     # 2849 passed, 0 failed
```

Run on Rust 1.96.1 rather than the pinned `stable`: that feature set cannot build on 1.93.0, because `libsqlite3-sys 0.38.1`'s build script uses unstable `cfg_select!` and dies before this crate compiles. Worth knowing separately — it means this lane is unreproducible locally on the toolchain `rust-toolchain.toml` pins, which is part of why a merge-only breakage sat on `main` for an hour.

Found while investigating a failure on #636, which turned out to be this and not that PR.