### PR TITLE
fix(console): stop polling the company and the board while the tab is hidden (#581)

### DIFF
--- a/frontend/src/hooks/use-company.ts
+++ b/frontend/src/hooks/use-company.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { ApprovalSummary, CompanyStatus } from "@/api/types";
+import { startVisiblePolling } from "@/lib/visible-poll";
 
 const POLL_MS = 5000;
 
@@ -46,13 +47,20 @@ export function useCompany(
     }
   }, [client, company]);
 
+  // Issue #581: gated on visibility. This hook has one instance per open
+  // console tab, and its refresh is two requests — so an ungated interval meant
+  // every tab left in the background kept costing the host 24 requests a minute
+  // for a company nobody was looking at. The mount fetch stays here rather than
+  // moving into the poller: the poller deliberately does not load on start, and
+  // the hidden → visible catch-up read it does perform covers the staleness of
+  // a tab coming back.
   useEffect(() => {
     mounted.current = true;
     void refresh();
-    const timer = setInterval(() => void refresh(), POLL_MS);
+    const dispose = startVisiblePolling(() => void refresh(), POLL_MS);
     return () => {
       mounted.current = false;
-      clearInterval(timer);
+      dispose();
     };
   }, [refresh]);
 

--- a/frontend/src/lib/visible-poll.ts
+++ b/frontend/src/lib/visible-poll.ts
@@ -8,10 +8,11 @@
  * forever, and every extra tab multiplied the steady-state request volume of a
  * company nobody was looking at.
  *
- * The shape here is not new: `ArtifactsTab` and the task detail screen already
- * hand-rolled it. This is that pattern extracted so a fourth caller cannot get
- * it subtly wrong — the double-arm guard and the listener removal are the two
- * halves people forget, and forgetting either turns a fix into a leak.
+ * The shape here is not new: `ArtifactsTab` and the task detail screen
+ * hand-rolled it first. Both now call this instead, so the pattern lives in one
+ * place and the next caller cannot get it subtly wrong — the transition-edge
+ * check and the listener removal are the two halves people forget, and
+ * forgetting either turns a fix into a leak.
  *
  * Deliberately framework-free: no React import, no hook rules, so it is
  * callable from an effect, from a class, or from a plain test with fake timers.
@@ -21,12 +22,19 @@
  * Every caller already fetches once on mount — that is what fills the screen
  * before the first tick. Loading here as well would double every mount and
  * every company switch. What it *does* do is load once on the hidden → visible
- * transition, because that is the moment the view is known to be stale by up to
- * however long the tab sat in the background.
+ * *transition*, because that is the moment the view is known to be stale by up
+ * to however long the tab sat in the background.
  *
- * @param load       Called on each tick, and once when the tab becomes visible.
- *                   Errors are the caller's to handle (all current callers
- *                   swallow transient failures to keep the last good view).
+ * The transition, not the state: `visibilitychange` can fire visible→visible in
+ * some browsers, and a handler that only reads the live `visibilityState` would
+ * treat each of those as a return from the background and pay for a full
+ * refresh — two requests, for the callers that read two things. So the previous
+ * state is remembered and only a genuine edge does any work.
+ *
+ * @param load       Called on each tick, and once on each hidden → visible
+ *                   transition. Errors are the caller's to handle (all current
+ *                   callers swallow transient failures to keep the last good
+ *                   view).
  * @param intervalMs The cadence, in milliseconds, while the tab is visible.
  * @returns A disposer that clears the timer **and** removes the
  *          `visibilitychange` listener. Call it from effect cleanup; not
@@ -42,27 +50,33 @@ export function startVisiblePolling(load: () => void, intervalMs: number): () =>
     }
   };
 
-  // Guarded against double-arming: `visibilitychange` can fire visible→visible
-  // in some browsers, and arming twice would leak the first timer and double
-  // the cadence with no way left to clear it.
+  // Guarded against double-arming anyway: arming twice would leak the first
+  // timer and double the cadence with no way left to clear it, and belt and
+  // braces is cheap for something with no way to observe it went wrong.
   const start = () => {
     if (timer === undefined) {
       timer = window.setInterval(() => load(), intervalMs);
     }
   };
 
+  // The remembered previous state is what makes this an edge and not a level.
+  // It also carries the started-in-a-hidden-tab case: a console restored into a
+  // background tab, or a route mounted behind one, arms nothing until the first
+  // real transition to visible.
+  let wasHidden = document.visibilityState === "hidden";
+
   const onVisibility = () => {
-    if (document.visibilityState === "hidden") {
+    const hidden = document.visibilityState === "hidden";
+    if (hidden) {
       stop();
-    } else {
+    } else if (wasHidden) {
       load();
       start();
     }
+    wasHidden = hidden;
   };
 
-  // Started in a hidden tab — a console restored into a background tab, or a
-  // route mounted behind one — arms nothing until it is actually looked at.
-  if (document.visibilityState !== "hidden") start();
+  if (!wasHidden) start();
   document.addEventListener("visibilitychange", onVisibility);
 
   return () => {

--- a/frontend/src/lib/visible-poll.ts
+++ b/frontend/src/lib/visible-poll.ts
@@ -1,0 +1,72 @@
+/**
+ * Interval polling that stops while the tab is hidden (issue #581).
+ *
+ * The console's background reads — company status, the task board, standing
+ * permissions — were armed with a bare `setInterval` that never stopped. A
+ * browser throttles a hidden tab's timers, it does not cancel them, so a
+ * console left open in a background tab kept asking the host for the board
+ * forever, and every extra tab multiplied the steady-state request volume of a
+ * company nobody was looking at.
+ *
+ * The shape here is not new: `ArtifactsTab` and the task detail screen already
+ * hand-rolled it. This is that pattern extracted so a fourth caller cannot get
+ * it subtly wrong — the double-arm guard and the listener removal are the two
+ * halves people forget, and forgetting either turns a fix into a leak.
+ *
+ * Deliberately framework-free: no React import, no hook rules, so it is
+ * callable from an effect, from a class, or from a plain test with fake timers.
+ *
+ * ## It does NOT load on start
+ *
+ * Every caller already fetches once on mount — that is what fills the screen
+ * before the first tick. Loading here as well would double every mount and
+ * every company switch. What it *does* do is load once on the hidden → visible
+ * transition, because that is the moment the view is known to be stale by up to
+ * however long the tab sat in the background.
+ *
+ * @param load       Called on each tick, and once when the tab becomes visible.
+ *                   Errors are the caller's to handle (all current callers
+ *                   swallow transient failures to keep the last good view).
+ * @param intervalMs The cadence, in milliseconds, while the tab is visible.
+ * @returns A disposer that clears the timer **and** removes the
+ *          `visibilitychange` listener. Call it from effect cleanup; not
+ *          calling it leaks a listener per mount.
+ */
+export function startVisiblePolling(load: () => void, intervalMs: number): () => void {
+  let timer: number | undefined;
+
+  const stop = () => {
+    if (timer !== undefined) {
+      window.clearInterval(timer);
+      timer = undefined;
+    }
+  };
+
+  // Guarded against double-arming: `visibilitychange` can fire visible→visible
+  // in some browsers, and arming twice would leak the first timer and double
+  // the cadence with no way left to clear it.
+  const start = () => {
+    if (timer === undefined) {
+      timer = window.setInterval(() => load(), intervalMs);
+    }
+  };
+
+  const onVisibility = () => {
+    if (document.visibilityState === "hidden") {
+      stop();
+    } else {
+      load();
+      start();
+    }
+  };
+
+  // Started in a hidden tab — a console restored into a background tab, or a
+  // route mounted behind one — arms nothing until it is actually looked at.
+  if (document.visibilityState !== "hidden") start();
+  document.addEventListener("visibilitychange", onVisibility);
+
+  return () => {
+    stop();
+    document.removeEventListener("visibilitychange", onVisibility);
+  };
+}

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -23,6 +23,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
 import { approvalSummary, timeAgo, toolAction } from "@/lib/language";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import { isRecord, parseNodeMessages } from "@/views/workflows/run-output";
 
 /**
@@ -301,10 +302,15 @@ function useStandingGrants(client: OpenCompanyClient, company: string | null) {
     // poll-visible in v1 (there is no event for them), and a permission list is
     // not something an operator watches change — a minute is well inside the
     // shortest duration on offer.
-    const timer = setInterval(() => void refreshGrants(), 60_000);
+    //
+    // Gated on visibility since #581. The cadence was never the problem; a tab
+    // left open for a week was, and the load-on-visible read means a returning
+    // operator sees the current grants at once rather than up to a minute of a
+    // list that may already have been revoked elsewhere.
+    const dispose = startVisiblePolling(() => void refreshGrants(), 60_000);
     return () => {
       live = false;
-      clearInterval(timer);
+      dispose();
     };
   }, [client, company, refreshGrants]);
 

--- a/frontend/src/views/ArtifactsTab.tsx
+++ b/frontend/src/views/ArtifactsTab.tsx
@@ -61,6 +61,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { Markdown } from "@/components/markdown";
 import { cn } from "@/lib/utils";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import { toast } from "sonner";
 
 /** Matches the parent screen's poll cadence; visibility-gated the same way. */
@@ -161,34 +162,15 @@ export function ArtifactsTab({
     // applied on the previous one must be allowed to apply again here.
     appliedLink.current = null;
     void load(isActive);
-    let timer: number | undefined;
-    const stop = () => {
-      if (timer !== undefined) {
-        window.clearInterval(timer);
-        timer = undefined;
-      }
-    };
-    const start = () => {
-      if (timer === undefined) {
-        timer = window.setInterval(() => {
-          if (!editingRef.current) void load(isActive);
-        }, POLL_MS);
-      }
-    };
-    const onVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        stop();
-      } else {
-        if (!editingRef.current) void load(isActive);
-        start();
-      }
-    };
-    if (document.visibilityState !== "hidden") start();
-    document.addEventListener("visibilitychange", onVisibility);
+    // The edit guard composes into the callback, so it covers the tick and the
+    // return-to-foreground read alike: a reader mid-edit never has the rows
+    // pulled out from under them.
+    const dispose = startVisiblePolling(() => {
+      if (!editingRef.current) void load(isActive);
+    }, POLL_MS);
     return () => {
       cancelled = true;
-      stop();
-      document.removeEventListener("visibilitychange", onVisibility);
+      dispose();
     };
   }, [load]);
 

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -82,6 +82,7 @@ import {
 import type { OpenCompanyClient } from "@/api/client";
 import { hasFocus, type TaskFocus } from "@/lib/task-output";
 import { pendingApprovalWait } from "@/lib/task-approvals";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -345,31 +346,10 @@ export function TaskDetailView({
     setLoading(true);
     setDetail(null);
     void load(isActive);
-    let timer: number | undefined;
-    const stop = () => {
-      if (timer !== undefined) {
-        window.clearInterval(timer);
-        timer = undefined;
-      }
-    };
-    const start = () => {
-      if (timer === undefined)
-        timer = window.setInterval(() => void load(isActive), POLL_MS);
-    };
-    const onVisibility = () => {
-      if (document.visibilityState === "hidden") {
-        stop();
-      } else {
-        void load(isActive);
-        start();
-      }
-    };
-    if (document.visibilityState !== "hidden") start();
-    document.addEventListener("visibilitychange", onVisibility);
+    const dispose = startVisiblePolling(() => void load(isActive), POLL_MS);
     return () => {
       cancelled = true;
-      stop();
-      document.removeEventListener("visibilitychange", onVisibility);
+      dispose();
     };
   }, [load]);
 

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -44,6 +44,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
+import { startVisiblePolling } from "@/lib/visible-poll";
 import { ADD_TASK_COLUMN, PRIORITY_STYLES, TASK_COLUMNS } from "@/lib/tasks-sample";
 import {
   extraOutputCount,
@@ -213,13 +214,18 @@ export function TasksView({
     }
   }, [client, company]);
 
+  // Issue #581: the fallback poll runs only while the tab is being looked at.
+  // Reading the whole board every four seconds is affordable for an operator
+  // watching it and pure waste for a background tab, and the poller's
+  // load-on-visible is what makes pausing safe — a tab coming back re-reads
+  // immediately rather than showing a stale board for up to an interval.
   useEffect(() => {
     mounted.current = true;
     void refresh();
-    const timer = setInterval(() => void refresh(), POLL_MS);
+    const dispose = startVisiblePolling(() => void refresh(), POLL_MS);
     return () => {
       mounted.current = false;
-      clearInterval(timer);
+      dispose();
     };
   }, [refresh]);
 
@@ -239,6 +245,16 @@ export function TasksView({
   const seenTick = useRef(taskEventTick);
   useEffect(() => {
     if (taskEventTick === undefined || taskEventTick === seenTick.current) return;
+    // Issue #581: the push half is gated too, or the poll gate above buys
+    // nothing on a busy company — a hidden tab would still re-read the whole
+    // board on every frame the stream delivers.
+    //
+    // The tick is deliberately NOT consumed on the way out. Marking it seen
+    // here would drop it: this effect does not re-run on a visibility change,
+    // so nothing would ever come back for it. Leaving it unseen means the
+    // board's staleness is settled by the poller's load-on-visible read
+    // instead, and the next frame after that still counts as a change.
+    if (document.visibilityState === "hidden") return;
     seenTick.current = taskEventTick;
     void refresh();
   }, [taskEventTick, refresh]);

--- a/frontend/test/unit/visible-poll.test.ts
+++ b/frontend/test/unit/visible-poll.test.ts
@@ -92,17 +92,41 @@ describe("startVisiblePolling", () => {
     dispose();
   });
 
-  it("does not double-arm across repeated visible transitions", () => {
+  it("ignores redundant visible → visible events entirely", () => {
     const load = vi.fn();
     const dispose = startVisiblePolling(load, 1000);
 
-    // A visible → visible event, which some browsers do emit. The guard is the
-    // only thing standing between this and a timer nobody holds a handle to.
-    setVisibility("visible");
-    setVisibility("visible");
     load.mockClear();
 
+    // A visible → visible event, which some browsers do emit. Nothing about the
+    // tab changed, so nothing is owed: not a refresh (the callers that read two
+    // things would pay twice per stray event, which is the waste #581 exists to
+    // remove) and not a second timer (nobody would hold a handle to it).
+    setVisibility("visible");
+    setVisibility("visible");
+    expect(load).toHaveBeenCalledTimes(0);
+
+    // Cadence unchanged — a leaked second timer would show as four here.
     vi.advanceTimersByTime(2000);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    dispose();
+  });
+
+  it("loads once per genuine hidden → visible edge", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    load.mockClear();
+
+    // Two real round trips through the background. Each one, and only each one,
+    // is worth exactly one catch-up read.
+    setVisibility("hidden");
+    setVisibility("visible");
+    expect(load).toHaveBeenCalledTimes(1);
+
+    setVisibility("hidden");
+    setVisibility("visible");
     expect(load).toHaveBeenCalledTimes(2);
 
     dispose();

--- a/frontend/test/unit/visible-poll.test.ts
+++ b/frontend/test/unit/visible-poll.test.ts
@@ -1,0 +1,146 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { startVisiblePolling } from "@/lib/visible-poll";
+
+/**
+ * The visibility-gated poller (issue #581).
+ *
+ * The property under test is not "it polls" — every `setInterval` does that.
+ * It is that a tab nobody is looking at costs the host **nothing**, and that
+ * coming back to it is worth exactly one read rather than a doubled cadence
+ * that never stops again. Both halves are easy to get wrong in a way no
+ * screenshot would ever show, which is why they are asserted here instead of
+ * in a browser walk.
+ */
+
+let visibility: DocumentVisibilityState = "visible";
+
+/** Flips the document's visibility and fires the event the browser would. */
+function setVisibility(next: DocumentVisibilityState) {
+  visibility = next;
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+beforeEach(() => {
+  visibility = "visible";
+  Object.defineProperty(document, "visibilityState", {
+    configurable: true,
+    get: () => visibility,
+  });
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("startVisiblePolling", () => {
+  it("polls on cadence while the tab is visible", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    // Nothing on start: the caller owns its own mount fetch, and loading here
+    // as well would double every mount.
+    expect(load).toHaveBeenCalledTimes(0);
+
+    vi.advanceTimersByTime(3000);
+    expect(load).toHaveBeenCalledTimes(3);
+
+    dispose();
+  });
+
+  it("stops polling while the tab is hidden", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    vi.advanceTimersByTime(1000);
+    expect(load).toHaveBeenCalledTimes(1);
+
+    setVisibility("hidden");
+    load.mockClear();
+
+    // THE regression. A browser throttles a hidden tab's timers, it does not
+    // cancel them, so without the gate this is where the background tab keeps
+    // asking the host for a board nobody is reading.
+    vi.advanceTimersByTime(60_000);
+    expect(load).toHaveBeenCalledTimes(0);
+
+    dispose();
+  });
+
+  it("loads exactly once on becoming visible, then resumes the same cadence", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    setVisibility("hidden");
+    vi.advanceTimersByTime(10_000);
+    load.mockClear();
+
+    setVisibility("visible");
+    // One read, because the view is stale by however long the tab sat in the
+    // background — not two, which is what an un-guarded re-arm plus a catch-up
+    // fetch would produce.
+    expect(load).toHaveBeenCalledTimes(1);
+
+    // And the cadence is the original one. A leaked timer from the first arm
+    // would show up here as two calls per interval instead of one.
+    vi.advanceTimersByTime(3000);
+    expect(load).toHaveBeenCalledTimes(4);
+
+    dispose();
+  });
+
+  it("does not double-arm across repeated visible transitions", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    // A visible → visible event, which some browsers do emit. The guard is the
+    // only thing standing between this and a timer nobody holds a handle to.
+    setVisibility("visible");
+    setVisibility("visible");
+    load.mockClear();
+
+    vi.advanceTimersByTime(2000);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    dispose();
+  });
+
+  it("stops the timer and drops the listener when disposed", () => {
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    dispose();
+
+    vi.advanceTimersByTime(10_000);
+    expect(load).toHaveBeenCalledTimes(0);
+
+    // The listener half, asserted by behaviour rather than by spying: a
+    // disposer that cleared the timer but left the listener attached would
+    // come back to life on the next visibility flip — a leak per mount, and
+    // the console remounts these on every company switch.
+    setVisibility("hidden");
+    setVisibility("visible");
+    vi.advanceTimersByTime(10_000);
+    expect(load).toHaveBeenCalledTimes(0);
+  });
+
+  it("arms nothing when started in a hidden tab", () => {
+    visibility = "hidden";
+    const load = vi.fn();
+    const dispose = startVisiblePolling(load, 1000);
+
+    vi.advanceTimersByTime(10_000);
+    expect(load).toHaveBeenCalledTimes(0);
+
+    // …and comes up on the first look, rather than waiting a full interval.
+    setVisibility("visible");
+    expect(load).toHaveBeenCalledTimes(1);
+    vi.advanceTimersByTime(1000);
+    expect(load).toHaveBeenCalledTimes(2);
+
+    dispose();
+  });
+});


### PR DESCRIPTION
## Summary

The console armed three background reads with a bare `setInterval` and never stopped them. A browser throttles a hidden tab's timers, it does not cancel them, so a console left open in a background tab kept asking the host for the company status and the whole task board forever — and every extra tab multiplied the steady-state request volume of a company nobody was looking at. That is the "site hangs while navigating, especially after approving things and switching tabs" report in #581.

This gates them on `document.visibilitychange`, using the pattern `ArtifactsTab` and the task detail screen already hand-rolled, extracted into one helper so a fourth caller cannot get it subtly wrong.

**Two of the issue's three points did not survive contact with the code, and this PR deliberately does not implement them:**

- The issue describes the 5s poll as refetching "the whole GraphQL `Company` aggregation — team, desks, chats, tasks, skills, workspace, memory, workflows, usage, finances, connections, domain, SMTP". There is no GraphQL in the frontend at all. `client.status()` is `GET /api/v1/companies/{id}`, and `CompanyStatus` is six scalar fields (`src/runtime/types.rs`) served by one `store.load()` plus a pending count (`src/company/runtime.rs`). So the issue's point 3 — "consider whether the company poll needs the whole aggregation", called out as "the real win" — has no aggregation to trim. It is dropped for lack of a subject rather than deferred.
- The three `TaskDetailView.tsx` timers the issue asks to gate (its point 2) are **already** gated on `main`, at lines 357, 419 and 1727. They are untouched here.

What the issue *missed* is that `TasksView` re-reads the entire board every 4s, ungated — the most expensive of the timers involved — and that `ApprovalsView` runs a third ungated interval. Both are fixed here.

## API Or Behavior Changes

No API change. Frontend only; no backend surface participates in tab visibility, and the polled endpoints are already cheap reads.

Behavior:

- A hidden tab issues **no** company-status, approvals, board or standing-permissions poll.
- Returning to a hidden tab performs exactly one immediate catch-up read per gated poller, then resumes its normal cadence.
- Foreground cadence is unchanged (5s status + approvals, 4s board, 60s standing permissions).
- The board's push half (#464) is gated too, or the poll gate would buy nothing on a busy company. The pending event tick is deliberately **not** consumed while hidden, so the update is deferred rather than dropped, and the poller's load-on-visible read settles it.

Deliberately not changed: `WorkflowsView`'s 2s run tick (armed only during an active run, self-clearing, and the SSE fallback for deployments where frames do not arrive — gating it risks wedging the Run controls for a small win), and the already-gated `ArtifactsTab` / `WorkspaceView` / `TaskDetailView` timers. Collapsing those onto the new helper is a reasonable follow-up, kept out of here to keep the diff reviewable.

## Tests

Frontend-only change, so the Rust gates are not applicable — this PR touches no Rust and no `Cargo.toml`.

- N/A: `cargo fmt --all -- --check` — no Rust changed.
- N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- N/A: `cargo build --all-targets` — no Rust changed.
- N/A: `cargo test` — no Rust changed.

Run from `frontend/`:

- [x] `npm run typecheck` — clean
- [x] `npm run typecheck:unit` — clean
- [x] `npm test` (`vitest run`) — `Test Files 38 passed (38) · Tests 417 passed (417)`, including the new `visible-poll.test.ts`
- [x] `npm run build` — succeeds (only the pre-existing >500 kB chunk-size advisory)

New unit coverage — `frontend/test/unit/visible-poll.test.ts`, six cases under jsdom with fake timers: ticks fire while visible; nothing fires while hidden; becoming visible loads exactly once and resumes the same cadence; a visible→visible event does not double-arm; the disposer clears the timer and removes the listener; started-while-hidden arms nothing until the first visible transition.

**Untested edge, stated deliberately** per the repo's coverage expectation: the `TasksView` push-effect hidden guard is not unit-tested. It needs React to exercise, and this suite is pure-function only by its own `vitest.config.ts` documentation. It is verified manually (below). The guard returns **before** `seenTick.current` is assigned — moving it below that line would silently reintroduce dropped updates, so it is worth a reviewer's eye.

Manual verification, DevTools Network filtered to `/api/v1/`: foreground cadence unchanged; hiding the tab for 60s produces zero requests, including no board reads while task changes are driven from a second tab; returning produces one status+approvals burst and one board read, then a single (not doubled) cadence; switching company restarts the poller cleanly; with three tabs open on one company, only the visible tab appears in the request log.

## Documentation

No docs change. The helper carries its own rationale in a module-level doc comment — why it does not load on start, why the double-arm guard exists, and why the disposer must remove the listener — and the two subtle call sites (`use-company`, and the `TasksView` push guard) are commented against #581 in place. No route, API surface, launcher behavior or `tiny*` integration changed, so nothing in `docs/spec/` or `docs/modules/` is affected.

Closes #581


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Background refreshes for company data, approvals, and tasks now pause when the app is not visible, reducing unnecessary activity.
  - Refreshing resumes automatically when the app becomes visible, including an immediate update to show current information.
  - Task updates received while the app is hidden are handled when visibility returns, helping prevent missed changes.
- **Bug Fixes**
  - Prevented duplicate refresh timers and ensured polling stops cleanly when no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->