### PR TITLE
overview: draw a teammate's declared tier instead of a hardcoded worker (#643)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -520,6 +520,33 @@ export interface TeamMemberDto {
   /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
   budgetSetAtMillis?: number;
   /**
+   * The declared cognition-tier hint (`[[agent]].tier`) verbatim, from the same
+   * host-side helper that answers `GET .../team/{agentId}` (issue #643).
+   *
+   * **Optional on the type, and genuinely absent on the wire** for a teammate
+   * that declares none — which is a different statement from any tier string.
+   * Do not coalesce it to a default: the overview graph stamped a literal
+   * `"worker"` on every node for exactly this reason, so a company declaring
+   * `tier = "orchestrator"` read back as a worker on its own graph. `undefined`
+   * means "cannot say", and the honest rendering of that is "not declared".
+   */
+  tier?: string;
+  /**
+   * Whether this teammate is the company's orchestrator (issue #643).
+   *
+   * **NOT the same question as `tier`** — this is the host's roster rule (the
+   * agent tagged with the orchestrator tier, else the first declared agent),
+   * and the two disagree in both directions: a company that tags nobody still
+   * has an orchestrator (no `tier`, `true` here), and a second agent tagged
+   * with that tier is not one (`tier` present, `false` here). Never re-derive
+   * this from the tier string; read it.
+   *
+   * Optional only because a host predating #643 does not send it, in which case
+   * `undefined` means "this host cannot say" — draw no marker rather than
+   * guessing one from `tier`.
+   */
+  isOrchestrator?: boolean;
+  /**
    * This teammate's tool grants (issue #601) — the **same** three lists, from
    * the same host-side constructor, that `GET .../team/{agentId}` serves.
    *

--- a/frontend/src/lib/team.ts
+++ b/frontend/src/lib/team.ts
@@ -43,6 +43,21 @@ export interface TeamMember {
   /** When that cap was set (epoch millis). Paired with `budgetSetBy`. */
   budgetSetAtMillis?: number;
   /**
+   * The cognition tier this company declared for the teammate, verbatim
+   * (issue #643). Undefined means it declared none — render that as "not
+   * declared", never as a default tier.
+   */
+  tier?: string;
+  /**
+   * Whether the host resolved this teammate as the company's orchestrator.
+   *
+   * A separate question from `tier`, answered by the host's roster rule: an
+   * untagged company still has an orchestrator, and a second teammate tagged
+   * with the orchestrator tier is not one. Undefined means the host does not
+   * answer it.
+   */
+  isOrchestrator?: boolean;
+  /**
    * The tool grants this teammate **actually holds** — its own `[[agent]].tools`
    * line narrowed by the company's `[tools].allow`, resolved by the host
    * (issue #601).
@@ -101,6 +116,11 @@ export function fromDto(dto: TeamMemberDto): TeamMember {
     // which the card renders differently from "an admin set this".
     budgetSetBy: dto.budgetSetBy,
     budgetSetAtMillis: dto.budgetSetAtMillis,
+    // Same rule again (issue #643): `undefined` means the company declared no
+    // tier, or the host predates the field. Both are "cannot say" — coalescing
+    // either into a tier string is the bug this closed.
+    tier: dto.tier,
+    isOrchestrator: dto.isOrchestrator,
     // A host predating issue #601 sends neither, and an empty list is the
     // honest reading of that: it draws no tools and no desk rather than a
     // guess at either.

--- a/frontend/src/views/overview/kg/KnowledgeDetail.tsx
+++ b/frontend/src/views/overview/kg/KnowledgeDetail.tsx
@@ -146,7 +146,15 @@ export function AgentHarnessCard({
   agent, task, parentName, parentAgentId, subAgents, lastRun, runLabel, tools,
   onBack, onClose, onTool, onAgent, onTask,
 }: {
-  agent: { name: string; role: string; model: string; tier: string; instance: string; description: string };
+  /**
+   * `tier` is the company's declaration verbatim, `null` when it declared none;
+   * `isOrchestrator` is the host's separate roster answer (issue #643). The
+   * card renders both as given and derives neither from the other.
+   */
+  agent: {
+    name: string; role: string; model: string; tier: string | null;
+    isOrchestrator: boolean; instance: string; description: string;
+  };
   task: SopTask | null;
   parentName: string | null;
   parentAgentId: string | null;
@@ -191,7 +199,8 @@ export function AgentHarnessCard({
         <SectionLabel icon={Server}>harness</SectionLabel>
         <div className="mb-4 flex flex-col gap-1 font-mono text-[10.5px] text-os-muted">
           <span>
-            <span className="text-os-dim">tier</span> {agent.tier} · <span className="text-os-dim">runs on</span>{' '}
+            <span className="text-os-dim">tier</span> {agent.tier ?? 'not declared'}
+            {agent.isOrchestrator ? ' · orchestrator' : ''} · <span className="text-os-dim">runs on</span>{' '}
             {agent.instance} · {agent.model}
           </span>
           {parentName && (

--- a/frontend/src/views/overview/kg/adapter.ts
+++ b/frontend/src/views/overview/kg/adapter.ts
@@ -37,6 +37,14 @@
 // constructor the per-agent detail read uses, so the graph and the agent card
 // cannot disagree about who holds what (the rule issue #264 established).
 //
+// An agent's **tier** was the same gap with a louder symptom (issue #643): the
+// list carried none, so every node was stamped a literal `worker` and a company
+// declaring `tier = "orchestrator"` read back as a worker on its own graph. The
+// tier and the orchestrator marker are both host-answered now, through the same
+// constructor the detail card reads — and they are two questions, not one: the
+// tier is the declaration verbatim, the marker is the host's roster rule, and
+// nothing here re-derives the second from the first.
+//
 // Workflows were the last invention: `WORKFLOW_ROUTINES` dealt one made-up
 // routine per desk by position, and `model.ts` dealt its stages round-robin
 // across that desk's agents. Both are gone (issue #601). A workflow is one of
@@ -249,8 +257,21 @@ export function adapt(input: AdaptInput): Adapted {
     name: member.name,
     role: member.role,
     status: "active",
-    tier: "worker",
+    // The company's own answer, verbatim (issue #643). This was a literal
+    // `"worker"` on every node, so a company declaring `tier = "orchestrator"`
+    // read back as a worker on its own graph. `null` means the company declared
+    // no tier, which the card draws as "not declared" rather than as a default.
+    tier: member.tier ?? null,
+    // The host's roster rule, read — never re-derived from `tier`. The two are
+    // different questions: an untagged company still has an orchestrator, and a
+    // second agent tagged with that tier is not one.
+    isOrchestrator: member.isOrchestrator ?? false,
     description: member.description,
+    // Still a placeholder, deliberately. Resolving it console-side would mean a
+    // second copy of the host's `model_for_tier` — the #264 drift hazard this
+    // file keeps closing — and resolving it host-side is not available today:
+    // `src/harness` is feature-gated out of the default build that `src/server`
+    // compiles in, so the roster read has nothing to ask.
     model: "—",
     // What the host says this teammate actually holds, straight through: its
     // own `[[agent]].tools` line narrowed by the company's `[tools] allow`,

--- a/frontend/src/views/overview/kg/schemas.ts
+++ b/frontend/src/views/overview/kg/schemas.ts
@@ -9,7 +9,6 @@
 // the types both sides agree on.
 
 export type AgentStatus = "active" | "idle" | "paused";
-export type AgentTier = "lead" | "worker";
 
 export interface Department {
   id: string;
@@ -26,7 +25,22 @@ export interface Agent {
   name: string;
   role: string;
   status: AgentStatus;
-  tier: AgentTier;
+  /**
+   * The cognition tier this company declared for the agent, verbatim, or `null`
+   * when it declared none (issue #643).
+   *
+   * A free string rather than a closed union: the tier is the host's
+   * vocabulary, not the graph's, and the previous `"lead" | "worker"` union was
+   * a set the host never used — which is how every node came to be stamped
+   * `worker`. `null` is "not declared" and must be drawn as such.
+   */
+  tier: string | null;
+  /**
+   * Whether the host resolved this agent as the company's orchestrator — a
+   * separate question from {@link Agent.tier}, answered by the host's roster
+   * rule. Never re-derive it from the tier string.
+   */
+  isOrchestrator: boolean;
   description: string;
   model: string;
   tools: string[];

--- a/frontend/test/unit/overview-agent-tier.test.ts
+++ b/frontend/test/unit/overview-agent-tier.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+
+import type { Person as HostPerson } from "@/api/auth";
+import type { Task } from "@/api/tasks";
+import type { TeamMemberDto } from "@/api/types";
+import { fromDto, type TeamMember } from "@/lib/team";
+import { adapt } from "@/views/overview/kg/adapter";
+import { ownedBy } from "@/views/overview/pulse";
+
+/**
+ * The tier an agent draws with on the Overview graph (issue #643).
+ *
+ * The graph built every agent node with a literal `tier: "worker"`, so a
+ * company declaring `[[agent]] tier = "orchestrator"` read back as `tier
+ * worker` on its own graph. The root cause was a DTO gap, not a rendering bug:
+ * the graph is built from the roster **list**, and only the single-agent detail
+ * read carried a tier — the same gap #635 closed for tool grants and desks.
+ *
+ * Every failure here is silent on screen. A wrong tier draws a perfectly clean
+ * node; it just describes a company that does not exist, and it contradicts the
+ * agent detail card one click away.
+ *
+ * The two values are deliberately **two questions**, and each case below pins
+ * one of them against the other:
+ *
+ * - `tier` is the declaration, verbatim — absent means the company declared
+ *   none, which is not the same as any tier string.
+ * - `isOrchestrator` is the host's roster rule (tagged tier first, else the
+ *   first declared agent). The console must never re-derive it from `tier`:
+ *   an untagged CEO is the orchestrator with no tier at all, and a *second*
+ *   agent tagged with the orchestrator tier carries the tag without being one.
+ */
+
+const BASE = {
+  tasks: [] as Task[],
+  people: [] as HostPerson[],
+  workflows: [],
+  desks: [],
+  ownedBy,
+};
+
+/** A roster member as the console holds it, with the tier fields under test. */
+function member(id: string, over: Partial<TeamMember> = {}): TeamMember {
+  return {
+    id,
+    name: id,
+    role: "Worker",
+    description: "",
+    tone: "a",
+    inboxEnabled: false,
+    effectiveTools: [],
+    desks: [],
+    ...over,
+  };
+}
+
+/** The agents the graph would draw for this roster. */
+function graphAgents(members: TeamMember[]) {
+  return adapt({ ...BASE, members }).agents;
+}
+
+describe("the graph draws the tier the company declared", () => {
+  it("carries a declared tier through to the node verbatim", () => {
+    const agents = graphAgents([
+      member("ceo", { tier: "orchestrator", isOrchestrator: true }),
+      member("writer", { tier: "reasoning" }),
+      member("intern"),
+    ]);
+
+    expect(agents.find((a) => a.id === "ceo")!.tier).toBe("orchestrator");
+    expect(agents.find((a) => a.id === "writer")!.tier).toBe("reasoning");
+
+    // The negative control: an undeclared tier stays undeclared. `null` is the
+    // graph's "cannot say" — substituting anything here is the whole of #643.
+    expect(agents.find((a) => a.id === "intern")!.tier).toBeNull();
+
+    // The literal regression assertion. Nobody declared "worker", so no node
+    // may carry it — this is the exact string the graph used to stamp on every
+    // agent it drew.
+    expect(agents.map((a) => a.tier)).not.toContain("worker");
+  });
+
+  it("reads the orchestrator marker from the host rather than from the tier", () => {
+    // An untagged CEO: the host resolved it as the orchestrator by roster
+    // position, and it declares no tier at all. A console deriving the marker
+    // from the tier string would draw this one unmarked.
+    const [ceo] = graphAgents([member("ceo", { isOrchestrator: true })]);
+    expect(ceo.tier).toBeNull();
+    expect(ceo.isOrchestrator).toBe(true);
+
+    // The negative control, the other way round: a second agent tagged with the
+    // orchestrator tier is not the orchestrator. The tag shows; the marker does
+    // not. A tier-derived marker would draw two orchestrators on one company.
+    const [, second] = graphAgents([
+      member("ceo", { tier: "orchestrator", isOrchestrator: true }),
+      member("deputy", { tier: "orchestrator", isOrchestrator: false }),
+    ]);
+    expect(second.tier).toBe("orchestrator");
+    expect(second.isOrchestrator).toBe(false);
+  });
+
+  it("says nothing for a host that answers neither", () => {
+    // A host predating #643 sends no tier and no marker. `fromDto` leaves both
+    // undefined, and the graph draws "cannot say" — never a default tier and
+    // never a marker guessed from the tier's absence.
+    const old = fromDto({ id: "ada", role: "Engineer" } satisfies TeamMemberDto);
+    const [agent] = graphAgents([old]);
+
+    expect(agent.tier).toBeNull();
+    expect(agent.tier).not.toBe("worker");
+    expect(agent.isOrchestrator).toBe(false);
+  });
+});
+
+describe("fromDto passes both fields straight through", () => {
+  it("keeps an absent field absent rather than defaulting it", () => {
+    const declared = fromDto({
+      id: "ceo",
+      role: "Chief Executive",
+      tier: "orchestrator",
+      isOrchestrator: true,
+    });
+    expect(declared.tier).toBe("orchestrator");
+    expect(declared.isOrchestrator).toBe(true);
+
+    // The negative control: `undefined` must survive the mapping as
+    // `undefined`. The same rule `budgetUsdDaily` follows — a coalesced default
+    // here would be indistinguishable from a host that answered.
+    const silent = fromDto({ id: "intern", role: "Intern" });
+    expect(silent.tier).toBeUndefined();
+    expect(silent.isOrchestrator).toBeUndefined();
+
+    // And a host that answers `false` is not the same as one that says nothing,
+    // even though both draw unmarked.
+    expect(fromDto({ id: "w", role: "W", isOrchestrator: false }).isOrchestrator).toBe(false);
+  });
+});

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -79,6 +79,32 @@ struct TeamMemberDto {
     role: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     description: Option<String>,
+    /// The declared cognition-tier hint (`[[agent]].tier`) **verbatim**, absent
+    /// when this teammate declares none — from the same constructor as
+    /// `GET …/team/{agent_id}` (issue #643).
+    ///
+    /// Carried on the list for the reason `tools` and `desks` are: the overview
+    /// graph is built from the roster read, so a field the list omitted was a
+    /// field the graph had to invent. It invented this one as a literal
+    /// `worker` on every node, and a company declaring `tier = "orchestrator"`
+    /// read back as a worker on its own graph.
+    ///
+    /// Absent is a real answer — "this teammate declares no tier" — and is why
+    /// the key is skipped rather than defaulted. A default here is precisely
+    /// the bug: it is indistinguishable from a declaration on the wire.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tier: Option<String>,
+    /// Whether this teammate is the company's orchestrator, resolved by the
+    /// roster rule (tagged tier first, else the first declared agent) — the
+    /// same field, from the same helper, as the detail read (issue #643).
+    ///
+    /// **Not** derivable from `tier`, which is why it is sent rather than left
+    /// to the client: a company that tags nobody still has an orchestrator (no
+    /// tier, `true` here), and a second agent tagged with the orchestrator tier
+    /// is not one (tier present, `false` here). Always sent, so a client never
+    /// has to guess — unlike `tier`, "no orchestrator" is not a state a company
+    /// with a roster can be in.
+    is_orchestrator: bool,
     /// This teammate's tool grants, in the **same shape and from the same
     /// constructor** as `GET …/team/{agent_id}` (issue #601).
     ///
@@ -293,9 +319,13 @@ fn member_row(
         name,
         role,
         description,
-        // Both through `team_agent`'s constructors, never recomputed here: the
+        // All four through `team_agent`'s helpers, never recomputed here: the
         // roster list and the detail read must not be able to disagree about
-        // the same teammate (issues #264, #601).
+        // the same teammate (issues #264, #601, #643). A second copy of the
+        // orchestrator rule in particular would be a copy of a rule that has
+        // two arms, and the arm it dropped would be invisible on screen.
+        tier: super::team_agent::declared_tier(record, agent_id),
+        is_orchestrator: super::team_agent::is_orchestrator(record, agent_id),
         tools: super::team_agent::agent_tools(
             &record.manifest.tools.allow,
             super::team_agent::requested_grants(record, agent_id),
@@ -413,10 +443,13 @@ async fn add_member(
         .save(&record)
         .await
         .map_err(|e| ApiError(e).into_response())?;
-    // A brand-new overlay teammate has no `[[agent]].tools` line, so it holds
-    // the company's standard grant, and it sits on no desk until somebody adds
-    // it to one. Resolved through the shared constructors rather than written
-    // out here, so this response cannot drift from the two reads (issue #601).
+    // A brand-new overlay teammate has no `[[agent]]` row at all, so it declares
+    // no tier, holds the company's standard grant, and sits on no desk until
+    // somebody adds it to one. Resolved through the shared helpers rather than
+    // written out here, so this response cannot drift from the two reads
+    // (issues #601, #643).
+    let tier = super::team_agent::declared_tier(&record, &agent.id);
+    let is_orchestrator = super::team_agent::is_orchestrator(&record, &agent.id);
     let tools = super::team_agent::agent_tools(
         &record.manifest.tools.allow,
         super::team_agent::requested_grants(&record, &agent.id),
@@ -427,6 +460,8 @@ async fn add_member(
         name: Some(agent.name),
         role: agent.role,
         description: agent.description,
+        tier,
+        is_orchestrator,
         tools,
         desks,
         // A brand-new teammate has no inbox until the toggle writes one.
@@ -1421,6 +1456,158 @@ mod tests {
         assert!(
             writer.get("budgetUsdDaily").is_none() && writer.get("spentTodayUsd").is_none(),
             "{writer}"
+        );
+    }
+
+    // --- Declared tier on the roster list (issue #643) -----------------------
+
+    /// A roster whose three teammates each answer the tier question
+    /// differently: `ceo` is tagged as the orchestrator, `writer` declares a
+    /// *non*-orchestrator tier, and `intern` declares nothing at all.
+    const TIERED_ROSTER: &str = "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief Executive\"\ntier = \"orchestrator\"\n\
+         [[agent]]\nid = \"writer\"\nrole = \"Writer\"\ntier = \"reasoning\"\n\
+         [[agent]]\nid = \"intern\"\nrole = \"Intern\"\n";
+
+    /// One agent from `GET …/team/{id}` — the detail read, for cross-checking
+    /// that the list has not grown a second opinion.
+    async fn agent_detail_row(state: &AppState, agent: &str) -> Value {
+        let (status, body) = send(
+            state,
+            "GET",
+            &format!("/api/v1/company/team/{agent}"),
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        body
+    }
+
+    /// Issue #643 — the declared tier reaches the roster list verbatim.
+    ///
+    /// The list carried no tier at all, so the overview graph (built from this
+    /// read) stamped a literal `worker` on every node: a company declaring
+    /// `tier = "orchestrator"` read back as a worker on its own graph.
+    ///
+    /// The **undeclared** teammate is the half that keeps the fix honest. Its
+    /// row must omit the key entirely — not `"worker"`, not `null` — because
+    /// absence is the only wire shape that says "this company declares no tier
+    /// here" rather than asserting one on its behalf.
+    #[tokio::test]
+    async fn the_roster_list_carries_each_declared_tier_verbatim() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), TIERED_ROSTER).await;
+
+        let ceo = team_row(&state, "ceo").await;
+        assert_eq!(ceo["tier"], "orchestrator", "{ceo}");
+        assert_eq!(ceo["isOrchestrator"], true, "{ceo}");
+
+        // A declared tier that is not the orchestrator tier: carried verbatim,
+        // and it does not make the teammate the orchestrator.
+        let writer = team_row(&state, "writer").await;
+        assert_eq!(writer["tier"], "reasoning", "{writer}");
+        assert_eq!(
+            writer["isOrchestrator"], false,
+            "a declared tier is a hint, not the roster rule: {writer}"
+        );
+
+        // The negative control: undeclared means no key.
+        let intern = team_row(&state, "intern").await;
+        assert!(
+            intern.get("tier").is_none(),
+            "an undeclared tier omits the key — a defaulted \"worker\" here is \
+             indistinguishable from a declaration and is the whole of #643: {intern}"
+        );
+        assert_eq!(intern["isOrchestrator"], false, "{intern}");
+
+        // No row anywhere invents the literal the graph used to print.
+        let (_, all) = get_team(&state).await;
+        for row in all.as_array().unwrap() {
+            assert_ne!(row["tier"], "worker", "nobody declared \"worker\": {row}");
+        }
+
+        // And the list agrees with the detail read, which is the property the
+        // shared helpers exist to make unrepresentable rather than merely true.
+        for id in ["ceo", "writer", "intern"] {
+            let (list, detail) = (
+                team_row(&state, id).await,
+                agent_detail_row(&state, id).await,
+            );
+            assert_eq!(
+                list.get("tier"),
+                detail.get("tier"),
+                "{id}: {list} {detail}"
+            );
+            assert_eq!(
+                list["isOrchestrator"], detail["isOrchestrator"],
+                "{id}: {list} {detail}"
+            );
+        }
+    }
+
+    /// A company that tags nobody still has an orchestrator: the first declared
+    /// agent, by the same roster rule the harness resolves with.
+    ///
+    /// This is the case a console that re-derived the marker from the tier
+    /// string would get wrong — and get wrong invisibly, since an untagged CEO
+    /// draws as an ordinary worker rather than as an error.
+    #[tokio::test]
+    async fn an_untagged_roster_still_names_an_orchestrator_on_the_list() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let analyst = team_row(&state, "analyst").await;
+        assert_eq!(
+            analyst["isOrchestrator"], true,
+            "the first declared agent is the orchestrator when nobody is tagged: {analyst}"
+        );
+        assert!(
+            analyst.get("tier").is_none(),
+            "…and it says so without inventing a tier for them: {analyst}"
+        );
+
+        // The negative control: exactly one, and it is the first.
+        let writer = team_row(&state, "writer").await;
+        assert_eq!(writer["isOrchestrator"], false, "{writer}");
+    }
+
+    /// An overlay teammate has no manifest row, so it declares no tier and the
+    /// roster rule never picks it — even on a company whose manifest roster is
+    /// empty, where "the first declared agent" names nobody at all.
+    #[tokio::test]
+    async fn an_overlay_teammate_declares_no_tier_and_is_not_the_orchestrator() {
+        let home_dir = home();
+        let state = state_with_manifest(
+            home_dir.path(),
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+
+        let (status, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Nova", "role": "Researcher"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{created}");
+        assert!(
+            created.get("tier").is_none() && created["isOrchestrator"] == false,
+            "the create response answers both the same way the reads do: {created}"
+        );
+
+        let id = created["id"].as_str().unwrap().to_string();
+        let row = team_row(&state, &id).await;
+        assert!(
+            row.get("tier").is_none(),
+            "an overlay teammate has no `[[agent]]` row to declare a tier: {row}"
+        );
+        assert_eq!(
+            row["isOrchestrator"], false,
+            "an empty manifest roster names nobody, so it does not fall through \
+             to the overlay half: {row}"
         );
     }
 }

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -193,6 +193,46 @@ pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<St
         .unwrap_or_default()
 }
 
+/// The **declared** cognition-tier hint for `agent_id`: the manifest
+/// `[[agent]].tier` line verbatim, or `None` when the row declares none — and
+/// for every overlay teammate, which has no manifest row to declare one.
+///
+/// Verbatim is the whole contract. This is what the company *wrote*, not a
+/// resolved answer, and `None` means **undeclared** — a reader has to render
+/// that as "cannot say" rather than substituting a default. Issue #643 is
+/// exactly that substitution: the overview graph printed a literal `worker` for
+/// every teammate, so a company declaring `tier = "orchestrator"` read back as
+/// a worker on its own graph.
+///
+/// Sibling of [`requested_grants`] in shape and in reason: one lookup, shared
+/// by the roster list and the detail read, so the two cannot answer differently
+/// for the same teammate.
+pub(super) fn declared_tier(record: &CompanyRecord, agent_id: &str) -> Option<String> {
+    record
+        .manifest
+        .agents
+        .iter()
+        .find(|agent| agent.id == agent_id)
+        .and_then(|agent| agent.tier.clone())
+}
+
+/// Whether `agent_id` is this company's orchestrator.
+///
+/// Delegates to [`crate::company::orchestrator_id`] — the roster rule the
+/// harness itself resolves the orchestrator with (the agent tagged with the
+/// orchestrator tier, else the first declared agent), never a re-read of
+/// [`declared_tier`].
+///
+/// **This is not the same question as the tier.** A company that tags nobody
+/// still has an orchestrator, so an untagged first agent answers `true` here
+/// while [`declared_tier`] answers `None`; and a *second* agent tagged with the
+/// orchestrator tier carries that tier while answering `false` here, because the
+/// rule picks one. A caller that re-derived the marker from the tier string
+/// would get both of those backwards.
+pub(super) fn is_orchestrator(record: &CompanyRecord, agent_id: &str) -> bool {
+    crate::company::orchestrator_id(&record.manifest.agents) == Some(agent_id)
+}
+
 /// One agent's grants at all three levels — the single constructor for
 /// [`AgentToolsDto`].
 ///
@@ -368,7 +408,7 @@ async fn detail(
     let manifest_agent = record.manifest.agents.iter().find(|a| a.id == agent_id);
     let overlay_agent = record.overlay_agents.iter().find(|a| a.id == agent_id);
 
-    let (source, name, role, description, tier) = match (manifest_agent, overlay_agent) {
+    let (source, name, role, description) = match (manifest_agent, overlay_agent) {
         // A manifest agent wins an id collision, exactly as `build_roster`
         // resolves one: the version-controlled roster is authoritative.
         (Some(agent), _) => (
@@ -376,18 +416,15 @@ async fn detail(
             None,
             agent.role.clone(),
             agent.description.clone(),
-            agent.tier.clone(),
         ),
+        // An overlay teammate has no manifest row, so `declared_tier` below
+        // misses — and so does `requested_grants`: it holds the company's
+        // standard grant, mirroring `harness::overlay_agent_to_manifest`.
         (None, Some(agent)) => (
             AgentSource::Overlay,
             Some(agent.name.clone()),
             agent.role.clone(),
             agent.description.clone(),
-            // An overlay teammate has no manifest row, so no tier — and, in
-            // `requested_grants` below, no per-agent tool line either: it holds
-            // the company's standard grant, mirroring
-            // `harness::overlay_agent_to_manifest`.
-            None,
         ),
         (None, None) => {
             return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
@@ -423,8 +460,8 @@ async fn detail(
             AgentSource::Overlay => OVERLAY_EDITABLE.to_vec(),
             AgentSource::Manifest => Vec::new(),
         },
-        tier,
-        is_orchestrator: crate::company::orchestrator_id(&record.manifest.agents) == Some(agent_id),
+        tier: declared_tier(record, agent_id),
+        is_orchestrator: is_orchestrator(record, agent_id),
         tools: agent_tools(
             &record.manifest.tools.allow,
             requested_grants(record, agent_id),


### PR DESCRIPTION
## Summary

The Overview knowledge graph told every teammate they were a worker. It built each agent node with a literal `tier: "worker"`, so a company declaring

```toml
[[agent]]
id = "ceo"
tier = "orchestrator"
```

still read `tier worker` on the one screen an operator opens to understand how the company is arranged.

`tier` is not cosmetic — it selects the model a teammate runs on (`model_for_tier`) and it is how the orchestrator is distinguished from the rest of the roster.

The cause is the DTO gap #601 closed for tool grants and desks: the graph is built from the **roster list**, and the roster list carried no tier. Only the single-agent detail read did. So the console had nothing to ask and asserted a value instead.

This closes the gap the same way #635 did — one constructor, read by both surfaces, so they cannot drift (#264).

**Two facts, not one.** `tier` is the declared hint, verbatim. `isOrchestrator` is the host's roster rule — *first agent tagged orchestrator, else the first agent declared* — which is a different question, because a company that tags nobody still has a real orchestrator. The console never re-derives the marker from the tier string; it carries the host's answer.

## API Or Behavior Changes

**Host — additive only.** `TeamMemberDto` on `GET {scope}/team` gains `tier: Option<String>` (omitted entirely when undeclared) and `is_orchestrator: bool`. Both are filled through two new shared helpers — `declared_tier()` and `is_orchestrator()` — that the single-agent detail read now also uses. No new endpoint, no removed field, no manifest change.

**Console:**

1. An agent's card shows the declared tier verbatim, and appends ` · orchestrator` when the host resolves that teammate as the orchestrator.
2. **An undeclared tier renders `not declared`, never `worker`.** Defaulting to a plausible value is the original bug in a quieter form, so it is pinned by tests on both sides of the wire.
3. `AgentTier` (`"lead" | "worker"`) is deleted. It could not represent the manifest's vocabulary (`orchestrator`, `reasoning`, `agentic`, `vision`), and `"lead"` was never produced by anything. The renderer's "tier radius" is a level-of-detail concept and is untouched.
4. The console fields are optional, so an older host reads as "cannot say" rather than a wrong value.

**`model` deliberately stays `"—"`.** Filling it console-side would duplicate the host's `model_for_tier` — the exact drift #264 forbids. Filling it host-side is blocked today because `src/harness` is feature-gated out of the default build, where `src/server/ops` compiles; doing it properly means ungating `model_for_tier` and deciding what "model" means on a build with no harness. That is a deliberate follow-up, not a rider, and the placeholder now carries a comment saying so rather than reading as data.

## Tests

Rust (`src/server/ops/team.rs`), 638 passed:

- Tagged CEO + a `reasoning` writer + an undeclared intern → tiers verbatim on the list rows. Negative controls: the intern row carries **no `tier` key at all** (not `"worker"`, not `null`), and the writer is not the orchestrator.
- A fully untagged roster → the first declared agent resolves as orchestrator with no tier key; the second does not.
- An overlay teammate → no tier, not the orchestrator, even against an empty manifest roster.
- The create response (`add_member`) is asserted to agree with both reads.

Console (`frontend/test/unit/overview-agent-tier.test.ts`), 364 passed:

- A declared tier reaches the graph verbatim; an undeclared one becomes `null`, and **no agent anywhere carries `"worker"`** — the literal regression assertion for this issue.
- The marker is the host's answer: `isOrchestrator` passes through with no tier, and a teammate tagged `orchestrator` whose host answer is `false` stays **unmarked**.
- A DTO carrying neither key (older host) reads as `null` with no marker.

**Six negative controls were run for real** — each fix broken, the specific test watched to fail, then restored: tier defaulting to `"worker"`; the orchestrator re-derived from the tier string; the orchestrator falling through on an empty manifest roster; the adapter hardcode restored; the adapter re-deriving the marker; and `fromDto` coalescing.

Three honest limits, stated rather than dressed up:

- The list-vs-detail cross-check did **not** fail when the shared helper was broken — both surfaces read the same broken rule and still agreed. That assertion guards drift between the two reads, not correctness of the rule; a different test catches a wrong rule.
- Some tests pass under breaks in a layer they do not exercise. Each guards its own layer, and no cross-layer coverage is claimed.
- One assertion expected to fail under a control was short-circuited by an earlier one in the same test, so it was not observed failing independently.

**Verified on a running host**, not only in unit tests. Against the `e2e_harness` company, whose CEO is declared `orchestrator` and whose other two teammates declare nothing:

- CEO card reads `tier orchestrator · orchestrator`.
- Engineer reads `tier not declared`, with no marker — both halves of the fix in one card.
- The org chart agrees with the graph, and the console logs no errors.

Not verified by eye: the untagged-orchestrator case (`tier not declared · orchestrator`), because the fixture tags its CEO. That path is covered by the Rust test above rather than in a browser.

## Documentation

- The adapter's file-header provenance table now records tier and orchestrator as host-answered through the same constructor as the detail card.
- The `model` placeholder carries the two reasons it is still a placeholder.
- The console DTO mirrors the host's warning that the orchestrator marker is **not** the same question as `tier == "orchestrator"`.

Closes #643
