### PR TITLE
fix(harness): announce query_company's event-tail cut + bound the insight document (#420)

### DIFF
--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -100,6 +100,24 @@ pub const MAX_DELEGATIONS_PER_TURN: usize = 3;
 const RECENT_EVENTS: usize = 10;
 /// How many facts [`QueryCompanyTool`] surfaces.
 const FACT_LIMIT: usize = 20;
+/// Longest a single fact body may render in the insight document before it is
+/// cut with an ellipsis. One verbose fact must not be able to crowd the whole
+/// budget on its own; the full body is still reachable through the fact store.
+const MAX_FACT_BODY_CHARS: usize = 400;
+/// Byte ceiling for the whole Facts section of the insight document.
+///
+/// The insight document is handed to the model through the harness tool-result
+/// path, which hard-cuts anything past
+/// [`TOOL_RESULT_BUDGET_BYTES`](crate::harness::build::TOOL_RESULT_BUDGET_BYTES)
+/// — and that outer cut is blind, so a facts list long enough to blow the
+/// budget would take the facts `[TRUNCATED …]` marker AND every section below
+/// it (Recent activity, Saved workflows, Team, Desks) over the edge with it,
+/// including the Desks list `delegate_to_desk` depends on. Bounding the facts
+/// section here — the one section with a `query` narrowing argument to fall
+/// back on — keeps the announcement and the delegation-grounding sections
+/// inside the outer budget. Half the budget leaves the other half for
+/// everything below. Sized against the real ceiling per issue #417.
+const FACTS_SECTION_BUDGET_BYTES: usize = crate::harness::build::TOOL_RESULT_BUDGET_BYTES / 2;
 
 /// The `query_company` tool name.
 pub const QUERY_COMPANY_TOOL: &str = "query_company";
@@ -646,24 +664,44 @@ impl Tool for QueryCompanyTool {
         if facts.is_empty() {
             md.push_str("_No durable facts recorded._\n");
         } else {
+            // Two bounds, so the facts section can never be the thing that
+            // pushes the outer tool-result cut into the sections below it
+            // (issue #420): each body is capped at MAX_FACT_BODY_CHARS, and the
+            // section as a whole stops once its rendered bytes reach
+            // FACTS_SECTION_BUDGET_BYTES. The budget is charged in bytes because
+            // the outer cut is bytes; the body cut counts characters so it can
+            // never split a codepoint.
+            let mut shown = 0usize;
+            let mut section_bytes = 0usize;
             for fact in facts.iter().take(FACT_LIMIT) {
-                md.push_str(&format!(
+                let line = format!(
                     "- **{}**: {}\n",
                     fact.title.trim(),
-                    fact.body.trim()
-                ));
+                    truncate_chars(fact.body.trim(), MAX_FACT_BODY_CHARS)
+                );
+                // Always render at least one fact; past that, stop before a line
+                // would carry the section over its byte budget.
+                if shown > 0 && section_bytes + line.len() > FACTS_SECTION_BUDGET_BYTES {
+                    break;
+                }
+                section_bytes += line.len();
+                md.push_str(&line);
+                shown += 1;
             }
             // Issue #410, the same silent-cut class one tool over: this list was
             // capped at FACT_LIMIT with no marker, so a company past twenty facts
             // handed the orchestrator a partial memory that read as complete —
             // and the narrowing argument that would have fixed it (`query`) was
-            // never mentioned at the point the cut happened.
-            if facts.len() > FACT_LIMIT {
+            // never mentioned at the point the cut happened. The count now covers
+            // both the FACT_LIMIT cap and the byte-budget cut (issue #420); the
+            // marker line itself is charged outside the budget so the
+            // announcement can never be the fact that gets squeezed out.
+            if shown < facts.len() {
                 md.push_str(&format!(
                     "\n[TRUNCATED — {} more fact(s) not shown. This is NOT the whole record. \
                      Narrow it with `{QUERY_COMPANY_TOOL}({{\"query\": \"<substring>\"}})` before \
                      concluding a fact is absent.]\n",
-                    facts.len() - FACT_LIMIT
+                    facts.len() - shown
                 ));
             }
         }
@@ -789,6 +827,25 @@ impl Tool for QueryCompanyTool {
             md,
         ))
     }
+}
+
+/// Cut `s` to at most `max` characters, marking a cut with a trailing ellipsis.
+///
+/// Sibling of [`memory_loop::truncate_chars`](crate::harness::memory_loop) —
+/// kept a private copy here rather than coupled to it, since the two callers
+/// share only the shape, not a contract. The ellipsis is budgeted *inside*
+/// `max`: taking `max` characters and then appending would return `max + 1` and
+/// quietly exceed the cap it advertises. Cutting counts characters, never
+/// bytes, so a multibyte body can never be split mid-codepoint.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    if max == 0 {
+        return String::new();
+    }
+    let head: String = s.chars().take(max - 1).collect();
+    format!("{head}…")
 }
 
 /// A short, non-sensitive one-line summary of an event for the insight surface.
@@ -3931,6 +3988,118 @@ members = ["nobody"]
         );
         assert!(out.contains("7 more fact(s) not shown"), "{out}");
         assert!(out.contains("query_company"), "{out}");
+    }
+
+    /// Issue #420, the residual: the whole insight document is handed to the
+    /// model through the harness tool-result path, which hard-cuts anything past
+    /// its byte budget — blindly. A facts list long enough would carry that cut
+    /// into the sections below it, dropping the facts `[TRUNCATED]` marker and
+    /// the Desks list `delegate_to_desk` reads. So each fact body is capped and
+    /// the facts section is bounded in bytes; the marker and every later section
+    /// stay inside the outer budget. Cutting a body counts characters, never
+    /// bytes, so a multibyte body cannot panic mid-codepoint.
+    #[tokio::test]
+    async fn query_company_bounds_the_insight_document_size() {
+        use crate::ports::FactStore;
+        use crate::ports::facts::{FactKind, FactRecord};
+
+        struct Facts(Vec<FactRecord>);
+        #[async_trait]
+        impl FactStore for Facts {
+            async fn list(
+                &self,
+                _c: &CompanyId,
+                _q: Option<&str>,
+                _k: Option<FactKind>,
+            ) -> crate::Result<Vec<FactRecord>> {
+                Ok(self.0.clone())
+            }
+            async fn upsert(&self, _c: &CompanyId, _f: &FactRecord) -> crate::Result<()> {
+                Ok(())
+            }
+            async fn delete(&self, _c: &CompanyId, _id: &str) -> crate::Result<bool> {
+                Ok(false)
+            }
+        }
+
+        let mk = |i: usize, body: String| FactRecord {
+            id: format!("f-{i}"),
+            kind: FactKind::Fact,
+            title: format!("Fact {i}"),
+            body,
+            source: "ceo".to_string(),
+            updated_at_millis: i as u64,
+        };
+        let render = |facts: Vec<FactRecord>| async move {
+            let store: Arc<dyn FactStore> = Arc::new(Facts(facts));
+            QueryCompanyTool::new(CompanyId::new("acme"), Some(store), None, None, None)
+                .execute(json!({}))
+                .await
+                .expect("execute")
+                .output_for_llm(true)
+        };
+
+        // (e) A single multi-KB multibyte body: cut on a char boundary, marked
+        // with an ellipsis, exactly the cap wide, and no panic.
+        let out = render(vec![mk(0, "é".repeat(5_000))]).await;
+        let line = out
+            .lines()
+            .find(|l| l.starts_with("- **Fact 0**: "))
+            .expect("fact line");
+        let body = line.strip_prefix("- **Fact 0**: ").unwrap();
+        assert!(body.ends_with('…'), "a cut body is marked: {body:?}");
+        assert_eq!(
+            body.chars().count(),
+            MAX_FACT_BODY_CHARS,
+            "the body is cut to exactly the cap"
+        );
+        assert!(
+            body.chars().take(MAX_FACT_BODY_CHARS - 1).all(|c| c == 'é'),
+            "the cut landed on a codepoint boundary, not inside one"
+        );
+
+        // (f) Enough capped bodies to blow the section byte budget. The count
+        // reflects the budget cut, not merely FACT_LIMIT, and the marker plus
+        // every section below Facts survives the outer tool-result cut.
+        let heavy: Vec<FactRecord> = (0..FACT_LIMIT)
+            .map(|i| mk(i, "é".repeat(MAX_FACT_BODY_CHARS)))
+            .collect();
+        let out = render(heavy).await;
+        let shown = out.matches("- **Fact ").count();
+        assert!(
+            (1..FACT_LIMIT).contains(&shown),
+            "the byte budget must cut before FACT_LIMIT yet keep at least one: shown={shown}"
+        );
+        assert!(
+            out.contains(&format!("{} more fact(s) not shown", FACT_LIMIT - shown)),
+            "the marker counts the budget cut: {out}"
+        );
+        for header in [
+            "[TRUNCATED",
+            "## Recent activity",
+            "## Saved workflows",
+            "## Team",
+            "## Desks",
+        ] {
+            assert!(
+                out.contains(header),
+                "the facts cut must not carry the outer budget into `{header}`: {out}"
+            );
+        }
+
+        // (g) A small document is byte-for-byte the pre-guard behavior: bodies
+        // under the cap render verbatim and nothing is announced.
+        let out = render(vec![
+            mk(0, "Body 0".to_string()),
+            mk(1, "Body 1".to_string()),
+        ])
+        .await;
+        assert!(
+            out.contains("## Facts\n- **Fact 0**: Body 0\n- **Fact 1**: Body 1\n"),
+            "the small-document path is unchanged: {out}"
+        );
+        assert!(!out.contains("TRUNCATED"), "nothing was cut: {out}");
+        assert!(!out.contains('…'), "nothing was truncated: {out}");
     }
 
     #[tokio::test]

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -599,10 +599,15 @@ impl Tool for QueryCompanyTool {
         };
         let mut recent: Vec<String> = Vec::new();
         let mut discussion_posts = 0usize;
+        // Events actually visited before the tail filled. Anything past this is
+        // strictly older than everything shown (we walk newest-first), so it is
+        // the exact count of activity dropped off the far end.
+        let mut consumed = 0usize;
         for event in stored.iter().rev() {
             if recent.len() == RECENT_EVENTS {
                 break;
             }
+            consumed += 1;
             if matches!(event.event, CompanyEvent::TaskDiscussionPosted { .. }) {
                 // Counted over the same span the tail covers, not over all of
                 // history: this line reads as "recent activity" like the rows
@@ -616,7 +621,19 @@ impl Tool for QueryCompanyTool {
                 summarize_event(&event.event)
             ));
         }
+        // Older events the tail could not reach. The facts section one block
+        // down already announces its own cut (issue #410); this is the same
+        // silent-cut class on the activity tail — a full log handed the
+        // orchestrator only its last ten rows and read as complete. `stored`
+        // holds the whole log, so the drop is exactly countable. No remediation
+        // clause: `query_company` has no pagination argument to point at.
+        let older = stored.len() - consumed;
         recent.reverse(); // back to chronological order
+        if older > 0 {
+            // Dropped rows are older than everything below; the list renders
+            // oldest→newest, so the notice belongs at the top.
+            recent.insert(0, format!("- […{older} earlier event(s) not shown]"));
+        }
         if discussion_posts > 0 {
             let plural = if discussion_posts == 1 { "" } else { "s" };
             recent.push(format!(
@@ -764,6 +781,7 @@ impl Tool for QueryCompanyTool {
             json!({
                 "facts": facts.len(),
                 "recent_events": recent.len(),
+                "events_not_shown": older,
                 "workflows": workflows.len(),
                 "team": roster.len(),
                 "desks": desks.len(),
@@ -3704,6 +3722,151 @@ members = ["nobody"]
             out.matches("discussion post").count(),
             1,
             "a post must not hold a slot of its own: {out}"
+        );
+    }
+
+    /// Issue #420: the recent-activity tail keeps only [`RECENT_EVENTS`] rows,
+    /// and it used to drop everything older in silence — a full log read as
+    /// complete, the same silent-cut class the facts section one block down
+    /// already announces. The tail now names how many rows fell off the far end
+    /// (in the markdown) and reports the count (in the JSON summary). Discussion
+    /// posts pushed past the tail are dropped rows too, so they count toward it
+    /// rather than folding into their own line.
+    #[tokio::test]
+    async fn query_company_announces_the_dropped_event_tail() {
+        use crate::ports::types::StoredEvent;
+        use futures::stream::{self, BoxStream};
+
+        /// A log that replays a fixed history.
+        struct FixedLog(Vec<StoredEvent>);
+
+        #[async_trait]
+        impl EventLog for FixedLog {
+            async fn append(
+                &self,
+                _id: &CompanyId,
+                _event: CompanyEvent,
+            ) -> crate::Result<EventSeq> {
+                unreachable!("the insight surface only reads")
+            }
+            async fn read_from(
+                &self,
+                _id: &CompanyId,
+                seq: EventSeq,
+                limit: usize,
+            ) -> crate::Result<Vec<StoredEvent>> {
+                Ok(self
+                    .0
+                    .iter()
+                    .filter(|e| e.seq.value() >= seq.value())
+                    .take(limit)
+                    .cloned()
+                    .collect())
+            }
+            fn subscribe(&self, _id: &CompanyId) -> BoxStream<'static, StoredEvent> {
+                Box::pin(stream::empty())
+            }
+        }
+
+        let company = CompanyId::new("acme");
+
+        // A distinct, non-discussion event so every row occupies a tail slot.
+        let dispatch = |seq: u64| StoredEvent {
+            seq: EventSeq::new(seq),
+            company: company.clone(),
+            event: CompanyEvent::TaskDispatched {
+                task_id: format!("t-{seq}"),
+                run_id: None,
+            },
+            at_millis: seq + 1,
+        };
+
+        // (a) Five more row-events than the tail is wide: the five oldest fall
+        // off, the notice sits at the top, and the JSON summary counts them.
+        let over: Vec<StoredEvent> = (0..(RECENT_EVENTS as u64 + 5)).map(dispatch).collect();
+        let log: Arc<dyn EventLog> = Arc::new(FixedLog(over));
+        let tool = QueryCompanyTool::new(company.clone(), None, Some(log), None, None);
+        let result = tool.execute(json!({})).await.expect("execute");
+        let md = result.output_for_llm(true);
+        let activity = md
+            .split("## Recent activity\n")
+            .nth(1)
+            .expect("recent activity section");
+        assert!(
+            activity.starts_with("- […5 earlier event(s) not shown]"),
+            "the dropped tail must be announced at the top: {md}"
+        );
+        assert!(
+            result
+                .output_for_llm(false)
+                .contains("\"events_not_shown\": 5"),
+            "the JSON summary must count the drop: {}",
+            result.output_for_llm(false)
+        );
+
+        // (b) Exactly the tail width: nothing was dropped, so nothing is said.
+        let exact: Vec<StoredEvent> = (0..RECENT_EVENTS as u64).map(dispatch).collect();
+        let log: Arc<dyn EventLog> = Arc::new(FixedLog(exact));
+        let result = QueryCompanyTool::new(company.clone(), None, Some(log), None, None)
+            .execute(json!({}))
+            .await
+            .expect("execute");
+        assert!(
+            !result
+                .output_for_llm(true)
+                .contains("earlier event(s) not shown"),
+            "a complete tail must stay silent: {}",
+            result.output_for_llm(true)
+        );
+        assert!(
+            result
+                .output_for_llm(false)
+                .contains("\"events_not_shown\": 0"),
+            "a complete tail reports zero dropped: {}",
+            result.output_for_llm(false)
+        );
+
+        // (c) Discussion posts older than the tail are dropped rows: they count
+        // toward the drop, not toward the fold line. Three posts (oldest) then
+        // enough dispatches to fill the tail — the posts never get visited.
+        let mut mixed: Vec<StoredEvent> = Vec::new();
+        for seq in 0..3u64 {
+            mixed.push(StoredEvent {
+                seq: EventSeq::new(seq),
+                company: company.clone(),
+                event: CompanyEvent::TaskDiscussionPosted {
+                    task_id: "t-1".to_string(),
+                    text: format!("older chatter {seq}"),
+                    by: None,
+                },
+                at_millis: seq + 1,
+            });
+        }
+        for seq in 3..(RECENT_EVENTS as u64 + 5) {
+            mixed.push(dispatch(seq));
+        }
+        // total = 3 posts + (RECENT_EVENTS + 2) dispatches; the tail holds
+        // RECENT_EVENTS dispatches, so 2 dispatches + 3 posts = 5 fall off.
+        let log: Arc<dyn EventLog> = Arc::new(FixedLog(mixed));
+        let result = QueryCompanyTool::new(company.clone(), None, Some(log), None, None)
+            .execute(json!({}))
+            .await
+            .expect("execute");
+        let md = result.output_for_llm(true);
+        assert!(
+            md.contains("- […5 earlier event(s) not shown]"),
+            "dropped discussion posts must count toward the tail drop: {md}"
+        );
+        assert!(
+            !md.contains("discussion post"),
+            "an unvisited post must not also fold into its own line: {md}"
+        );
+        assert!(
+            result
+                .output_for_llm(false)
+                .contains("\"events_not_shown\": 5"),
+            "{}",
+            result.output_for_llm(false)
         );
     }
 


### PR DESCRIPTION
## Summary

Tail of the #410 truncation audit: places where text that reaches a model is shortened without saying so. Three of the four sites named in #420 were already fixed on `main` (via #491 and later commits) — verified and left untouched. This PR closes the two that remained, both in `query_company`'s insight document:

- **Event tail**: the Recent-activity list stops at `RECENT_EVENTS` (10) but, unlike the facts section beside it, never said how many older events it dropped. `stored` holds the full log, so the drop is exactly countable — it now prepends `- […N earlier event(s) not shown]` and adds `"events_not_shown": N` to the JSON. Pure counting, no string slicing.
- **Insight-doc size guard**: the whole document had no size bound, so past the harness's 16 KiB budget the *outer* cut could silently amputate the facts `[TRUNCATED — …]` marker and the `Desks` section that `delegate_to_desk` depends on. Fact bodies are now capped (`MAX_FACT_BODY_CHARS = 400`, char-boundary cut with `…` budgeted inside) and the facts section is byte-budgeted (`FACTS_SECTION_BUDGET_BYTES = TOOL_RESULT_BUDGET_BYTES / 2`, byte-accounted against the byte ceiling, cut only on char boundaries). The existing `[TRUNCATED — N …]` count widens to `facts.len() - shown`; the marker line is charged outside the budget so the announcement itself can never be squeezed out. Facts (which have a `query` remediation) are the victim; Desks/Team/workflows always survive.

Closes #420.

## API Or Behavior Changes

`query_company`'s insight document (an agent-facing tool result) now: shows `- […N earlier event(s) not shown]` when the event tail is trimmed, carries `events_not_shown` in its JSON summary, caps individual fact bodies, and bounds the facts section by bytes. Additive to agent-visible text (one new line, one widened count) — no existing sentence reworded. No UI surface. Sites 1–3 (`cap_redirect`, memory preamble, publish scan) were already shipped on main (#491) and are untouched.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo build --all-targets` / `cargo check --all-features`
- [x] `cargo test` — default **1924 passed / 0 failed**, gated (`--features openhuman,tinycortex`) **2882 passed / 0 failed**

New tests: event tail beyond the cap shows the count + `events_not_shown`; exactly-cap shows no marker; discussion posts past the break count into `older`; a multi-KB `'é'` fact body cuts on a char boundary ending `…` with no panic; blowing the section budget keeps the `TRUNCATED` count == `facts.len() - shown` and all four later section headers (Recent activity, Saved workflows, Team, Desks) present; small-document path byte-identical.

## Documentation

No doc page describes the insight document, so none updated.
