### PR TITLE
feat(workflows): bound in-flight workflow runs per company (#401)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -83,6 +83,19 @@ closed tab or a proxy giving up no longer cancels it mid-graph — before this i
 did, and because a run journals a start first, the abandoned run then folded as
 `running: true` until the next host restart swept it.
 
+**A company bounds how many runs it will execute at once** (issue #401). Every
+run — this manual route, a cron fire, an approved gate's continuation, and one
+an orchestrator agent starts — counts against `[workflows].max_in_flight_runs`
+(default 8; see `manifest.md`). A run over the ceiling is **refused, never
+queued**: the route answers **`429 Too Many Requests`** with the standard
+`{ "error", "code": "workflow_run_limit" }` envelope and **no `runId`**, because
+nothing started. Both `detach` modes refuse identically — the check precedes the
+detach/sync branch, so a rejected run journals no `WorkflowRunStarted`. The
+message names the three levers: wait for a run to finish, stop one via
+`…/workflows/runs/{runId}/cancel`, or raise the manifest cap. A slot frees the
+moment a run settles (including on cancel or panic), so a refused run succeeds on
+the next attempt once the company is back under its ceiling.
+
 `…/runs/{runId}/cancel` answers `200 { "cancelling": true }` when the run is
 live and `404` when the run is unknown **or has already settled** — one answer,
 because they mean the same thing to the caller: there is nothing to stop. It is

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -88,6 +88,10 @@ name = "starter"                   # free | starter | pro | unlimited (optional)
 period = "daily"                   # daily (default) | monthly
 token_budgets = { web = 500000 }   # override/extend the named tier per namespace
 
+[workflows]                        # saved workflow graphs (issue #401)
+enabled = ["digest"]               # ids of workflows/<id>.toml graphs to enable
+max_in_flight_runs = 8             # concurrent-run ceiling (default 8; must be >= 1)
+
 [[schedule]]
 cron = "0 9 * * MON"
 prompt = "Weekly review and operator digest"
@@ -313,6 +317,19 @@ prompt = "Weekly review and operator digest"
   separately, with the same dialect: its `trigger` node carries a `schedule`
   cron that the workflow scheduler fires (issue #169). A manifest schedule
   drives a company cycle; a trigger schedule drives one workflow run.
+- **`[workflows]`** enables saved graphs and bounds how many may run at once.
+  `enabled` lists the `workflows/<id>.toml` ids to turn on. `max_in_flight_runs`
+  (issue #401) is the company's concurrent-run ceiling — default **8**,
+  validated **>= 1** (a `0` would refuse every run and is rejected at load). It
+  applies to *every* entry point that starts a run (the manual run route, the
+  cron scheduler, an approved gate's continuation, and the orchestrator's
+  `run_workflow` tool), enforced at one choke point. The default sits above 1
+  deliberately: a running workflow's agent node can call `run_workflow` while
+  the parent run still holds a slot, so a ceiling of 1 would refuse legitimate
+  nesting. A run over the ceiling is **refused, never queued** — the run route
+  answers `429` (see `api.md`), a scheduled fire is skipped for that minute, and
+  the orchestrator tool tells the agent to wait. A slot frees the instant a run
+  settles.
 
 ## Layering and provenance
 

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -218,6 +218,15 @@ impl CompanyManifest {
             }
         }
 
+        // The concurrent-run ceiling must admit at least one run (issue #401). A
+        // `0` is a misconfiguration that would refuse every run, so it fails
+        // here rather than silently wedging the company's workflows.
+        if self.workflows.max_in_flight_runs == 0 {
+            problems.push(
+                "`[workflows].max_in_flight_runs` must be at least 1 — a value of 0 would refuse every workflow run.".into(),
+            );
+        }
+
         if !BRAIN_MODES.contains(&self.brain.mode.as_str()) {
             problems.push(one_of("`[brain].mode`", BRAIN_MODES, &self.brain.mode));
         }
@@ -447,6 +456,40 @@ mod tests {
         assert_eq!(
             manifest.policy.always_approve,
             vec!["payment.send", "filing.submit", "external.publish"]
+        );
+    }
+
+    #[test]
+    fn workflows_run_cap_defaults_when_omitted() {
+        // Issue #401: an absent `[workflows].max_in_flight_runs` takes the
+        // generous default and never trips validation.
+        let manifest = parse("[company]\nname = \"X\"\n");
+        assert_eq!(
+            manifest.workflows.max_in_flight_runs,
+            crate::company::types::DEFAULT_MAX_IN_FLIGHT_RUNS
+        );
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+    }
+
+    #[test]
+    fn workflows_run_cap_parses_explicit_value() {
+        let manifest = parse("[company]\nname = \"X\"\n[workflows]\nmax_in_flight_runs = 3\n");
+        assert_eq!(manifest.workflows.max_in_flight_runs, 3);
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+    }
+
+    #[test]
+    fn workflows_run_cap_of_zero_is_rejected() {
+        // Issue #401: `0` would refuse every run, so it is a validation error
+        // named in prosumer language rather than a silently wedged company.
+        let manifest = parse("[company]\nname = \"X\"\n[workflows]\nmax_in_flight_runs = 0\n");
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("`[workflows].max_in_flight_runs`")
+                    && p.contains("at least 1")),
+            "{problems:?}"
         );
     }
 

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -61,11 +61,11 @@ pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
-    Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES,
-    INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS, McpServer, ORCHESTRATOR_TIER,
-    PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy, Schedule, Skill, TIERS,
-    TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit, grants_search_explicit,
-    grants_workspace_write_explicit, orchestrator_id,
+    Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS,
+    GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
+    McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
+    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit,
+    grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -372,13 +372,42 @@ fn default_true() -> bool {
     true
 }
 
+/// The default ceiling on concurrent in-flight workflow runs per company
+/// (issue #401), applied when `[workflows].max_in_flight_runs` is omitted.
+///
+/// Deliberately well above 1: a running workflow's agent node can itself call
+/// the `run_workflow` tool, so the parent run holds a slot while a child begins.
+/// A ceiling of 1 would refuse that legitimate nesting on the first hop, which
+/// is why the field's validation floor is 1 but its default is generous.
+pub const DEFAULT_MAX_IN_FLIGHT_RUNS: usize = 8;
+
+fn default_max_in_flight_runs() -> usize {
+    DEFAULT_MAX_IN_FLIGHT_RUNS
+}
+
 /// `[workflows]` — references to the workflow graphs to enable. The graphs live
 /// as separate files under the company's `workflows/` directory.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Workflows {
     /// Workflow ids to enable, each a `workflows/<id>.toml` graph file.
     #[serde(default)]
     pub enabled: Vec<String>,
+    /// The most workflow runs this company may have executing at once
+    /// (issue #401). Every run — manual, scheduled, gate-resume, or one an
+    /// orchestrator agent starts — is admitted through the same choke point and
+    /// counts against this ceiling; a run over it is refused, never queued.
+    /// Defaults to [`DEFAULT_MAX_IN_FLIGHT_RUNS`]; validation requires `>= 1`.
+    #[serde(default = "default_max_in_flight_runs")]
+    pub max_in_flight_runs: usize,
+}
+
+impl Default for Workflows {
+    fn default() -> Self {
+        Self {
+            enabled: Vec::new(),
+            max_in_flight_runs: DEFAULT_MAX_IN_FLIGHT_RUNS,
+        }
+    }
 }
 
 /// `[users]` — the company's human collaborators.

--- a/src/error.rs
+++ b/src/error.rs
@@ -130,6 +130,20 @@ pub enum OpenCompanyError {
     #[error("{0}")]
     WorkspaceQuota(String),
 
+    /// A workflow run was refused because the company is already at its
+    /// configured ceiling of concurrent in-flight runs (issue #401).
+    ///
+    /// Raised before the run is registered or spawned, so nothing is journaled
+    /// and no run id is minted — the caller gets a `429` with no run to follow.
+    /// The message is actionable because the operator has three real levers.
+    #[error(
+        "this company is already running its maximum of {limit} workflow runs at once; wait for one to finish, stop one from the runs view (POST …/workflows/runs/{{id}}/cancel), or raise `[workflows].max_in_flight_runs`"
+    )]
+    WorkflowRunLimit {
+        /// The configured ceiling that was hit.
+        limit: usize,
+    },
+
     /// An operation conflicts with the company's lifecycle state (e.g. the
     /// company is paused or archived).
     #[error("company is {0}")]
@@ -272,6 +286,7 @@ impl OpenCompanyError {
             Self::ToolNotGranted(_) => "tool_not_granted".to_string(),
             Self::BudgetExceeded(_) => "budget_exceeded".to_string(),
             Self::WorkspaceQuota(_) => "workspace_quota_exceeded".to_string(),
+            Self::WorkflowRunLimit { .. } => "workflow_run_limit".to_string(),
             Self::LifecycleConflict(_) => "lifecycle_conflict".to_string(),
             Self::EmergencyStop(_) => "emergency_stop".to_string(),
             Self::Conflict(_) => "conflict".to_string(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -2047,7 +2047,28 @@ impl Tool for RunWorkflowTool {
         // re-entry guard that bounds a workflow reaching back into itself is
         // task-local. Spawning here would reset the depth mid-chain and turn the
         // guard off exactly where it is load-bearing.
-        let (ctx, _run_guard) = self.run_supervisor.begin(&wid, false);
+        // Issue #401: `begin` refuses when the company is already at its
+        // in-flight run ceiling. Return a `ToolResult::error` with retry-later
+        // guidance — the same "stop, don't retry blindly" convention as the
+        // cancelled-run arm below — rather than an `Err`, so the agent treats it
+        // as a reason to wait instead of a tool failure to surface as a crash.
+        // Nothing was started: no context, no run id, nothing journaled.
+        let (ctx, _run_guard) = match self.run_supervisor.begin(&wid, false) {
+            Ok(started) => started,
+            Err(err) => {
+                tracing::info!(
+                    company = %self.company,
+                    workflow = %wid,
+                    %err,
+                    "run_workflow: refused — company is at its in-flight run cap"
+                );
+                return Ok(ToolResult::error(format!(
+                    "Workflow `{wid}` wasn't started: {err}. Wait for a running workflow to finish \
+                     (or ask an operator to stop one from the runs view), then try again — don't \
+                     retry in a loop."
+                )));
+            }
+        };
         match runner.run(&self.company, &file, input, &ctx).await {
             Ok(run) => {
                 tracing::debug!(
@@ -4529,6 +4550,78 @@ name = "Morning"
         assert!(
             result.output_for_llm(true).contains("Greeter"),
             "{result:?}"
+        );
+    }
+
+    /// Issue #401: the orchestrator's run tool refuses when the company is
+    /// already at its in-flight run ceiling. The refusal is a
+    /// `ToolResult::error` the agent should treat as "wait / stop one", NOT an
+    /// `Err`, and it registers nothing — a held guard stands in for the
+    /// in-flight run, so no wall-clock and no real second run is needed.
+    #[tokio::test]
+    async fn run_workflow_tool_refuses_at_the_in_flight_cap() {
+        let dir = tempfile::tempdir().unwrap();
+        let company = CompanyId::new("acme");
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(record_with_assistant(&company)));
+
+        // Author a runnable graph on disk so `execute` reaches the cap check.
+        let create = CreateWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            None,
+            WorkflowRefQueue::default(),
+        );
+        assert!(
+            !create
+                .execute(greeter_body())
+                .await
+                .expect("execute")
+                .is_error
+        );
+
+        // A supervisor with room for one run, whose only slot is already taken
+        // by a (simulated) in-flight run held for the length of the test.
+        let supervisor = crate::runtime::RunSupervisor::with_limit(1);
+        let (_ctx, _held) = supervisor
+            .begin("greeter", false)
+            .expect("the held run fills the cap of 1");
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({}),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            cancelled: false,
+            nodes: Vec::new(),
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+        let run = RunWorkflowTool::new(
+            company.clone(),
+            Some(dir.path().to_path_buf()),
+            store.clone(),
+            handle,
+            supervisor.clone(),
+            None,
+            WorkflowRefQueue::default(),
+            RunOutputCache::default(),
+        );
+
+        let result = run
+            .execute(json!({ "id": "greeter" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "a run over the cap is refused: {result:?}");
+        let text = result.output_for_llm(false);
+        assert!(
+            text.contains("wasn't started") && text.contains("maximum"),
+            "the refusal names the cap and is actionable: {text}"
+        );
+        assert_eq!(
+            supervisor.len(),
+            1,
+            "the refused run registered nothing — only the held run remains"
         );
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1515,8 +1515,14 @@ impl RuntimeBuilder {
                             // onto the runtime below.
                             let steer = crate::company::steer::InflightRegistry::new();
                             steer_registry = Some(steer.clone());
-                            // Same shape, same reason (issue #383).
-                            let supervisor = crate::runtime::RunSupervisor::new();
+                            // Same shape, same reason (issue #383). Issue #401:
+                            // the per-company concurrency ceiling comes from the
+                            // manifest (validated `>= 1`), so this supervisor —
+                            // the one the harness deps and the console cancel
+                            // route both hold — enforces that cap on every run.
+                            let supervisor = crate::runtime::RunSupervisor::with_limit(
+                                self.manifest.workflows.max_in_flight_runs,
+                            );
                             run_supervisor = Some(supervisor.clone());
                             // Resolve the company's effective MCP servers to data
                             // (manifest ∪ runtime index, credentials materialized)

--- a/src/runtime/run_supervisor.rs
+++ b/src/runtime/run_supervisor.rs
@@ -44,6 +44,9 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
+use crate::Result;
+use crate::company::DEFAULT_MAX_IN_FLIGHT_RUNS;
+use crate::error::OpenCompanyError;
 use crate::ports::{RunCancel, WorkflowRunContext};
 
 /// One registered run: its stop signal, plus the graph it belongs to for the log
@@ -60,31 +63,91 @@ struct Slot {
 /// before it got here. Cheap to [`Clone`] (a shared handle): the same map is
 /// seen by the HTTP run route that registers runs, the cancel route that fires
 /// them, the cron scheduler, and the orchestrator's `run_workflow` tool.
-#[derive(Clone, Default)]
+///
+/// # The concurrency cap lives here (issue #401)
+///
+/// Every entry point that starts a run — the manual run route, the cron
+/// scheduler, an approved gate's continuation, and the orchestrator's
+/// `run_workflow` tool — reaches a run through [`begin`](Self::begin), so this
+/// map is the one choke point where a per-company ceiling can be enforced
+/// without trusting each caller to remember it. `begin` is fallible for exactly
+/// that reason: the check and the insert happen under the same lock, so the
+/// count can never be raced past the limit, and the compiler forces every
+/// present and future caller to handle a refusal rather than silently
+/// overshoot. A run over the ceiling is refused, never queued.
+#[derive(Clone)]
 pub struct RunSupervisor {
     inner: Arc<Mutex<HashMap<String, Slot>>>,
+    /// The most runs that may be registered at once. Enforced by
+    /// [`begin`](Self::begin) under the map lock.
+    limit: usize,
+}
+
+impl Default for RunSupervisor {
+    /// A supervisor with the default ceiling
+    /// ([`DEFAULT_MAX_IN_FLIGHT_RUNS`]). The builder overrides it per company
+    /// from the manifest via [`with_limit`](Self::with_limit); this default is
+    /// what the default build's runtime (which can start no run at all) keeps.
+    fn default() -> Self {
+        Self::with_limit(DEFAULT_MAX_IN_FLIGHT_RUNS)
+    }
 }
 
 impl RunSupervisor {
-    /// An empty supervisor.
+    /// An empty supervisor with the default concurrency ceiling.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Mints a run context and registers its stop signal.
+    /// An empty supervisor that admits at most `limit` concurrent runs
+    /// (issue #401).
+    ///
+    /// The builder constructs one per company from
+    /// `manifest.workflows.max_in_flight_runs`, which validation has already
+    /// held at `>= 1`.
+    pub fn with_limit(limit: usize) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+            limit,
+        }
+    }
+
+    /// This supervisor's concurrency ceiling. For diagnostics and tests.
+    pub fn limit(&self) -> usize {
+        self.limit
+    }
+
+    /// Mints a run context and registers its stop signal, or refuses when the
+    /// company is already at its concurrency ceiling (issue #401).
     ///
     /// `workflow_id` is the graph about to run and `scheduled` says whether a
     /// cron started it — both ride the context exactly as they did before, so
-    /// this is a drop-in for [`WorkflowRunContext::new`] that additionally makes
-    /// the run reachable.
+    /// on the success path this is a drop-in for [`WorkflowRunContext::new`]
+    /// that additionally makes the run reachable.
+    ///
+    /// The ceiling check and the registration happen under **one** hold of the
+    /// map lock, so two callers racing at the boundary cannot both see room and
+    /// both insert — the count is authoritative, not a separate counter that
+    /// could drift from the map [`RunGuard`] drops entries from. On refusal no
+    /// context is minted: there is deliberately no run id to hand back, because
+    /// nothing started.
     ///
     /// The returned [`RunGuard`] MUST be held for the duration of the run.
     /// Dropping it deregisters the entry, which is what keeps a settled run from
-    /// lingering as a cancellable one — and because it is a `Drop`, that holds
-    /// on the error and panic paths too.
-    pub fn begin(&self, workflow_id: &str, scheduled: bool) -> (WorkflowRunContext, RunGuard) {
+    /// lingering as a cancellable one *and* frees the slot it held against the
+    /// ceiling — and because it is a `Drop`, that holds on the error and panic
+    /// paths too.
+    pub fn begin(
+        &self,
+        workflow_id: &str,
+        scheduled: bool,
+    ) -> Result<(WorkflowRunContext, RunGuard)> {
+        let mut map = self.inner.lock().expect("run supervisor poisoned");
+        if map.len() >= self.limit {
+            return Err(OpenCompanyError::WorkflowRunLimit { limit: self.limit });
+        }
         let ctx = WorkflowRunContext::new(scheduled);
-        self.inner.lock().expect("run supervisor poisoned").insert(
+        map.insert(
             ctx.run_id.clone(),
             Slot {
                 workflow_id: workflow_id.to_string(),
@@ -95,7 +158,7 @@ impl RunSupervisor {
             supervisor: self.clone(),
             run_id: ctx.run_id.clone(),
         };
-        (ctx, guard)
+        Ok((ctx, guard))
     }
 
     /// Fires a registered run's stop signal.
@@ -191,7 +254,9 @@ mod test {
         let supervisor = RunSupervisor::new();
         assert!(supervisor.is_empty());
 
-        let (ctx, guard) = supervisor.begin("digest", false);
+        let (ctx, guard) = supervisor
+            .begin("digest", false)
+            .expect("the first run is under any cap");
         assert_eq!(supervisor.len(), 1);
         assert_eq!(guard.run_id(), ctx.run_id);
         assert!(!ctx.cancel.is_cancelled());
@@ -220,7 +285,9 @@ mod test {
         let supervisor = RunSupervisor::new();
         assert!(!supervisor.cancel("never-existed"));
 
-        let (ctx, guard) = supervisor.begin("digest", false);
+        let (ctx, guard) = supervisor
+            .begin("digest", false)
+            .expect("under the default cap");
         drop(guard);
         assert!(
             !supervisor.cancel(&ctx.run_id),
@@ -237,7 +304,7 @@ mod test {
         let supervisor = RunSupervisor::new();
         let outer = supervisor.clone();
         let result = std::panic::catch_unwind(move || {
-            let (_ctx, _guard) = outer.begin("digest", false);
+            let (_ctx, _guard) = outer.begin("digest", false).expect("under the default cap");
             assert_eq!(outer.len(), 1);
             panic!("the run blew up");
         });
@@ -255,8 +322,12 @@ mod test {
     #[test]
     fn concurrent_runs_of_one_workflow_cancel_independently() {
         let supervisor = RunSupervisor::new();
-        let (first, _first_guard) = supervisor.begin("digest", false);
-        let (second, _second_guard) = supervisor.begin("digest", true);
+        let (first, _first_guard) = supervisor
+            .begin("digest", false)
+            .expect("under the default cap");
+        let (second, _second_guard) = supervisor
+            .begin("digest", true)
+            .expect("under the default cap");
         assert_eq!(supervisor.len(), 2);
         assert_ne!(first.run_id, second.run_id);
 
@@ -275,7 +346,9 @@ mod test {
     #[tokio::test]
     async fn a_cancel_before_the_await_is_still_seen() {
         let supervisor = RunSupervisor::new();
-        let (ctx, _guard) = supervisor.begin("digest", false);
+        let (ctx, _guard) = supervisor
+            .begin("digest", false)
+            .expect("under the default cap");
         supervisor.cancel(&ctx.run_id);
 
         tokio::time::timeout(std::time::Duration::from_secs(1), ctx.cancel.cancelled())
@@ -287,7 +360,9 @@ mod test {
     #[tokio::test]
     async fn a_cancel_after_the_await_wakes_it() {
         let supervisor = RunSupervisor::new();
-        let (ctx, _guard) = supervisor.begin("digest", false);
+        let (ctx, _guard) = supervisor
+            .begin("digest", false)
+            .expect("under the default cap");
         let waiter = tokio::spawn({
             let cancel = ctx.cancel.clone();
             async move { cancel.cancelled().await }
@@ -300,5 +375,81 @@ mod test {
             .await
             .expect("the waiter woke")
             .expect("the waiter did not panic");
+    }
+
+    /// Issue #401: the ceiling admits exactly `limit` runs and refuses the next,
+    /// naming the limit it enforced. Held guards stand in for in-flight runs, so
+    /// the property is proven without a single spawned task or wall-clock wait.
+    #[test]
+    fn the_cap_admits_up_to_the_limit_then_refuses() {
+        let supervisor = RunSupervisor::with_limit(2);
+        assert_eq!(supervisor.limit(), 2);
+
+        let (_first, _g1) = supervisor
+            .begin("digest", false)
+            .expect("first run is under the cap of 2");
+        let (_second, _g2) = supervisor
+            .begin("digest", false)
+            .expect("second run reaches the cap of 2");
+        assert_eq!(supervisor.len(), 2);
+
+        match supervisor.begin("digest", false) {
+            Err(OpenCompanyError::WorkflowRunLimit { limit }) => assert_eq!(limit, 2),
+            Ok(_) => panic!("a third run must be refused, not admitted, at the cap of 2"),
+            Err(other) => panic!("expected a run-limit refusal, got {other:?}"),
+        }
+        assert_eq!(
+            supervisor.len(),
+            2,
+            "a refused run registers nothing — the map is untouched"
+        );
+    }
+
+    /// Issue #401: dropping a guard frees the slot it held, so a run refused at
+    /// the ceiling succeeds once an in-flight run settles. This is the RAII
+    /// release the whole design leans on — no second ledger to keep in step.
+    #[test]
+    fn dropping_a_guard_frees_a_slot_for_a_refused_run() {
+        let supervisor = RunSupervisor::with_limit(1);
+        let (_first, guard) = supervisor
+            .begin("digest", false)
+            .expect("first run fills the cap of 1");
+
+        assert!(
+            matches!(
+                supervisor.begin("digest", false),
+                Err(OpenCompanyError::WorkflowRunLimit { limit: 1 })
+            ),
+            "the second run is refused while the first holds the only slot"
+        );
+
+        drop(guard);
+        let (_second, _g2) = supervisor
+            .begin("digest", false)
+            .expect("the freed slot admits a new run");
+        assert_eq!(supervisor.len(), 1);
+    }
+
+    /// Issue #401: a **panicking** run frees its capped slot on the unwind, not
+    /// just on a clean return. Extends the existing panic test to prove the
+    /// ceiling recovers — a run that blew up must not permanently retire a slot.
+    #[test]
+    fn a_panicking_run_frees_its_capped_slot() {
+        let supervisor = RunSupervisor::with_limit(1);
+        let outer = supervisor.clone();
+        let result = std::panic::catch_unwind(move || {
+            let (_ctx, _guard) = outer.begin("digest", false).expect("fills the cap of 1");
+            assert_eq!(outer.len(), 1);
+            panic!("the run blew up while holding the only slot");
+        });
+        assert!(result.is_err(), "the panic really happened");
+        assert_eq!(
+            supervisor.len(),
+            0,
+            "the guard unwound and freed the slot it held against the cap"
+        );
+        supervisor
+            .begin("digest", false)
+            .expect("the recovered slot admits a fresh run");
     }
 }

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -489,8 +489,10 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
     // approvals request open for the length of a whole workflow run, which is
     // the drop-safety failure issue #380 already paid for once.
     // Issue #542: resuming an approved gate is always a real run — `false`.
+    // Issue #401: `spawn` refuses at the concurrency ceiling; propagate it so
+    // the approval-resume caller surfaces the same `WorkflowRunLimit` refusal.
     let (run_id, _handle) =
-        WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false, false);
+        WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false, false)?;
     tracing::info!(
         company = %runtime.id(),
         workflow = %workflow_id,

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -693,7 +693,25 @@ fn spawn_scheduled_run(
         // overlap guard and has to outlive the run, and the delivery-log sweep
         // below needs the outcome.
         // Issue #542: a scheduled run is always for real — `false`.
-        let (_run_id, handle) = spawn.spawn(workflow, input, true, false);
+        //
+        // Issue #401: `spawn` refuses when the company is at its in-flight run
+        // ceiling. A scheduled fire is SKIPPED, not queued: log it, drop the
+        // overlap `_claim` (on return below), and leave the durable minute
+        // burned — this minute is forfeited, and the schedule's next tick is the
+        // natural retry once a slot frees. A cron fire nobody is waiting on has
+        // nowhere to surface a 429, so the host log is the record.
+        let (_run_id, handle) = match spawn.spawn(workflow, input, true, false) {
+            Ok(started) => started,
+            Err(err) => {
+                tracing::warn!(
+                    %company,
+                    workflow = %workflow_id,
+                    %err,
+                    "workflow scheduler: scheduled fire skipped — company is at its in-flight run cap"
+                );
+                return;
+            }
+        };
         match handle.await {
             Ok(Ok(run)) => {
                 // A manual run hands `deliveries` back in the HTTP response and
@@ -1838,12 +1856,9 @@ to = "done"
             .cloned()
             .expect("the same runner the scheduler used");
         let workflow = parse_workflow(&body("digest", Some("* * * * *"))).expect("parses");
-        let (_run_id, handle) = crate::runtime::WorkflowSpawn::new(&runtime, runner).spawn(
-            workflow,
-            json!({}),
-            false,
-            false,
-        );
+        let (_run_id, handle) = crate::runtime::WorkflowSpawn::new(&runtime, runner)
+            .spawn(workflow, json!({}), false, false)
+            .expect("under the run cap");
         handle.await.expect("the run task completes").expect("runs");
         let outcomes = wait_for_outcomes(&registry, company, 2).await;
 

--- a/src/runtime/workflow_spawn.rs
+++ b/src/runtime/workflow_spawn.rs
@@ -109,23 +109,36 @@ impl WorkflowSpawn {
     /// [`record_run_finished`] must not write a `WorkflowRunFinished` for it any
     /// more than the runner writes a `WorkflowRunStarted`. Every entry point but
     /// the run route passes `false`; a scheduled or resumed run is always real.
+    ///
+    /// # Fallible before it spawns (issue #401)
+    ///
+    /// [`begin`](RunSupervisor::begin) admits the run against the company's
+    /// concurrency ceiling *before* any task exists, so a company at its cap
+    /// gets an `Err(WorkflowRunLimit)` here and **nothing is started** — no
+    /// task, no `WorkflowRunStarted`, no run id. A dry run counts too: it drives
+    /// the real engine and spends real inference, so it is registered like any
+    /// other run and the flag is only stamped afterwards.
     pub fn spawn(
         self,
         workflow: WorkflowFile,
         input: Value,
         scheduled: bool,
         dry_run: bool,
-    ) -> (String, JoinHandle<Result<WorkflowRun>>) {
+    ) -> Result<(String, JoinHandle<Result<WorkflowRun>>)> {
         // Issue #371 mints the id above the runner so the error arm can still
         // correlate; issue #383 mints it HERE, through the supervisor, so the
         // same id is also an address an operator can send "stop" to.
         // Deliberately not a second identifier — the run id the console already
         // correlates SSE frames on IS the cancellation handle.
         //
+        // Issue #401: `begin` is the concurrency choke point and is fallible —
+        // over the cap it refuses here, before the `tokio::spawn` below, so a
+        // rejected run leaves nothing behind to journal or reap.
+        //
         // Issue #542: the dry flag is stamped on the freshly-minted context
         // AFTER `begin`, so the supervisor is untouched — a dry run registers
         // and cancels exactly like a real one.
-        let (mut ctx, guard) = self.supervisor.begin(&workflow.id, scheduled);
+        let (mut ctx, guard) = self.supervisor.begin(&workflow.id, scheduled)?;
         ctx.dry_run = dry_run;
         let run_id = ctx.run_id.clone();
         let handle = tokio::spawn(async move {
@@ -174,6 +187,6 @@ impl WorkflowSpawn {
             }
             result
         });
-        (run_id, handle)
+        Ok((run_id, handle))
     }
 }

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -56,6 +56,12 @@ impl ApiError {
             // statuses depending on which one noticed first would make the API
             // look inconsistent for one cause.
             OpenCompanyError::WorkspaceQuota(_) => StatusCode::PAYLOAD_TOO_LARGE,
+            // The company is at its concurrent-run ceiling (issue #401). The run
+            // was never started; the operator waits for a slot or raises the cap,
+            // so this is a rate-limit refusal — 429, the same status
+            // `provision.rs` already answers when a tenant asks for too much at
+            // once — rather than a 4xx that reads as a bad request.
+            OpenCompanyError::WorkflowRunLimit { .. } => StatusCode::TOO_MANY_REQUESTS,
             // tiny.place transport: an unreachable backend degrades to 503 so
             // callers retry; any other protocol failure is an upstream 502.
             OpenCompanyError::Tinyplace { code, .. } if code == "unreachable" => {
@@ -107,6 +113,12 @@ mod test {
 
         let tool = ApiError(OpenCompanyError::ToolNotGranted("payment.send".into()));
         assert_eq!(tool.status(), StatusCode::FORBIDDEN);
+
+        // Issue #401: the concurrent-run ceiling renders as 429, and its stable
+        // code is what the console (and the orchestrator tool) branch on.
+        let run_cap = ApiError(OpenCompanyError::WorkflowRunLimit { limit: 8 });
+        assert_eq!(run_cap.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(run_cap.0.code(), "workflow_run_limit");
 
         let other = ApiError(OpenCompanyError::Store("disk full".into()));
         assert_eq!(other.status(), StatusCode::INTERNAL_SERVER_ERROR);

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1174,14 +1174,18 @@ fn spawn_workflow_run(
     workflow: WorkflowFile,
     input: Value,
     dry_run: bool,
-) -> (
+) -> crate::Result<(
     String,
     tokio::task::JoinHandle<crate::Result<crate::ports::WorkflowRun>>,
-) {
+)> {
     // Issue #395: the supervisor registration and the both-arms outcome
     // journalling that used to live here now live in `WorkflowSpawn`, because
     // approving a paused workflow gate starts a run too and owes exactly the
     // same two things. One copy of the discipline, two entry points.
+    //
+    // Issue #401: `spawn` is fallible — a company at its in-flight run ceiling
+    // is refused here, before any task is spawned, and the caller maps that to
+    // a 429.
     //
     // Issue #542: `dry_run` rides through to the spawn task, which stamps it on
     // the run context and skips the outcome journal write when set.
@@ -1248,13 +1252,20 @@ async fn run_workflow(
     // Issue #383: registered and spawned before either mode branches, so the two
     // modes cannot drift in what they start. Issue #228's journalling now lives
     // inside the task rather than around this await.
+    //
+    // Issue #401: the concurrency ceiling is enforced HERE, before the
+    // detach/sync branch below, so both modes refuse identically — a 429 with
+    // the actionable `{error, code: "workflow_run_limit"}` envelope and no run
+    // id, because nothing started. The rejection precedes any task or any
+    // `WorkflowRunStarted`, so there is nothing to unwind.
     let (run_id, handle) = spawn_workflow_run(
         company.runtime.as_ref(),
         runner.clone(),
         file,
         body.input,
         dry_run,
-    );
+    )
+    .map_err(|e| ApiError(e).into_response())?;
 
     if detach {
         // Returned before the engine has walked a node. From here the client


### PR DESCRIPTION
## Summary

Nothing bounded how many workflow runs a company could have in flight at once. Before #383 the blocking run route accidentally self-limited (one socket per run); now that `detach:true` answers in milliseconds, the manual route, the cron scheduler, gate-resume, and the agent's `run_workflow` tool can all start unbounded concurrent runs — N runs is N× inference spend before it is a memory problem.

This adds a per-company cap, enforced at the one choke point every run path traverses (`RunSupervisor::begin`), and rejects over-cap runs rather than queuing them.

- **Cap config**: new manifest field `[workflows].max_in_flight_runs`, default `8`, validated `>= 1` (a workflow's agent node can call `run_workflow` while the parent holds a slot, so `1` is too low). Per-company, version-controlled — same posture as `[users].admins`.
- **Enforcement**: `RunSupervisor::begin` is now fallible and does an atomic check-and-insert under one mutex lock (no TOCTOU, no separate counter). Making `begin` fallible forces every current and future entry point through the cap at compile time.
- **Over-cap = reject, never queue**: new `WorkflowRunLimit { limit }` error → `429 Too Many Requests` with `code = "workflow_run_limit"` and an actionable message (wait, cancel a run, or raise the cap). Route rejects before any task/journal; cron warns and skips the fire (next minute retries); agent-tool and resume surface the error.
- **Release** is the existing `RunGuard` RAII drop — the count *is* the supervisor's registry map, freed on every terminal arm including panic.

Closes #401.

## API Or Behavior Changes

- New manifest field `[workflows].max_in_flight_runs` (usize, default 8).
- `POST …/workflows/{id}/run` can now return `429` with `{ "error", "code": "workflow_run_limit" }` when the company is at its cap; both detach and sync modes reject identically, before any run id is minted.
- Cron fires that arrive at the cap are skipped (logged), not deferred.
- Note for #627: this touches `src/runtime/workflow_resume.rs:493` with a single additive `?` on the now-fallible spawn — trivial rebase if #627 lands first.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--no-deps --features openhuman,tinycortex`)
- [x] `cargo build --all-targets` / `cargo check --all-features`
- [x] `cargo test` — default **1941 passed / 0 failed**, gated (`--features openhuman,tinycortex`) **2911 passed / 0 failed**

New tests: supervisor admits to the cap and rejects the next with `WorkflowRunLimit`; a dropped/panicking guard frees a slot; spawn rejects before any task at cap; route returns 429 (detach + sync); cron at cap skips and releases the claim; agent-tool and resume error at cap; manifest parses/defaults/rejects `0`; `server/error.rs` 429 mapping.

## Documentation

`docs/spec/runtime/api.md` (429 response) and `docs/spec/runtime/manifest.md` (new field) updated.
