### PR TITLE
feat(policy): let the operator change the autonomy tier from the console (#562)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -322,24 +322,25 @@ The three **policy** routes (issue #562) are the company-scoped twin of the
 budget pair. Before them the autonomy tier lived only in `[policy].mode` and
 nothing in the console read or wrote it, so an operator drowning in approval
 cards could change it only by redeploying an edited `company.toml` — or, on a
-hosted tenant whose manifest is a read-only snapshot, not at all.
+hosted tenant with a read-only manifest snapshot, not at all.
 
 `GET` returns the tier and always-ask list **in force**, what the manifest would
 restore, whether an override is set and by whom, and the selectable tiers with
 the host's own description of each (`POLICY_MODES` narrowed to tiers the console
-has text for, so it never offers one the host would downgrade). `PUT` takes
-`mode` and `alwaysApprove`, both optional and independent — `{"mode": "auto"}`
+has text for, so it never offers one the host would downgrade). `PUT` takes `mode`
+and `alwaysApprove`, both optional and independent — `{"mode": "auto"}`
 leaves the list alone, `{"alwaysApprove": []}` clears it (a real state, not a
 reset), `{"mode": null}` stops overriding the tier, and `{}` is a **`422`**
 because a body that sets nothing is never stored. An unknown `mode` is `422`
 too, not accepted-and-downgraded, or the console would show a tier the gate was
 not running. Both writes are admin-only and attributed. `DELETE` restores the
 manifest's `[policy]` — its own verb, since a `PUT` of the manifest's current
-values would pin them against a later `company.toml` edit. The change takes
-effect on the company's **next turn** (`ApprovalPolicy` is built per roster
-build, and this override is fingerprinted alongside the other freshness axes),
-and it survives a rebuild — so tightening `[policy]` in `company.toml` does not
-clear a looser tier set here.
+values would pin them. The change takes effect on the company's **next turn**
+(`ApprovalPolicy` is built per roster build, and this override is fingerprinted
+alongside the other freshness axes). It survives a rebuild unless the seed's
+`[policy]` itself changed: version control wins when it speaks, so tightening
+`company.toml` clears a looser tier set here, and a redeploy that changed
+nothing does not.
 
 ### Credential-bearing surfaces (feature-gated)
 

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -153,6 +153,9 @@ DELETE …/team/{agentId}                      remove an overlay teammate
 PUT    …/team/{agentId}/inbox                toggle a teammate's inbox
 PUT    …/team/{agentId}/budget               set / change / remove a daily cap
 DELETE …/team/{agentId}/budget               reset the cap to the manifest default
+GET    …/policy                              the autonomy tier + always-ask list
+PUT    …/policy                              set the tier and/or the always-ask list
+DELETE …/policy                              reset the policy to the manifest's
 POST   …/inboxes/{key}/read                  mark inbox messages read
 POST   …/inboxes/ingest                     HMAC-signed inbound email → inbox
 GET    …/inboxes                            list inboxes + unread counts
@@ -314,6 +317,29 @@ A negative or non-finite amount is `400`; an unknown teammate is `404`.
 from `PUT null`, and not expressible by it. `POST …/team` also accepts an
 optional `budgetUsdDaily`, so a console-created teammate can be given a cap at
 creation; only that form of the add requires an admin.
+
+The three **policy** routes (issue #562) are the company-scoped twin of the
+budget pair. Before them the autonomy tier lived only in `[policy].mode` and
+nothing in the console read or wrote it, so an operator drowning in approval
+cards could change it only by redeploying an edited `company.toml` — or, on a
+hosted tenant whose manifest is a read-only snapshot, not at all.
+
+`GET` returns the tier and always-ask list **in force**, what the manifest would
+restore, whether an override is set and by whom, and the selectable tiers with
+the host's own description of each (`POLICY_MODES` narrowed to tiers the console
+has text for, so it never offers one the host would downgrade). `PUT` takes
+`mode` and `alwaysApprove`, both optional and independent — `{"mode": "auto"}`
+leaves the list alone, `{"alwaysApprove": []}` clears it (a real state, not a
+reset), `{"mode": null}` stops overriding the tier, and `{}` is a **`422`**
+because a body that sets nothing is never stored. An unknown `mode` is `422`
+too, not accepted-and-downgraded, or the console would show a tier the gate was
+not running. Both writes are admin-only and attributed. `DELETE` restores the
+manifest's `[policy]` — its own verb, since a `PUT` of the manifest's current
+values would pin them against a later `company.toml` edit. The change takes
+effect on the company's **next turn** (`ApprovalPolicy` is built per roster
+build, and this override is fingerprinted alongside the other freshness axes),
+and it survives a rebuild — so tightening `[policy]` in `company.toml` does not
+clear a looser tier set here.
 
 ### Credential-bearing surfaces (feature-gated)
 

--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -28,9 +28,12 @@ fields are independently optional, so `None` means "not overridden" while
 rather than a manifest write **by necessity**: a rebuild re-persists
 `record.manifest` from the seed and merges only `[workflows].enabled`, because
 for `[tools]` / `[policy]` a record-wins merge would let a runtime grant outlive
-the operator revoking it in version control. The trade that leaves is real and
-deliberate — a tier loosened here outlives a `company.toml` edit, so it is
-attributed and clearing it is its own explicit operation.
+the operator revoking it in version control. It is cleared by either of two paths: the seed's
+`[policy]` **changing** across a rebuild (`carry_policy_override` — version
+control wins when it speaks, and stays quiet when it doesn't, so a redeploy that
+changed nothing does not silently revert the operator), or an explicit
+`DELETE …/policy`. Between seed edits it is durable, and attributed, so the
+console can show who moved the gate and when.
 And (issue #168) `overlay_workflows`: the
 workflow graph bodies authored at runtime through the console's create dialog or
 the orchestrator's `create_workflow` tool. These are persisted here rather than

--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -19,6 +19,18 @@ console cannot be honoured by one surface and ignored by another. At most one
 `overlay_budgets` entry may exist per teammate — the console write path upserts
 through `CompanyRecord::upsert_budget_override`, and a bundle import carrying two
 entries for the same teammate is rejected rather than resolved by guesswork.
+And (issue #562) `overlay_policy`: the operator's `[policy]` override — the
+autonomy tier and always-ask list an admin sets from the console, read through
+`CompanyRecord::effective_policy`, which resolves it *ahead* of the manifest for
+the same single-reconciliation-point reason as `effective_budget`. Its two
+fields are independently optional, so `None` means "not overridden" while
+`Some(vec![])` is a deliberately emptied always-ask list. It is an overlay
+rather than a manifest write **by necessity**: a rebuild re-persists
+`record.manifest` from the seed and merges only `[workflows].enabled`, because
+for `[tools]` / `[policy]` a record-wins merge would let a runtime grant outlive
+the operator revoking it in version control. The trade that leaves is real and
+deliberate — a tier loosened here outlives a `company.toml` edit, so it is
+attributed and clearing it is its own explicit operation.
 And (issue #168) `overlay_workflows`: the
 workflow graph bodies authored at runtime through the console's create dialog or
 the orchestrator's `create_workflow` tool. These are persisted here rather than

--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -24,7 +24,9 @@ autonomy tier and always-ask list an admin sets from the console, read through
 `CompanyRecord::effective_policy`, which resolves it *ahead* of the manifest for
 the same single-reconciliation-point reason as `effective_budget`. Its two
 fields are independently optional, so `None` means "not overridden" while
-`Some(vec![])` is a deliberately emptied always-ask list. It is an overlay
+`Some(vec![])` is a deliberately emptied always-ask list. An unknown stored
+tier falls back to the manifest rather than to `supervised`, so version skew
+cannot loosen a `readonly` seed. It is an overlay
 rather than a manifest write **by necessity**: a rebuild re-persists
 `record.manifest` from the seed and merges only `[workflows].enabled`, because
 for `[tools]` / `[policy]` a record-wins merge would let a runtime grant outlive

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -92,6 +92,7 @@ async fn main() -> anyhow::Result<()> {
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/frontend/src/api/policy.ts
+++ b/frontend/src/api/policy.ts
@@ -1,0 +1,108 @@
+// The autonomy-tier API (issue #562): the console reads and writes the
+// company's effective `[policy]` through the host's `.../policy` routes (REST,
+// camelCase over the wire).
+//
+// The effective policy is the operator's console override where it sets a
+// field, and the committed manifest `[policy]` everywhere else. The console
+// never writes the manifest — a rebuild re-persists that from the seed, and for
+// `[policy]` that is a deliberate security property — so a change here is a
+// durable, attributed *override* the host resolves ahead of the manifest.
+//
+// Standalone functions over the shared client (mirrors `api/inference.ts`), so
+// no change to `OpenCompanyClient` or the shared `api/types.ts` is needed.
+
+import type { OpenCompanyClient } from "./client";
+
+/**
+ * One selectable tier, with the host's own words for what it means.
+ *
+ * The prose comes from the host rather than living here on purpose: it
+ * describes what this runtime's approval gate actually does, and a copy in
+ * TypeScript would drift from the behaviour it claims to describe. The list
+ * also only contains tiers the host accepts, so a console built against a newer
+ * or older host offers exactly what that host can honour.
+ */
+export interface PolicyTier {
+  /** The `[policy].mode` word. */
+  value: string;
+  /** The operator-facing label. */
+  label: string;
+  /** What choosing it means, in consequences rather than tier vocabulary. */
+  description: string;
+}
+
+/** The company's effective policy, plus what a reset would restore. */
+export interface PolicyStatus {
+  /** The tier actually in force. */
+  mode: string;
+  /**
+   * The always-ask list actually in force — the operator's real lever. It wins
+   * over every tier, `full` included.
+   */
+  alwaysApprove: string[];
+  /** The manifest's tier, so "reset" can name what it would restore. */
+  manifestMode: string;
+  /** The manifest's always-ask list, for the same reason. */
+  manifestAlwaysApprove: string[];
+  /**
+   * Whether an operator override is in force.
+   *
+   * Deliberately not derivable by comparing the values: an override that
+   * happens to match the manifest is still an override, and is still what a
+   * reset would remove.
+   */
+  overridden: boolean;
+  /** Who set the override, if one is set. */
+  setBy?: string;
+  /** When it was set (epoch millis), if one is set. */
+  setAtMillis?: number;
+  /** The selectable tiers, in increasing order of autonomy. */
+  tiers: PolicyTier[];
+  /**
+   * When a change bites, in the host's words.
+   *
+   * Rendered rather than paraphrased: a tier change lands on the company's
+   * NEXT turn, so a turn already running finishes under the previous tier.
+   * Since "stop the flood now" is what an operator comes here to do, that gap
+   * is worth stating rather than leaving them to discover.
+   */
+  takesEffect: string;
+}
+
+/**
+ * The set-policy body. Omit a field to leave it alone; send `null` to stop
+ * overriding it.
+ *
+ * `alwaysApprove: []` is an operator deliberately clearing the always-ask list,
+ * which is NOT the same as omitting the field. Sending neither field is a 422
+ * rather than a silent no-op.
+ */
+export interface SetPolicyInput {
+  mode?: string | null;
+  alwaysApprove?: string[] | null;
+}
+
+/** The company's effective policy. */
+export function getPolicy(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<PolicyStatus> {
+  return client.get<PolicyStatus>(`${client.scopeFor(company)}/policy`);
+}
+
+/** Set the tier and/or the always-ask list. Admin-only, attributed. */
+export function setPolicy(
+  client: OpenCompanyClient,
+  company: string | null,
+  body: SetPolicyInput,
+): Promise<PolicyStatus> {
+  return client.put<PolicyStatus>(`${client.scopeFor(company)}/policy`, body);
+}
+
+/** Drop the override so the manifest's `[policy]` applies again. */
+export function resetPolicy(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<PolicyStatus> {
+  return client.del<PolicyStatus>(`${client.scopeFor(company)}/policy`);
+}

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -54,6 +54,10 @@ export function PolicySettings({ client, company }: Props) {
   const [status, setStatus] = useState<PolicyStatus | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  // Distinguishes "still loading" from "load finished and failed". Without it,
+  // `loading || !status` renders the spinner forever on a failed load and the
+  // operator has no way to retry.
+  const [loadError, setLoadError] = useState<string | null>(null);
   // The always-ask list is edited as text and only committed on Save, so a
   // half-typed effect kind never reaches the gate.
   const [draftAlways, setDraftAlways] = useState("");
@@ -61,15 +65,17 @@ export function PolicySettings({ client, company }: Props) {
 
   const load = useCallback(async () => {
     setLoading(true);
+    setLoadError(null);
     try {
       const next = await getPolicy(client, company);
       setStatus(next);
       setDraftAlways(next.alwaysApprove.join(", "));
       setDirty(false);
     } catch (error) {
-      toast.error(
-        error instanceof Error ? error.message : "Could not load the policy.",
-      );
+      const message =
+        error instanceof Error ? error.message : "Could not load the policy.";
+      setLoadError(message);
+      toast.error(message);
     } finally {
       setLoading(false);
     }
@@ -79,11 +85,21 @@ export function PolicySettings({ client, company }: Props) {
     void load();
   }, [load]);
 
-  /** Applies a server response, resyncing the draft so it cannot drift. */
-  const apply = (next: PolicyStatus, message: string) => {
+  /**
+   * Applies a server response.
+   *
+   * `resyncDraft` is false when the operator has unsaved always-ask edits: the
+   * server's list is authoritative for what the gate is enforcing, but
+   * overwriting the box would silently discard what they were part-way through
+   * typing. The tier request does not touch the list, so leaving the draft
+   * alone keeps the two independent — the same separation the `PUT` body has.
+   */
+  const apply = (next: PolicyStatus, message: string, resyncDraft = true) => {
     setStatus(next);
-    setDraftAlways(next.alwaysApprove.join(", "));
-    setDirty(false);
+    if (resyncDraft) {
+      setDraftAlways(next.alwaysApprove.join(", "));
+      setDirty(false);
+    }
     toast.success(message, { description: next.takesEffect });
   };
 
@@ -94,7 +110,12 @@ export function PolicySettings({ client, company }: Props) {
       // Only `mode` is sent: an omitted field leaves the always-ask list where
       // it is, so picking a tier cannot silently discard a list the operator
       // edited earlier.
-      apply(await setPolicy(client, company, { mode }), "Autonomy tier updated");
+      // `dirty` means the operator has unsaved list edits; keep them.
+      apply(
+        await setPolicy(client, company, { mode }),
+        "Autonomy tier updated",
+        !dirty,
+      );
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Could not change the tier.",
@@ -157,10 +178,19 @@ export function PolicySettings({ client, company }: Props) {
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-6">
-        {loading || !status ? (
+        {loading ? (
           <div className="flex items-center gap-2 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" />
             Loading the current policy…
+          </div>
+        ) : !status ? (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              {loadError ?? "Could not load the policy."}
+            </p>
+            <Button size="sm" variant="outline" onClick={() => void load()}>
+              Try again
+            </Button>
           </div>
         ) : (
           <>

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -46,6 +46,9 @@ interface Props {
  *   so a turn already running finishes under the old one. Since stopping the
  *   flood *now* is exactly why an operator is here, that gap is stated instead
  *   of being left to discover.
+ * - **That version control outranks it.** The override is durable between seed
+ *   edits, but editing `[policy]` in `company.toml` clears it. An operator who
+ *   cannot see that would be surprised by a redeploy.
  */
 export function PolicySettings({ client, company }: Props) {
   const [status, setStatus] = useState<PolicyStatus | null>(null);
@@ -229,8 +232,9 @@ export function PolicySettings({ client, company }: Props) {
               <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-dashed p-3">
                 <p className="text-xs text-muted-foreground">
                   Set here{status.setBy ? ` by ${status.setBy}` : ""}, overriding
-                  the manifest ({status.manifestMode}). A{" "}
-                  <code>company.toml</code> edit will not clear it.
+                  the manifest ({status.manifestMode}). Editing{" "}
+                  <code>[policy]</code> in <code>company.toml</code> clears it —
+                  version control wins when it speaks.
                 </p>
                 <Button
                   size="sm"

--- a/frontend/src/components/policy-settings.tsx
+++ b/frontend/src/components/policy-settings.tsx
@@ -1,0 +1,251 @@
+import { useCallback, useEffect, useState } from "react";
+import { Loader2, RotateCcw, ShieldCheck } from "lucide-react";
+import { toast } from "sonner";
+
+import type { OpenCompanyClient } from "@/api/client";
+import {
+  getPolicy,
+  type PolicyStatus,
+  resetPolicy,
+  setPolicy,
+} from "@/api/policy";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+/**
+ * The autonomy tier and the always-ask list (issue #562).
+ *
+ * An operator drowning in approval cards previously had no way to stop it: the
+ * tier lives in the company manifest, and nothing in the console read or wrote
+ * it — so changing it meant editing a version-controlled file and redeploying,
+ * or on a hosted tenant (where the manifest is a read-only boot snapshot) it
+ * meant nothing at all.
+ *
+ * Two things this deliberately renders rather than hides:
+ *
+ * - **The tiers are described by consequence, not by name.** "Supervised" and
+ *   "full" mean nothing to someone deciding between them; "asks before every
+ *   change, including its own scratch files" does. The prose comes from the
+ *   host, because it describes what that host's approval gate actually does.
+ * - **When a change bites.** A tier change lands on the company's *next* turn,
+ *   so a turn already running finishes under the old one. Since stopping the
+ *   flood *now* is exactly why an operator is here, that gap is stated instead
+ *   of being left to discover.
+ */
+export function PolicySettings({ client, company }: Props) {
+  const [status, setStatus] = useState<PolicyStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  // The always-ask list is edited as text and only committed on Save, so a
+  // half-typed effect kind never reaches the gate.
+  const [draftAlways, setDraftAlways] = useState("");
+  const [dirty, setDirty] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const next = await getPolicy(client, company);
+      setStatus(next);
+      setDraftAlways(next.alwaysApprove.join(", "));
+      setDirty(false);
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not load the policy.",
+      );
+    } finally {
+      setLoading(false);
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  /** Applies a server response, resyncing the draft so it cannot drift. */
+  const apply = (next: PolicyStatus, message: string) => {
+    setStatus(next);
+    setDraftAlways(next.alwaysApprove.join(", "));
+    setDirty(false);
+    toast.success(message, { description: next.takesEffect });
+  };
+
+  const chooseTier = async (mode: string) => {
+    if (!status || saving || mode === status.mode) return;
+    setSaving(true);
+    try {
+      // Only `mode` is sent: an omitted field leaves the always-ask list where
+      // it is, so picking a tier cannot silently discard a list the operator
+      // edited earlier.
+      apply(await setPolicy(client, company, { mode }), "Autonomy tier updated");
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not change the tier.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveAlways = async () => {
+    if (!status || saving) return;
+    setSaving(true);
+    try {
+      // An empty box means an empty list, not "leave it alone" — the host keeps
+      // those apart and so must this.
+      const kinds = draftAlways
+        .split(",")
+        .map((kind) => kind.trim())
+        .filter(Boolean);
+      apply(
+        await setPolicy(client, company, { alwaysApprove: kinds }),
+        "Always-ask list updated",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not save the list.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const reset = async () => {
+    if (!status || saving) return;
+    setSaving(true);
+    try {
+      apply(
+        await resetPolicy(client, company),
+        "Reverted to the manifest's policy",
+      );
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Could not reset the policy.",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <Card data-testid="policy-settings">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <ShieldCheck className="h-4 w-4" />
+          Approvals
+        </CardTitle>
+        <CardDescription>
+          How much the agents do on their own, and what they always ask about
+          first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {loading || !status ? (
+          <div className="flex items-center gap-2 text-sm text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading the current policy…
+          </div>
+        ) : (
+          <>
+            <div className="space-y-2">
+              {status.tiers.map((tier) => {
+                const active = tier.value === status.mode;
+                return (
+                  <button
+                    key={tier.value}
+                    type="button"
+                    disabled={saving}
+                    onClick={() => void chooseTier(tier.value)}
+                    aria-pressed={active}
+                    className={cn(
+                      "w-full rounded-md border p-3 text-left transition-colors",
+                      "disabled:cursor-not-allowed disabled:opacity-60",
+                      active
+                        ? "border-primary bg-primary/5"
+                        : "hover:bg-muted/50",
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium">{tier.label}</span>
+                      {active && (
+                        <Badge variant="secondary" className="text-xs">
+                          Current
+                        </Badge>
+                      )}
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {tier.description}
+                    </p>
+                  </button>
+                );
+              })}
+              <p className="text-xs text-muted-foreground">
+                Takes effect {status.takesEffect}.
+              </p>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="always-approve">Always ask first</Label>
+              <p className="text-xs text-muted-foreground">
+                Effect kinds that park for approval whatever the tier — these win
+                even on Full. Comma-separated.
+              </p>
+              <Input
+                id="always-approve"
+                value={draftAlways}
+                disabled={saving}
+                placeholder="payment.send, filing.submit, external.publish"
+                onChange={(event) => {
+                  setDraftAlways(event.target.value);
+                  setDirty(true);
+                }}
+              />
+              {dirty && (
+                <Button
+                  size="sm"
+                  disabled={saving}
+                  onClick={() => void saveAlways()}
+                >
+                  Save list
+                </Button>
+              )}
+            </div>
+
+            {status.overridden && (
+              <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-dashed p-3">
+                <p className="text-xs text-muted-foreground">
+                  Set here{status.setBy ? ` by ${status.setBy}` : ""}, overriding
+                  the manifest ({status.manifestMode}). A{" "}
+                  <code>company.toml</code> edit will not clear it.
+                </p>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  disabled={saving}
+                  onClick={() => void reset()}
+                >
+                  <RotateCcw className="mr-1 h-3 w-3" />
+                  Use the manifest's policy
+                </Button>
+              </div>
+            )}
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -25,6 +25,7 @@ import {
 } from "@/components/ui/card";
 import { DevicePairing } from "@/components/device-pairing";
 import { DomainSettings } from "@/components/domain-settings";
+import { PolicySettings } from "@/components/policy-settings";
 import { StatusPill } from "@/components/status-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { CompanyFeed } from "@/hooks/use-company";
@@ -51,6 +52,11 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
         {/* Pairing this machine. Renders nothing in a browser, where the
             session cookie already works. */}
         <DevicePairing />
+
+        {/* Approvals: the autonomy tier and the always-ask list (issue #562).
+            High in the page on purpose — an operator who comes to settings
+            because they are drowning in approval cards is here for this. */}
+        <PolicySettings client={client} company={company} />
 
         {/* Connection */}
         <Card>

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -601,7 +601,11 @@ fn default_tool_provider() -> String {
 }
 
 /// `[policy]` — the default `ApprovalGate` configuration.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+///
+/// `PartialEq` is load-bearing rather than incidental: `runtime::builder`
+/// compares the previous boot's seed `[policy]` with this one's to decide
+/// whether a console override survives the rebuild (issue #562).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Policy {
     /// `readonly` | `supervised` (default) | `auto` | `full`.
     ///

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1647,6 +1647,7 @@ to = "done"
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -503,6 +503,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2561,6 +2561,7 @@ description = "Runs Acme."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -2717,6 +2718,7 @@ description = "Builds it."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -4720,6 +4722,7 @@ members = ["engineer"]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -4873,6 +4876,7 @@ name = "Design"
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -4933,6 +4937,7 @@ members = ["eng1", "eng2"]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -4989,6 +4994,7 @@ members = ["eng1", "eng2"]
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/harness/composio_turn_test.rs
+++ b/src/harness/composio_turn_test.rs
@@ -381,6 +381,7 @@ async fn harness(
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -152,7 +152,9 @@ use crate::harness::mcp_probe::McpFailureQueue;
 use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
-use crate::ports::types::{BudgetOverride, CompanyId, CompanyRecord, OverlayAgent, TurnStep};
+use crate::ports::types::{
+    BudgetOverride, CompanyId, CompanyRecord, OverlayAgent, PolicyOverride, TurnStep,
+};
 use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,
     UsageMeter,
@@ -815,6 +817,11 @@ pub struct HarnessPool {
     /// A company that never sets an override keeps an empty set and a stable
     /// fingerprint — no rebuild, byte-identical to the pre-#343 behaviour.
     budget_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Per-company fingerprint of the operator `[policy]` override (issue #562),
+    /// so a console tier change rebuilds the roster instead of waiting for a
+    /// restart. Without this axis the override persists and is silently ignored:
+    /// `ApprovalPolicy` is built once per roster, not once per call.
+    policy_fingerprints: RwLock<HashMap<CompanyId, u64>>,
     /// The `(company, agent)` pairs whose last workspace-ensure failed and whose
     /// failure has already been reported (issue #449).
     ///
@@ -860,6 +867,7 @@ impl HarnessPool {
             composio_fingerprints: RwLock::new(HashMap::new()),
             skill_fingerprints: RwLock::new(HashMap::new()),
             budget_fingerprints: RwLock::new(HashMap::new()),
+            policy_fingerprints: RwLock::new(HashMap::new()),
             workspace_failures: std::sync::Mutex::new(HashSet::new()),
         }
     }
@@ -943,9 +951,11 @@ impl HarnessPool {
 
         // Re-resolve + fingerprint the live overlay-agent set the same way, and
         // the operator budget overrides riding the same store read (issue #343).
-        let (overlay_agents, overlay_budgets) = self.resolve_effective_overlay(company, deps).await;
+        let (overlay_agents, overlay_budgets, overlay_policy) =
+            self.resolve_effective_overlay(company, deps).await;
         let overlay_fp = overlay_fingerprint(&overlay_agents);
         let budget_fp = budget_fingerprint(&overlay_budgets);
+        let policy_fp = policy_fingerprint(overlay_policy.as_ref());
 
         // Re-resolve + fingerprint the tenant's capability filter (issue #108):
         // a per-tenant, per-period, fail-closed budget read from the meter. With
@@ -983,6 +993,7 @@ impl HarnessPool {
             let composio_fingerprints = self.composio_fingerprints.read().await;
             let skill_fingerprints = self.skill_fingerprints.read().await;
             let budget_fingerprints = self.budget_fingerprints.read().await;
+            let policy_fingerprints = self.policy_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)
@@ -990,6 +1001,7 @@ impl HarnessPool {
                 && composio_fingerprints.get(&company.id) == Some(&composio_fp)
                 && skill_fingerprints.get(&company.id) == Some(&skill_fp)
                 && budget_fingerprints.get(&company.id) == Some(&budget_fp)
+                && policy_fingerprints.get(&company.id) == Some(&policy_fp)
             {
                 return Ok(());
             }
@@ -1018,6 +1030,11 @@ impl HarnessPool {
         // so installing the live set here is what carries a console budget edit
         // into the roster the very next turn runs on.
         fresh_company.overlay_budgets = overlay_budgets;
+        // Issue #562: same treatment for the policy override — `build_roster`
+        // resolves the tier through `fresh_company.effective_policy`, so installing
+        // the live value here is what carries a console tier change into the roster
+        // the next turn runs on.
+        fresh_company.overlay_policy = overlay_policy;
 
         // Issue #551 note — this rebuild deliberately touches no workspace.
         //
@@ -1062,6 +1079,10 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), budget_fp);
+        self.policy_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), policy_fp);
         Ok(())
     }
 
@@ -1181,12 +1202,21 @@ impl HarnessPool {
         &self,
         company: &CompanyRecord,
         deps: &HarnessDeps,
-    ) -> (Vec<OverlayAgent>, Vec<BudgetOverride>) {
+    ) -> (
+        Vec<OverlayAgent>,
+        Vec<BudgetOverride>,
+        Option<PolicyOverride>,
+    ) {
         match deps.store.load(&company.id).await {
-            Ok(Some(record)) => (record.overlay_agents, record.overlay_budgets),
+            Ok(Some(record)) => (
+                record.overlay_agents,
+                record.overlay_budgets,
+                record.overlay_policy,
+            ),
             _ => (
                 company.overlay_agents.clone(),
                 company.overlay_budgets.clone(),
+                company.overlay_policy.clone(),
             ),
         }
     }
@@ -1857,6 +1887,67 @@ fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
 ///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
 ///   distinction the issue insists must not collapse. `to_bits` additionally
 ///   makes the hash total over values `PartialEq` would call incomparable.
+/// A stable hash of the operator's `[policy]` override, so a console tier change
+/// rebuilds the roster on the company's next `ensure` (issue #562).
+///
+/// # Why this axis has to exist at all
+///
+/// `ApprovalPolicy` is constructed in [`build_roster`], **once per roster
+/// build** — not once per call. The roster is cached and rebuilt only when one
+/// of the fingerprints in the staleness check moves. So without this function a
+/// console tier change would be written, persisted, and then **silently ignored
+/// until the process restarted**: the write route would return `204`, the
+/// console would show the new tier, and every agent would keep running the old
+/// one. That is the same failure the skill-delta fingerprint above exists to
+/// prevent, and it is invisible from the outside.
+///
+/// # What is hashed, and what deliberately is not
+///
+/// - `mode` and `always_approve` are hashed — they are what the gate reads.
+/// - `always_approve` is hashed **in order**, unlike the budget set. The order
+///   is the operator's own list as they wrote it, not an accumulation of
+///   independent rows, so a reorder is a real edit rather than a spurious
+///   difference. Its length is folded in first so `["a","b"]` cannot collide
+///   with `["ab"]`.
+/// - The `Some`/`None` distinction is hashed for both fields, because "not
+///   overridden" and "overridden to the manifest's current value" must stay
+///   apart: the manifest can change under a rebuild, and collapsing them would
+///   pin the override to a value the operator never chose.
+/// - **Attribution (`set_by`, `at_millis`) is deliberately NOT hashed**, for the
+///   same reason the budget fingerprint omits it: who set the tier and when
+///   changes nothing an agent can act on, and folding it in would rebuild the
+///   roster — dropping live agent sessions — on a save that re-set the same tier.
+fn policy_fingerprint(override_: Option<&PolicyOverride>) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+    match override_ {
+        None => 0u8.hash(&mut hasher),
+        Some(entry) => {
+            1u8.hash(&mut hasher);
+            match &entry.mode {
+                Some(mode) => {
+                    1u8.hash(&mut hasher);
+                    mode.hash(&mut hasher);
+                }
+                None => 0u8.hash(&mut hasher),
+            }
+            match &entry.always_approve {
+                Some(kinds) => {
+                    1u8.hash(&mut hasher);
+                    kinds.len().hash(&mut hasher);
+                    for kind in kinds {
+                        kind.hash(&mut hasher);
+                    }
+                }
+                None => 0u8.hash(&mut hasher),
+            }
+        }
+    }
+    hasher.finish()
+}
+
 fn budget_fingerprint(overrides: &[BudgetOverride]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};
@@ -1931,7 +2022,15 @@ pub(crate) fn build_roster(
     deps: &HarnessDeps,
     skill_deltas: &[SkillState],
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
-    let policy: &Policy = &company.manifest.policy;
+    // Issue #562: the policy in force, not the one the manifest shipped with —
+    // the same relationship `effective_budget` (issue #343) has to the manifest
+    // cap, and resolved through the same record so the console and this gate
+    // cannot disagree about which tier is live.
+    //
+    // Owned rather than borrowed because the effective value is a field-wise
+    // merge of the override and the manifest, so there may be nothing to borrow.
+    let effective = company.effective_policy();
+    let policy: &Policy = &effective;
     let company_name = &company.manifest.company.name;
     let allow = &company.manifest.tools.allow;
     // The orchestrator agent (tier `orchestrator`, else the first agent) receives

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2233,6 +2233,7 @@ description = "Builds the product."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -3635,6 +3636,7 @@ description = "Sets direction."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2166,6 +2166,106 @@ mod tests {
         ChunkAddr, ChunkHit, ChunkMeta, CompanySummary, ContextChunk, LedgerEntry,
     };
 
+    fn fp_entry(mode: Option<&str>, always: Option<Vec<&str>>) -> PolicyOverride {
+        use crate::ports::types::{Actor, ActorKind};
+        PolicyOverride {
+            mode: mode.map(str::to_string),
+            always_approve: always.map(|v| v.into_iter().map(str::to_string).collect()),
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "user-1".to_string(),
+            },
+            at_millis: 1_700_000_000_000,
+        }
+    }
+
+    /// The fingerprint moves when the tier moves (issue #562).
+    ///
+    /// This is the assertion that keeps the feature from being a no-op.
+    /// `ApprovalPolicy` is built once per roster build, and `ensure` reuses the
+    /// cached roster unless a fingerprint changed — so if this returned a
+    /// constant, a console tier change would persist, return `204`, render as
+    /// applied, and be **silently ignored until the process restarted**. Every
+    /// other test in this change would still pass.
+    #[test]
+    fn the_policy_fingerprint_moves_when_the_tier_does() {
+        let none = policy_fingerprint(None);
+        let supervised = policy_fingerprint(Some(&fp_entry(Some("supervised"), None)));
+        let full = policy_fingerprint(Some(&fp_entry(Some("full"), None)));
+
+        assert_ne!(
+            supervised, full,
+            "a tier change must move the fingerprint or the roster is never rebuilt"
+        );
+        assert_ne!(
+            none, supervised,
+            "setting an override must move the fingerprint even when it names the \
+             tier the manifest already had — the manifest can change under a rebuild"
+        );
+    }
+
+    /// An always-ask edit moves it too, including clearing the list.
+    ///
+    /// `always_approve` wins over every tier including `full`, so an edit that
+    /// did not rebuild would leave the gate enforcing a list the operator had
+    /// already changed — the failure mode is stricter *or* looser than what the
+    /// console shows, depending on the edit.
+    #[test]
+    fn the_policy_fingerprint_moves_when_the_always_ask_list_does() {
+        let absent = policy_fingerprint(Some(&fp_entry(Some("auto"), None)));
+        let empty = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec![]))));
+        let one = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec!["payment.send"]))));
+        let two = policy_fingerprint(Some(&fp_entry(
+            Some("auto"),
+            Some(vec!["payment.send", "filing.submit"]),
+        )));
+
+        assert_ne!(
+            absent, empty,
+            "clearing the list is not the same as not overriding it"
+        );
+        assert_ne!(empty, one);
+        assert_ne!(one, two);
+
+        // Order is part of the value: the list is the operator's own, not an
+        // accumulation of independent rows, so a reorder is a real edit.
+        let reordered = policy_fingerprint(Some(&fp_entry(
+            Some("auto"),
+            Some(vec!["filing.submit", "payment.send"]),
+        )));
+        assert_ne!(two, reordered);
+
+        // Length is folded in, so concatenation cannot collide.
+        let split = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec!["a", "b"]))));
+        let joined = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec!["ab"]))));
+        assert_ne!(split, joined);
+    }
+
+    /// Attribution is deliberately NOT hashed.
+    ///
+    /// Re-setting the same tier writes a fresh `set_by`/`at_millis`. If those
+    /// moved the fingerprint, every such save would rebuild the roster and drop
+    /// live agent sessions for a change no agent can observe — the same reason
+    /// `budget_fingerprint` omits them.
+    #[test]
+    fn re_setting_the_same_tier_does_not_rebuild_the_roster() {
+        use crate::ports::types::{Actor, ActorKind};
+        let first = fp_entry(Some("auto"), Some(vec!["payment.send"]));
+        let second = PolicyOverride {
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "a-different-admin".to_string(),
+            },
+            at_millis: 1_900_000_000_000,
+            ..first.clone()
+        };
+        assert_eq!(
+            policy_fingerprint(Some(&first)),
+            policy_fingerprint(Some(&second)),
+            "attribution must not move the fingerprint"
+        );
+    }
+
     /// In-memory `ContextStore` so `OcMemory` has somewhere to land.
     #[derive(Default)]
     struct MockContext {

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1871,22 +1871,6 @@ fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
     hasher.finish()
 }
 
-/// A stable fingerprint of a company's operator budget-override set (issue
-/// #343), used to detect a cap set / changed / cleared / reset between
-/// [`HarnessPool::ensure`] calls. Mirrors [`overlay_fingerprint`]'s shape; a
-/// [`BudgetOverride`] holds no secret.
-///
-/// Two details carry weight:
-///
-/// - The set is **sorted by `agent_id`** first, because the write routes push
-///   and retain rather than maintain an order, and an order-sensitive hash would
-///   rebuild the roster (dropping live agent sessions) on a save that changed
-///   nothing an agent can observe.
-/// - The cap is hashed as an `Option` **discriminant plus `f64::to_bits`**, not
-///   through `PartialEq`. `f64` is not `Hash`, and going through bits is also
-///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
-///   distinction the issue insists must not collapse. `to_bits` additionally
-///   makes the hash total over values `PartialEq` would call incomparable.
 /// A stable hash of the operator's `[policy]` override, so a console tier change
 /// rebuilds the roster on the company's next `ensure` (issue #562).
 ///
@@ -1948,6 +1932,22 @@ fn policy_fingerprint(override_: Option<&PolicyOverride>) -> u64 {
     hasher.finish()
 }
 
+/// A stable fingerprint of a company's operator budget-override set (issue
+/// #343), used to detect a cap set / changed / cleared / reset between
+/// [`HarnessPool::ensure`] calls. Mirrors [`overlay_fingerprint`]'s shape; a
+/// [`BudgetOverride`] holds no secret.
+///
+/// Two details carry weight:
+///
+/// - The set is **sorted by `agent_id`** first, because the write routes push
+///   and retain rather than maintain an order, and an order-sensitive hash would
+///   rebuild the roster (dropping live agent sessions) on a save that changed
+///   nothing an agent can observe.
+/// - The cap is hashed as an `Option` **discriminant plus `f64::to_bits`**, not
+///   through `PartialEq`. `f64` is not `Hash`, and going through bits is also
+///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
+///   distinction the issue insists must not collapse. `to_bits` additionally
+///   makes the hash total over values `PartialEq` would call incomparable.
 fn budget_fingerprint(overrides: &[BudgetOverride]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4463,6 +4463,7 @@ name = "Morning"
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -5082,6 +5083,7 @@ name = "Morning"
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -168,6 +168,7 @@ fn record() -> CompanyRecord {
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -353,6 +353,7 @@ fn brain_with(
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/search_turn_test.rs
+++ b/src/harness/search_turn_test.rs
@@ -324,6 +324,7 @@ async fn harness(
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -237,6 +237,7 @@ fn record(overlays: Vec<OverlayAgent>) -> CompanyRecord {
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -321,6 +321,7 @@ async fn harness(
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };
@@ -751,6 +752,7 @@ async fn supervised(deps: &HarnessDeps, grants: &str) -> (HarnessPool, CompanyRe
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2388,16 +2388,26 @@ impl BudgetOverride {
 /// [`CompanyRecord::effective_policy`] resolves *ahead* of the manifest at read
 /// time.
 ///
-/// # It is still a live override of a security setting
+/// # Version control still wins when it speaks
 ///
-/// The invariant above is about the seed winning a *merge*; it does not make an
-/// operator override harmless. An admin who loosens the tier here has loosened
-/// it until someone explicitly resets it — editing `company.toml` and
-/// redeploying will **not** clear it. That is the same bargain #343 struck for
-/// spend caps, with the same two mitigations, and they are load-bearing rather
-/// than decorative: every override is **attributed** (`set_by` + `at_millis`),
-/// and "reset to the manifest" is a real, distinct operation (drop the row)
-/// rather than a value that has to be guessed at.
+/// The invariant above is about the seed winning a *merge*, and an override that
+/// simply outlived every seed edit would reproduce its named harm by another
+/// route: an operator tightens `[policy]` in `company.toml`, redeploys, and the
+/// looser console override silently wins — a runtime write outliving a seed
+/// rollback. #343 makes the opposite trade for spend caps and is right to; a cap
+/// is a number, not the gate.
+///
+/// So there are **two** clearing paths, and they answer different questions:
+///
+/// - `runtime::builder::carry_policy_override` drops the override when the
+///   seed's `[policy]` **changes** — and only then, so a routine redeploy that
+///   said nothing does not silently revert the operator.
+/// - `DELETE …/policy` is how an operator clears their own override without
+///   touching version control.
+///
+/// Between seed edits the override is durable, which is what makes it usable at
+/// all, and every one is **attributed** (`set_by` + `at_millis`) so the console
+/// can show who moved the gate and when.
 ///
 /// # Absent fields mean "not overridden"
 ///

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -13,7 +13,7 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-use crate::company::{CompanyManifest, Policy};
+use crate::company::{CompanyManifest, POLICY_MODES, Policy};
 use crate::ports::ids::{agent_slug, generate_id, now_millis};
 use crate::ports::workflow_runner::DeliveryReport;
 
@@ -2422,8 +2422,9 @@ pub struct PolicyOverride {
     /// The autonomy tier to run, or `None` to leave the manifest's in force.
     ///
     /// A `POLICY_MODES` word. Validated at the write route rather than here:
-    /// this type is inert data, and an unknown value still degrades safely
-    /// because `PolicyMode::parse` falls back to `supervised`.
+    /// this type is inert data. [`CompanyRecord::effective_policy`] ignores an
+    /// unknown stored value and keeps the manifest's tier, so version skew can
+    /// never loosen a stricter seed policy.
     #[serde(default)]
     pub mode: Option<String>,
     /// The always-ask effect kinds, or `None` to leave the manifest's in force.
@@ -2976,7 +2977,10 @@ impl CompanyRecord {
     /// The merge is per field and `None` means "not overridden", so an operator
     /// who moved the tier has not thereby silently reset the always-ask list to
     /// the manifest's. An explicitly emptied list (`Some(vec![])`) survives as
-    /// empty; only an absent field falls through.
+    /// empty; only an absent field falls through. An unknown stored mode also
+    /// falls through to the manifest: it can arise under version skew, and
+    /// allowing the policy parser to downgrade it to `supervised` would loosen
+    /// a `readonly` manifest.
     pub fn effective_policy(&self) -> Policy {
         let manifest = &self.manifest.policy;
         let Some(override_) = &self.overlay_policy else {
@@ -2985,7 +2989,9 @@ impl CompanyRecord {
         Policy {
             mode: override_
                 .mode
-                .clone()
+                .as_deref()
+                .filter(|mode| POLICY_MODES.contains(mode))
+                .map(str::to_owned)
                 .unwrap_or_else(|| manifest.mode.clone()),
             always_approve: override_
                 .always_approve
@@ -4513,6 +4519,24 @@ mod test {
         let mut record = desk_record(POLICY_MANIFEST, Vec::new());
         record.overlay_policy = Some(policy_entry(Some("full"), None));
         assert_eq!(record.effective_policy().mode, "full");
+    }
+
+    /// Version skew can leave an override written by a newer host on a build
+    /// that does not recognise its tier. Falling through to `supervised` would
+    /// loosen a `readonly` seed, so the manifest wins for that field while any
+    /// independently valid always-ask override remains in force.
+    #[test]
+    fn an_unknown_stored_policy_mode_cannot_loosen_the_manifest() {
+        let manifest = POLICY_MANIFEST.replace("mode = \"supervised\"", "mode = \"readonly\"");
+        let mut record = desk_record(&manifest, Vec::new());
+        record.overlay_policy = Some(policy_entry(
+            Some("future-tier"),
+            Some(vec!["external.publish"]),
+        ));
+
+        let effective = record.effective_policy();
+        assert_eq!(effective.mode, "readonly");
+        assert_eq!(effective.always_approve, vec!["external.publish"]);
     }
 
     /// The two fields are independent: moving the tier must not silently reset

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -4432,6 +4432,114 @@ mod test {
         }
     }
 
+    // ---- `[policy]` override (issue #562) --------------------------------
+
+    const POLICY_MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"analyst\"\nrole = \"Analyst\"\n\
+         [policy]\nmode = \"supervised\"\n\
+         always_approve = [\"payment.send\", \"filing.submit\"]\n";
+
+    fn policy_entry(mode: Option<&str>, always: Option<Vec<&str>>) -> PolicyOverride {
+        PolicyOverride {
+            mode: mode.map(str::to_string),
+            always_approve: always.map(|v| v.into_iter().map(str::to_string).collect()),
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "user-1".to_string(),
+            },
+            at_millis: 1_700_000_000_000,
+        }
+    }
+
+    /// With no override stored, `effective_policy` is the manifest verbatim —
+    /// the pre-#562 behaviour, and the net that says adding this field changed
+    /// nothing for a company that never uses it.
+    #[test]
+    fn effective_policy_falls_back_to_the_manifest() {
+        let record = desk_record(POLICY_MANIFEST, Vec::new());
+        let effective = record.effective_policy();
+        assert_eq!(effective.mode, "supervised");
+        assert_eq!(
+            effective.always_approve,
+            vec!["payment.send", "filing.submit"]
+        );
+    }
+
+    /// A stored override beats the manifest. This is the "no redeploy" property
+    /// at its source: nothing here consults `company.toml` once a row exists.
+    #[test]
+    fn a_stored_policy_override_beats_the_manifest() {
+        let mut record = desk_record(POLICY_MANIFEST, Vec::new());
+        record.overlay_policy = Some(policy_entry(Some("full"), None));
+        assert_eq!(record.effective_policy().mode, "full");
+    }
+
+    /// The two fields are independent: moving the tier must not silently reset
+    /// the always-ask list to the manifest's, nor the reverse.
+    ///
+    /// This is the merge that makes the console usable — the tier control and
+    /// the always-ask editor are separate widgets, and each `PUT` names only
+    /// what it changed. If either field reset the other, using one control would
+    /// quietly undo the other, and the always-ask list is the operator's real
+    /// lever: it wins over every tier including `full`.
+    #[test]
+    fn overriding_one_policy_field_leaves_the_other_alone() {
+        let mut record = desk_record(POLICY_MANIFEST, Vec::new());
+
+        record.overlay_policy = Some(policy_entry(Some("full"), None));
+        let effective = record.effective_policy();
+        assert_eq!(effective.mode, "full");
+        assert_eq!(
+            effective.always_approve,
+            vec!["payment.send", "filing.submit"],
+            "moving the tier must not discard the manifest's always-ask list"
+        );
+
+        record.overlay_policy = Some(policy_entry(None, Some(vec!["external.publish"])));
+        let effective = record.effective_policy();
+        assert_eq!(
+            effective.mode, "supervised",
+            "editing the always-ask list must not move the tier"
+        );
+        assert_eq!(effective.always_approve, vec!["external.publish"]);
+    }
+
+    /// An emptied always-ask list is a real state, not a fallback.
+    ///
+    /// `Some(vec![])` is an operator deliberately clearing the list; `None` is
+    /// "not overridden". If these collapsed, an operator clearing the list would
+    /// instead get the manifest's three defaults back — silently re-imposing the
+    /// gates they had just removed, and with no way to express what they meant.
+    #[test]
+    fn an_emptied_always_approve_list_is_not_a_fallback() {
+        let mut record = desk_record(POLICY_MANIFEST, Vec::new());
+
+        record.overlay_policy = Some(policy_entry(None, Some(vec![])));
+        assert!(
+            record.effective_policy().always_approve.is_empty(),
+            "an explicitly emptied always-ask list must survive as empty"
+        );
+
+        record.overlay_policy = Some(policy_entry(None, None));
+        assert_eq!(
+            record.effective_policy().always_approve,
+            vec!["payment.send", "filing.submit"],
+            "an absent field must fall through to the manifest"
+        );
+    }
+
+    /// `auto_approve_under_usd` is not overridable and keeps reading the
+    /// manifest, so the merge cannot silently drop a threshold it does not carry.
+    #[test]
+    fn the_spend_threshold_is_untouched_by_a_policy_override() {
+        let manifest = "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"analyst\"\nrole = \"Analyst\"\n\
+             [policy]\nmode = \"supervised\"\nauto_approve_under_usd = 2.5\n";
+        let mut record = desk_record(manifest, Vec::new());
+        record.overlay_policy = Some(policy_entry(Some("full"), Some(vec![])));
+        assert_eq!(record.effective_policy().auto_approve_under_usd, Some(2.5));
+    }
+
     /// Issue #343: with no override stored, `effective_budget` is the manifest
     /// value verbatim — the pre-#343 behaviour, and the regression net that says
     /// adding this field changed nothing for a company that never uses it.

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -13,7 +13,7 @@ use std::ops::Range;
 
 use serde::{Deserialize, Serialize};
 
-use crate::company::CompanyManifest;
+use crate::company::{CompanyManifest, Policy};
 use crate::ports::ids::{agent_slug, generate_id, now_millis};
 use crate::ports::workflow_runner::DeliveryReport;
 
@@ -2362,6 +2362,85 @@ impl BudgetOverride {
     }
 }
 
+/// An operator-set override of the company's `[policy]` block, persisted on the
+/// [`CompanyRecord`] so a tier change wins over the manifest without rewriting
+/// `company.toml` and without a redeploy (issue #562).
+///
+/// The company-scoped twin of [`BudgetOverride`], and it exists for the same
+/// reason: the manifest is a **boot snapshot** baked into the tenant image, so
+/// before this the shipped tier was the only tier an operator could ever run —
+/// and the tier is what decides whether they drown in approval cards.
+///
+/// # Why an overlay and not a manifest write
+///
+/// This is the constraint that shapes the whole feature. A rebuild
+/// (`runtime::builder`) re-persists `record.manifest` **from the seed**, merging
+/// only `[workflows].enabled` from the overlays; every other field is
+/// seed-authoritative, *"and for `[tools]` / `[policy]` that is a security
+/// property — a record-wins merge would let a runtime grant outlive the operator
+/// revoking it in version control."*
+///
+/// So writing `[policy].mode` into `record.manifest` would be wiped by the next
+/// rebuild **and** would contradict a stated invariant. An overlay is a
+/// different thing: it is not a merge into the blueprint, it is a durable,
+/// attributed operator decision that survives the rebuild the way
+/// [`overlay_budgets`](CompanyRecord::overlay_budgets) does, and that
+/// [`CompanyRecord::effective_policy`] resolves *ahead* of the manifest at read
+/// time.
+///
+/// # It is still a live override of a security setting
+///
+/// The invariant above is about the seed winning a *merge*; it does not make an
+/// operator override harmless. An admin who loosens the tier here has loosened
+/// it until someone explicitly resets it — editing `company.toml` and
+/// redeploying will **not** clear it. That is the same bargain #343 struck for
+/// spend caps, with the same two mitigations, and they are load-bearing rather
+/// than decorative: every override is **attributed** (`set_by` + `at_millis`),
+/// and "reset to the manifest" is a real, distinct operation (drop the row)
+/// rather than a value that has to be guessed at.
+///
+/// # Absent fields mean "not overridden"
+///
+/// Both fields are optional and independent, so an operator can move the tier
+/// without touching the always-ask list, or edit the list while leaving the tier
+/// where the manifest put it. `None` is never "empty" — an explicitly emptied
+/// always-ask list is `Some(vec![])`, which is a real state an operator can
+/// choose and which must not collapse into "fall back to the manifest's three
+/// defaults".
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct PolicyOverride {
+    /// The autonomy tier to run, or `None` to leave the manifest's in force.
+    ///
+    /// A `POLICY_MODES` word. Validated at the write route rather than here:
+    /// this type is inert data, and an unknown value still degrades safely
+    /// because `PolicyMode::parse` falls back to `supervised`.
+    #[serde(default)]
+    pub mode: Option<String>,
+    /// The always-ask effect kinds, or `None` to leave the manifest's in force.
+    ///
+    /// `Some(vec![])` is an operator deliberately clearing the list, which is
+    /// **not** the same as `None`. It is the operator's real lever and it wins
+    /// over every tier including `full`, so the two must stay distinguishable.
+    #[serde(default)]
+    pub always_approve: Option<Vec<String>>,
+    /// Who set it. A tier that can be loosened anonymously is not much of a gate.
+    pub set_by: Actor,
+    /// When it was set (epoch millis).
+    pub at_millis: u64,
+}
+
+impl PolicyOverride {
+    /// Does this override actually change anything?
+    ///
+    /// An override with both fields `None` carries only attribution, and
+    /// resolving it is a no-op. The write route rejects one rather than
+    /// persisting a row that says nothing but whose presence the console renders
+    /// as "overridden".
+    pub fn is_empty(&self) -> bool {
+        self.mode.is_none() && self.always_approve.is_none()
+    }
+}
+
 /// The operator overlays persisted as a single JSON blob by the string-column
 /// stores (sqlite + mongodb `overlay_json`). The filesystem store keeps the two
 /// collections as typed fields on its own `Meta` instead.
@@ -2394,6 +2473,12 @@ pub struct OverlayBlob {
     /// loads them as empty — which is exactly "the manifest still decides".
     #[serde(default)]
     pub budgets: Vec<BudgetOverride>,
+    /// The operator's `[policy]` override (issue #562). Absent on rows written
+    /// before console policy writes existed, and `#[serde(default)]` reads that
+    /// absence as `None` — "the manifest's `[policy]` still decides", which is
+    /// the pre-#562 behaviour exactly.
+    #[serde(default)]
+    pub policy: Option<PolicyOverride>,
     /// The workflow ids the operator has switched off (issue #276). Absent on
     /// rows written before the pause switch existed, and `#[serde(default)]`
     /// reads that absence as "nothing is paused" — the pre-#276 behaviour
@@ -2417,6 +2502,7 @@ impl OverlayBlob {
             desks: record.overlay_desks.clone(),
             workflows: record.overlay_workflows.clone(),
             budgets: record.overlay_budgets.clone(),
+            policy: record.overlay_policy.clone(),
             disabled_workflows: record.disabled_workflows.clone(),
             provenance: record.template_provenance.clone(),
         }
@@ -2441,6 +2527,7 @@ impl OverlayBlob {
                     desks: Vec::new(),
                     workflows: Vec::new(),
                     budgets: Vec::new(),
+                    policy: None,
                     disabled_workflows: Vec::new(),
                     provenance: None,
                 })
@@ -2515,6 +2602,13 @@ pub struct CompanyRecord {
     /// check untrusted input with [`Self::duplicate_budget_agent_id`].
     #[serde(default)]
     pub overlay_budgets: Vec<BudgetOverride>,
+    /// The operator's `[policy]` override, if one is set (issue #562).
+    ///
+    /// `None` — the manifest's `[policy]` applies, exactly as before this
+    /// existed. Read through [`Self::effective_policy`], never directly, so the
+    /// approval gate and the console cannot disagree about which tier is live.
+    #[serde(default)]
+    pub overlay_policy: Option<PolicyOverride>,
     /// Workflow ids the operator has switched **off** (issue #276). A workflow
     /// named here keeps its graph, stays listed and stays runnable by hand, and
     /// is skipped by
@@ -2854,6 +2948,45 @@ impl CompanyRecord {
         self.overlay_budgets
             .retain(|held| held.agent_id != entry.agent_id);
         self.overlay_budgets.push(entry);
+    }
+
+    /// The `[policy]` actually in force: the operator's override where it sets a
+    /// field, the manifest's `[policy]` everywhere else (issue #562).
+    ///
+    /// **The single source of truth for "which tier is this company running"**,
+    /// in the shape of [`Self::effective_budget`]. `build_roster`'s
+    /// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy), the workflow
+    /// capability bundle and the console read through here, so a tier changed in
+    /// the console cannot be honoured by one and ignored by another.
+    ///
+    /// Returns an owned [`Policy`] rather than a borrow because the effective
+    /// value may not exist anywhere to borrow from — it is a field-wise merge of
+    /// two sources.
+    ///
+    /// The merge is per field and `None` means "not overridden", so an operator
+    /// who moved the tier has not thereby silently reset the always-ask list to
+    /// the manifest's. An explicitly emptied list (`Some(vec![])`) survives as
+    /// empty; only an absent field falls through.
+    pub fn effective_policy(&self) -> Policy {
+        let manifest = &self.manifest.policy;
+        let Some(override_) = &self.overlay_policy else {
+            return manifest.clone();
+        };
+        Policy {
+            mode: override_
+                .mode
+                .clone()
+                .unwrap_or_else(|| manifest.mode.clone()),
+            always_approve: override_
+                .always_approve
+                .clone()
+                .unwrap_or_else(|| manifest.always_approve.clone()),
+            // Not overridable from the console today. Left reading the manifest
+            // rather than added to `PolicyOverride` speculatively: the issue asks
+            // for the tier and the always-ask list, and a spend threshold whose
+            // console control does not exist would be a field nothing can write.
+            auto_approve_under_usd: manifest.auto_approve_under_usd,
+        }
     }
 
     /// The first `agent_id` on this record carrying more than one override, if
@@ -3840,6 +3973,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -4146,6 +4146,37 @@ mod test {
         assert_eq!(parsed.desk_order, record.overlay_desk_order);
     }
 
+    /// The persisted overlay blob round-trips the `[policy]` override, and a
+    /// blob written before it existed still parses (issue #562).
+    ///
+    /// Both halves matter. Without the first, a serialization path that dropped
+    /// the field would move an operator's approval gate back to the manifest on
+    /// the next load, silently. Without the second, every company record written
+    /// before this feature would fail to parse at all.
+    #[test]
+    fn overlay_blob_round_trips_the_policy_override() {
+        let mut record = desk_record(POLICY_MANIFEST, Vec::new());
+        record.overlay_policy = Some(policy_entry(Some("auto"), Some(vec!["payment.send"])));
+
+        let blob = OverlayBlob::from_record(&record);
+        let json = serde_json::to_string(&blob).expect("serialize blob");
+        let parsed = OverlayBlob::parse(&json).expect("parse blob");
+        assert_eq!(parsed.policy, record.overlay_policy);
+
+        // A blob from before this field existed loads as "not overridden",
+        // which is the pre-#562 behaviour exactly.
+        let legacy = r#"{"agents":[],"desk_members":[],"budgets":[]}"#;
+        let blob = OverlayBlob::parse(legacy).expect("blob without a policy key");
+        assert!(
+            blob.policy.is_none(),
+            "an older record must load with the manifest's policy in charge"
+        );
+
+        // And so does the oldest form of all, the bare agent array.
+        let bare = OverlayBlob::parse("[]").expect("legacy array");
+        assert!(bare.policy.is_none());
+    }
+
     /// An object-form blob written before `desk_order` existed still parses, and
     /// the legacy bare-array form still parses — both with an empty order.
     #[test]

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -206,6 +206,7 @@ mod tests {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -17,10 +17,10 @@ use crate::app::config::BrainMode;
 use crate::brain::medulla::MedullaTransport;
 use crate::brain::medulla::wire::ToolManifestEntry;
 use crate::brain::{EchoBrain, HostedMedullaBrain};
-use crate::company::CompanyManifest;
 #[cfg(feature = "openhuman")]
 use crate::company::inference::{self, EnvDefault};
 use crate::company::runtime::{CompanyMail, CompanyRuntime, OpsStores};
+use crate::company::{CompanyManifest, Policy};
 use crate::feedback::github::{GitHubClient, RateLimiter};
 use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;
@@ -37,7 +37,7 @@ use crate::policy::ManifestApprovalGate;
 #[cfg(feature = "openhuman")]
 use crate::ports::WorkflowRunner;
 use crate::ports::types::{
-    CompanyId, CompanyRecord, OverlayWorkflow, SecretValue, TemplateProvenance,
+    CompanyId, CompanyRecord, OverlayWorkflow, PolicyOverride, SecretValue, TemplateProvenance,
 };
 use crate::ports::{
     AgentEconomy, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore, EventLog,
@@ -183,6 +183,61 @@ fn dedup(grants: Vec<String>) -> Vec<String> {
 /// than a convention: `[tools]` and `[policy]` must be seed-wins, because a
 /// record-wins merge would let a runtime write **outlive a seed rollback** —
 /// privilege persisting after the operator revoked it in version control.
+/// Whether the operator's console `[policy]` override survives this rebuild
+/// (issue #562).
+///
+/// **Version control wins when it speaks, and stays quiet when it doesn't.**
+/// The override is kept while the seed's `[policy]` is unchanged, and dropped
+/// the moment the seed's `[policy]` differs from the one the previous boot ran.
+///
+/// # Why the condition is the whole point
+///
+/// The override is deliberately *not* a manifest merge — [`CompanyRecord::effective_policy`]
+/// resolves it ahead of the manifest instead, so `record.manifest` stays
+/// seed-authoritative and the invariant stated on [`merge_enabled_workflows`]
+/// is untouched in the letter.
+///
+/// Carrying it unconditionally would nonetheless reproduce that invariant's own
+/// named harm in the spirit. An operator tightens `[policy]` in `company.toml`,
+/// redeploys, and a looser console override silently wins — *"a runtime write
+/// outliving a seed rollback; privilege persisting after the operator revoked it
+/// in version control."* That reasoning is exactly why `[tools]` and `[policy]`
+/// are the two fields singled out, and an approval gate is precisely the thing
+/// it was written about. The per-teammate spend cap (issue #343) makes the
+/// opposite trade and is defensible doing so: a cap is a number, not the gate.
+///
+/// # Why it is conditional rather than always-clear
+///
+/// Dropping the override on *every* rebuild would be the opposite failure, and
+/// just as silent: a routine redeploy that changed nothing would revert the
+/// operator's console action, and nothing in the console would show the tier had
+/// moved back. So the seed only wins when it actually says something new.
+///
+/// # What counts as the seed speaking
+///
+/// Any change to `[policy]` — `mode`, `always_approve`, or
+/// `auto_approve_under_usd`. Comparing the whole block rather than just the
+/// field being overridden is deliberate: an operator who edits `[policy]` at all
+/// has turned their attention to the approval gate, and resolving *which* of
+/// their edits was meant to override the console is a guess. Clearing and
+/// letting them re-apply is the answer that cannot silently pick wrong.
+///
+/// `previous_seed` is the prior boot's `record.manifest.policy`, which is that
+/// boot's seed verbatim — `[policy]` is never merged, so the persisted manifest
+/// is the seed for this field.
+///
+/// This is a **second** clearing path, not a replacement for the explicit
+/// `DELETE …/policy` reset: that one is how an operator clears their own
+/// override without touching version control.
+fn carry_policy_override(
+    previous_seed: &Policy,
+    next_seed: &Policy,
+    held: Option<&PolicyOverride>,
+) -> Option<PolicyOverride> {
+    let held = held?;
+    (previous_seed == next_seed).then(|| held.clone())
+}
+
 fn merge_enabled_workflows(seed_enabled: &[String], overlays: &[OverlayWorkflow]) -> Vec<String> {
     let mut merged: Vec<String> = Vec::with_capacity(seed_enabled.len() + overlays.len());
     let mut seen = std::collections::HashSet::new();
@@ -1417,25 +1472,25 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_budgets.clone())
             .unwrap_or_default();
-        // Issue #562: the operator's `[policy]` override. Carried across the
-        // rebuild for the same reason as the caps above — but note carefully
-        // that this is NOT a weakening of the seed-authoritative rule stated at
-        // the save below. That rule is about `record.manifest`, which is still
-        // re-persisted from the seed with only `[workflows].enabled` merged; an
-        // operator who tightens `[policy]` in version control still has that
-        // land in the manifest on the next rebuild.
-        //
-        // This is the separate, attributed override that
-        // `CompanyRecord::effective_policy` resolves *ahead* of the manifest.
-        // Dropping it here would silently revert a console tier change on every
-        // restart, which is the failure this issue exists to end — and it would
-        // do so invisibly, since nothing in the console would show the tier had
-        // moved back.
-        //
-        // The trade this makes is real and is documented on `PolicyOverride`: a
-        // loosened tier set here outlives a `company.toml` edit, so clearing it
-        // is an explicit operation rather than a side effect of a redeploy.
-        let overlay_policy = existing.as_ref().and_then(|r| r.overlay_policy.clone());
+        // Issue #562: the operator's `[policy]` override, carried across the
+        // rebuild — but ONLY while the seed's `[policy]` has not itself changed.
+        // See `carry_policy_override` for why that condition is the whole point.
+        let overlay_policy = existing.as_ref().and_then(|r| {
+            let carried = carry_policy_override(
+                &r.manifest.policy,
+                &self.manifest.policy,
+                r.overlay_policy.as_ref(),
+            );
+            if carried.is_none() && r.overlay_policy.is_some() {
+                tracing::info!(
+                    company = %id,
+                    seed_mode = %self.manifest.policy.mode,
+                    "[policy] the seed `[policy]` changed, so the console override was cleared — \
+                     version control wins when it speaks"
+                );
+            }
+            carried
+        });
         // Issue #276: the workflows the operator switched off. This is the field
         // that makes the pause switch durable, and it is carried across the
         // rebuild for a sharper reason than the two above: `merge_enabled_workflows`
@@ -3170,6 +3225,103 @@ mod test {
 
     fn parse(toml_src: &str) -> CompanyManifest {
         toml::from_str(toml_src).expect("valid manifest")
+    }
+
+    // ---- `[policy]` override across a rebuild (issue #562) ----------------
+
+    fn seed_policy(mode: &str, always: &[&str], under: Option<f64>) -> Policy {
+        Policy {
+            mode: mode.to_string(),
+            always_approve: always.iter().map(|s| s.to_string()).collect(),
+            auto_approve_under_usd: under,
+        }
+    }
+
+    fn held_override(mode: &str) -> PolicyOverride {
+        use crate::ports::types::{Actor, ActorKind};
+        PolicyOverride {
+            mode: Some(mode.to_string()),
+            always_approve: None,
+            set_by: Actor {
+                kind: ActorKind::User,
+                id: "admin-1".to_string(),
+            },
+            at_millis: 1_700_000_000_000,
+        }
+    }
+
+    /// A rebuild that does not touch `[policy]` leaves the console override
+    /// alone (issue #562).
+    ///
+    /// The half that makes the feature durable. Clearing on every rebuild would
+    /// mean a routine redeploy silently reverting the operator's console action,
+    /// with nothing in the console showing the tier had moved back — the exact
+    /// mirror of the failure the other half prevents.
+    #[test]
+    fn an_unchanged_seed_policy_leaves_the_override_alone() {
+        let seed = seed_policy("supervised", &["payment.send"], None);
+        let carried = carry_policy_override(&seed, &seed.clone(), Some(&held_override("full")));
+        assert_eq!(carried.and_then(|o| o.mode).as_deref(), Some("full"));
+    }
+
+    /// A seed `[policy]` change clears the override — version control wins when
+    /// it speaks.
+    ///
+    /// **The security half.** Without it, an operator tightening `[policy]` in
+    /// `company.toml` and redeploying would find a looser console override
+    /// silently still in force: a runtime write outliving a seed rollback, which
+    /// is the named harm that makes `[tools]` / `[policy]` seed-authoritative in
+    /// the first place. An approval gate is precisely what that rule was written
+    /// about.
+    #[test]
+    fn a_changed_seed_policy_clears_the_override() {
+        let before = seed_policy("full", &["payment.send"], None);
+        let tightened = seed_policy("supervised", &["payment.send"], None);
+        assert!(
+            carry_policy_override(&before, &tightened, Some(&held_override("full"))).is_none(),
+            "a tightened seed must clear a looser console override"
+        );
+
+        // Loosening the seed clears it too. The rule is "the seed spoke", not
+        // "the seed got stricter" — an operator who edits `[policy]` at all has
+        // turned their attention to the gate, and guessing which of their edits
+        // was meant to lose to the console is a guess that can pick wrong
+        // silently.
+        let loosened = seed_policy("full", &["payment.send"], None);
+        assert!(
+            carry_policy_override(&tightened, &loosened, Some(&held_override("readonly")))
+                .is_none()
+        );
+    }
+
+    /// Any field of `[policy]` counts as the seed speaking, not just `mode`.
+    ///
+    /// `always_approve` is the operator's real lever — it wins over every tier
+    /// including `full` — so an edit to it that left a console override standing
+    /// would be the same hole through a different field.
+    #[test]
+    fn every_policy_field_counts_as_the_seed_speaking() {
+        let base = seed_policy("supervised", &["payment.send"], None);
+
+        let list_changed = seed_policy("supervised", &["payment.send", "filing.submit"], None);
+        assert!(
+            carry_policy_override(&base, &list_changed, Some(&held_override("full"))).is_none()
+        );
+
+        let threshold_changed = seed_policy("supervised", &["payment.send"], Some(1.0));
+        assert!(
+            carry_policy_override(&base, &threshold_changed, Some(&held_override("full")))
+                .is_none()
+        );
+    }
+
+    /// With no override held there is nothing to carry, whatever the seed did.
+    #[test]
+    fn no_override_carries_nothing() {
+        let before = seed_policy("supervised", &[], None);
+        let after = seed_policy("full", &[], None);
+        assert!(carry_policy_override(&before, &before.clone(), None).is_none());
+        assert!(carry_policy_override(&before, &after, None).is_none());
     }
 
     /// A bodiless overlay stub — `merge_enabled_workflows` only reads the id.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1417,6 +1417,25 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_budgets.clone())
             .unwrap_or_default();
+        // Issue #562: the operator's `[policy]` override. Carried across the
+        // rebuild for the same reason as the caps above — but note carefully
+        // that this is NOT a weakening of the seed-authoritative rule stated at
+        // the save below. That rule is about `record.manifest`, which is still
+        // re-persisted from the seed with only `[workflows].enabled` merged; an
+        // operator who tightens `[policy]` in version control still has that
+        // land in the manifest on the next rebuild.
+        //
+        // This is the separate, attributed override that
+        // `CompanyRecord::effective_policy` resolves *ahead* of the manifest.
+        // Dropping it here would silently revert a console tier change on every
+        // restart, which is the failure this issue exists to end — and it would
+        // do so invisibly, since nothing in the console would show the tier had
+        // moved back.
+        //
+        // The trade this makes is real and is documented on `PolicyOverride`: a
+        // loosened tier set here outlives a `company.toml` edit, so clearing it
+        // is an explicit operation rather than a side effect of a redeploy.
+        let overlay_policy = existing.as_ref().and_then(|r| r.overlay_policy.clone());
         // Issue #276: the workflows the operator switched off. This is the field
         // that makes the pause switch durable, and it is carried across the
         // rebuild for a sharper reason than the two above: `merge_enabled_workflows`
@@ -1770,6 +1789,7 @@ impl RuntimeBuilder {
                                 overlay_desks: overlay_desks.clone(),
                                 overlay_workflows: overlay_workflows.clone(),
                                 overlay_budgets: overlay_budgets.clone(),
+                                overlay_policy: overlay_policy.clone(),
                                 disabled_workflows: disabled_workflows.clone(),
                                 template_provenance: template_provenance.clone(),
                             };
@@ -1901,6 +1921,7 @@ impl RuntimeBuilder {
                 overlay_desks,
                 overlay_workflows,
                 overlay_budgets,
+                overlay_policy,
                 disabled_workflows,
                 template_provenance,
             })
@@ -3833,6 +3854,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1965,6 +1965,7 @@ members = ["engineer"]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -386,6 +386,7 @@ members = ["counsel"]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -41,6 +41,7 @@ pub(crate) async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -185,6 +186,7 @@ async fn state_with_rich_company(home: &std::path::Path) -> AppState {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1035,6 +1037,7 @@ async fn skills_and_workflows_resolve_from_source_dir() {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1108,6 +1111,7 @@ async fn company_skills_project_the_pinned_snapshot_of_a_registry_install() {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1222,6 +1226,7 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
                     .to_string(),
             }],
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1315,6 +1320,7 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
                     .to_string(),
             }],
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2146,6 +2146,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -2269,6 +2270,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -2387,6 +2389,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -355,6 +355,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -48,6 +48,7 @@ async fn state_with_manifest(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -694,6 +694,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -487,6 +487,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -104,6 +104,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -625,6 +625,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -32,6 +32,7 @@ pub mod mail;
 pub mod mailer;
 pub mod mcp;
 pub mod memory;
+pub mod policy;
 pub mod runs;
 pub mod scope;
 pub mod skills;
@@ -171,6 +172,7 @@ pub fn router() -> Router<AppState> {
         .merge(mcp::router())
         .merge(inference::router())
         .merge(team::router())
+        .merge(policy::router())
         .merge(workflows::router())
         .merge(mail::router());
     #[cfg(feature = "oauth")]

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -265,9 +265,9 @@ async fn set_policy(
 
     // Validate against the same list `company.toml` is validated against, so a
     // tier the console accepts is one the manifest would have accepted too. An
-    // unknown mode would not be *unsafe* — `PolicyMode::parse` falls back to
-    // `supervised` — but it would be silently ignored, which is worse: the
-    // console would show a tier the gate was not running.
+    // A stored unknown mode falls back to the manifest for version-skew safety,
+    // but a fresh write must still be refused: accepting it would leave the
+    // console showing a tier the gate was not running.
     if let Some(Some(mode)) = &body.mode
         && !POLICY_MODES.contains(&mode.as_str())
     {

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -1,0 +1,399 @@
+//! The autonomy-tier write plane: `GET`/`PUT`/`DELETE {scope}/policy`
+//! (issue #562).
+//!
+//! An operator drowning in approval cards had no way to stop it. The tier is
+//! read from `[policy].mode` in the company manifest, and nothing in the console
+//! read or wrote it — so the only ways to change it were editing a
+//! version-controlled file and redeploying, or, on a hosted tenant where the
+//! manifest is a read-only boot snapshot baked into the image, nothing at all.
+//!
+//! This is the company-scoped twin of the per-teammate budget surface in
+//! [`team`](crate::server::ops::team), and it keeps the same three rules for the
+//! same reasons:
+//!
+//! - **Admin-only, and attributed.** Loosening the approval gate is a privilege
+//!   boundary at least as sharp as raising a spend cap, so both writes go through
+//!   [`require_admin`](crate::server::users::admin::require_admin) and stamp who
+//!   did it and when. The console renders that attribution: a tier that can be
+//!   loosened anonymously is not much of a gate.
+//! - **Absent is not empty.** An omitted key leaves that field on the manifest's
+//!   value; `"alwaysApprove": []` is an operator deliberately clearing the
+//!   always-ask list. Those are different stored states and different
+//!   behaviours, so the body uses a double option and an empty `{}` is a `422`
+//!   rather than a silent no-op.
+//! - **Reset is its own verb.** `DELETE` drops the override so the manifest's
+//!   `[policy]` applies again, which no `PUT` body can express — writing the
+//!   manifest's *current* values would pin them, and the manifest can change
+//!   under a rebuild.
+//!
+//! ## Why this writes an overlay and not the manifest
+//!
+//! A rebuild re-persists `record.manifest` **from the seed**, merging only
+//! `[workflows].enabled`; every other field is seed-authoritative, *"and for
+//! `[tools]` / `[policy]` that is a security property"* (`runtime::builder`). A
+//! manifest write would be wiped by the next rebuild **and** would contradict
+//! that invariant. So this route writes
+//! [`PolicyOverride`](crate::ports::types::PolicyOverride), which
+//! [`CompanyRecord::effective_policy`](crate::ports::types::CompanyRecord::effective_policy)
+//! resolves *ahead* of the manifest at read time.
+//!
+//! ## When a change takes effect, stated precisely
+//!
+//! On the company's **next turn**, not on the turn already running.
+//! `ApprovalPolicy` is built once per roster build, and
+//! `HarnessPool::ensure` rebuilds the roster when the policy fingerprint moves
+//! (issue #562's `policy_fingerprint`). So the write lands, the next `ensure`
+//! rebuilds, and the following turn runs on the new tier — an in-flight turn
+//! finishes under the old one. Since "stop the flood **now**" is the motivating
+//! complaint, the response says so rather than leaving an operator to discover
+//! it: see [`PolicyDto::takes_effect`].
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::{POLICY_MODES, Policy};
+use crate::error::OpenCompanyError;
+use crate::ports::now_millis;
+use crate::ports::store::company_write_lock;
+use crate::ports::types::{Actor, ActorKind, CompanyRecord, PolicyOverride};
+use crate::server::error::ApiError;
+use crate::server::ops::team::double_option;
+use crate::server::ops::{ScopedCompany, scoped};
+use crate::server::users::admin::require_admin;
+
+/// What the console tells an operator about when a tier change bites.
+///
+/// A constant rather than prose invented at the call site, so the two write
+/// routes and the read route cannot describe the timing differently.
+const TAKES_EFFECT: &str =
+    "on the next turn — a turn already running finishes under the previous tier";
+
+/// Builds the policy route fragment.
+pub fn router() -> Router<AppState> {
+    scoped(
+        "/policy",
+        get(read_policy).put(set_policy).delete(clear_policy),
+    )
+}
+
+/// One tier as the console renders it: the value, and what it means in the
+/// operator's own words rather than in tier names.
+///
+/// The descriptions live here rather than in the frontend because they describe
+/// *this* runtime's behaviour — `auto`'s line in particular is the contract
+/// `Consequence::parks_under_auto` implements — and a copy in TypeScript would
+/// drift from the gate it claims to describe.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct TierDto {
+    /// The `[policy].mode` word.
+    value: &'static str,
+    /// The operator-facing label.
+    label: &'static str,
+    /// What choosing it means, in consequences rather than in tier vocabulary.
+    description: &'static str,
+}
+
+/// The operator-facing text for every tier this console knows how to describe,
+/// in increasing order of autonomy.
+///
+/// **Not** what gets offered — [`selectable_tiers`] filters this by
+/// [`POLICY_MODES`], so the console offers exactly what the runtime accepts.
+/// The two are separate because they move independently: `auto` is issue #560,
+/// landing in its own PR, and hard-coding it here would either offer a tier the
+/// gate would silently downgrade to `supervised` (if #562 landed first) or need
+/// a cross-PR edit to appear (if #560 did).
+///
+/// With the filter, neither happens: an entry ahead of the runtime is inert, and
+/// the day `auto` joins `POLICY_MODES` it appears in the console with no further
+/// change. An entry *behind* the runtime is the real error, and
+/// `every_runtime_tier_has_console_text` fails on it.
+const TIER_TEXT: &[TierDto] = &[
+    TierDto {
+        value: "readonly",
+        label: "Read-only",
+        description: "The agents can look at things but change nothing and spend nothing.",
+    },
+    TierDto {
+        value: "supervised",
+        label: "Supervised",
+        description: "The agents ask before every change, including their own scratch files.",
+    },
+    TierDto {
+        value: "auto",
+        label: "Auto",
+        description: "The agents work on their own and stop before anything that leaves the \
+                      company or spends money.",
+    },
+    TierDto {
+        value: "full",
+        label: "Full",
+        description: "The agents act without asking, except for the few things on the \
+                      always-ask list.",
+    },
+];
+
+/// The tiers this company can actually be set to: [`TIER_TEXT`] narrowed to the
+/// modes [`POLICY_MODES`] accepts, in `POLICY_MODES` order.
+///
+/// Driving the order from `POLICY_MODES` rather than from `TIER_TEXT` keeps one
+/// list authoritative about what exists; `TIER_TEXT` is only authoritative about
+/// how it reads.
+fn selectable_tiers() -> Vec<&'static TierDto> {
+    POLICY_MODES
+        .iter()
+        .filter_map(|mode| TIER_TEXT.iter().find(|tier| tier.value == *mode))
+        .collect()
+}
+
+/// The policy surface as the console reads it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PolicyDto {
+    /// The tier actually in force.
+    mode: String,
+    /// The always-ask list actually in force. The operator's real lever: it
+    /// wins over every tier, `full` included.
+    always_approve: Vec<String>,
+    /// The manifest's tier, so the console can show what "reset" would restore
+    /// rather than describing it abstractly.
+    manifest_mode: String,
+    /// The manifest's always-ask list, for the same reason.
+    manifest_always_approve: Vec<String>,
+    /// Whether an operator override is in force. Distinct from comparing the
+    /// values: an override that happens to match the manifest is still an
+    /// override, and still what `DELETE` would remove.
+    overridden: bool,
+    /// Who set the override, if one is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    set_by: Option<String>,
+    /// When it was set (epoch millis), if one is set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    set_at_millis: Option<u64>,
+    /// The selectable tiers with their operator-facing consequences.
+    tiers: Vec<&'static TierDto>,
+    /// When a change bites. Stated because "stop the flood now" is what an
+    /// operator comes here to do, and this is not quite that.
+    takes_effect: &'static str,
+}
+
+impl PolicyDto {
+    fn build(record: &CompanyRecord) -> Self {
+        let effective: Policy = record.effective_policy();
+        let manifest = &record.manifest.policy;
+        Self {
+            mode: effective.mode,
+            always_approve: effective.always_approve,
+            manifest_mode: manifest.mode.clone(),
+            manifest_always_approve: manifest.always_approve.clone(),
+            overridden: record.overlay_policy.is_some(),
+            set_by: record.overlay_policy.as_ref().map(|o| o.set_by.id.clone()),
+            set_at_millis: record.overlay_policy.as_ref().map(|o| o.at_millis),
+            tiers: selectable_tiers(),
+            takes_effect: TAKES_EFFECT,
+        }
+    }
+}
+
+/// The set-policy body.
+///
+/// Both fields are **double options** so "leave this alone" and "set it to this"
+/// stay apart on the wire:
+///
+/// | body | parses as | means |
+/// |---|---|---|
+/// | `{"mode": "auto"}` | `Some(Some("auto"))` | run `auto`; leave the list alone |
+/// | `{"alwaysApprove": []}` | `Some(Some([]))` | clear the always-ask list |
+/// | `{"mode": null}` | `Some(None)` | stop overriding the tier |
+/// | `{}` | *rejected* | — |
+///
+/// `#[serde(default)]` on each field makes an omitted key legal individually —
+/// otherwise setting the tier would force the caller to restate the whole list —
+/// but a body that sets *neither* is refused by [`set_policy`] rather than
+/// stored, because a row with both fields `None` says nothing while still
+/// rendering in the console as "overridden".
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetPolicy {
+    #[serde(default, deserialize_with = "double_option")]
+    mode: Option<Option<String>>,
+    #[serde(default, deserialize_with = "double_option")]
+    always_approve: Option<Option<Vec<String>>>,
+}
+
+/// `GET {scope}/policy` — the tier in force, what the manifest would restore,
+/// and the selectable tiers with their consequences.
+async fn read_policy(company: ScopedCompany) -> Result<Json<PolicyDto>, Response> {
+    let record = load_record(&company).await?;
+    Ok(Json(PolicyDto::build(&record)))
+}
+
+/// `PUT {scope}/policy` — set the tier and/or the always-ask list. Admin-only,
+/// attributed, in force on the next turn.
+async fn set_policy(
+    company: ScopedCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Json(body): Json<SetPolicy>,
+) -> Result<Json<PolicyDto>, Response> {
+    let admin = require_admin(&headers, &state, &company.runtime).await?;
+
+    if body.mode.is_none() && body.always_approve.is_none() {
+        return Err(refusal(
+            "Nothing to set. Send `mode`, `alwaysApprove`, or both — or `DELETE` \
+             this endpoint to go back to the manifest's policy.",
+        ));
+    }
+
+    // Validate against the same list `company.toml` is validated against, so a
+    // tier the console accepts is one the manifest would have accepted too. An
+    // unknown mode would not be *unsafe* — `PolicyMode::parse` falls back to
+    // `supervised` — but it would be silently ignored, which is worse: the
+    // console would show a tier the gate was not running.
+    if let Some(Some(mode)) = &body.mode
+        && !POLICY_MODES.contains(&mode.as_str())
+    {
+        return Err(refusal(&format!(
+            "`mode` must be one of {} — you sent `{mode}`.",
+            POLICY_MODES.join(", ")
+        )));
+    }
+
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
+
+    let mut record = load_record(&company).await?;
+
+    // Merge onto whatever is already stored, so setting the tier does not
+    // silently discard an always-ask list a previous call set (and vice versa).
+    // The outer `Option` is "did the caller mention this field"; the inner one is
+    // the value or an explicit "stop overriding it".
+    let held = record.overlay_policy.clone();
+    let mode = match body.mode {
+        Some(value) => value,
+        None => held.as_ref().and_then(|o| o.mode.clone()),
+    };
+    let always_approve = match body.always_approve {
+        Some(value) => value,
+        None => held.as_ref().and_then(|o| o.always_approve.clone()),
+    };
+
+    let entry = PolicyOverride {
+        mode,
+        always_approve,
+        set_by: Actor {
+            kind: ActorKind::User,
+            id: admin.user_id,
+        },
+        at_millis: now_millis(),
+    };
+    // A merge that cleared both fields is a reset, and storing an empty row
+    // would leave the console showing "overridden" over the manifest's own
+    // values. `DELETE`'s outcome is the honest one.
+    record.overlay_policy = (!entry.is_empty()).then_some(entry);
+
+    save(&company, &record).await?;
+    Ok(Json(PolicyDto::build(&record)))
+}
+
+/// `DELETE {scope}/policy` — drop the override so the manifest's `[policy]`
+/// applies again.
+///
+/// Not expressible as a `PUT`: writing the manifest's current values would pin
+/// them, and a later `company.toml` edit would then be silently overridden by
+/// the values it replaced. Deleting when nothing is stored is a no-op rather
+/// than a `404` — the caller's intent ("this company should follow the
+/// manifest") is already satisfied.
+async fn clear_policy(
+    company: ScopedCompany,
+    State(state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<Json<PolicyDto>, Response> {
+    require_admin(&headers, &state, &company.runtime).await?;
+
+    let write_lock = company_write_lock(company.id());
+    let _lock = write_lock.lock().await;
+
+    let mut record = load_record(&company).await?;
+    record.overlay_policy = None;
+    save(&company, &record).await?;
+    Ok(Json(PolicyDto::build(&record)))
+}
+
+fn refusal(message: &str) -> Response {
+    (StatusCode::UNPROCESSABLE_ENTITY, message.to_string()).into_response()
+}
+
+async fn load_record(company: &ScopedCompany) -> Result<CompanyRecord, Response> {
+    company
+        .runtime
+        .store()
+        .load(company.id())
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+        .ok_or_else(|| {
+            ApiError(OpenCompanyError::CompanyNotFound(company.id().to_string())).into_response()
+        })
+}
+
+async fn save(company: &ScopedCompany, record: &CompanyRecord) -> Result<(), Response> {
+    company
+        .runtime
+        .store()
+        .save(record)
+        .await
+        .map_err(|e| ApiError(e).into_response())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every tier the runtime accepts has console text, so none is
+    /// unselectable (issue #562).
+    ///
+    /// Asserted in **one** direction on purpose. A `POLICY_MODES` entry with no
+    /// text here is a tier an operator cannot pick — the same class of gap as a
+    /// mode the manifest validator rejects, and equally invisible, since every
+    /// other test would pass. The converse is harmless and deliberate: text for
+    /// a tier the runtime has not gained yet (`auto`, issue #560, landing in its
+    /// own PR) is filtered out by `selectable_tiers` and simply does not appear.
+    /// Asserting that direction too would force the two PRs to be stacked.
+    #[test]
+    fn every_runtime_tier_has_console_text() {
+        let offered: Vec<&str> = selectable_tiers().iter().map(|t| t.value).collect();
+        assert_eq!(
+            offered,
+            POLICY_MODES.to_vec(),
+            "a tier the runtime accepts has no console text, so an operator cannot select it"
+        );
+        for tier in selectable_tiers() {
+            assert!(
+                !tier.description.is_empty() && !tier.label.is_empty(),
+                "tier `{}` has no operator-facing text, which is the whole point \
+                 of showing tiers rather than mode names",
+                tier.value
+            );
+        }
+    }
+
+    /// The text table stays a superset of the runtime's tiers, and every entry
+    /// in it is a real mode name rather than a typo that would silently never
+    /// render.
+    #[test]
+    fn console_text_names_only_plausible_tiers() {
+        for tier in TIER_TEXT {
+            assert!(
+                POLICY_MODES.contains(&tier.value) || tier.value == "auto",
+                "`{}` is neither an accepted mode nor the known-pending `auto` — \
+                 a typo here silently drops the tier from the console",
+                tier.value
+            );
+        }
+    }
+}

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -145,7 +145,20 @@ const TIER_TEXT: &[TierDto] = &[
 /// list authoritative about what exists; `TIER_TEXT` is only authoritative about
 /// how it reads.
 fn selectable_tiers() -> Vec<&'static TierDto> {
-    POLICY_MODES
+    tiers_for(POLICY_MODES)
+}
+
+/// [`selectable_tiers`] over an explicit mode list.
+///
+/// Split out so the filter can be tested against a list that is not
+/// `POLICY_MODES`. That is not ceremony: `TIER_TEXT` and `POLICY_MODES` now hold
+/// the same four tiers (issue #560 landed `auto`), so a test driven off
+/// `POLICY_MODES` alone can no longer tell a filtered list from an unfiltered
+/// one — deleting the filter would leave every such assertion passing. A test
+/// that has stopped discriminating looks exactly like coverage, which is worse
+/// than no test at all.
+fn tiers_for(modes: &[&str]) -> Vec<&'static TierDto> {
+    modes
         .iter()
         .filter_map(|mode| TIER_TEXT.iter().find(|tier| tier.value == *mode))
         .collect()
@@ -354,6 +367,170 @@ async fn save(company: &ScopedCompany, record: &CompanyRecord) -> Result<(), Res
 mod tests {
     use super::*;
 
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::CompanyId;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+         [policy]\nmode = \"supervised\"\n\
+         always_approve = [\"payment.send\", \"filing.submit\"]\n";
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-policy-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    async fn call(state: &AppState, method: &str, body: Option<Value>) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method(method)
+            .uri("/api/v1/company/policy")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .header("content-type", "application/json");
+        let request = match body {
+            Some(value) => request.body(Body::from(value.to_string())).unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value = serde_json::from_slice(&bytes).unwrap_or(Value::Null);
+        (status, value)
+    }
+
+    /// `GET` reports the manifest's policy when nothing is overridden, and says
+    /// so — `overridden` is what the console keys the reset control off.
+    #[tokio::test]
+    async fn get_reports_the_manifest_policy_when_nothing_is_overridden() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let (status, body) = call(&state, "GET", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["mode"], "supervised");
+        assert_eq!(body["manifestMode"], "supervised");
+        assert_eq!(body["overridden"], false);
+        assert!(body["setBy"].is_null());
+        assert!(!body["tiers"].as_array().unwrap().is_empty());
+    }
+
+    /// A tier `PUT` moves the tier and leaves the always-ask list on the
+    /// manifest's value — the independence the console's two controls rely on.
+    #[tokio::test]
+    async fn putting_a_tier_leaves_the_always_ask_list_alone() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let (status, body) = call(&state, "PUT", Some(json!({ "mode": "full" }))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["mode"], "full");
+        assert_eq!(body["overridden"], true);
+        assert_eq!(
+            body["alwaysApprove"],
+            json!(["payment.send", "filing.submit"]),
+            "setting the tier must not discard the manifest's always-ask list"
+        );
+        // And it persisted, rather than only being reflected in the response.
+        let (_, reread) = call(&state, "GET", None).await;
+        assert_eq!(reread["mode"], "full");
+    }
+
+    /// An emptied always-ask list is stored as empty, not resolved back to the
+    /// manifest's three defaults.
+    #[tokio::test]
+    async fn an_emptied_always_ask_list_is_stored_as_empty() {
+        let dir = home();
+        let state = state(dir.path()).await;
+        let (status, body) = call(&state, "PUT", Some(json!({ "alwaysApprove": [] }))).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["alwaysApprove"], json!([]));
+        assert_eq!(body["mode"], "supervised", "the tier must not have moved");
+    }
+
+    /// A body that sets nothing is refused rather than stored, and an unknown
+    /// tier is refused rather than silently downgraded to `supervised`.
+    #[tokio::test]
+    async fn an_empty_body_and_an_unknown_tier_are_both_refused() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        let (status, _) = call(&state, "PUT", Some(json!({}))).await;
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+
+        let (status, _) = call(&state, "PUT", Some(json!({ "mode": "supervized" }))).await;
+        assert_eq!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "an unknown tier must be refused — accepting it would leave the console \
+             showing a tier the gate was not running"
+        );
+
+        // Neither refusal stored anything.
+        let (_, body) = call(&state, "GET", None).await;
+        assert_eq!(body["overridden"], false);
+    }
+
+    /// `DELETE` restores the manifest's policy and is a no-op when nothing is
+    /// stored.
+    #[tokio::test]
+    async fn delete_restores_the_manifest_policy() {
+        let dir = home();
+        let state = state(dir.path()).await;
+
+        call(&state, "PUT", Some(json!({ "mode": "full" }))).await;
+        let (status, body) = call(&state, "DELETE", None).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(body["mode"], "supervised");
+        assert_eq!(body["overridden"], false);
+
+        // Deleting again is a no-op, not a 404: the caller's intent is already
+        // satisfied.
+        let (status, _) = call(&state, "DELETE", None).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
     /// Every tier the runtime accepts has console text, so none is
     /// unselectable (issue #562).
     ///
@@ -389,11 +566,43 @@ mod tests {
     fn console_text_names_only_plausible_tiers() {
         for tier in TIER_TEXT {
             assert!(
-                POLICY_MODES.contains(&tier.value) || tier.value == "auto",
-                "`{}` is neither an accepted mode nor the known-pending `auto` — \
-                 a typo here silently drops the tier from the console",
+                POLICY_MODES.contains(&tier.value),
+                "`{}` is not an accepted mode — a typo here silently drops the \
+                 tier from the console",
                 tier.value
             );
         }
+    }
+
+    /// The host's mode list decides what is offered, not the text table.
+    ///
+    /// Driven off synthetic lists rather than `POLICY_MODES`, and that is the
+    /// whole point. `TIER_TEXT` and `POLICY_MODES` now hold the same four tiers,
+    /// so an assertion built on `POLICY_MODES` cannot distinguish a filtered
+    /// list from an unfiltered one, and deleting the filter would leave it
+    /// green. This one fails.
+    #[test]
+    fn a_tier_the_host_does_not_accept_is_not_offered() {
+        // A host without `auto` (every release before #560) must not be offered
+        // it, even though the text for it is compiled in.
+        let older_host = tiers_for(&["readonly", "supervised", "full"]);
+        assert_eq!(
+            older_host.iter().map(|t| t.value).collect::<Vec<_>>(),
+            vec!["readonly", "supervised", "full"],
+            "text for a tier the host does not accept must not be offered — the \
+             gate would silently downgrade it to `supervised`"
+        );
+
+        // Order follows the host's list, not the text table's.
+        let reordered = tiers_for(&["full", "readonly"]);
+        assert_eq!(
+            reordered.iter().map(|t| t.value).collect::<Vec<_>>(),
+            vec!["full", "readonly"]
+        );
+
+        // A mode with no text is skipped rather than panicking or rendering
+        // blank; `every_runtime_tier_has_console_text` is what stops that state
+        // reaching a release.
+        assert!(tiers_for(&["not_a_tier"]).is_empty());
     }
 }

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -534,6 +534,17 @@ mod tests {
     /// Every tier the runtime accepts has console text, so none is
     /// unselectable (issue #562).
     ///
+    /// **This assertion can no longer fail on its own, and that is recorded
+    /// rather than hidden.** It compares `selectable_tiers()` against
+    /// `POLICY_MODES`, and since #560 landed `auto` the text table holds exactly
+    /// those four tiers — so deleting the `POLICY_MODES` filter entirely leaves
+    /// this green. A revert-and-check confirmed it.
+    ///
+    /// It is kept because the invariant it states is real and will bite the next
+    /// time a tier is added to `POLICY_MODES` without text. The filter itself is
+    /// pinned by `a_tier_the_host_does_not_accept_is_not_offered`, which drives
+    /// `tiers_for` from synthetic lists and does fail against that revert.
+    ///
     /// Asserted in **one** direction on purpose. A `POLICY_MODES` entry with no
     /// text here is a tier an operator cannot pick — the same class of gap as a
     /// mode the manifest validator rejects, and equally invisible, since every

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -472,6 +472,7 @@ mod tests {
                 overlay_desk_order: Vec::new(),
                 overlay_desks: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 overlay_workflows: Vec::new(),
                 template_provenance: None,

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -2395,6 +2395,7 @@ mod steer_redirect_test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -816,6 +816,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -580,6 +580,7 @@ members = ["writer", "ceo"]
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -51,6 +51,7 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -158,6 +158,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2454,6 +2454,7 @@ mod tests {
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
+                    overlay_policy: None,
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -2530,6 +2531,7 @@ mod tests {
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
+                    overlay_policy: None,
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -4129,6 +4131,7 @@ mod tests {
                     overlay_desks: Vec::new(),
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
+                    overlay_policy: None,
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -4296,6 +4299,7 @@ label = "ok"
                         toml: GRAPH.to_string(),
                     }],
                     overlay_budgets: Vec::new(),
+                    overlay_policy: None,
                     disabled_workflows: Vec::new(),
                     lifecycle: "running".to_string(),
                     template_provenance: None,
@@ -4890,6 +4894,7 @@ label = "ok"
                         toml: GRAPH.to_string(),
                     }],
                     overlay_budgets: Vec::new(),
+                    overlay_policy: None,
                     disabled_workflows: Vec::new(),
                     lifecycle: "running".to_string(),
                     template_provenance: None,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -78,6 +78,7 @@ async fn state_with_quota(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -2512,6 +2513,7 @@ async fn state_with_manifest_and_defaults(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -3026,6 +3028,7 @@ async fn state_with_source_dir(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -3346,6 +3349,7 @@ async fn state_with_telegram_at(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2554,6 +2554,7 @@ async fn state_with_manifest_and_overlays(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -50,6 +50,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/users/devices_test.rs
+++ b/src/server/users/devices_test.rs
@@ -50,6 +50,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -61,6 +61,7 @@ async fn state_with(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -85,6 +85,7 @@ async fn state_from(
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -651,6 +652,7 @@ async fn a_https_deployment_marks_the_cookie_secure() {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -121,12 +121,31 @@ fn sample_budget_overrides() -> Vec<crate::ports::types::BudgetOverride> {
     ]
 }
 
+/// A populated `[policy]` override, so every store's round-trip proves a
+/// console-set tier survives persistence (issue #562).
+///
+/// Both fields are `Some`, and `always_approve` is deliberately **not** the
+/// manifest default — a round-trip that stored the manifest's own list would
+/// pass whether or not the override had been persisted at all.
+fn sample_policy_override() -> crate::ports::types::PolicyOverride {
+    use crate::ports::types::{Actor, ActorKind, PolicyOverride};
+    PolicyOverride {
+        mode: Some("auto".to_string()),
+        always_approve: Some(vec!["payment.send".to_string()]),
+        set_by: Actor {
+            kind: ActorKind::User,
+            id: "user-conformance".to_string(),
+        },
+        at_millis: 1_700_000_000_002,
+    }
+}
+
 /// Builds a running record for `id` carrying a non-empty desk-order overlay (so
 /// the store round-trip covers the operator desk-hierarchy field, issue #131), a
 /// runtime-authored workflow body (issue #168), a populated budget-override set
-/// (issue #343), a paused workflow id (issue #276), and stamped with the sample
-/// template provenance (so round-trips assert it survives persistence, issue
-/// #85).
+/// (issue #343), a `[policy]` override (issue #562), a paused workflow id
+/// (issue #276), and stamped with the sample template provenance (so round-trips
+/// assert it survives persistence, issue #85).
 fn record(id: &CompanyId) -> CompanyRecord {
     CompanyRecord {
         id: id.clone(),
@@ -142,6 +161,7 @@ fn record(id: &CompanyId) -> CompanyRecord {
         overlay_desks: Vec::new(),
         overlay_workflows: vec![sample_overlay_workflow()],
         overlay_budgets: sample_budget_overrides(),
+        overlay_policy: Some(sample_policy_override()),
         disabled_workflows: vec!["digest".to_string()],
         template_provenance: Some(sample_provenance()),
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -279,6 +279,21 @@ pub async fn assert_isolation_by_company(
             .any(|entry| entry.agent_id == "writer" && entry.budget_usd_daily.is_none()),
         "the explicitly-uncapped override decayed into an absent or zeroed entry"
     );
+    // The operator's `[policy]` override survives too (issue #562). Seeding the
+    // fixture is not enough on its own: without this assertion a backend that
+    // dropped the field would still pass, which is the failure the populated
+    // fixture exists to catch.
+    assert_eq!(
+        loaded.overlay_policy,
+        Some(sample_policy_override()),
+        "overlay_policy did not survive save/load"
+    );
+    assert_eq!(
+        loaded.effective_policy().mode,
+        "auto",
+        "the effective tier did not survive the round-trip, so a restart would \
+         silently move the company back to the manifest's gate"
+    );
     // Issue #276: a paused workflow survives save/load. A backend that dropped
     // this field would re-arm every schedule an operator had switched off, and
     // the only symptom would be a workflow firing again after a restart.
@@ -662,6 +677,14 @@ pub async fn assert_export_totality(
         sample_budget_overrides(),
         "overlay_budgets did not round-trip through the store"
     );
+    // Issue #562: the console-set tier round-trips on every backend, for the
+    // same reason — an approval gate that forgets across a restart is not a gate.
+    assert_eq!(
+        loaded.overlay_policy,
+        Some(sample_policy_override()),
+        "overlay_policy did not round-trip through the store"
+    );
+    assert_eq!(loaded.effective_policy().mode, "auto");
     // Issue #276: the pause switch round-trips on every backend, for the same
     // reason the caps do — a switch that forgets across a restart is not a
     // safety switch.

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1558,6 +1558,26 @@ mod test {
             !dst_record.workflow_enabled("digest"),
             "the bundle round-trip re-armed a paused workflow"
         );
+        // Issue #562: the console-set tier survives export→import, attribution
+        // included. Without this the seeded fixture proves nothing — a bundle
+        // path that dropped the field would still pass every other assertion
+        // here, and an imported company would silently run the manifest's gate.
+        let policy = dst_record
+            .overlay_policy
+            .as_ref()
+            .expect("the policy override was dropped by the bundle round-trip");
+        assert_eq!(policy.mode.as_deref(), Some("auto"));
+        assert_eq!(
+            policy.always_approve.as_deref(),
+            Some(["payment.send".to_string()].as_slice())
+        );
+        assert_eq!(policy.set_by, admin_actor());
+        assert_eq!(policy.at_millis, 1_700_000_000_002);
+        assert_eq!(
+            dst_record.effective_policy().mode,
+            "auto",
+            "the imported company must run the tier the operator set, not the manifest's"
+        );
 
         // Cap, attribution and timestamp, read the way every surface reads them.
         assert_eq!(

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -33,7 +33,7 @@ use crate::ports::store::CompanyStore;
 use crate::ports::types::{
     BudgetOverride, CompanyEvent, CompanyId, CompanyRecord, CompressedTrace, ContextChunk,
     EventSeq, LedgerEntry, OverlayAgent, OverlayDesk, OverlayDeskMember, OverlayDeskOrder,
-    OverlayWorkflow, StoredEvent, TemplateProvenance,
+    OverlayWorkflow, PolicyOverride, StoredEvent, TemplateProvenance,
 };
 
 /// Canonical bundle file and directory names, matching the fs
@@ -124,6 +124,11 @@ struct BundleMeta {
     /// `#[serde(default)]` for back-compat with older bundles.
     #[serde(default)]
     overlay_budgets: Vec<BudgetOverride>,
+    /// The operator's `[policy]` override at export time (issue #562).
+    /// `#[serde(default)]` for back-compat with older bundles, which read as
+    /// `None` — the manifest's `[policy]` decides, exactly as before.
+    #[serde(default)]
+    overlay_policy: Option<PolicyOverride>,
     /// The workflow ids switched off at export time (issue #276). Preserved so
     /// an export→import does not silently re-arm a schedule the operator had
     /// paused — which is the one direction this bundle must never move on its
@@ -181,6 +186,13 @@ struct BundleContents {
     /// The operator-set per-teammate daily spend caps, carried through the
     /// bundle so export→import preserves console-set budgets (issue #343).
     overlay_budgets: Vec<BudgetOverride>,
+    /// The operator's `[policy]` override, carried through the bundle so
+    /// export→import preserves a console-set autonomy tier (issue #562).
+    ///
+    /// Without this an exported company would come back on the manifest's tier,
+    /// silently re-tightening (or re-loosening) the approval gate on import —
+    /// the same class of loss #343 fixed for spend caps.
+    overlay_policy: Option<PolicyOverride>,
     /// The workflow ids switched off, carried through the bundle so an import
     /// restores a paused workflow paused (issue #276).
     disabled_workflows: Vec<String>,
@@ -235,6 +247,7 @@ impl BundleContents {
             overlay_desks: record.overlay_desks,
             overlay_workflows: record.overlay_workflows,
             overlay_budgets: record.overlay_budgets,
+            overlay_policy: record.overlay_policy,
             disabled_workflows: record.disabled_workflows,
         })
     }
@@ -264,6 +277,7 @@ impl BundleContents {
                 overlay_desks: self.overlay_desks.clone(),
                 overlay_workflows: self.overlay_workflows.clone(),
                 overlay_budgets: self.overlay_budgets.clone(),
+                overlay_policy: self.overlay_policy.clone(),
                 disabled_workflows: self.disabled_workflows.clone(),
                 template_provenance: self.template_provenance.clone(),
             })
@@ -308,6 +322,7 @@ impl BundleContents {
             overlay_desks: self.overlay_desks.clone(),
             overlay_workflows: self.overlay_workflows.clone(),
             overlay_budgets: self.overlay_budgets.clone(),
+            overlay_policy: self.overlay_policy.clone(),
             disabled_workflows: self.disabled_workflows.clone(),
             template_provenance: self.template_provenance.clone(),
         };
@@ -417,6 +432,7 @@ impl BundleContents {
             overlay_desks: meta.overlay_desks,
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
+            overlay_policy: meta.overlay_policy,
             disabled_workflows: meta.disabled_workflows,
         })
     }
@@ -941,6 +957,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1019,6 +1036,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1146,6 +1164,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1233,6 +1252,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: Some(provenance.clone()),
         })
@@ -1344,6 +1364,7 @@ mod test {
             overlay_desks: desks.clone(),
             overlay_workflows: workflows.clone(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1495,6 +1516,17 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: budgets.clone(),
+            // Issue #562: a console-set tier rides the same bundle, and for the
+            // same reason the paused workflow below does — a `None` here could
+            // not have detected the field being dropped, and dropping it would
+            // silently move an imported company's approval gate back to whatever
+            // the manifest shipped with.
+            overlay_policy: Some(PolicyOverride {
+                mode: Some("auto".to_string()),
+                always_approve: Some(vec!["payment.send".to_string()]),
+                set_by: admin_actor(),
+                at_millis: 1_700_000_000_002,
+            }),
             // Issue #276: a paused workflow rides the same bundle. The empty
             // list this fixture used to carry could not have detected the field
             // being dropped — and dropping it would silently re-arm a schedule
@@ -1581,6 +1613,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -310,6 +310,11 @@ struct Meta {
     /// `#[serde(default)]` keeps those loading with the manifest in charge.
     #[serde(default)]
     overlay_budgets: Vec<crate::ports::types::BudgetOverride>,
+    /// The operator's `[policy]` override (issue #562). Absent on meta files
+    /// written before the console could write a tier, so `#[serde(default)]`
+    /// keeps those loading with the manifest's `[policy]` in charge.
+    #[serde(default)]
+    overlay_policy: Option<crate::ports::types::PolicyOverride>,
     /// The workflow ids the operator has switched off (issue #276). Absent on
     /// meta files written before the pause switch existed, and
     /// `#[serde(default)]` reads that absence as "nothing is paused" — which is
@@ -337,6 +342,7 @@ impl Default for Meta {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -429,6 +435,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_desks: meta.overlay_desks,
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
+            overlay_policy: meta.overlay_policy,
             disabled_workflows: meta.disabled_workflows,
             template_provenance: meta.template_provenance,
         }))
@@ -450,6 +457,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_desks: record.overlay_desks.clone(),
             overlay_workflows: record.overlay_workflows.clone(),
             overlay_budgets: record.overlay_budgets.clone(),
+            overlay_policy: record.overlay_policy.clone(),
             disabled_workflows: record.disabled_workflows.clone(),
             template_provenance: record.template_provenance.clone(),
         };
@@ -1282,6 +1290,7 @@ mod test {
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -1323,6 +1332,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -1379,6 +1389,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -382,6 +382,7 @@ impl CompanyStore for MongoStore {
             overlay_desks: overlay.desks,
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
+            overlay_policy: overlay.policy,
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2854,6 +2854,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             };

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -446,6 +446,7 @@ impl CompanyStore for SqliteStore {
             overlay_desks: overlay.desks,
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
+            overlay_policy: overlay.policy,
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2921,6 +2921,7 @@ mod test {
                 overlay_desks: Vec::new(),
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
+                overlay_policy: None,
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -122,7 +122,11 @@ pub async fn build_capabilities(
     dry_run: bool,
 ) -> Capabilities {
     let company = record.id.clone();
-    let mode = PolicyMode::parse(&record.manifest.policy.mode);
+    // Issue #562: the tier actually in force — the operator's console override
+    // when one is set, the manifest's otherwise. Reading `manifest.policy` here
+    // would leave a workflow run on the shipped tier while the roster ran on the
+    // operator's, which is the disagreement `effective_policy` exists to prevent.
+    let mode = PolicyMode::parse(&record.effective_policy().mode);
     let grants = record.manifest.tools.allow.clone();
 
     // sub_workflow-by-id resolves children from the union of the company's seed

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -365,6 +365,7 @@ mod tests {
             overlay_desks: Vec::new(),
             overlay_workflows: overlays,
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }))))

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1294,6 +1294,7 @@ allow = [{allow}]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -470,6 +470,7 @@ description = "Runs Acme."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -252,6 +252,7 @@ pub(super) fn record() -> CompanyRecord {
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
+        overlay_policy: None,
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -994,6 +994,7 @@ description = "Runs Acme."
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -1083,6 +1084,7 @@ allow = ["*"]
             overlay_desks: Vec::new(),
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
+            overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }


### PR DESCRIPTION
## Summary

> **Current refresh (2026-08-12):** Rebased onto `upstream/main` at `474bf935`; current head `ceeda8a`. The refresh initializes `overlay_policy` in the new #637 fixture and makes unknown persisted override tiers fall back to the manifest, so version skew cannot loosen a `readonly` seed. The seed-authority rule remains unchanged: any seed `[policy]` change clears the console override.

Lets an operator see and change the autonomy tier from the console (#562).

Before this, the tier lived only in `[policy].mode` and **nothing in `frontend/src` read or wrote it** — searching the whole console for `policyMode` / `policy_mode` / `always_approve` / `alwaysApprove` returns zero matches. So an operator drowning in approval cards could change it by editing a version-controlled file and redeploying, or — on a hosted tenant, where the manifest is a read-only boot snapshot baked into the image — not at all.

### Read this first: version control outranks the console override

An earlier revision of this PR let the override survive **every** rebuild, and flagged that as a trade to be reviewed. On review it was resolved rather than documented, and toward the invariant.

Carrying it unconditionally reproduced the exact harm that makes `[tools]` / `[policy]` seed-authoritative in the first place: an operator tightens `[policy]` in `company.toml`, redeploys, and the looser console override silently wins — *"a runtime write outliving a seed rollback; privilege persisting after the operator revoked it in version control."* #343 makes the opposite trade for a spend cap and is right to; a cap is a number, not the gate.

So `carry_policy_override` drops the override **when the seed's `[policy]` changes, and only then**:

- **Seed changed → override cleared.** Version control wins when it speaks. Any `[policy]` field counts — `mode`, `always_approve`, `auto_approve_under_usd` — because an operator who edits `[policy]` at all has turned their attention to the gate, and guessing which of their edits was meant to lose to the console is a guess that can pick wrong silently.
- **Seed unchanged → override kept.** Clearing on every rebuild would be the mirror failure and just as quiet: a routine redeploy reverting the operator's console action, with nothing showing the tier had moved back.

This is a **second** clearing path, not a replacement — the explicit `DELETE …/policy` is still how an operator clears their own override without touching version control. Between seed edits the override is durable, which is what makes it usable, and every one is attributed so the console can show who moved the gate and when. The console says so too: the panel tells the operator that editing `[policy]` in `company.toml` clears it.

Four tests cover the rule; three reverts of it fail.

### The blocker the issue flagged, resolved: there is no manifest-write path, and there should not be

The issue asks to "check whether that path exists before scoping". It does not, and the reason is stronger than absence.

Every mutating operator route writes an `overlay_*` field on `CompanyRecord`; `record.manifest` appears in them only as a *read*. The convention is stated at `operator.rs:223` — *"The manifest's `[[group_chat]]` blueprint is never rewritten."* And `runtime/builder.rs` states why it must hold for this field in particular:

> Every other manifest field is seed-authoritative: the seed wins, and for `[tools]` / `[policy]` that is a security property — a record-wins merge would let a runtime grant outlive the operator revoking it in version control.

So writing `[policy].mode` into `record.manifest` would be **wiped by the next rebuild** *and* would contradict a stated invariant. An overlay is a different thing: not a merge into the blueprint, but a durable attributed operator decision that `CompanyRecord::effective_policy` resolves *ahead* of the manifest at read time. **This is a host change with a console change on top**, not a console change.

### The failure that would have survived review

The issue's own safety note says:

> Changing the tier mid-flight should be safe by construction: the policy is read per call, so the next call picks up the new tier. Confirm rather than assume.

Confirmed, and **the optimistic reading is wrong**. `ApprovalPolicy::new` is called from `build_roster`, which reads the policy **once per roster build**. `HarnessPool` caches the roster and rebuilds only when one of the fingerprints in its staleness check moves — and there was no policy axis among them.

Shipping the route and the panel without a fingerprint would therefore have produced a feature that **demos perfectly and does not work**: the `PUT` returns `200`, the console shows the new tier, and every agent keeps running the old one **until the process restarts**. Nothing user-visible reports the discrepancy.

That is why this PR is all six seams of the #343 template or none:

| # | Seam | Where |
| --- | --- | --- |
| 1 | overlay field on `CompanyRecord` | `PolicyOverride`, `ports/types.rs` |
| 2 | effective-value accessor | `CompanyRecord::effective_policy` |
| 3 | fingerprint map on `HarnessPool` | `policy_fingerprints` |
| 4 | fingerprint in the staleness fast-path | `harness/mod.rs` `ensure` |
| 5 | live value folded in before rebuild | `fresh_company.overlay_policy = …` |
| 6 | console route + UI | `server/ops/policy.rs`, `policy-settings.tsx` |

Plus the two read sites switched off the manifest: `build_roster` and `workflows/caps/mod.rs` (a workflow run must not sit on a different tier from the roster).

### This does **not** need to be stacked on #560

My own test caught the coupling: this branch is off `main`, which has no `auto` yet, so a hard-coded four-tier console list failed immediately.

Resolved by splitting the two concerns — `TIER_TEXT` holds the operator-facing prose (including `auto`'s), and `selectable_tiers()` narrows it by `POLICY_MODES`. An entry ahead of the runtime is inert; an entry *behind* it fails `every_runtime_tier_has_console_text`. So **the two PRs can land in either order**, and `auto` appears in the console the moment #604 merges, with no further edit.

The invariant is asserted in one direction only, deliberately — asserting the converse would force the stacking this avoids.

### Smaller decisions worth seeing

- **`mode` and `always_approve` are independently optional.** The tier control and the always-ask editor are separate widgets and each `PUT` names only what it changed; if either field reset the other, using one control would silently undo the other. `always_approve` is the operator's real lever — it wins over every tier including `full`.
- **`Some(vec![])` ≠ `None`.** An emptied always-ask list is a state an operator can choose. Collapsing it into "fall back to the manifest" would silently restore the three gates they had just removed, with no way to express what they meant.
- **An unknown `mode` is `422`, not accepted.** `PolicyMode::parse` falls back to `supervised`, so accepting it would leave the console showing a tier the gate was not running — worse than refusing.
- **Attribution is not hashed into the fingerprint.** Re-setting the same tier writes a fresh `set_by`/`at_millis`; hashing those would rebuild the roster and drop live agent sessions for a change no agent can observe.
- **`auto_approve_under_usd` stays manifest-only** — adding it to the override would create a field nothing can write.
- **The console renders the timing gap.** A change lands on the *next* turn; a turn already running finishes under the previous tier. Since "stop the flood **now**" is exactly why an operator is here, `takesEffect` says so rather than leaving them to find out.

## API Or Behavior Changes

**New routes** (admin-only for writes; `GET` is a read of configuration):

- `GET …/policy` — tier + always-ask list in force, what the manifest would restore, whether overridden and by whom, selectable tiers with descriptions, and when a change takes effect.
- `PUT …/policy` — `{"mode": <string|null>, "alwaysApprove": <string[]|null>}`, both optional and independent. `{}` is `422`; an unknown mode is `422`.
- `DELETE …/policy` — drop the override so the manifest's `[policy]` applies again.

**New public types:** `PolicyOverride`; `CompanyRecord::overlay_policy`; `CompanyRecord::effective_policy()`; `OverlayBlob::policy`. `CompanyRecord` gains a field, so every struct literal of it must be updated — 90 sites in-tree, all handled.

**Behaviour:** no change for any company that never sets an override. `effective_policy()` with `overlay_policy: None` is the manifest verbatim, asserted by test. Persistence is back-compatible in every backend: `#[serde(default)]` reads a row written before this as `None`.

**Console:** a new "Approvals" card in Settings.

## Tests

Current head `ceeda8a` is rebased onto `474bf935`. Under the current workflow, Rust compilation and tests run in CI only.

- [x] `cargo fmt --all -- --check` — ran on the current head, exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A — local Rust compilation is prohibited; CI is authoritative.
- [x] `cargo build --all-targets` — N/A — local Rust builds are prohibited; CI is authoritative.
- [x] `cargo test` — N/A — local Rust tests are prohibited; CI is authoritative.

**Console lane:** `npm run typecheck`, `npm run typecheck:e2e`, and `npm run typecheck:unit` all ran on the current head, exit 0.

### Historical pre-rebase revert-and-check

Every new test proven to fail with its fix reverted, one at a time, verifying the edit applied before running:

| Revert | Test that must fail | Result |
| --- | --- | --- |
| `effective_policy` ignores the override | `a_stored_policy_override_beats_the_manifest` | ✅ failed |
| Emptied `always_approve` falls back to the manifest | `an_emptied_always_approve_list_is_not_a_fallback` | ✅ failed |
| Setting one field resets the other | `overriding_one_policy_field_leaves_the_other_alone` | ✅ failed |
| `policy_fingerprint` returns a constant | `the_policy_fingerprint_moves_when_the_tier_does` | ✅ failed |
| `policy_fingerprint` returns a constant | `the_policy_fingerprint_moves_when_the_always_ask_list_does` | ✅ failed |
| Attribution hashed into the fingerprint | `re_setting_the_same_tier_does_not_rebuild_the_roster` | ✅ failed |
| Console offers `TIER_TEXT` unfiltered | `every_runtime_tier_has_console_text` | ✅ failed |

The store round-trip fixtures (`store/conformance.rs`, `store/export.rs`) carry a **populated** override rather than `None` — a `None` there could not detect the field being dropped from a backend, which is the whole reason those fixtures exist.

### Not verified

- **Not run in a live app.** No manual end-to-end drive of the panel against a running company; the route and the resolution are proven by unit test only. Given this touches an approval gate, that is the gap I would most want closed before merge.
- **No frontend unit test for the panel.** `npm run test` has **38 pre-existing failures** on this machine — `window.localStorage.clear is not a function`, a local Node/vitest shim issue. **Proven pre-existing**: identical failures with my changes stashed. CI's Console lane runs only the three typecheck commands, all of which pass.
- **The `takesEffect` claim is reasoned, not measured.** That a change lands on the next turn follows from `build_roster` + the fingerprint; I did not observe a live roster rebuild.
- Coverage percentage not measured.

## Documentation

- `docs/spec/runtime/api.md` — the three routes in the route table, plus the `PUT` semantics, the `422` cases, and the two facts the route states rather than hides (next-turn timing; the override surviving a rebuild).
- `docs/spec/runtime/ports-state.md` — `overlay_policy`, `effective_policy`, and why it cannot be a manifest write.
- Rustdoc carries the arguments at their sites: `PolicyOverride` (why an overlay, and the trade it makes), `CompanyRecord::effective_policy`, `policy_fingerprint` (why the axis has to exist at all), `server::ops::policy` (the module header), and `runtime::builder` where the override is carried across a rebuild.

**Note on `api.md`:** it was already 474 lines against the repo's 500-line Markdown limit, so this section is condensed to land exactly at 500. That file now has no headroom — the next addition to it forces the split `CLAUDE.md` describes.

Refs #562. Related: #560 / #604 (the `auto` tier — composes, does not need stacking), #605 (whether `auto` becomes the default), #343 (the precedent this follows), #558.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added company-scoped controls to view, update, and reset autonomy tiers and always-ask settings.
  * Added console policy settings with effective policy details, activation timing, reset controls, and success or error feedback.
  * Policy changes support independent updates, attribution, admin authorization, persistence, next-turn activation, and preservation across roster rebuilds and bundle transfers.

* **Documentation**
  * Documented policy overrides, precedence, persistence, reset behavior, and authorization requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

