### PR TITLE
approvals: decide which calls need a human, per call (#338)

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -76,6 +76,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [company-brain/README.md](company-brain/README.md) | What the company brain is; the cycle |
 | [company-brain/charter.md](company-brain/charter.md) | The company constitution |
 | [company-brain/approvals.md](company-brain/approvals.md) | Checkpoints and the approval model |
+| [company-brain/per-call-judgement.md](company-brain/per-call-judgement.md) | Which calls warrant a human, per call (step 7 of the gate) |
 | [company-brain/memory.md](company-brain/memory.md) | Long-term memory and retention |
 | [runtime/README.md](runtime/README.md) | Kernel architecture and crate layout |
 | [runtime/ports.md](runtime/ports.md) | Port trait contracts (normative) — index, assembly, defaults |

--- a/docs/spec/company-brain/README.md
+++ b/docs/spec/company-brain/README.md
@@ -7,6 +7,7 @@ that state through the `Brain` port. Cognition itself is
 it.
 
 Supporting docs: [charter.md](charter.md), [approvals.md](approvals.md),
+[per-call-judgement.md](per-call-judgement.md),
 [memory.md](memory.md).
 
 ## Definition

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -355,7 +355,10 @@ A tool call is decided in this order:
    and it re-checks the live arguments, so a grant minted on a Composio read
    cannot admit a Composio send.
 4. `[policy].always_approve` → park.
-5. mode dispatch (`readonly` / `supervised` / `auto` / `full`).
+5. the per-agent daily cap, then `auto_approve_under_usd`.
+6. mode dispatch (`readonly` / `supervised` / `auto` / `full`).
+7. **per-call judgement** (issue #338) → park. Consulted *only* where step 6
+   allowed the call, and its only answers are "stop" and "say nothing".
 
 The grant sits **above** `always_approve` on purpose. A tool on that list still
 parks the first time, which is what the list is for; but once the operator has
@@ -367,6 +370,18 @@ narrow.
 Note this is the *tool* gate (`ApprovalPolicy`), which is a different path from
 the *effect* gate (`ManifestApprovalGate::evaluate`) the taxonomy above
 describes. A harness tool call parks directly and never reaches `evaluate`.
+
+### Per-call judgement (issue #338)
+
+Steps 1–6 are all decided before the run starts, by an operator writing a
+manifest; nothing in them looks at what the run is about to do. Step 7 closes
+that gap: `src/policy/judgement.rs` asks, per candidate call, whether it
+warrants a human on its own merits, and it can **only ever add a stop**.
+
+It is documented in full — the placement argument, the three rules, the
+no-learning boundary against #563, why it is not a model call, fail-closed, and
+the deliberate `publish_artifact` exclusion — in
+[per-call-judgement.md](per-call-judgement.md).
 
 ## Approvals inside a workflow run (issue #395)
 

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -378,9 +378,17 @@ manifest; nothing in them looks at what the run is about to do. Step 7 closes
 that gap: `src/policy/judgement.rs` asks, per candidate call, whether it
 warrants a human on its own merits, and it can **only ever add a stop**.
 
-It is documented in full — the placement argument, the three rules, the
-no-learning boundary against #563, why it is not a model call, fail-closed, and
-the deliberate `publish_artifact` exclusion — in
+Step 7 is also the one step scoped by **which path the call arrived on** (issue
+#674): #338's rules govern an agent turn, and #614's position governs a node an
+operator authored into a saved workflow — unless that node's arguments are
+templated from an upstream node's output, which returns it to the agent rule.
+Steps 1–6 decide identically on both paths, so `always_approve` still gates a
+workflow node.
+
+It is documented in full — the placement argument, the three rules, the path
+split and its boundary condition, the acceptance verbs per path, the no-learning
+boundary against #563, why it is not a model call, fail-closed, and the
+`publish_artifact` carve-out #658 ruled correct — in
 [per-call-judgement.md](per-call-judgement.md).
 
 ## Approvals inside a workflow run (issue #395)

--- a/docs/spec/company-brain/per-call-judgement.md
+++ b/docs/spec/company-brain/per-call-judgement.md
@@ -26,14 +26,18 @@ where the mode allowed.** A tier that already parks or denies a call keeps its
 own answer, whatever it is called and however many tiers there are — so a tier
 an operator has already reasoned about does not shift under them.
 
-Today that leaves **`full` alone**. `supervised` parks a `Consequence` call,
-`readonly` denies it, and `auto` (#560) parks everything that is not
-`Grantable` — which covers every rule below, so this adds nothing there. That
-last one holds by a property of the declaration table rather than by
-construction: the day a `Grantable` + `Consequence` tool with a named
-consequence class is declared, `auto` would shift silently. The test
-`the_arm_adds_nothing_under_auto` walks the whole table and fails on that day,
-rather than the claim resting on a paragraph.
+Which tiers that leaves the arm speaking on is deliberately **not enumerated
+here, in `judgement.rs`, or in `policy.rs`**. A prose list of tiers is a copy to
+miss the next time one lands, and `auto` (#560) landing mid-review is the proof
+that they land. The question is answered in the one copy that cannot go stale:
+`the_arm_adds_nothing_under_auto` walks **every declared tool** and asserts this
+arm is silent on each one a tier still allows.
+
+Which matters most where the answer holds by a property of the declaration
+table rather than by construction. The day a `Grantable` + `Consequence` tool
+with a named consequence class is declared, a tier an operator has already
+reasoned about would shift under them silently — and that test fails that day,
+rather than the claim resting on a paragraph nobody re-reads.
 
 `full`'s contract is "act without asking, *except the few things on the
 always-ask list*", and this is what makes that exception mean something without

--- a/docs/spec/company-brain/per-call-judgement.md
+++ b/docs/spec/company-brain/per-call-judgement.md
@@ -20,15 +20,23 @@ stop**. It runs only where step 6 already allowed the call, so:
   already had their say and returned before it is reached;
 - it cannot turn a deny into a park, skip `always_approve`, or spend a grant.
 
-`supervised` and `readonly` are untouched by construction: a `Consequence` call
-already parks under one and is already denied under the other, so every call
-this would stop has already been stopped. That leaves the two autonomous tiers.
+The invariant, phrased so it survives the next tier: **this arm only ever speaks
+where the mode allowed.** A tier that already parks or denies a call keeps its
+own answer, whatever it is called and however many tiers there are — so a tier
+an operator has already reasoned about does not shift under them.
+
+Today that leaves **`full` alone**. `supervised` parks a `Consequence` call,
+`readonly` denies it, and `auto` (#560) parks everything that is not
+`Grantable` — which covers every rule below, so this adds nothing there. That
+last one holds by a property of the declaration table rather than by
+construction: the day a `Grantable` + `Consequence` tool with a named
+consequence class is declared, `auto` would shift silently. The test
+`the_arm_adds_nothing_under_auto` walks the whole table and fails on that day,
+rather than the claim resting on a paragraph.
+
 `full`'s contract is "act without asking, *except the few things on the
 always-ask list*", and this is what makes that exception mean something without
-an operator having to anticipate each one by name. `auto` (#560) already parks
-what leaves the company or spends money, so this adds only the unbounded tools
-its line does not draw — `shell` and its family. The same rule applies in both;
-no tier gets a carve-out of its own.
+an operator having to anticipate each one by name.
 
 ## What stops
 
@@ -62,13 +70,27 @@ broke publishing outright. What keeps it narrow at the other end is
 that only reads, searches, or drafts does not stop" stays true.
 
 **What it deliberately does not stop.** #338's acceptance says "send, publish,
-pay, or delete"; this delivers three of the four. **`publish_artifact` is
-excluded** (`DEFERRED` in `src/policy/judgement.rs`), pending issue #658. It is
-declared `EffectGroup::Publish` + `Reach::Consequence` and so qualifies under
-rule 1, but this gate's only escape is a per-call grant — so stopping it would
-end unattended publishing for every `full` company with no operator override,
-which is a product decision belonging to the owners of #244 rather than a side
-effect of adding a classifier. #658 carries the argument and the options.
+pay, or delete". Of those, **send, pay and delete are gated; publish is not**,
+and the outward-HTTP family is held back as well. Both carve-outs live in
+`DEFERRED` in `src/policy/judgement.rs`:
+
+- **`publish_artifact`** — issue #658. It qualifies under rule 1
+  (`EffectGroup::Publish` + `Reach::Consequence`), but this gate's only escape
+  is a per-call grant, so stopping it would end unattended publishing for every
+  `full` company with no operator override. That is a product decision owned by
+  #244, not a side effect of adding a classifier.
+- **`http_request`, `curl`, `web_fetch`** — issue #674. They qualify under rule
+  3, and #614 (merged as #627) states the opposite premise in a test named
+  `an_http_request_node_does_not_gate_under_full`. A named test is a stated
+  position; choosing between two defensible premises belongs to #614's owner.
+
+**`shell` stays gated**, which is what keeps "or delete" real: destruction has
+no `EffectGroup` of its own, `shell` is how a run deletes, and #614 does not
+touch it. `git_operations` and `run_workflow` stay too.
+
+A test asserts every deferred tool *qualifies* on the declaration and is silent
+anyway, so deleting a carve-out fails loudly rather than silently re-opening
+the question.
 
 **It does not learn.** If an operator approves the same shape of call five
 times, the sixth still stops. The module holds no state across calls at all.

--- a/docs/spec/company-brain/per-call-judgement.md
+++ b/docs/spec/company-brain/per-call-judgement.md
@@ -1,0 +1,100 @@
+# Per-call judgement
+
+How the approval gate decides which calls warrant a human *on their own merits*,
+in the gap the static configuration leaves (issue #338, spine epic #183 §4).
+
+Read [approvals.md](approvals.md) first: this is **step 7** of the precedence
+chain documented there, and the placement is most of the argument.
+
+Steps 1–6 are all decided before the run starts, by an operator writing a
+manifest. Nothing in them looks at what the run is about to do. That is a bad
+trade in both directions: a low bar stops the run constantly, and `full` lets it
+send, publish, pay or delete without asking anyone.
+
+Step 7 closes that gap. `src/policy/judgement.rs` asks, per candidate call,
+whether it warrants a human on its own merits — and it can **only ever add a
+stop**. It runs only where step 6 already allowed the call, so:
+
+- the reserved `never_do` slot, the `readonly` brake, both grant arms,
+  `always_approve`, the daily cap and `auto_approve_under_usd` have each
+  already had their say and returned before it is reached;
+- it cannot turn a deny into a park, skip `always_approve`, or spend a grant.
+
+`supervised` and `readonly` are untouched by construction: a `Consequence` call
+already parks under one and is already denied under the other, so every call
+this would stop has already been stopped. That leaves the two autonomous tiers.
+`full`'s contract is "act without asking, *except the few things on the
+always-ask list*", and this is what makes that exception mean something without
+an operator having to anticipate each one by name. `auto` (#560) already parks
+what leaves the company or spends money, so this adds only the unbounded tools
+its line does not draw — `shell` and its family. The same rule applies in both;
+no tier gets a carve-out of its own.
+
+## What stops
+
+**In order:** Three rules, in order, all derived from declarations that
+already exist rather than a new taxonomy:
+
+1. a **declared consequence class** (`Spend`, `Send`, `Sign`, `Publish`,
+   `Hire`, `Identity`) **paired with `Reach::Consequence`**. Both halves are
+   required: `web_search` is declared `Spend` because the backend bills per
+   request, but its reach is `Money` — the spend buys the call, nothing changes
+   and nothing leaves. Stopping on the group alone parks every search in the
+   company, and a parked search is a search that never happens. Media
+   generation is `Spend` + `Consequence` and does stop, because it moves real
+   money on submit;
+2. **money named in the arguments** — a positive `amount_usd`, whatever the
+   tool's own class says;
+3. **unbounded reach** — a named set (`shell`, `curl`, `http_request`,
+   `web_fetch`, `git_operations`, `run_workflow`) that is `Consequence`.
+   This is how a *delete* stops: destruction has no `EffectGroup` of its own,
+   and `shell` is how a run deletes.
+
+Rule 3 is a **list, and was briefly a derivation**. `Consequence` +
+`Standing::PerCall` looks like it names exactly this set, since #444 refuses a
+standing grant to all of it — but `PerCall` is refused for two reasons the flag
+cannot tell apart: *unbounded* (`shell`) versus *bounded but overwriting
+operator-authored state* (`workspace_write`). Deriving from it swept up the
+workspace tools, which is how a company publishes to its own note tree, and
+broke publishing outright. What keeps it narrow at the other end is
+`Grantable`: the agent's own scratch writes (`file_write`, `edit`,
+`apply_patch`, `memory_store`) are `Consequence` too and do not stop, so "a run
+that only reads, searches, or drafts does not stop" stays true.
+
+**What it deliberately does not stop.** #338's acceptance says "send, publish,
+pay, or delete"; this delivers three of the four. **`publish_artifact` is
+excluded** (`DEFERRED` in `src/policy/judgement.rs`), pending issue #658. It is
+declared `EffectGroup::Publish` + `Reach::Consequence` and so qualifies under
+rule 1, but this gate's only escape is a per-call grant — so stopping it would
+end unattended publishing for every `full` company with no operator override,
+which is a product decision belonging to the owners of #244 rather than a side
+effect of adding a classifier. #658 carries the argument and the options.
+
+**It does not learn.** If an operator approves the same shape of call five
+times, the sixth still stops. The module holds no state across calls at all.
+Consent is an operator writing a rule — that is issue #563 — and a rule can be
+read, revoked and shown. A classifier noticing a habit is none of those, and
+turning a security boundary into a frequency count is how it stops being one.
+The two mechanisms must not converge.
+
+This is also why **novelty is not a signal**, though #338 lists it among the
+four. Every use of "we have seen this before" makes the gate looser, and the
+looser second call is already governed by the single-use grant: the operator
+approves one call, redeeming it consumes it, the next identical call parks
+again. A novelty rule that skipped the second stop would quietly repeal that.
+
+**It is not a model call.** A classifier LLM on the approval path costs money
+and latency per candidate, is itself an external effect deciding whether
+external effects are allowed, and returns different verdicts on different days —
+and "why did this stop?" has to be answerable from the trace months later.
+
+**Failure is a stop.** There is no unclassified-so-allow path: an undeclared
+tool reaches `consequence_of`'s cautious fallback and a Composio slug nobody
+has classified is treated as a send, so both stop. Fail-closed is not a branch
+to remember — it falls out of reusing a classifier that is already cautious.
+
+**Coverage.** The workflow `tool_call` path never consults `ApprovalPolicy` at
+all (issue #460), so nothing here reaches it. The acceptance criterion "stops
+regardless of mode" holds on the harness path; on that path it is unreachable
+until #460 lands.
+

--- a/docs/spec/company-brain/per-call-judgement.md
+++ b/docs/spec/company-brain/per-call-judgement.md
@@ -8,8 +8,9 @@ chain documented there, and the placement is most of the argument.
 
 Steps 1–6 are all decided before the run starts, by an operator writing a
 manifest. Nothing in them looks at what the run is about to do. That is a bad
-trade in both directions: a low bar stops the run constantly, and `full` lets it
-send, publish, pay or delete without asking anyone.
+trade in both directions: a low bar stops the run constantly, and `full` lets an
+agent-picked call send, pay, delete or otherwise cross an unbounded boundary
+without asking anyone. Publishing is the deliberate #658 exception below.
 
 Step 7 closes that gap. `src/policy/judgement.rs` asks, per candidate call,
 whether it warrants a human on its own merits — and it can **only ever add a
@@ -69,27 +70,76 @@ broke publishing outright. What keeps it narrow at the other end is
 `apply_patch`, `memory_store`) are `Consequence` too and do not stop, so "a run
 that only reads, searches, or drafts does not stop" stays true.
 
-**What it deliberately does not stop.** #338's acceptance says "send, publish,
-pay, or delete". Of those, **send, pay and delete are gated; publish is not**,
-and the outward-HTTP family is held back as well. Both carve-outs live in
-`DEFERRED` in `src/policy/judgement.rs`:
+## Which path the call arrived on
 
-- **`publish_artifact`** — issue #658. It qualifies under rule 1
-  (`EffectGroup::Publish` + `Reach::Consequence`), but this gate's only escape
-  is a per-call grant, so stopping it would end unattended publishing for every
-  `full` company with no operator override. That is a product decision owned by
-  #244, not a side effect of adding a classifier.
-- **`http_request`, `curl`, `web_fetch`** — issue #674. They qualify under rule
-  3, and #614 (merged as #627) states the opposite premise in a test named
-  `an_http_request_node_does_not_gate_under_full`. A named test is a stated
-  position; choosing between two defensible premises belongs to #614's owner.
+The three rules above do not apply to every call the same way. **Issue #674 split
+them by path**, and the split is not a convention — it is a difference in what an
+operator actually consented to.
 
-**`shell` stays gated**, which is what keeps "or delete" real: destruction has
-no `EffectGroup` of its own, `shell` is how a run deletes, and #614 does not
-touch it. `git_operations` and `run_workflow` stay too.
+A workflow `tool_call` node is **refused at author time** unless its namespace is
+one the workflow invoker wires *and* the company's `[tools].allow` grants it. So
+a saved `shell` node has passed **two operator gates** — the manifest grant, then
+authoring — and the operator saw the command they saved. An agent turn has passed
+**neither**: the model picks the tool and the arguments at run time. That is why
+`full` meaning "do not ask me about what I authored" is coherent, while "do not
+ask me about anything the model decides to run" is not.
 
-A test asserts every deferred tool *qualifies* on the declaration and is silent
-anyway, so deleting a carve-out fails loudly rather than silently re-opening
+- **Agent path** (`CallPath::Agent`) — #338's rules govern. The default at every
+  construction site, because it is the strict one.
+- **Authored workflow node** (`CallPath::AuthoredWorkflowNode`) — #614's position
+  governs: this step is silent. The workflow gate pass opts in explicitly, on the
+  private policy instance it builds for that pass. The operator's controls there
+  are the two gates above plus `always_approve`, which still gates a node the
+  tier would allow.
+
+**The boundary condition, without which the split is a hole.** A node whose
+arguments are **templated from an upstream node's output is not pre-declared**,
+and follows the *agent* rule. The operator declared the *shape*; the *content*
+arrives at run time from data they never saw. Without it, one `shell` node whose
+`command` is `=previous.output` defeats the split outright — the two-gate
+argument stops describing what actually runs while still being cited as the
+reason not to ask. `an_authored_node_templated_from_upstream_output_follows_the_agent_rule`
+pins the rule and
+`a_shell_node_templated_from_upstream_output_gates_under_full` pins it at the
+gate pass itself.
+
+### The acceptance verbs, per path
+
+#338's acceptance says "a run that would **send, publish, pay, or delete** stops
+for approval regardless of mode". Restated so it is true of the code:
+
+| Verb | Agent path | Authored workflow node |
+|---|---|---|
+| **send** | **Stops** — rule 1 (`Send` + `Consequence`), or fail-closed if the tool is undeclared | Not stopped here. `always_approve` and `[tools].allow` are the operator's controls — **unless templated**, then the agent rule |
+| **publish** | **Not stopped** — `publish_artifact` is carved out; see #658 below | Not stopped, on the same carve-out. The carve-out is not part of the split, and holds on both paths even when templated |
+| **pay** | **Stops** — rule 1 (`Spend` + `Consequence`) and rule 2 (a positive `amount_usd`) | Not stopped here — **unless templated**, then the agent rule |
+| **delete** | **Stops** — rule 3, via `shell`; destruction has no `EffectGroup` of its own | Not stopped here — **unless templated**, then the agent rule |
+
+"Regardless of mode" is exact and unchanged: on the agent path no tier exempts a
+call from this step. "Regardless of *path*" was never claimed and is now
+explicitly not true.
+
+**What it deliberately does not stop, on either path.** `publish_artifact`, named
+in `DEFERRED` in `src/policy/judgement.rs`. It qualifies under rule 1
+(`EffectGroup::Publish` + `Reach::Consequence`) and is silent anyway.
+
+**#658 ruled this correct behaviour rather than a stopgap.** Under `full` a
+company publishes without asking, and `always_approve` is the operator's
+override. The argument it settled: this step's only escape is a single-use,
+argument-exact per-call grant (#243), and there is no manifest knob — so stopping
+`publish_artifact` here would end unattended publishing for every `full` company
+permanently, with no way to opt out short of editing the declaration table. An
+operator who wants publishing gated names it in `always_approve`, which is read
+at step 4 and is a thing they can see, change and revoke.
+
+`http_request`, `curl` and `web_fetch` **were** deferred pending #674 and are
+not any more. They are **scoped by path**, not excluded from the rule: governed
+by #614 on the authored-node path and by #338 on the agent path. `shell`,
+`git_operations` and `run_workflow` are the same.
+
+`every_deferred_tool_would_otherwise_be_stopped` asserts every remaining
+carve-out *qualifies* on the declaration and is silent anyway — and fails if the
+list is emptied — so deleting one fails loudly rather than silently re-opening
 the question.
 
 **It does not learn.** If an operator approves the same shape of call five
@@ -115,8 +165,13 @@ tool reaches `consequence_of`'s cautious fallback and a Composio slug nobody
 has classified is treated as a send, so both stop. Fail-closed is not a branch
 to remember — it falls out of reusing a classifier that is already cautious.
 
-**Coverage.** The workflow `tool_call` path never consults `ApprovalPolicy` at
-all (issue #460), so nothing here reaches it. The acceptance criterion "stops
-regardless of mode" holds on the harness path; on that path it is unreachable
-until #460 lands.
+**Coverage.** This step is reached from two places, and both are deliberate.
+`ApprovalPolicy::check` on the agent path, and `apply_policy_gates` on the
+workflow path — where #612 (closing #460) and #627 (closing #614) made
+`tool_call` and `http_request` nodes consult the same policy. The earlier
+statement that "the workflow path never consults `ApprovalPolicy`" was true when
+this was written and is not any more; the path split above is what governs there
+now, rather than the step being unreachable.
 
+`sub_workflow` children remain ungated on that path — the engine cannot resume a
+child across the boundary — which is issue #617, not this step's scope.

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1305,21 +1305,22 @@ impl ToolPolicy for ApprovalPolicy {
         // into a stop; it can never turn a deny into an allow, skip
         // `always_approve`, or spend a grant.
         //
-        // `supervised` and `readonly` are untouched by construction: a
-        // `Consequence` call already parked above under one and was already
-        // denied under the other, so every call this would stop has already
-        // been stopped. That is deliberate — a tier an operator has already
-        // reasoned about does not shift under them.
+        // The invariant, phrased to survive the next tier: this arm only ever
+        // speaks where the mode allowed. A tier that already parks or denies a
+        // call keeps its own answer — deliberately, so a tier an operator has
+        // already reasoned about does not shift under them.
         //
-        // Which leaves `full` and `auto`. `full`'s contract is "act without
-        // asking, EXCEPT the few things on the always-ask list", and this is
-        // what makes that exception mean something without requiring an
-        // operator to have anticipated each one by name. `auto` (issue #560)
-        // already parks what leaves the company or spends, so this adds only
-        // the unbounded ones its line does not draw — `shell` and its family,
-        // which run arbitrary code in a sandbox whose permissions are not
-        // visible from here. Same rule in both tiers, applied wherever the mode
-        // said allow; no tier gets a carve-out of its own.
+        // Today that leaves `full` alone. `supervised` parks a consequence,
+        // `readonly` denies it, and `auto` (issue #560) parks everything that
+        // is not `Grantable` — which covers every rule `judge` applies, so it
+        // adds nothing there. That last one holds by a property of the
+        // declaration table rather than by construction, so it is pinned by
+        // `the_arm_adds_nothing_under_auto` instead of asserted here.
+        //
+        // `full`'s contract is "act without asking, EXCEPT the few things on
+        // the always-ask list", and this is what makes that exception mean
+        // something without requiring an operator to have anticipated each one
+        // by name.
         if matches!(by_mode, ToolPolicyDecision::Allow)
             && let Some(stop) = crate::policy::judge(tool, &request.arguments).stop_reason()
         {

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -80,8 +80,18 @@
 //! It is **last**, and consulted only where the mode already said allow. That
 //! placement is the whole safety argument: it can turn an allow into a stop and
 //! can do nothing else, so every arm above keeps its authority unchanged. The
-//! practical effect is confined to `full` — `supervised` already parks a
-//! consequence and `readonly` already denies one.
+//! invariant, phrased so it survives the next tier: **this arm only ever speaks
+//! where the mode allowed.**
+//!
+//! It is also scoped by **which path the call arrived on** (issue #674). A
+//! policy built by [`ApprovalPolicy::new`] judges an agent turn, where the model
+//! picked the tool and the arguments and nobody saw the call first. The workflow
+//! gate pass opts into
+//! [`for_authored_workflow_nodes`](ApprovalPolicy::for_authored_workflow_nodes),
+//! where an operator authored the node past the manifest grant and the authoring
+//! refusal — unless its arguments are templated from an upstream node's output,
+//! which un-declares it. Only this last arm reads the path; every arm above
+//! decides identically on both.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -94,6 +104,7 @@ use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 
 use crate::company::Policy;
 use crate::metering::{usd_spent_by_agent, utc_day_start_millis};
+use crate::policy::CallPath;
 use crate::ports::UsageMeter;
 use crate::ports::types::{CompanyId, Effect, EffectGroup};
 use crate::runtime::grants::{GrantSet, GrantedCall};
@@ -702,6 +713,17 @@ pub struct ApprovalPolicy {
     /// projected before: no agent, so no grant, so the runtime executes it
     /// natively. Only `build_roster` sets it.
     agent: Option<String>,
+    /// Which of the two paths the calls this instance judges arrive on (issue
+    /// #674), read by the per-call judgement arm and by nothing else.
+    ///
+    /// [`CallPath::Agent`] — the strict one — at every construction site except
+    /// the workflow gate pass, which opts in via
+    /// [`for_authored_workflow_nodes`](Self::for_authored_workflow_nodes). A
+    /// field rather than a `check` parameter because the trait's signature is
+    /// openhuman's, and because the path is a property of the instance: the
+    /// gate pass builds its own policy for its own pass, and nothing else shares
+    /// it.
+    call_path: CallPath,
 }
 
 /// Where the per-agent daily spend cap reads today's spend from (issue #304):
@@ -739,6 +761,8 @@ impl ApprovalPolicy {
             agent: None,
             spend: None,
             no_meter_warned: AtomicBool::new(false),
+            // The strict path by default — see `for_authored_workflow_nodes`.
+            call_path: CallPath::Agent,
         }
     }
 
@@ -763,6 +787,27 @@ impl ApprovalPolicy {
     /// effect knows whose tool call it came from (issue #243).
     pub fn with_agent(mut self, agent: impl Into<String>) -> Self {
         self.agent = Some(agent.into());
+        self
+    }
+
+    /// Declares that this policy instance judges calls an operator **authored**
+    /// into a saved workflow, not calls a model chose during a turn (issue
+    /// #674).
+    ///
+    /// It changes one arm and one arm only: the per-call judgement at the end of
+    /// [`check`](ToolPolicy::check). Every arm above — the reserved `never_do`
+    /// slot, the `readonly` brake, both grant arms, `always_approve`, the daily
+    /// cap, `auto_approve_under_usd` and the tier — decides exactly as it does
+    /// on the agent path. An operator who wants a node gated still names it in
+    /// `always_approve` and still gets it, on either path.
+    ///
+    /// **Opt-in, and deliberately so.** [`new`](Self::new) yields the agent
+    /// path, which is the strict one, so a construction site that has not
+    /// thought about this gets judged in full rather than silently exempted.
+    /// Only [`apply_policy_gates`](crate::workflows::gate) calls this, on the
+    /// private instance it builds for exactly that pass.
+    pub fn for_authored_workflow_nodes(mut self) -> Self {
+        self.call_path = CallPath::AuthoredWorkflowNode;
         self
     }
 
@@ -1322,7 +1367,8 @@ impl ToolPolicy for ApprovalPolicy {
         // something without requiring an operator to have anticipated each one
         // by name.
         if matches!(by_mode, ToolPolicyDecision::Allow)
-            && let Some(stop) = crate::policy::judge(tool, &request.arguments).stop_reason()
+            && let Some(stop) =
+                crate::policy::judge(tool, &request.arguments, self.call_path).stop_reason()
         {
             return self.require_approval(
                 tool,
@@ -1992,8 +2038,9 @@ mod tests {
         // it stops: it is internal, and the gate is scoped to what leaves the
         // company or cannot be bounded. These tools keep their own safeguards:
         // writes and deletes require an `expected_updated_at` compare-and-swap
-        // token, creates refuse paths that already resolve, and deletes refuse
-        // folders that still hold anything.
+        // token, creates refuse paths that already resolve, deletes refuse
+        // folders that still hold anything, and renames refuse occupied
+        // destinations.
         //
         // This is the assertion that caught the first version of that gate,
         // which stopped both: publishing runs through them, and thirteen
@@ -4146,9 +4193,9 @@ mod tests {
         }
     }
 
-    /// The behaviour change, stated as #338's acceptance states it: a call that
-    /// sends, publishes or pays stops **regardless of mode** — and `full` is
-    /// the mode where that was not already true.
+    /// The agent-path behaviour change after #658's ruling: sends, payments and
+    /// undeclared publish-shaped calls stop regardless of mode. The declared
+    /// `publish_artifact` exception has its own tests in `judgement.rs`.
     #[tokio::test]
     async fn full_autonomy_stops_for_an_irreversible_call() {
         let p = policy("full", &[], None);
@@ -4307,5 +4354,101 @@ mod tests {
             ),
             other => panic!("expected a park, got {}", decision_name(&other)),
         }
+    }
+
+    // ---- The path split (issue #674) --------------------------------------
+
+    /// A policy nobody told about the path judges the strict way.
+    ///
+    /// The default is the safety property: a construction site added later,
+    /// which has not thought about #674 at all, gets the agent rule rather than
+    /// being silently exempted from it.
+    #[tokio::test]
+    async fn the_default_path_is_the_strict_one() {
+        let p = policy("full", &[], None);
+        assert_eq!(p.call_path, CallPath::Agent);
+        let d = p
+            .check(&request(
+                "shell",
+                serde_json::json!({ "command": "rm -rf ." }),
+            ))
+            .await;
+        assert_eq!(decision_name(&d), "park");
+    }
+
+    /// ...and the workflow gate pass opts out of exactly that arm, because an
+    /// operator authored the node past the manifest grant.
+    #[tokio::test]
+    async fn an_authored_node_is_not_stopped_by_the_judgement_arm() {
+        let p = policy("full", &[], None).for_authored_workflow_nodes();
+        let d = p
+            .check(&request(
+                "shell",
+                serde_json::json!({ "command": "rm -rf ." }),
+            ))
+            .await;
+        assert_eq!(decision_name(&d), "allow");
+    }
+
+    /// The opt-out scopes ONE arm. This is the assertion that keeps it from
+    /// becoming a way to run a workflow node past the whole chain.
+    ///
+    /// Each case below is decided by an arm ABOVE the judgement one, so each
+    /// must decide identically on both paths. A refactor that moved the path
+    /// check any earlier — the obvious "simplification", since it would let
+    /// `check` return before doing any work — fails here rather than shipping a
+    /// bypass.
+    #[tokio::test]
+    async fn the_authored_path_changes_nothing_above_the_judgement_arm() {
+        let cases: &[(&str, &[&str], &str, &str)] = &[
+            // `readonly` denies an external effect; it does not park it, and it
+            // certainly does not allow it because a workflow authored it.
+            ("readonly", &[], "send_email", "deny"),
+            // `always_approve` is the operator asking to be told. It outranks
+            // the tier on both paths — and on the authored path it is now the
+            // operator's whole control surface, so it had better work.
+            ("full", &["shell"], "shell", "park"),
+            // `supervised` parks a consequence on its own.
+            ("supervised", &[], "shell", "park"),
+        ];
+        for (mode, always, tool, expected) in cases {
+            let args = serde_json::json!({ "command": "ls" });
+            let agent_path = policy(mode, always, None)
+                .check(&request(tool, args.clone()))
+                .await;
+            let node_path = policy(mode, always, None)
+                .for_authored_workflow_nodes()
+                .check(&request(tool, args))
+                .await;
+            assert_eq!(
+                decision_name(&agent_path),
+                *expected,
+                "{mode}/{tool}: the arm under test is not the one deciding here"
+            );
+            assert_eq!(
+                decision_name(&node_path),
+                *expected,
+                "{mode}/{tool}: the authored path must only scope the judgement \
+                 arm, and this decision is made above it"
+            );
+        }
+    }
+
+    /// The boundary condition, at the chain rather than in the pure module: the
+    /// same node, the same tier, the same path — and templated arguments.
+    #[tokio::test]
+    async fn an_authored_node_templated_from_upstream_output_still_stops() {
+        let p = policy("full", &[], None).for_authored_workflow_nodes();
+        let d = p
+            .check(&request(
+                "shell",
+                serde_json::json!({ "command": "=previous.output" }),
+            ))
+            .await;
+        assert_eq!(
+            decision_name(&d),
+            "park",
+            "the operator declared the shape, not the command"
+        );
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -68,6 +68,20 @@
 //! See [`ApprovalPolicy::daily_budget_verdict`] for why the arm sits exactly
 //! where it does, why an at-cap call **parks** rather than being denied, and
 //! what the cap does not see.
+//!
+//! ## Per-call judgement (issue #338)
+//!
+//! Everything above is decided before the run starts, by an operator writing a
+//! manifest; nothing in it looks at what the run is about to do. The last arm
+//! of [`check`](ToolPolicy::check) asks that question — see
+//! [`crate::policy::judgement`], where the verdict itself lives as a pure,
+//! separately tested function.
+//!
+//! It is **last**, and consulted only where the mode already said allow. That
+//! placement is the whole safety argument: it can turn an allow into a stop and
+//! can do nothing else, so every arm above keeps its authority unchanged. The
+//! practical effect is confined to `full` — `supervised` already parks a
+//! consequence and `readonly` already denies one.
 
 use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -1234,7 +1248,7 @@ impl ToolPolicy for ApprovalPolicy {
         // tier including `full`.
         let consequence = crate::policy::consequence_of(tool, &request.arguments);
         let reach = consequence.reach;
-        match self.mode {
+        let by_mode = match self.mode {
             PolicyMode::Full => ToolPolicyDecision::Allow,
             // `auto` sits between the two (issue #560): the agent's own sandbox
             // writes and its outward reads run unattended, and anything that
@@ -1277,7 +1291,46 @@ impl ToolPolicy for ApprovalPolicy {
                     ToolPolicyDecision::Allow
                 }
             }
+        };
+
+        // 5. Per-call judgement (issue #338): the last word, and only ever a
+        //    stricter one.
+        //
+        // LAST, and gated on the mode having already said Allow, because that
+        // placement *is* the safety argument. Static configuration stays
+        // authoritative everywhere it speaks: the reserved `never_do` slot, the
+        // `readonly` brake, a redeemed grant, `always_approve`, the daily cap
+        // and `auto_approve_under_usd` have all had their say above and every
+        // one of them returned before reaching here. This can turn an Allow
+        // into a stop; it can never turn a deny into an allow, skip
+        // `always_approve`, or spend a grant.
+        //
+        // `supervised` and `readonly` are untouched by construction: a
+        // `Consequence` call already parked above under one and was already
+        // denied under the other, so every call this would stop has already
+        // been stopped. That is deliberate — a tier an operator has already
+        // reasoned about does not shift under them.
+        //
+        // Which leaves `full` and `auto`. `full`'s contract is "act without
+        // asking, EXCEPT the few things on the always-ask list", and this is
+        // what makes that exception mean something without requiring an
+        // operator to have anticipated each one by name. `auto` (issue #560)
+        // already parks what leaves the company or spends, so this adds only
+        // the unbounded ones its line does not draw — `shell` and its family,
+        // which run arbitrary code in a sandbox whose permissions are not
+        // visible from here. Same rule in both tiers, applied wherever the mode
+        // said allow; no tier gets a carve-out of its own.
+        if matches!(by_mode, ToolPolicyDecision::Allow)
+            && let Some(stop) = crate::policy::judge(tool, &request.arguments).stop_reason()
+        {
+            return self.require_approval(
+                tool,
+                &request.arguments,
+                format!("'{tool}' {}", stop.describe()),
+            );
         }
+
+        by_mode
     }
 }
 
@@ -1447,8 +1500,15 @@ mod tests {
     #[tokio::test]
     async fn full_allows_but_always_approve_still_parks() {
         let p = policy("full", &["payment"], None);
+        // `file_write`, not `write_file`. This asserted the undeclared
+        // `write_file`, which the per-call judgement arm (issue #338) now stops
+        // fail-closed — nobody has declared what it does. The point being made
+        // here is that `full` allows a tool absent from `always_approve`, so it
+        // wants a tool `full` genuinely allows: `file_write` is declared, and is
+        // one of the low-consequence scratch writes #444 found safe enough to
+        // grant standing.
         assert_eq!(
-            p.check(&request("write_file", serde_json::json!({}))).await,
+            p.check(&request("file_write", serde_json::json!({}))).await,
             ToolPolicyDecision::Allow
         );
         assert!(matches!(
@@ -1926,12 +1986,18 @@ mod tests {
             );
         }
 
-        // Under `full` there is no per-call gate at all — which is precisely
-        // why `workspace_write` and `workspace_delete` each carry a required
-        // `expected_updated_at` compare-and-swap token of their own, why
-        // `workspace_create` refuses a path that already resolves rather than
-        // overwriting it, and why `workspace_delete` refuses a folder that
-        // still holds anything.
+        // Under `full` these still run. There IS a per-call gate now (issue
+        // #338), but writing the company's own note tree is not one of the acts
+        // it stops: it is internal, and the gate is scoped to what leaves the
+        // company or cannot be bounded. These tools keep their own safeguards:
+        // writes and deletes require an `expected_updated_at` compare-and-swap
+        // token, creates refuse paths that already resolve, and deletes refuse
+        // folders that still hold anything.
+        //
+        // This is the assertion that caught the first version of that gate,
+        // which stopped both: publishing runs through them, and thirteen
+        // `publish_turn_test` cases failed with "the model was never handed a
+        // publish receipt".
         let full = policy("full", &[], None);
         for tool in [
             "workspace_write",
@@ -3274,12 +3340,15 @@ mod tests {
             .with_agent("analyst")
             .with_spend(meter.clone() as Arc<dyn UsageMeter>, CompanyId::new("acme"));
 
+        // `web_search`, not `pay_invoice`. Both are priced calls — `web_search`
+        // is declared `EffectGroup::Spend`, which is what `is_priced_call`
+        // reads — so this still exercises the cap arm. `pay_invoice` would now
+        // also be stopped by the per-call judgement arm (issue #338), and a
+        // test about the *meter* should not be able to fail for a reason that
+        // has nothing to do with the meter.
         assert_eq!(
             uncapped
-                .check(&request(
-                    "pay_invoice",
-                    serde_json::json!({ "amount_usd": 400.0 })
-                ))
+                .check(&request("web_search", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::Allow
         );
@@ -3305,12 +3374,12 @@ mod tests {
             .with_requests(ApprovalRequestQueue::default())
             .with_agent("analyst");
 
+        // `web_search` for the same reason as `an_uncapped_agent_never_queries_
+        // the_meter`: a priced call the per-call judgement arm is silent on, so
+        // this keeps testing the cap and only the cap.
         assert_eq!(
             no_meter
-                .check(&request(
-                    "pay_invoice",
-                    serde_json::json!({ "amount_usd": 400.0 })
-                ))
+                .check(&request("web_search", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::Allow,
             "an unenforceable cap must not park what it can never release"
@@ -4057,6 +4126,185 @@ mod tests {
             assert!(classify_group(tool, &args).is_unclassified(), "{tool}");
             assert!(!grantable(tool, &args), "{tool}");
             assert!(is_external_effect(tool, &args), "{tool}");
+        }
+    }
+
+    // ---- Per-call judgement (issue #338) ----------------------------------
+    //
+    // The unit tests for the verdict itself live in `crate::policy::judgement`,
+    // which is pure and compiles in the default build. What is tested HERE is
+    // the only thing that needs the harness: **where the arm sits in the
+    // chain**. Every test below is an assertion that the arm did not move
+    // something above it.
+
+    fn decision_name(d: &ToolPolicyDecision) -> &'static str {
+        match d {
+            ToolPolicyDecision::Allow => "allow",
+            ToolPolicyDecision::RequireApproval { .. } => "park",
+            ToolPolicyDecision::Deny { .. } => "deny",
+        }
+    }
+
+    /// The behaviour change, stated as #338's acceptance states it: a call that
+    /// sends, publishes or pays stops **regardless of mode** — and `full` is
+    /// the mode where that was not already true.
+    #[tokio::test]
+    async fn full_autonomy_stops_for_an_irreversible_call() {
+        let p = policy("full", &[], None);
+        for tool in ["send_email", "publish_post", "pay_invoice"] {
+            let d = p.check(&request(tool, serde_json::json!({}))).await;
+            assert_eq!(decision_name(&d), "park", "`{tool}` must stop under full");
+        }
+    }
+
+    /// The other half: `full` still means full for everything that does not
+    /// warrant a human. A gate that stopped reads would simply be `supervised`
+    /// with extra steps.
+    #[tokio::test]
+    async fn full_autonomy_still_allows_reads_and_drafts() {
+        let p = policy("full", &[], None);
+        for tool in ["file_read", "grep", "list", "memory_recall", "web_search"] {
+            let d = p.check(&request(tool, serde_json::json!({}))).await;
+            assert_eq!(decision_name(&d), "allow", "`{tool}` must still run");
+        }
+    }
+
+    /// `readonly` DENIES an irreversible call; it does not park it.
+    ///
+    /// The failure this guards is subtle and would look like an improvement: if
+    /// the judgement arm ran before the mode, a send on a read-only desk would
+    /// come back as "ask the operator" instead of "no". That converts the
+    /// emergency stop into a prompt, which is the one thing the brake exists to
+    /// not be.
+    #[tokio::test]
+    async fn the_readonly_brake_still_denies_rather_than_parking() {
+        let p = policy("readonly", &[], None);
+        let d = p.check(&request("send_email", serde_json::json!({}))).await;
+        assert_eq!(decision_name(&d), "deny");
+    }
+
+    /// `supervised` is untouched: the call already parked, and it still parks
+    /// with the reason `supervised` gives rather than the judgement one.
+    ///
+    /// Reason text is asserted because it is the operator-visible half — a tier
+    /// silently re-labelling its stops would be a change nobody asked for.
+    #[tokio::test]
+    async fn supervised_keeps_its_own_reason() {
+        let p = policy("supervised", &[], None);
+        let d = p.check(&request("send_email", serde_json::json!({}))).await;
+        match d {
+            ToolPolicyDecision::RequireApproval { reason } => {
+                assert!(
+                    reason.contains("supervised"),
+                    "expected the supervised reason, got: {reason}"
+                );
+            }
+            other => panic!("expected a park, got {}", decision_name(&other)),
+        }
+    }
+
+    /// A pre-granted call still runs under `full` — "unless explicitly
+    /// pre-granted", in the acceptance's words.
+    ///
+    /// This is the arm's placement doing the work: the grant check returns
+    /// `Allow` long before the judgement arm is reached, so the operator's
+    /// approval is not re-litigated by a classifier.
+    #[tokio::test]
+    async fn a_pre_granted_irreversible_call_still_runs() {
+        let (p, grants) = granting_policy("full", &[], "finance");
+        let args = serde_json::json!({ "to": "customer@example.com" });
+        grants.grant(granted("finance", "send_email", args.clone()));
+        let d = p.check(&request("send_email", args.clone())).await;
+        assert_eq!(
+            decision_name(&d),
+            "allow",
+            "the grant must still be honoured"
+        );
+
+        // ...and it was consumed, so the next identical call stops again
+        // (#243 semantics, and #183 decision 3: a run may stop more than once).
+        let again = p.check(&request("send_email", args)).await;
+        assert_eq!(decision_name(&again), "park");
+    }
+
+    /// `always_approve` keeps its own reason under `full`.
+    ///
+    /// Both arms would park this call, so the decision alone cannot tell them
+    /// apart — the reason can, and the operator's card shows the reason. If the
+    /// judgement arm had been placed above `always_approve`, the operator would
+    /// stop being told that this stop is one they themselves configured.
+    #[tokio::test]
+    async fn always_approve_keeps_its_own_reason_under_full() {
+        let p = policy("full", &["send_email"], None);
+        let d = p.check(&request("send_email", serde_json::json!({}))).await;
+        match d {
+            ToolPolicyDecision::RequireApproval { reason } => {
+                assert!(
+                    reason.contains("always-approve"),
+                    "expected the always-approve reason, got: {reason}"
+                );
+            }
+            other => panic!("expected a park, got {}", decision_name(&other)),
+        }
+    }
+
+    /// `auto_approve_under_usd` is static configuration about spend, and it
+    /// still speaks first.
+    ///
+    /// Worth stating as a test rather than leaving implicit: an operator who
+    /// wrote "anything under $5 is fine" said something specific about money,
+    /// and this arm does not get to overrule it. The daily cap above still
+    /// does.
+    #[tokio::test]
+    async fn a_sub_threshold_spend_is_still_auto_approved() {
+        let p = policy("full", &[], Some(5.0));
+        let d = p
+            .check(&request(
+                "pay_invoice",
+                serde_json::json!({ "amount_usd": 1.0 }),
+            ))
+            .await;
+        assert_eq!(decision_name(&d), "allow");
+    }
+
+    /// Fail closed: a tool nobody declared stops under `full` rather than
+    /// running because nothing recognised it.
+    #[tokio::test]
+    async fn an_undeclared_tool_stops_under_full() {
+        let p = policy("full", &[], None);
+        let d = p
+            .check(&request("frobnicate_the_widget", serde_json::json!({})))
+            .await;
+        assert_eq!(decision_name(&d), "park");
+    }
+
+    /// Every stop reaches the operator. A `RequireApproval` that skipped
+    /// `require_approval` would refuse the tool without ever queueing anything
+    /// to park — the bug issue #172 closed — so the new arm is checked to go
+    /// through the same door as every other.
+    #[tokio::test]
+    async fn a_judgement_stop_is_queued_for_the_operator() {
+        let queue = ApprovalRequestQueue::default();
+        let p = policy("full", &[], None).with_requests(queue.clone());
+        let d = p.check(&request("send_email", serde_json::json!({}))).await;
+        assert_eq!(decision_name(&d), "park");
+        // `queued()`, deliberately, and neither `drain` nor `take_from`. Both of
+        // those are being reshaped by PRs in flight — #625 changes `drain`'s
+        // return type to `DrainedRequests`, and #439 removes `take_from`
+        // entirely — and neither would conflict with this branch *textually*,
+        // so both lanes would be green and whoever merged second would break
+        // the tree. `queued()` is untouched by both and answers the question
+        // this test is actually asking.
+        assert_eq!(queue.queued(), 1, "the stop must be queued to park");
+        // The reason reaching the operator is the same string the decision
+        // carries — `require_approval` clones it onto the queued request — so
+        // asserting it here needs no queue read at all.
+        match d {
+            ToolPolicyDecision::RequireApproval { reason } => assert!(
+                !reason.is_empty(),
+                "the operator needs a reason on the card"
+            ),
+            other => panic!("expected a park, got {}", decision_name(&other)),
         }
     }
 }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1,8 +1,11 @@
 //! [`ApprovalPolicy`] — a manifest `[policy]` → openhuman [`ToolPolicy`] bridge.
 //!
 //! Manifest `[policy].mode` deliberately uses OpenHuman's own security-tier
-//! words — `readonly` / `supervised` / `full` — so the mapping to
-//! [`PolicyMode`] is 1:1. On top of the tier the bridge honours the manifest's
+//! words, so the mapping to [`PolicyMode`] is 1:1 — and that enum is where the
+//! tiers are listed, deliberately the only place. Spelling them out here as
+//! well went stale the moment `auto` landed (issue #560), which is the whole
+//! reason this file stopped enumerating them. On top of the tier the bridge
+//! honours the manifest's
 //! `always_approve` effect kinds and the per-agent `budget_usd_daily` /
 //! `auto_approve_under_usd` thresholds.
 //!

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -34,13 +34,16 @@
 //! The invariant, phrased so it survives the next tier: **this arm only ever
 //! speaks where the mode allowed.** A tier that already parks or denies a call
 //! keeps its own answer, whatever the tier is called and however many there
-//! are. Spelling out which tiers those are dates the moment a tier lands — as
-//! it did when `auto` (issue #560) arrived mid-review.
+//! are.
 //!
-//! As it happens the arm today changes `full` alone: `supervised` parks a
-//! [`Reach::Consequence`] call, `readonly` denies it, and `auto` parks
-//! everything that is not `Grantable`, which covers every rule below.
-//! `the_arm_adds_nothing_under_auto` pins that rather than trusting it.
+//! Which tiers that leaves the arm speaking on is deliberately **not
+//! enumerated** — not here, not in [`crate::harness::policy`], and not in the
+//! spec. A prose tier list is a copy to miss the next time a tier lands, and
+//! `auto` (issue #560) landing mid-review is the proof that they land. The
+//! question is answered instead by the one copy that cannot go stale:
+//! `the_arm_adds_nothing_under_auto` walks **every declared tool** and asserts
+//! this arm is silent on each one a tier still allows — so a new tier or a new
+//! declaration fails a test rather than outdating a paragraph.
 //!
 //! # Where the classification lives
 //!
@@ -271,9 +274,10 @@ fn is_irreversible_group(group: EffectGroup) -> bool {
 /// Only the first warrants stopping a call that changes nothing outside the
 /// company. Deriving the set from the flag swept up `workspace_write` and
 /// `workspace_create`, which is how the company publishes to its own note
-/// tree — and stopping those broke publishing outright: thirteen
-/// `publish_turn_test` cases went from passing to "the model was never handed
-/// a publish receipt", because a parked call is a call that never happens.
+/// tree — and stopping those broke publishing outright: thirteen of the
+/// `publish_turn_test` cases as the suite then stood went from passing to "the
+/// model was never handed a publish receipt", because a parked call is a call
+/// that never happens.
 ///
 /// So the set is named. `every_unbounded_tool_is_declared` keeps it honest: a
 /// rename in the declaration table fails that test rather than silently
@@ -328,9 +332,12 @@ fn is_unbounded(tool: &str, consequence: Consequence) -> bool {
 /// who wants publishing gated names it in `always_approve`, which is read before
 /// this arm and is a thing they can see, change and revoke.
 ///
-/// The size of the alternative is visible in the tests: excluding it keeps the
-/// 11 `publish_turn_test` cases green, and gating it would need a grant minted
+/// The size of the alternative is visible in the tests: excluding it keeps all
+/// 19 `publish_turn_test` cases green, and gating it would need a grant minted
 /// per scripted call in a suite that is about publish mechanics, not approvals.
+/// That count is re-checked against #659's merged fixtures rather than carried
+/// forward — #659 landed first and touched this suite, so the evidence the
+/// carve-out rests on was re-measured on top of it, not assumed.
 ///
 /// `http_request`, `curl` and `web_fetch` **were** on this list pending #674 and
 /// are not deferred any more. #674 ruled that they are governed by #614 on the
@@ -572,10 +579,10 @@ mod tests {
         }
     }
 
-    /// The agent's own scratch space. These mutate, so `supervised` still parks
-    /// them and `readonly` still denies them — but they are the low-consequence
-    /// writes #444 found safe enough to hand over for a week, so the judgement
-    /// gate does not add a stop of its own under `full`.
+    /// The agent's own scratch space. These mutate, so any tier that parks or
+    /// denies a mutating call keeps its own answer — but they are the
+    /// low-consequence writes #444 found safe enough to hand over for a week,
+    /// so the judgement arm adds no stop of its own where a tier allowed them.
     #[test]
     fn the_agents_own_drafts_do_not_stop() {
         for tool in [
@@ -653,11 +660,12 @@ mod tests {
     }
 
     /// The company writing to its own note tree is not an unbounded act, and
-    /// stopping it broke publishing (13 `publish_turn_test` cases). They are
+    /// stopping it broke publishing (13 `publish_turn_test` cases at the
+    /// time; the suite now stands at 19, all green). They are
     /// `Standing::PerCall` — issue #444 refuses them a standing grant because
     /// they overwrite guidance the operator authored — and that is a different
-    /// reason from "what this reaches cannot be bounded". `supervised` still
-    /// parks them and `readonly` still denies them; this arm adds nothing.
+    /// reason from "what this reaches cannot be bounded". A tier that parks or
+    /// denies them keeps its own answer; this arm adds nothing on top.
     #[test]
     fn writing_the_companys_own_notes_is_not_unbounded() {
         for tool in ["workspace_write", "workspace_create"] {

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -1,0 +1,679 @@
+//! Per-call judgement: which calls stop for a human, beyond what the static
+//! configuration says (issue #338, spine epic #183 §4).
+//!
+//! Specified in `docs/spec/company-brain/per-call-judgement.md`.
+//!
+//! # The gap this fills
+//!
+//! Whether a call stops is answered entirely by configuration decided before
+//! the run starts: reserved `never_do`, the `readonly` brake, a live grant,
+//! `always_approve`, the daily cap, `auto_approve_under_usd`, then the mode.
+//! Nothing looks at what the run is about to do.
+//!
+//! That is a bad trade in both directions. Set the bar low and every run stops
+//! constantly, which is the batching pressure #183 decision 3 exists to avoid.
+//! Set it high — `full` — and the run sends, publishes, pays or deletes without
+//! asking anyone.
+//!
+//! `full`'s stated contract is "the agents act without asking, **except the few
+//! things on the always-ask list**". Without this module that exception is
+//! whatever one operator remembered to type into `always_approve`. With it, the
+//! irreversible acts stop on their own merits.
+//!
+//! # This can only ever ADD a stop
+//!
+//! The single most important property here, and the one the tests pin. This is
+//! consulted **only where the rest of the chain has already decided to allow**,
+//! and its only possible answers are "stop" and "say nothing". It cannot
+//! un-deny a `readonly` refusal, cannot skip `always_approve`, cannot spend a
+//! grant, and cannot soften the reserved `never_do` slot. Static configuration
+//! stays authoritative everywhere it speaks; this speaks only in the silence
+//! after it.
+//!
+//! A consequence worth stating plainly: **`supervised` and `readonly` are
+//! unchanged**. Under `supervised` a [`Reach::Consequence`] call already parks
+//! and under `readonly` it is already denied, so every call this module would
+//! stop has already been stopped by the mode. The behaviour it changes is
+//! `full`, and only `full`.
+//!
+//! # Where the classification lives
+//!
+//! The issue asks whether this is a property of the tool definition or a runtime
+//! judgement per candidate call. It is a **hybrid**, and deliberately not the
+//! third option:
+//!
+//! - **Declared**, from [`crate::policy::consequence`]'s table — the same
+//!   declaration the approval card and the standing-grant rule already read. No
+//!   new column and no second taxonomy: a second list would drift against the
+//!   first, and the drift would be silent in the safe-looking direction.
+//! - **Runtime**, from the arguments of the actual call — a `composio_execute`
+//!   slug that names a send, or a declared amount of money. Deterministic
+//!   inspection, not inference.
+//! - **Not a model call.** A classifier LLM on the approval path costs money and
+//!   latency per candidate call, is itself an external effect being made to
+//!   decide whether external effects are allowed, and — fatally — returns a
+//!   different verdict on different days. "Why did it stop?" must have an
+//!   answer that can be re-derived from the record months later, which #242's
+//!   trace exists to make possible. A sampled verdict cannot be audited.
+//!
+//! # It does not learn
+//!
+//! Firmly, and not as an oversight. If an operator approves the same shape of
+//! call five times, the sixth still stops. Consent is an operator writing a
+//! rule — that is issue #563, and a rule is a thing they can read, revoke and
+//! be shown. A classifier noticing a habit is not consent: nobody agreed to it,
+//! it cannot be pointed at, and it converts a security boundary into a
+//! frequency count. The two mechanisms must not converge, so this one holds no
+//! state across calls at all.
+//!
+//! That is also why **novelty is not a signal here**, though #338 lists it.
+//! Every use of "we have seen this before" makes the gate *looser*, and a
+//! looser second call is precisely what #243's single-use grant already governs:
+//! the operator approves one call, redeeming it consumes it, and the next
+//! identical call parks again. A novelty rule that skipped the second stop would
+//! quietly repeal that. It is recorded as a signal on the trace instead, where
+//! it informs a human without deciding anything.
+//!
+//! # What this deliberately does NOT stop
+//!
+//! #338's acceptance says "send, publish, pay, or delete". This delivers three
+//! of those four: **`publish_artifact` is excluded**, see `DEFERRED` and issue
+//! #658. The short version is that this gate's only escape is a per-call grant,
+//! so stopping publishing would end unattended publishing for every `full`
+//! company with no operator override — a product decision that belongs to the
+//! people who own #244, not to a classifier landing at the end of a build day.
+//!
+//! # Failure is a stop
+//!
+//! There is no "unclassified, so allow" path. A tool nobody declared stops
+//! ([`StopReason::Undeclared`]) unless `consequence_of` can see from its name
+//! that it only reads, and a Composio slug nobody classified is already treated
+//! as a send by the catalogue's own cautious fallback.
+//!
+//! The undeclared case gets its **own** reason rather than borrowing the group
+//! one, because for an undeclared tool the group is a guess made from words in
+//! the name. That guess is good enough to label a card and not good enough to
+//! justify a stop to an operator: `write_file` contains "file", so the guess is
+//! `Sign`, and "signs or files a document" is a confident false statement about
+//! a file write. The call stops either way; only the sentence differs, and the
+//! sentence is what a human reads.
+
+use serde_json::Value;
+
+use crate::policy::consequence::{Consequence, Reach, consequence_of, declared_tools};
+use crate::ports::types::EffectGroup;
+
+/// Why a call stopped, in the operator's terms.
+///
+/// Carried into the reason string on the parked effect, so the answer to "why
+/// did this stop?" is on the approval card and in the attempt's trace rather
+/// than only in this module's head.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum StopReason {
+    /// The tool's declared consequence class is one the company cannot take
+    /// back: spending, sending, signing, publishing, hiring, or touching the
+    /// company's identity.
+    Irreversible(EffectGroup),
+    /// The call changes state or reaches out, and what it can reach is not
+    /// bounded by anything this layer can see — arbitrary code, an arbitrary
+    /// address, or a saved workflow that performs whatever it performs.
+    UnboundedReach,
+    /// The arguments declare money leaving the company.
+    MoneyLeaves,
+    /// Nobody declared this tool, so what it does cannot be established here.
+    ///
+    /// The fail-closed case, and its own reason rather than a borrowed one. A
+    /// tool absent from the table still gets a `group` — [`consequence_of`]
+    /// falls back to matching *words in the name*, which exists so an approval
+    /// card for an unknown tool is still labelled. That heuristic is fine for a
+    /// label and wrong for a verdict: `write_file` contains "file", so it is
+    /// labelled `Sign`, and reporting "signs or files a document" to an operator
+    /// about a file write is a confident false statement. Saying "this is not
+    /// declared" is the true one, and it stops the call just the same.
+    Undeclared,
+}
+
+impl StopReason {
+    /// The operator-facing half of the reason string.
+    ///
+    /// Deliberately says what the *call* does, not which rule fired: an operator
+    /// deciding whether to approve needs the consequence, not this module's
+    /// name. The tool name is prepended by the caller.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::Irreversible(EffectGroup::Spend) => "spends money, which cannot be taken back",
+            Self::Irreversible(EffectGroup::Send) => {
+                "sends to a counterparty, which cannot be taken back"
+            }
+            Self::Irreversible(EffectGroup::Sign) => {
+                "signs or files a document, which cannot be taken back"
+            }
+            Self::Irreversible(EffectGroup::Publish) => {
+                "publishes externally, which cannot be taken back"
+            }
+            Self::Irreversible(EffectGroup::Hire) => {
+                "hires or contracts, which cannot be taken back"
+            }
+            Self::Irreversible(EffectGroup::Identity) => {
+                "changes the company's identity, which cannot be taken back"
+            }
+            // Unreachable via `judge` — `Other` is the unclassified bucket and
+            // never produces `Irreversible` — but stated rather than
+            // `unreachable!()`, because a panic on the approval path would be a
+            // denial of service triggered by a tool name.
+            Self::Irreversible(EffectGroup::Other) => "has a consequence that cannot be taken back",
+            Self::UnboundedReach => {
+                "can run arbitrary code or reach an arbitrary address, so what it \
+                 changes cannot be bounded from here"
+            }
+            Self::MoneyLeaves => "moves money out of the company",
+            Self::Undeclared => {
+                "is not a declared tool, so what it does cannot be established here"
+            }
+        }
+    }
+}
+
+/// The verdict for one candidate call.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Judgement {
+    /// This module has nothing to add; whatever the chain decided stands.
+    Silent,
+    /// Stop for a human, whatever the mode says.
+    Stop(StopReason),
+}
+
+impl Judgement {
+    /// The reason this stopped, if it did.
+    pub fn stop_reason(self) -> Option<StopReason> {
+        match self {
+            Self::Stop(reason) => Some(reason),
+            Self::Silent => None,
+        }
+    }
+}
+
+/// Is this consequence class one the company cannot take back?
+///
+/// Every named class is. [`EffectGroup::Other`] is the *unclassified* bucket
+/// rather than a "harmless" one — it is where a tool lands when the classifier
+/// found no particular consequence to name — so it is decided by reach below
+/// instead of being waved through here.
+fn is_irreversible_group(group: EffectGroup) -> bool {
+    match group {
+        EffectGroup::Spend
+        | EffectGroup::Send
+        | EffectGroup::Sign
+        | EffectGroup::Publish
+        | EffectGroup::Hire
+        | EffectGroup::Identity => true,
+        EffectGroup::Other => false,
+    }
+}
+
+/// The tools whose reach this layer cannot bound: arbitrary code, an arbitrary
+/// address, or a saved workflow that performs whatever it performs.
+///
+/// # Why this is a list and not a derivation
+///
+/// It was a derivation, and the derivation was wrong. `Reach::Consequence` +
+/// `Standing::PerCall` looked like it named exactly this set — issue #444
+/// refuses a standing grant to everything here — so it was tempting to read
+/// "an operator cannot consent to this for a week" as the same judgement as
+/// "an operator should see this once".
+///
+/// It is not. `Standing::PerCall` is refused for **two** different reasons that
+/// the flag does not distinguish: a tool can be unbounded (`shell`), or it can
+/// be bounded but overwrite state the operator authored (`workspace_write`).
+/// Only the first warrants stopping a call that changes nothing outside the
+/// company. Deriving the set from the flag swept up `workspace_write` and
+/// `workspace_create`, which is how the company publishes to its own note
+/// tree — and stopping those broke publishing outright: thirteen
+/// `publish_turn_test` cases went from passing to "the model was never handed
+/// a publish receipt", because a parked call is a call that never happens.
+///
+/// So the set is named. `every_unbounded_tool_is_declared` keeps it honest: a
+/// rename in the declaration table fails that test rather than silently
+/// dropping a tool out of this list.
+const UNBOUNDED: &[&str] = &[
+    // Arbitrary code, in a sandbox whose permissions this layer cannot see.
+    // Also the way a run *deletes*: destruction has no `EffectGroup` of its
+    // own, so this is what makes #338's "or delete" acceptance real.
+    "shell",
+    // An arbitrary address, with the tenant's own credentials.
+    "curl",
+    "http_request",
+    "web_fetch",
+    // Can push to a configured remote — an address this layer does not see.
+    // The declaration table already singles it out for that, refusing it the
+    // standing grant its filesystem siblings get.
+    "git_operations",
+    // Performs whatever the saved workflow performs, which is not visible here.
+    "run_workflow",
+];
+
+/// Does this call change things without a bound this layer can see?
+///
+/// The [`Reach::Consequence`] half still matters: it is what keeps a metered
+/// read out. `web_search` is [`Reach::Money`] — nothing changes and nothing
+/// leaves — and parking it would be worse than useless, because openhuman
+/// resolves a `RequireApproval` inline, so a parked search is a search that
+/// never happens and an agent with no search invents citations.
+fn is_unbounded(tool: &str, consequence: Consequence) -> bool {
+    consequence.reach == Reach::Consequence && UNBOUNDED.contains(&tool)
+}
+
+/// Tools held back from this gate pending a decision that is not this issue's
+/// to take.
+///
+/// **This is a deliberate exclusion, not an oversight. Do not delete it without
+/// reading issue #658.**
+///
+/// `publish_artifact` is declared `EffectGroup::Publish` + `Reach::Consequence`,
+/// under a table comment reading "Externally visible and not reversible by the
+/// company alone" — so by rule 1 below it should stop, and #338's acceptance
+/// names "publish" outright. It is excluded anyway, because stopping it decides
+/// a product question that belongs to whoever owns #244:
+///
+/// This gate has exactly one escape — a single-use, argument-exact grant per
+/// call (#243). There is no manifest knob. So stopping `publish_artifact` means
+/// **every company running `full` stops for a human on every deliverable it
+/// publishes**, permanently, with no way to opt out short of editing the
+/// declaration table. That may be right; it is not a call to make as a side
+/// effect of adding a classifier.
+///
+/// The size of the change is visible in the tests: excluding it keeps the 11
+/// `publish_turn_test` cases green, and shipping it needs a grant minted per
+/// scripted call in a suite that is about publish mechanics, not approvals.
+///
+/// Issue #658 carries the argument and the options. When it is settled, this
+/// list goes away in one direction or the other.
+const DEFERRED: &[&str] = &["publish_artifact"];
+
+/// The argument key a declared amount of money arrives under.
+///
+/// Mirrors the harness policy's own reader, which is where the spend arms
+/// already look. Kept in sync by `amount_key_matches_the_harness_reader`.
+const AMOUNT_KEY: &str = "amount_usd";
+
+/// Money named in the arguments, when it is a positive number.
+///
+/// Zero and negative are not "money leaving": a zero-amount call moves nothing,
+/// and a negative one is a refund shape this layer has no business guessing at.
+fn declared_amount_usd(args: &Value) -> Option<f64> {
+    args.get(AMOUNT_KEY)
+        .and_then(Value::as_f64)
+        .filter(|amount| *amount > 0.0)
+}
+
+/// Should this call stop for a human on its own merits?
+///
+/// Pure, total and deterministic: the same call judged twice gives the same
+/// answer, which is what makes a stop explainable from the trace long after the
+/// run. Consulted only where the rest of the chain has already decided to
+/// allow — see the module docs for why that placement is the whole safety
+/// argument.
+pub fn judge(tool: &str, args: &Value) -> Judgement {
+    let consequence = consequence_of(tool, args);
+    let name = tool.to_ascii_lowercase();
+    let declared = declared_tools().any(|d| d == name);
+
+    // Held back pending issue #658 — see `DEFERRED`. First, so that no rule
+    // below can reach it and so the exclusion is impossible to miss.
+    if DEFERRED.contains(&name.as_str()) {
+        return Judgement::Silent;
+    }
+
+    // Declared first: a named consequence class is the honest answer and the
+    // one the operator's card already shows.
+    //
+    // Restricted to DECLARED tools, which is not a detail. An undeclared tool
+    // is given a group by matching words in its name — a fallback that exists
+    // to label a card, not to decide one. `write_file` contains "file" and is
+    // therefore labelled `Sign`; gating on that would stop it while telling the
+    // operator it "signs or files a document". Undeclared tools stop below, on
+    // the honest ground that nobody has said what they do.
+    //
+    // Both halves are required, and the pairing is not obvious. The group names
+    // *what kind* of consequence a tool has; the reach says whether this call
+    // actually has one. `web_search` and the `media_generate_*` tools are
+    // declared `Spend` because the backend bills per request, but their reach is
+    // `Money`: nothing changes anywhere and nothing leaves the company — the
+    // money buys the call itself. Stopping them on the group alone parked every
+    // search, which is worse than useless: openhuman resolves a
+    // `RequireApproval` inline, so a parked search is a search that never
+    // happens and an agent with no search invents citations. The per-company
+    // daily cap is the boundary for that spend, and it has already had its say
+    // above.
+    if declared
+        && is_irreversible_group(consequence.group)
+        && consequence.reach == Reach::Consequence
+    {
+        return Judgement::Stop(StopReason::Irreversible(consequence.group));
+    }
+
+    // Then the arguments of this actual call. A tool the table calls
+    // unclassified can still be carrying money.
+    if declared_amount_usd(args).is_some() {
+        return Judgement::Stop(StopReason::MoneyLeaves);
+    }
+
+    // Fail closed on anything nobody declared that is not a pure read. The
+    // read carve-out is what keeps fail-closed from collapsing into
+    // stop-everything: `consequence_of` already answers `Reach::Nothing` for a
+    // name that reads, and an unknown read changes nothing by definition.
+    if !declared && consequence.reach != Reach::Nothing {
+        return Judgement::Stop(StopReason::Undeclared);
+    }
+
+    // Then reach: declared, unclassified, but able to do anything.
+    if is_unbounded(&name, consequence) {
+        return Judgement::Stop(StopReason::UnboundedReach);
+    }
+
+    Judgement::Silent
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn judge_bare(tool: &str) -> Judgement {
+        judge(tool, &json!({}))
+    }
+
+    /// #338's acceptance, stated as it is written: "a run that would send,
+    /// publish, pay, or delete stops for approval regardless of mode".
+    ///
+    /// `delete` has no declared [`EffectGroup`] of its own — the taxonomy names
+    /// six consequence classes and destruction is not one — so it arrives here
+    /// as the unbounded-reach case. `shell` is how a run deletes.
+    #[test]
+    fn a_send_publish_pay_or_delete_stops() {
+        // Declared, so the verdict names the consequence the table declares.
+        assert_eq!(
+            judge_bare("media_generate_image"),
+            Judgement::Stop(StopReason::Irreversible(EffectGroup::Spend)),
+        );
+        assert_eq!(
+            judge("composio_execute", &json!({ "tool": "GMAIL_SEND_EMAIL" })),
+            Judgement::Stop(StopReason::Irreversible(EffectGroup::Send)),
+        );
+        // Undeclared, so they stop on the fail-closed ground instead — see
+        // `an_undeclared_tool_stops_without_borrowing_a_guessed_reason`.
+        for tool in ["send_email", "publish_post", "pay_invoice"] {
+            assert!(
+                matches!(judge_bare(tool), Judgement::Stop(_)),
+                "`{tool}` must stop"
+            );
+        }
+        assert_eq!(
+            judge_bare("shell"),
+            Judgement::Stop(StopReason::UnboundedReach),
+            "deleting is reached through arbitrary code, not a declared group"
+        );
+    }
+
+    /// The other half of the acceptance, and the half that makes the feature
+    /// usable rather than merely safe.
+    #[test]
+    fn reads_searches_and_drafts_do_not_stop() {
+        for tool in [
+            "file_read",
+            "glob",
+            "grep",
+            "list",
+            "read_workspace_state",
+            "memory_recall",
+            "image_info",
+            "query_company",
+        ] {
+            assert_eq!(judge_bare(tool), Judgement::Silent, "`{tool}` reads");
+        }
+    }
+
+    /// The agent's own scratch space. These mutate, so `supervised` still parks
+    /// them and `readonly` still denies them — but they are the low-consequence
+    /// writes #444 found safe enough to hand over for a week, so the judgement
+    /// gate does not add a stop of its own under `full`.
+    #[test]
+    fn the_agents_own_drafts_do_not_stop() {
+        for tool in [
+            "file_write",
+            "edit",
+            "apply_patch",
+            "csv_export",
+            "memory_store",
+        ] {
+            assert_eq!(judge_bare(tool), Judgement::Silent, "`{tool}` is a draft");
+        }
+    }
+
+    /// A metered call must never stop here: openhuman resolves a
+    /// `RequireApproval` inline, so a parked search is a search that never
+    /// happens.
+    ///
+    /// This is the sharp edge of the whole module, and the pair below is why
+    /// the rule reads reach as well as group.
+    ///
+    /// Both are declared [`EffectGroup::Spend`], so a rule keyed on the group
+    /// alone parked every search in the company. They differ in reach, and the
+    /// reach is the part that matters: `web_search` is [`Reach::Money`] — the
+    /// spend buys the call, nothing changes and nothing leaves, and the daily
+    /// cap governs it — while media generation is [`Reach::Consequence`],
+    /// because it "moves real money on submit" (issue #109).
+    #[test]
+    fn a_metered_read_never_stops_but_a_real_spend_does() {
+        for tool in ["web_search", "media_generate_image", "media_generate_video"] {
+            assert_eq!(
+                consequence_of(tool, &json!({})).group,
+                EffectGroup::Spend,
+                "`{tool}` is declared Spend — that is the trap this test guards"
+            );
+        }
+        assert_eq!(
+            judge_bare("web_search"),
+            Judgement::Silent,
+            "billed, but nothing changes and nothing leaves"
+        );
+        for tool in ["media_generate_image", "media_generate_video"] {
+            assert_eq!(
+                judge_bare(tool),
+                Judgement::Stop(StopReason::Irreversible(EffectGroup::Spend)),
+                "`{tool}` moves real money on submit"
+            );
+        }
+    }
+
+    /// Arbitrary code and arbitrary addresses, which the table already refuses
+    /// a standing grant for the same reason.
+    #[test]
+    fn unbounded_tools_stop() {
+        for tool in UNBOUNDED {
+            assert_eq!(
+                judge_bare(tool),
+                Judgement::Stop(StopReason::UnboundedReach),
+                "`{tool}` is unbounded"
+            );
+        }
+    }
+
+    /// The company writing to its own note tree is not an unbounded act, and
+    /// stopping it broke publishing (13 `publish_turn_test` cases). They are
+    /// `Standing::PerCall` — issue #444 refuses them a standing grant because
+    /// they overwrite guidance the operator authored — and that is a different
+    /// reason from "what this reaches cannot be bounded". `supervised` still
+    /// parks them and `readonly` still denies them; this arm adds nothing.
+    #[test]
+    fn writing_the_companys_own_notes_is_not_unbounded() {
+        for tool in ["workspace_write", "workspace_create"] {
+            assert!(
+                !consequence_of(tool, &json!({})).standing.is_grantable(),
+                "`{tool}` is PerCall — the trap this test guards"
+            );
+            assert_eq!(judge_bare(tool), Judgement::Silent, "`{tool}` is internal");
+        }
+    }
+
+    /// The carve-out, pinned so it is a decision rather than a drift.
+    ///
+    /// `publish_artifact` satisfies rule 1 outright — declared `Publish` and
+    /// `Consequence` — and is excluded anyway pending issue #658. If somebody
+    /// deletes `DEFERRED` without settling that issue, this fails and says why.
+    #[test]
+    fn publish_artifact_is_deliberately_excluded_pending_658() {
+        let c = consequence_of("publish_artifact", &json!({}));
+        assert_eq!(c.group, EffectGroup::Publish);
+        assert_eq!(c.reach, Reach::Consequence);
+        assert!(
+            is_irreversible_group(c.group),
+            "it qualifies — the exclusion is what keeps it silent"
+        );
+        assert_eq!(
+            judge_bare("publish_artifact"),
+            Judgement::Silent,
+            "excluded pending #658; do not 'fix' this without reading it"
+        );
+    }
+
+    /// Everything held back must be a declared tool, or the exclusion silently
+    /// stops matching anything.
+    #[test]
+    fn every_deferred_tool_is_declared() {
+        for tool in DEFERRED {
+            assert!(
+                declared_tools().any(|d| d == *tool),
+                "`{tool}` is in DEFERRED but not declared"
+            );
+        }
+    }
+
+    /// A rename in the declaration table must fail loudly here rather than
+    /// silently dropping a tool out of `UNBOUNDED`.
+    #[test]
+    fn every_unbounded_tool_is_declared() {
+        for tool in UNBOUNDED {
+            assert!(
+                declared_tools().any(|d| d == *tool),
+                "`{tool}` is in UNBOUNDED but not declared — it would never match"
+            );
+        }
+    }
+
+    /// Fail closed: a tool nobody declared stops rather than passing.
+    #[test]
+    fn an_undeclared_tool_stops() {
+        assert_eq!(
+            judge_bare("frobnicate_the_widget"),
+            Judgement::Stop(StopReason::Undeclared)
+        );
+    }
+
+    /// ...and it says so, rather than repeating a guess as if it were a fact.
+    ///
+    /// `write_file` is undeclared and `consequence_of` labels it `Sign`, purely
+    /// because the name contains "file". Both verdicts stop the call; only one
+    /// of them tells the operator something true. This is the regression guard
+    /// for that: the reason must be the honest one, not the borrowed one.
+    #[test]
+    fn an_undeclared_tool_stops_without_borrowing_a_guessed_reason() {
+        assert_eq!(
+            consequence_of("write_file", &json!({})).group,
+            EffectGroup::Sign,
+            "the name heuristic guesses Sign — that is what must not be quoted"
+        );
+        assert_eq!(
+            judge_bare("write_file"),
+            Judgement::Stop(StopReason::Undeclared)
+        );
+    }
+
+    /// ...but an undeclared tool that only reads still does not stop, so
+    /// fail-closed does not collapse into stop-everything.
+    #[test]
+    fn an_undeclared_read_does_not_stop() {
+        assert_eq!(judge_bare("get_the_weather"), Judgement::Silent);
+    }
+
+    /// A Composio slug nobody has classified is treated as a send by
+    /// `consequence_of`, and a send stops.
+    #[test]
+    fn an_unclassified_composio_action_stops() {
+        let args = json!({ "tool": "SOME_TOOLKIT_ACTION_NOBODY_CLASSIFIED" });
+        assert_eq!(
+            judge("composio_execute", &args),
+            Judgement::Stop(StopReason::Irreversible(EffectGroup::Send))
+        );
+    }
+
+    /// Money named in the arguments stops even when the tool's own class is the
+    /// unclassified bucket.
+    #[test]
+    fn a_declared_amount_stops_an_otherwise_silent_tool() {
+        // `list` is a declared pure read: silent on its own.
+        assert_eq!(judge_bare("list"), Judgement::Silent);
+        assert_eq!(
+            judge("list", &json!({ "amount_usd": 12.5 })),
+            Judgement::Stop(StopReason::MoneyLeaves)
+        );
+    }
+
+    /// Zero is not money leaving, and neither is a negative.
+    #[test]
+    fn a_zero_or_negative_amount_is_not_money_leaving() {
+        assert_eq!(
+            judge("list", &json!({ "amount_usd": 0 })),
+            Judgement::Silent
+        );
+        assert_eq!(
+            judge("list", &json!({ "amount_usd": -5 })),
+            Judgement::Silent
+        );
+    }
+
+    /// The gate holds no state, so it cannot learn: the sixth identical call is
+    /// judged exactly as the first. #563 is where consent lives, and consent is
+    /// an operator writing a rule — not this noticing a habit.
+    #[test]
+    fn the_gate_does_not_learn_from_repetition() {
+        let args = json!({ "to": "customer@example.com" });
+        let first = judge("send_email", &args);
+        for _ in 0..5 {
+            assert_eq!(
+                judge("send_email", &args),
+                first,
+                "repetition must not soften the verdict"
+            );
+        }
+    }
+
+    /// Same call, same answer — the property that makes a stop explainable from
+    /// the trace months later, and the reason this is not a model call.
+    #[test]
+    fn the_verdict_is_deterministic() {
+        let args = json!({ "body": "hello", "to": "a@example.com" });
+        assert_eq!(judge("send_email", &args), judge("send_email", &args));
+    }
+
+    /// Every stop can say why, in the operator's terms rather than this
+    /// module's.
+    #[test]
+    fn every_stop_reason_describes_itself() {
+        let groups = [
+            EffectGroup::Spend,
+            EffectGroup::Send,
+            EffectGroup::Sign,
+            EffectGroup::Publish,
+            EffectGroup::Hire,
+            EffectGroup::Identity,
+            EffectGroup::Other,
+        ];
+        for group in groups {
+            assert!(!StopReason::Irreversible(group).describe().is_empty());
+        }
+        assert!(!StopReason::UnboundedReach.describe().is_empty());
+        assert!(!StopReason::MoneyLeaves.describe().is_empty());
+        assert!(!StopReason::Undeclared.describe().is_empty());
+    }
+}

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -12,8 +12,9 @@
 //!
 //! That is a bad trade in both directions. Set the bar low and every run stops
 //! constantly, which is the batching pressure #183 decision 3 exists to avoid.
-//! Set it high — `full` — and the run sends, publishes, pays or deletes without
-//! asking anyone.
+//! Set it high — `full` — and an agent-picked call can send, pay, delete or
+//! otherwise reach beyond a boundary this layer can see without asking anyone.
+//! Publishing is the deliberate #658 exception described below.
 //!
 //! `full`'s stated contract is "the agents act without asking, **except the few
 //! things on the always-ask list**". Without this module that exception is
@@ -79,21 +80,51 @@
 //! quietly repeal that. It is recorded as a signal on the trace instead, where
 //! it informs a human without deciding anything.
 //!
+//! # Which path a call arrives on decides whether this speaks at all
+//!
+//! Issue #674's ruling, and the reason this module takes a [`CallPath`] rather
+//! than judging every call the same way.
+//!
+//! A workflow `tool_call` node is **refused at author time** unless its
+//! namespace is one the workflow invoker wires *and* the company's
+//! `[tools].allow` grants it. So a saved `shell` node has already passed **two
+//! operator gates** — the manifest grant, then authoring — and the operator has
+//! seen the actual command they saved.
+//!
+//! An agent turn has passed **neither**. The model picks the tool and the
+//! arguments at run time. That is a real difference in what the operator
+//! consented to, which is why `full` meaning "do not ask me about what I
+//! authored" is coherent while "do not ask me about anything the model decides
+//! to run" is not.
+//!
+//! So: **#338's rules govern [`CallPath::Agent`]. #614's position governs
+//! [`CallPath::AuthoredWorkflowNode`]** — on that path this module is silent,
+//! and the operator's controls are the two gates above plus `always_approve`,
+//! which still gates a node the tier would allow.
+//!
+//! ## The boundary condition, without which the split is a hole
+//!
+//! **A node whose arguments are templated from an upstream node's output is not
+//! pre-declared**, and follows the *agent* rule. The operator declared the
+//! *shape*; the *content* arrives at run time from data they never saw.
+//!
+//! Without this the split is trivially defeated: author one `shell` node whose
+//! `command` is `=previous.output` and the two-gate argument stops describing
+//! what actually runs. See [`any_argument_is_templated`].
+//!
 //! # What this deliberately does NOT stop
 //!
-//! #338's acceptance says "send, publish, pay, or delete". Of those, **send,
-//! pay and delete are gated; publish is not**, and the outward-HTTP family is
-//! held back too. See `DEFERRED`:
+//! #338's acceptance says "send, publish, pay, or delete". Read against the
+//! split above: on the agent path **send, pay and delete are gated and publish
+//! is not**; on the authored-node path none of the four are gated here unless
+//! the boundary condition returns the node to the agent rule.
 //!
-//! * `publish_artifact` — issue #658. This gate's only escape is a per-call
-//!   grant, so stopping it would end unattended publishing for every `full`
-//!   company with no operator override.
-//! * `http_request`, `curl`, `web_fetch` — issue #674. #614 states the opposite
-//!   premise in a named test; that contradiction has an owner, and it is not
-//!   this module.
+//! `publish_artifact` is carved out on **both** paths, permanently — see
+//! `DEFERRED` and issue #658.
 //!
-//! `shell` stays gated, which is what keeps "or delete" real: destruction has
-//! no `EffectGroup` of its own, and `shell` is how a run deletes.
+//! `shell` stays gated on the agent path, which is what keeps "or delete" real:
+//! destruction has no `EffectGroup` of its own, and `shell` is how a run
+//! deletes.
 //!
 //! # Failure is a stop
 //!
@@ -275,49 +306,97 @@ fn is_unbounded(tool: &str, consequence: Consequence) -> bool {
     consequence.reach == Reach::Consequence && UNBOUNDED.contains(&tool)
 }
 
-/// Tools held back from this gate pending a decision that is not this issue's
-/// to take.
+/// Tools this gate never speaks about, on either path.
 ///
-/// **This is a deliberate exclusion, not an oversight. Do not delete it without
-/// reading issue #658.**
+/// **This is a deliberate exclusion, not an oversight, and it is not
+/// provisional. Do not delete it without reading issue #658.**
 ///
 /// `publish_artifact` is declared `EffectGroup::Publish` + `Reach::Consequence`,
 /// under a table comment reading "Externally visible and not reversible by the
-/// company alone" — so by rule 1 below it should stop, and #338's acceptance
-/// names "publish" outright. It is excluded anyway, because stopping it decides
-/// a product question that belongs to whoever owns #244:
+/// company alone" — so by rule 1 below it qualifies, and #338's acceptance names
+/// "publish" outright. It is excluded anyway, and **#658 has now ruled that this
+/// is the correct behaviour rather than a stopgap**: under `full` a company
+/// publishes without asking, and `always_approve` is the operator's override for
+/// companies that want to be asked.
 ///
-/// This gate has exactly one escape — a single-use, argument-exact grant per
-/// call (#243). There is no manifest knob. So stopping `publish_artifact` means
-/// **every company running `full` stops for a human on every deliverable it
-/// publishes**, permanently, with no way to opt out short of editing the
-/// declaration table. That may be right; it is not a call to make as a side
-/// effect of adding a classifier.
+/// The argument #658 settled: this gate has exactly one escape — a single-use,
+/// argument-exact grant per call (#243). There is no manifest knob. So stopping
+/// `publish_artifact` here would mean **every company running `full` stops for a
+/// human on every deliverable it publishes**, permanently, with no way to opt
+/// out short of editing the declaration table. That is not a call to make as a
+/// side effect of adding a classifier, and #658 declined to make it: an operator
+/// who wants publishing gated names it in `always_approve`, which is read before
+/// this arm and is a thing they can see, change and revoke.
 ///
-/// The size of the change is visible in the tests: excluding it keeps the 11
-/// `publish_turn_test` cases green, and shipping it needs a grant minted per
-/// scripted call in a suite that is about publish mechanics, not approvals.
+/// The size of the alternative is visible in the tests: excluding it keeps the
+/// 11 `publish_turn_test` cases green, and gating it would need a grant minted
+/// per scripted call in a suite that is about publish mechanics, not approvals.
 ///
-/// Issues #658 and #674 carry the arguments and the options. When they are
-/// settled, each entry goes away in one direction or the other.
+/// `http_request`, `curl` and `web_fetch` **were** on this list pending #674 and
+/// are not deferred any more. #674 ruled that they are governed by #614 on the
+/// authored-node path and by #338 on the agent path — which is a scoping of the
+/// rule, not an exclusion from it, so it is expressed by [`CallPath`] rather
+/// than here. See the module docs.
 const DEFERRED: &[&str] = &[
-    // Issue #658 — see the note above.
+    // Issue #658 — see the note above. Ruled, not pending.
     "publish_artifact",
-    // Issue #674. These reach an arbitrary address with the tenant's own
-    // credentials, so `UNBOUNDED` names them and rule 3 would stop them. #614
-    // (merged as #627) states the opposite premise, in a test named
-    // `an_http_request_node_does_not_gate_under_full` — and a named test is a
-    // stated position, not an accident.
-    //
-    // Both are defensible and they cannot both hold. Choosing between them is a
-    // product decision belonging to #614's owner, so it is deferred rather than
-    // taken here: #674 puts the two premises side by side and asks which one it
-    // is. `shell`, `git_operations` and `run_workflow` stay gated — `shell` is
-    // how a run deletes, and #614 does not touch it.
-    "http_request",
-    "curl",
-    "web_fetch",
 ];
+
+/// The prefix tinyflows gives an expression bound at run time.
+///
+/// Both binding forms wear it: the dotted shorthand (`=item.brief`) and a jq
+/// program (`=.items | length`). `t_transform_resolves_expr_bindings_engine_side`
+/// in [`crate::workflows::runner`] pins that they resolve engine-side, and
+/// `every_reachable_workflow_tool_is_classified_by_name_alone` in
+/// [`crate::workflows::gate`] pins that a node's args may still be carrying them
+/// unresolved when the gate pass runs — which is exactly the window this reads.
+const EXPRESSION_PREFIX: &str = "=";
+
+/// Which of the two paths a candidate call arrived on.
+///
+/// Issue #674's ruling made this the first thing [`judge`] asks. The variants
+/// are not two flavours of caller; they are two different things an operator
+/// consented to. See the module docs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CallPath {
+    /// A model picked this tool and these arguments during a turn. Nobody saw
+    /// the call before it was made, so #338's rules apply in full.
+    Agent,
+    /// An operator authored this node into a saved workflow, past the manifest
+    /// grant and the authoring refusal. #614's position applies: this module is
+    /// silent — **unless the arguments are templated**, which un-declares the
+    /// call and returns it to the agent rule.
+    AuthoredWorkflowNode,
+}
+
+/// Does any argument of this call arrive from the run rather than from the
+/// author?
+///
+/// **The boundary condition of #674's split, and the part that stops it being a
+/// hole.** The authored-node path is silent because an operator saw the call.
+/// They did not see `=previous.output`; they saw the *shape*, and the content
+/// arrives at run time from data they never read. So a templated node is judged
+/// as an agent call.
+///
+/// Without this, one `shell` node whose `command` is `=previous.output` defeats
+/// the split outright: the two-gate argument stops describing what actually runs
+/// while still being cited as the reason not to ask.
+///
+/// Recurses through objects and arrays, because an expression is a *value*
+/// anywhere in the descriptor, not a top-level key — `{"body": {"cmd":
+/// "=item.x"}}` is as templated as `{"cmd": "=item.x"}`.
+///
+/// Errs toward "templated": a literal string that merely starts with `=` is read
+/// as an expression, which sends the call to the stricter rule. That is the
+/// direction to be wrong in, and tinyflows reads it that way too.
+fn any_argument_is_templated(args: &Value) -> bool {
+    match args {
+        Value::String(text) => text.starts_with(EXPRESSION_PREFIX),
+        Value::Array(items) => items.iter().any(any_argument_is_templated),
+        Value::Object(fields) => fields.values().any(any_argument_is_templated),
+        Value::Null | Value::Bool(_) | Value::Number(_) => false,
+    }
+}
 
 /// The argument key a declared amount of money arrives under.
 ///
@@ -342,13 +421,32 @@ fn declared_amount_usd(args: &Value) -> Option<f64> {
 /// run. Consulted only where the rest of the chain has already decided to
 /// allow — see the module docs for why that placement is the whole safety
 /// argument.
-pub fn judge(tool: &str, args: &Value) -> Judgement {
+///
+/// `path` decides whether this speaks at all (issue #674). It is a required
+/// argument rather than a defaulted one on purpose: a caller that has not
+/// thought about which path it is on should not compile.
+pub fn judge(tool: &str, args: &Value, path: CallPath) -> Judgement {
+    // Issue #674's split, FIRST — before any rule can reach the call.
+    //
+    // An authored node passed two operator gates (the manifest grant, then
+    // authoring) and the operator saw the call. An agent turn passed neither.
+    //
+    // The `!any_argument_is_templated` half is the boundary condition, not a
+    // refinement: an authored node whose arguments come from an upstream node's
+    // output was never pre-declared — the operator declared the shape, the
+    // content arrives at run time — so it is judged as an agent call. Deleting
+    // that half leaves a split that one `=previous.output` defeats.
+    if path == CallPath::AuthoredWorkflowNode && !any_argument_is_templated(args) {
+        return Judgement::Silent;
+    }
+
     let consequence = consequence_of(tool, args);
     let name = tool.to_ascii_lowercase();
     let declared = declared_tools().any(|d| d == name);
 
-    // Held back pending issue #658 — see `DEFERRED`. First, so that no rule
-    // below can reach it and so the exclusion is impossible to miss.
+    // Carved out on both paths — see `DEFERRED` and issue #658. Ahead of every
+    // rule, so none of them can reach it and so the exclusion is impossible to
+    // miss.
     if DEFERRED.contains(&name.as_str()) {
         return Judgement::Silent;
     }
@@ -408,25 +506,37 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    /// Every test below that does not name a path is about the **agent** path —
+    /// the one #338's rules govern. The authored-node path has its own section
+    /// at the end of this module.
     fn judge_bare(tool: &str) -> Judgement {
-        judge(tool, &json!({}))
+        judge_agent(tool, &json!({}))
     }
 
-    /// #338's acceptance, stated as it is written: "a run that would send,
-    /// publish, pay, or delete stops for approval regardless of mode".
+    fn judge_agent(tool: &str, args: &Value) -> Judgement {
+        judge(tool, args, CallPath::Agent)
+    }
+
+    fn judge_node(tool: &str, args: &Value) -> Judgement {
+        judge(tool, args, CallPath::AuthoredWorkflowNode)
+    }
+
+    /// The agent-path half of #338's acceptance after #658's ruling: sends,
+    /// payments and deletes stop, and an undeclared publish-shaped call fails
+    /// closed. The declared `publish_artifact` exception is pinned separately.
     ///
     /// `delete` has no declared [`EffectGroup`] of its own — the taxonomy names
     /// six consequence classes and destruction is not one — so it arrives here
     /// as the unbounded-reach case. `shell` is how a run deletes.
     #[test]
-    fn a_send_publish_pay_or_delete_stops() {
+    fn agent_calls_that_send_pay_delete_or_use_an_undeclared_publish_shape_stop() {
         // Declared, so the verdict names the consequence the table declares.
         assert_eq!(
             judge_bare("media_generate_image"),
             Judgement::Stop(StopReason::Irreversible(EffectGroup::Spend)),
         );
         assert_eq!(
-            judge("composio_execute", &json!({ "tool": "GMAIL_SEND_EMAIL" })),
+            judge_agent("composio_execute", &json!({ "tool": "GMAIL_SEND_EMAIL" })),
             Judgement::Stop(StopReason::Irreversible(EffectGroup::Send)),
         );
         // Undeclared, so they stop on the fail-closed ground instead — see
@@ -517,11 +627,22 @@ mod tests {
 
     /// Arbitrary code and arbitrary addresses, which the table already refuses
     /// a standing grant for the same reason.
+    ///
+    /// The outward-HTTP family — `http_request`, `curl`, `web_fetch` — is
+    /// asserted here rather than carved out. Before #674 it sat in `DEFERRED`
+    /// and this loop skipped it; the ruling put it back under the rule **on this
+    /// path**, and under #614's position on the authored-node path.
     #[test]
     fn unbounded_tools_stop() {
-        // Minus the ones held back — `UNBOUNDED` says what the rule *names*,
-        // `DEFERRED` says what is withheld from it, and this test is about the
-        // rule. The carve-outs have their own tests.
+        for tool in ["http_request", "curl", "web_fetch"] {
+            assert!(
+                !DEFERRED.contains(&tool),
+                "#674 ruled `{tool}` scoped by path, not deferred"
+            );
+        }
+        // The filter is retained rather than dropped: nothing in `UNBOUNDED` is
+        // deferred today, but `DEFERRED` is what is withheld from the rule and
+        // this test is about the rule. The carve-outs have their own tests.
         for tool in UNBOUNDED.iter().filter(|t| !DEFERRED.contains(t)) {
             assert_eq!(
                 judge_bare(tool),
@@ -551,10 +672,15 @@ mod tests {
     /// The carve-out, pinned so it is a decision rather than a drift.
     ///
     /// `publish_artifact` satisfies rule 1 outright — declared `Publish` and
-    /// `Consequence` — and is excluded anyway pending issue #658. If somebody
-    /// deletes `DEFERRED` without settling that issue, this fails and says why.
+    /// `Consequence` — and is silent anyway. Issue #658 **ruled** that this is
+    /// the behaviour it wants rather than a stopgap: under `full` a company
+    /// publishes without asking, and an operator who wants to be asked names it
+    /// in `always_approve`, which is read before this arm.
+    ///
+    /// Asserted on **both** paths: the carve-out is not part of #674's split, so
+    /// a rework of that split must not accidentally make one path speak.
     #[test]
-    fn publish_artifact_is_deliberately_excluded_pending_658() {
+    fn publish_artifact_is_excluded_by_the_658_ruling() {
         let c = consequence_of("publish_artifact", &json!({}));
         assert_eq!(c.group, EffectGroup::Publish);
         assert_eq!(c.reach, Reach::Consequence);
@@ -562,10 +688,20 @@ mod tests {
             is_irreversible_group(c.group),
             "it qualifies — the exclusion is what keeps it silent"
         );
+        for path in [CallPath::Agent, CallPath::AuthoredWorkflowNode] {
+            assert_eq!(
+                judge("publish_artifact", &json!({}), path),
+                Judgement::Silent,
+                "{path:?}: #658 ruled `full` publishes without asking; \
+                 `always_approve` is the override"
+            );
+        }
+        // Templated arguments return an authored node to the agent rule — and
+        // the agent rule is silent here too, so the carve-out survives the one
+        // condition that reopens every other node.
         assert_eq!(
-            judge_bare("publish_artifact"),
+            judge_node("publish_artifact", &json!({ "body": "=previous.output" })),
             Judgement::Silent,
-            "excluded pending #658; do not 'fix' this without reading it"
         );
     }
 
@@ -582,20 +718,30 @@ mod tests {
     /// Reach::Consequence)`, `auto` would shift silently under operators who
     /// chose it — exactly the failure the placement argument exists to prevent.
     /// This walks every declared tool and fails on that day instead.
+    ///
+    /// Judged on [`CallPath::Agent`] deliberately: that is the strict path, so
+    /// this asserts the strongest form of the claim. If it held only on the
+    /// authored-node path it would be asserting #674's split, not `auto`.
     #[test]
     fn the_arm_adds_nothing_under_auto() {
+        let mut checked = 0;
         for tool in declared_tools() {
             let c = consequence_of(tool, &json!({}));
             if c.parks_under_auto() {
                 continue; // `auto` already stops it; this arm is never reached.
             }
+            checked += 1;
             assert_eq!(
-                judge(tool, &json!({})),
+                judge_agent(tool, &json!({})),
                 Judgement::Silent,
                 "`{tool}` runs under `auto` but this arm would stop it — `auto` \
                  has shifted under operators who chose it"
             );
         }
+        assert!(
+            checked > 0,
+            "no declared tool runs under `auto` — the walk asserted nothing"
+        );
     }
 
     /// Every carve-out must be a tool a rule would otherwise have stopped.
@@ -605,8 +751,22 @@ mod tests {
     /// and it would sit there looking like a decision. This fails if the
     /// declaration table moves under a carve-out, so a deferral cannot quietly
     /// become a no-op.
+    ///
+    /// It also fails if `DEFERRED` is emptied. Without that, deleting the
+    /// `publish_artifact` carve-out would make this loop over nothing and pass —
+    /// a test that scores green having asserted zero things, which is the
+    /// failure mode it exists to prevent.
+    ///
+    /// `http_request` / `curl` / `web_fetch` were here and are not any more:
+    /// #674 ruled them **scoped by path**, not deferred, so they are governed by
+    /// `CallPath` and are asserted in the authored-node section below.
     #[test]
     fn every_deferred_tool_would_otherwise_be_stopped() {
+        assert!(
+            !DEFERRED.is_empty(),
+            "DEFERRED is empty — this test would assert nothing. #658 ruled the \
+             `publish_artifact` carve-out correct; read it before removing it"
+        );
         for tool in DEFERRED {
             let c = consequence_of(tool, &json!({}));
             let would_stop = (is_irreversible_group(c.group) && c.reach == Reach::Consequence)
@@ -618,7 +778,7 @@ mod tests {
             assert_eq!(
                 judge_bare(tool),
                 Judgement::Silent,
-                "`{tool}` is deferred; do not 'fix' this without reading #658 / #674"
+                "`{tool}` is deferred; do not 'fix' this without reading #658"
             );
         }
     }
@@ -688,7 +848,7 @@ mod tests {
     fn an_unclassified_composio_action_stops() {
         let args = json!({ "tool": "SOME_TOOLKIT_ACTION_NOBODY_CLASSIFIED" });
         assert_eq!(
-            judge("composio_execute", &args),
+            judge_agent("composio_execute", &args),
             Judgement::Stop(StopReason::Irreversible(EffectGroup::Send))
         );
     }
@@ -700,7 +860,7 @@ mod tests {
         // `list` is a declared pure read: silent on its own.
         assert_eq!(judge_bare("list"), Judgement::Silent);
         assert_eq!(
-            judge("list", &json!({ "amount_usd": 12.5 })),
+            judge_agent("list", &json!({ "amount_usd": 12.5 })),
             Judgement::Stop(StopReason::MoneyLeaves)
         );
     }
@@ -709,11 +869,11 @@ mod tests {
     #[test]
     fn a_zero_or_negative_amount_is_not_money_leaving() {
         assert_eq!(
-            judge("list", &json!({ "amount_usd": 0 })),
+            judge_agent("list", &json!({ "amount_usd": 0 })),
             Judgement::Silent
         );
         assert_eq!(
-            judge("list", &json!({ "amount_usd": -5 })),
+            judge_agent("list", &json!({ "amount_usd": -5 })),
             Judgement::Silent
         );
     }
@@ -724,10 +884,10 @@ mod tests {
     #[test]
     fn the_gate_does_not_learn_from_repetition() {
         let args = json!({ "to": "customer@example.com" });
-        let first = judge("send_email", &args);
+        let first = judge_agent("send_email", &args);
         for _ in 0..5 {
             assert_eq!(
-                judge("send_email", &args),
+                judge_agent("send_email", &args),
                 first,
                 "repetition must not soften the verdict"
             );
@@ -739,7 +899,10 @@ mod tests {
     #[test]
     fn the_verdict_is_deterministic() {
         let args = json!({ "body": "hello", "to": "a@example.com" });
-        assert_eq!(judge("send_email", &args), judge("send_email", &args));
+        assert_eq!(
+            judge_agent("send_email", &args),
+            judge_agent("send_email", &args)
+        );
     }
 
     /// Every stop can say why, in the operator's terms rather than this
@@ -761,5 +924,136 @@ mod tests {
         assert!(!StopReason::UnboundedReach.describe().is_empty());
         assert!(!StopReason::MoneyLeaves.describe().is_empty());
         assert!(!StopReason::Undeclared.describe().is_empty());
+    }
+
+    // ---- #674: the split by path ------------------------------------------
+    //
+    // Everything above is the agent path. These are the authored-node path and
+    // the boundary condition that governs when a node leaves it.
+
+    /// #614's position, stated as a rule over the whole strict set rather than
+    /// as the three tools whose tests forced the question.
+    ///
+    /// A node an operator authored has passed the manifest grant and the
+    /// authoring refusal, and they saw the call. This module is silent on it.
+    #[test]
+    fn an_authored_node_with_literal_arguments_is_not_judged() {
+        // Every tool the agent path stops for a reason other than a carve-out,
+        // so this is the rule and not a sample of it.
+        let cases: &[(&str, Value)] = &[
+            ("shell", json!({ "command": "echo hello > out.txt" })),
+            ("curl", json!({ "url": "https://api.example.com/x" })),
+            (
+                "http_request",
+                json!({ "url": "https://api.example.com/x" }),
+            ),
+            ("web_fetch", json!({ "url": "https://example.com" })),
+            ("git_operations", json!({ "op": "push" })),
+            ("run_workflow", json!({ "workflow_id": "nightly" })),
+            ("media_generate_image", json!({ "prompt": "a cat" })),
+            (
+                "composio_execute",
+                json!({ "tool": "GMAIL_SEND_EMAIL", "to": "a@example.com" }),
+            ),
+            ("frobnicate_the_widget", json!({})),
+            ("list", json!({ "amount_usd": 400.0 })),
+        ];
+        for (tool, args) in cases {
+            assert!(
+                matches!(judge_agent(tool, args), Judgement::Stop(_)),
+                "`{tool}` must stop on the agent path — otherwise this case \
+                 proves nothing about the split"
+            );
+            assert_eq!(
+                judge_node(tool, args),
+                Judgement::Silent,
+                "`{tool}` was authored into a saved workflow: two operator gates \
+                 and the operator saw the call (#674 / #614)"
+            );
+        }
+    }
+
+    /// **The boundary condition.** An authored node whose arguments come from an
+    /// upstream node's output was never pre-declared, so it is judged as an
+    /// agent call.
+    ///
+    /// This is the test that stops the split being a hole. Delete it and one
+    /// `shell` node whose `command` is `=previous.output` walks through a gate
+    /// justified by an operator having seen a command they never saw.
+    #[test]
+    fn an_authored_node_templated_from_upstream_output_follows_the_agent_rule() {
+        assert_eq!(
+            judge_node("shell", &json!({ "command": "=previous.output" })),
+            Judgement::Stop(StopReason::UnboundedReach),
+            "the operator declared the shape; the content arrives at run time"
+        );
+        // The same node with the command actually written out is silent — which
+        // is what makes the assertion above about templating rather than about
+        // `shell`.
+        assert_eq!(
+            judge_node("shell", &json!({ "command": "echo hi" })),
+            Judgement::Silent,
+        );
+        // Money, and the jq binding form as well as the dotted shorthand.
+        assert_eq!(
+            judge_node(
+                "list",
+                &json!({ "amount_usd": 400.0, "note": "=.items[0]" })
+            ),
+            Judgement::Stop(StopReason::MoneyLeaves),
+        );
+    }
+
+    /// An expression is a *value* anywhere in the descriptor, not a top-level
+    /// key — so the check recurses. A node that buried `=previous.output` one
+    /// object deep would otherwise read as fully authored.
+    #[test]
+    fn a_templated_value_is_found_at_any_depth() {
+        for args in [
+            json!("=item.everything"),
+            json!({ "cmd": "=item.x" }),
+            json!({ "body": { "cmd": "=item.x" } }),
+            json!({ "argv": ["bash", "-c", "=item.x"] }),
+            json!({ "body": { "steps": [{ "cmd": "=item.x" }] } }),
+        ] {
+            assert!(
+                any_argument_is_templated(&args),
+                "{args} is templated and must be judged as an agent call"
+            );
+            assert_eq!(
+                judge_node("shell", &args),
+                Judgement::Stop(StopReason::UnboundedReach),
+                "{args}"
+            );
+        }
+    }
+
+    /// ...and a descriptor with nothing templated in it is not dragged back to
+    /// the agent rule by a value that merely looks structured.
+    #[test]
+    fn a_fully_authored_descriptor_is_not_templated() {
+        for args in [
+            json!({}),
+            json!({ "command": "echo hi", "timeout": 30, "quiet": true }),
+            json!({ "url": "https://example.com/a=b?c=d" }),
+            json!({ "argv": ["bash", "-c", "ls"], "env": { "A": "1" } }),
+            json!({ "body": null }),
+        ] {
+            assert!(!any_argument_is_templated(&args), "{args}");
+            assert_eq!(judge_node("shell", &args), Judgement::Silent, "{args}");
+        }
+    }
+
+    /// The two paths are not two names for one behaviour. If a refactor
+    /// collapsed them — passing `Agent` everywhere, or `AuthoredWorkflowNode`
+    /// everywhere — every test above could still pass while the split was gone.
+    #[test]
+    fn the_two_paths_actually_differ() {
+        let args = json!({ "command": "echo hi" });
+        assert_ne!(
+            judge_agent("shell", &args),
+            judge_node("shell", &args),
+            "the paths have collapsed into one — #674's split is not implemented"
+        );
     }
 }

--- a/src/policy/judgement.rs
+++ b/src/policy/judgement.rs
@@ -30,11 +30,16 @@
 //! stays authoritative everywhere it speaks; this speaks only in the silence
 //! after it.
 //!
-//! A consequence worth stating plainly: **`supervised` and `readonly` are
-//! unchanged**. Under `supervised` a [`Reach::Consequence`] call already parks
-//! and under `readonly` it is already denied, so every call this module would
-//! stop has already been stopped by the mode. The behaviour it changes is
-//! `full`, and only `full`.
+//! The invariant, phrased so it survives the next tier: **this arm only ever
+//! speaks where the mode allowed.** A tier that already parks or denies a call
+//! keeps its own answer, whatever the tier is called and however many there
+//! are. Spelling out which tiers those are dates the moment a tier lands — as
+//! it did when `auto` (issue #560) arrived mid-review.
+//!
+//! As it happens the arm today changes `full` alone: `supervised` parks a
+//! [`Reach::Consequence`] call, `readonly` denies it, and `auto` parks
+//! everything that is not `Grantable`, which covers every rule below.
+//! `the_arm_adds_nothing_under_auto` pins that rather than trusting it.
 //!
 //! # Where the classification lives
 //!
@@ -76,12 +81,19 @@
 //!
 //! # What this deliberately does NOT stop
 //!
-//! #338's acceptance says "send, publish, pay, or delete". This delivers three
-//! of those four: **`publish_artifact` is excluded**, see `DEFERRED` and issue
-//! #658. The short version is that this gate's only escape is a per-call grant,
-//! so stopping publishing would end unattended publishing for every `full`
-//! company with no operator override — a product decision that belongs to the
-//! people who own #244, not to a classifier landing at the end of a build day.
+//! #338's acceptance says "send, publish, pay, or delete". Of those, **send,
+//! pay and delete are gated; publish is not**, and the outward-HTTP family is
+//! held back too. See `DEFERRED`:
+//!
+//! * `publish_artifact` — issue #658. This gate's only escape is a per-call
+//!   grant, so stopping it would end unattended publishing for every `full`
+//!   company with no operator override.
+//! * `http_request`, `curl`, `web_fetch` — issue #674. #614 states the opposite
+//!   premise in a named test; that contradiction has an owner, and it is not
+//!   this module.
+//!
+//! `shell` stays gated, which is what keeps "or delete" real: destruction has
+//! no `EffectGroup` of its own, and `shell` is how a run deletes.
 //!
 //! # Failure is a stop
 //!
@@ -286,9 +298,26 @@ fn is_unbounded(tool: &str, consequence: Consequence) -> bool {
 /// `publish_turn_test` cases green, and shipping it needs a grant minted per
 /// scripted call in a suite that is about publish mechanics, not approvals.
 ///
-/// Issue #658 carries the argument and the options. When it is settled, this
-/// list goes away in one direction or the other.
-const DEFERRED: &[&str] = &["publish_artifact"];
+/// Issues #658 and #674 carry the arguments and the options. When they are
+/// settled, each entry goes away in one direction or the other.
+const DEFERRED: &[&str] = &[
+    // Issue #658 — see the note above.
+    "publish_artifact",
+    // Issue #674. These reach an arbitrary address with the tenant's own
+    // credentials, so `UNBOUNDED` names them and rule 3 would stop them. #614
+    // (merged as #627) states the opposite premise, in a test named
+    // `an_http_request_node_does_not_gate_under_full` — and a named test is a
+    // stated position, not an accident.
+    //
+    // Both are defensible and they cannot both hold. Choosing between them is a
+    // product decision belonging to #614's owner, so it is deferred rather than
+    // taken here: #674 puts the two premises side by side and asks which one it
+    // is. `shell`, `git_operations` and `run_workflow` stay gated — `shell` is
+    // how a run deletes, and #614 does not touch it.
+    "http_request",
+    "curl",
+    "web_fetch",
+];
 
 /// The argument key a declared amount of money arrives under.
 ///
@@ -490,7 +519,10 @@ mod tests {
     /// a standing grant for the same reason.
     #[test]
     fn unbounded_tools_stop() {
-        for tool in UNBOUNDED {
+        // Minus the ones held back — `UNBOUNDED` says what the rule *names*,
+        // `DEFERRED` says what is withheld from it, and this test is about the
+        // rule. The carve-outs have their own tests.
+        for tool in UNBOUNDED.iter().filter(|t| !DEFERRED.contains(t)) {
             assert_eq!(
                 judge_bare(tool),
                 Judgement::Stop(StopReason::UnboundedReach),
@@ -535,6 +567,60 @@ mod tests {
             Judgement::Silent,
             "excluded pending #658; do not 'fix' this without reading it"
         );
+    }
+
+    /// The arm adds nothing under `auto` (issue #560) — pinned as a rule over
+    /// the whole declaration table, not as a snapshot of what it holds today.
+    ///
+    /// `auto` parks `parks_under_supervision() && !is_grantable()`, so the only
+    /// calls it allows that `supervised` would park are the `Grantable` ones.
+    /// Today every `d_grantable` row is `EffectGroup::Other`, none is in
+    /// `UNBOUNDED` and none carries an amount, so no rule fires — but that is a
+    /// property of the table's current contents, and nothing pinned it.
+    ///
+    /// The day somebody adds `d_grantable("send_invoice", EffectGroup::Send,
+    /// Reach::Consequence)`, `auto` would shift silently under operators who
+    /// chose it — exactly the failure the placement argument exists to prevent.
+    /// This walks every declared tool and fails on that day instead.
+    #[test]
+    fn the_arm_adds_nothing_under_auto() {
+        for tool in declared_tools() {
+            let c = consequence_of(tool, &json!({}));
+            if c.parks_under_auto() {
+                continue; // `auto` already stops it; this arm is never reached.
+            }
+            assert_eq!(
+                judge(tool, &json!({})),
+                Judgement::Silent,
+                "`{tool}` runs under `auto` but this arm would stop it — `auto` \
+                 has shifted under operators who chose it"
+            );
+        }
+    }
+
+    /// Every carve-out must be a tool a rule would otherwise have stopped.
+    ///
+    /// The point of the list is to hold back calls this gate *would* gate. An
+    /// entry that no rule fires on is not a deferral, it is a misunderstanding —
+    /// and it would sit there looking like a decision. This fails if the
+    /// declaration table moves under a carve-out, so a deferral cannot quietly
+    /// become a no-op.
+    #[test]
+    fn every_deferred_tool_would_otherwise_be_stopped() {
+        for tool in DEFERRED {
+            let c = consequence_of(tool, &json!({}));
+            let would_stop = (is_irreversible_group(c.group) && c.reach == Reach::Consequence)
+                || is_unbounded(tool, c);
+            assert!(
+                would_stop,
+                "`{tool}` is deferred but no rule would stop it — the entry is inert"
+            );
+            assert_eq!(
+                judge_bare(tool),
+                Judgement::Silent,
+                "`{tool}` is deferred; do not 'fix' this without reading #658 / #674"
+            );
+        }
     }
 
     /// Everything held back must be a declared tool, or the exclusion silently

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -30,4 +30,4 @@ pub(crate) mod test_support;
 
 pub use consequence::{Consequence, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};
-pub use judgement::{Judgement, StopReason, judge};
+pub use judgement::{CallPath, Judgement, StopReason, judge};

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -11,8 +11,15 @@
 //! console card) while the tool policy that parks calls compiles only under the
 //! `openhuman` feature.
 
+//! The [`judgement`] module answers the question neither of the above asks:
+//! which calls should stop for a human *on their own merits*, in the gap the
+//! static configuration leaves (issue #338). Always compiled for the same
+//! reason [`consequence`] is — it is pure, it has no harness types in it, and
+//! keeping it out of the gated build means its tests run in the plain lane.
+
 pub mod consequence;
 pub mod gate;
+pub mod judgement;
 
 /// Shared `composio_execute` call fixtures (issue #470). Test-only, and
 /// deliberately here rather than in any one test module: the key they build
@@ -23,3 +30,4 @@ pub(crate) mod test_support;
 
 pub use consequence::{Consequence, Reach, Standing, consequence_of};
 pub use gate::{DEFAULT_TTL_MILLIS, ManifestApprovalGate};
+pub use judgement::{Judgement, StopReason, judge};

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -195,6 +195,29 @@ pub(crate) struct GatedCall {
 /// no agent, which is precisely the synthetic-principal decision this module's
 /// docs record. The context below names that principal so a log line says which
 /// workflow asked.
+///
+/// # Why it declares the authored-node path (issue #674)
+///
+/// [`for_authored_workflow_nodes`](ApprovalPolicy::for_authored_workflow_nodes)
+/// scopes one arm — the per-call judgement #338 added — and nothing else.
+///
+/// A node reaching this pass has passed **two operator gates**: the company's
+/// `[tools].allow` grant, which [`WorkflowToolInvoker`](super::caps) checks
+/// fail-closed, and authoring, which refuses a namespace the invoker does not
+/// wire. The operator saw the call. An agent turn has passed neither — the model
+/// picks the tool and the arguments at run time — so #338's rules stay in force
+/// there and #614's position holds here. #674 ruled the split.
+///
+/// The boundary condition lives in [`judge`](crate::policy::judge) rather than
+/// here, because it is about the call and not about the caller: a node whose
+/// arguments are templated from an upstream node's output was never
+/// pre-declared, so it is judged as an agent call. This pass is exactly where
+/// that matters — `every_reachable_workflow_tool_is_classified_by_name_alone`
+/// records that node args may still be unresolved `=`-expressions when it runs.
+///
+/// The policy instance is private to this pass, so the declaration cannot leak
+/// onto the agent path: no other caller shares it, and
+/// [`ApprovalPolicy::new`] yields the strict path.
 pub(crate) async fn apply_policy_gates(
     graph: &mut WorkflowGraph,
     record: &CompanyRecord,
@@ -246,7 +269,7 @@ pub(crate) async fn policy_gates(
     // same `auto_approve_under_usd` the roster runs under. No per-agent budget:
     // a workflow node is not a teammate, and the company-wide ceiling is
     // enforced elsewhere.
-    let policy = ApprovalPolicy::new(company_policy, None);
+    let policy = ApprovalPolicy::new(company_policy, None).for_authored_workflow_nodes();
     let mut gated = Vec::new();
 
     for node in &graph.nodes {
@@ -534,6 +557,60 @@ description = "Runs Acme."
 
         assert!(gated.is_empty());
         assert_eq!(after.nodes[0].config, before.nodes[0].config);
+    }
+
+    /// #674's boundary condition, at the seam rather than in a unit test.
+    ///
+    /// The `full` company above runs an authored `shell` node without asking,
+    /// because the operator passed the `[tools].allow` grant, authored the node
+    /// and saw the command. Template that command from an upstream node's output
+    /// and they saw a *shape*: the content arrives at run time from data they
+    /// never read, so the node is judged as an agent call and gates.
+    ///
+    /// Without this the split is defeated by one line of authoring, and the
+    /// judgement unit tests cannot catch it — they prove `judge` answers
+    /// correctly, not that this pass hands it the arguments it must see.
+    #[tokio::test]
+    async fn a_shell_node_templated_from_upstream_output_gates_under_full() {
+        let mut node = tool_node("run-it", "shell");
+        node.config = json!({ "slug": "shell", "args": { "command": "=previous.output" } });
+        let mut g = graph(vec![node]);
+
+        let gated = apply_policy_gates(&mut g, &company("full", &[]), "wf", "run-1").await;
+
+        assert_eq!(gate_ids(&g), vec!["run-it"]);
+        assert_eq!(gated.len(), 1, "{gated:?}");
+        assert_eq!(gated[0].slug, "shell");
+        assert!(
+            gated[0].reason.contains("arbitrary code"),
+            "the card must say what it is asking about: {}",
+            gated[0].reason
+        );
+    }
+
+    /// The same condition on the other gated node kind: an `http_request` node
+    /// with a literal URL does not gate under `full`
+    /// (`an_http_request_node_does_not_gate_under_full`), and one whose
+    /// destination is decided by the run does.
+    ///
+    /// This is the pair that shows the rule is about the *arguments* and not
+    /// about `tool_call` nodes specifically.
+    #[tokio::test]
+    async fn an_http_request_node_with_a_templated_url_gates_under_full() {
+        let mut node = tool_node("fetch", "unused");
+        node.kind = NodeKind::HttpRequest;
+        node.config = json!({ "method": "POST", "url": "=item.endpoint" });
+        let mut g = graph(vec![node]);
+
+        let gated = apply_policy_gates(&mut g, &company("full", &[]), "wf", "run-1").await;
+
+        assert_eq!(gated.len(), 1, "{gated:?}");
+        assert_eq!(
+            gated[0].target.as_deref(),
+            Some("POST (destination resolved at run time)"),
+            "an operator approving an outbound request with no host shown \
+             should be told that is what they are doing"
+        );
     }
 
     /// A pure read of the agent's own workspace is `Reach::Nothing`, and a


### PR DESCRIPTION
## Summary

Reworked under **#674's ruling**, which closed the contradiction this PR was parked on. The gate itself is unchanged; what changed is **who it speaks about**.

The "should this stop for a human?" question was answered entirely by static configuration decided before the run starts — reserved `never_do`, the `readonly` brake, a live grant, `always_approve`, the daily cap, `auto_approve_under_usd`, then the mode. Nothing looked at what the run was about to do, so `full` admitted agent-picked sends, payments, deletes and other unbounded calls without asking. Publishing is the deliberate #658 exception below.

`src/policy/judgement.rs` asks that question per candidate call, as the **last** arm of `ApprovalPolicy::check`.

### What #674 decided, and what that made this PR

#338's rule ("unbounded reach stops regardless of mode") and #614's position ("a `tool_call` node does not gate under `full`", stated in a named test) were in direct contradiction. #674 **split them by path**, and the justification is stronger than "pre-declared intent":

A workflow `tool_call` node is **refused at author time** unless its namespace is one the workflow invoker wires *and* the company's `[tools].allow` grants it. So a saved `shell` node has passed **two operator gates** — the manifest grant, then authoring — and the operator saw the command they saved. An agent turn has passed **neither**: the model picks the tool and the arguments at run time.

- **`CallPath::Agent`** — #338's rules govern. The default at every construction site, because it is the strict one.
- **`CallPath::AuthoredWorkflowNode`** — #614's position governs; this module is silent. Only `apply_policy_gates` opts in, on the private policy instance it already builds for that pass.

### The boundary condition, which is the part that matters

**A node whose arguments are templated from an upstream node's output is not pre-declared, and follows the agent rule.** The operator declared the *shape*; the *content* arrives at run time from data they never saw.

Without it the split is trivially defeated: author one `shell` node whose `command` is `=previous.output`, and the two-gate argument stops describing what actually runs while still being cited as the reason not to ask. It is implemented in `judge` rather than at the call site, so it is pinned by pure tests as well as at the gate pass — and the discriminator is not invented here: `every_reachable_workflow_tool_is_classified_by_name_alone` already exists because "node `args` may still carry unresolved `=`-expressions when this pass runs".

`a_shell_node_templated_from_upstream_output_gates_under_full` pins it at the real seam, alongside an `http_request` case whose URL is resolved at run time.

## API Or Behavior Changes

**One new public type and one new builder method.** `crate::policy::CallPath`, and `ApprovalPolicy::for_authored_workflow_nodes()`. `ApprovalPolicy::new`'s signature is unchanged and yields the strict path, so **every existing construction site is judged in full rather than silently exempted** — `the_default_path_is_the_strict_one` pins that.

**The arm can only ever ADD a stop**, and that placement is still the entire safety argument. It is consulted *only* where the mode already returned `Allow`, and its only answers are "stop" and "say nothing". `never_do`, the `readonly` brake, both grant arms, `always_approve`, the daily cap and `auto_approve_under_usd` have each already had their say and returned before it is reached.

**The path opt-out scopes exactly one arm.** `the_authored_path_changes_nothing_above_the_judgement_arm` walks three cases decided above it — a denying tier, `always_approve` parking, a parking tier — and asserts both paths agree. That matters more than it looks: on the authored-node path `always_approve` is now the operator's whole control surface, so it had better still work. A refactor that moved the path check earlier in `check` — the obvious simplification, since it would let the function return before doing any work — fails there rather than shipping a bypass.

### Changes since the previous revision

1. **`http_request` / `curl` / `web_fetch` are out of `DEFERRED`.** #674 ruled them **scoped by path**, not deferred: governed by #614 on the workflow path and #338 on the agent path. `unbounded_tools_stop` now asserts them under the rule and asserts they are *not* in `DEFERRED`, so they cannot quietly be carved out again.
2. **`publish_artifact` stays in `DEFERRED`, permanently.** #658 ruled that `full` publishes without asking, because `always_approve` is the operator's override — so this is correct behaviour, not a stopgap, and the comment now states the ruling instead of "pending #658". The test is renamed `publish_artifact_is_excluded_by_the_658_ruling` and now asserts silence on **both** paths *and* under templated arguments, because the carve-out is not part of #674's split and must survive the one condition that reopens every other node.
3. **The five pre-ruling workflow failures are resolved by the scoping**, without weakening either test that had to survive.
4. **The acceptance-verb statement is rewritten per path** — see Documentation.
5. **Rebased onto current `main`** (was `DIRTY`, 46 commits behind). `mergeStateStatus` is now `CLEAN`.
6. **The tier list is no longer enumerated in prose anywhere** — see Review follow-ups.

### The two tests that had to survive, and did

- **`the_arm_adds_nothing_under_auto`** — walks *every declared tool* and asserts anything `auto` allows, this arm leaves silent. Kept, still judged on `CallPath::Agent` (the strict path — asserting it on the lenient one would be asserting #674's split, not `auto`), and it **fails if the walk checks zero tools**.
- **`every_deferred_tool_would_otherwise_be_stopped`** — updated for the new list, not removed. It **fails if `DEFERRED` is emptied**: without that, deleting the `publish_artifact` carve-out would make it loop over nothing and score green, which is the exact failure it exists to prevent.

## Review follow-ups (@oxoxDev)

**Major — the rebase and the fourth tier: done.** Rebased onto current `main`; the branch is `MERGEABLE` / `CLEAN`. `by_mode`'s `PolicyMode::Auto` arm is in place and the branch compiles and tests against it. `the_arm_adds_nothing_under_auto` is the test you asked for, and it walks the whole declaration table rather than sampling it — so the `d_grantable("send_invoice", Send, Consequence)` day fails a test instead of shifting `auto` silently under operators who chose it.

**Minor — the tier list spelled out in three places: done, and in a fourth you had not seen.** No prose anywhere now enumerates the tiers:

- `judgement.rs` module docs — the "as it happens the arm today changes `full` alone" paragraph is gone. It now says the tier question is deliberately not enumerated here or anywhere else, and is answered by `the_arm_adds_nothing_under_auto`, the one copy that cannot go stale.
- `per-call-judgement.md` — same treatment (this file is new in this PR, so it was a fourth copy).
- Two **test** doc comments in `judgement.rs` carried the same "`supervised` parks, `readonly` denies" pair; both now phrase the invariant instead.
- `src/harness/policy.rs:3` claimed the manifest tier words are `readonly` / `supervised` / `full` "so the mapping is 1:1" — a three-item list next to a four-variant enum. That is stale on `main`, not from this branch: `1852b7d5`, the commit that added `auto`, left it behind. It is exactly the drift you were describing, so I fixed it here rather than leaving it; it now points at `PolicyMode` as the single place the tiers are listed.

`policy.rs`'s per-call-judgement section and `approvals.md` step 7 already stated only the invariant, so they were left as they were.

**Question — `publish_turn_test` overlaps #659: re-checked on the merged fixtures, and the evidence is intact.** #659 landed first (merged 2026-08-11T20:26; its merge `c5b43ab6` is in this branch's base), so this is the "whichever lands second" re-check you asked for. Its only edit to `publish_turn_test.rs` was `b60346e7`, adding `overlay_policy: None` to a helper struct literal — a mechanical field addition, not a fixture reshape. The suite has since grown to **19 cases, and all 19 pass** with the gate in place. The stale "11" and "13" counts in the `DEFERRED` comment are corrected against that measurement rather than carried forward.

## Issue #681, as an acceptance criterion

An undeclared slug on a **workflow error path** must route as an error, not park for approval. Both named tests pass with the gate in place:

- `workflows::runner::tests::t2_unknown_slug_retries_then_continues_with_error_item` — **ok**
- `workflows::runner::tests::t3_on_error_route_sends_failure_down_the_error_edge` — **ok**

They pass structurally, not by luck. A `bogus_tool` node carries literal config and no templated arguments, so `judge` returns `Silent` on the authored-node path before any rule can reach it — which leaves the run free to fail at slug resolution and take its `on_error` edge. Nothing special-cases unknown slugs; the split delivers the ordering #681 asked for. Fail-closed is untouched: the same slug on the **agent** path still stops as `StopReason::Undeclared`.

That they are a genuine check rather than incidentally green is shown by revert 9 below — removing the path split makes **both of them fail**. So #681's criterion is pinned by tests that are demonstrably sensitive to the mechanism, and no new test was needed to assert it.

## Tests

The path split adds 6 tests in `src/policy/judgement.rs`, 4 in `src/harness/policy.rs`, and 2 in `src/workflows/gate.rs`.

`the_two_paths_actually_differ` is there because every other test in the split could pass under a refactor that collapsed the two paths into one.

### Verified locally on the rebased tree

- [x] `cargo fmt --all -- --check` — exit 0, clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; exit 0, no lints. `--no-deps` so pre-existing `vendor/tinyagents` lints that CI never sees cannot mask the result.
- [x] `cargo build --all-targets` — exit 0 (`--features openhuman,tinycortex`). Also `cargo check --locked --all-features --all-targets`, exit 0 — run because `mongodb.rs` / `sqlite.rs` build `CompanyRecord` from a row, which neither the default nor the gated lane can see.
- [x] `cargo test` — ran as `cargo test --features openhuman,tinycortex`; exit 0. **3168 passed, 0 failed, 3 ignored** in the lib target, plus 5 integration targets green.

### Revert-and-check: every rule is covered by a test that fails without it

Each row applies one revert, **proves the file actually changed** (a pattern that matches nothing is a silent no-op that would otherwise score green), runs the full gated lib suite, records the failures and restores. All twelve fail; none is uncovered. Re-run in full **after** the rebase, since a rebase can hollow a test without the diff moving.

| # | Revert | Tests failed |
|---|---|---|
| 1 | drop the `Reach` pairing on rule 1 (declared group alone decides) | 9 |
| 2 | drop the unbounded-reach rule | 10 |
| 3 | drop the money-in-arguments rule | 3 |
| 4 | fail **open** on undeclared tools | 8 |
| 5 | let the undeclared name heuristic decide rule 1 | 1 |
| 6 | remove the positive-amount filter | 1 |
| 7 | run the arm regardless of the mode's decision | 2 |
| 8 | remove the arm entirely | 8 |
| 9 | remove #674's path split (every call judged as an agent call) | 14 |
| 10 | remove the templated-argument boundary condition | 5 |
| 11 | make the templating check non-recursive (top level only) | 5 |
| 12 | default the policy to the lenient authored-node path | 5 |

Rows 9–12 are the ones that matter most for this rework: 9 and 12 prove the split exists and defaults strict, 10 and 11 prove the boundary condition is load-bearing both at the top level and at depth. Row 12 fails `the_default_path_is_the_strict_one` among four others, which is the guard against a construction site being silently exempted.

## Documentation

- `docs/spec/company-brain/per-call-judgement.md` — a **"Which path the call arrived on"** section carrying the two-gate justification and the boundary condition, and an **acceptance-verbs-per-path table**. The old sentence — "send, pay and delete are gated; publish is not" — was correct only under assumptions #674 removed; it now says which path each of send / publish / pay / delete is gated on, and states plainly that *"regardless of mode"* is exact and unchanged while *"regardless of path"* was never claimed and is now explicitly not true.
- The **Coverage** paragraph is corrected rather than carried forward. It said the workflow `tool_call` path never consults `ApprovalPolicy` (#460). #612 and #627 made that false; the path split is what governs there now, rather than the step being unreachable.
- `docs/spec/company-brain/approvals.md` — step 7 gains the path split, and the note that steps 1–6 decide identically on both paths.
- `src/policy/judgement.rs`, `src/harness/policy.rs`, `src/workflows/gate.rs` — module docs carry the same argument at the code.
- Both spec files remain under the repo's 500-line cap.

## Still open, deliberately not fixed here

**#617** — `sub_workflow` children remain ungated on the workflow path. Named in the spec, not touched.

**#681 — met as scoped, but referenced rather than closed.** Its acceptance criterion is satisfied: both runner tests pass with the gate in place, and revert 9 shows the path split is what delivers that rather than luck.

It is not closed here because one case its title still describes remains. An undeclared slug on a **templated** node follows the agent rule, so it stops as `StopReason::Undeclared` and parks instead of routing as an error — `an_undeclared_tool_stops` and `a_templated_value_is_found_at_any_depth` together pin exactly that composition. That is fail-closed working as designed rather than a regression, but the question #681 actually asked — *resolve the slug before consulting the approval gate* — is untouched by this PR. Closing it would record that question as answered when it is not. Refs #681.

Closes #338
