### PR TITLE
approvals: give each turn its own approval scope instead of one pool-wide queue

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -32,6 +32,7 @@ use crate::harness::confine;
 // two note formats depending on which path touched it last.
 use crate::harness::lifecycle::{self, TaskRunEnd};
 use crate::harness::orchestrator;
+use crate::harness::policy::ApprovalScope;
 use crate::harness::publish::{self, WorkspaceSnapshot};
 use crate::runtime::advance::append_result;
 // `Delegation` is only named by the test-only `run_delegation` wrapper and the
@@ -2094,15 +2095,45 @@ fn settle(card: &mut TaskRecord, end: TaskRunEnd, responder: &str, body: &str) {
 #[async_trait]
 impl Brain for HarnessBrain {
     async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
+        // Issue #439: everything this cycle does runs inside its own approval
+        // scope, so a workflow run executing concurrently cannot see, take, or
+        // be taken by it.
+        //
+        // The claim replaces the `clear()` that used to open this function. It
+        // clears on the way in exactly as that did, and additionally on the way
+        // out via `Drop` — which is the half `clear()` never had. A cycle that
+        // returned early used to leave its entries for the *next* cycle to
+        // park; now the window is the claim's lifetime and nothing outlives it.
+        let claim = self.deps.approval_requests.claim(ApprovalScope::Cycle);
+        claim.scoped(self.run_cycle_scoped(req, host)).await
+    }
+
+    /// The harness meters itself per turn in [`HarnessPool::run`], against the
+    /// live provider slug the turn resolved to — which is why `run_cycle` reports
+    /// zero `token_usage` and the runtime's cycle-level metering is a no-op here.
+    fn cognition(&self) -> Cognition {
+        Cognition {
+            path: crate::ports::brain::HARNESS_PATH,
+            provider: "per-turn",
+            metering: UsageMetering::PerTurn,
+        }
+    }
+}
+
+impl HarnessBrain {
+    /// The cycle body, running inside its [`ApprovalScope::Cycle`] claim.
+    ///
+    /// Split out only so the claim can wrap the whole of it: every turn this
+    /// cycle runs — the operator turn, its delegated desk turns, a dispatched
+    /// card, a re-dispatch after an approval — happens in here, and therefore
+    /// files its gated calls into this cycle's bucket.
+    async fn run_cycle_scoped(
+        &self,
+        req: CycleRequest,
+        host: &dyn CycleHost,
+    ) -> Result<CycleResult> {
         // Idempotent — builds the roster on the first cycle, a no-op after.
         self.pool.ensure(&self.record, &self.deps).await?;
-
-        // Issue #172: start from an empty approval queue so nothing a prior
-        // cycle — or a workflow run sharing these deps — left behind is parked
-        // under this cycle. Every turn this cycle runs (the operator turn, its
-        // delegated desk turns, a dispatched card) pushes onto the same queue and
-        // is drained once at the end.
-        self.deps.approval_requests.clear();
 
         let mut channel_responses = Vec::new();
         for event in &req.events {
@@ -2364,17 +2395,6 @@ impl Brain for HarnessBrain {
             ledger_deltas: Vec::new(),
             token_usage: TokenUsage::default(),
         })
-    }
-
-    /// The harness meters itself per turn in [`HarnessPool::run`], against the
-    /// live provider slug the turn resolved to — which is why `run_cycle` reports
-    /// zero `token_usage` and the runtime's cycle-level metering is a no-op here.
-    fn cognition(&self) -> Cognition {
-        Cognition {
-            path: crate::ports::brain::HARNESS_PATH,
-            provider: "per-turn",
-            metering: UsageMetering::PerTurn,
-        }
     }
 }
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -69,6 +69,7 @@
 //! where it does, why an at-cap call **parks** rather than being denied, and
 //! what the cap does not see.
 
+use std::collections::BTreeMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -172,6 +173,39 @@ pub struct ApprovalRequest {
     pub effect: Effect,
 }
 
+/// Which turn a queued approval request belongs to (issue #439).
+///
+/// The queue handle is one per company and cannot be otherwise — see
+/// [`ApprovalRequestQueue`] — so the separation between turns lives here, in
+/// the key, rather than in separate queues.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ApprovalScope {
+    /// A request pushed outside any [`claim`](ApprovalRequestQueue::claim).
+    ///
+    /// The default, and deliberately **not** an error. Every production turn
+    /// runs under a claim, so this bucket should stay empty there; making an
+    /// unclaimed push panic or drop would trade a mis-attribution bug for a
+    /// lost-approval bug, and #395 exists because a lost approval is the worse
+    /// one. It is drained by the chat cycle alongside [`Cycle`](Self::Unscoped)
+    /// — which is exactly the pre-#439 behaviour for anything unclaimed.
+    #[default]
+    Unscoped,
+    /// The company's chat cycle, including every dispatched card and delegated
+    /// turn that runs inside it.
+    ///
+    /// One at a time per company: `CycleRunner` holds a serial lock, so this
+    /// bucket has a single writer. It is still concurrent with any number of
+    /// workflow runs, which is the race #439 is about.
+    Cycle,
+    /// One workflow run, keyed by its run id.
+    ///
+    /// Workflow runs are `tokio::spawn`ed and are **not** under the cycle lock,
+    /// so two of them genuinely overlap. That is the race a boundary index
+    /// could never fix: both runs take a boundary against one shared vector and
+    /// the later `split_off` swallows the earlier run's tail.
+    Run(String),
+}
+
 /// A shared, in-memory queue of approval-gated tool calls — the exact
 /// [`DelegationQueue`](crate::harness::orchestrator::DelegationQueue) /
 /// [`McpFailureQueue`](crate::harness::mcp_probe::McpFailureQueue) pattern.
@@ -179,9 +213,24 @@ pub struct ApprovalRequest {
 /// every roster agent and the [`HarnessBrain`](crate::harness::HarnessBrain)
 /// that drains it see the same queue because
 /// [`HarnessDeps`](crate::harness::HarnessDeps) clones share this handle.
-#[derive(Clone, Default)]
+///
+/// # One handle, many turns (issue #439)
+///
+/// The handle is shared and **has to be**. `ApprovalPolicy` is installed once
+/// per roster agent inside [`build_roster`](crate::harness::build_roster),
+/// which runs in a fingerprint-cached, per-company `HarnessPool::ensure` with
+/// no run id in scope, and the policy is then sealed into the vendored agent
+/// with no setter. So "one queue per run" cannot be built by handing each run
+/// its own queue — there is nowhere to hand it to.
+///
+/// The separation is therefore in the **key**, not the handle: entries are
+/// bucketed by [`ApprovalScope`], a turn declares its scope by taking a
+/// [`claim`](Self::claim), and [`push`](Self::push) files into whichever bucket
+/// the surrounding claim named. A turn can then only ever see its own entries,
+/// which is the property the issue asks for.
+#[derive(Clone)]
 pub struct ApprovalRequestQueue {
-    inner: Arc<Mutex<Vec<ApprovalRequest>>>,
+    inner: Arc<Mutex<BTreeMap<ApprovalScope, Vec<ApprovalRequest>>>>,
     /// The live single-use grants (issue #243), riding along so the whole
     /// approval round-trip travels on one handle.
     ///
@@ -196,6 +245,15 @@ pub struct ApprovalRequestQueue {
     /// by the very cycle that was dispatched to redeem it, so the feature would
     /// fail in exactly its own happy path. The test
     /// `grants_survive_a_queue_clear` pins this.
+    ///
+    /// **Issue #439 made this sharper, not looser.** Buckets come and go with
+    /// the turns that claim them; grants outlive every one of them. A grant is
+    /// minted by one turn's decision, redeemed by a *different, later* turn,
+    /// swept by a periodic pass, and rehydrated from the journal on boot — so
+    /// it belongs to the company, never to a scope. Folding it into the
+    /// per-scope map would break redemption in exactly its own happy path, the
+    /// same way folding it into `inner` would have. `grants_outlive_a_scope`
+    /// pins the #439 half of that alongside `grants_survive_a_queue_clear`.
     grants: GrantSet,
 }
 
@@ -254,6 +312,26 @@ impl DrainedRequests {
     /// discarded" alone invites the reading that the calls happened and only the
     /// records were lost; they did not happen, they were refused, and the only
     /// way to get them is to ask the agent again.
+    ///
+    /// # "this turn" (issue #439)
+    ///
+    /// The original wording said "from this turn" and "a single turn", which
+    /// was true while the cap only ever bounded a chat cycle. A drain is now
+    /// taken per [`ApprovalScope`], and a workflow run's scope spans that run
+    /// rather than a turn — so for [`ApprovalScope::Run`] the sentence named
+    /// the wrong unit of work.
+    ///
+    /// It says "one batch" instead: the set of requests this drain took, which
+    /// is true of a cycle and of a run alike. The alternative — branching the
+    /// sentence on the scope — would put the notice back in the business of
+    /// being worded twice, which is precisely what putting it on this type
+    /// avoided.
+    ///
+    /// "at most {cap}" stays lowercase and mid-sentence deliberately:
+    /// `the_notice_quotes_the_cap_the_drain_was_taken_against` matches on it,
+    /// and that assertion is #561's real guarantee — the cap quoted is the one
+    /// the drain was taken against, never a constant the call site had lying
+    /// around. Rewording around it beat loosening it.
     pub fn overflow_notice(&self) -> Option<String> {
         (self.discarded > 0).then(|| {
             let n = self.discarded;
@@ -261,12 +339,109 @@ impl DrainedRequests {
             let calls = if n == 1 { "call" } else { "calls" };
             let them = if n == 1 { "it" } else { "them" };
             format!(
-                "Heads up: {n} further gated tool {calls} from this turn were not raised for \
-                 approval. A single turn can raise at most {cap}, and {n} more needed your \
-                 sign-off than that. They were **not** run and they are **not** on the \
-                 Approvals page — ask the agent again to get {them} back."
+                "Heads up: {n} further gated tool {calls} were not raised for approval. One \
+                 batch can raise at most {cap}, and {n} more needed your sign-off than that. \
+                 They were **not** run and they are **not** on the Approvals page — ask the \
+                 agent again to get {them} back."
             )
         })
+    }
+}
+
+/// A queue with **its own, unshared** [`GrantSet`] — an isolated fixture, never
+/// the company's queue.
+///
+/// Spelled out by hand rather than derived, because the derive made a real trap
+/// look like a default. `GrantSet` is a shared handle whose whole purpose is
+/// that the runtime that *mints* a grant and the policy that *redeems* it see
+/// one set; a queue built here sees neither. Redemption through it silently
+/// never matches, so every approval re-parks forever — the feature failing in
+/// exactly its own happy path, with no error anywhere.
+///
+/// Production must use [`with_grants`](ApprovalRequestQueue::with_grants), and
+/// does: `RuntimeBuilder` is the single construction site and hands in the
+/// runtime's own set. `grants_are_not_shared_by_default` pins the difference so
+/// the trap is a stated property rather than a footgun.
+///
+/// This matters more after issue #439, not less. The obvious way to build a
+/// per-run queue is one `default()` per run — which would have scoped grants
+/// per run and broken every approval. The chosen design keeps one handle for
+/// exactly this reason; see [`ApprovalRequestQueue`].
+impl Default for ApprovalRequestQueue {
+    fn default() -> Self {
+        Self {
+            inner: Arc::default(),
+            grants: GrantSet::default(),
+        }
+    }
+}
+
+tokio::task_local! {
+    /// The scope [`ApprovalRequestQueue::push`] files into, set for the
+    /// duration of a turn by [`ApprovalRequestQueue::claim`] (issue #439).
+    ///
+    /// # Why ambient, and why that is safe here
+    ///
+    /// `push` happens deep inside `ApprovalPolicy::require_approval`, which
+    /// openhuman calls synchronously from the tool loop. The policy is
+    /// per-agent, cached, and outlives every run, so it cannot hold a run id —
+    /// and there is no parameter to thread one through, because the call comes
+    /// from the vendored engine rather than from us.
+    ///
+    /// A task-local is sound on this path because the turn does not leave its
+    /// task: `run_background` → `run_inner` is awaited directly (the one
+    /// `tokio::spawn` nearby collects progress events, not the turn), and the
+    /// turn body runs inside `with_stop_hooks` on that same task. This is also
+    /// not a new dependency — `with_stop_hooks` is itself a task-local scope on
+    /// this exact path.
+    static CURRENT_SCOPE: ApprovalScope;
+}
+
+/// A turn's exclusive claim on one [`ApprovalScope`]'s bucket (issue #439).
+///
+/// Modelled on [`PublishClaim`](crate::harness::publish::PublishClaim) and
+/// [`DelegationClaim`](crate::harness::orchestrator::DelegationClaim), which
+/// solve the same problem one queue over: the claim's scope **is** the window
+/// in which the queue means anything, and `Drop` closes it on the way out so a
+/// turn that returned early cannot leave entries behind for the next one to
+/// find.
+///
+/// Obtained from [`ApprovalRequestQueue::claim`]. The turn must run inside
+/// [`ApprovalClaim::scoped`] for pushes to be routed to it.
+pub struct ApprovalClaim {
+    queue: ApprovalRequestQueue,
+    scope: ApprovalScope,
+}
+
+impl ApprovalClaim {
+    /// The scope this claim owns.
+    pub fn scope(&self) -> &ApprovalScope {
+        &self.scope
+    }
+
+    /// Runs `fut` with this claim's scope installed, so every
+    /// [`push`](ApprovalRequestQueue::push) inside it files into this bucket.
+    ///
+    /// The whole turn goes inside. A push that escapes the future lands in
+    /// [`ApprovalScope::Unscoped`] rather than in another turn's bucket — the
+    /// conservative direction, since the cycle drains that too.
+    pub async fn scoped<F, T>(&self, fut: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        CURRENT_SCOPE.scope(self.scope.clone(), fut).await
+    }
+}
+
+impl Drop for ApprovalClaim {
+    fn drop(&mut self) {
+        // The exit half, and the load-bearing one: a turn that returned early —
+        // an error, a steer, a panic unwinding through here — must not leave
+        // its entries for whoever claims this scope next. A workflow run id is
+        // unique, so this is belt-and-braces there; for `Cycle` it is the
+        // guarantee that replaced the explicit `clear()` at the top of
+        // `run_cycle`.
+        self.queue.discard(&self.scope);
     }
 }
 
@@ -277,87 +452,125 @@ impl ApprovalRequestQueue {
     /// openhuman blocks the call but lets the turn continue, so a model that
     /// re-tries the same tool would otherwise park the identical request several
     /// times over and show the operator a queue of duplicates.
+    /// Records a gated call **in the surrounding claim's scope** (issue #439),
+    /// ignoring one already queued in that same scope for the same tool and
+    /// arguments.
+    ///
+    /// openhuman blocks the call but lets the turn continue, so a model that
+    /// re-tries the same tool would otherwise park the identical request several
+    /// times over and show the operator a queue of duplicates. De-duplication is
+    /// per scope, which is the only reading that makes sense once buckets are
+    /// separate: two different turns asking for the same tool are two requests,
+    /// and collapsing them would hide one turn's ask behind another's.
     pub fn push(&self, request: ApprovalRequest) {
+        let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
-        if guard.iter().any(|q| {
+        let bucket = guard.entry(scope).or_default();
+        if bucket.iter().any(|q| {
             q.effect.kind == request.effect.kind && q.effect.payload == request.effect.payload
         }) {
             return;
         }
-        guard.push(request);
+        bucket.push(request);
     }
 
-    /// Empties the queue (called before a turn so a request from a prior turn —
-    /// or from a workflow run that shares these deps — never leaks into it).
-    pub fn clear(&self) {
-        self.inner.lock().expect("approval request queue").clear();
-    }
-
-    /// Drains up to `cap` queued requests (FIFO) and discards the rest, so one
-    /// turn can never flood the operator's queue.
+    /// The scope pushes are currently filing into.
     ///
-    /// # Why this returns a struct rather than a `Vec`
+    /// Outside any claim — every test that pushes directly, and any turn entry
+    /// point not yet under one — this is [`ApprovalScope::Unscoped`], which the
+    /// chat cycle drains. That fallback is why adding a scope cannot lose a
+    /// request.
+    fn current_scope() -> ApprovalScope {
+        CURRENT_SCOPE
+            .try_with(ApprovalScope::clone)
+            .unwrap_or_default()
+    }
+
+    /// Takes exclusive ownership of `scope`'s bucket for the life of the
+    /// returned claim (issue #439).
+    ///
+    /// Clears on the way in, and via [`Drop`] on the way out too, so the
+    /// claim's lifetime *is* the window in which the scope holds anything. Run
+    /// the turn inside [`ApprovalClaim::scoped`] to route its pushes here.
+    pub fn claim(&self, scope: ApprovalScope) -> ApprovalClaim {
+        self.discard(&scope);
+        ApprovalClaim {
+            queue: self.clone(),
+            scope,
+        }
+    }
+
+    /// Drops `scope`'s bucket entirely, so an empty scope costs no memory.
+    fn discard(&self, scope: &ApprovalScope) {
+        self.inner
+            .lock()
+            .expect("approval request queue")
+            .remove(scope);
+    }
+
+    /// How many requests sit in `scope`, observed **without** claiming it.
+    ///
+    /// Test-only, and it exists because claiming is not a neutral observation:
+    /// [`claim`](Self::claim) clears on entry, so asserting through a fresh
+    /// claim cannot distinguish "`Drop` emptied this" from "my own claim just
+    /// did". Reading the map directly is the only way to test the exit half.
+    #[cfg(test)]
+    fn len_in(&self, scope: &ApprovalScope) -> usize {
+        self.inner
+            .lock()
+            .expect("approval request queue")
+            .get(scope)
+            .map_or(0, Vec::len)
+    }
+
+    /// Empties the current scope's bucket.
+    ///
+    /// Retained for the callers that clear without claiming. Under a claim this
+    /// is redundant — [`claim`](Self::claim) already clears on entry and `Drop`
+    /// clears on exit.
+    pub fn clear(&self) {
+        self.discard(&Self::current_scope());
+    }
+
+    /// Drains up to `cap` requests (FIFO) from the **current scope**, discarding
+    /// that scope's remainder, so one turn can never flood the operator's queue.
+    ///
+    /// # Why this returns a struct rather than a `Vec` (issue #561)
     ///
     /// The discard is the whole point of the cap and it used to be invisible:
     /// this method dropped the overflow on the floor and handed back a `Vec`
-    /// that looked exactly like a complete one. A caller could not tell a turn
-    /// that parked everything from a turn that parked eight of thirteen, so the
-    /// operator was shown eight cards and no indication that five more calls had
-    /// been gated — a queue that quietly truncates reads as "nothing else needed
-    /// approving", which is the opposite of true (issue #561).
+    /// that looked exactly like a complete one, so the operator was shown eight
+    /// cards and no indication that five more calls had been gated. `cap`
+    /// travels into the result so the count and the number that produced it
+    /// stay one value — see [`DrainedRequests`].
     ///
-    /// Returning [`DrainedRequests`] makes the overflow part of the value. A
-    /// caller that wants only the requests writes `.requests` and is at least
-    /// choosing to; it can no longer happen by not knowing there was a second
-    /// number.
+    /// # What #439 changed, and what it did not
     ///
-    /// `cap` travels into the result rather than being asked for again when the
-    /// notice is rendered: the count and the number that produced it are then
-    /// one value, and a caller cannot pair a drain of eight with a sentence
-    /// that claims the limit is twenty.
+    /// The shape is #561's; only *which* requests it can see is #439's. It used
+    /// to drain one company-wide vector, which is why a concurrent turn's
+    /// entries could be taken by whoever drained first. It now sees the calling
+    /// turn's bucket and nothing else — **which also makes `discarded` mean
+    /// something it could not mean before**. A count taken off a shared vector
+    /// mixed in whatever a concurrent run had appended, so "this turn
+    /// overflowed" was never reliably this turn's fact. Scoped, it is.
+    ///
+    /// From the chat cycle this also drains [`ApprovalScope::Unscoped`], so a
+    /// push from any turn entry point not yet under a claim still reaches the
+    /// operator exactly as it did before — the fallback that makes #439
+    /// non-lossy. A workflow run drains only its own bucket and can no longer
+    /// swallow anyone else's.
     pub fn drain(&self, cap: usize) -> DrainedRequests {
+        let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
-        let take = guard.len().min(cap);
-        let requests: Vec<ApprovalRequest> = guard.drain(..take).collect();
-        let discarded = guard.len();
-        guard.clear();
-        DrainedRequests {
-            requests,
-            discarded,
-            cap,
+        let mut queued: Vec<ApprovalRequest> = guard.remove(&scope).unwrap_or_default();
+        // The cycle owns anything nobody claimed. A workflow run must not take
+        // it: that would be the shared-queue theft this issue removes.
+        if scope == ApprovalScope::Cycle {
+            queued.extend(guard.remove(&ApprovalScope::Unscoped).unwrap_or_default());
         }
-    }
-
-    /// Splits off every request queued **at or after** `from`, leaving the ones
-    /// below it in place (issue #395).
-    ///
-    /// # Why this exists next to [`drain`](Self::drain)
-    ///
-    /// `drain` is a *cycle-end* verb: it takes the front of the queue and
-    /// **clears whatever is left**, which is correct when the cycle owns the
-    /// whole queue and is about to finish with it. A workflow agent node owns
-    /// no such thing. It runs on the same shared
-    /// [`HarnessDeps`](crate::harness::HarnessDeps) as the chat cycles, and a
-    /// cycle may be part-way through its own turn when the node's turn parks a
-    /// request. Calling `drain` there would steal that cycle's entries and then
-    /// wipe the rest — one workflow node silently swallowing another
-    /// conversation's pending approvals.
-    ///
-    /// So this takes only the tail the caller is entitled to. The boundary is
-    /// valid for exactly the reason [`queued`](Self::queued) is documented to
-    /// be one: [`push`](Self::push) only ever appends, so a position taken
-    /// before the turn stays the line between "somebody else parked that" and
-    /// "this turn did".
-    ///
-    /// A `from` past the end yields nothing rather than panicking, so a caller
-    /// that raced a [`clear`](Self::clear) degrades to parking nothing instead
-    /// of aborting the run.
-    pub fn take_from(&self, from: usize) -> Vec<ApprovalRequest> {
-        let mut guard = self.inner.lock().expect("approval request queue");
-        if from >= guard.len() {
-            return Vec::new();
-        }
-        guard.split_off(from)
+        let discarded = queued.len().saturating_sub(cap);
+        queued.truncate(cap);
+        DrainedRequests::new(queued, discarded, cap)
     }
 
     /// Builds a queue whose grant set is one the caller already holds.
@@ -377,14 +590,24 @@ impl ApprovalRequestQueue {
         self.grants.clone()
     }
 
-    /// The number of queued requests.
+    /// The number of requests queued **in the current scope**.
     ///
     /// Read by a dispatched card **before** its turns run, so it can tell which
-    /// of the queue's entries are its own (issue #242) — the queue is shared
-    /// with the cycle's chat turns, and [`push`](Self::push) only ever appends,
-    /// so a position taken now stays a valid boundary until the cycle-end drain.
+    /// of the entries are its own (issue #242) — [`push`](Self::push) only ever
+    /// appends, so a position taken now stays a valid boundary until the
+    /// cycle-end drain.
+    ///
+    /// Issue #439 narrowed what this counts, which is what finally makes the
+    /// boundary sound: it used to index into a vector a concurrent workflow run
+    /// could append to between the read and the turn, so the position meant
+    /// "everything so far, from anyone". Within a scope there is one writer, so
+    /// it now means what #242 always assumed it did.
     pub fn queued(&self) -> usize {
-        self.inner.lock().expect("approval request queue").len()
+        self.inner
+            .lock()
+            .expect("approval request queue")
+            .get(&Self::current_scope())
+            .map_or(0, Vec::len)
     }
 
     /// Stamps `run_id` onto every request queued at or after `from`, returning
@@ -397,10 +620,18 @@ impl ApprovalRequestQueue {
     /// dispatched card knows exactly which of the queue's entries its own turns
     /// added. Requests below `from` belong to a chat turn earlier in the same
     /// cycle and are deliberately left `None`.
+    ///
+    /// Scoped to the current bucket since #439, so "the entries its own turns
+    /// added" is now true by construction rather than by a boundary that a
+    /// concurrent run could invalidate.
     pub fn stamp_run(&self, from: usize, run_id: &str) -> usize {
+        let scope = Self::current_scope();
         let mut guard = self.inner.lock().expect("approval request queue");
+        let Some(bucket) = guard.get_mut(&scope) else {
+            return 0;
+        };
         let mut stamped = 0;
-        for request in guard.iter_mut().skip(from) {
+        for request in bucket.iter_mut().skip(from) {
             request.effect.run_id = Some(run_id.to_string());
             stamped += 1;
         }
@@ -826,8 +1057,15 @@ impl ApprovalPolicy {
     }
 
     /// The one construction site for a `RequireApproval` decision (issue #172):
-    /// record the projected effect on the shared queue so the brain can park it
-    /// after the turn, then return the decision openhuman blocks the call with.
+    /// record the projected effect on the approval queue so the brain can park
+    /// it after the turn, then return the decision openhuman blocks the call
+    /// with.
+    ///
+    /// The entry lands in the surrounding turn's
+    /// [`ApprovalScope`] (issue #439). This function is the reason the scope is
+    /// ambient rather than a parameter: it is called synchronously by the
+    /// vendored tool loop, through a per-agent policy that outlives every run,
+    /// so there is no argument here that could carry a run id.
     ///
     /// Every `RequireApproval` arm of [`check`](ToolPolicy::check) goes through
     /// here — a decision that skipped it would refuse the tool without ever
@@ -2377,16 +2615,10 @@ mod tests {
         assert_eq!(queue.stamp_run(queue.queued(), "run-1"), 0);
     }
 
-    // --- `take_from`: a workflow node's own tail, and nobody else's (#395) ----
+    // --- scopes: a turn's entries are its own, and nobody else's (#439) ------
 
-    /// The regression this method exists for. A workflow agent node parks its
-    /// gated calls while a chat cycle is part-way through its own turn; taking
-    /// the tail must leave that cycle's entries exactly where they were, and
-    /// `drain` would not — it takes from the front and clears the rest.
-    #[test]
-    fn taking_from_a_boundary_leaves_everything_below_it_untouched() {
-        let queue = ApprovalRequestQueue::default();
-        let queued = |kind: &str| ApprovalRequest {
+    fn gated(kind: &str) -> ApprovalRequest {
+        ApprovalRequest {
             tool: kind.to_string(),
             reason: "gated".to_string(),
             effect: Effect {
@@ -2399,74 +2631,246 @@ mod tests {
                 agent: Some("ceo".to_string()),
                 run_id: None,
             },
-        };
+        }
+    }
+
+    /// The regression #395 narrowed and #439 removes: a workflow node parks its
+    /// gated calls while a chat cycle is part-way through its own turn.
+    ///
+    /// #395 did this with a boundary index, which worked only because the queue
+    /// was append-only — it encoded a *guess* about who wrote what. The scope
+    /// encodes the fact, so the node cannot see the cycle's entry at all rather
+    /// than merely declining to take it.
+    #[tokio::test]
+    async fn a_run_drains_its_own_entries_and_cannot_see_another_turns() {
+        let queue = ApprovalRequestQueue::default();
 
         // A chat cycle's own turn parked this one and has not drained yet.
-        queue.push(queued("chat.thing"));
-        let boundary = queue.queued();
-        // The workflow node's turn parks two.
-        queue.push(queued("node.thing"));
-        queue.push(queued("node.other"));
+        let cycle = queue.claim(ApprovalScope::Cycle);
+        cycle
+            .scoped(async { queue.push(gated("chat.thing")) })
+            .await;
 
-        let taken = queue.take_from(boundary);
+        // The workflow node's turn parks two, concurrently.
+        let run = queue.claim(ApprovalScope::Run("run-1".into()));
+        let taken = run
+            .scoped(async {
+                queue.push(gated("node.thing"));
+                queue.push(gated("node.other"));
+                assert_eq!(queue.queued(), 2, "the run sees only its own");
+                queue.drain(10)
+            })
+            .await;
         assert_eq!(
-            taken.iter().map(|r| r.tool.as_str()).collect::<Vec<_>>(),
+            taken
+                .requests
+                .iter()
+                .map(|r| r.tool.as_str())
+                .collect::<Vec<_>>(),
             vec!["node.thing", "node.other"],
-            "only the node's own tail comes back"
+            "only the node's own entries come back"
         );
+
+        // The cycle's entry is untouched and still drains as its own.
+        let drained = cycle.scoped(async { queue.drain(10) }).await;
         assert_eq!(
-            queue.queued(),
-            1,
-            "the chat cycle's entry is still queued for its own drain"
-        );
-        assert_eq!(
-            queue.drain(10).requests[0].tool,
-            "chat.thing",
-            "…and it is the same entry, not a survivor of a clear-and-rebuild"
+            drained
+                .requests
+                .iter()
+                .map(|r| r.tool.as_str())
+                .collect::<Vec<_>>(),
+            vec!["chat.thing"],
+            "the chat cycle's entry survived the run's drain, unmoved"
         );
     }
 
-    /// A node whose turn parked nothing takes nothing — and a boundary past the
-    /// end (a `clear` raced in between) yields nothing rather than panicking.
-    #[test]
-    fn taking_from_the_end_or_past_it_yields_nothing() {
+    /// The race a boundary index could never fix: **two concurrent workflow
+    /// runs**. Both took a boundary against one shared vector, so the later
+    /// `split_off` swallowed the earlier run's tail. Scopes make them disjoint.
+    #[tokio::test]
+    async fn two_concurrent_runs_cannot_take_each_others_entries() {
         let queue = ApprovalRequestQueue::default();
-        assert!(queue.take_from(queue.queued()).is_empty());
-        assert!(queue.take_from(0).is_empty());
+        let one = queue.claim(ApprovalScope::Run("run-1".into()));
+        let two = queue.claim(ApprovalScope::Run("run-2".into()));
+
+        // Interleaved exactly as two spawned runs would be.
+        one.scoped(async { queue.push(gated("one.a")) }).await;
+        two.scoped(async { queue.push(gated("two.a")) }).await;
+        one.scoped(async { queue.push(gated("one.b")) }).await;
+
+        let two_got = two.scoped(async { queue.drain(10) }).await;
+        assert_eq!(
+            two_got
+                .requests
+                .iter()
+                .map(|r| r.tool.as_str())
+                .collect::<Vec<_>>(),
+            vec!["two.a"],
+            "run-2 must not swallow run-1's tail",
+        );
+        let one_got = one.scoped(async { queue.drain(10) }).await;
+        assert_eq!(
+            one_got
+                .requests
+                .iter()
+                .map(|r| r.tool.as_str())
+                .collect::<Vec<_>>(),
+            vec!["one.a", "one.b"],
+            "and run-1 keeps both of its own, in order",
+        );
+    }
+
+    /// The non-lossy fallback. A push outside any claim is not dropped and not
+    /// an error — it lands in `Unscoped`, which the **chat cycle** drains and a
+    /// workflow run does not.
+    ///
+    /// This is the direction that matters: a missed turn entry point degrades
+    /// to today's behaviour (the operator is still asked) rather than to a
+    /// silently discarded approval, which is the failure #395 existed to fix.
+    #[tokio::test]
+    async fn an_unclaimed_push_is_drained_by_the_cycle_never_by_a_run() {
+        let queue = ApprovalRequestQueue::default();
+        queue.push(gated("orphan"));
+
+        let run = queue.claim(ApprovalScope::Run("run-1".into()));
         assert!(
-            queue.take_from(9_000).is_empty(),
-            "a boundary past the end must not panic — a raced clear degrades to \
-             parking nothing"
+            run.scoped(async { queue.drain(10) })
+                .await
+                .requests
+                .is_empty(),
+            "a run must not adopt an entry it did not raise",
+        );
+
+        let cycle = queue.claim(ApprovalScope::Cycle);
+        let drained = cycle.scoped(async { queue.drain(10) }).await;
+        assert_eq!(
+            drained
+                .requests
+                .iter()
+                .map(|r| r.tool.as_str())
+                .collect::<Vec<_>>(),
+            vec!["orphan"],
+            "the cycle owns whatever nobody claimed — the pre-#439 behaviour",
         );
     }
 
-    /// The append-only property the boundary rests on: a push while the node's
-    /// turn is running lands *after* the boundary, never before it, so the
-    /// entitlement split can never mis-attribute an entry downward.
-    #[test]
-    fn pushes_only_ever_append_so_a_boundary_stays_valid() {
+    /// The claim's exit half. A turn that returns early — an error, a steer, an
+    /// `?` — must not leave its entries for whoever claims that scope next.
+    /// `clear()` at the top of a cycle never gave this; `Drop` does.
+    #[tokio::test]
+    async fn dropping_a_claim_discards_that_scopes_entries() {
         let queue = ApprovalRequestQueue::default();
-        let queued = |kind: &str| ApprovalRequest {
-            tool: kind.to_string(),
-            reason: "gated".to_string(),
-            effect: Effect {
-                kind: kind.to_string(),
-                group: EffectGroup::Other,
-                amount_usd: None,
-                established_thread: false,
-                first_time_counterparty: false,
-                payload: serde_json::json!({ "kind": kind }),
-                agent: None,
-                run_id: None,
-            },
-        };
-        queue.push(queued("a"));
-        let boundary = queue.queued();
-        for kind in ["b", "c", "d"] {
-            queue.push(queued(kind));
+        {
+            let cycle = queue.claim(ApprovalScope::Cycle);
+            cycle.scoped(async { queue.push(gated("abandoned")) }).await;
+            assert_eq!(queue.len_in(&ApprovalScope::Cycle), 1, "parked mid-turn");
         }
-        assert_eq!(queue.take_from(boundary).len(), 3);
-        assert_eq!(queue.queued(), 1);
+        // Observed WITHOUT claiming. Asserting through a fresh claim would pass
+        // even with `Drop` removed, because `claim` clears on entry too — this
+        // assertion was vacuous until it read the bucket directly.
+        assert_eq!(
+            queue.len_in(&ApprovalScope::Cycle),
+            0,
+            "the abandoned entries must go when the claim does, not when the \
+             next claim happens to clear them",
+        );
+    }
+
+    /// De-duplication is per scope. Two turns asking for the same tool are two
+    /// asks; collapsing them would hide one turn's request behind another's.
+    #[tokio::test]
+    async fn duplicate_suppression_is_per_scope_not_global() {
+        let queue = ApprovalRequestQueue::default();
+        let cycle = queue.claim(ApprovalScope::Cycle);
+        let run = queue.claim(ApprovalScope::Run("run-1".into()));
+
+        cycle
+            .scoped(async {
+                queue.push(gated("same"));
+                queue.push(gated("same"));
+                assert_eq!(queue.queued(), 1, "a retry within one turn is one ask");
+            })
+            .await;
+        run.scoped(async {
+            queue.push(gated("same"));
+            assert_eq!(queue.queued(), 1, "the other turn's ask is its own");
+        })
+        .await;
+    }
+
+    /// Issue #439's half of the grant-lifetime guarantee, alongside
+    /// `grants_survive_a_queue_clear`.
+    ///
+    /// A grant is minted by one turn's decision and redeemed by a different,
+    /// later one, so it belongs to the company and never to a scope. If it had
+    /// been folded into the per-scope map, dropping the claim would take it —
+    /// and approvals would fail in exactly their own happy path.
+    #[tokio::test]
+    async fn grants_outlive_a_scope() {
+        let grants = GrantSet::default();
+        let queue = ApprovalRequestQueue::with_grants(grants.clone());
+        let args = serde_json::json!({ "to": "a@b.test" });
+        grants.grant(GrantedCall {
+            approval_id: crate::ports::types::ApprovalId::new("a1"),
+            agent: "finance".to_string(),
+            tool: "composio_execute".to_string(),
+            args: args.clone(),
+            at_millis: 1_000,
+            origin_thread: None,
+            origin_parent: None,
+        });
+
+        {
+            let cycle = queue.claim(ApprovalScope::Cycle);
+            cycle.scoped(async { queue.push(gated("whatever")) }).await;
+        }
+
+        assert!(
+            queue
+                .grants()
+                .consume("finance", "composio_execute", &args)
+                .is_some(),
+            "the scope went; the grant did not",
+        );
+    }
+
+    /// The trap the derived `Default` used to hide: a queue built with
+    /// `default()` has its **own** grant set, so a grant minted elsewhere can
+    /// never be redeemed through it and every approval re-parks forever.
+    ///
+    /// Production uses `with_grants` and is safe; this pins the difference so
+    /// the hazard is a stated property rather than a footgun — and so a future
+    /// per-scope refactor cannot reach for `default()` and silently scope
+    /// grants along with the requests.
+    #[test]
+    fn grants_are_not_shared_by_default() {
+        let shared = GrantSet::default();
+        let args = serde_json::json!({ "to": "a@b.test" });
+        let call = GrantedCall {
+            approval_id: crate::ports::types::ApprovalId::new("a1"),
+            agent: "finance".to_string(),
+            tool: "composio_execute".to_string(),
+            args: args.clone(),
+            at_millis: 1_000,
+            origin_thread: None,
+            origin_parent: None,
+        };
+        shared.grant(call.clone());
+
+        assert!(
+            ApprovalRequestQueue::default()
+                .grants()
+                .consume("finance", "composio_execute", &args)
+                .is_none(),
+            "a default queue cannot see a grant minted anywhere else",
+        );
+        assert!(
+            ApprovalRequestQueue::with_grants(shared)
+                .grants()
+                .consume("finance", "composio_execute", &args)
+                .is_some(),
+            "…and `with_grants` is the constructor that can — the one production uses",
+        );
     }
 
     /// A queue nobody installed stays inert — the default policy behaves exactly

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -790,19 +790,26 @@ async fn a_supervised_turn_reads_the_workspace_freely_and_parks_a_write_with_no_
     let (_pool, deps, _record, _store) = harness(base, "\"workspace\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"workspace\"").await;
 
-    let queued_before = deps.approval_requests.queued();
     pool.run(&record.id, "ceo", "tidy the standards", &deps, None)
         .await
         .expect("the turn runs");
-    let parked = deps.approval_requests.take_from(queued_before);
+    // Issue #439: no boundary index — this turn ran outside any claim, so its
+    // requests are in the `Unscoped` bucket and `drain` reads exactly them.
+    let parked = deps
+        .approval_requests
+        .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN);
 
     assert_eq!(
-        parked.len(),
+        parked.requests.len(),
         1,
         "the read must not park and the write must: {:?}",
-        parked.iter().map(|r| r.tool.clone()).collect::<Vec<_>>()
+        parked
+            .requests
+            .iter()
+            .map(|r| r.tool.clone())
+            .collect::<Vec<_>>()
     );
-    assert_eq!(parked[0].tool, "workspace_write");
+    assert_eq!(parked.requests[0].tool, "workspace_write");
     // Not vacuous: the read that did not park was really made, and really
     // returned — so "one parked request" is one write, not one read the belt
     // silently withheld.
@@ -811,7 +818,7 @@ async fn a_supervised_turn_reads_the_workspace_freely_and_parks_a_write_with_no_
         "both the read and the (blocked) write must have fed a result back"
     );
     assert!(
-        !parked[0].effect.may_be_granted_standing(),
+        !parked.requests[0].effect.may_be_granted_standing(),
         "a card for overwriting operator-owned guidance must not offer a standing scope"
     );
 }
@@ -837,16 +844,19 @@ async fn a_parked_write_to_the_agents_own_workspace_does_offer_a_standing_scope(
         harness(base, "\"files\", \"workspace\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"files\", \"workspace\"").await;
 
-    let queued_before = deps.approval_requests.queued();
     pool.run(&record.id, "ceo", "jot a note", &deps, None)
         .await
         .expect("the turn runs");
-    let parked = deps.approval_requests.take_from(queued_before);
+    // Issue #439: no boundary index — this turn ran outside any claim, so its
+    // requests are in the `Unscoped` bucket and `drain` reads exactly them.
+    let parked = deps
+        .approval_requests
+        .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN);
 
-    assert_eq!(parked.len(), 1, "the sandboxed write parks");
-    assert_eq!(parked[0].tool, "file_write");
+    assert_eq!(parked.requests.len(), 1, "the sandboxed write parks");
+    assert_eq!(parked.requests[0].tool, "file_write");
     assert!(
-        parked[0].effect.may_be_granted_standing(),
+        parked.requests[0].effect.may_be_granted_standing(),
         "a write confined to the agent's own sandbox is exactly what a standing \
          grant is for; refusing it would leave the feature with nothing to apply to"
     );
@@ -878,16 +888,23 @@ async fn a_supervised_turn_reads_its_own_workspace_without_asking() {
     let (_pool, deps, _record, _store) = harness(base, "\"files\"", dir.path()).await;
     let (pool, record) = supervised(&deps, "\"files\"").await;
 
-    let queued_before = deps.approval_requests.queued();
     pool.run(&record.id, "ceo", "what do we have?", &deps, None)
         .await
         .expect("the turn runs");
-    let parked = deps.approval_requests.take_from(queued_before);
+    // Issue #439: no boundary index — this turn ran outside any claim, so its
+    // requests are in the `Unscoped` bucket and `drain` reads exactly them.
+    let parked = deps
+        .approval_requests
+        .drain(crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN);
 
     assert!(
-        parked.is_empty(),
+        parked.requests.is_empty(),
         "reading the agent's own workspace must not interrupt an operator: {:?}",
-        parked.iter().map(|r| r.tool.clone()).collect::<Vec<_>>()
+        parked
+            .requests
+            .iter()
+            .map(|r| r.tool.clone())
+            .collect::<Vec<_>>()
     );
     // Not vacuous: both reads were genuinely offered to the model and both
     // came back with a result, so the calls reached the gate and returned.

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -62,7 +62,7 @@ use tinyflows::caps::{
 };
 use tinyflows::error::{EngineError, Result as TfResult};
 
-use crate::harness::policy::PolicyMode;
+use crate::harness::policy::{ApprovalScope, MAX_APPROVAL_REQUESTS_PER_TURN, PolicyMode};
 use crate::harness::{HarnessDeps, HarnessPool, toolbelt};
 use crate::ports::types::{CompanyId, CompanyRecord};
 
@@ -361,22 +361,32 @@ impl HarnessAgentRunner {
     /// prevented; the parking was never added. That is why the Approvals page
     /// stayed "All clear" through a run an operator watched get gated.
     ///
-    /// # Boundary, not drain
+    /// # Scope, not boundary (issue #439)
     ///
-    /// `from` is taken *before* the turn, and only the tail above it is claimed
-    /// — see
-    /// [`take_from`](crate::harness::policy::ApprovalRequestQueue::take_from).
-    /// The queue is shared with whatever chat cycle happens to be running, and
-    /// `drain` would take that cycle's entries and clear the rest.
+    /// This block used to describe a boundary index: `from` taken before the
+    /// turn, only the tail above it claimed, because the queue was shared with
+    /// whatever chat cycle happened to be running and `drain` would have taken
+    /// that cycle's entries and cleared the rest.
     ///
-    /// This narrows the shared-queue race to a turn-sized window; it does not
-    /// eliminate it. If a chat turn pushes *while* this node's turn is running,
-    /// its request lands above the boundary and is parked here — with this
-    /// run's id stamped on it. The real fix is a per-run queue, which means
-    /// re-plumbing `ApprovalPolicy` installation out of `build_roster`; that is
-    /// deliberately out of scope for #395. The failure mode is a mis-attributed
-    /// `run_id` on a card that is otherwise correct and decidable, which is
-    /// strictly better than the request vanishing.
+    /// It also said, accurately, that this **narrowed** the race rather than
+    /// eliminating it — a chat turn pushing while this node ran landed above
+    /// the boundary and was parked here with this run's id on it — and that the
+    /// real fix was a per-run queue, deferred out of #395.
+    ///
+    /// That is now done, though **not** in the shape that sentence predicted.
+    /// One queue per run is unbuildable: `ApprovalPolicy` is installed by
+    /// `build_roster` inside a fingerprint-cached, per-company
+    /// `HarnessPool::ensure` with no run id in scope, and is then sealed into
+    /// the vendored agent with no setter, so there is nowhere to hand a
+    /// per-run queue *to*. The separation is in the key instead — the run takes
+    /// an [`ApprovalScope::Run`](crate::harness::policy::ApprovalScope) claim
+    /// and pushes route into its own bucket — which yields the same property
+    /// the issue asked for: a turn sees only its own requests.
+    ///
+    /// It also closes a race the boundary never addressed. Two workflow runs
+    /// overlap (they are spawned, not under the cycle lock), and both took a
+    /// boundary against the same vector, so the later `split_off` swallowed the
+    /// earlier run's tail. Scopes are disjoint, so that cannot happen.
     ///
     /// # Never fails the node
     ///
@@ -388,18 +398,36 @@ impl HarnessAgentRunner {
     /// # A run cancelled mid-turn parks nothing, deliberately
     ///
     /// Stopping a run drops the engine future *mid-await* (issue #383), which
-    /// takes this call with it — so a call the policy had already gated stays on
-    /// the shared queue and the next chat cycle's `clear` discards it. That is
-    /// the intended outcome, not a residual leak: an operator who stopped a run
-    /// is not asking to be asked about the work they stopped. It is the same
-    /// judgement `cancelled_run` makes in reporting no `pending_approvals`, and
-    /// the same one `park_pending_gates` makes in skipping a cancelled run.
-    async fn park_gated_calls(&self, from: usize) {
+    /// takes this call with it — so a call the policy had already gated is
+    /// discarded rather than parked. That is the intended outcome, not a
+    /// residual leak: an operator who stopped a run is not asking to be asked
+    /// about the work they stopped. It is the same judgement `cancelled_run`
+    /// makes in reporting no `pending_approvals`, and the same one
+    /// `park_pending_gates` makes in skipping a cancelled run.
+    ///
+    /// Issue #439 made this **cleaner, and no longer anyone else's business**.
+    /// The discard used to be performed by the next chat cycle's `clear`, which
+    /// only worked because the queue was shared — the cancelled run's leftovers
+    /// were sitting in the cycle's way. Now the claim's `Drop` takes them as the
+    /// dropped future unwinds, so the entries never outlive the run and no
+    /// other turn has to sweep up after it.
+    async fn park_gated_calls(&self) {
         let queue = &self.deps.approval_requests;
-        // Issue #242's stamp, applied at the boundary the run owns: this is
-        // where an approval learns which workflow run is waiting on it.
-        queue.stamp_run(from, &self.run_id);
-        let requests = queue.take_from(from);
+        // Issue #242's stamp. The `from` is now 0 because the scope *is* the
+        // entitlement: every entry in this bucket was pushed by this run's own
+        // turn, so there is no prefix belonging to anyone else to skip past.
+        // That is what #439 bought — the boundary index encoded a guess about
+        // who wrote what, and the scope encodes the fact.
+        queue.stamp_run(0, &self.run_id);
+        // The discard count comes off the drain itself (issue #561): `drain`
+        // caps and drops the remainder in one step, so by the time it returns,
+        // how many went is not recoverable from what came back. Reading it
+        // here is what keeps the overflow warning below reachable — without a
+        // count, a run that flooded the gate looks identical to one that did
+        // not.
+        let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        let discarded = drained.discarded;
+        let requests = drained.requests;
         if requests.is_empty() {
             return;
         }
@@ -422,8 +450,7 @@ impl HarnessAgentRunner {
             return;
         };
 
-        let cap = crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN;
-        if requests.len() > cap {
+        if discarded > 0 {
             // Bounded exactly as the cycle drain is: a model that keeps
             // re-trying a blocked tool must not be able to flood the queue.
             //
@@ -436,12 +463,12 @@ impl HarnessAgentRunner {
             tracing::warn!(
                 company = %self.company,
                 run_id = %self.run_id,
-                discarded = requests.len() - cap,
-                "workflow agent node: more gated tool calls than one turn may park; the excess \
+                discarded,
+                "workflow agent node: more gated tool calls than one run may park; the excess \
                  was discarded"
             );
         }
-        for request in requests.into_iter().take(cap) {
+        for request in requests {
             // The delivery precedent: a workflow run has no board card behind it
             // and no conversation to raise the request in, so it is recorded
             // explicitly unlinked (#333) and stays Approvals-page-only (#379).
@@ -489,19 +516,32 @@ impl AgentRunner for HarnessAgentRunner {
             agent = agent_ref,
             "workflow agent node: routing to harness pool"
         );
-        // Issue #395: where this turn's own approval requests begin, taken
-        // BEFORE the turn so the queue's append-only property makes it a valid
-        // entitlement boundary.
-        let from = self.deps.approval_requests.queued();
-        let outcome = self
-            .pool
-            .run_background(&self.company, agent_ref, &message, &self.deps)
+        // Issue #439: this run's own approval scope, replacing #395's boundary
+        // index. The index was only ever a narrowing — it was taken against a
+        // vector any concurrent turn could append to, so a chat cycle pushing
+        // inside the window landed above the boundary and was parked here with
+        // this run's id on it, and two concurrent runs each took a boundary
+        // against the same vector so the later `split_off` swallowed the
+        // earlier one's tail. A scope removes both by construction: nothing
+        // else can write into this bucket.
+        let claim = self
+            .deps
+            .approval_requests
+            .claim(ApprovalScope::Run(self.run_id.clone()));
+        let outcome = claim
+            .scoped(
+                self.pool
+                    .run_background(&self.company, agent_ref, &message, &self.deps),
+            )
             .await;
         // Drained on BOTH arms, deliberately. A turn that errored may still have
         // had a tool call gated before it failed, and that request is just as
-        // real — leaving it on the queue hands it to the next chat cycle's
-        // `clear()`, which is the exact disappearance this issue is about.
-        self.park_gated_calls(from).await;
+        // real — dropping the claim without parking would discard it, which is
+        // the exact disappearance this issue is about.
+        //
+        // Inside the scope, so the drain reads this run's bucket rather than
+        // whatever `Unscoped` happens to hold.
+        claim.scoped(self.park_gated_calls()).await;
         let outcome = outcome
             .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -324,10 +324,15 @@ async fn a_gated_tool_call_inside_a_workflow_node_parks_for_approval() {
 }
 
 /// The regression this issue is actually about. Parking is only half the fix:
-/// the shared queue is cleared at the top of **every** chat cycle, and before
-/// #395 a workflow's request sat on it waiting to be wiped by the next
-/// conversation. A card in the journal is independent of that queue, and this
-/// asserts it.
+/// the in-memory queue is emptied around **every** chat cycle, and before #395
+/// a workflow's request sat on it waiting to be wiped by the next conversation.
+/// A card in the journal is independent of that queue, and this asserts it.
+///
+/// Still worth pinning after issue #439, on narrower grounds. A workflow run's
+/// entries now live in their own scope, so a chat cycle can no longer reach
+/// them at all — but the property under test was never really about who could
+/// reach the queue. It is that the journal is the durable record and the queue
+/// is not, which is what makes the card survive *any* queue lifecycle.
 #[tokio::test]
 async fn the_parked_request_survives_a_later_chat_cycle() {
     let dir = tempfile::tempdir().unwrap();
@@ -337,7 +342,9 @@ async fn the_parked_request_survives_a_later_chat_cycle() {
         "precondition: the request parked"
     );
 
-    // Exactly what `HarnessBrain::run_cycle` does at the top of every cycle.
+    // Stands in for the cycle's own queue lifecycle — `clear()` outside a claim
+    // empties the unscoped bucket, and #439's `Cycle` claim clears on entry and
+    // on drop. Either way the journal must not care.
     deps.approval_requests.clear();
 
     assert!(


### PR DESCRIPTION
## Summary

One `ApprovalRequestQueue` was shared by every agent and every turn, so draining it had to **guess** which entries belonged to the draining turn. #395 narrowed that with a boundary index and documented the residual races at the call site. This removes the guess.

### ⚠️ Not the shape the issue names — read this first

The issue asks for **"one queue per run"**. That is **unbuildable**, and a reviewer comparing this diff to the issue will otherwise think I solved a different problem.

`ApprovalPolicy` is installed by `build_roster` (`harness/mod.rs:1920,1971`) inside `HarnessPool::ensure` — a **fingerprint-cached, per-company** function with no run id in scope and none possible, since it is idempotent per company. The policy is then sealed into the vendored agent (`build.rs:644` → `tool_policy: Arc<dyn ToolPolicy>`, no setter). So there is nowhere to hand a per-run queue *to*, and `approval_requests` is not part of any fingerprint, so passing a fresh queue would silently no-op against the cached roster. Rebuilding the roster per run would defeat the cache it exists for (MCP resolution, skills, tools, budgets) on every workflow run.

So the handle stays single and **the separation moves into the key**: entries are bucketed by `ApprovalScope`, a turn takes a `claim`, and `push` files into the surrounding claim's bucket. That delivers the property the issue actually asks for — *a turn sees only its own requests* — by construction rather than by boundary arithmetic.

### It also fixes a race the boundary never addressed

The issue names two races, both cycle∥run. There is a third: **run∥run**. Workflow runs are `tokio::spawn`ed and are *not* under the cycle's serial lock, so two genuinely overlap — and both took a boundary against the same vector, so the later `split_off` swallowed the earlier run's tail. A boundary index cannot fix that at all. Scopes are disjoint, so it cannot happen. Pinned by `two_concurrent_runs_cannot_take_each_others_entries`.

### The claim, and why `Drop` matters

`ApprovalClaim` copies the `PublishClaim` / `DelegationClaim` pattern already in this crate: it clears on entry exactly as the cycle's `clear()` did, **and on exit via `Drop`, which `clear()` never had**. A cycle that returned early — an error, a steer, an `?` — used to leave its entries for the *next* cycle to park. Now the claim's lifetime *is* the window.

This also makes the cancelled-run discard cleaner: it used to be performed by the next chat cycle's `clear`, which only worked because the leftovers were sitting in that cycle's way. Now `Drop` takes them as the dropped future unwinds, and no other turn has to sweep up after a run.

### Why the scope is ambient

`push` happens inside `require_approval`, called **synchronously by the vendored tool loop** through a per-agent policy that outlives every run. There is no parameter that could carry a run id. A `tokio::task_local` is sound here because the turn does not leave its task — `run_background` → `run_inner` is awaited directly (the one nearby `tokio::spawn` collects progress events, not the turn), and the body runs inside `with_stop_hooks`. **This is not a new dependency:** `with_stop_hooks` is itself a task-local scope on this exact path. I verified this before designing, because it is the assumption the whole approach rests on.

### `Unscoped` is deliberate, not laziness

A push outside any claim lands in `ApprovalScope::Unscoped`, which the **chat cycle** drains and a workflow run does not — i.e. exactly today's behaviour. It is not an error on purpose: a hard error would only be right if an unscoped push were impossible by construction, and I cannot prove that about turn entry points I have not enumerated. A missed entry point therefore degrades to "the operator is still asked" rather than to a silently discarded approval — **which is the precise failure #395 existed to fix**. Non-lossy by construction beats strict-and-brittle here.

### `take_from` collapsed

The boundary API meant nothing once buckets are disjoint, so the two call patterns become one: `claim` + `drain`. `drain`, `push`, `clear`, `queued` and `stamp_run` **keep their signatures**; only *which* requests they see changes. In the workflow path `stamp_run`'s `from` is now `0`, because the scope *is* the entitlement — there is no prefix belonging to anyone else to skip.

### `GrantSet` `Default` trap (fixed here, deliberately)

`ApprovalRequestQueue::default()` derived a **fresh `GrantSet`**. A grant redeemed through such a queue can never match, so every approval re-parks forever — the feature failing in its own happy path, with no error anywhere. Production is safe only because `RuntimeBuilder` uses `with_grants`.

Fixed in this PR rather than separately because it is **directly load-bearing**: the obvious way to build a per-run queue is one `default()` per run, which would have scoped grants per run and broken every approval. `Default` is now spelled out by hand with the hazard documented, and `grants_are_not_shared_by_default` pins the difference.

## API Or Behavior Changes

**No HTTP/GraphQL/wire changes.** Internal harness API only.

- `ApprovalScope` (new, public), `ApprovalClaim` (new, public), `ApprovalRequestQueue::claim` (new).
- `ApprovalRequestQueue::take_from` **removed**.
- `push` / `clear` / `drain` / `queued` / `stamp_run` — **signatures unchanged**, now scope-relative.
- `#[derive(Default)]` on `ApprovalRequestQueue` replaced with an explicit `impl`. Same behaviour, documented hazard.
- De-duplication is now **per scope**: two turns asking for the same tool are two asks. Collapsing them would hide one turn's request behind another's.

Behaviour that does **not** change: an unclaimed push still reaches the operator via the cycle; the per-turn cap still bounds a flooding model; the journal is still the durable record.

### ✅ Rebased onto current main; #625 reconciled here

#625 is **merged**, so `drain` now returns `DrainedRequests { requests, discarded, cap }`. Reconciled in this branch rather than left for a second lander:

- `drain` keeps #561's shape and gains #439's scoping. **The two compose better than either alone:** a `discarded` count taken off a shared vector mixed in whatever a concurrent run had appended, so "this turn overflowed" was never reliably *this turn's* fact. Scoped, it is.
- **`overflow_notice` reworded.** It said "from this turn" / "a single turn", true only while the cap bounded a chat cycle. A drain is now per-scope and a run spans more than a turn, so for `ApprovalScope::Run` it named the wrong unit of work. It now says "one batch" — true of a cycle and a run alike. Branching the sentence on the scope would have put the notice back in the business of being worded twice, which is what putting it on the type avoided.
- The workflow path drops the hand-rolled pre-count I had added and uses `drained.discarded`.

**The rebase surfaced a real break, which is the point of not trusting a clean merge.** My reword broke #625's `the_notice_quotes_the_cap_the_drain_was_taken_against`, which matches lowercase `"at most 3"`. I reworded my prose to keep it lowercase and mid-sentence rather than loosening their assertion — that assertion *is* #561's guarantee (the cap quoted is the one the drain was taken against, never a constant the call site had lying around), and weakening it to accommodate my sentence would have been the wrong trade.

## Tests

Gated lane throughout. Exit codes from unpiped redirects to a non-shared path.

- [x] `cargo fmt --all -- --check` — **EXIT 0**.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as **`cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`** (CI's own flags; `--no-deps` is load-bearing per `ci.yml`). **EXIT 0**.
- [x] `cargo build --all-targets` — ran as `cargo build --features openhuman,tinycortex --all-targets`. **EXIT 0**.
- [x] `cargo test` — ran as `cargo test --features openhuman,tinycortex`. **EXIT 0, 2962 + 10 + 1 + 11 + 2 passed, 0 failed.**

All four re-run **from scratch on the rebased tree**; the pre-rebase greens were not carried over.

**Test-count delta accounted for, not assumed.** True base (`git checkout --detach upstream/main`) is **2958**; mine is **2962**. `+4` = **7 new** scope tests **− 3 deleted** `take_from` tests, the same delta as before the rebase.

> A note on how that base was measured, because I got it wrong once: `git stash` is **not** a baseline when your work is committed. It removed only my uncommitted files and left the rebase in place, so "base" was my own change measured against itself — and it reported a failure I could easily have misread as main being broken.

**All six revert-checks were re-run on the rebased tree. All six still fail on revert** — none went stale against #625's changes to the same type.

### Seven new tests, six revert-checked

| test | reverted | result |
|---|---|---|
| `a_run_drains_its_own_entries_and_cannot_see_another_turns` | `push` ignores the scope | **FAILS** |
| `two_concurrent_runs_cannot_take_each_others_entries` | `drain` takes every bucket | **FAILS** |
| `an_unclaimed_push_is_drained_by_the_cycle_never_by_a_run` | cycle stops draining `Unscoped` | **FAILS** |
| `dropping_a_claim_discards_that_scopes_entries` | remove `Drop` | **FAILS** |
| `duplicate_suppression_is_per_scope_not_global` | de-dup made global | **FAILS** |
| `grants_outlive_a_scope` | grants folded into the scope lifetime | **FAILS** |
| `grants_are_not_shared_by_default` | — | **characterization test, see below** |

**`grants_are_not_shared_by_default` is not revert-checked, and I am not claiming it is.** It pins pre-existing behaviour so a future refactor cannot silently change it; there is no fix beneath it to revert. Calling it out rather than implying six-of-six.

**One of these was vacuous first time round and is reported rather than quietly fixed.** `dropping_a_claim_discards_that_scopes_entries` originally asserted through a *fresh claim* — which passes even with `Drop` removed, because `claim()` clears on entry too. It proved nothing. It now reads the bucket directly via a `#[cfg(test)] len_in`, because claiming is not a neutral observation. It fails on revert, as shown.

**A regression in my own diff, caught the same way.** Switching the workflow path to `drain(cap)` made its "excess was discarded" warning dead code — `drain` truncates, so `requests.len() > cap` could never hold and the discard count was unrecoverable. Now counted *before* the drain.

### NOT verified

- **Not run in the live app**, and this one deserves emphasis: the races are concurrency bugs, and the tests exercise scope isolation deterministically rather than under real overlap. A genuine cycle∥run or run∥run soak was not run.
- **No test proves the task-local actually reaches `push` through the real vendored tool loop.** The scope plumbing is unit-tested directly; the end-to-end path rests on reading `run_inner` and confirming no `spawn` intervenes. This is the assumption most worth a reviewer's eye.
- No frontend involvement.
- `#[cfg(test)] len_in` is test-only surface by design.

## Documentation

No `docs/` change; the contract lives at the code and is updated there. Notably the doc block **the issue itself quotes** (`workflows/caps/mod.rs`, "Boundary, not drain") is rewritten to "Scope, not boundary" — leaving a comment that says "the real fix is a per-run queue, deliberately out of scope" would be actively misleading once this lands. Also updated: the queue type's own sharing contract, `require_approval` (why the scope is ambient), the cancelled-run note, and `gated_tool_turn_test`'s premise.

Fixes #439
