### PR TITLE
feat(chat): triage a message as answer, work, or chatter before it becomes a card (#267)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -435,10 +435,22 @@ scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
   `409` a graph that moved underneath it earns.
 
   Two more consequences worth knowing before reusing the seam. A chat turn
-  runs the **whole** company cycle, so an actionable message also opens a
-  board card via `company::task_intent` — on every thread *except* a copilot
-  one, where that is suppressed (#416) precisely because the seam is being
-  reused for a conversation that is not a request to the company. And an
+  runs the **whole** company cycle, so every message is first classified by
+  `company::task_intent::triage_message` (#267) into `Track` (an instruction —
+  the route opens a `todo` card), `Answer` (a question or read — no card), or
+  `Chatter` (greetings, and anything ambiguous — no card). `Answer` is also the
+  only class that *gates*: the harness withholds the issue-#453 delegation
+  claim for that turn, so the model's own `spawn_task` / `delegate_to_desk` /
+  `assign_task` / `review_task` fail at the tool boundary with the do-not-retry
+  refusal, while `query_company` / `run_workflow` / `read_run_output` run inline
+  and are untouched — the turn loses the ability to *write*, never the ability
+  to answer. Ambiguity falls to `Chatter`, which neither cards nor gates: a
+  missed card costs one follow-up message, a spurious card pollutes the board
+  permanently. The gate is harness-only — `HostedMedullaBrain` has no
+  delegation stack to gate (#176) — while the triage itself is compiled into
+  every build and fronts both brains. The card half is suppressed wholesale on
+  a copilot thread (#416), precisely because the seam is being reused for a
+  conversation that is not a request to the company. And an
   unconfigured company answers
   `200` with the echo brain's `"You said: …"` rather than an error, so a caller
   that needs a real answer must check `cognition` from `GET {scope}/inference`

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -439,12 +439,15 @@ scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
   `company::task_intent::triage_message` (#267) into `Track` (an instruction —
   the route opens a `todo` card), `Answer` (a question or read — no card), or
   `Chatter` (greetings, and anything ambiguous — no card). `Answer` is also the
-  only class that *gates*: the harness withholds the issue-#453 delegation
-  claim for that turn, so the model's own `spawn_task` / `delegate_to_desk` /
-  `assign_task` / `review_task` fail at the tool boundary with the do-not-retry
-  refusal, while `query_company` / `run_workflow` / `read_run_output` run inline
-  and are untouched — the turn loses the ability to *write*, never the ability
-  to answer. Ambiguity falls to `Chatter`, which neither cards nor gates: a
+  only class that *gates*: the harness narrows the issue-#453 delegation claim
+  to answering for that turn, so the model's own `spawn_task` / `assign_task` /
+  `review_task` fail at the tool boundary with the do-not-retry refusal.
+  `delegate_to_desk` is deliberately **not** refused — it is how a question the
+  orchestrator cannot answer alone reaches a desk that can — so it runs the
+  desk lead and relays their reply, and only its board card stands down.
+  `query_company` / `run_workflow` / `read_run_output` run inline and are
+  untouched throughout. The turn loses the ability to *write*, never the
+  ability to answer. Ambiguity falls to `Chatter`, which neither cards nor gates: a
   missed card costs one follow-up message, a spurious card pollutes the board
   permanently. The gate is harness-only — `HostedMedullaBrain` has no
   delegation stack to gate (#176) — while the triage itself is compiled into

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -1,19 +1,50 @@
-//! Detect an **actionable request** in an operator chat message, so the chat
-//! handler can deterministically open a dashboard task card for it.
+//! Triage an operator chat message **before** anything is written to the board:
+//! is this a question to answer, work to track, or neither?
 //!
-//! OpenCompany's chat can already produce task cards — but only when the
-//! orchestrator model chooses to call its `spawn_task` tool, and the
-//! orchestrator brief biases toward just replying, so a "do this" ask often
-//! leaves no visible work item. This module adds the deterministic half: when an
-//! operator message is an actionable request ("build the landing page",
-//! "can you set up the newsletter"), [`detect_task_intent`] returns a cleaned
-//! task title and the handler opens a `todo` card. The model's `spawn_task`
-//! stays available for sub-tasks it wants to open on top.
+//! # Two doors, not one (issue #267)
 //!
-//! Conservative and cheap by design (no model call): it fires on imperative
-//! requests and request-framed action asks, and stays silent on pure questions
-//! ("what's our revenue?"), greetings/acknowledgements ("hi", "thanks"), and
-//! neutral chatter — so the board fills with work, not small talk.
+//! Cards reach the board through two independent paths, and a fix on one leaves
+//! the other open:
+//!
+//! 1. **Deterministic** — the REST chat handler runs [`triage_message`] over the
+//!    operator's words and opens a `todo` card on [`MessageTriage::Track`]. This
+//!    is the path that produced five of the six dead `backlog` cards observed on
+//!    a live company ("Call the composio_authorize tool …", four × "Create a
+//!    workflow …"), because every one of them leads with an action verb.
+//! 2. **The model's own** — the orchestrator calls `spawn_task` /
+//!    `delegate_to_desk` / `assign_task` / `review_task`. That is where the
+//!    sixth card came from ("Tell what is there in the tasks list" — no action
+//!    verb, no request frame, so this module never saw it as work).
+//!
+//! [`triage_message`] is **Layer A**: it lives in the REST chat handler, is
+//! compiled into every build, and fronts both cognition brains. Its answer is
+//! also what the harness delegation seam uses to gate door 2 (Layer B) — an
+//! [`MessageTriage::Answer`] turn does not claim the delegation queue, so the
+//! model's board-writing tools refuse in its own turn.
+//!
+//! # Positive triage, and a deliberate lean toward answering
+//!
+//! The classification is a **three-way** decision rather than a card/no-card
+//! boolean, because "not work" and "a question about state" need different
+//! treatment: only the latter may gate the model's board tools, and gating
+//! small talk would be both pointless and risky.
+//!
+//! Tie-breakers lean toward [`MessageTriage::Answer`] and, when even that is
+//! not clear, toward [`MessageTriage::Chatter`] — which neither cards nor
+//! gates, and is the safe middle state. Straight from the issue: *a missed card
+//! costs one follow-up message, a spurious card pollutes the board
+//! permanently.*
+//!
+//! Conservative and cheap by design (**no model call**): it fires `Track` on
+//! imperative requests and request-framed action asks, `Answer` on
+//! interrogatives and read requests ("what's our revenue?", "show me the
+//! board"), and `Chatter` on greetings, acknowledgements and everything
+//! ambiguous.
+//!
+//! [`detect_task_intent`] remains as the thin `Track`-only wrapper the card
+//! paths call, so the issue-#463 title contract with
+//! `DelegationRunner::chat_handler_card` — which has to derive byte-for-byte
+//! the same title the handler wrote — is untouched.
 
 /// Bare greeting / acknowledgement messages that must never open a card, matched
 /// against the whole message (punctuation stripped). Kept short and exact so a
@@ -63,6 +94,13 @@ const GREETINGS: &[&str] = &[
 
 /// Single-word imperative action verbs. A message whose first word is one of
 /// these is an instruction to act.
+///
+/// `list` used to be here and was removed for issue #267: a bare "list X" is a
+/// **read**, not work — "list the tasks" is answered by one `query_company`
+/// call and must never mint a card. It now leads [`READ_VERBS`] instead. The
+/// removal also narrows [`contains_action`], which is what makes "can you list
+/// the tasks?" an [`MessageTriage::Answer`] rather than a request frame around
+/// an action verb.
 const ACTION_VERBS: &[&str] = &[
     "build",
     "create",
@@ -112,7 +150,6 @@ const ACTION_VERBS: &[&str] = &[
     "upload",
     "summarize",
     "summarise",
-    "list",
     "track",
     "monitor",
     "investigate",
@@ -213,32 +250,124 @@ const LEAD_INS: &[&str] = &[
     "actually ",
 ];
 
+/// Lead words that open a question about the company's state. A message
+/// starting with one of these wants an answer, not a card (issue #267).
+///
+/// Deliberately excludes the auxiliaries that double as imperatives — `do`,
+/// `have`, `can`, `could`, `should`, `will` — because "do the newsletter" and
+/// "have the team look at it" are asks, not questions. The ones they *do* open
+/// as questions ("can you tell me the numbers?", "should we ship?") end in a
+/// `?` and are caught by the trailing-`?` rule below instead.
+const INTERROGATIVE_LEADS: &[&str] = &[
+    "what", "what's", "whats", "who", "who's", "whos", "whose", "when", "where", "why", "which",
+    "how", "how's", "hows", "is", "are", "was", "were", "anyone", "anybody", "anything",
+];
+
+/// Lead verbs that ask to be **told** something rather than to have something
+/// done. "Tell what is there in the tasks list" — the sixth dead card from
+/// issue #267 — opens with one of these.
+const READ_VERBS: &[&str] = &[
+    "tell", "show", "explain", "describe", "list", "recap", "clarify", "compare",
+];
+
+/// Multi-word read requests (checked as a prefix + word boundary).
+const READ_PHRASES: &[&str] = &["give me", "walk me through", "let me know", "remind me"];
+
 /// Max length of a generated task title.
 const TITLE_MAX: usize = 80;
 
-/// Returns a cleaned task title when `text` is an actionable request, else
-/// `None`. See the module docs for the intent.
-pub fn detect_task_intent(text: &str) -> Option<String> {
+/// What an operator chat message is, decided before anything reaches the board
+/// (issue #267).
+///
+/// Three states rather than two: `Chatter` is not "a weaker `Answer`" — it is
+/// the state in which the runtime asserts *nothing*, so it neither opens a card
+/// nor takes the model's board tools away.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MessageTriage {
+    /// A question about state, or a request to be told something. Answer it
+    /// from the read path; **no board write**, by either door.
+    Answer,
+    /// Real work. Opens a `todo` card under the carried title.
+    Track(String),
+    /// Neither — greetings, acknowledgements, and everything too ambiguous to
+    /// call. Cards nothing and gates nothing.
+    Chatter,
+}
+
+impl MessageTriage {
+    /// Whether this is [`MessageTriage::Answer`] — the one class that gates the
+    /// model's board-writing tools (issue #267, Layer B).
+    pub fn is_answer(&self) -> bool {
+        matches!(self, Self::Answer)
+    }
+
+    /// The task title when this is [`MessageTriage::Track`], else `None`.
+    pub fn title(&self) -> Option<&str> {
+        match self {
+            Self::Track(title) => Some(title),
+            _ => None,
+        }
+    }
+}
+
+/// Classifies an operator chat message as [`Answer`](MessageTriage::Answer),
+/// [`Track`](MessageTriage::Track) or [`Chatter`](MessageTriage::Chatter).
+///
+/// # The order is the design
+///
+/// 1. **Empty** → `Chatter`. Nothing was said.
+/// 2. **A bare greeting / acknowledgement** → `Chatter`.
+/// 3. **A request frame around an action verb** → `Track`. Checked *before* any
+///    question test on purpose: "can you build the landing page?" is work
+///    despite the `?`, and reading the `?` first would lose every politely
+///    phrased instruction an operator ever types.
+/// 4. **A question or read request** → `Answer`: an interrogative lead word, a
+///    [`READ_VERBS`] / [`READ_PHRASES`] lead, or a trailing `?` with no action
+///    verb anywhere.
+/// 5. **A leading imperative** → `Track`.
+/// 6. **Anything else** → `Chatter`, the safe middle.
+pub fn triage_message(text: &str) -> MessageTriage {
     let trimmed = text.trim();
     if trimmed.is_empty() {
-        return None;
+        return MessageTriage::Chatter;
     }
 
     let lower = trimmed.to_lowercase();
     // Whole-message greeting/ack check (strip trailing punctuation first).
     let bare = lower.trim_end_matches(['.', '!', '?', ' ']).trim();
     if GREETINGS.contains(&bare) {
-        return None;
+        return MessageTriage::Chatter;
     }
 
     // Strip leading filler ("ok now …", "and also …") so the ask underneath is
     // judged on its own.
     let core = strip_lead_ins(&lower);
-    if !is_actionable(core) {
-        return None;
-    }
 
-    Some(to_title(trimmed))
+    // Frame beats interrogative: a polite instruction stays work.
+    if REQUEST_FRAMES.iter().any(|f| core.starts_with(f)) && contains_action(core) {
+        return MessageTriage::Track(to_title(trimmed));
+    }
+    if is_question(core) {
+        return MessageTriage::Answer;
+    }
+    if starts_with_action(core) {
+        return MessageTriage::Track(to_title(trimmed));
+    }
+    MessageTriage::Chatter
+}
+
+/// Returns a cleaned task title when `text` is an actionable request, else
+/// `None` — the [`MessageTriage::Track`]-only view of [`triage_message`].
+///
+/// Kept as its own function because two card paths depend on it agreeing with
+/// itself byte-for-byte: the REST chat handler writes the title, and
+/// `DelegationRunner::chat_handler_card` re-derives it moments later to find
+/// the card that handler wrote (issue #463).
+pub fn detect_task_intent(text: &str) -> Option<String> {
+    match triage_message(text) {
+        MessageTriage::Track(title) => Some(title),
+        MessageTriage::Answer | MessageTriage::Chatter => None,
+    }
 }
 
 /// Remove stacked leading filler words from a lowercased message.
@@ -256,18 +385,25 @@ fn strip_lead_ins(lower: &str) -> &str {
     }
 }
 
-/// Whether the lowercased message is an actionable request.
-fn is_actionable(lower: &str) -> bool {
-    // A leading imperative verb/phrase is unambiguously an instruction.
-    if starts_with_action(lower) {
+/// Whether the lowercased message asks for an answer rather than for work
+/// (issue #267). Only reached once a request-framed instruction has been ruled
+/// out, so a `?` here is a real question mark and not politeness.
+fn is_question(lower: &str) -> bool {
+    if READ_PHRASES.iter().any(|p| starts_with_word(lower, p)) {
         return true;
     }
-    // A request frame counts only when it wraps an actual action verb, so a
-    // framed question ("can you tell me …") does not qualify.
-    if REQUEST_FRAMES.iter().any(|f| lower.starts_with(f)) && contains_action(lower) {
+    let first = lower
+        .split_whitespace()
+        .next()
+        .unwrap_or("")
+        .trim_end_matches([',', ':', ';', '.', '!', '?']);
+    if INTERROGATIVE_LEADS.contains(&first) || READ_VERBS.contains(&first) {
         return true;
     }
-    false
+    // A trailing `?` with no action verb anywhere. The action-verb guard is
+    // what keeps "fix the login bug?" out of here — an operator second-guessing
+    // their own instruction is still an instruction.
+    lower.trim_end().ends_with('?') && !contains_action(lower)
 }
 
 /// The message's first word (or a leading multi-word phrase) is an action verb.
@@ -386,6 +522,138 @@ mod tests {
             "why did signups drop?",
         ] {
             assert!(detect_task_intent(msg).is_none(), "should not fire: {msg}");
+            assert_eq!(
+                triage_message(msg),
+                MessageTriage::Answer,
+                "should be an answer: {msg}"
+            );
+        }
+    }
+
+    /// Issue #267: the six cards found sitting unworked in `backlog` on a live
+    /// company, each pinned to the class it now triages as.
+    ///
+    /// Five of the six lead with an action verb, so they came through the
+    /// deterministic handler path and stay `Track` — they *are* instructions,
+    /// and the fix for the four workflow asks is that the orchestrator now
+    /// authors the graph in-turn rather than parking the card. The sixth has no
+    /// action verb and no request frame, so this module never saw it: it was
+    /// the model's own `spawn_task`, and `Answer` is what takes that tool away.
+    #[test]
+    fn the_six_observed_dead_cards_triage_as_recorded() {
+        let cases: &[(&str, MessageTriage)] = &[
+            (
+                "Tell what is there in the tasks list",
+                MessageTriage::Answer,
+            ),
+            (
+                "Call the composio_authorize tool with toolkit = gmail and reply with the result",
+                MessageTriage::Track(
+                    "Call the composio_authorize tool with toolkit = gmail and reply with the \
+                     result"
+                        .to_string(),
+                ),
+            ),
+            (
+                "Create a workflow to, write a 2-sentence status update",
+                MessageTriage::Track(
+                    "Create a workflow to, write a 2-sentence status update".to_string(),
+                ),
+            ),
+            (
+                "Create a simple workflow, Write a 2-sentence status update",
+                MessageTriage::Track(
+                    "Create a simple workflow, Write a 2-sentence status update".to_string(),
+                ),
+            ),
+            (
+                "Create a workflow named topic-to-visual",
+                MessageTriage::Track("Create a workflow named topic-to-visual".to_string()),
+            ),
+            (
+                "Create a workflow called Daily Standup",
+                MessageTriage::Track("Create a workflow called Daily Standup".to_string()),
+            ),
+        ];
+        for (msg, expected) in cases {
+            assert_eq!(&triage_message(msg), expected, "triage of: {msg}");
+        }
+    }
+
+    /// The class the issue is really about: reads that were becoming cards.
+    #[test]
+    fn read_requests_are_answers() {
+        for msg in [
+            "list the tasks",
+            "show me the board",
+            "what's our revenue?",
+            "Tell what is there in the tasks list",
+            "explain how the newsletter works",
+            "describe the current backlog",
+            "give me the headcount",
+            "walk me through the funnel",
+            "can you list the tasks?",
+            "where do we stand on the launch?",
+        ] {
+            assert_eq!(
+                triage_message(msg),
+                MessageTriage::Answer,
+                "should be an answer: {msg}"
+            );
+            assert!(detect_task_intent(msg).is_none(), "no card for: {msg}");
+        }
+    }
+
+    /// A request frame is read before any question test, so a politely phrased
+    /// instruction stays work even when it ends in `?`.
+    #[test]
+    fn a_request_frame_beats_an_interrogative() {
+        assert_eq!(
+            triage_message("can you build the landing page?"),
+            MessageTriage::Track("Build the landing page".to_string())
+        );
+        assert_eq!(
+            triage_message("could you please fix the checkout bug?"),
+            MessageTriage::Track("Fix the checkout bug".to_string())
+        );
+    }
+
+    /// Neither work nor a question: the safe middle that cards nothing and
+    /// gates nothing.
+    #[test]
+    fn neutral_chatter_is_chatter() {
+        for msg in [
+            "hi",
+            "thanks",
+            "the deck looks good to me",
+            "i'll be offline tomorrow",
+            "nice work on the launch",
+            "…",
+        ] {
+            assert_eq!(
+                triage_message(msg),
+                MessageTriage::Chatter,
+                "should be chatter: {msg}"
+            );
+        }
+    }
+
+    /// The `Track` arm still carries the exact string the REST handler writes,
+    /// which `chat_handler_card` re-derives to find that card (issue #463).
+    #[test]
+    fn track_titles_stay_byte_identical_to_detect_task_intent() {
+        for msg in [
+            "Build the landing page",
+            "please can you fix the login bug!",
+            "go ahead and publish the blog post",
+            "ok now build the dashboard",
+            "Can you build the landing page?",
+        ] {
+            assert_eq!(
+                triage_message(msg).title().map(str::to_string),
+                detect_task_intent(msg),
+                "title contract for: {msg}"
+            );
         }
     }
 

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -281,7 +281,17 @@ const READ_VERBS: &[&str] = &[
 ];
 
 /// Multi-word read requests (checked as a prefix + word boundary).
-const READ_PHRASES: &[&str] = &["give me", "walk me through", "let me know", "remind me"];
+///
+/// `give me` used to be here and was removed on review of issue #267: every
+/// other entry means *tell me* — `walk me through`, `let me know`, `remind me`
+/// — while `give me` overwhelmingly means *produce me*. It was the one lead in
+/// this list that fired [`MessageTriage::Answer`] on "give me a landing page",
+/// which withdraws the board tools from a request to build something. Without
+/// it "give me the headcount" falls to [`MessageTriage::Chatter`], which is a
+/// deliberate and cheap trade: `Chatter` opens no card and gates nothing, so a
+/// read that lands there costs the operator nothing, whereas the gated request
+/// cost them the work.
+const READ_PHRASES: &[&str] = &["walk me through", "let me know", "remind me"];
 
 /// Max length of a generated task title.
 const TITLE_MAX: usize = 80;
@@ -333,7 +343,9 @@ impl MessageTriage {
 ///    phrased instruction an operator ever types.
 /// 4. **A question or read request** → `Answer`: an interrogative lead word, a
 ///    [`READ_VERBS`] / [`READ_PHRASES`] lead, or a trailing `?` with no action
-///    verb anywhere.
+///    verb anywhere. Both lead-word branches are vetoed when a *later* clause
+///    is an imperative ([`later_clause_is_imperative`]) — `Answer` is the one
+///    class with teeth, so its entry conditions are the ones held tightest.
 /// 5. **A leading imperative** → `Track`.
 /// 6. **Anything else** → `Chatter`, the safe middle.
 pub fn triage_message(text: &str) -> MessageTriage {
@@ -398,8 +410,27 @@ fn strip_lead_ins(lower: &str) -> &str {
 /// Whether the lowercased message asks for an answer rather than for work
 /// (issue #267). Only reached once a request-framed instruction has been ruled
 /// out, so a `?` here is a real question mark and not politeness.
+///
+/// # The asymmetry that sets how tight this is
+///
+/// [`MessageTriage::Answer`] is the only class with teeth: it suppresses the
+/// direct-work card and narrows the model's board tools, so a false `Answer`
+/// costs the operator the work itself, while a false [`MessageTriage::Chatter`]
+/// costs nothing at all. The trailing-`?` branch has always carried that
+/// asymmetry — its `contains_action` guard is there because "fix the login
+/// bug?" is an operator second-guessing their own instruction, and an
+/// instruction is still an instruction. The lead-word branches did not, and
+/// entered `Answer` on a single word with no look at the rest of the sentence
+/// (issue #267 review). [`later_clause_is_imperative`] is that same principle
+/// applied to them, scoped to conjoined clauses so a single-clause question is
+/// untouched.
 fn is_question(lower: &str) -> bool {
-    if READ_PHRASES.iter().any(|p| starts_with_word(lower, p)) {
+    // A lead word speaks for its own clause, not for the whole message
+    // (issue #267 review). Checked before either lead-word branch because both
+    // of them read exactly one word and would otherwise answer for a conjoined
+    // imperative they never looked at.
+    let conjoined_imperative = later_clause_is_imperative(lower);
+    if !conjoined_imperative && READ_PHRASES.iter().any(|p| starts_with_word(lower, p)) {
         return true;
     }
     let first = lower
@@ -407,13 +438,58 @@ fn is_question(lower: &str) -> bool {
         .next()
         .unwrap_or("")
         .trim_end_matches([',', ':', ';', '.', '!', '?']);
-    if INTERROGATIVE_LEADS.contains(&first) || READ_VERBS.contains(&first) {
+    if !conjoined_imperative
+        && (INTERROGATIVE_LEADS.contains(&first) || READ_VERBS.contains(&first))
+    {
         return true;
     }
     // A trailing `?` with no action verb anywhere. The action-verb guard is
     // what keeps "fix the login bug?" out of here — an operator second-guessing
     // their own instruction is still an instruction.
     lower.trim_end().ends_with('?') && !contains_action(lower)
+}
+
+/// The clauses of a lowercased message, split on the joins an operator actually
+/// stacks two asks with: ` and `, a semicolon, and a sentence boundary.
+///
+/// Empty clauses are dropped so a trailing `?` or a doubled separator does not
+/// manufacture one — "what's our revenue?" is a single clause, not two.
+fn clauses(lower: &str) -> impl Iterator<Item = &str> {
+    lower
+        .split([';', '.', '!', '?'])
+        .flat_map(|sentence| sentence.split(" and "))
+        .map(str::trim)
+        .filter(|clause| !clause.is_empty())
+}
+
+/// Whether a clause *after the first* is an imperative — the veto that stops a
+/// leading question word speaking for a conjoined instruction (issue #267
+/// review).
+///
+/// "Explain the auth flow and then fix the login bug" is a read AND work, and
+/// [`MessageTriage::Answer`] is the expensive way to be wrong about it: it
+/// withdraws the board tools from the half of the sentence that needs them.
+/// Each later clause is passed through [`strip_lead_ins`] first, so the
+/// connective an operator writes the second ask with ("and **then** fix …")
+/// does not hide the verb underneath it.
+///
+/// Deliberately only the LATER clauses. Re-judging the first would collapse
+/// into a blanket `!contains_action(...)` veto over the whole message, and
+/// [`ACTION_VERBS`] is full of words that are commonly nouns — `review`,
+/// `design`, `audit`, `plan`, `update` — so that would degrade genuine
+/// questions like "what's the status of the design review?" to
+/// [`MessageTriage::Chatter`] and gut the layer.
+///
+/// The residual is the mirror of that: a later clause whose first word is one
+/// of those noun-ish verbs ("show me the design and review queue") vetoes when
+/// it should not, and the message falls to `Chatter` rather than `Answer`.
+/// `Chatter` cards nothing and gates nothing, so the cost is a lost gate rather
+/// than a spurious card — the cheap direction. A keyword classifier cannot do
+/// better than trade here; issue #678 is where it stops having to.
+fn later_clause_is_imperative(lower: &str) -> bool {
+    clauses(lower)
+        .skip(1)
+        .any(|clause| starts_with_action(strip_lead_ins(clause)))
 }
 
 /// The message's first word (or a leading multi-word phrase) is an action verb.
@@ -600,7 +676,6 @@ mod tests {
             "Tell what is there in the tasks list",
             "explain how the newsletter works",
             "describe the current backlog",
-            "give me the headcount",
             "walk me through the funnel",
             "can you list the tasks?",
             "where do we stand on the launch?",
@@ -612,6 +687,71 @@ mod tests {
             );
             assert!(detect_task_intent(msg).is_none(), "no card for: {msg}");
         }
+    }
+
+    /// The class the original suite never probed: for every lead-word pattern
+    /// it pinned, it picked the *read*-flavoured instance ("give me the
+    /// headcount", "walk me through the funnel", "describe the current
+    /// backlog") — so the work-flavoured instance of the same pattern went
+    /// unmeasured, and every one of these was [`MessageTriage::Answer`], which
+    /// withdraws the board tools from a request to build something (issue #267
+    /// review, finding 1).
+    ///
+    /// The assertion is `!= Answer` rather than `== Track` on purpose. What
+    /// costs the operator is the gate; whether one of these lands in `Track` or
+    /// in the `Chatter` middle is the classifier's own tie-break and not what
+    /// this pins.
+    #[test]
+    fn a_work_ask_behind_a_read_lead_is_not_gated() {
+        for msg in [
+            // `give me` no longer leads READ_PHRASES.
+            "give me a landing page",
+            // …and a lead word no longer speaks for a conjoined imperative.
+            "explain the auth flow and then fix the login bug",
+            "compare our pricing to competitors and write up a doc",
+            "walk me through the funnel and build a dashboard for it",
+            "tell me the headcount; then draft the hiring plan",
+            "show me the board. create a card for the launch",
+        ] {
+            assert_ne!(
+                triage_message(msg),
+                MessageTriage::Answer,
+                "a request to produce something must not be gated: {msg}"
+            );
+        }
+    }
+
+    /// The other side of the same trade, and the reason the veto is scoped to
+    /// *later* clauses rather than applied as a blanket `!contains_action`:
+    /// [`ACTION_VERBS`] is full of words that are commonly nouns, so a blanket
+    /// veto would degrade these to `Chatter` and gut the layer.
+    #[test]
+    fn a_noun_that_doubles_as_an_action_verb_stays_a_question() {
+        for msg in [
+            "what's the status of the design review?",
+            "who is running the security audit?",
+            "when is the next product review and the board update?",
+            "what's our revenue and how did it change?",
+            "is the campaign live and is the newsletter out?",
+        ] {
+            assert_eq!(
+                triage_message(msg),
+                MessageTriage::Answer,
+                "should stay an answer: {msg}"
+            );
+        }
+    }
+
+    /// Dropping `give me` from [`READ_PHRASES`] moves the read-flavoured
+    /// instance to `Chatter`, which is the whole cost of the change: no card,
+    /// no gate, so the operator loses nothing.
+    #[test]
+    fn a_read_flavoured_give_me_falls_to_the_safe_middle() {
+        assert_eq!(
+            triage_message("give me the headcount"),
+            MessageTriage::Chatter
+        );
+        assert!(detect_task_intent("give me the headcount").is_none());
     }
 
     /// A request frame is read before any question test, so a politely phrased

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -19,8 +19,13 @@
 //! [`triage_message`] is **Layer A**: it lives in the REST chat handler, is
 //! compiled into every build, and fronts both cognition brains. Its answer is
 //! also what the harness delegation seam uses to gate door 2 (Layer B) — an
-//! [`MessageTriage::Answer`] turn does not claim the delegation queue, so the
-//! model's board-writing tools refuse in its own turn.
+//! [`MessageTriage::Answer`] turn claims the delegation queue for *answering
+//! only*, so the model's board-writing tools refuse in its own turn.
+//!
+//! The gate is a narrowing, not a withdrawal. `delegate_to_desk` still runs on
+//! an `Answer` turn — it is how a question the orchestrator cannot answer alone
+//! reaches a desk that can — and what stands down is its *card*. So the layer
+//! removes the ability to write and never the ability to reply.
 //!
 //! # Positive triage, and a deliberate lean toward answering
 //!

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -45,6 +45,16 @@
 //! paths call, so the issue-#463 title contract with
 //! `DelegationRunner::chat_handler_card` — which has to derive byte-for-byte
 //! the same title the handler wrote — is untouched.
+//!
+//! # What this deliberately is not
+//!
+//! Not the LLM classifier issue #267 sketches. OpenHuman's `trigger_triage`
+//! precedent classifies *external* triggers and pays a fast model to do it;
+//! OpenCompany has one `ChatModel` per company and no fast tier, so a
+//! pre-turn classifier would add a full-price serial round-trip to every
+//! message. It is tracked in **issue #678** along with fast-model routing, a
+//! first-class `automate` class, and gating the hosted path once #176 gives it
+//! a delegation stack to gate.
 
 /// Bare greeting / acknowledgement messages that must never open a card, matched
 /// against the whole message (punctuation stripped). Kept short and exact so a

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -295,7 +295,7 @@ impl HarnessBrain {
             .delegation_runner(&run_turn)
             .drain_and_execute(
                 grant.origin_thread.as_deref(),
-                false,
+                delegation::MessageContext::default(),
                 delegation::HandOffs::Run,
             )
             .await
@@ -2032,7 +2032,7 @@ impl HarnessBrain {
     ) -> Result<delegation::DelegationOutcome> {
         let run_turn = HarnessRunTurn::new(&self.pool, &self.deps);
         self.delegation_runner(&run_turn)
-            .run_delegation(delegation, chat_id, false)
+            .run_delegation(delegation, chat_id, delegation::MessageContext::default())
             .await
     }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -469,10 +469,12 @@ impl DelegationQueue {
     #[must_use = "a refused delegation must be reported to the model, not dropped"]
     pub fn push_within_cap(&self, delegation: Delegation, cap: usize) -> Staged {
         match self.claim_state() {
-            DrainClaim::Unclaimed => return Staged::NoDrain,
+            DrainClaim::Unclaimed => return Staged::NoDrain(NoDrainReason::Unwired),
             // Issue #267: the operator asked a question. A hand-off is how one
             // gets answered, so it stages; the pure board writes do not.
-            DrainClaim::Answering if !delegation.answers() => return Staged::NoDrain,
+            DrainClaim::Answering if !delegation.answers() => {
+                return Staged::NoDrain(NoDrainReason::Triage);
+            }
             DrainClaim::Answering | DrainClaim::Full => {}
         }
         let mut guard = self.inner.lock().expect("delegation queue");
@@ -564,13 +566,49 @@ impl DelegationQueue {
 pub enum Staged {
     /// Queued; some drain site will execute it as this turn completes.
     Queued,
-    /// Nothing that would execute *this* delegation has claimed the queue —
-    /// either because nobody claimed it at all (issue #453) or because the
-    /// claim is narrowed to answering and this is a pure board write
-    /// (issue #267, [`DrainClaim::Answering`]).
-    NoDrain,
+    /// Nothing that would execute *this* delegation has claimed the queue. The
+    /// [`NoDrainReason`] says which of the two very different causes it was.
+    NoDrain(NoDrainReason),
     /// This turn has already queued [`MAX_DELEGATIONS_PER_TURN`].
     OverCap,
+}
+
+/// Why a delegation found nothing that would drain it (issues #453, #267).
+///
+/// One refusal used to speak for both of these, and they are not the same
+/// condition: one is a context that can never do board work, the other is a
+/// fully capable company reading *this message* as a question. Sharing a
+/// sentence made the refusal wrong for the second case — "board actions are
+/// unavailable in this context" is false when they would have worked on a
+/// differently-phrased message — and, worse, made the two indistinguishable in
+/// the logs, so the rate at which the triage gate fires could not be measured
+/// after shipping a keyword classifier with teeth.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NoDrainReason {
+    /// No drain site claimed the queue at all ([`DrainClaim::Unclaimed`]):
+    /// nothing in this context can carry out board work, for any message.
+    Unwired,
+    /// The queue is claimed for answering ([`DrainClaim::Answering`]): the
+    /// operator's message triaged as a question, so board writes are held back
+    /// for **this message only** (issue #267).
+    Triage,
+}
+
+impl NoDrainReason {
+    /// The value the `reason` log field carries, so the two causes can be
+    /// counted apart in production.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Unwired => "no_drain_wired",
+            Self::Triage => "triaged_as_question",
+        }
+    }
+}
+
+impl std::fmt::Display for NoDrainReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
 }
 
 /// What the live claim on a [`DelegationQueue`] permits (issues #453, #267).
@@ -1234,7 +1272,9 @@ impl Tool for SpawnTaskTool {
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
-            Staged::NoDrain => return Ok(ToolResult::error(no_drain(SPAWN_TASK_TOOL, &effect))),
+            Staged::NoDrain(why) => {
+                return Ok(ToolResult::error(no_drain(SPAWN_TASK_TOOL, &effect, why)));
+            }
         }
         Ok(ToolResult::success(format!(
             "Queued a task card: \"{title}\". It will be opened on the board this turn."
@@ -1359,8 +1399,12 @@ impl Tool for DelegateToDeskTool {
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
-            Staged::NoDrain => {
-                return Ok(ToolResult::error(no_drain(DELEGATE_TO_DESK_TOOL, &effect)));
+            Staged::NoDrain(why) => {
+                return Ok(ToolResult::error(no_drain(
+                    DELEGATE_TO_DESK_TOOL,
+                    &effect,
+                    why,
+                )));
             }
         }
         Ok(ToolResult::success(format!(
@@ -1441,7 +1485,9 @@ impl Tool for AssignTaskTool {
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
-            Staged::NoDrain => return Ok(ToolResult::error(no_drain(ASSIGN_TASK_TOOL, &effect))),
+            Staged::NoDrain(why) => {
+                return Ok(ToolResult::error(no_drain(ASSIGN_TASK_TOOL, &effect, why)));
+            }
         }
         // Staged truth, not the past tense (issue #453). Nothing has been
         // written yet; the drain this turn's claim promises is what writes it.
@@ -1526,7 +1572,9 @@ impl Tool for ReviewTaskTool {
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
-            Staged::NoDrain => return Ok(ToolResult::error(no_drain(REVIEW_TASK_TOOL, &effect))),
+            Staged::NoDrain(why) => {
+                return Ok(ToolResult::error(no_drain(REVIEW_TASK_TOOL, &effect, why)));
+            }
         }
         // Issue #453: the card has NOT moved yet. It moves when the drain runs,
         // and the drain runs because this turn is claimed — which is what makes
@@ -1563,7 +1611,7 @@ operator which items you got to and which you did not, and raise the rest in you
 }
 
 /// The refusal a delegation tool returns when **nothing will drain** what it
-/// would queue (issue #453) — modelled on
+/// would queue (issues #453, #267) — modelled on
 /// [`cannot_publish_here`](crate::harness::publish) one module over.
 ///
 /// It has to do two jobs, and they are not the two [`over_cap`] does. It must
@@ -1572,17 +1620,53 @@ operator which items you got to and which you did not, and raise the rest in you
 /// the failure this replaces was one the agent could not detect: it was told the
 /// card had moved, so it told the operator the card had moved, and the next
 /// turn's `clear()` threw the delegation away.
-fn no_drain(tool: &str, effect: &str) -> String {
+///
+/// # One sentence could not do both causes
+///
+/// It was written for a genuinely inert context and then inherited, unchanged,
+/// by [`NoDrainReason::Triage`] — a **fully capable** company whose triage read
+/// this message as a question. There, "nothing here can carry out board work"
+/// and "board actions are unavailable in this context" are both false as the
+/// operator will hear them: board actions work fine, and would have worked on a
+/// differently-phrased message. Paired with a triage miss the experience was
+/// *ask for a landing page → "I could not do it; board actions are
+/// unavailable"*, with no hint that rephrasing would work.
+///
+/// So the triage case gets its own text, which says what was actually read,
+/// keeps the do-not-report-it-as-done half that both causes need, and gives the
+/// model something recoverable to offer: restate it as a request.
+///
+/// # The log field is the measurement
+///
+/// `reason` is on the warn as well as in the message. The triage gate ships a
+/// keyword classifier with teeth, and its residual miss rate is exactly the
+/// number worth having afterwards — with both causes emitting identical text
+/// there was no way to count one without the other. Kept at `warn` rather than
+/// demoted to `info`: a refusal here means either the model over-reached on a
+/// question or the triage misread a request, and both are worth seeing.
+fn no_drain(tool: &str, effect: &str, reason: NoDrainReason) -> String {
     tracing::warn!(
         tool = %tool,
-        "[delegation] a delegation tool was called from a turn with no claimed drain; refusing \
-         rather than queuing into a queue nothing will drain"
+        reason = %reason,
+        "[delegation] a delegation tool found no drain that would execute it; refusing in the \
+         model's own turn rather than queuing into a queue nothing will drain"
     );
-    format!(
-        "Refused: nothing here can carry out board work, so {effect}. Board actions are \
-         unavailable in this context. Do not retry — it will fail the same way — and do NOT report \
-         the action as done or describe the card as moved. Say plainly that you could not do it."
-    )
+    match reason {
+        NoDrainReason::Unwired => format!(
+            "Refused: nothing here can carry out board work, so {effect}. Board actions are \
+             unavailable in this context. Do not retry — it will fail the same way — and do NOT \
+             report the action as done or describe the card as moved. Say plainly that you could \
+             not do it."
+        ),
+        NoDrainReason::Triage => format!(
+            "Refused: this message was read as a question rather than a request to do work, so \
+             {effect}. Board writes are held back for this message only — answer it from what you \
+             can read, and hand it to a desk if somebody else knows better. Do not retry this \
+             call; it will fail the same way. Do NOT report the action as done or describe the \
+             card as moved. If the operator did mean it as work, say so plainly and ask them to \
+             restate it as a direct request."
+        ),
+    }
 }
 
 /// Reads a required non-empty string argument, trimmed.
@@ -3355,7 +3439,7 @@ mod tests {
                 },
                 MAX_DELEGATIONS_PER_TURN,
             ),
-            Staged::NoDrain,
+            Staged::NoDrain(NoDrainReason::Unwired),
             "an EMPTY unclaimed queue is still a queue nothing drains"
         );
         assert_eq!(queue.queued(), 0);
@@ -3461,6 +3545,119 @@ mod tests {
             assert!(!text.contains("delegations"), "{name}: {text}");
         }
         assert_eq!(queue.queued(), 0, "nothing may be staged by a refusal");
+    }
+
+    /// **Issue #267 review, finding 3.** The two no-drain causes stop sharing a
+    /// sentence.
+    ///
+    /// Written for a genuinely inert context, the refusal was then inherited by
+    /// a fully capable company whose triage read the message as a question —
+    /// where "board actions are unavailable in this context" is simply false as
+    /// the operator will hear it. Paired with a triage miss the experience was
+    /// *ask for a landing page → "I could not do it; board actions are
+    /// unavailable"*, with nothing to suggest that rephrasing would work.
+    ///
+    /// The halves both causes need stay on both; what differs is what the model
+    /// is told happened, and what it can offer next.
+    #[tokio::test]
+    async fn the_triage_refusal_says_it_read_a_question_and_offers_a_way_forward() {
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim_answering();
+        let refused = SpawnTaskTool::new(queue.clone())
+            .execute(json!({ "title": "Build the landing page" }))
+            .await
+            .expect("execute");
+        assert!(refused.is_error, "{}", refused.text());
+        let text = refused.text();
+
+        assert!(
+            text.contains("read as a question"),
+            "it must name what actually happened: {text}"
+        );
+        assert!(
+            text.contains("this message only"),
+            "…and scope it to this message, not to the whole context: {text}"
+        );
+        assert!(
+            text.contains("restate it"),
+            "…and leave the model something recoverable to offer: {text}"
+        );
+        // The two claims that are false here, and were the whole complaint.
+        assert!(
+            !text.contains("nothing here can carry out board work"),
+            "a capable company must not claim it cannot do board work: {text}"
+        );
+        assert!(
+            !text.contains("unavailable in this context"),
+            "the context is fine; the message was a question: {text}"
+        );
+        // …while everything both causes owe the model survives.
+        assert!(text.contains("Do not retry"), "{text}");
+        assert!(text.contains("report the action as done"), "{text}");
+        assert!(
+            text.contains("the card \"Build the landing page\" was NOT opened"),
+            "the tool's own effect clause is untouched: {text}"
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// …and the inert-context refusal keeps saying the thing that is true only
+    /// of it, so the split is a split rather than a rename.
+    #[tokio::test]
+    async fn the_unwired_refusal_still_says_the_context_cannot_do_board_work() {
+        let queue = DelegationQueue::default();
+        let refused = SpawnTaskTool::new(queue.clone())
+            .execute(json!({ "title": "Ship it" }))
+            .await
+            .expect("execute");
+        let text = refused.text();
+        assert!(refused.is_error, "{text}");
+        assert!(
+            text.contains("nothing here can carry out board work"),
+            "{text}"
+        );
+        assert!(!text.contains("read as a question"), "{text}");
+    }
+
+    /// The measurement finding 3 asks for: the two causes are distinguishable
+    /// as data, not only as prose. Without this the rate at which the triage
+    /// gate fires — the residual miss rate of a keyword classifier with teeth —
+    /// could not be counted apart from a genuinely unwired context.
+    #[test]
+    fn the_two_no_drain_causes_are_countable_apart() {
+        let queue = DelegationQueue::default();
+        let spawn = || Delegation::SpawnTask {
+            title: "Build the landing page".to_string(),
+            note: None,
+            assignee: None,
+        };
+        assert_eq!(
+            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN),
+            Staged::NoDrain(NoDrainReason::Unwired)
+        );
+        let claim = queue.claim_answering();
+        assert_eq!(
+            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN),
+            Staged::NoDrain(NoDrainReason::Triage)
+        );
+        // …and a hand-off is not refused at all under the same claim, because it
+        // is how the question gets answered (finding 2).
+        assert_eq!(
+            queue.push_within_cap(
+                Delegation::DelegateToDesk {
+                    desk: "eng".to_string(),
+                    instruction: "what did you ship?".to_string(),
+                },
+                MAX_DELEGATIONS_PER_TURN,
+            ),
+            Staged::Queued
+        );
+        drop(claim);
+        assert_ne!(
+            NoDrainReason::Unwired.as_str(),
+            NoDrainReason::Triage.as_str(),
+            "the log field must separate them"
+        );
     }
 
     /// The defect #419 names: the tool told the model "it will be opened on the

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -300,6 +300,24 @@ pub enum Delegation {
     },
 }
 
+impl Delegation {
+    /// Whether this delegation is a way of **answering** the operator, rather
+    /// than only a write to the board (issue #267).
+    ///
+    /// Only [`DelegateToDesk`](Self::DelegateToDesk) is. It runs a teammate's
+    /// turn and hands their reply back for the orchestrator to relay, so it is
+    /// how a question the orchestrator cannot answer alone reaches somebody who
+    /// can — "what did the design desk ship this week?" is unanswerable without
+    /// it. [`SpawnTask`](Self::SpawnTask), [`AssignTask`](Self::AssignTask) and
+    /// [`ReviewTask`](Self::ReviewTask) change the board and return nothing to
+    /// say, so they have no answering role and stay refused on a question turn.
+    ///
+    /// This is what [`DrainClaim::Answering`] filters on.
+    pub fn answers(&self) -> bool {
+        matches!(self, Self::DelegateToDesk { .. })
+    }
+}
+
 /// A shared, in-memory queue the delegation tools push onto and the harness
 /// brain drains. Cheap to [`Clone`] (a shared handle); the same underlying
 /// queue is seen by the tools captured into the orchestrator agent and by the
@@ -332,10 +350,10 @@ pub enum Delegation {
 #[derive(Clone, Default)]
 pub struct DelegationQueue {
     inner: Arc<Mutex<Vec<Delegation>>>,
-    /// Whether some drain site has promised to drain what is staged here
-    /// (issue #453). `false` — nothing drains — is the default and the
+    /// What the live claim on this queue permits (issues #453, #267).
+    /// [`DrainClaim::Unclaimed`] — nothing drains — is the default and the
     /// fail-safe direction.
-    committed: Arc<Mutex<bool>>,
+    committed: Arc<Mutex<DrainClaim>>,
     /// Desk keys a `delegate_to_desk` call named that the company does not have
     /// (issue #272).
     ///
@@ -366,9 +384,18 @@ impl DelegationQueue {
             .push(delegation);
     }
 
-    /// Whether a drain site has committed to draining this queue (issue #453).
-    pub fn drain_committed(&self) -> bool {
+    /// What the live claim on this queue permits (issues #453, #267).
+    pub fn claim_state(&self) -> DrainClaim {
         *self.committed.lock().expect("delegation commitment")
+    }
+
+    /// Whether a drain site has committed to draining this queue (issue #453).
+    ///
+    /// True for **both** claim kinds: an answering claim drains exactly like a
+    /// full one, it merely narrows what may be staged. Callers that need the
+    /// distinction want [`claim_state`](Self::claim_state).
+    pub fn drain_committed(&self) -> bool {
+        self.claim_state() != DrainClaim::Unclaimed
     }
 
     /// Claims this queue for a drain site that promises to drain it, for as long
@@ -383,8 +410,29 @@ impl DelegationQueue {
     /// the claim's scope *is* the window in which delegating works.
     #[must_use = "the claim releases on drop; dropping it immediately un-claims the queue"]
     pub fn claim(&self) -> DelegationClaim {
+        self.claim_as(DrainClaim::Full)
+    }
+
+    /// Claims this queue for a turn whose operator message triaged as a
+    /// question (issue #267).
+    ///
+    /// Identical to [`claim`](Self::claim) in every way that matters to the
+    /// drain — it runs, and it runs the same code — but only delegations that
+    /// [`answer`](Delegation::answers) may be staged under it. The three pure
+    /// board writes are refused at the tool boundary in the model's own turn.
+    ///
+    /// This exists because withholding the claim outright was too blunt: it
+    /// took `delegate_to_desk` away too, and that tool is how a question the
+    /// orchestrator cannot answer alone gets routed to a desk that can.
+    #[must_use = "the claim releases on drop; dropping it immediately un-claims the queue"]
+    pub fn claim_answering(&self) -> DelegationClaim {
+        self.claim_as(DrainClaim::Answering)
+    }
+
+    /// The shared body of the two claim constructors.
+    fn claim_as(&self, state: DrainClaim) -> DelegationClaim {
         self.clear();
-        *self.committed.lock().expect("delegation commitment") = true;
+        *self.committed.lock().expect("delegation commitment") = state;
         DelegationClaim {
             queue: self.clone(),
         }
@@ -420,8 +468,12 @@ impl DelegationQueue {
     /// therefore distinct [`Staged`] variants and never collapsed.
     #[must_use = "a refused delegation must be reported to the model, not dropped"]
     pub fn push_within_cap(&self, delegation: Delegation, cap: usize) -> Staged {
-        if !self.drain_committed() {
-            return Staged::NoDrain;
+        match self.claim_state() {
+            DrainClaim::Unclaimed => return Staged::NoDrain,
+            // Issue #267: the operator asked a question. A hand-off is how one
+            // gets answered, so it stages; the pure board writes do not.
+            DrainClaim::Answering if !delegation.answers() => return Staged::NoDrain,
+            DrainClaim::Answering | DrainClaim::Full => {}
         }
         let mut guard = self.inner.lock().expect("delegation queue");
         if guard.len() >= cap {
@@ -512,10 +564,35 @@ impl DelegationQueue {
 pub enum Staged {
     /// Queued; some drain site will execute it as this turn completes.
     Queued,
-    /// Nothing has claimed the queue, so nothing would ever execute it.
+    /// Nothing that would execute *this* delegation has claimed the queue —
+    /// either because nobody claimed it at all (issue #453) or because the
+    /// claim is narrowed to answering and this is a pure board write
+    /// (issue #267, [`DrainClaim::Answering`]).
     NoDrain,
     /// This turn has already queued [`MAX_DELEGATIONS_PER_TURN`].
     OverCap,
+}
+
+/// What the live claim on a [`DelegationQueue`] permits (issues #453, #267).
+///
+/// The gate on a question turn is a *narrowing* rather than a withdrawal, and
+/// this is where the difference lives. Before #267's review the answering case
+/// was expressed by simply not claiming, which could only say "no board work at
+/// all" — and that took `delegate_to_desk` with it, leaving the orchestrator
+/// unable to consult a desk about the very question it was asked.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum DrainClaim {
+    /// No drain site has claimed the queue: nothing may be staged, because
+    /// nothing would ever execute it. The default and the fail-safe direction.
+    #[default]
+    Unclaimed,
+    /// A drain site has claimed the queue and will execute anything staged.
+    Full,
+    /// A drain site has claimed the queue for a turn whose operator message
+    /// triaged as [`MessageTriage::Answer`](crate::company::task_intent::MessageTriage)
+    /// (issue #267). The drain runs exactly as under [`Full`](Self::Full); only
+    /// delegations that [`answer`](Delegation::answers) may be staged.
+    Answering,
 }
 
 /// The live claim on a [`DelegationQueue`] — proof that some drain site is
@@ -537,7 +614,7 @@ pub struct DelegationClaim {
 
 impl Drop for DelegationClaim {
     fn drop(&mut self) {
-        *self.queue.committed.lock().expect("delegation commitment") = false;
+        *self.queue.committed.lock().expect("delegation commitment") = DrainClaim::Unclaimed;
         self.queue.clear();
     }
 }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -597,9 +597,14 @@ pub enum NoDrainReason {
 impl NoDrainReason {
     /// The value the `reason` log field carries, so the two causes can be
     /// counted apart in production.
+    ///
+    /// `drain_unwired` rather than the `no_drain_wired` this shipped with: the
+    /// old value parsed just as readily as "a no-drain **was** wired", the
+    /// opposite of what it records, and this label is the field the whole
+    /// countability argument rests on (issue #267 review).
     pub fn as_str(&self) -> &'static str {
         match self {
-            Self::Unwired => "no_drain_wired",
+            Self::Unwired => "drain_unwired",
             Self::Triage => "triaged_as_question",
         }
     }

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -190,39 +190,68 @@ pub fn is_delegation_tool(tool: &str) -> bool {
 /// whichever tool was chosen. What the brief has to do now is stop the model
 /// *double-tracking* (a `spawn_task` beside every hand-off), which is why it
 /// tells it what `spawn_task` is still for.
+///
+/// # Answering leads, and the tool list stopped being the shape (issue #267)
+///
+/// The discrimination rule was already here — *"act on the board only when it
+/// genuinely helps — otherwise answer directly and concisely"* — as the closing
+/// clause of a brief that spent its length enumerating seven action tools and
+/// how to use each. **The structure read as an invitation to act with a caveat
+/// attached, and behaviour followed the structure rather than the caveat.** Six
+/// cards sat unworked in `backlog` on a live company, and four of them were
+/// asks to *create a workflow* that the orchestrator could have authored in the
+/// turn it was asked.
+///
+/// So the default moved to the front and the enumeration was trimmed to fit
+/// underneath it. Two things changed in substance rather than order:
+///
+/// * *A question about state is never a card* is now stated, not implied.
+/// * `create_workflow` is framed as **something to do this turn**, not a
+///   capability to mention. That is what un-deadens the four workflow cards'
+///   class: Layer A still opens the `Track` card for "create a workflow named
+///   X" — it *is* an instruction — but the orchestrator now completes it
+///   instead of leaving it to rot.
+///
+/// This is guidance, and the two deterministic layers in
+/// [`triage_message`](crate::company::task_intent::triage_message) and
+/// `DelegationRunner::handle_operator_message` are what make the outcome not
+/// depend on it.
+///
+/// # Budget
+///
+/// Persona-appended, so it sits OUTSIDE the issue-#417
+/// [`TOOL_RESULT_BUDGET_BYTES`](crate::harness::build::TOOL_RESULT_BUDGET_BYTES)
+/// insight-document budget and cannot crowd out the Desks section
+/// `delegate_to_desk` depends on. Kept no longer than it already was regardless
+/// — see `the_brief_leads_with_answering_and_did_not_grow`.
 pub fn orchestrator_brief() -> String {
     " You are also this company's orchestrator: the single point of contact for the operator. \
-Answer from whole-company context. Two decisions come up constantly and they are INDEPENDENT — do \
-not collapse them into one. (1) WHO SHOULD DO THIS: when a request belongs to a specialist desk, \
-hand it to that desk with `delegate_to_desk` rather than answering from your own guess; when it is \
-yours to answer, answer it. (2) SHOULD THIS BE TRACKED: you do not have to decide this, and you \
-must not pick a tool in order to influence it. Anything substantial handed to a desk is opened as a \
-board card automatically, and so is anything substantial an operator asks a desk or teammate \
-directly — the hand-off IS the card, so never call `spawn_task` alongside a `delegate_to_desk` for \
-the same work, and never prefer one over the other to get something tracked. Reach for `spawn_task` \
-only for work that belongs on the board but must NOT start in this turn: something for later, for \
-somebody else, or waiting on a person. Use `query_company` to ground answers in the \
-company's durable facts, recent activity, saved workflows, team roster, and desks — it is the \
-source of truth for what workflows exist, who is on the team, and which desks can take work, so \
-consult it before answering \"what workflows/teammates do we have?\" or before delegating, rather \
-than guessing or naming a skill \
-— `delegate_to_desk` to hand a turn to a desk's lead \
-member, naming the desk by an id `query_company` lists under Desks (a desk is not a person: \
-handing work to a teammate's name is not a delegation), \
-`spawn_task` to open a card for work that should wait rather than start now, `run_workflow` to execute one of the \
-company's saved workflows by id (for example to advance or finish a task that is waiting on a \
-workflow run) — you can run workflows yourself; never claim the run_workflow tool is unavailable — \
-`create_workflow` to author and save a brand-new workflow graph (a trigger plus agent / tool / \
-condition / output steps) when a repeatable process is worth capturing — it's enabled immediately \
-and runnable with run_workflow — and `add_agent` to bring on a new teammate (a name, role, and \
-optional mandate) when the company genuinely needs one — it becomes a real, addressable member of \
-the team starting next turn. \
-You also own the board's lifecycle: `assign_task` to set or change who owns an existing card (this \
-records ownership only — moving the card to In Progress is what starts the work), and \
-`review_task` to record your verdict on a card awaiting review, either `approve` when the work is \
-accepted or `revise` to send it back to To-do for another pass. \
-Delegate, run or create a workflow, add a teammate, or act on the board only when it genuinely \
-helps — otherwise answer directly and concisely."
+MOST MESSAGES ARE QUESTIONS OR QUICK READS. Answer them from whole-company context and touch \
+nothing else. A question about state — what is on the board, what workflows exist, who is on the \
+team, what happened — is NEVER a card. Use `query_company`: it is the source of truth for the \
+company's durable facts, recent activity, saved workflows, team roster and desks, so consult it \
+before answering rather than guessing, then answer directly and concisely. A board write is the \
+exception and needs a reason. \
+When there IS work, two decisions come up and they are INDEPENDENT — do not collapse them into \
+one. (1) WHO SHOULD DO THIS: when a request belongs to a specialist desk, hand it to that desk \
+with `delegate_to_desk`, naming the desk by an id `query_company` lists under Desks (a desk is not \
+a person: handing work to a teammate's name is not a delegation); when it is yours to answer, \
+answer it. (2) SHOULD THIS BE TRACKED: you do not have to decide this, and you must not pick a \
+tool in order to influence it. Anything substantial handed to a desk is opened as a board card \
+automatically, and so is anything substantial an operator asks a desk or teammate directly — the \
+hand-off IS the card, so never call `spawn_task` alongside a `delegate_to_desk` for the same work, \
+and never prefer one over the other to get something tracked. Reach for `spawn_task` only for work \
+that belongs on the board but must NOT start in this turn: something for later, for somebody else, \
+or waiting on a person. \
+WHEN YOU CAN DO THE WORK IN THIS TURN, DO IT — do not park it as a card for later. Asked to \
+capture a repeatable process (\"create a workflow that…\"), author it NOW with `create_workflow` — \
+a trigger plus agent / tool / condition / output steps — and say it is ready; it is enabled \
+immediately and runnable. `run_workflow` executes a saved workflow by id, including to advance a \
+task waiting on a run; you can run workflows yourself, so never claim that tool is unavailable. \
+`add_agent` brings on a new teammate when the company genuinely needs one. \
+You also own the board's lifecycle: `assign_task` sets who owns an existing card (ownership only — \
+moving it to In Progress is what starts the work), and `review_task` records `approve` or `revise` \
+on a card awaiting review."
         .to_string()
 }
 
@@ -2947,6 +2976,59 @@ mod tests {
             tools: Vec::new(),
             budget_usd_daily: None,
         }
+    }
+
+    /// Issue #267: the brief's **shape** is the thing under test, because the
+    /// shape is what the model followed. Answering has to lead, the
+    /// never-a-card rule has to be stated rather than implied, authoring a
+    /// workflow has to read as something done in this turn, and the whole thing
+    /// has to be no longer than the version it replaced — a "rebalance" that
+    /// grew the brief would just be more prose competing with the lead.
+    #[test]
+    fn the_brief_leads_with_answering_and_did_not_grow() {
+        let brief = orchestrator_brief();
+
+        // The default leads. Measured by position, not by presence: the old
+        // brief contained the same rule as its closing clause and behaviour
+        // followed the enumeration instead.
+        let answer_first = brief
+            .find("MOST MESSAGES ARE QUESTIONS OR QUICK READS")
+            .expect("the answering default is stated");
+        for later in [
+            "delegate_to_desk",
+            "spawn_task",
+            "create_workflow",
+            "add_agent",
+            "assign_task",
+            "review_task",
+        ] {
+            let at = brief.find(later).unwrap_or_else(|| panic!("names {later}"));
+            assert!(
+                answer_first < at,
+                "`{later}` is introduced before the answering default"
+            );
+        }
+
+        assert!(
+            brief.contains("is NEVER a card"),
+            "the never-a-card rule must be stated, not implied: {brief}"
+        );
+        // The #442 two-decisions block survives the restructure.
+        assert!(brief.contains("they are INDEPENDENT"), "{brief}");
+        assert!(brief.contains("the hand-off IS the card"), "{brief}");
+        // A "create a workflow" ask is authored now, not parked.
+        assert!(
+            brief.contains("author it NOW with `create_workflow`"),
+            "the automate path must read as this-turn work: {brief}"
+        );
+
+        // The length of the brief this replaced. A ceiling, not a target.
+        const PREVIOUS_LEN: usize = 2784;
+        assert!(
+            brief.len() <= PREVIOUS_LEN,
+            "the brief grew to {} (was {PREVIOUS_LEN})",
+            brief.len()
+        );
     }
 
     /// Issue #276: both directions of the arming summary, including the name

--- a/src/runtime/board_events.rs
+++ b/src/runtime/board_events.rs
@@ -1,8 +1,9 @@
 //! Issue #464: the board announces its own writes.
 //!
 //! A card can come into being on several paths — chat intake's deterministic
-//! `detect_task_intent`, a delegation opening a card for a desk, the publish
-//! drain, the console's `POST …/tasks` — and before this nothing on the company
+//! triage (`company::task_intent::triage_message`, which opens a card only for
+//! the messages it classes as work), a delegation opening a card for a desk,
+//! the publish drain, the console's `POST …/tasks` — and before this nothing on the company
 //! feed said so. The durable task events all describe a card that *already*
 //! exists ([`TaskDispatched`](CompanyEvent::TaskDispatched) fires on the
 //! `in_progress` edge, [`DeskTaskCompleted`](CompanyEvent::DeskTaskCompleted) on

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -354,6 +354,50 @@ impl<'a> DelegationRunner<'a> {
         message: &str,
         chat_id: Option<&str>,
     ) -> Result<OperatorTurn> {
+        // What this message IS, decided once (issue #267).
+        //
+        // Evaluated here, and only here, for one reason: this is the only place
+        // the operator's OWN words are still in scope. `run_delegation` receives
+        // the instruction the model wrote, which is a different sentence — a
+        // guard placed there would be asking the triage about the model's prose
+        // rather than about the message the handler classified. #442 put the
+        // stand-down in `open_direct_work_card` only, so a recognised imperative
+        // the orchestrator handed off produced the REST card AND the delegation
+        // card. One message, one card — so every card-opening path below reads
+        // this same answer.
+        let triage = crate::company::task_intent::triage_message(operator_words(message));
+        // Issue #267, Layer B: on a question, the model may NOT write to the
+        // board at all.
+        //
+        // Layer A (the REST handler) already declines to card a question, but
+        // that closes one of two doors. The other is the model calling
+        // `spawn_task` / `delegate_to_desk` / `assign_task` / `review_task`
+        // itself — which is exactly where the "Tell what is there in the tasks
+        // list" card came from, a pure read that only wanted one
+        // `query_company` call. A brief cannot close that door; it is guidance,
+        // and behaviour follows structure rather than caveats.
+        //
+        // Withholding the #453 claim is what closes it, and it reuses semantics
+        // that already exist rather than adding a second mechanism: with no
+        // claim, `push_within_cap` returns `Staged::NoDrain` and every one of
+        // those tools fails **in the model's own turn** with a message telling
+        // it not to retry and not to report the action as done. The read tools
+        // are untouched — `query_company`, `run_workflow` and `read_run_output`
+        // execute inline and never reach the queue — so the turn keeps every
+        // means of actually answering the question. That asymmetry is the whole
+        // design: it removes the ability to write, not the ability to reply.
+        //
+        // `Chatter` deliberately does NOT gate. It is the ambiguous bucket, and
+        // taking board tools away on a maybe would turn a triage miss into work
+        // the company silently refuses to do — the expensive direction of the
+        // issue's own tie-breaker (a missed card costs one follow-up message).
+        //
+        // Cross-brain: this is the harness path only. `HostedMedullaBrain` has
+        // no delegation stack at all (issue #176), so there is no model
+        // board-write path to gate there; when #176 copies this drain site
+        // through the canonical `delegation_tools` seam, the conditional claim
+        // comes with it. Layer A above fronts both brains in the meantime.
+        let answering = triage.is_answer();
         // Claim the delegation queue for this turn and its drain (issue #453).
         //
         // The acquire-clear subsumes the bare `clear()` this used to open with —
@@ -367,20 +411,18 @@ impl<'a> DelegationRunner<'a> {
         // Additive beside the `approvals` handle #474 wired: they do not
         // interact — one reads a count either side of a turn, this one owns the
         // queue's write window.
-        let _claim = self.queue.claim();
+        let _claim = match answering {
+            // No claim — but still do the half of it that is a safety property
+            // rather than a permission: a delegation some other path staged must
+            // never be executed by this turn's drain below.
+            true => {
+                self.queue.clear();
+                None
+            }
+            false => Some(self.queue.claim()),
+        };
         // Issue #463: did the REST chat handler already card this message?
-        //
-        // Evaluated ONCE, here, and for one reason: this is the only place the
-        // operator's OWN words are still in scope. `run_delegation` receives the
-        // instruction the model wrote, which is a different sentence — a guard
-        // placed there would be asking the detector about the model's prose
-        // rather than about the message the handler classified. #442 put the
-        // stand-down in `open_direct_work_card` only, so a recognised imperative
-        // the orchestrator handed off produced the REST card AND the delegation
-        // card. One message, one card — so every card-opening path below reads
-        // this same answer.
-        let carded_by_handler =
-            crate::company::task_intent::detect_task_intent(operator_words(message)).is_some();
+        let carded_by_handler = triage.title().is_some();
         // …and *which* card that is, when it is still on the board. Adopting it
         // is what carries "one message, one card" through the publish drain too:
         // the caller files a published deliverable onto `spawned_task` rather
@@ -397,7 +439,7 @@ impl<'a> DelegationRunner<'a> {
         // the tracking decision stops depending on which agent answered or which
         // tools it happens to carry.
         let mut direct_card = self
-            .open_direct_work_card(responder, message, chat_id, carded_by_handler)
+            .open_direct_work_card(responder, message, chat_id, carded_by_handler, answering)
             .await?;
         // Issue #465: sampled either side of the turn so the settle below reads
         // what *this* turn parked, not what the cycle was already holding from
@@ -862,14 +904,37 @@ impl<'a> DelegationRunner<'a> {
     /// `carded_by_handler`, because the hand-off path needed the same guard and
     /// only [`handle_operator_message`](Self::handle_operator_message) can
     /// answer the question (issue #463).
+    /// # It also stands down on a question (issue #267)
+    ///
+    /// This is the **third** card path, and it is the one a triage layer would
+    /// miss if it only looked at the orchestrator: asking a desk lead "what did
+    /// you ship this week?" runs their turn directly, and [`is_trackable_work`]
+    /// — whose default is `true` by design — reads a sentence that long as work
+    /// and cards it. `answering` is the operator's own message triaged as
+    /// [`MessageTriage::Answer`](crate::company::task_intent::MessageTriage),
+    /// which is a positive statement that the message was a read, so it
+    /// outranks that default.
+    ///
+    /// Deliberately narrower than the queue gate above: this suppresses a card,
+    /// it does not take any tool away, and the desk lead still answers exactly
+    /// as before.
     async fn open_direct_work_card(
         &self,
         responder: &str,
         message: &str,
         chat_id: Option<&str>,
         carded_by_handler: bool,
+        answering: bool,
     ) -> Result<Option<TaskRecord>> {
         if responder == self.orchestrator_id() {
+            return Ok(None);
+        }
+        if answering {
+            tracing::debug!(
+                company = %self.company,
+                responder = %responder,
+                "[delegation] not opening a direct card: the operator asked a question"
+            );
             return Ok(None);
         }
         self.open_work_card(responder, message, chat_id, carded_by_handler)
@@ -1742,6 +1807,15 @@ investor update for the quarter\n]"
         /// (issue #465), pushed onto the shared approval queue exactly as the
         /// real [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) does.
         parks: Vec<String>,
+        /// Board writes this turn attempts **through the real tool boundary**
+        /// ([`DelegationQueue::push_within_cap`]) rather than through
+        /// [`queues`](Self::queues), which is the test escape hatch and bypasses
+        /// both the cap and the #453 commitment.
+        ///
+        /// Issue #267 needs the boundary: the whole gate is that a `spawn_task`
+        /// on a question turn is REFUSED in the model's own turn, and a fixture
+        /// that pushed straight onto the queue could never observe the refusal.
+        tool_pushes: Vec<Delegation>,
     }
 
     impl Turn {
@@ -1756,6 +1830,16 @@ investor update for the quarter\n]"
             Self {
                 reply: reply.to_string(),
                 queues,
+                ..Self::default()
+            }
+        }
+
+        /// A turn that reaches for a board tool the way the model does — through
+        /// the tool boundary, where it can be refused (issue #267).
+        fn tooling(reply: &str, tool_pushes: Vec<Delegation>) -> Self {
+            Self {
+                reply: reply.to_string(),
+                tool_pushes,
                 ..Self::default()
             }
         }
@@ -1799,6 +1883,9 @@ investor update for the quarter\n]"
         /// turn was entitled to delegate at all — rather than only that the
         /// drain happened to run afterwards.
         committed_at_turn: Mutex<Vec<bool>>,
+        /// What the tool boundary answered for each
+        /// [`Turn::tool_pushes`] entry, in order across all turns (issue #267).
+        staged: Mutex<Vec<orchestrator::Staged>>,
         tasks: Arc<dyn TaskStore>,
         company: CompanyId,
     }
@@ -1812,9 +1899,16 @@ investor update for the quarter\n]"
                 calls: Mutex::new(Vec::new()),
                 board_at_turn: Mutex::new(Vec::new()),
                 committed_at_turn: Mutex::new(Vec::new()),
+                staged: Mutex::new(Vec::new()),
                 tasks: fx.tasks.clone(),
                 company: fx.record.id.clone(),
             }
+        }
+
+        /// What the tool boundary answered every [`Turn::tool_pushes`] call, in
+        /// order (issue #267).
+        fn staged(&self) -> Vec<orchestrator::Staged> {
+            self.staged.lock().expect("staged").clone()
         }
 
         /// `(agent_id, message)` for every turn run, in order.
@@ -1865,6 +1959,14 @@ investor update for the quarter\n]"
                 .unwrap_or_else(|| panic!("unscripted turn: {agent_id} <- {message}"));
             for delegation in turn.queues {
                 self.queue.push(delegation);
+            }
+            // …and the ones that go through the boundary a real tool goes
+            // through, recording what it answered (issue #267).
+            for delegation in turn.tool_pushes {
+                let staged = self
+                    .queue
+                    .push_within_cap(delegation, orchestrator::MAX_DELEGATIONS_PER_TURN);
+                self.staged.lock().expect("staged").push(staged);
             }
             for tool in turn.parks {
                 self.approvals
@@ -2532,6 +2634,174 @@ members = ["engineer"]
             .expect("operator message handled");
         assert!(fx.cards().await.is_empty());
         assert!(turn.spawned_task.is_none());
+    }
+
+    // ── Issue #267: a question may not write to the board, by either door ────
+
+    /// The gate itself. On a question the queue is never claimed, so the
+    /// **model's own** `spawn_task` is refused inside its turn — with the
+    /// `NoDrain` refusal, which is the one that tells it not to retry — and no
+    /// card exists afterwards.
+    ///
+    /// This is the door Layer A cannot close. "Tell what is there in the tasks
+    /// list" has no action verb and no request frame, so the REST handler never
+    /// saw it as work; it became a card because the orchestrator called
+    /// `spawn_task` on a pure read.
+    #[tokio::test]
+    async fn a_question_turn_has_its_board_tools_refused_and_leaves_no_card() {
+        let question = "Tell what is there in the tasks list";
+        assert!(
+            crate::company::task_intent::triage_message(question).is_answer(),
+            "fixture must triage as a question, or this proves nothing"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::tooling(
+                "here is the list",
+                vec![Delegation::SpawnTask {
+                    title: "Tell what is there in the tasks list".to_string(),
+                    note: None,
+                    assignee: None,
+                }],
+            )],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", question, None)
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            !turns.committed_at_turn(0),
+            "a question turn must run with the delegation queue unclaimed"
+        );
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::NoDrain],
+            "the refusal must be the do-not-retry one, not the try-again-next-turn one"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "a question left work on the board"
+        );
+        assert!(turn.spawned_task.is_none());
+        // The reply still comes back: the gate removes the ability to write, not
+        // the ability to answer.
+        assert_eq!(turn.reply, "here is the list");
+    }
+
+    /// `Chatter` is NOT gated. It is the ambiguous bucket, and taking board
+    /// tools away on a maybe would turn a triage miss into work the company
+    /// silently refuses to do.
+    #[tokio::test]
+    async fn an_ambiguous_message_keeps_its_board_tools() {
+        let neutral = "the deck looks good to me";
+        assert_eq!(
+            crate::company::task_intent::triage_message(neutral),
+            crate::company::task_intent::MessageTriage::Chatter,
+            "fixture must be the ambiguous bucket, or this proves nothing"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "noted — I'll track the follow-up",
+                    vec![Delegation::SpawnTask {
+                        title: "Follow up on the deck".to_string(),
+                        note: None,
+                        assignee: None,
+                    }],
+                ),
+                Turn::reply("relayed"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", neutral, None)
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            turns.committed_at_turn(0),
+            "chatter must still run under a claim"
+        );
+        assert_eq!(turns.staged(), vec![orchestrator::Staged::Queued]);
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "the delegation still ran: {cards:?}");
+        assert_eq!(cards[0].title, "Follow up on the deck");
+        assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
+    }
+
+    /// `Track` is unchanged: a real instruction still runs under a claim, still
+    /// delegates, and the #463 stand-down still holds.
+    #[tokio::test]
+    async fn a_tracked_instruction_still_delegates_under_a_claim() {
+        let imperative = "draft the launch plan for next quarter";
+        assert!(
+            crate::company::task_intent::detect_task_intent(imperative).is_some(),
+            "fixture must be a message the chat handler cards"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it over", vec![handoff("Draft the launch plan.")]),
+                Turn::reply("drafted"),
+                Turn::reply("the desk drafted it"),
+            ],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        assert!(turns.committed_at_turn(0), "an instruction turn is claimed");
+        assert_eq!(turns.staged(), vec![orchestrator::Staged::Queued]);
+        assert_eq!(
+            turns.calls().len(),
+            3,
+            "the hand-off, the desk turn and the relay all ran: {:?}",
+            turns.calls()
+        );
+        // Stand-down intact: the handler's card is the card, and this path,
+        // finding none on the board, opens none either (issue #463).
+        assert!(fx.cards().await.is_empty(), "no second card");
+    }
+
+    /// The third card path (issue #442 path one), which a triage layer looking
+    /// only at the orchestrator would miss: asking a desk lead a question about
+    /// their own work runs their turn directly, and `is_trackable_work` — whose
+    /// default is `true` — used to read a sentence that long as work.
+    #[tokio::test]
+    async fn a_desk_lead_asked_a_question_directly_opens_no_card() {
+        // Long enough and free enough of question punctuation that the
+        // opposite-defaults detector on this path calls it work on its own.
+        let question = "Tell me what you shipped this week and what is still open on your plate";
+        assert!(
+            is_trackable_work(question),
+            "the fixture must be work by the direct path's own default, or the \
+             stand-down under test is doing nothing"
+        );
+        assert!(
+            crate::company::task_intent::triage_message(question).is_answer(),
+            "…and a question by the triage, which is what must outrank it"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("shipped the importer")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("engineer", question, Some("eng_desk"))
+            .await
+            .expect("operator message handled");
+
+        assert!(
+            fx.cards().await.is_empty(),
+            "asking a desk lead what they shipped opened a card"
+        );
+        assert!(turn.spawned_task.is_none());
+        assert_eq!(turn.reply, "shipped the importer");
     }
 
     /// The orchestrator's own chat turn is not tracked here. It is the front

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -427,6 +427,19 @@ impl<'a> DelegationRunner<'a> {
         // is what carries "one message, one card" through the publish drain too:
         // the caller files a published deliverable onto `spawned_task` rather
         // than minting a second card beside this one (issue #463).
+        //
+        // Adoption is NOT a settle, and one path notices (issue #678). When the
+        // orchestrator answers "create a workflow named X" by authoring the
+        // graph in-turn with the inline `create_workflow` tool, this card is
+        // adopted — the bubble links to it — but nothing moves it out of To-do:
+        // `CreateWorkflowTool` stages onto the `WorkflowRefQueue`, which is
+        // drained only by the dispatched-card path in `HarnessBrain::run_task`,
+        // and the publish drain settles from `pending_publishes`, which
+        // `create_workflow` never populates. The operator does get the workflow;
+        // the card is what lags. Fixing it needs a `workflow_refs` handle here
+        // AND a notion of task output without a run row (`TaskOutput.run_id` is
+        // required and a chat turn has no run) — both #183's territory, so it is
+        // tracked rather than bolted on.
         let handler_card = match carded_by_handler {
             true => self.chat_handler_card(message).await?,
             false => None,

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -570,6 +570,25 @@ impl<'a> DelegationRunner<'a> {
             // the turn that wanted it happened to be a relay, which is invisible
             // from the operator's side. Board writes are executed; hand-offs are
             // still dropped, so the bound stays exactly one extra turn.
+            //
+            // On a question turn the relay's board writes are held back too, and
+            // that is deliberate rather than an oversight of the paragraph above
+            // (issue #267 review). `_claim` is still live here — the relay runs
+            // inside the same `claim_answering` scope as the turn that asked —
+            // so `push_within_cap` refuses a relay `spawn_task` with
+            // `NoDrainReason::Triage`, in the relay's own turn, and the model is
+            // told this message was a question rather than that its context
+            // cannot do board work. #442's reasoning does not survive the
+            // narrowing: it says the relay is better placed to decide something
+            // should be *tracked*, and #267 says a message the operator posed as
+            // a question mints no card by any door. The relay is a door, and
+            // seeing the answer first does not change who asked — replying to
+            // "is the build ok?" with a card nobody asked for is the exact
+            // behaviour #267 exists to stop. A relay that genuinely must
+            // commission work has the same recourse the first turn has: say so,
+            // and let the operator ask for it. Pinned by
+            // `the_relay_turns_card_is_held_back_on_a_question_turn` and its
+            // non-question sibling.
             let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Drop).await?;
             if let Some(id) = drained.spawned_task {
                 spawned_task.get_or_insert(id);
@@ -3085,15 +3104,87 @@ members = ["engineer"]
     /// the desk answered, which is exactly when the orchestrator is best placed
     /// to decide something should be followed up — and that decision used to be
     /// dropped by design.
+    ///
+    /// Driven through [`Turn::tooling`] on purpose (issue #267, review round 2):
+    /// the relay's `spawn_task` goes through the real
+    /// [`DelegationQueue::push_within_cap`] boundary, so this pins that the
+    /// board write is *accepted* there rather than only that a delegation pushed
+    /// onto the queue behind the boundary's back gets executed. The fixture
+    /// message is deliberately not a question — the sibling below is the other
+    /// half.
     #[tokio::test]
     async fn the_relay_turn_can_no_longer_lose_a_card() {
+        let instruction = "the pricing repo needs a map";
+        assert!(
+            !crate::company::task_intent::triage_message(instruction).is_answer(),
+            "the fixture must NOT be a question, or #267 holds the relay's card back \
+             and this proves nothing about #442"
+        );
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(
             &fx,
             vec![
-                Turn::queueing("asking", vec![handoff("what's the status of the build?")]),
+                Turn::tooling("asking", vec![handoff("what's the status of the build?")]),
                 Turn::reply("it's red — someone should fix the flaky test"),
-                Turn::queueing(
+                Turn::tooling(
+                    "it's red; I've opened a card",
+                    vec![Delegation::SpawnTask {
+                        title: "Fix the flaky test".to_string(),
+                        note: None,
+                        assignee: None,
+                    }],
+                ),
+            ],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", instruction, None)
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued, orchestrator::Staged::Queued],
+            "the relay turn's board write is accepted at the tool boundary, not \
+             merely executed once past it"
+        );
+        let cards = fx.cards().await;
+        assert!(
+            cards.iter().any(|c| c.title == "Fix the flaky test"),
+            "the relay's card survives: {cards:?}"
+        );
+    }
+
+    /// …and the other half: on a **question** the relay's board write is held
+    /// back too, refused at the boundary with the triage named as the cause.
+    ///
+    /// This is the #442 × #267 interaction, and it is deliberate rather than an
+    /// oversight. #442 restored the relay's board writes because a card the
+    /// relay opens is not a re-delegation — it is the orchestrator deciding,
+    /// having now seen what came back, that something should be tracked. #267
+    /// says a message the operator posed as a question mints no card by *any*
+    /// door, and the relay turn is a door: it runs under the same live
+    /// `claim_answering` as the turn that asked, so the narrowing reaches it.
+    /// Answering "is the build ok?" with a card nobody asked for is exactly the
+    /// behaviour #267 exists to stop, and the relay seeing the answer first does
+    /// not change who asked.
+    ///
+    /// The refusal is [`orchestrator::NoDrainReason::Triage`], not `Unwired` —
+    /// the claim is live throughout, so the relay is told *this message* is a
+    /// question rather than that its context can never do board work.
+    #[tokio::test]
+    async fn the_relay_turns_card_is_held_back_on_a_question_turn() {
+        let question = "is the build ok?";
+        assert!(
+            crate::company::task_intent::triage_message(question).is_answer(),
+            "fixture must triage as a question, or this proves nothing"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("asking", vec![handoff("what's the status of the build?")]),
+                Turn::reply("it's red — someone should fix the flaky test"),
+                Turn::tooling(
                     "it's red; I've opened a card",
                     vec![Delegation::SpawnTask {
                         title: "Fix the flaky test".to_string(),
@@ -3105,28 +3196,49 @@ members = ["engineer"]
         );
         let turn = fx
             .runner(&turns)
-            .handle_operator_message("chief", "is the build ok?", None)
+            .handle_operator_message("chief", question, None)
             .await
             .expect("operator message handled");
 
-        let cards = fx.cards().await;
-        assert_eq!(cards.len(), 1, "the relay's card survives: {cards:?}");
-        assert_eq!(cards[0].title, "Fix the flaky test");
-        assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
+        assert_eq!(
+            turns.claim_at_turn(2),
+            orchestrator::DrainClaim::Answering,
+            "the answering claim is still live for the relay turn"
+        );
+        assert_eq!(
+            turns.staged(),
+            vec![
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::NoDrain(orchestrator::NoDrainReason::Triage),
+            ],
+            "the hand-off answers and stages; the relay's card is refused, and the \
+             refusal names the triage rather than blaming an unwired context"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "a question minted a card through the relay"
+        );
+        assert!(turn.spawned_task.is_none());
     }
 
     /// …while the rule the discard existed for still holds: a relay may relay,
     /// never re-delegate. A hand-off queued by the relay turn is dropped, so
     /// there is no second desk turn and no loop.
+    ///
+    /// Through the real boundary too: the relay's hand-off *stages* — it
+    /// answers, so even the narrowed claim admits it — and is dropped at the
+    /// drain by [`HandOffs::Drop`]. Which is the point: the loop is stopped by
+    /// the drain's own rule and not incidentally by #267's gate, so the bound
+    /// survives on a non-question message as well.
     #[tokio::test]
     async fn the_relay_turn_still_cannot_re_delegate() {
         let fx = Fixture::new();
         let turns = ScriptedTurns::new(
             &fx,
             vec![
-                Turn::queueing("asking", vec![handoff("what's the status of the build?")]),
+                Turn::tooling("asking", vec![handoff("what's the status of the build?")]),
                 Turn::reply("green"),
-                Turn::queueing("relaying", vec![handoff("now write the release notes")]),
+                Turn::tooling("relaying", vec![handoff("now write the release notes")]),
             ],
         );
         fx.runner(&turns)
@@ -3134,6 +3246,12 @@ members = ["engineer"]
             .await
             .expect("operator message handled");
 
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued, orchestrator::Staged::Queued],
+            "the relay's hand-off is not refused at the boundary — it is dropped at \
+             the drain, which is what bounds the turn count"
+        );
         // Three turns total — orchestrator, desk, relay. A fourth would be the
         // re-delegation the drain exists to prevent.
         let calls = turns.calls();

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -162,6 +162,27 @@ pub(crate) struct DeskReply {
     pub(crate) steps: Vec<TurnStep>,
 }
 
+/// What was already decided about the operator message a drain belongs to,
+/// before the model said anything (issues #463, #267).
+///
+/// Two facts carried together because they answer the same question and because
+/// a pair of bare `bool` parameters at a call site is a swap waiting to happen.
+/// Both default to `false`, which is the honest reading for every drain with no
+/// operator message in scope — a dispatched card's turn, the approval
+/// re-dispatch — neither of which has a message to have carded or triaged.
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MessageContext {
+    /// The REST chat handler already opened a To-do card for this message
+    /// (issue #463), so no path below may open a second one.
+    pub(crate) carded_by_handler: bool,
+    /// The message triaged as
+    /// [`MessageTriage::Answer`](crate::company::task_intent::MessageTriage)
+    /// (issue #267). A hand-off still **runs** — consulting a desk is how a
+    /// question the orchestrator cannot answer alone gets answered — but it
+    /// opens no card, because nobody commissioned work.
+    pub(crate) answering: bool,
+}
+
 /// Whether a drain may run the hand-offs it finds, or must drop them.
 ///
 /// The CEO-relay turn is the one caller that must drop: a second hand-off from
@@ -366,8 +387,9 @@ impl<'a> DelegationRunner<'a> {
         // card. One message, one card — so every card-opening path below reads
         // this same answer.
         let triage = crate::company::task_intent::triage_message(operator_words(message));
-        // Issue #267, Layer B: on a question, the model may NOT write to the
-        // board at all.
+        // Issue #267, Layer B: on a question, the model may not WRITE to the
+        // board — but it keeps every means of answering, including the one that
+        // runs somebody else's turn.
         //
         // Layer A (the REST handler) already declines to card a question, but
         // that closes one of two doors. The other is the model calling
@@ -377,20 +399,32 @@ impl<'a> DelegationRunner<'a> {
         // `query_company` call. A brief cannot close that door; it is guidance,
         // and behaviour follows structure rather than caveats.
         //
-        // Withholding the #453 claim is what closes it, and it reuses semantics
-        // that already exist rather than adding a second mechanism: with no
-        // claim, `push_within_cap` returns `Staged::NoDrain` and every one of
-        // those tools fails **in the model's own turn** with a message telling
-        // it not to retry and not to report the action as done. The read tools
-        // are untouched — `query_company`, `run_workflow` and `read_run_output`
-        // execute inline and never reach the queue — so the turn keeps every
-        // means of actually answering the question. That asymmetry is the whole
-        // design: it removes the ability to write, not the ability to reply.
+        // The claim is what closes it, and it reuses semantics that already
+        // exist rather than adding a second mechanism. It is **narrowed**, not
+        // withheld (issue #267 review): under `claim_answering` the queue still
+        // drains, `push_within_cap` refuses the three pure board writes with
+        // `Staged::NoDrain` — in the model's own turn, telling it not to retry
+        // and not to report the action as done — and lets a hand-off through.
         //
-        // `Chatter` deliberately does NOT gate. It is the ambiguous bucket, and
-        // taking board tools away on a maybe would turn a triage miss into work
-        // the company silently refuses to do — the expensive direction of the
-        // issue's own tie-breaker (a missed card costs one follow-up message).
+        // Withholding the claim outright was over-broad. `delegate_to_desk` is
+        // not only a board write: it is how a question the orchestrator cannot
+        // answer alone gets routed to a desk that can, and taking it away left
+        // "what did the design desk ship this week?" unanswerable. Its *card*
+        // is the part that must not happen on a question turn, and that is
+        // suppressed one layer down in `run_delegation` — exactly the shape
+        // `open_direct_work_card` already uses. So the claim on the queue
+        // removes the ability to write, and nothing removes the ability to
+        // reply.
+        //
+        // The read tools are untouched throughout — `query_company`,
+        // `run_workflow` and `read_run_output` execute inline and never reach
+        // the queue.
+        //
+        // `Chatter` deliberately does NOT gate at all. It is the ambiguous
+        // bucket, and taking board tools away on a maybe would turn a triage
+        // miss into work the company silently refuses to do — the expensive
+        // direction of the issue's own tie-breaker (a missed card costs one
+        // follow-up message).
         //
         // Cross-brain: this is the harness path only. `HostedMedullaBrain` has
         // no delegation stack at all (issue #176), so there is no model
@@ -412,17 +446,18 @@ impl<'a> DelegationRunner<'a> {
         // interact — one reads a count either side of a turn, this one owns the
         // queue's write window.
         let _claim = match answering {
-            // No claim — but still do the half of it that is a safety property
-            // rather than a permission: a delegation some other path staged must
-            // never be executed by this turn's drain below.
-            true => {
-                self.queue.clear();
-                None
-            }
-            false => Some(self.queue.claim()),
+            true => self.queue.claim_answering(),
+            false => self.queue.claim(),
         };
         // Issue #463: did the REST chat handler already card this message?
         let carded_by_handler = triage.title().is_some();
+        // Everything below that could open a card reads these two facts about
+        // the operator's message rather than re-deriving them from text that is
+        // no longer the operator's (issues #463, #267).
+        let ctx = MessageContext {
+            carded_by_handler,
+            answering,
+        };
         // …and *which* card that is, when it is still on the board. Adopting it
         // is what carries "one message, one card" through the publish drain too:
         // the caller files a published deliverable onto `spawned_task` rather
@@ -452,7 +487,7 @@ impl<'a> DelegationRunner<'a> {
         // the tracking decision stops depending on which agent answered or which
         // tools it happens to carry.
         let mut direct_card = self
-            .open_direct_work_card(responder, message, chat_id, carded_by_handler, answering)
+            .open_direct_work_card(responder, message, chat_id, ctx)
             .await?;
         // Issue #465: sampled either side of the turn so the settle below reads
         // what *this* turn parked, not what the cycle was already holding from
@@ -502,9 +537,7 @@ impl<'a> DelegationRunner<'a> {
         // why the operator bubble linked to nothing on a recognised imperative
         // even though the board carried a card for it.
         let mut spawned_task: Option<String> = handler_card.or(direct_card_id);
-        let drained = self
-            .drain_and_execute(chat_id, carded_by_handler, HandOffs::Run)
-            .await?;
+        let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Run).await?;
         if let Some(id) = drained.spawned_task {
             spawned_task.get_or_insert(id);
         }
@@ -537,9 +570,7 @@ impl<'a> DelegationRunner<'a> {
             // the turn that wanted it happened to be a relay, which is invisible
             // from the operator's side. Board writes are executed; hand-offs are
             // still dropped, so the bound stays exactly one extra turn.
-            let drained = self
-                .drain_and_execute(chat_id, carded_by_handler, HandOffs::Drop)
-                .await?;
+            let drained = self.drain_and_execute(chat_id, ctx, HandOffs::Drop).await?;
             if let Some(id) = drained.spawned_task {
                 spawned_task.get_or_insert(id);
             }
@@ -600,7 +631,7 @@ impl<'a> DelegationRunner<'a> {
     pub(crate) async fn drain_and_execute(
         &self,
         chat_id: Option<&str>,
-        carded_by_handler: bool,
+        ctx: MessageContext,
         hand_offs: HandOffs,
     ) -> Result<Drained> {
         let mut drained = Drained::default();
@@ -616,9 +647,7 @@ impl<'a> DelegationRunner<'a> {
                 );
                 continue;
             }
-            let out = self
-                .run_delegation(delegation, chat_id, carded_by_handler)
-                .await?;
+            let out = self.run_delegation(delegation, chat_id, ctx).await?;
             if let Some(id) = out.spawned_task {
                 drained.spawned_task.get_or_insert(id);
             }
@@ -724,7 +753,8 @@ impl<'a> DelegationRunner<'a> {
                 // therefore no chat-handler card to defer to. It opens no card
                 // of its own regardless — `for_task` is set, which
                 // `open_work_card` refuses on first.
-                self.run_delegation(delegation, None, false).await?;
+                self.run_delegation(delegation, None, MessageContext::default())
+                    .await?;
                 if let Some(desk) = desk {
                     card.note = Some(append_note(
                         card.note.as_deref(),
@@ -751,7 +781,9 @@ impl<'a> DelegationRunner<'a> {
                 self.hand_card_over(card, delegator, &member, instruction_of(&delegation))
                     .await?;
             }
-            let outcome = self.run_delegation(delegation, None, false).await?;
+            let outcome = self
+                .run_delegation(delegation, None, MessageContext::default())
+                .await?;
             match (owns_card, outcome.desk_reply, outcome.cancelled) {
                 // The delegate answered: they own the card and it settles from
                 // their output.
@@ -884,6 +916,49 @@ impl<'a> DelegationRunner<'a> {
         Ok(Some(card))
     }
 
+    /// The card a **hand-off** opens (issue #442, path two), or `None` when
+    /// this hand-off must not open one.
+    ///
+    /// # It stands down on a question, and only the card does (issue #267)
+    ///
+    /// `delegate_to_desk` is the one delegation that ANSWERS. It runs the
+    /// desk's lead and hands their reply back for the orchestrator to relay, so
+    /// it is how a question the orchestrator cannot answer alone — "what did the
+    /// design desk ship this week?" — reaches somebody who can. Refusing the
+    /// tool on a question turn therefore cost the operator the answer, not just
+    /// a card.
+    ///
+    /// So the tool runs and this suppresses the card, which is the same shape
+    /// [`open_direct_work_card`](Self::open_direct_work_card) uses one path
+    /// over and for the same reason: nobody commissioned work, so nothing
+    /// should be tracked — but somebody did ask a question, so somebody should
+    /// answer it. Everything else about the hand-off is untouched: the delegate
+    /// runs, their steps fold onto the operator timeline, and the CEO-relay
+    /// hand-back surfaces their answer.
+    ///
+    /// With no card there is nothing to settle and nothing to report on
+    /// `spawned_task`, which is the honest reading — the console's "Card
+    /// opened" chip must not claim a card that does not exist.
+    async fn open_hand_off_work_card(
+        &self,
+        member: &str,
+        instruction: &str,
+        chat_id: Option<&str>,
+        ctx: MessageContext,
+    ) -> Result<Option<TaskRecord>> {
+        if ctx.answering {
+            tracing::debug!(
+                company = %self.company,
+                delegate = %member,
+                "[delegation] not opening a hand-off card: the operator asked a question, so the \
+                 desk lead answers it without the board carrying work nobody commissioned"
+            );
+            return Ok(None);
+        }
+        self.open_work_card(member, instruction, chat_id, ctx.carded_by_handler)
+            .await
+    }
+
     /// The card for a **desk lead or teammate asked directly** (issue #442,
     /// path one), or `None` when this turn is not that.
     ///
@@ -928,21 +1003,23 @@ impl<'a> DelegationRunner<'a> {
     /// which is a positive statement that the message was a read, so it
     /// outranks that default.
     ///
-    /// Deliberately narrower than the queue gate above: this suppresses a card,
+    /// Deliberately narrower than the queue claim above: this suppresses a card,
     /// it does not take any tool away, and the desk lead still answers exactly
-    /// as before.
+    /// as before. Since #267's review it is no longer the odd one out —
+    /// [`open_hand_off_work_card`](Self::open_hand_off_work_card) stands down
+    /// the same way, so every card path treats a question identically and the
+    /// tool set is narrowed in exactly one place.
     async fn open_direct_work_card(
         &self,
         responder: &str,
         message: &str,
         chat_id: Option<&str>,
-        carded_by_handler: bool,
-        answering: bool,
+        ctx: MessageContext,
     ) -> Result<Option<TaskRecord>> {
         if responder == self.orchestrator_id() {
             return Ok(None);
         }
-        if answering {
+        if ctx.answering {
             tracing::debug!(
                 company = %self.company,
                 responder = %responder,
@@ -950,7 +1027,7 @@ impl<'a> DelegationRunner<'a> {
             );
             return Ok(None);
         }
-        self.open_work_card(responder, message, chat_id, carded_by_handler)
+        self.open_work_card(responder, message, chat_id, ctx.carded_by_handler)
             .await
     }
 
@@ -1087,17 +1164,20 @@ impl<'a> DelegationRunner<'a> {
     /// relay. No sub-agent re-delegation in v1: desk members carry no delegation
     /// tools, so their turns queue nothing.
     ///
-    /// `carded_by_handler` is [`handle_operator_message`](Self::handle_operator_message)'s
-    /// answer to "did the REST chat handler already card the operator message
-    /// this drain belongs to?" (issue #463). It is threaded in rather than
-    /// recomputed because the only text in scope here is the instruction the
-    /// model wrote, which is not what the handler classified. A dispatched
-    /// card's drain has no operator message and passes `false`.
+    /// `ctx` carries what
+    /// [`handle_operator_message`](Self::handle_operator_message) already
+    /// decided about the operator message this drain belongs to — whether the
+    /// REST chat handler carded it (issue #463) and whether it triaged as a
+    /// question (issue #267). Both are threaded in rather than recomputed
+    /// because the only text in scope here is the instruction the *model*
+    /// wrote, which is a different sentence from the one those decisions were
+    /// made about. A dispatched card's drain has no operator message and passes
+    /// [`MessageContext::default`].
     pub(crate) async fn run_delegation(
         &self,
         delegation: Delegation,
         chat_id: Option<&str>,
-        carded_by_handler: bool,
+        ctx: MessageContext,
     ) -> Result<DelegationOutcome> {
         match delegation {
             Delegation::SpawnTask {
@@ -1175,7 +1255,7 @@ impl<'a> DelegationRunner<'a> {
                 // (issue #463), or when the instruction is not a piece of work —
                 // see `is_trackable_work`.
                 let mut card = self
-                    .open_work_card(&member, &instruction, chat_id, carded_by_handler)
+                    .open_hand_off_work_card(&member, &instruction, chat_id, ctx)
                     .await?;
                 // Register the delegated turn so an operator can CANCEL it
                 // mid-flight (cancel-only in v1 — pause/redirect are rejected at
@@ -1890,12 +1970,13 @@ investor update for the quarter\n]"
         /// The board as it looked at the START of each turn, so a test can prove
         /// a card existed *while* an agent worked rather than only afterwards.
         board_at_turn: Mutex<Vec<Vec<(String, String)>>>,
-        /// Whether the delegation queue was **claimed** while each turn ran
-        /// (issue #453). This is what a real tool reads to decide between
+        /// How the delegation queue was **claimed** while each turn ran (issues
+        /// #453, #267). This is what a real tool reads to decide between
         /// staging and refusing, so recording it here is how a test proves the
         /// turn was entitled to delegate at all — rather than only that the
-        /// drain happened to run afterwards.
-        committed_at_turn: Mutex<Vec<bool>>,
+        /// drain happened to run afterwards. Since #267's review it also
+        /// distinguishes the narrowed answering claim from the full one.
+        committed_at_turn: Mutex<Vec<orchestrator::DrainClaim>>,
         /// What the tool boundary answered for each
         /// [`Turn::tool_pushes`] entry, in order across all turns (issue #267).
         staged: Mutex<Vec<orchestrator::Staged>>,
@@ -1935,9 +2016,15 @@ investor update for the quarter\n]"
             self.board_at_turn.lock().expect("board")[n].clone()
         }
 
-        /// Whether the delegation queue was claimed while turn `n` ran (issue
-        /// #453).
+        /// Whether the delegation queue was claimed at all while turn `n` ran
+        /// (issue #453).
         fn committed_at_turn(&self, n: usize) -> bool {
+            self.claim_at_turn(n) != orchestrator::DrainClaim::Unclaimed
+        }
+
+        /// *How* the delegation queue was claimed while turn `n` ran — full, or
+        /// narrowed to answering (issue #267).
+        fn claim_at_turn(&self, n: usize) -> orchestrator::DrainClaim {
             self.committed_at_turn.lock().expect("committed")[n]
         }
 
@@ -1963,7 +2050,7 @@ investor update for the quarter\n]"
             self.committed_at_turn
                 .lock()
                 .expect("committed")
-                .push(self.queue.drain_committed());
+                .push(self.queue.claim_state());
             let turn = self
                 .script
                 .lock()
@@ -2282,7 +2369,11 @@ members = ["engineer"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::reply("done")]);
         let outcome = fx
             .runner(&turns)
-            .run_delegation(handoff("draft the launch plan"), None, false)
+            .run_delegation(
+                handoff("draft the launch plan"),
+                None,
+                MessageContext::default(),
+            )
             .await
             .expect("delegation runs");
         assert!(outcome.spawned_task.is_some());
@@ -2307,7 +2398,11 @@ members = ["engineer"]
         let turns = ScriptedTurns::new(&fx, vec![Turn::cancelled("half-written")]);
         let outcome = fx
             .runner(&turns)
-            .run_delegation(handoff("write the migration plan"), None, false)
+            .run_delegation(
+                handoff("write the migration plan"),
+                None,
+                MessageContext::default(),
+            )
             .await
             .expect("delegation runs");
         assert!(outcome.cancelled);
@@ -2348,7 +2443,11 @@ members = ["engineer"]
         let outcome = fx
             .runner(&turns)
             .for_task("card-1")
-            .run_delegation(handoff("write the migration plan"), None, false)
+            .run_delegation(
+                handoff("write the migration plan"),
+                None,
+                MessageContext::default(),
+            )
             .await
             .expect("delegation runs");
         assert!(outcome.spawned_task.is_none());
@@ -2651,10 +2750,10 @@ members = ["engineer"]
 
     // ── Issue #267: a question may not write to the board, by either door ────
 
-    /// The gate itself. On a question the queue is never claimed, so the
-    /// **model's own** `spawn_task` is refused inside its turn — with the
-    /// `NoDrain` refusal, which is the one that tells it not to retry — and no
-    /// card exists afterwards.
+    /// The gate itself. On a question the queue is claimed for **answering
+    /// only**, so the model's own `spawn_task` is refused inside its turn —
+    /// with the `NoDrain` refusal, which is the one that tells it not to retry
+    /// — and no card exists afterwards.
     ///
     /// This is the door Layer A cannot close. "Tell what is there in the tasks
     /// list" has no action verb and no request frame, so the REST handler never
@@ -2685,9 +2784,10 @@ members = ["engineer"]
             .await
             .expect("operator message handled");
 
-        assert!(
-            !turns.committed_at_turn(0),
-            "a question turn must run with the delegation queue unclaimed"
+        assert_eq!(
+            turns.claim_at_turn(0),
+            orchestrator::DrainClaim::Answering,
+            "a question turn runs under the narrowed claim"
         );
         assert_eq!(
             turns.staged(),
@@ -2702,6 +2802,148 @@ members = ["engineer"]
         // The reply still comes back: the gate removes the ability to write, not
         // the ability to answer.
         assert_eq!(turn.reply, "here is the list");
+    }
+
+    /// The other two pure board writes are refused on the same turn, for the
+    /// same reason: they change the board and return nothing to say, so they
+    /// have no answering role.
+    ///
+    /// Pinned separately from `spawn_task` because the narrowed claim decides
+    /// per delegation kind, and a filter that let `assign_task` through would
+    /// pass every test above.
+    #[tokio::test]
+    async fn the_lifecycle_writes_are_refused_on_a_question_turn_too() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::tooling(
+                "here is the list",
+                vec![
+                    Delegation::AssignTask {
+                        task_id: "card-1".to_string(),
+                        assignee: "engineer".to_string(),
+                        note: None,
+                    },
+                    Delegation::ReviewTask {
+                        task_id: "card-1".to_string(),
+                        decision: lifecycle::ReviewDecision::Approve,
+                        note: None,
+                    },
+                ],
+            )],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", "Tell what is there in the tasks list", None)
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::NoDrain, orchestrator::Staged::NoDrain],
+            "neither lifecycle write may stage on a question turn"
+        );
+    }
+
+    /// **Issue #267 review, finding 2.** `delegate_to_desk` is not only a board
+    /// write — it is how a question the orchestrator cannot answer alone gets
+    /// routed to a desk that can. Refusing it alongside the board writes left
+    /// "what did the design desk ship this week?" answerable by nobody.
+    ///
+    /// So on a question turn the hand-off RUNS — it stages, the desk lead's
+    /// turn happens, and the CEO-relay hand-back surfaces their answer — and
+    /// only its *card* is suppressed. Every assertion here is one half of that:
+    /// the tool was not refused, three turns really ran, the answer came back,
+    /// and the board stayed empty.
+    #[tokio::test]
+    async fn a_hand_off_runs_on_a_question_turn_but_opens_no_card() {
+        let question = "Tell what is there in the tasks list";
+        assert!(
+            crate::company::task_intent::triage_message(question).is_answer(),
+            "fixture must triage as a question, or this proves nothing"
+        );
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "asking engineering",
+                    vec![handoff("what have you shipped?")],
+                ),
+                Turn::reply("we shipped the importer"),
+                Turn::reply("engineering shipped the importer"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", question, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued],
+            "the hand-off must NOT be refused: it is how the question gets answered"
+        );
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            3,
+            "the orchestrator, the desk lead and the relay all ran: {calls:?}"
+        );
+        assert_eq!(
+            calls[1].0, "engineer",
+            "the desk lead really ran: {calls:?}"
+        );
+        assert_eq!(
+            turn.reply, "engineering shipped the importer",
+            "and the operator gets the relayed answer"
+        );
+        assert!(
+            fx.cards().await.is_empty(),
+            "nobody commissioned work, so nothing is tracked"
+        );
+        assert!(
+            turn.spawned_task.is_none(),
+            "and the bubble claims no card, because there is none"
+        );
+    }
+
+    /// The same hand-off on a message that is NOT a question still opens its
+    /// card, so the suppression above is keyed on the triage rather than having
+    /// quietly disabled the #442 card path.
+    ///
+    /// Paired with the test above for the reason `a_desk_that_finished_cleanly_
+    /// still_lands_in_review` is paired with its own opposite: a "fix" that
+    /// simply stopped opening hand-off cards would satisfy one of them.
+    #[tokio::test]
+    async fn the_same_hand_off_on_a_non_question_still_opens_its_card() {
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling(
+                    "asking engineering",
+                    vec![handoff("Read the pricing repo and write modules.md")],
+                ),
+                Turn::reply("modules.md is written"),
+                Turn::reply("engineering wrote it up"),
+            ],
+        );
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "the pricing repo needs a map", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(turns.staged(), vec![orchestrator::Staged::Queued]);
+        let cards = fx.cards().await;
+        assert_eq!(
+            cards.len(),
+            1,
+            "the hand-off card is still opened: {cards:?}"
+        );
+        assert_eq!(cards[0].assignee, "engineer");
+        assert_eq!(turn.spawned_task.as_deref(), Some(cards[0].id.as_str()));
     }
 
     /// `Chatter` is NOT gated. It is the ambiguous bucket, and taking board

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -2791,8 +2791,11 @@ members = ["engineer"]
         );
         assert_eq!(
             turns.staged(),
-            vec![orchestrator::Staged::NoDrain],
-            "the refusal must be the do-not-retry one, not the try-again-next-turn one"
+            vec![orchestrator::Staged::NoDrain(
+                orchestrator::NoDrainReason::Triage
+            )],
+            "the refusal must be the do-not-retry one, and it must name the triage as the \
+             cause rather than blaming a context that cannot do board work"
         );
         assert!(
             fx.cards().await.is_empty(),
@@ -2839,7 +2842,10 @@ members = ["engineer"]
 
         assert_eq!(
             turns.staged(),
-            vec![orchestrator::Staged::NoDrain, orchestrator::Staged::NoDrain],
+            vec![
+                orchestrator::Staged::NoDrain(orchestrator::NoDrainReason::Triage),
+                orchestrator::Staged::NoDrain(orchestrator::NoDrainReason::Triage),
+            ],
             "neither lifecycle write may stage on a question turn"
         );
     }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1131,25 +1131,39 @@ async fn run_chat(
     } else {
         None
     };
-    // Deterministic task card: an actionable operator request ("build the
-    // landing page", "can you set up the newsletter") opens a `todo` card so
-    // "do X" always leaves a visible work item on the dashboard — independent of
-    // whether the orchestrator model also calls `spawn_task` (it may open
-    // sub-tasks on top). Pure questions, greetings, and acknowledgements don't
-    // fire, so the board fills with work, not small talk. Best-effort: a card
-    // write failure must never sink the chat reply.
+    // Deterministic task card, opened only for a message the triage calls
+    // `Track`: an actionable operator request ("build the landing page", "can
+    // you set up the newsletter") opens a `todo` card so "do X" always leaves a
+    // visible work item on the dashboard — independent of whether the
+    // orchestrator model also calls `spawn_task` (it may open sub-tasks on top).
+    // Best-effort: a card write failure must never sink the chat reply.
+    //
+    // Issue #267 turned the boolean this used to read into a positive three-way
+    // classification. `Answer` (a question about state, a read request) and
+    // `Chatter` (greetings, acknowledgements, anything ambiguous) both open
+    // nothing here — but they are NOT the same answer, and the difference
+    // matters one layer down: `Answer` additionally takes the model's own
+    // board-writing tools away for the turn, in
+    // `DelegationRunner::handle_operator_message`, because a question was the
+    // other door dead cards came through. This site is Layer A of that pair: it
+    // is compiled into every build and fronts both cognition brains, whereas the
+    // gate is on the harness path only.
     //
     // NOT on a workflow copilot thread (issue #416). A copilot question is
     // phrased at the workflow — "add a node that emails the report", "why does
-    // this fail on Mondays" — and the intent detector reads the first of those
-    // as a request to the company, which would put a card on the board from a
+    // this fail on Mondays" — and the triage reads the first of those as a
+    // request to the company, which would put a card on the board from a
     // conversation the operator was having *about a graph*. The confinement in
     // the harness stops the turn from acting; this stops the route from acting
     // on its behalf, and it holds in every build because it is here rather than
     // behind the `openhuman` feature.
     if let Some(title) = (!confined)
-        .then(|| crate::company::task_intent::detect_task_intent(&message.text))
-        .flatten()
+        .then(|| crate::company::task_intent::triage_message(&message.text))
+        .and_then(|triage| match triage {
+            crate::company::task_intent::MessageTriage::Track(title) => Some(title),
+            crate::company::task_intent::MessageTriage::Answer
+            | crate::company::task_intent::MessageTriage::Chatter => None,
+        })
     {
         // Keep the full message as the note only when the title was shortened
         // from it, so a one-line ask doesn't duplicate itself.

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2383,6 +2383,68 @@ async fn a_copilot_thread_question_opens_no_board_card() {
     );
 }
 
+/// Issue #267: a question about the board's own state is answered, not carded.
+///
+/// This is the exact message that produced one of the six dead `backlog` cards
+/// on a live company. The route now triages it as `Answer`, so the
+/// deterministic card path stands down — and the reply still comes back OK,
+/// because triage decides what gets *written*, never whether the operator gets
+/// an answer.
+///
+/// The control half is the point: the same route, one sentence later, still
+/// opens a card for a real instruction. A test that only proved the question
+/// wrote nothing would also pass on a route that had stopped carding entirely.
+#[tokio::test]
+async fn a_question_about_the_board_opens_no_card() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    for ask in [
+        "what is there in the tasks list?",
+        "Tell what is there in the tasks list",
+        "list the tasks",
+        "show me the board",
+    ] {
+        let (status, body) = send(
+            &state,
+            "POST",
+            "/api/v1/company/chat",
+            Some(json!({ "message": ask })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "asking `{ask}` must still answer");
+        assert!(body["responses"].is_array(), "no reply for `{ask}`: {body}");
+
+        let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+        assert_eq!(status, StatusCode::OK);
+        let cards = board.as_array().expect("the board lists cards");
+        assert!(
+            cards.is_empty(),
+            "the question `{ask}` left work on the board: {board}"
+        );
+    }
+
+    // Control: a real instruction on the same route still opens exactly one
+    // card, so this narrows the detector rather than switching it off.
+    let (status, _) = send(
+        &state,
+        "POST",
+        "/api/v1/company/chat",
+        Some(json!({"message": "build the landing page"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let (status, board) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let cards = board.as_array().expect("the board lists cards");
+    assert_eq!(
+        cards.len(),
+        1,
+        "an instruction must still open exactly one card: {board}"
+    );
+}
+
 #[tokio::test]
 async fn chat_accepts_desk_id_and_replies() {
     let home_dir = home();


### PR DESCRIPTION
## Summary

Ask the company a plain question and you get a card on the board that nobody ever works. This classifies an operator message as **answer**, **work**, or **chatter** before anything is written to the board, and closes both of the doors a dead card comes through.

**The issue's premise needed correcting first.** #267 states "Nothing auto-creates cards — there is no chat-message-to-card pipeline". There is one: `detect_task_intent` in `src/company/task_intent.rs`, wired into `run_chat`. Evaluated against its actual rules, **five of the six dead cards the issue observed came through that deterministic detector** ("Call the composio_authorize tool…" and 4× "Create a workflow…"); only "Tell what is there in the tasks list" — where `tell` is not an action verb and there is no request frame — can have come from the model calling `spawn_task`. Cards enter through *both* doors, so a fix on either one alone leaves the other open. That is why this is three layers rather than the single triage step the issue describes.

**Layer A — the detector answers a positive question.** `triage_message` returns `Answer` / `Track(title)` / `Chatter`. It now *recognises a question* rather than merely failing to recognise a command: interrogative lead words, read verbs (`tell`, `show`, `explain`, `describe`, "give me"), or a trailing `?` with no action verb. Request frames still win over the question mark, so "can you build the landing page?" stays work. `list` is removed from the action verbs — a bare "list X" is a read. `detect_task_intent` survives as a thin wrapper so the #463 byte-for-byte card-title contract is untouched. Everything ambiguous falls to `Chatter`, which neither cards nor gates.

**Layer B — the model may not write to the board on a question turn.** A brief cannot close that door; it is guidance, and the issue's own diagnosis is that behaviour follows structure rather than caveats. Withholding the #453 queue claim closes it using semantics that already exist: with no claim, `spawn_task` / `delegate_to_desk` / `assign_task` / `review_task` hit `Staged::NoDrain` and fail **in the model's own turn** with a message telling it not to retry and not to report the action as done (verified at `orchestrator.rs` `no_drain()` — it is a real tool error, not a silent drop). Read tools are untouched: `query_company`, `run_workflow` and `read_run_output` run inline and never reach the queue, so the turn keeps every means of actually answering. The asymmetry is the design — it removes the ability to write, not the ability to reply. The direct-desk card path stands down on `Answer` too, so asking a desk lead "what did you ship this week?" opens no card.

**Layer C — the brief leads with answering.** It now opens with the default ("most messages are questions or quick reads — answer from `query_company` and touch nothing else; a question about state is NEVER a card") instead of trailing it as a caveat after eight enumerated action tools. It also says a "create a workflow" ask is authored **this turn** with `create_workflow`, not parked — which is what un-deadens that whole class of card.

**No added model calls.** An LLM pre-classifier was considered and rejected for now: OpenHuman's `trigger_triage` precedent classifies *external* triggers, and OpenHuman itself routes interactive operator chat straight to its orchestrator with no pre-turn model call. There is one `ChatModel` per company here and no fast-model tier, so a pre-classifier would put a full-price serial round-trip in front of every message plus routing that does not exist. Deferred to **#678**, opened alongside this PR.

## API Or Behavior Changes

No HTTP API change — no route, request body or response shape moves.

Behavior:

- A message triaged `Answer` opens **no** card, on any of the three paths (REST handler, model delegation tools, direct-desk hand-off), and the model's board-write tools fail in-turn on that message.
- A message triaged `Track` behaves exactly as before, with byte-identical card titles.
- `Chatter` — the ambiguous bucket — neither cards nor gates, so a triage miss costs a follow-up message rather than silently refusing work.
- `list` no longer counts as an action verb, so "list the tasks" is a read.
- Copilot-thread suppression (#416) is preserved unchanged.

**Cross-brain**: Layer A lives in `run_chat`, is compiled in every build, and fronts both brains. Layer B is harness-path only — `HostedMedullaBrain` has no delegation stack at all (#176), so there is no model board-write path to gate there; when #176 copies the drain site through the canonical `delegation_tools` seam, the conditional claim comes with it.

**Three places the code contradicted the plan, stated rather than smoothed over:**

1. **The gate is narrower than "board tools are withheld" suggests.** `create_workflow` and `add_agent` are also inline and never touch the delegation queue, so they remain available on an `Answer` turn. Harmless in practice — a "create a workflow" ask triages `Track`, not `Answer` — but the boundary is queue-membership, not intent.
2. **Skipping the claim would have skipped its clear.** `claim()` clears the queue on acquire, and that half is a safety property, not a permission: a delegation staged by some other path must never be executed by this turn's drain. The answering path therefore does `clear()` and holds no claim, rather than simply not claiming.
3. **`is_actionable` collapsed.** With the request-frame branch firing earlier in the new ordering, it reduced to `starts_with_action`; the wrapper was removed rather than left with a dead branch.

## Tests

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — 0 errors
- [x] `cargo build --all-targets` — ok
- [x] `cargo test` — 1985 + 10 + 1 passed, 0 failed

Additionally, because the harness and delegation tests only compile under the full feature combo and no CI lane builds it:

- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings` — 0 errors (`--no-deps` required, per `ci.yml`)
- [x] `cargo test --features openhuman,mcp,telegram` — 2947 + 10 + 1 + 11 + 2 passed, 0 failed
- [x] frontend `npm ci && npm run typecheck && npm run build` — exit 0, no source change (run to prove no drift)

New coverage: a regression block asserting the triage class of all six messages observed in the issue; `Answer` positives ("list the tasks", "show me the board", "what's our revenue?", "Tell what is there in the tasks list"); the existing `Track` suite green with byte-identical titles; `Chatter` neutrals; frame-beats-interrogative. On the delegation side — an `Answer` turn leaves the queue unclaimed and a `spawn_task` push refused in-turn with no card after, a `Chatter` turn still delegates, and a direct-desk `Answer` opens no card. Plus a server-level test that chatting "what is there in the tasks list?" replies normally and leaves the task store untouched.

**Test-harness change worth a reviewer's eye**: `ScriptedTurns`' `Turn::queues` pushes via `DelegationQueue::push`, the escape hatch that bypasses both the cap and the #453 commitment — so a gate test written against it would have asserted nothing. `Turn::tool_pushes` / `Turn::tooling` were added to route through the real `push_within_cap`, with a `staged()` accessor.

## Documentation

`docs/spec/runtime/api.md` describes the three-way triage; `src/runtime/board_events.rs`' module doc — which named `detect_task_intent` as a card path — is updated to match. The two subtle sites (the withheld claim, the adopted-but-unsettled card) carry their reasoning inline.

**Known deviation from the repo's 500-line Markdown cap**: `docs/spec/runtime/api.md` is now 518 lines. It was already **506 on `main`** before this branch; the addition here was compressed from 28 lines to 17 but does not bring it under. Splitting the file is a separate change and is deliberately not bundled into a behavior PR — flagging it rather than letting it pass unremarked.

**A card that still lags, traced and tracked (#678).** When the orchestrator answers "create a workflow named X" by authoring the graph in-turn, the handler card is adopted but never settles: `CreateWorkflowTool` stages onto the `WorkflowRefQueue`, drained only by the dispatched-card path in `HarnessBrain::run_task`, and the publish drain settles from `pending_publishes`, which `create_workflow` never populates. So the operator does get the workflow; the card stays in To-do. It is not fixed here because `DelegationRunner` holds no `workflow_refs` handle and `TaskOutput.run_id` is required while a chat turn has no run row — task output without a run is #183's territory. Recorded at the call site in code and folded into #678 rather than left silent.

Closes #267


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat messages are now classified as questions, actionable work, or casual conversation.
  * Questions receive direct answers without creating task cards.
  * Action requests continue to create task cards, while workflow copilot conversations suppress card creation.
  * Desk delegation remains available during question-answering turns, while board-only actions are appropriately restricted.

* **Bug Fixes**
  * Prevented duplicate task cards during delegated conversations.
  * Improved delegation refusal messages with clearer explanations and guidance.
  * Ensured staged delegation work is safely released when a claim ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->