### PR TITLE
fix(workspace): an over-cap upload reports 413, not a parse error (#647)

### DIFF
--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -176,8 +176,11 @@ the store at the single assembly site, inside the announcer, and sees the full
 size **before** anything is written — so a refused write leaves no partial
 blob, no node and no orphan. It meters payloads only (prose is uncounted; the
 threat model is media) against a per-file cap (`[workspace] max_blob_mb`,
-default 256 MiB) and a per-company total (`[workspace] tree_quota_gb`,
-unlimited by default), answering 413.
+default 64 MiB) and a per-company total (`[workspace] tree_quota_gb`,
+unlimited by default), answering 413. The console's upload route holds a
+separate 256 MiB body limit — a backstop against buffering an unbounded
+request, deliberately above the cap so the store's refusal is the one an
+operator sees (#647); see `storage.md`.
 
 Backends: sqlite keeps the blob in the node's own row, so it cannot orphan one.
 `FsOps` writes the file then the index — the benign order the text path already

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -301,9 +301,19 @@ GridFS the 16 MB BSON document limit was an accidental brake on how much an
 agent could write; GridFS removes it by chunking, so the cap is what replaces
 it deliberately. It defaults to 64 MiB — an order of magnitude above a
 generated image or document, and above a short generated video, so no
-deliverable this feature exists to make durable is near it. It is also the
-upload route's request body limit, so an over-cap upload is rejected at the
-edge instead of being buffered and then refused.
+deliverable this feature exists to make durable is near it.
+
+The console's upload route holds a **separate** `DefaultBodyLimit` of 256 MiB
+(4× the default cap), and the gap is deliberate (#647). One shared number made
+the store's refusal unreachable there: the body limit fired mid-parse, a body
+that stops mid-part is indistinguishable from a malformed one, so an oversized
+upload answered `400 malformed multipart` — a correct request called broken —
+and `max_blob_mb` above 64 bought only a different way to fail. With headroom
+the store speaks first. The route limit is a backstop against buffering an
+unbounded body; when it does fire the handler classifies axum's parse error via
+`MultipartError::status()` and answers 413 naming the 256 MiB ceiling but never
+a size, since a truncated body has no knowable total. Both share the
+`workspace_quota_exceeded` code, so callers need not know which limit noticed.
 
 One decorator covers every writer: the console's REST surface, the agent
 workspace tools and the publish drain all hold the *same* `ops.workspace`

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -129,7 +129,9 @@ pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
 pub use workflow_spawn::WorkflowSpawn;
 pub use workspace_events::WorkspaceAnnouncer;
-pub use workspace_quota::{DEFAULT_MAX_BLOB_BYTES, QuotaEnforcedWorkspace, WorkspaceQuota};
+pub use workspace_quota::{
+    DEFAULT_MAX_BLOB_BYTES, QuotaEnforcedWorkspace, UPLOAD_BODY_LIMIT_BYTES, WorkspaceQuota,
+};
 
 // The assembly struct lives under `company/` to match the `ports.md` sketch
 // (`src/company/runtime.rs`); re-export it here as the kernel's public surface.

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -90,13 +90,55 @@ use crate::ports::workspace::{BlobStream, WorkspaceNode, WorkspaceOrigin, Worksp
 /// Operators who need more set `[workspace] max_blob_mb`; the constant is only
 /// the default.
 ///
-/// # One number, two enforcement points
+/// # This is the *policy* limit, and not the transport one
 ///
-/// Also the upload route's `DefaultBodyLimit`, so a request too large to accept
-/// is rejected at the edge with the same number and the same 413 the store
-/// would have used. One limit stated twice is a bug waiting to happen — so both
-/// read it from here.
+/// The upload route reads up to [`UPLOAD_BODY_LIMIT_BYTES`], which is
+/// deliberately larger. Until issue #647 the two were the same number, and that
+/// made this constant unreachable through that route: the body limit always
+/// tripped first, a truncated body is a parse failure, and so an oversized
+/// upload answered `400 malformed multipart` — a request the operator had made
+/// perfectly correctly, described as broken. The refusal below, which names the
+/// file, its size and the cap, was written and could never be seen.
+///
+/// The two limits answer different questions — "may this company keep these
+/// bytes?" versus "will this process read this many bytes at all?" — so they
+/// hold different numbers, and the smaller one is the one that speaks.
 pub const DEFAULT_MAX_BLOB_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The most an upload request body may weigh before the route stops reading it:
+/// four times [`DEFAULT_MAX_BLOB_BYTES`], so 256 MiB.
+///
+/// # Why it is not the same number as the cap
+///
+/// A `DefaultBodyLimit` set *at* the per-file cap cannot produce a good error,
+/// because it fires while the multipart body is still being parsed: the reader
+/// sees a stream that stops mid-part, which is indistinguishable from a
+/// malformed one at that layer. Only a limit the store's cap sits comfortably
+/// *inside* lets the whole body arrive, the real size be measured, and the
+/// refusal name it. Headroom is what buys the honest message (issue #647).
+///
+/// # Why 4×
+///
+/// The multiplier is what keeps [`crate::app::WorkspaceConfig`]'s
+/// `[workspace] max_blob_mb` knob real. Routers are built once, before any
+/// company exists, so the route cannot read a company's configured cap — it can
+/// only leave room above the default for one. Anything a company raises the cap
+/// to within 4× of the default is enforced exactly, by the store, with the
+/// store's message. Beyond that the route refuses first — still a 413, still
+/// naming a limit, but this one rather than the company's.
+///
+/// 256 MiB is also the number this route has claimed to allow since #553; the
+/// comment said so while the code did not. This makes the published contract
+/// true rather than quietly lowering it.
+///
+/// # What it costs
+///
+/// The upload path buffers (see the module docs on why refusing beats cleaning
+/// up), so this is also the ceiling on how much one in-flight upload can hold
+/// in memory. 256 MiB per concurrent upload is the deliberate trade for an
+/// error message that tells the truth; it is not a licence to store that much,
+/// which is still [`DEFAULT_MAX_BLOB_BYTES`]' decision.
+pub const UPLOAD_BODY_LIMIT_BYTES: u64 = 4 * DEFAULT_MAX_BLOB_BYTES;
 
 /// The limits a company's workspace is held to.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -131,7 +173,12 @@ impl WorkspaceQuota {
 }
 
 /// Renders a byte count the way an operator reads one.
-fn human(bytes: u64) -> String {
+///
+/// Crate-visible so the upload route's own refusal (issue #647) spells a limit
+/// the same way this store's does. Two renderers would eventually disagree
+/// about the same number, and the operator would have no way to tell that the
+/// two messages were describing one thing.
+pub(crate) fn human(bytes: u64) -> String {
     const MIB: f64 = 1024.0 * 1024.0;
     const GIB: f64 = MIB * 1024.0;
     let b = bytes as f64;

--- a/src/server/error.rs
+++ b/src/server/error.rs
@@ -50,11 +50,14 @@ impl ApiError {
             OpenCompanyError::Quiescing(_) => StatusCode::SERVICE_UNAVAILABLE,
             OpenCompanyError::ToolNotGranted(_) => StatusCode::FORBIDDEN,
             OpenCompanyError::BudgetExceeded(_) => StatusCode::PAYMENT_REQUIRED,
-            // 413, matching what axum's `DefaultBodyLimit` returns when the
-            // upload route rejects an over-cap body before a handler runs. The
-            // two limits are the same number, so answering with two different
-            // statuses depending on which one noticed first would make the API
-            // look inconsistent for one cause.
+            // 413 — for both ways an upload can be too big. The store's per-file
+            // cap raises this variant with the file and the limit named; the
+            // upload route's `DefaultBodyLimit` backstop raises it too, after
+            // classifying the parse failure axum reports (issue #647). The two
+            // limits are deliberately *different* numbers, but they are one
+            // cause as far as a caller is concerned, so they share this status
+            // and the `workspace_quota_exceeded` code rather than splitting into
+            // two vocabularies for "too big".
             OpenCompanyError::WorkspaceQuota(_) => StatusCode::PAYLOAD_TOO_LARGE,
             // The company is at its concurrent-run ceiling (issue #401). The run
             // was never started; the operator waits for a slot or raises the cap,

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -52,6 +52,7 @@
 use std::num::NonZeroUsize;
 
 use axum::body::Body;
+use axum::extract::multipart::MultipartError;
 use axum::extract::{DefaultBodyLimit, Multipart, Path, Query};
 use axum::http::{StatusCode, header};
 use axum::response::Response;
@@ -69,6 +70,8 @@ use crate::error::OpenCompanyError;
 use crate::ports::artifacts::ArtifactAuthor;
 use crate::ports::generate_id;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
+use crate::runtime::UPLOAD_BODY_LIMIT_BYTES;
+use crate::runtime::workspace_quota::human;
 use crate::server::error::ApiError;
 use crate::server::ops::artifacts::OPERATOR_EDIT_NOTE;
 use crate::server::ops::{ScopedCompany, scoped};
@@ -93,17 +96,30 @@ pub fn router() -> Router<AppState> {
                 // handler in the process, which is the opposite of what an
                 // upload endpoint should cost its neighbours.
                 //
-                // The number is the *default* per-file cap rather than the
-                // company's configured one: routers are built once, before any
-                // company exists, so a per-company limit cannot be applied
-                // here. A company configured **below** the default is still
-                // enforced exactly, by the store — this only decides how much
-                // is read before that refusal. A company configured **above**
-                // it is capped here at 256 MiB, which is a known limit rather
-                // than a silent one: raising it means raising
-                // [`DEFAULT_MAX_BLOB_BYTES`] too.
+                // Two limits, in this order (issue #647):
+                //
+                // 1. The **store's** per-file cap decides policy. It sees the
+                //    whole payload, so it refuses by name and size —
+                //    "`hero.mov` is 91.4 MiB, over the 64.0 MiB limit for a
+                //    single file" — and it honours the company's configured
+                //    `[workspace] max_blob_mb`, which this layer cannot: routers
+                //    are built once, before any company exists.
+                // 2. This layer is the **backstop**, four times the default cap.
+                //    It exists so an unbounded body cannot be buffered, not to
+                //    express policy, and the headroom is what lets the store
+                //    speak first for every realistic over-cap upload.
+                //
+                // Both answer 413. Setting this *at* the cap — what it used to
+                // be — made (1) unreachable: the body limit fired mid-parse, and
+                // a body that stops mid-part is indistinguishable from a
+                // malformed one, so the honest 413 came out as `400 malformed
+                // multipart`. `upload` below still has to classify, because this
+                // layer's own failure arrives through the same parse error.
+                //
+                // The trade: this is also how much one in-flight upload may hold
+                // in memory, because the write path buffers by design.
                 .layer(DefaultBodyLimit::max(
-                    crate::runtime::DEFAULT_MAX_BLOB_BYTES as usize,
+                    crate::runtime::UPLOAD_BODY_LIMIT_BYTES as usize,
                 )),
         )
         .merge(scoped(
@@ -461,6 +477,43 @@ async fn read_blob(
     })
 }
 
+/// Names a multipart failure for what it actually was (issue #647).
+///
+/// One error type carries two unrelated causes. A body that ran past the
+/// route's `DefaultBodyLimit` stops mid-part, and to the multipart reader that
+/// looks exactly like a body that was malformed to begin with — so reporting
+/// every failure here as `InvalidRequest` told an operator whose only mistake
+/// was picking a large file that their request was broken. It is not: it is
+/// oversized, which is a different sentence and a different fix.
+///
+/// axum keeps the two apart. `MultipartError::status()` answers 413 for the
+/// size-limit variants — multer's own `FieldSizeExceeded` / `StreamSizeExceeded`
+/// and the `StreamReadFailed` whose source is `http_body_util`'s
+/// `LengthLimitError`, which is the `DefaultBodyLimit` case — and 400 for the
+/// genuinely malformed ones. Reading that rather than matching on the message
+/// keeps this from breaking when axum rewords an error.
+///
+/// The 413 is raised as [`OpenCompanyError::WorkspaceQuota`] on purpose: that
+/// is already the store's over-cap refusal, so the two causes share a status
+/// (413) and a stable code (`workspace_quota_exceeded`) rather than inventing a
+/// second vocabulary for "too big". A caller keying on the code cannot tell —
+/// and should not have to — which of the two limits noticed.
+///
+/// Only the limit is named, never a size. The body was cut off, so the true
+/// total is not knowable here; guessing at it would be worse than omitting it.
+fn multipart_error(error: MultipartError, context: &str) -> ApiError {
+    if error.status() == StatusCode::PAYLOAD_TOO_LARGE {
+        return ApiError(OpenCompanyError::WorkspaceQuota(format!(
+            "this upload is larger than the {} this endpoint will read in one request, \
+             so it was cut off before its size could be measured. Nothing was stored.",
+            human(UPLOAD_BODY_LIMIT_BYTES),
+        )));
+    }
+    ApiError(OpenCompanyError::InvalidRequest(format!(
+        "{context}: {error}"
+    )))
+}
+
 /// `POST …/workspace/upload` — multipart upload of a file of any kind.
 ///
 /// The existing create route takes a JSON body, which cannot carry bytes; this
@@ -482,18 +535,21 @@ async fn upload(
     let mut file: Option<(String, Option<String>, Vec<u8>)> = None;
     let mut parent_id: Option<String> = None;
 
-    while let Some(field) = multipart.next_field().await.map_err(|e| {
-        ApiError(OpenCompanyError::InvalidRequest(format!(
-            "malformed multipart upload: {e}"
-        )))
-    })? {
+    // Every one of these three is a place the body limit can be noticed — this
+    // one while draining a part the route ignores, the two below while reading
+    // one it wants — so all three classify rather than the one that happened to
+    // be reported first.
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| multipart_error(e, "malformed multipart upload"))?
+    {
         match field.name() {
             Some("parentId") | Some("parent_id") => {
-                let value = field.text().await.map_err(|e| {
-                    ApiError(OpenCompanyError::InvalidRequest(format!(
-                        "unreadable parentId: {e}"
-                    )))
-                })?;
+                let value = field
+                    .text()
+                    .await
+                    .map_err(|e| multipart_error(e, "unreadable parentId"))?;
                 // An empty value is the console saying "the workspace root",
                 // which is what an absent field means too.
                 if !value.trim().is_empty() {
@@ -511,11 +567,10 @@ async fn upload(
                         ))
                     })?;
                 let declared = field.content_type().map(str::to_string);
-                let bytes = field.bytes().await.map_err(|e| {
-                    ApiError(OpenCompanyError::InvalidRequest(format!(
-                        "unreadable file part: {e}"
-                    )))
-                })?;
+                let bytes = field
+                    .bytes()
+                    .await
+                    .map_err(|e| multipart_error(e, "unreadable file part"))?;
                 file = Some((name, declared, bytes.to_vec()));
             }
             // Ignored rather than rejected: a browser's `FormData` may carry

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -51,6 +51,18 @@ fn provisioned_names(tree: &serde_json::Value) -> Vec<String> {
 }
 
 async fn state_with_company(home: &std::path::Path) -> AppState {
+    state_with_quota(home, crate::runtime::WorkspaceQuota::default()).await
+}
+
+/// [`state_with_company`], with the workspace held to `quota`.
+///
+/// Parameterised rather than duplicated so the one test that needs a non-default
+/// `[workspace] max_blob_mb` (issue #647) exercises the same wiring every other
+/// test here does, instead of a second harness that could drift from it.
+async fn state_with_quota(
+    home: &std::path::Path,
+    quota: crate::runtime::WorkspaceQuota,
+) -> AppState {
     use crate::ports::CompanyStore;
     let store = FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
@@ -73,6 +85,7 @@ async fn state_with_company(home: &std::path::Path) -> AppState {
         .unwrap();
     let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
         .with_id(id.clone())
+        .with_workspace_quota(quota)
         .build()
         .await
         .unwrap();
@@ -7096,4 +7109,299 @@ async fn an_upload_can_target_a_parent_folder() {
     .await;
     assert_eq!(status, StatusCode::OK, "{node}");
     assert_eq!(node["parentId"], folder_id.as_str());
+}
+
+// ---------------------------------------------------------------------------
+// An over-cap upload says "too large", not "malformed" (issue #647)
+// ---------------------------------------------------------------------------
+
+/// The boundary the raw-body helpers below agree on.
+const OVERSIZE_BOUNDARY: &str = "----opencompany647boundary";
+
+/// Posts an already-built body at the upload route.
+///
+/// [`upload_file`] assembles its body into a `Vec`, which is the one thing these
+/// tests cannot do: the smallest of them weighs 65 MiB and two of them have to
+/// out-weigh a 256 MiB limit. Taking a `Body` lets the caller stream one — or
+/// malform one on purpose.
+async fn post_upload(state: &AppState, body: Body) -> (StatusCode, Value) {
+    let request = Request::builder()
+        .method("POST")
+        .uri("/api/v1/company/workspace/upload")
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={OVERSIZE_BOUNDARY}"),
+        )
+        .body(body)
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    let status = response.status();
+    let out = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let value = serde_json::from_slice(&out).unwrap_or(Value::Null);
+    (status, value)
+}
+
+/// A body of `prefix` + `payload` zero bytes + `suffix`, streamed in 1 MiB
+/// frames with a yield before each.
+///
+/// The framing is load-bearing, not tidiness. A contiguous body would make the
+/// *test process* hold the whole payload before the server saw a byte of it,
+/// and the multipart reader drains every frame that is ready in one poll — so
+/// an always-ready stream is buffered whole however finely it was cut up. The
+/// yield keeps the reader one frame ahead of the parser rather than a whole
+/// body ahead, which is what lets a 257 MiB request that the handler *skips*
+/// cost about a megabyte instead of 257 of them.
+fn streamed_multipart(prefix: Vec<u8>, payload: usize, suffix: Vec<u8>) -> Body {
+    const FRAME: usize = 1024 * 1024;
+    let prefix = std::sync::Arc::new(prefix);
+    let suffix = std::sync::Arc::new(suffix);
+    let filler = bytes::Bytes::from(vec![0u8; FRAME]);
+    let frames = payload.div_ceil(FRAME);
+
+    let stream = futures::stream::unfold(0usize, move |step| {
+        let prefix = prefix.clone();
+        let suffix = suffix.clone();
+        let filler = filler.clone();
+        async move {
+            tokio::task::yield_now().await;
+            let frame = if step == 0 {
+                bytes::Bytes::from(prefix.as_ref().clone())
+            } else if step <= frames {
+                filler.slice(..(payload - (step - 1) * FRAME).min(FRAME))
+            } else if step == frames + 1 {
+                bytes::Bytes::from(suffix.as_ref().clone())
+            } else {
+                return None;
+            };
+            Some((Ok::<_, std::io::Error>(frame), step + 1))
+        }
+    });
+    Body::from_stream(stream)
+}
+
+/// The opening of a `file` part, up to (not including) its bytes.
+fn file_part_prefix(filename: &str) -> Vec<u8> {
+    format!(
+        "--{OVERSIZE_BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; \
+         filename=\"{filename}\"\r\nContent-Type: application/octet-stream\r\n\r\n"
+    )
+    .into_bytes()
+}
+
+/// The node names currently in the workspace tree.
+async fn tree_names(state: &AppState) -> Vec<String> {
+    let (status, tree) = send(state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(status, StatusCode::OK);
+    provisioned_names(&tree)
+}
+
+/// The headline of #647: a file over the store's per-file cap is refused as
+/// **too large**, with the sentence an operator can act on.
+///
+/// This failed before the fix, and not subtly — the route's `DefaultBodyLimit`
+/// was the same 64 MiB as the cap, so it truncated the body first and the
+/// truncation surfaced as a parse failure: `400 invalid request: unreadable
+/// file part: Error parsing multipart/form-data request`. A correctly-formed
+/// request, described as broken, for a reason the operator could not guess.
+/// The store's refusal below existed the whole time and could never be reached
+/// through this route.
+#[tokio::test]
+async fn a_file_over_the_per_file_cap_is_refused_as_too_large_not_as_malformed() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let before = tree_names(&state).await;
+
+    // One megabyte over the 64 MiB default: enough to break the cap, nowhere
+    // near the 256 MiB the route will now read.
+    let oversize = 65 * 1024 * 1024;
+    let (status, body) = post_upload(
+        &state,
+        streamed_multipart(
+            file_part_prefix("hero.mov"),
+            oversize,
+            format!("\r\n--{OVERSIZE_BOUNDARY}--\r\n").into_bytes(),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    assert_eq!(body["code"], "workspace_quota_exceeded", "{body}");
+    let message = body["error"].as_str().expect("an error message");
+    assert!(message.contains("hero.mov"), "names the file: {message}");
+    assert!(message.contains("65.0 MiB"), "names its size: {message}");
+    assert!(message.contains("64.0 MiB"), "names the limit: {message}");
+    assert!(message.contains("Nothing was stored"), "{message}");
+
+    // The two words the bug used to answer with. Asserting on their absence is
+    // the regression guard: a future change that lets the body limit preempt
+    // the store again would put them straight back.
+    assert!(
+        !message.contains("unreadable file part"),
+        "the request was not unreadable: {message}"
+    );
+    assert!(
+        !message.contains("Error parsing"),
+        "nor was it malformed: {message}"
+    );
+
+    assert_eq!(tree_names(&state).await, before, "and nothing was stored");
+}
+
+/// The route's own backstop is classified too, and it fires while *skipping* a
+/// part — the reader can notice the limit anywhere it reads, not only where the
+/// handler wants bytes.
+///
+/// Without this the classifier arm ships untested and a drift in axum's status
+/// mapping would silently regress the answer to the old lying 400.
+#[tokio::test]
+async fn a_body_over_the_route_limit_is_classified_while_a_part_is_skipped() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let before = tree_names(&state).await;
+
+    // A field the handler ignores by name, so it is drained rather than
+    // buffered — and the drain runs past the 256 MiB the route will read.
+    let prefix = format!(
+        "--{OVERSIZE_BOUNDARY}\r\nContent-Disposition: form-data; name=\"ignored\"\r\n\r\n"
+    )
+    .into_bytes();
+    let mut suffix = format!("\r\n--{OVERSIZE_BOUNDARY}\r\n").into_bytes();
+    suffix.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"a.bin\"\r\n\r\nxx\r\n",
+    );
+    suffix.extend_from_slice(format!("--{OVERSIZE_BOUNDARY}--\r\n").as_bytes());
+
+    let (status, body) = post_upload(
+        &state,
+        streamed_multipart(prefix, 257 * 1024 * 1024, suffix),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    assert_eq!(body["code"], "workspace_quota_exceeded", "{body}");
+    let message = body["error"].as_str().expect("an error message");
+    assert!(
+        message.contains("256.0 MiB"),
+        "names the ceiling: {message}"
+    );
+    assert!(message.contains("Nothing was stored"), "{message}");
+    // The size is deliberately absent: the body was cut off, so the true total
+    // is not knowable here and a guess would be worse than silence.
+    assert!(
+        !message.contains("Error parsing"),
+        "still not a parse failure: {message}"
+    );
+
+    assert_eq!(tree_names(&state).await, before, "and nothing was stored");
+}
+
+/// The same backstop, noticed at the other read site — while the handler is
+/// pulling the `file` part's bytes rather than skipping past someone else's.
+#[tokio::test]
+async fn a_file_part_over_the_route_limit_is_classified_too() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let before = tree_names(&state).await;
+
+    let (status, body) = post_upload(
+        &state,
+        streamed_multipart(
+            file_part_prefix("enormous.bin"),
+            257 * 1024 * 1024,
+            format!("\r\n--{OVERSIZE_BOUNDARY}--\r\n").into_bytes(),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    assert_eq!(body["code"], "workspace_quota_exceeded", "{body}");
+    let message = body["error"].as_str().expect("an error message");
+    assert!(
+        message.contains("256.0 MiB"),
+        "names the ceiling: {message}"
+    );
+    assert!(
+        !message.contains("unreadable file part"),
+        "the part was readable, just too long: {message}"
+    );
+
+    assert_eq!(tree_names(&state).await, before, "and nothing was stored");
+}
+
+/// The counter-test, and the half of the issue that is easiest to lose: a
+/// genuinely malformed body still answers 400.
+///
+/// Classifying by size must not swallow the case the old message was right
+/// about. These two shapes stay `invalid_request` — and stay distinguishable
+/// from the 413s above, which is the whole point of the change.
+#[tokio::test]
+async fn a_malformed_multipart_body_is_still_a_400() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    // The declared boundary never appears.
+    let (status, body) =
+        post_upload(&state, Body::from(b"this is not a multipart body".to_vec())).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["code"], "invalid_request", "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|m| m.contains("malformed multipart upload")),
+        "{body}"
+    );
+
+    // A part that opens and never closes: headers, some bytes, no terminating
+    // boundary. Truncated — the shape the body limit used to be mistaken for.
+    let mut unterminated = file_part_prefix("half.bin");
+    unterminated.extend_from_slice(b"partial bytes and then nothing");
+    let (status, body) = post_upload(&state, Body::from(unterminated)).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+    assert_eq!(body["code"], "invalid_request", "{body}");
+    assert!(
+        body["error"]
+            .as_str()
+            .is_some_and(|m| m.contains("unreadable file part")),
+        "{body}"
+    );
+}
+
+/// `[workspace] max_blob_mb` above the default is a real knob again.
+///
+/// It never was one: the route stopped reading at 64 MiB whatever a company had
+/// configured, so raising the cap bought nothing but a different way to fail.
+/// A company at 128 MiB can now actually store a 65 MiB file.
+#[tokio::test]
+async fn a_company_that_raised_its_blob_cap_can_use_it() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_quota(
+        &home,
+        crate::runtime::WorkspaceQuota {
+            max_blob_bytes: 128 * 1024 * 1024,
+            tree_quota_bytes: None,
+        },
+    )
+    .await;
+
+    let size = 65 * 1024 * 1024;
+    let (status, node) = post_upload(
+        &state,
+        streamed_multipart(
+            file_part_prefix("raised.bin"),
+            size,
+            format!("\r\n--{OVERSIZE_BOUNDARY}--\r\n").into_bytes(),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{node}");
+    assert_eq!(node["name"], "raised.bin");
+    assert_eq!(node["size"], size as u64);
+    assert!(tree_names(&state).await.contains(&"raised.bin".to_string()));
 }


### PR DESCRIPTION
## Summary

Uploading a file over the 64 MiB cap told the operator their file was **malformed**, not that it was **too large**:

```
HTTP 400 {"error":"invalid request: unreadable file part: Error parsing `multipart/form-data` request"}
```

The upload was refused and nothing was stored — never a safety hole. The defect was the diagnosis. An operator dragging in a 70 MB video is told the request could not be parsed; nothing names a size, a limit, or the file, so the obvious next moves (re-export, another browser, suspect the network) are all wasted against a limit working exactly as designed.

`DEFAULT_MAX_BLOB_BYTES` did two jobs with one number: the store's per-write quota (413, with a good message naming the file, its size and the limit) **and** the upload route's `DefaultBodyLimit`. Identical numbers, so the body limit always tripped first, `Multipart` surfaced the truncated body as a parse error, and **the 413 was unreachable at default configuration** — the good message existed, was tested, and no operator could ever see it.

Found by manual end-to-end testing on a live host — the first such pass over #551/#570/#552/#553, which had all shipped on unit tests and CI alone.

Closes #647.

## API Or Behavior Changes

**Both halves of the fix, because either alone is insufficient.** Headroom alone just moves the lying-400 cliff to the new edge; classification alone leaves the store's better message unreachable and `max_blob_mb` still broken.

**`UPLOAD_BODY_LIMIT_BYTES = 4 * DEFAULT_MAX_BLOB_BYTES`** (256 MiB), expressed as a derived constant so the relationship between the two limits is stated rather than implied — changing either is now a visible decision. **256 MiB is not a new promise**: it is the contract the route's own comment already published, so this makes that comment true rather than quietly lowering it.

**An over-cap upload now reaches the store and gets the real 413**, naming the file, its actual size, the company's *configured* limit, and "Nothing was stored."

**The backstop classifies honestly.** `multipart_error(e, context)` reads `MultipartError::status()`: `PAYLOAD_TOO_LARGE` (multer's `FieldSizeExceeded`/`StreamSizeExceeded`, and `StreamReadFailed` whose source chain downcasts to `LengthLimitError` — the `DefaultBodyLimit` case) raises `WorkspaceQuota` → 413 + `workspace_quota_exceeded`; everything else reproduces today's `InvalidRequest` texts **verbatim**. Reusing the existing error variant means **no new variant and no new code string**.

**The 413 never guesses a size.** When the body was truncated the true total is genuinely unknowable, so the message names only the limit. A fabricated number would be a worse lie than the one being fixed.

**The plan named two `map_err` sites; there are three.** `:373` is `next_field()` ("malformed multipart upload"), `:402` is `field.bytes()` (the only one producing the issue's message), and `field.text()` on the `parentId` part has the identical defect and appeared in neither the issue nor the plan. All three classify now.

**This also closes a silently broken config knob.** `[workspace] max_blob_mb` is real (`src/app/config.rs`), and today any value **above** 64 MiB is broken — you configure 128 MiB and uploads still die at 64 with the misleading 400. After this, configs up to 256 MiB work as configured; above that gets an honest, documented 413 naming the route ceiling. There is no configuration that reproduces the misleading message.

**A fourth defect in the same family, fixed here**: `docs/spec/runtime/ports-console.md:178` documented the `max_blob_mb` default as 256 MiB. It is 64. Same one-number-two-jobs confusion, one layer out.

## Tests

Re-run in full **after rebasing onto current `main`** (`9181d679`), with exit codes captured directly rather than through a pipe:

- [x] `cargo fmt --all -- --check` — exit 0
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — exit 0
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings` — exit 0
- [x] `cargo build --all-targets` (via `cargo check --locked --all-features --all-targets`) — exit 0
- [x] `cargo test --locked` — **1929 passed**, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **2885 passed**, 0 failed

Five new end-to-end tests through the **real** router (`router(state).oneshot`, so the `DefaultBodyLimit` layer is genuinely in the path), beside their #553 siblings in `write_test.rs`:

1. 65 MiB upload → 413 `workspace_quota_exceeded` naming file, size and the 64 MiB limit; asserts `"unreadable file part"` and `"Error parsing"` are **absent**; asserts the node is absent from the tree.
2. \>256 MiB body → the backstop's classified 413 naming 256 MiB, tree unchanged.
3. Malformed multipart framing → still **400** `invalid_request` with the parse-error text. This is the criterion most likely to be skipped: without it, the fix could collapse both causes into one message and still look correct.
4. `parentId` text-part classification (the third site).
5. A company configured `max_blob_mb = 128` uploads 100 MiB successfully — pinning the un-broken knob. (`RuntimeBuilder::with_workspace_quota` already existed; only the test helper needed parameterising.)

**Four of the five were proven to fail on pre-fix code** by temporarily restoring `f6667d19:src/server/ops/workspace.rs`, returning the literal issue text. The malformed counter-test passes on both, by design — that is what makes it a counter-test.

**Test 2 peak memory: 31 MB for a 257 MiB body.** Bodies stream in 1 MiB frames with a `yield_now()` between them, and that yield is load-bearing rather than cosmetic: multer's `poll_stream` drains every ready frame in a single poll, so an always-ready stream is buffered whole however finely it is chunked. The other four peak at 167/101/165 MB.

**No frontend change, verified rather than assumed**: `WorkspaceView.tsx:868-871` → `message()` → `ApiError` → `client.ts httpError()` renders the host envelope's `error` string verbatim in the toast, so the honest refusal reaches the operator with no console edit.

## Documentation

`workspace_quota.rs`'s doc section — which claimed one number does both jobs — rewritten, along with the route comment describing the real layering (store = precise policy refusal, route limit = backstop, both 413) and the buffering trade it accepts. `src/server/error.rs` had a comment asserting the mapping "matches what `DefaultBodyLimit` returns"; it does not, and that false equivalence is what hid this. Comment-only there; the mapping was always right.

Flagged, not fixed: **`docs/spec/runtime/storage.md` was already 565 lines** — over the 500-line Markdown cap in `CLAUDE.md`, introduced by #553 — and this takes it to 575. Splitting it is separate work.

## Related

- #553 — added the cap, the quota decorator and the upload route; its PR body asserted the 413 "matches what `DefaultBodyLimit` returns for the same cause", which is the incorrect assumption at the centre of this
- #555 — the same shape one layer down: two components each correct alone, disagreeing about a boundary value, invisible until something executed the path
- #607 — workspace search; **merges before this**. It edits `router()` a few lines from this PR's `.layer(...)`; additive both ways, take both hunks
- #645 — the `Desks/` scaffold; runs in parallel and shares `src/server/ops/write_test.rs` in a **different region** (it edits existing sites ~1228–1443; this appends new tests). A conflict-free `git merge` proves nothing there — whoever rebases second must run the tests
