### PR TITLE
workflows: record a sub_workflow child's calls that were never offered for approval

### DIFF
--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -416,6 +416,24 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             format!("Workflow {workflow_id} delivered its {kind} report from node {node}"),
             "workflow.report_delivered",
         ),
+        // Issue #617. Structural only, like every arm here: the child graph,
+        // the node and the tool. The policy's `reason` is deliberately NOT
+        // carried onto the wire — it is a sentence built for an operator's
+        // approval card, and this surface is a short non-sensitive one-liner.
+        CompanyEvent::WorkflowChildCallNotOffered {
+            child_workflow_id,
+            node,
+            tool,
+            ..
+        } => (
+            Role::System,
+            "workflow".to_string(),
+            format!(
+                "Workflow child {child_workflow_id} ran {tool} at node {node} without offering \
+                 it for approval"
+            ),
+            "workflow.child_call_not_offered",
+        ),
     };
     WireEvent {
         seq,

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1062,6 +1062,14 @@ fn summarize_event(event: &CompanyEvent) -> String {
             kind,
             ..
         } => format!("workflow {workflow_id} delivered {kind} report from node {node}"),
+        // Issue #617. Structural only, and without the policy's `reason` for
+        // the same rule the arms above follow.
+        CompanyEvent::WorkflowChildCallNotOffered {
+            child_workflow_id,
+            node,
+            tool,
+            ..
+        } => format!("workflow child {child_workflow_id} ran {tool} at node {node} unapproved"),
     }
 }
 

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -1134,6 +1134,49 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         target: Option<String>,
     },
+    /// A call inside a `sub_workflow` child ran **without** being offered for
+    /// approval, on a company whose policy would have parked the same call at
+    /// the top level (issue #617).
+    ///
+    /// # Why this is a journal line and not a fix
+    ///
+    /// A child graph is resolved and run *inside* the engine, so its nodes never
+    /// reach the gate pass that #460 and #614 added. Gating them is not
+    /// available: tinyflows cannot resume a child across the sub-workflow
+    /// boundary, and a paused child halts the parent with an unresumable error —
+    /// so marking the child's node would convert a run that works into one that
+    /// fails with no card to decide. Until the engine can resume across that
+    /// boundary, the honest thing is to keep running and **say so**.
+    ///
+    /// That is what this records. An operator auditing what the company was
+    /// asked to approve would otherwise see a hole with nothing explaining it;
+    /// this turns the hole into a line naming the child, the node and the call.
+    /// It is an audit record of a known limitation, not a decision anybody made.
+    ///
+    /// Journaled best-effort at child *resolution*, so it lands whether or not
+    /// the child's node is ultimately reached — the point is that the call was
+    /// never offered, and a run that stops earlier for another reason does not
+    /// make that less true. Deliberately **not** written for a dry run, which
+    /// executes nothing.
+    ///
+    /// Additive: an entirely new `kind`, so no journal written before it existed
+    /// carries it, and its presence changes how no existing variant serializes.
+    WorkflowChildCallNotOffered {
+        /// The graph the run started from — the one an operator recognises.
+        workflow_id: String,
+        /// The child graph the call actually sits in. Equal to `workflow_id`
+        /// only if a workflow references itself, which the cycle guard rejects.
+        child_workflow_id: String,
+        /// The run that resolved the child.
+        run_id: String,
+        /// The node inside the child that makes the call.
+        node: String,
+        /// The tool it would run — a `tool_call` node's slug, or `http_request`.
+        tool: String,
+        /// The policy's own words for why this call would have been parked at
+        /// the top level, so the line says what the operator was not asked.
+        reason: String,
+    },
 }
 
 impl CompanyEvent {
@@ -1172,6 +1215,7 @@ impl CompanyEvent {
             Self::TaskDiscussionRedacted { .. } => "TaskDiscussionRedacted",
             Self::WorkflowEnabledChanged { .. } => "WorkflowEnabledChanged",
             Self::WorkflowReportDelivered { .. } => "WorkflowReportDelivered",
+            Self::WorkflowChildCallNotOffered { .. } => "WorkflowChildCallNotOffered",
             Self::WorkflowRunFinished { .. } => "WorkflowRunFinished",
             Self::WorkflowRunStarted { .. } => "WorkflowRunStarted",
             Self::WorkflowNodeStarted { .. } => "WorkflowNodeStarted",
@@ -1279,6 +1323,17 @@ impl CompanyEvent {
             // next re-run, which is the exact failure the variant exists to
             // prevent. See its own docs.
             | Self::WorkflowReportDelivered { .. } => Permanent,
+            // Issue #617: permanent, and it is the clearest kind of evidence
+            // this enum carries — the record that a consequential call ran
+            // WITHOUT the operator being asked. Pruning it would delete the only
+            // trace that the company acted unapproved, which is precisely the
+            // question an approvals audit exists to answer. It fails the "is
+            // this evidence" test in the strongest possible direction.
+            //
+            // Nothing reads it back today, and that does not soften the class:
+            // the reader is a person reviewing what happened, not a boot-time
+            // fold.
+            Self::WorkflowChildCallNotOffered { .. } => Permanent,
         }
     }
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1410,6 +1410,11 @@ fn cycle_task_id(
             // re-run can skip it. Like the run outcome it precedes, it starts no
             // cycle and rivals no card.
             | CompanyEvent::WorkflowReportDelivered { .. }
+            // Issue #617: a disclosure that a child's call was never offered for
+            // approval. It records something a run already did; it names no card
+            // and asks nothing of anyone, so it starts no cycle. Neutral for the
+            // same reason the run bracket above is.
+            | CompanyEvent::WorkflowChildCallNotOffered { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
             // A withdrawal (#358) is a record about a record: it starts no
@@ -1579,6 +1584,9 @@ fn cycle_conversation(
             // Issue #529: a record of a report already dispatched — names no
             // thread and rivals none, exactly like the run events it sits among.
             | CompanyEvent::WorkflowReportDelivered { .. }
+            // Issue #617: likewise a record, not a message. It belongs to no
+            // conversation and rivals none.
+            | CompanyEvent::WorkflowChildCallNotOffered { .. }
             | CompanyEvent::TaskSteered { .. }
             | CompanyEvent::TaskDiscussionPosted { .. }
             // A withdrawal (#358) is a record about a record: it starts no

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -131,11 +131,21 @@ pub async fn build_capabilities(
     // created (issue #168). Read before `deps` may move into the agent runner.
     // REAL in both modes: it is a read, and a dry sub_workflow child runs under
     // this same (dry) bundle, so dry propagates rather than stopping here.
+    // Issue #617: a child's nodes never reach the gate pass, so the resolver
+    // carries the policy in order to *say* which of its calls were never
+    // offered for approval. `None` for a dry run — nothing executes, so there
+    // is nothing to disclose, and the resolver behaves exactly as before.
+    let audit = (!dry_run).then(|| self::resolver::ChildCallAudit {
+        policy: record.manifest.policy.clone(),
+        run_id: run_id.to_string(),
+        events: deps.events.clone(),
+    });
     let resolver: Arc<dyn WorkflowResolver> = Arc::new(StoreWorkflowResolver::new(
         deps.workflow_source_dir.clone(),
         deps.store.clone(),
         company.clone(),
         workflow_id.to_string(),
+        audit,
     ));
 
     // The four effectful slots, chosen by mode at this one point.

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -66,6 +66,26 @@ pub struct StoreWorkflowResolver {
     /// The id of the top-level workflow the current run started from — a child
     /// whose closure reaches back to it would loop the whole run.
     root_id: String,
+    /// What the company's policy would park, and where to record that it was
+    /// not asked (issue #617). `None` for a dry run, which executes nothing and
+    /// therefore has nothing to disclose.
+    audit: Option<ChildCallAudit>,
+}
+
+/// Everything the #617 audit line needs: the policy to ask, the run to name,
+/// and the log to write to.
+///
+/// Grouped so [`StoreWorkflowResolver::new`] does not grow three more
+/// parameters for one concern, and so the whole concern is `Option` — a dry run
+/// passes `None` and the resolver behaves exactly as it did before.
+pub struct ChildCallAudit {
+    /// The company `[policy]` block, verbatim — the same input the top-level
+    /// gate pass reads, so the two can never disagree about the same call.
+    pub policy: crate::company::Policy,
+    /// The run resolving this child, for the journal line.
+    pub run_id: String,
+    /// Where the line goes. Without it the disclosure is a log warning only.
+    pub events: Option<Arc<dyn crate::ports::EventLog>>,
 }
 
 impl StoreWorkflowResolver {
@@ -76,12 +96,82 @@ impl StoreWorkflowResolver {
         store: Arc<dyn CompanyStore>,
         company: CompanyId,
         root_id: String,
+        audit: Option<ChildCallAudit>,
     ) -> Self {
         Self {
             source_dir,
             store,
             company,
             root_id,
+            audit,
+        }
+    }
+
+    /// Issue #617: say, on the record, that this child's calls were never
+    /// offered for approval.
+    ///
+    /// # Why this discloses rather than gates
+    ///
+    /// The child is resolved and run *inside* the engine, so its nodes never
+    /// reach the gate pass #460 and #614 added. Gating them is not on the table:
+    /// tinyflows cannot resume a child across the sub-workflow boundary, and a
+    /// paused child halts the parent with an unresumable error — so marking the
+    /// node would turn a run that works into one that fails with **no card to
+    /// decide**, which is worse than the hole. Closing it properly is engine
+    /// work (#617).
+    ///
+    /// So the run proceeds and the omission is recorded. The value is exactly
+    /// the value #460 argued for: an operator auditing what the company was
+    /// asked to approve stops seeing a gap with nothing to explain it.
+    ///
+    /// Best-effort and never fails a resolve — a journal write must not be able
+    /// to stop a workflow that would otherwise run. The `warn!` lands either
+    /// way, so a build with no event log still says it out loud.
+    async fn disclose_ungated_calls(&self, child_id: &str, graph: &WorkflowGraph) {
+        let Some(audit) = self.audit.as_ref() else {
+            return;
+        };
+        let ungated = crate::workflows::gate::policy_gates(
+            graph,
+            &audit.policy,
+            &self.company,
+            child_id,
+            &audit.run_id,
+        )
+        .await;
+
+        for call in ungated {
+            tracing::warn!(
+                company = %self.company,
+                workflow = %self.root_id,
+                child_workflow = child_id,
+                run_id = %audit.run_id,
+                node = %call.node_id,
+                tool = %call.slug,
+                "workflow: this call was NOT offered for approval because it is inside a \
+                 sub_workflow; the engine cannot resume a child across that boundary (issue \
+                 #617), so it runs unparked"
+            );
+            let Some(events) = audit.events.as_ref() else {
+                continue;
+            };
+            let event = crate::ports::types::CompanyEvent::WorkflowChildCallNotOffered {
+                workflow_id: self.root_id.clone(),
+                child_workflow_id: child_id.to_string(),
+                run_id: audit.run_id.clone(),
+                node: call.node_id,
+                tool: call.slug,
+                reason: call.reason,
+            };
+            if let Err(err) = events.append(&self.company, event).await {
+                tracing::warn!(
+                    company = %self.company,
+                    child_workflow = child_id,
+                    %err,
+                    "workflow: could not journal an ungated sub_workflow call; the run is \
+                     unaffected but the audit line is lost"
+                );
+            }
         }
     }
 
@@ -212,7 +302,11 @@ impl WorkflowResolver for StoreWorkflowResolver {
         })??;
 
         // (e) Translate to a runnable tinyflows graph.
-        Ok(crate::workflows::translate::translate(&file))
+        let graph = crate::workflows::translate::translate(&file);
+        // (f) Issue #617: the child's calls never reach the gate pass, so say
+        // so on the record before handing the graph to the engine.
+        self.disclose_ungated_calls(workflow_id, &graph).await;
+        Ok(graph)
     }
 }
 
@@ -231,7 +325,9 @@ mod tests {
 
     use crate::company::CompanyManifest;
     use crate::error::Result as OcResult;
-    use crate::ports::types::{CompanyRecord, CompanySummary, LedgerEntry};
+    use crate::ports::types::{
+        CompanyEvent, CompanyRecord, CompanySummary, EventSeq, LedgerEntry, StoredEvent,
+    };
 
     /// An in-memory `CompanyStore` holding one record, so the resolver's overlay
     /// half can be seeded without a real backend.
@@ -281,6 +377,7 @@ mod tests {
             store_with(Vec::new()),
             CompanyId::new("acme"),
             root_id.to_string(),
+            None,
         )
     }
 
@@ -292,6 +389,7 @@ mod tests {
             store_with(overlays),
             CompanyId::new("acme"),
             root_id.to_string(),
+            None,
         )
     }
 
@@ -473,6 +571,7 @@ to = "sub"
             store_with(vec![overlay("child", parent_of("child", "other"))]),
             CompanyId::new("acme"),
             "root".to_string(),
+            None,
         );
         let graph = resolver.resolve("child").await.expect("resolves");
         assert_eq!(graph.id.as_deref(), Some("child"));
@@ -481,5 +580,153 @@ to = "sub"
             2,
             "the seed leaf must win over the overlay parent"
         );
+    }
+
+    // ---- Issue #617: disclosing a child's ungated calls -------------------
+
+    /// An [`EventLog`] that only remembers what it was handed.
+    struct RecordingEvents(std::sync::Mutex<Vec<CompanyEvent>>);
+
+    #[async_trait]
+    impl crate::ports::EventLog for RecordingEvents {
+        async fn append(&self, _id: &CompanyId, event: CompanyEvent) -> OcResult<EventSeq> {
+            self.0.lock().unwrap().push(event);
+            Ok(EventSeq::from(1))
+        }
+        async fn read_from(
+            &self,
+            _id: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> OcResult<Vec<StoredEvent>> {
+            Ok(Vec::new())
+        }
+        fn subscribe(&self, _id: &CompanyId) -> futures::stream::BoxStream<'static, StoredEvent> {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// A child graph whose one working node is a `tool_call` the policy parks.
+    fn child_with_shell(id: &str) -> String {
+        format!(
+            r#"
+id = "{id}"
+name = "{id}"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "run"
+kind = "tool_call"
+name = "Run"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo hi"
+[[edge]]
+from = "start"
+to = "run"
+"#
+        )
+    }
+
+    fn audited_resolver(
+        overlays: Vec<OverlayWorkflow>,
+        mode: &str,
+        events: Arc<RecordingEvents>,
+    ) -> StoreWorkflowResolver {
+        let policy: crate::company::Policy =
+            toml::from_str(&format!("mode = \"{mode}\"\nalways_approve = []\n"))
+                .expect("valid [policy]");
+        StoreWorkflowResolver::new(
+            None,
+            store_with(overlays),
+            CompanyId::new("acme"),
+            "root".to_string(),
+            Some(ChildCallAudit {
+                policy,
+                run_id: "run-1".to_string(),
+                events: Some(events),
+            }),
+        )
+    }
+
+    /// Issue #617. The child's `shell` call is one the policy would park at the
+    /// top level. It cannot be parked here — the engine cannot resume a child
+    /// across the boundary — so the resolver must **say so on the record**
+    /// rather than let the call disappear from the approvals story.
+    #[tokio::test]
+    async fn an_ungated_child_call_is_disclosed_to_the_journal() {
+        let events = Arc::new(RecordingEvents(std::sync::Mutex::new(Vec::new())));
+        let resolver = audited_resolver(
+            vec![overlay("child", child_with_shell("child"))],
+            "supervised",
+            events.clone(),
+        );
+
+        let graph = resolver.resolve("child").await.expect("child resolves");
+
+        let seen = events.0.lock().unwrap();
+        let [
+            CompanyEvent::WorkflowChildCallNotOffered {
+                workflow_id,
+                child_workflow_id,
+                run_id,
+                node,
+                tool,
+                reason,
+            },
+        ] = seen.as_slice()
+        else {
+            panic!("expected exactly one disclosure: {seen:?}");
+        };
+        assert_eq!(workflow_id, "root", "the line names the run's own workflow");
+        assert_eq!(child_workflow_id, "child");
+        assert_eq!(run_id, "run-1");
+        assert_eq!(node, "run");
+        assert_eq!(tool, "shell");
+        assert!(reason.contains("shell"), "{reason}");
+
+        // And the child is NOT gated: marking it would pause a child the engine
+        // cannot resume, turning a working run into a dead one (issue #617).
+        let run = graph
+            .nodes
+            .iter()
+            .find(|n| n.id == "run")
+            .expect("the child's node survives");
+        assert!(
+            run.config.get("requires_approval").is_none(),
+            "disclosing must not gate the child: {:?}",
+            run.config
+        );
+    }
+
+    /// A company that would not park the call has nothing to disclose. Without
+    /// this, the test above is also satisfied by a resolver that logs on every
+    /// child regardless of policy.
+    #[tokio::test]
+    async fn a_child_the_policy_would_not_park_discloses_nothing() {
+        let events = Arc::new(RecordingEvents(std::sync::Mutex::new(Vec::new())));
+        let resolver = audited_resolver(
+            vec![overlay("child", child_with_shell("child"))],
+            "full",
+            events.clone(),
+        );
+
+        resolver.resolve("child").await.expect("child resolves");
+
+        assert!(
+            events.0.lock().unwrap().is_empty(),
+            "an ungated-by-policy call is not a disclosure"
+        );
+    }
+
+    /// A dry run executes nothing, so there is no omission to confess. The
+    /// audit is `None` there and the resolver behaves exactly as before.
+    #[tokio::test]
+    async fn a_resolver_without_an_audit_discloses_nothing() {
+        let resolver = overlay_resolver(vec![overlay("child", child_with_shell("child"))], "root");
+        resolver.resolve("child").await.expect("child resolves");
     }
 }

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -130,8 +130,9 @@ use tinyflows::model::{NodeKind, WorkflowGraph};
 use oh::agent::tool_policy::{ToolCallContext, ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 use openhuman_core::openhuman as oh;
 
+use crate::company::Policy;
 use crate::harness::policy::ApprovalPolicy;
-use crate::ports::types::CompanyRecord;
+use crate::ports::types::{CompanyId, CompanyRecord};
 
 /// The tool name an `http_request` node's call is classified as (issue #614).
 ///
@@ -200,14 +201,55 @@ pub(crate) async fn apply_policy_gates(
     workflow_id: &str,
     run_id: &str,
 ) -> Vec<GatedCall> {
+    let gated = policy_gates(
+        graph,
+        &record.manifest.policy,
+        &record.id,
+        workflow_id,
+        run_id,
+    )
+    .await;
+
+    // Written LAST and unconditionally: the policy's gate outranks an authored
+    // `requires_approval`, in both directions. An author may add a gate the
+    // policy does not require; they may not remove one it does.
+    for node in &mut graph.nodes {
+        if gated.iter().any(|call| call.node_id == node.id)
+            && let Value::Object(config) = &mut node.config
+        {
+            config.insert("requires_approval".to_string(), json!(true));
+        }
+    }
+
+    gated
+}
+
+/// Which of `graph`'s nodes the company's policy would stop — **classification
+/// only**, no mutation.
+///
+/// Split out from [`apply_policy_gates`] for issue #617's audit line: a
+/// `sub_workflow` child is resolved and run inside the engine, so its nodes
+/// never reach the gate pass and a call the policy would park at the top level
+/// runs unparked one level down. The resolver cannot *fix* that — the engine
+/// cannot resume across the boundary — but it can ask the same question and say
+/// what it found, so an operator reviewing what was approved is not left with a
+/// hole they cannot account for. One classifier, so the audit line and the gate
+/// can never disagree about the same call.
+pub(crate) async fn policy_gates(
+    graph: &WorkflowGraph,
+    company_policy: &Policy,
+    company: &CompanyId,
+    workflow_id: &str,
+    run_id: &str,
+) -> Vec<GatedCall> {
     // The manifest's `[policy]` verbatim — same mode, same `always_approve`,
     // same `auto_approve_under_usd` the roster runs under. No per-agent budget:
     // a workflow node is not a teammate, and the company-wide ceiling is
     // enforced elsewhere.
-    let policy = ApprovalPolicy::new(&record.manifest.policy, None);
+    let policy = ApprovalPolicy::new(company_policy, None);
     let mut gated = Vec::new();
 
-    for node in &mut graph.nodes {
+    for node in &graph.nodes {
         let Some((slug, args, target)) = call_of(node) else {
             continue;
         };
@@ -229,18 +271,12 @@ pub(crate) async fn apply_policy_gates(
         };
 
         tracing::debug!(
-            company = %record.id,
+            company = %company,
             workflow = workflow_id,
             node = %node.id,
             tool = %slug,
             "workflow: the company's policy stops this node's call for an operator"
         );
-        // Written LAST and unconditionally: the policy's gate outranks an
-        // authored `requires_approval`, in both directions. An author may add a
-        // gate the policy does not require; they may not remove one it does.
-        if let Value::Object(config) = &mut node.config {
-            config.insert("requires_approval".to_string(), json!(true));
-        }
         gated.push(GatedCall {
             node_id: node.id.clone(),
             slug,


### PR DESCRIPTION
## Summary

Partially addresses #617 — the **audit** half, deliberately not the behaviour half.

A `sub_workflow` child is resolved and run inside the engine, so its nodes never reach the per-run gate pass that #612 and #627 added. A call the company's policy would park at the top level therefore runs unparked one level down: real effects, company grants, no card, and **nothing anywhere recording that it happened**.

This does not gate the child, and that is the point of the change rather than a limitation of it. Gating is not available: tinyflows cannot resume a child across the sub-workflow boundary, and a paused child halts the parent with an unresumable error — so marking the child's node would convert a run that works today into one that fails with **no card to decide**. That is strictly worse than the hole, and it is the same regression #460 refused to ship.

So the run proceeds and the omission is written down. On resolving a child, the resolver asks the *same* classifier the top-level gate asks, and for every call the policy would have parked it emits a `warn!` and journals a new `CompanyEvent::WorkflowChildCallNotOffered` naming the child, the node, the tool and the policy's own reason.

The value is exactly the value #460 argued for: an operator reviewing what the company was asked to approve stops seeing a gap with nothing to explain it.

## API Or Behavior Changes

**Behavior.** No change to what executes. A company whose policy would park a call inside a `sub_workflow` child now gets one journal line and one warning per such call. A company whose policy would not park it gets nothing. A dry run gets nothing — it executes nothing, so there is no omission to confess.

**API.**
- New `CompanyEvent::WorkflowChildCallNotOffered { workflow_id, child_workflow_id, run_id, node, tool, reason }`. Classified **Permanent** in `retention_class` — it is the record that a consequential call ran *without* the operator being asked, which is the clearest evidence this enum carries; pruning it would delete the only trace that the company acted unapproved. Neutral in both `cycle.rs` classifiers (it starts no cycle and names no conversation), and carried structurally-only onto the medulla wire and the orchestrator's insight summary — the policy's `reason` is a sentence built for an approval card and deliberately does not go to those surfaces.
- `StoreWorkflowResolver::new` takes a fifth argument, `Option<ChildCallAudit>`. `None` restores the previous behaviour exactly, which is what a dry run passes.
- `gate::policy_gates` is split out of `apply_policy_gates`: classification without mutation. **One classifier**, so the audit line and the gate can never disagree about the same call.

The compiler named five exhaustive matches on `CompanyEvent`, not the six I had been told to expect — I ran it rather than trusting the count.

## Tests

Gated lane throughout. Exit codes captured with unpiped redirects to a session-private path.

- [x] `cargo fmt --all -- --check` — `EXIT:0`.
- [x] `cargo clippy --all-targets -- -D warnings` — CI's own form, `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, `EXIT:0`.
- [x] `cargo build --all-targets` — covered by the clippy `--all-targets` run on the same feature set.
- [x] `cargo test` — `cargo test --features openhuman,tinycortex`, `EXIT:0`. Not the bare `cargo test`: default features skip this module entirely.

New tests (3), all in `src/workflows/caps/resolver.rs`:

- `an_ungated_child_call_is_disclosed_to_the_journal` — the defect. A child whose `tool_call` runs `shell` on a `supervised` company produces exactly one `WorkflowChildCallNotOffered` naming the child, node, tool and reason — **and the child graph is not gated**, which is asserted in the same test so the disclosure can never quietly become a behaviour change.
- `a_child_the_policy_would_not_park_discloses_nothing` — control. Without it, the test above is also satisfied by a resolver that logs on every child regardless of policy.
- `a_resolver_without_an_audit_discloses_nothing` — the dry-run shape.

**Revert-and-check.** With `disclose_ungated_calls` made an unconditional no-op, `an_ungated_child_call_is_disclosed_to_the_journal` fails and the two controls pass — which is what controls are for. Per-test results in the PR comment.

**Not covered:** that the journal line reaches any console surface. It is journaled and wire-mapped; no UI reads it yet.

## Documentation

`disclose_ungated_calls` carries the reasoning for disclosing rather than gating; the new event variant documents why it is Permanent and why it is journaled at child *resolution* rather than at the node. #617 has been rewritten around the (a) silent / (b) loud split this work is based on.

## Related

- #617 — the tracking issue, corrected to separate the silent policy-gate hole from the loud authored-gate failure.
- #612 / #627 — the top-level gate this reuses the classifier from.
- #675 — a second, independent sub-workflow boundary defect found while scoping this one: cancelling a run does not stop a running child. Same structural cause, different consequence; verified end-to-end.
