### PR TITLE
fix(workspace): stop scaffolding the empty Desks/ root (#645)

### DIFF
--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -129,18 +129,17 @@ The workspace store seeds a new company from its `companies/<name>/workspace/**`
 template on first use (`WorkspaceStore::is_empty` gates the seed); skills read
 the company's `skills/<id>/SKILL.md` plus the repo-level shared registry.
 
-Boot also scaffolds the two reserved system roots, `Agents/` and `Desks/`
-(issue #551), via `company::workspace_scaffold::ensure_workspace_scaffold`.
-That call is gated on "this is not a rebuild" and on **nothing else** —
-deliberately not on `seed_dir`, since a provisioned tenant and the desktop
-build have no company bundle to seed from and their workspace needs the same
-shape; deliberately not on `is_empty`, since that gate exists to make operator
-deletions stick against re-seeding, and an existing company only ever picks the
-roots up on a later boot; and deliberately not on the roster, since the roots
-are part of what a workspace is. It is idempotent, so it costs one tree read
-per boot.
+Boot also scaffolds the reserved system root `Agents/` (issue #551), via
+`company::workspace_scaffold::ensure_workspace_scaffold`. That call is gated on
+"this is not a rebuild" and on **nothing else** — deliberately not on
+`seed_dir`, since a provisioned tenant and the desktop build have no company
+bundle to seed from and their workspace needs the same shape; deliberately not
+on `is_empty`, since that gate exists to make operator deletions stick against
+re-seeding, and an existing company only ever picks the root up on a later
+boot; and deliberately not on the roster, since the root is part of what a
+workspace is. It is idempotent, so it costs one tree read per boot.
 
-The roots are created **empty**. `Agents/<agent-id>/` and `Desks/<desk-id>/`
+The root is created **empty**. `Agents/<agent-id>/` and `Desks/<desk-id>/`
 are minted on demand by `ensure_agent_folder` / `ensure_desk_folder`, at the
 moment that agent or desk first produces something — a folder per roster member
 would fill the tree with empty directories for teammates who have done nothing.
@@ -148,6 +147,16 @@ The minters find-or-create the root they need, so they double as the repair
 path if boot's fail-soft create ever misses. There is deliberately no
 roster-rebuild seam: `HarnessPool::ensure` writes nothing to the workspace,
 because a member folder is no longer a function of the roster.
+
+`Desks/` is **not** scaffolded (issue #645). It was until nothing turned out to
+write into it: `ensure_desk_folder` still has no callers (#552's publish path
+is the intended first producer), so every company carried an empty root
+promising a feature it does not yet have. Because the minter already creates an
+absent root on its way down, dropping it from `SYSTEM_ROOTS` was enough —
+`Desks/` now appears whole, root and member folder together, the first time a
+desk actually produces something. Existing companies keep whatever `Desks/`
+they already have: the scaffold resolves only the names in `SYSTEM_ROOTS`, so
+an unmanaged root is never inspected, deduplicated, warned about or removed.
 
 The builder threads that same `WorkspaceStore` handle onto `HarnessDeps`
 (`workspace`), so agents read and write the shared note tree through the tools

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -181,9 +181,10 @@ reach the same tree through `workspace_list` / `workspace_read` /
 `workspace_create` / `workspace_write`, and a created note has its default home
 in the reserved `Agents/<agent-id>/` folder (#551) — a convention the persona
 brief steers toward, not a boundary the routes enforce. Boot scaffolds the
-`Agents/` and `Desks/` roots empty; an individual `Agents/<agent-id>/` is minted
-the first time that agent writes into it, so a tree read on a fresh company
-shows the two roots and no member folders.
+`Agents/` root empty; an individual `Agents/<agent-id>/` is minted the first
+time that agent writes into it, and the `Desks/` root is minted whole the first
+time a desk produces something (#645) — so a tree read on a fresh company shows
+exactly one root and no member folders.
 
 Team writes are an **operator overlay** persisted through the store, merged
 into the manifest roster at read time — the version-controlled `company.toml`

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -289,7 +289,8 @@ prompt = "Weekly review and operator digest"
     protect nothing. What keeps the tree navigable instead is steering plus
     attribution — the persona brief names the agent's own reserved folder
     `Agents/<agent-id>/` (minted the first time that agent puts something in it;
-    boot only scaffolds the empty `Agents/` and `Desks/` roots) as the default
+    boot only scaffolds the empty `Agents/` root, and since issue #645 `Desks/`
+    is minted on first use rather than scaffolded) as the default
     home for what it produces and marks shared
     guidance as something to edit only on purpose, and every node records who
     created it and who last wrote it (issue #326), which the console shows. Both

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -220,20 +220,29 @@ Backends persist the node as opaque JSON and both fields are
 round-trip, the write stamp, and the rename non-stamp across all three
 backends.
 
-**`Agents/` and `Desks/` (#551).** `company::workspace_scaffold` owns the
+**`Agents/` and `Desks/` (#551, #645).** `company::workspace_scaffold` owns the
 workspace's two reserved system roots and the folders beneath them, on two
 different schedules:
 
-* `ensure_workspace_scaffold` adopt-or-creates the `Agents` and `Desks` roots,
-  **empty**, from one seam: `RuntimeBuilder::build` (boot). It takes no roster
-  — a company with no agents gets both — so an existing company picks them up
-  on its next boot. Idempotent; one tree read.
+* `ensure_workspace_scaffold` adopt-or-creates the roots listed in
+  `SYSTEM_ROOTS` — `Agents` alone — **empty**, from one seam:
+  `RuntimeBuilder::build` (boot). It takes no roster (a company with no agents
+  still gets it), so an existing company picks it up on its next boot.
+  Idempotent; one tree read.
 * `ensure_agent_folder` / `ensure_desk_folder` adopt-or-create
   `Agents/<agent-id>/` and `Desks/<desk-id>/` **on demand**, returning the node
   id, called when that agent or desk first produces something. A folder means
   "this member produced something"; an eager folder per roster member would be
   a claim the tree cannot back. `workspace_create` calls the agent minter when
   an agent writes into its own home; #552's publish path is the next caller.
+* **`Desks/` is not scaffolded** (#645). Both minters have always created an
+  absent root on their way down, and `ensure_desk_folder` has no callers yet, so
+  scaffolding the root gave every company a permanently empty folder
+  advertising a feature nothing fills — the same promise-not-record shape #570
+  removed at the member level. `ensure_desk_folder` now mints root and member
+  folder together on first use. A `Desks/` that already exists is untouched:
+  the scaffold only ever looks up the names in `SYSTEM_ROOTS`, so a legacy
+  company keeps its root, its contents and its authorship, un-warned.
 
 Both are fail-closed: a name collision (a *file* of that name, or several nodes
 sharing it) is never resolved by creating a duplicate that would make the path

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -11,23 +11,37 @@
 //! up, for work a desk produces rather than one teammate (issue #552 wires the
 //! producer).
 //!
-//! # Eager roots, lazy members
+//! # One eager root, everything else lazy
 //!
-//! The two halves are provisioned on deliberately different schedules:
+//! Provisioning runs on deliberately different schedules, and the line between
+//! them is whether anything actually writes there yet:
 //!
-//! * The **roots** are scaffolding. `Agents/` and `Desks/` are laid down on
-//!   every boot by [`ensure_workspace_scaffold`], empty, whether or not the
-//!   company has a roster — they are part of what a workspace *is*, the same
-//!   way the template-seeded `Playbooks/` and `Standards/` are, and an operator
-//!   opening the Workspace tab on a brand-new company should see the shape of
-//!   the place rather than a void.
-//! * A **member folder** is not scaffolding, it is a container for something.
-//!   `Agents/<agent-id>/` and `Desks/<desk-id>/` are therefore minted on demand
+//! * `Agents/` is scaffolding. [`ensure_workspace_scaffold`] lays it down on
+//!   every boot, empty, whether or not the company has a roster — it is part of
+//!   what a workspace *is*, the same way the template-seeded `Playbooks/` and
+//!   `Standards/` are, and it has a real producer behind it: the persona brief
+//!   steers every agent to write beneath it, so an operator opening the
+//!   Workspace tab on a brand-new company is being shown where things are about
+//!   to appear rather than a void.
+//! * `Desks/` is **not** scaffolded (issue #645). It was, until it turned out
+//!   nothing writes into it: issue #552's publish path is still unwired, so
+//!   [`ensure_desk_folder`] has no callers and every company carried a
+//!   permanently empty root advertising a feature it does not yet have. An
+//!   eager root nobody fills is the same promise-not-record mistake as an eager
+//!   folder per roster member, one level up. It is therefore minted *whole* —
+//!   root and member folder in one call — by [`ensure_desk_folder`], so it
+//!   appears exactly when a desk first has something to put in it.
+//! * A **member folder** was never scaffolding either; it is a container for
+//!   something. `Agents/<agent-id>/` and `Desks/<desk-id>/` are minted on demand
 //!   — by [`ensure_agent_folder`] / [`ensure_desk_folder`], at the moment that
 //!   agent or desk first produces a task, artifact or note. An eager folder per
 //!   roster member fills the tree with empty directories for teammates who have
 //!   never done anything, which is noise that grows with the roster and tells
 //!   the operator nothing.
+//!
+//! Dropping the root changes nothing about how a desk folder is reached: the
+//! minter has always created an absent root on its way down, so it is the same
+//! one call it always was.
 //!
 //! # What this is, and what it very deliberately is not
 //!
@@ -82,26 +96,40 @@ pub const AGENTS_ROOT: &str = "Agents";
 
 /// The reserved root folder holding one subfolder per desk that has produced
 /// something.
+///
+/// Not scaffolded at boot — see [`SYSTEM_ROOTS`] and [`ensure_desk_folder`].
 pub const DESKS_ROOT: &str = "Desks";
 
-/// The system roots every company's workspace gets, in creation order.
+/// The system roots the runtime lays down eagerly, on every boot.
 ///
-/// Deliberately *not* derived from the manifest: these exist because a
-/// workspace has them, not because a particular company has agents or desks.
-/// Public so a caller that has to tell scaffolding apart from content — the
-/// re-seed tests, a future console filter — can ask rather than hard-code the
-/// pair.
-pub const SYSTEM_ROOTS: [&str; 2] = [AGENTS_ROOT, DESKS_ROOT];
+/// Deliberately *not* derived from the manifest: `Agents/` exists because a
+/// workspace has it, not because a particular company has agents.
+///
+/// [`DESKS_ROOT`] is deliberately absent (issue #645). Nothing writes into it
+/// yet, so scaffolding it gave every company a permanently empty root; it is
+/// minted on first use instead. It is a root either way — this list is about
+/// *when* a root appears, not which names are reserved.
+///
+/// Kept an array, and kept public, so a caller that has to tell scaffolding
+/// apart from content — the re-seed tests, a future console filter — can ask
+/// rather than hard-code the names, and so promoting a root back to eager stays
+/// a one-line change.
+pub const SYSTEM_ROOTS: [&str; 1] = [AGENTS_ROOT];
 
-/// Adopt-or-create the `Agents/` and `Desks/` roots for `company`.
+/// Adopt-or-create the eagerly-scaffolded roots ([`SYSTEM_ROOTS`]) for
+/// `company`.
 ///
 /// One `tree()` read, then only the creates that are actually missing. Safe to
 /// call on every boot: it depends on nothing but the company id, so an existing
 /// company picks the roots up the next time it starts.
 ///
-/// Both roots are stamped [`WorkspaceOrigin::Seed`] — they are scaffolding the
+/// What it creates is stamped [`WorkspaceOrigin::Seed`] — scaffolding the
 /// runtime lays down, authored by no operator and no agent. Nothing is created
-/// *inside* them here; see [`ensure_agent_folder`] / [`ensure_desk_folder`].
+/// *inside* a root here; see [`ensure_agent_folder`]. `Desks/` is not created
+/// here at all, and an existing one is never even looked at: this walks
+/// [`SYSTEM_ROOTS`] by name, so a legacy company's `Desks/` (from before issue
+/// #645, or hand-made by an operator) is left exactly as it stands, contents
+/// and authorship included.
 ///
 /// Errors from the tree read propagate; a failed or ambiguous *create* warns
 /// and moves on, and the next boot retries it.
@@ -112,8 +140,9 @@ pub async fn ensure_workspace_scaffold(
     let nodes = store.tree(company).await?;
 
     for root in SYSTEM_ROOTS {
-        // Each root is resolved independently: a colliding `Agents` note in the
-        // workspace root is no reason to withhold `Desks/`.
+        // Each root is resolved independently, so one colliding name never
+        // withholds another. The loop is the contract rather than an accident
+        // of arity — it read the same when there were two.
         match find(&nodes, None, root) {
             Found::Folder(_) => {}
             Found::Collision(why) => tracing::warn!(
@@ -170,14 +199,21 @@ pub async fn ensure_agent_folder(
 /// Adopt-or-create `Desks/<desk_id>/`, returning its node id.
 ///
 /// [`ensure_agent_folder`]'s counterpart for a desk — call it when a desk first
-/// produces an artifact. Nothing in this PR calls it; issue #552's publish path
-/// is the first producer.
+/// produces an artifact. Nothing calls it yet; issue #552's publish path is the
+/// first producer.
 ///
-/// Stamped [`WorkspaceOrigin::Seed`] rather than an author, because a desk is
-/// not one: [`WorkspaceOrigin`] names the seed, the operator, or a single
-/// agent, and claiming `Agent { id: <desk-id> }` would attribute the folder to
-/// a teammate that does not exist. The desk's *contents* still carry the real
-/// agent that wrote each of them.
+/// Unlike `Agents/`, the `Desks/` root is not scaffolded at boot (issue #645),
+/// so this mints the root as well when it is missing. That is the point rather
+/// than a fallback: `Desks/` appears the first time a desk has something to put
+/// in it, instead of standing empty in every company that never uses one.
+///
+/// Both the root and the member folder are stamped [`WorkspaceOrigin::Seed`]
+/// rather than an author, because a desk is not one: [`WorkspaceOrigin`] names
+/// the seed, the operator, or a single agent, and claiming
+/// `Agent { id: <desk-id> }` would attribute the folder to a teammate that does
+/// not exist. A lazily-minted root carries the same stamp the boot scaffold
+/// used to give it, so nothing downstream can tell the two apart. The desk's
+/// *contents* still carry the real agent that wrote each of them.
 pub async fn ensure_desk_folder(
     store: &dyn WorkspaceStore,
     company: &CompanyId,
@@ -342,12 +378,13 @@ mod tests {
         paths(&ws.tree(company).await.unwrap())
     }
 
-    /// The scaffold is exactly two empty roots — and, crucially, nothing else.
+    /// The scaffold is exactly one empty root — and, crucially, nothing else.
     /// A folder per roster member is what this feature stopped doing: a member
     /// folder means "this teammate produced something", so an empty one is a
-    /// claim the tree has no business making.
+    /// claim the tree has no business making. Issue #645 applied the same rule
+    /// to `Desks/` itself, which had no producer at all.
     #[tokio::test]
-    async fn it_provisions_two_empty_system_roots() {
+    async fn it_provisions_one_empty_system_root() {
         let (_dir, ws) = store().await;
         let company = CompanyId::new("acme");
 
@@ -356,7 +393,11 @@ mod tests {
             .unwrap();
 
         let nodes = ws.tree(&company).await.unwrap();
-        assert_eq!(paths(&nodes), vec!["Agents", "Desks"]);
+        assert_eq!(
+            paths(&nodes),
+            vec!["Agents"],
+            "`Desks/` has no producer, so boot must not lay it down"
+        );
         for node in &nodes {
             assert_eq!(node.kind, NodeKind::Folder, "{} is not a folder", node.name);
             assert_eq!(
@@ -373,7 +414,7 @@ mod tests {
     /// eager design, where an empty roster deliberately created nothing —
     /// there, a root with no children was a stray; here it is the point.)
     #[tokio::test]
-    async fn a_company_with_no_roster_still_gets_both_roots() {
+    async fn a_company_with_no_roster_still_gets_the_agents_root() {
         let (_dir, ws) = store().await;
         let company = CompanyId::new("solo");
 
@@ -381,7 +422,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents", "Desks"]);
+        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents"]);
     }
 
     /// The property that lets this run on every boot.
@@ -396,7 +437,7 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents", "Desks"]);
+        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents"]);
     }
 
     /// An operator-made `Agents/` folder is adopted as-is rather than
@@ -430,7 +471,7 @@ mod tests {
             .unwrap();
 
         let nodes = ws.tree(&company).await.unwrap();
-        assert_eq!(paths(&nodes), vec!["Agents", "Desks"]);
+        assert_eq!(paths(&nodes), vec!["Agents"]);
         let root = nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap();
         assert_eq!(root.id, "hand-made", "the operator's folder must be reused");
         assert_eq!(
@@ -442,10 +483,10 @@ mod tests {
 
     /// Fail-closed: a root *file* named `Agents` is a collision this module has
     /// no honest way to resolve, so it leaves it alone rather than shadowing
-    /// the operator's note with a rival folder of the same name. The other root
-    /// is unaffected — one odd name is no reason to withhold the rest.
+    /// the operator's note with a rival folder of the same name — and creates
+    /// nothing else in its place.
     #[tokio::test]
-    async fn a_root_file_blocks_only_its_own_root() {
+    async fn a_root_file_is_left_alone_rather_than_shadowed() {
         let (_dir, ws) = store().await;
         let company = CompanyId::new("acme");
         ws.create(
@@ -472,7 +513,11 @@ mod tests {
             .unwrap();
 
         let nodes = ws.tree(&company).await.unwrap();
-        assert_eq!(paths(&nodes), vec!["Agents", "Desks"]);
+        assert_eq!(
+            paths(&nodes),
+            vec!["Agents"],
+            "the collision must not be worked around by creating anything else"
+        );
         assert_eq!(
             nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap().kind,
             NodeKind::File,
@@ -491,7 +536,7 @@ mod tests {
                 &company,
                 &WorkspaceNode {
                     id: id.to_string(),
-                    name: DESKS_ROOT.to_string(),
+                    name: AGENTS_ROOT.to_string(),
                     kind: NodeKind::Folder,
                     parent_id: None,
                     updated_at_millis: 1,
@@ -513,11 +558,11 @@ mod tests {
 
         let nodes = ws.tree(&company).await.unwrap();
         assert_eq!(
-            nodes.iter().filter(|n| n.name == DESKS_ROOT).count(),
+            nodes.iter().filter(|n| n.name == AGENTS_ROOT).count(),
             2,
             "an ambiguous root must not gain a third candidate"
         );
-        assert_eq!(nodes.iter().filter(|n| n.name == AGENTS_ROOT).count(), 1);
+        assert_eq!(nodes.len(), 2, "nothing else was created either");
     }
 
     /// The tree is company-scoped: scaffolding one company leaves another's
@@ -556,7 +601,7 @@ mod tests {
         assert_eq!(first, second, "a second call minted a rival folder");
         assert_eq!(
             tree_paths(&ws, &company).await,
-            vec!["Agents", "Agents/ceo", "Desks"]
+            vec!["Agents", "Agents/ceo"]
         );
         let nodes = ws.tree(&company).await.unwrap();
         let ceo = nodes.iter().find(|n| n.name == "ceo").unwrap();
@@ -580,7 +625,7 @@ mod tests {
 
         assert_eq!(
             tree_paths(&ws, &company).await,
-            vec!["Agents", "Agents/cmo", "Desks"]
+            vec!["Agents", "Agents/cmo"]
         );
     }
 
@@ -726,16 +771,20 @@ mod tests {
         assert!(ws.is_empty(&company).await.unwrap());
     }
 
-    /// The desk minter is the same shape one root over. It stamps `Seed` rather
-    /// than an author: a desk is not an agent, and `WorkspaceOrigin` has no way
-    /// to name one.
+    /// The desk minter is the same shape one root over — and since issue #645
+    /// it is the *only* thing that ever creates `Desks/`. Deliberately run with
+    /// no scaffold at all: the first call must mint the root and the member
+    /// folder together, which is what lets boot stop laying down an empty root
+    /// nothing was filling.
+    ///
+    /// The root it mints stamps `Seed`, exactly as the boot scaffold used to,
+    /// so no consumer can tell a lazily-minted root from the old eager one. The
+    /// desk folder stamps `Seed` too, because a desk is not an agent and
+    /// `WorkspaceOrigin` has no way to name one.
     #[tokio::test]
-    async fn ensure_desk_folder_mints_under_the_desks_root() {
+    async fn ensure_desk_folder_mints_the_desks_root_on_first_use() {
         let (_dir, ws) = store().await;
         let company = CompanyId::new("acme");
-        ensure_workspace_scaffold(ws.as_ref(), &company)
-            .await
-            .unwrap();
 
         let first = ensure_desk_folder(ws.as_ref(), &company, "creative_studio")
             .await
@@ -744,15 +793,118 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(first, second);
+        assert_eq!(first, second, "a second call minted a rival folder");
         assert_eq!(
             tree_paths(&ws, &company).await,
-            vec!["Agents", "Desks", "Desks/creative_studio"]
+            vec!["Desks", "Desks/creative_studio"],
+            "the root appears with its first occupant, and brings nothing else"
         );
         let nodes = ws.tree(&company).await.unwrap();
         let desk = nodes.iter().find(|n| n.id == first).unwrap();
         assert_eq!(desk.kind, NodeKind::Folder);
         assert_eq!(desk.created_by, WorkspaceOrigin::Seed);
+        let root = nodes.iter().find(|n| n.name == DESKS_ROOT).unwrap();
+        assert_eq!(root.kind, NodeKind::Folder);
+        assert_eq!(
+            root.created_by,
+            WorkspaceOrigin::Seed,
+            "a lazily-minted root must carry the stamp boot used to give it"
+        );
+    }
+
+    /// The migration story for every company that booted before issue #645: its
+    /// `Desks/` root already exists, and the scaffold must leave it completely
+    /// alone rather than notice it is no longer managed and tidy it away.
+    ///
+    /// The scaffold only ever looks up the names in `SYSTEM_ROOTS`, so a
+    /// `Desks/` node is not even inspected — id, authorship and contents all
+    /// survive untouched.
+    #[tokio::test]
+    async fn a_pre_existing_desks_root_survives_the_scaffold_untouched() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("legacy");
+        ws.create(
+            &company,
+            &WorkspaceNode {
+                id: "legacy-desks".to_string(),
+                name: DESKS_ROOT.to_string(),
+                kind: NodeKind::Folder,
+                parent_id: None,
+                updated_at_millis: 1,
+                created_by: WorkspaceOrigin::Operator,
+                updated_by: WorkspaceOrigin::Operator,
+                mime: None,
+                size: None,
+                sha256: None,
+            },
+            None,
+        )
+        .await
+        .unwrap();
+
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+
+        let nodes = ws.tree(&company).await.unwrap();
+        assert_eq!(
+            paths(&nodes),
+            vec!["Agents", "Desks"],
+            "dropping `Desks/` from the scaffold must not delete an existing one"
+        );
+        let desks = nodes.iter().find(|n| n.name == DESKS_ROOT).unwrap();
+        assert_eq!(desks.id, "legacy-desks", "the existing root must be kept");
+        assert_eq!(
+            desks.created_by,
+            WorkspaceOrigin::Operator,
+            "an unmanaged root's authorship must not be rewritten"
+        );
+    }
+
+    /// The un-managed counterpart to `several_nodes_sharing_a_root_name_are_
+    /// left_alone`: duplicate `Desks` nodes are not a collision the scaffold
+    /// has to resolve any more, they are simply none of its business — and the
+    /// root it *does* manage still provisions beside them.
+    #[tokio::test]
+    async fn duplicate_desks_nodes_do_not_disturb_the_scaffold() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        for id in ["dup-a", "dup-b"] {
+            ws.create(
+                &company,
+                &WorkspaceNode {
+                    id: id.to_string(),
+                    name: DESKS_ROOT.to_string(),
+                    kind: NodeKind::Folder,
+                    parent_id: None,
+                    updated_at_millis: 1,
+                    created_by: WorkspaceOrigin::Operator,
+                    updated_by: WorkspaceOrigin::Operator,
+                    mime: None,
+                    size: None,
+                    sha256: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+        }
+
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+
+        let nodes = ws.tree(&company).await.unwrap();
+        assert_eq!(
+            nodes.iter().filter(|n| n.name == DESKS_ROOT).count(),
+            2,
+            "an unmanaged name must be neither deduplicated nor added to"
+        );
+        assert_eq!(
+            nodes.iter().filter(|n| n.name == AGENTS_ROOT).count(),
+            1,
+            "an odd name elsewhere is no reason to withhold a managed root"
+        );
     }
 
     /// The two roots stay independent: minting a desk folder does not reach

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2932,9 +2932,11 @@ mod test {
             .build()
             .await
             .unwrap();
-        // Seeded: README.md, Brand/, Brand/voice.md — plus the two system roots
+        // Seeded: README.md, Brand/, Brand/voice.md — plus the system roots
         // boot always scaffolds beside them (issue #551), which are not seeded
-        // content and so are not what the re-seed gate is about.
+        // content and so are not what the re-seed gate is about. Filtering by
+        // `SYSTEM_ROOTS` rather than by name keeps this honest as that set
+        // changes (issue #645 took `Desks/` out of it).
         let seeded = |tree: &[crate::ports::WorkspaceNode]| {
             let mut names: Vec<String> = tree
                 .iter()
@@ -2972,7 +2974,8 @@ mod test {
     }
 
     /// Issue #551: boot lays down the workspace's system roots — and nothing
-    /// inside them.
+    /// inside them. Since issue #645 that is `Agents/` alone: `Desks/` had no
+    /// producer, so it is minted on first use instead of standing empty here.
     ///
     /// The per-agent folder is deliberately absent: it is minted the first time
     /// that agent produces something, so a roster of teammates who have done
@@ -2981,10 +2984,10 @@ mod test {
     /// Also pins the two gates the seeding block above does NOT share: this
     /// runs with **no** `seed_dir` (the provisioned-tenant and desktop shape),
     /// and it runs again on a workspace that is no longer empty — which is how
-    /// an existing company picks the roots up.
+    /// an existing company picks the root up.
     #[tokio::test]
     async fn boot_provisions_the_system_roots_and_nothing_inside_them() {
-        use crate::company::workspace_scaffold::{AGENTS_ROOT, DESKS_ROOT};
+        use crate::company::workspace_scaffold::AGENTS_ROOT;
         use crate::ports::workspace::{NodeKind, WorkspaceOrigin};
 
         let home_dir = tmp_home("oc-agents-");
@@ -3009,9 +3012,9 @@ mod test {
         names.sort_unstable();
         assert_eq!(
             names,
-            vec![AGENTS_ROOT, DESKS_ROOT],
-            "boot provisions the two roots with no seed dir, and no folder for a \
-             teammate that has produced nothing"
+            vec![AGENTS_ROOT],
+            "boot provisions the managed root with no seed dir — no `Desks/`, and no \
+             folder for a teammate that has produced nothing"
         );
         for node in &tree {
             assert!(node.parent_id.is_none());
@@ -3022,6 +3025,19 @@ mod test {
         // An existing, non-empty workspace: an `is_empty` gate would have
         // skipped this boot entirely, and a company that predates the feature
         // would never get its roots.
+        //
+        // With one managed root, deleting it would leave the tree empty and
+        // stop pinning that. A lazily-minted desk folder stands in for the
+        // content a real company would have — and doubles as the #645 check
+        // that boot neither re-manages, duplicates nor disturbs a `Desks/` that
+        // already exists.
+        crate::company::workspace_scaffold::ensure_desk_folder(
+            runtime.workspace().as_ref(),
+            &id,
+            "creative_studio",
+        )
+        .await
+        .unwrap();
         let agents_root = tree
             .iter()
             .find(|n| n.name == AGENTS_ROOT)
@@ -3046,16 +3062,16 @@ mod test {
         names.sort_unstable();
         assert_eq!(
             names,
-            vec![AGENTS_ROOT, DESKS_ROOT],
-            "the deleted root was re-provisioned and the surviving one not duplicated"
+            vec![AGENTS_ROOT, "Desks", "creative_studio"],
+            "the deleted root was re-provisioned, and the unmanaged `Desks/` left as it stood"
         );
     }
 
-    /// The roots are part of what a workspace *is*, not a projection of the
-    /// roster: a company with no agents at all still gets both.
+    /// The root is part of what a workspace *is*, not a projection of the
+    /// roster: a company with no agents at all still gets it.
     #[tokio::test]
     async fn boot_provisions_the_roots_for_a_company_with_no_agents() {
-        use crate::company::workspace_scaffold::{AGENTS_ROOT, DESKS_ROOT};
+        use crate::company::workspace_scaffold::AGENTS_ROOT;
 
         let home_dir = tmp_home("oc-noagents-");
         let id = CompanyId::new("acme");
@@ -3071,7 +3087,7 @@ mod test {
         let tree = runtime.workspace().tree(&id).await.unwrap();
         let mut names: Vec<&str> = tree.iter().map(|n| n.name.as_str()).collect();
         names.sort_unstable();
-        assert_eq!(names, vec![AGENTS_ROOT, DESKS_ROOT]);
+        assert_eq!(names, vec![AGENTS_ROOT]);
     }
 
     /// Issue #85: the launch path's template provenance is stamped onto the

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -808,12 +808,12 @@ async fn memory_page_reflects_upserts() {
 /// An unpopulated surface resolves to `[]`, never to `null` or an error.
 ///
 /// `workspaceTree` is the exception and states why: since issue #551 a company
-/// is never born with an empty tree — boot scaffolds the reserved `Agents/` and
-/// `Desks/` roots — so what it proves here is that the resolver answers with
-/// exactly that and invents nothing else. A member folder is *not* part of that
-/// baseline; this mints one to pin the authorship projection (#326), which is
-/// the only place in the GraphQL surface where `WorkspaceOrigin` is rendered
-/// with an agent id.
+/// is never born with an empty tree — boot scaffolds the reserved `Agents/`
+/// root (and, until issue #645, an empty `Desks/` beside it) — so what it
+/// proves here is that the resolver answers with exactly that and invents
+/// nothing else. A member folder is *not* part of that baseline; this mints one
+/// to pin the authorship projection (#326), which is the only place in the
+/// GraphQL surface where `WorkspaceOrigin` is rendered with an agent id.
 #[tokio::test]
 async fn empty_surfaces_resolve_to_empty_lists() {
     let home_dir = home();
@@ -840,15 +840,13 @@ async fn empty_surfaces_resolve_to_empty_lists() {
         .map(|node| node["name"].as_str().unwrap())
         .collect();
     names.sort_unstable();
-    assert_eq!(names, vec!["Agents", "Desks", "maya"]);
-    for root in ["Agents", "Desks"] {
-        let node = tree
-            .iter()
-            .find(|node| node["name"] == serde_json::json!(root))
-            .unwrap();
-        assert_eq!(node["createdBy"]["kind"], "seed");
-        assert!(node["createdBy"]["agentId"].is_null());
-    }
+    assert_eq!(names, vec!["Agents", "maya"]);
+    let root = tree
+        .iter()
+        .find(|node| node["name"] == serde_json::json!("Agents"))
+        .unwrap();
+    assert_eq!(root["createdBy"]["kind"], "seed");
+    assert!(root["createdBy"]["agentId"].is_null());
     let folder = tree
         .iter()
         .find(|node| node["name"] == serde_json::json!("maya"))

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1228,15 +1228,16 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
 
     // A workspace with nothing seeded into it reads as a real tree, not a 404
     // and not a fixture. It is not *empty*, though: boot scaffolds the reserved
-    // `Agents/` and `Desks/` roots (issue #551). The manifest here has an agent
-    // and it gets no folder — a member folder is minted on first use, not on
-    // joining the roster.
+    // `Agents/` root (issue #551). The manifest here has an agent and it gets
+    // no folder — a member folder is minted on first use, not on joining the
+    // roster. `Desks/` is absent for the same reason since issue #645: nothing
+    // writes into it, so it is minted on first use rather than scaffolded.
     let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
         provisioned_names(&tree),
-        vec!["Agents", "Desks"],
-        "a fresh company starts with the two system roots and nothing else"
+        vec!["Agents"],
+        "a fresh company starts with the one system root and nothing else"
     );
     let provisioned = tree.as_array().unwrap().len();
 
@@ -1303,15 +1304,13 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
     assert_eq!(listed["updatedBy"], json!({"kind": "operator"}));
     // …and the scaffold's own nodes say what they are, so the console can tell
     // "the runtime laid this down" from "somebody wrote this".
-    for root in ["Agents", "Desks"] {
-        let node = tree
-            .iter()
-            .find(|node| node["name"] == json!(root))
-            .unwrap_or_else(|| panic!("the {root} root is in the tree"));
-        assert_eq!(node["createdBy"], json!({"kind": "seed"}));
-        assert_eq!(node["kind"], json!("folder"));
-        assert!(node["parentId"].is_null());
-    }
+    let root = tree
+        .iter()
+        .find(|node| node["name"] == json!("Agents"))
+        .expect("the Agents root is in the tree");
+    assert_eq!(root["createdBy"], json!({"kind": "seed"}));
+    assert_eq!(root["kind"], json!("folder"));
+    assert!(root["parentId"].is_null());
 
     // The file read carries the body and the inbound backlink, computed server
     // side — the console derives neither.
@@ -1433,7 +1432,7 @@ async fn workspace_reads_are_isolated_between_companies() {
     assert_eq!(status, StatusCode::OK);
     let note_id = note["id"].as_str().unwrap().to_string();
 
-    // B's own workspace holds only its own scaffolded system roots — A's note
+    // B's own workspace holds only its own scaffolded system root — A's note
     // is not in it.
     let (status, tree_b) = send_auth(
         &state,
@@ -1444,7 +1443,7 @@ async fn workspace_reads_are_isolated_between_companies() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(provisioned_names(&tree_b), vec!["Agents", "Desks"]);
+    assert_eq!(provisioned_names(&tree_b), vec!["Agents"]);
 
     // Even naming A's node id explicitly, B's scope does not resolve it.
     let (status, _) = send_auth(


### PR DESCRIPTION
## Summary

`Desks/` was scaffolded at boot for every company and **nothing ever wrote into it** — `ensure_desk_folder` had zero callers anywhere in `src/`. Confirmed on a live host, where it renders as an expanded top-level folder with nothing inside, indistinguishable from one whose contents were deleted.

That is precisely what #570 removed one level down: it deleted eager per-agent provisioning on the argument that *a folder should be the record of a member having produced something, not a promise that it might*. An eagerly-scaffolded empty `Desks/` is the same promise moved up a level. The principle was applied to the leaves and not to the root.

Boot now scaffolds `Agents/` only. `Desks/` is minted wholesale — root and member folder — the first time a real desk-level producer calls `ensure_desk_folder`.

Closes #645.

## API Or Behavior Changes

**`SYSTEM_ROOTS` is now `[&str; 1] = [AGENTS_ROOT]`.** Deliberately still an array: `src/brain/hosted/test.rs:504` derives `BOOT_JOURNAL_EVENTS` from `.len()` in a const context, so its count auto-synced 2→1 with no edit. `DESKS_ROOT`, `ensure_desk_folder` and the shared minter are otherwise untouched.

**This is a one-constant change because the minter already handled it.** `ensure_member_folder` creates an absent root on demand, and the pre-existing test `the_two_roots_do_not_leak_into_each_other` already exercised `ensure_desk_folder` with no scaffold at all. Both were verified before any edit rather than assumed — had either been false, this would have been a change to the helper instead.

**Reviewer-facing semantic shift, documented on the constant**: `SYSTEM_ROOTS` now means *"roots created eagerly at boot"*, not *"reserved names"*. `DESKS_ROOT` remains reserved and public. The one live consumer (`builder.rs`'s re-seed filter) is unaffected, but a future console "hide scaffolding" filter keyed on `SYSTEM_ROOTS` would now show `Desks/` — which is correct, since a lazily-minted `Desks/` only exists once something is in it.

**Existing companies keep any `Desks/` they already have.** The scaffold only inspects names in `SYSTEM_ROOTS`, so a legacy node is never looked at: not deleted, not re-attributed, not warned about. No migration, no backfill; provisioning stays idempotent. Two new tests pin this — one for a normal legacy root (id and `Operator` authorship both preserved), one for pre-existing *duplicate* `Desks` nodes (count unchanged, `Agents` still provisions).

**A lazily-minted `Desks/` is stamped `WorkspaceOrigin::Seed`** — identical to today's boot stamp and to the already-pinned lazily-minted `Agents/` root. **No new `WorkspaceOrigin` variant was added**; #570 deliberately deferred that question and it stays deferred until a real desk producer exists to answer it.

## Tests

Re-run in full **after rebasing onto current `main`** (`9181d679`), with exit codes captured directly rather than through a pipe:

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — exit 0
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings` — exit 0
- [x] `cargo build --all-targets` (via `cargo check --locked --all-targets` and `--all-features --all-targets`) — exit 0
- [x] `cargo test --locked` — **1926 passed**, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **2882 passed**, 0 failed

`workspace_scaffold` module: 17 passed (15 baseline + 2 new migration tests). No frontend gates — no frontend file is touched, and every `Desks` hit in `frontend/` and the e2e specs is the unrelated chat/org desk-as-team concept (checked, not assumed).

**Three things the plan got wrong, worth recording because two of them would have shipped red:**

1. **The planned file list was incomplete twice.** It cleared `hosted/test.rs` and `workspace_tools.rs` but never checked `src/server/graphql/test.rs` (asserts `["Agents","Desks","maya"]`) or `src/server/ops/write_test.rs` (three sites). Both break the moment `Desks` stops being scaffolded. A plan-scoped `git add` would have produced a red branch.
2. **A test would have silently stopped testing anything.** In `builder.rs`, the delete-and-rebuild half of `boot_provisions_the_system_roots_and_nothing_inside_them` exists to prove an `is_empty` gate would *not* have skipped that boot. With only one managed root, deleting it leaves the tree genuinely empty and the assertion pins nothing at all. A desk folder is minted first so the tree stays non-empty — which doubles as a check that boot leaves an existing `Desks/` alone.
3. `write_test.rs` turned out to be shared with #647, which the coordination manifest had declared impossible. Logged before editing; see Related.

## Documentation

`src/company/workspace_scaffold.rs` module and fn docs, plus `docs/spec/runtime/{ports-console,api,manifest}.md` and `docs/modules/runtime/README.md` — boot scaffolds `Agents/` only; `ensure_desk_folder` mints `Desks/` and the member folder on first use.

## Related

- #570 — established "mint on first use" for member folders; this applies the same rule to the root it left behind
- #552 — publishes deliverables under `Agents/<agent>/<task>/`; the reason `ensure_agent_folder` has a caller and `ensure_desk_folder` does not
- #607 — workspace search; **merges before this** (it is larger and was in flight; this rebases cheaply)
- #647 — over-cap upload error; runs in parallel with this and shares `src/server/ops/write_test.rs` in a **different region** (this edits three existing sites ~1228–1443; #647 appends new tests). A conflict-free `git merge` proves nothing there — whoever rebases second must actually run the tests.
