### PR TITLE
fix(workflows): enforce required node config at author time + repair broken seed workflows (#661)

### DIFF
--- a/companies/agentic_accounting_firm/workflows/month_end_close.toml
+++ b/companies/agentic_accounting_firm/workflows/month_end_close.toml
@@ -26,6 +26,8 @@ id = "gate"
 kind = "condition"
 name = "Filing due?"
 summary = "Branch on whether a tax filing is due."
+[node.config]
+field = "=item.filing_due"
 
 [[node]]
 id = "taxes"

--- a/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
+++ b/companies/agentic_consultation_firm/workflows/engagement_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Model needed?"
 summary = "Branch on whether the case needs a model."
+[node.config]
+field = "=item.model_needed"
 
 [[node]]
 id = "model"

--- a/companies/agentic_customer_support/workflows/ticket_pipeline.toml
+++ b/companies/agentic_customer_support/workflows/ticket_pipeline.toml
@@ -27,6 +27,8 @@ id = "gate"
 kind = "condition"
 name = "Resolvable now?"
 summary = "Resolve directly or escalate."
+[node.config]
+field = "=item.resolvable_now"
 
 [[node]]
 id = "escalate"
@@ -40,6 +42,8 @@ id = "gate2"
 kind = "condition"
 name = "Bug or refund?"
 summary = "Route the escalation to the right path."
+[node.config]
+field = "=item.is_bug"
 
 [[node]]
 id = "bug"
@@ -93,12 +97,12 @@ to = "gate2"
 [[edge]]
 from = "gate2"
 to = "bug"
-label = "bug"
+label = "yes"
 
 [[edge]]
 from = "gate2"
 to = "refund"
-label = "refund"
+label = "no"
 
 [[edge]]
 from = "bug"

--- a/companies/agentic_design_studio/workflows/design_pipeline.toml
+++ b/companies/agentic_design_studio/workflows/design_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Needs motion?"
 summary = "Branch on whether motion is in scope."
+[node.config]
+field = "=item.needs_motion"
 
 [[node]]
 id = "motion"

--- a/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
+++ b/companies/agentic_enterprise_sales/workflows/sales_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Qualified?"
 summary = "Advance or nurture the lead."
+[node.config]
+field = "=item.qualified"
 
 [[node]]
 id = "proposal"

--- a/companies/agentic_game_business/workflows/liveops_pipeline.toml
+++ b/companies/agentic_game_business/workflows/liveops_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Store update?"
 summary = "Branch on whether the store needs a refresh."
+[node.config]
+field = "=item.store_update"
 
 [[node]]
 id = "store"

--- a/companies/agentic_game_studio/workflows/game_build_pipeline.toml
+++ b/companies/agentic_game_studio/workflows/game_build_pipeline.toml
@@ -13,6 +13,12 @@ id = "concept"
 kind = "trigger"
 name = "New concept"
 summary = "A game or feature concept is greenlit."
+# The `QA passed?` gate loops a failed build back to `gameplay` for rework. A
+# guarded cycle needs an explicit bound or the engine rejects it (tinyflows
+# `IllegalCycle`): OpenCompany has no `loop` node kind, so the trigger's
+# `recursion_limit` is the sanctioned way to cap the rework passes.
+[node.config]
+recursion_limit = 100
 
 [[node]]
 id = "world"
@@ -61,6 +67,8 @@ id = "gate"
 kind = "condition"
 name = "QA passed?"
 summary = "Ship or send back for rework."
+[node.config]
+field = "=item.qa_passed"
 
 [[node]]
 id = "marketing"
@@ -106,12 +114,12 @@ to = "gate"
 [[edge]]
 from = "gate"
 to = "marketing"
-label = "pass"
+label = "yes"
 
 [[edge]]
 from = "gate"
 to = "gameplay"
-label = "fail"
+label = "no"
 
 [[edge]]
 from = "marketing"

--- a/companies/agentic_influencer_business/workflows/content_pipeline.toml
+++ b/companies/agentic_influencer_business/workflows/content_pipeline.toml
@@ -47,6 +47,8 @@ id = "gate"
 kind = "condition"
 name = "Sponsored?"
 summary = "Branch on whether this piece has a sponsor."
+[node.config]
+field = "=item.sponsored"
 
 [[node]]
 id = "sponsor"

--- a/companies/agentic_law_firm/workflows/matter_pipeline.toml
+++ b/companies/agentic_law_firm/workflows/matter_pipeline.toml
@@ -26,6 +26,8 @@ id = "gate"
 kind = "condition"
 name = "Contract or litigation?"
 summary = "Route by the kind of matter."
+[node.config]
+field = "=item.is_contract"
 
 [[node]]
 id = "draft"
@@ -65,12 +67,12 @@ to = "gate"
 [[edge]]
 from = "gate"
 to = "draft"
-label = "contract"
+label = "yes"
 
 [[edge]]
 from = "gate"
 to = "litigation"
-label = "litigation"
+label = "no"
 
 [[edge]]
 from = "draft"

--- a/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
+++ b/companies/agentic_marketing_agency/workflows/campaign_pipeline.toml
@@ -30,6 +30,8 @@ id = "gate"
 kind = "condition"
 name = "Needs research?"
 summary = "Branch on topic familiarity."
+[node.config]
+field = "=item.needs_research"
 
 [[node]]
 id = "research"

--- a/companies/agentic_media_company/workflows/newsroom_pipeline.toml
+++ b/companies/agentic_media_company/workflows/newsroom_pipeline.toml
@@ -33,6 +33,8 @@ id = "gate"
 kind = "condition"
 name = "Verified?"
 summary = "Run the story or spike it."
+[node.config]
+field = "=item.verified"
 
 [[node]]
 id = "write"
@@ -97,12 +99,12 @@ to = "gate"
 [[edge]]
 from = "gate"
 to = "write"
-label = "verified"
+label = "yes"
 
 [[edge]]
 from = "gate"
 to = "done"
-label = "spiked"
+label = "no"
 
 [[edge]]
 from = "write"

--- a/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
+++ b/companies/agentic_pharma_startup/workflows/discovery_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Promising?"
 summary = "Advance to trial planning or report back."
+[node.config]
+field = "=item.promising"
 
 [[node]]
 id = "trial"

--- a/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
+++ b/companies/agentic_realestate_company/workflows/acquisition_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Pencils out?"
 summary = "Advance to purchase or pass."
+[node.config]
+field = "=item.pencils_out"
 
 [[node]]
 id = "rehab"

--- a/companies/agentic_recruiting_company/workflows/hiring_pipeline.toml
+++ b/companies/agentic_recruiting_company/workflows/hiring_pipeline.toml
@@ -40,6 +40,8 @@ id = "gate"
 kind = "condition"
 name = "Qualified?"
 summary = "Advance or pass on the candidate."
+[node.config]
+field = "=item.qualified"
 
 [[node]]
 id = "interview"

--- a/companies/agentic_software_company/workflows/feature_pipeline.toml
+++ b/companies/agentic_software_company/workflows/feature_pipeline.toml
@@ -47,6 +47,8 @@ id = "gate"
 kind = "condition"
 name = "Security-sensitive?"
 summary = "Branch on whether a security review is needed."
+[node.config]
+field = "=item.security_sensitive"
 
 [[node]]
 id = "security"

--- a/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
+++ b/companies/agentic_venture_capital/workflows/diligence_pipeline.toml
@@ -33,6 +33,8 @@ id = "gate"
 kind = "condition"
 name = "Worth diligence?"
 summary = "Advance to diligence or pass."
+[node.config]
+field = "=item.worth_diligence"
 
 [[node]]
 id = "market"

--- a/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
+++ b/companies/agentic_venture_studio/workflows/venture_launch_pipeline.toml
@@ -33,6 +33,8 @@ id = "gate"
 kind = "condition"
 name = "Build it?"
 summary = "Commit to build or shelve the idea."
+[node.config]
+field = "=item.build_it"
 
 [[node]]
 id = "staff"

--- a/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
+++ b/companies/signals_opportunity_studio/workflows/opportunity_pipeline.toml
@@ -33,6 +33,8 @@ id = "gate"
 kind = "condition"
 name = "Strong signal?"
 summary = "Deep-dive the top opportunities or brief as-is."
+[node.config]
+field = "=item.strong_signal"
 
 [[node]]
 id = "research"

--- a/companies/startup_accelerator/workflows/cohort_pipeline.toml
+++ b/companies/startup_accelerator/workflows/cohort_pipeline.toml
@@ -33,6 +33,8 @@ id = "gate"
 kind = "condition"
 name = "Admit?"
 summary = "Admit to the cohort or pass."
+[node.config]
+field = "=item.admitted"
 
 [[node]]
 id = "mentor"
@@ -97,12 +99,12 @@ to = "gate"
 [[edge]]
 from = "gate"
 to = "mentor"
-label = "admit"
+label = "yes"
 
 [[edge]]
 from = "gate"
 to = "done"
-label = "pass"
+label = "no"
 
 [[edge]]
 from = "mentor"

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -87,7 +87,7 @@ function SelectContent({
           {...props}
         >
           <SelectScrollUpButton />
-          <SelectPrimitive.List>{children}</SelectPrimitive.List>
+          <SelectPrimitive.List className="p-1">{children}</SelectPrimitive.List>
           <SelectScrollDownButton />
         </SelectPrimitive.Popup>
       </SelectPrimitive.Positioner>

--- a/frontend/src/lib/workflow-node-config.ts
+++ b/frontend/src/lib/workflow-node-config.ts
@@ -18,6 +18,12 @@
 //   output_parser { schema, auto_fix }
 //   sub_workflow  { workflow_id }
 //
+// `condition` is a core palette kind (not one of the withheld five), but the
+// host now REQUIRES `config.field` at author time (#661 M1) — the engine
+// truthiness-tests that expression, and without it a condition always routed
+// `true`. So it carries a form too: `condition { field }` (the `yes`/`no`
+// branches are EDGE labels, not config).
+//
 // Keys the host REJECTS inside `config` — `on_error`, `retry`,
 // `requires_approval`, `schedule`, `destination`, `agent_ref` — are first-class
 // node fields and are never emitted here (see `src/company/workflow_file.rs`).
@@ -56,6 +62,16 @@ export interface ConfigFieldSpec {
  * `config` (if any) rides through an edit untouched, as before.
  */
 export const NODE_CONFIG_FIELDS: Record<string, readonly ConfigFieldSpec[]> = {
+  condition: [
+    {
+      key: "field",
+      label: "Field",
+      control: "line",
+      required: true,
+      placeholder: "=item.approved",
+      hint: "The boolean expression the branch tests. The `yes` edge takes the true branch, `no` the false.",
+    },
+  ],
   tool_call: [
     {
       key: "slug",

--- a/frontend/test/unit/workflow-node-config.test.ts
+++ b/frontend/test/unit/workflow-node-config.test.ts
@@ -27,20 +27,30 @@ import {
  */
 
 describe("hasConfigForm", () => {
-  it("covers exactly the five withheld kinds", () => {
+  it("covers the five withheld kinds plus condition (#661 M1)", () => {
     for (const kind of [
       "tool_call",
       "http_request",
       "switch",
       "output_parser",
       "sub_workflow",
+      // `condition` is a core palette kind, but the host now REQUIRES
+      // `config.field` at author time (#661 M1), so it carries a form too.
+      "condition",
     ]) {
       expect(hasConfigForm(kind), kind).toBe(true);
     }
-    for (const kind of ["trigger", "agent", "condition", "merge", "transform", "output"]) {
+    for (const kind of ["trigger", "agent", "merge", "transform", "output"]) {
       expect(hasConfigForm(kind), kind).toBe(false);
       expect(configFieldSpecs(kind)).toEqual([]);
     }
+  });
+
+  it("condition exposes a single required `field` (#661 M1)", () => {
+    const specs = configFieldSpecs("condition");
+    expect(specs).toHaveLength(1);
+    expect(specs[0].key).toBe("field");
+    expect(specs[0].required).toBe(true);
   });
 });
 

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -286,6 +286,22 @@ fn every_bundled_workflow_is_runnable_against_its_roster() {
                 .unwrap_or_else(|err| panic!("read {}: {err}", file.display()));
             let workflow =
                 parse_workflow(&text).unwrap_or_else(|err| panic!("{}: {err}", file.display()));
+
+            // `parse_workflow` is lenient on the #661 author-time rules (issue
+            // #682) so pre-#661 tenant graphs still load. That leniency must NOT
+            // apply to what WE ship: a seed a human could no longer author from
+            // the console (a field-less condition, a branch not labeled yes/no, a
+            // slug-less tool_call, an http_request missing method/url) has to fail
+            // CI here. Run the STRICT pass over every shipped seed.
+            let raw = super::raw_workflow_from_toml(&text)
+                .unwrap_or_else(|err| panic!("{}: {err}", file.display()));
+            let strict_problems = super::workflow_file::validate(&raw, true);
+            assert!(
+                strict_problems.is_empty(),
+                "{}: shipped seed fails strict author-time validation (issue #661/#682): {strict_problems:?}",
+                file.display()
+            );
+
             let graph = translate(&workflow);
 
             // Beyond parse+translate, every seed must COMPILE onto the tinyflows

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -257,10 +257,12 @@ fn the_repo_skill_registry_parses() {
 /// teammate — which is exactly how the marketing agency preset shipped pointing
 /// `research` at an unwired slug (halt) and `publish` at a nonexistent HTTP node.
 ///
-/// This translates each graph the way the engine will and asserts the two facts
-/// that decide whether a run halts: every `tool_call` slug resolves to a real
-/// toolbelt namespace ([`namespace_of`]), and every `agent` ref is on that
-/// company's roster.
+/// This translates each graph the way the engine will, **compiles** it onto the
+/// tinyflows engine (so a graph that parses but can't compile — an unbounded
+/// guarded cycle, say — is caught at load, not first run; issue #661), and
+/// asserts the two facts that decide whether a run halts: every `tool_call` slug
+/// resolves to a real toolbelt namespace ([`namespace_of`]), and every `agent`
+/// ref is on that company's roster.
 ///
 /// Gated on `openhuman` because `translate` and `namespace_of` live behind that
 /// feature; the `Rust (openhuman, tinycortex)` CI lane runs it.
@@ -285,6 +287,18 @@ fn every_bundled_workflow_is_runnable_against_its_roster() {
             let workflow =
                 parse_workflow(&text).unwrap_or_else(|err| panic!("{}: {err}", file.display()));
             let graph = translate(&workflow);
+
+            // Beyond parse+translate, every seed must COMPILE onto the tinyflows
+            // engine (issue #661). Compile is the pass that rejects an unbounded
+            // guarded cycle (`IllegalCycle`) and other structural faults a bare
+            // parse misses — a seed that parses but cannot compile would fail at
+            // first run, not at load, so the whole company's workflows break.
+            tinyflows::compiler::compile(&graph).unwrap_or_else(|err| {
+                panic!(
+                    "{}: translated graph does not compile: {err}",
+                    file.display()
+                )
+            });
 
             for node in &graph.nodes {
                 match node.kind {

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -89,6 +89,7 @@ pub use workflow_file::{
 // `parse_workflow` above for validation before writing to disk.
 pub(crate) use workflow_file::{
     RawEdge, RawNode, RawWorkflow, raw_workflow_from_toml, render_workflow,
+    required_config_problems,
 };
 // Crate-internal only: the shared validated-persist core (issue #112) both the
 // REST `POST …/workflows` route and the orchestrator `create_workflow` tool run.

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -153,8 +153,9 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
 use crate::company::{
-    RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowFile, list_workflows_union,
-    parse_workflow, raw_workflow_from_toml, render_workflow,
+    RawEdge, RawNode, RawWorkflow, WorkflowDestinationDef, WorkflowFile, WorkflowNodeKind,
+    list_workflows_union, parse_workflow, raw_workflow_from_toml, render_workflow,
+    required_config_problems,
 };
 use crate::error::{OpenCompanyError, Result};
 use crate::ports::CompanyStore;
@@ -648,6 +649,30 @@ fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) ->
                 }
             },
             "tool_call" => validate_tool_call_node(node, record)?,
+            // Per-kind required config (issue #661): reject a `condition` with no
+            // `field`, an `http_request` missing `method`/`url`, or a `switch`
+            // with no discriminant at author time — the same gate the on-disk
+            // `validate` applies, surfaced here as a 400 so the console/builder
+            // draft path never persists a graph whose runtime behaviour is
+            // silently wrong. `tool_call` keeps its richer `validate_tool_call_node`
+            // (slug + namespace/grant); the structural kinds share the helper.
+            "condition" | "http_request" | "switch" => {
+                let kind = match node.kind.as_str() {
+                    "condition" => WorkflowNodeKind::Condition,
+                    "http_request" => WorkflowNodeKind::HttpRequest,
+                    _ => WorkflowNodeKind::Switch,
+                };
+                if let Some(problem) = required_config_problems(
+                    kind,
+                    &format!("node `{}`", node.id),
+                    node.config.as_ref(),
+                )
+                .into_iter()
+                .next()
+                {
+                    return Err(OpenCompanyError::InvalidRequest(problem));
+                }
+            }
             _ => {}
         }
     }

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -662,18 +662,63 @@ fn validate_draft_against_record(draft: &RawWorkflow, record: &CompanyRecord) ->
                     "http_request" => WorkflowNodeKind::HttpRequest,
                     _ => WorkflowNodeKind::Switch,
                 };
-                if let Some(problem) = required_config_problems(
+                // Report EVERY missing-config problem for the node, not just the
+                // first: an `http_request` missing both `method` AND `url` should
+                // name both, since the draft path is where a human/model iterates.
+                let problems = required_config_problems(
                     kind,
                     &format!("node `{}`", node.id),
                     node.config.as_ref(),
-                )
-                .into_iter()
-                .next()
-                {
-                    return Err(OpenCompanyError::InvalidRequest(problem));
+                );
+                if !problems.is_empty() {
+                    return Err(OpenCompanyError::InvalidRequest(problems.join(" ")));
                 }
             }
             _ => {}
+        }
+    }
+
+    // Condition branch labels must read `yes`/`no` at author time (issue #661).
+    // `parse_workflow` is now LENIENT on this rule (issue #682) so pre-#661 saved
+    // graphs still load, which means ALL author-time strictness for it has to
+    // live here — mirroring the on-disk `validate` strict rule. The sole
+    // exception is the `error` recovery edge of a condition that is also
+    // `on_error = "route"`, whose routing is validated separately. The label is
+    // lowercased + trimmed before matching (it is compared, never persisted as a
+    // lookup key), matching the load rule's asymmetry vs the verbatim `slug`.
+    let condition_ids: HashSet<&str> = draft
+        .nodes
+        .iter()
+        .filter(|node| node.kind == "condition" && !node.id.trim().is_empty())
+        .map(|node| node.id.as_str())
+        .collect();
+    let route_ids: HashSet<&str> = draft
+        .nodes
+        .iter()
+        .filter(|node| node.on_error.as_deref() == Some("route") && !node.id.trim().is_empty())
+        .map(|node| node.id.as_str())
+        .collect();
+    for edge in &draft.edges {
+        if !condition_ids.contains(edge.from.as_str()) {
+            continue;
+        }
+        let is_route_error =
+            edge.label.as_deref() == Some("error") && route_ids.contains(edge.from.as_str());
+        let is_yes_no = edge
+            .label
+            .as_deref()
+            .map(|label| label.trim().to_ascii_lowercase())
+            .is_some_and(|label| matches!(label.as_str(), "yes" | "no"));
+        if !is_route_error && !is_yes_no {
+            let shown = edge
+                .label
+                .as_deref()
+                .map(|label| format!("`{label}`"))
+                .unwrap_or_else(|| "no label".to_string());
+            return Err(OpenCompanyError::InvalidRequest(format!(
+                "an edge leaves condition node `{}` with {shown} — a condition's branches must be labeled `yes` or `no`.",
+                edge.from
+            )));
         }
     }
 
@@ -3007,6 +3052,195 @@ to = "done"
             "{err:?}"
         );
         assert!(err.to_string().contains("cannot run"), "{err}");
+    }
+
+    // --- issue #661/#682: required config + condition labels on the draft path
+
+    /// A minimal draft — trigger → condition `gate` → two outputs — with the
+    /// gate's `config.field` and both branch labels parameterised. Since
+    /// `parse_workflow` is now lenient on the #661 rules (issue #682), these are
+    /// the graphs that prove the create/update path still enforces them strictly.
+    fn condition_draft(
+        field: Option<&str>,
+        yes_label: Option<&str>,
+        no_label: Option<&str>,
+    ) -> RawWorkflow {
+        let config = field.map(|field| {
+            let mut table = toml::map::Map::new();
+            table.insert("field".to_string(), toml::Value::String(field.to_string()));
+            toml::Value::Table(table)
+        });
+        let node = |id: &str, kind: &str, config: Option<toml::Value>| RawNode {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            name: id.to_string(),
+            summary: None,
+            agent: None,
+            schedule: None,
+            config,
+            on_error: None,
+            retry: None,
+            requires_approval: None,
+            destination: None,
+        };
+        RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![
+                node("start", "trigger", None),
+                node("gate", "condition", config),
+                node("a", "output", None),
+                node("b", "output", None),
+            ],
+            edges: vec![
+                RawEdge {
+                    from: "start".to_string(),
+                    to: "gate".to_string(),
+                    label: None,
+                },
+                RawEdge {
+                    from: "gate".to_string(),
+                    to: "a".to_string(),
+                    label: yes_label.map(str::to_string),
+                },
+                RawEdge {
+                    from: "gate".to_string(),
+                    to: "b".to_string(),
+                    label: no_label.map(str::to_string),
+                },
+            ],
+        }
+    }
+
+    /// A condition draft with no `config.field` is refused at author time even
+    /// though `parse_workflow` would now let it load.
+    #[tokio::test]
+    async fn draft_condition_without_field_is_invalid() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            condition_draft(None, Some("yes"), Some("no")),
+        )
+        .await
+        .expect_err("condition with no field");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("config.field"), "{err}");
+    }
+
+    /// A condition branch labeled anything but `yes`/`no` is refused at author
+    /// time — the load path is lenient, so this rule now lives entirely here.
+    #[tokio::test]
+    async fn draft_condition_with_non_yes_no_label_is_invalid() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            condition_draft(Some("=item.ok"), Some("pass"), Some("no")),
+        )
+        .await
+        .expect_err("off-vocabulary condition label");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        assert!(err.to_string().contains("labeled `yes` or `no`"), "{err}");
+    }
+
+    /// The positive control: a condition with a `field` and `yes`/`no` branches
+    /// is accepted by the same author path.
+    #[tokio::test]
+    async fn draft_condition_with_field_and_yes_no_labels_is_valid() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            condition_draft(Some("=item.approved"), Some("yes"), Some("no")),
+        )
+        .await
+        .expect("a well-formed condition draft is accepted");
+    }
+
+    /// An http_request draft missing BOTH `method` and `url` reports both in one
+    /// 400 — the draft path collects every required-config problem for a node,
+    /// not just the first, so a human/model iterating hears the full list.
+    #[tokio::test]
+    async fn draft_http_request_missing_method_and_url_reports_both() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_assistant(),
+        )));
+        let draft = RawWorkflow {
+            id: "wf".to_string(),
+            name: "WF".to_string(),
+            description: None,
+            nodes: vec![
+                RawNode {
+                    id: "start".to_string(),
+                    kind: "trigger".to_string(),
+                    name: "Start".to_string(),
+                    summary: None,
+                    agent: None,
+                    schedule: None,
+                    config: None,
+                    on_error: None,
+                    retry: None,
+                    requires_approval: None,
+                    destination: None,
+                },
+                RawNode {
+                    id: "fetch".to_string(),
+                    kind: "http_request".to_string(),
+                    name: "Fetch".to_string(),
+                    summary: None,
+                    agent: None,
+                    schedule: None,
+                    config: None,
+                    on_error: None,
+                    retry: None,
+                    requires_approval: None,
+                    destination: None,
+                },
+            ],
+            edges: vec![RawEdge {
+                from: "start".to_string(),
+                to: "fetch".to_string(),
+                label: None,
+            }],
+        };
+        let err = create_company_workflow(&company, None, &store, None, draft)
+            .await
+            .expect_err("http_request with no method or url");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        let message = err.to_string();
+        assert!(message.contains("config.method"), "{message}");
+        assert!(message.contains("config.url"), "{message}");
     }
 
     // --- issue #276: arming, disarming, and the switch -----------------------

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -660,6 +660,16 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
             condition_nodes.insert(node.id.as_str());
         }
 
+        // Per-kind required config (issue #661): a broken seed / hand-authored
+        // file that omits a `condition` `field`, an `http_request` `method`/`url`,
+        // a `switch` discriminant, or a `tool_call` `slug` must fail LOUD here
+        // rather than translate into a graph whose runtime behaviour is silently
+        // wrong. Same helper the console-draft path runs, so the two surfaces
+        // reject the same shapes identically.
+        if let Some(kind) = kind {
+            problems.extend(required_config_problems(kind, &label, node.config.as_ref()));
+        }
+
         // `schedule` says *when* the workflow starts, so it is trigger-only —
         // anywhere else it would sit inert and mislead (the same footgun the
         // stray-`agent` check above prevents). On a trigger it must be a real
@@ -904,6 +914,34 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
                 ));
             }
         }
+
+        // A `condition` node's branches steer the run onto the engine's `true`
+        // or `false` port, keyed off the edge label (issue #661). An unlabeled
+        // or oddly-labeled branch would silently funnel through `condition_port`
+        // onto the `true` port — a mislabeled branch that quietly runs the wrong
+        // way — so require every condition branch to read `yes` or `no`. The
+        // sole exception is the `error` recovery edge of a condition that is also
+        // `on_error = "route"`, already validated by the routing-edge rule above.
+        if condition_nodes.contains(edge.from.as_str()) {
+            let is_route_error =
+                edge.label.as_deref() == Some("error") && route_nodes.contains(edge.from.as_str());
+            let is_yes_no = edge
+                .label
+                .as_deref()
+                .map(|l| l.trim().to_ascii_lowercase())
+                .is_some_and(|l| matches!(l.as_str(), "yes" | "no"));
+            if !is_route_error && !is_yes_no {
+                let shown = edge
+                    .label
+                    .as_deref()
+                    .map(|l| format!("`{l}`"))
+                    .unwrap_or_else(|| "no label".to_string());
+                problems.push(format!(
+                    "{label} leaves condition node `{}` with {shown} — a condition's branches must be labeled `yes` or `no`.",
+                    edge.from
+                ));
+            }
+        }
     }
 
     // Every routing node must actually have somewhere to route its error to.
@@ -1077,6 +1115,69 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
         }
     }
 
+    problems
+}
+
+/// The per-kind required-`config` problems for one node, in prosumer language.
+///
+/// Shared by the on-disk [`validate`] pass and the console/builder draft path
+/// ([`validate_draft_against_record`](crate::company::workflow_create)) so the
+/// same missing config is rejected identically on BOTH author-time surfaces
+/// (issue #661): a `condition` with no `field`, an `http_request` missing
+/// `method`/`url`, a `switch` with no discriminant, or a `tool_call` with no
+/// `slug`. Each of those still *translates* into a runnable graph, but the
+/// node's behaviour is silently wrong — a field-less condition tests the whole
+/// item, a slug-less `tool_call` used to fall back to the node id (masking which
+/// tool would run) — so surfacing it at load/author time is the point.
+pub(crate) fn required_config_problems(
+    kind: WorkflowNodeKind,
+    label: &str,
+    config: Option<&toml::Value>,
+) -> Vec<String> {
+    let table = config.and_then(toml::Value::as_table);
+    // A config key set to a non-empty, non-whitespace string.
+    let non_empty = |key: &str| -> bool {
+        table
+            .and_then(|t| t.get(key))
+            .and_then(toml::Value::as_str)
+            .is_some_and(|value| !value.trim().is_empty())
+    };
+    let mut problems = Vec::new();
+    match kind {
+        WorkflowNodeKind::Condition if !non_empty("field") => {
+            problems.push(format!(
+                "{label} is a condition node but sets no `config.field` — give it the boolean \
+                 expression the branch tests (e.g. `field = \"=item.approved\"`)."
+            ));
+        }
+        WorkflowNodeKind::HttpRequest => {
+            if !non_empty("method") {
+                problems.push(format!(
+                    "{label} is an http_request node but sets no `config.method` — name the HTTP \
+                     method (e.g. `method = \"GET\"`)."
+                ));
+            }
+            if !non_empty("url") {
+                problems.push(format!(
+                    "{label} is an http_request node but sets no `config.url` — give the request \
+                     URL (e.g. `url = \"https://…\"`)."
+                ));
+            }
+        }
+        WorkflowNodeKind::Switch if !non_empty("field") && !non_empty("expression") => {
+            problems.push(format!(
+                "{label} is a switch node but names no discriminant — set `config.field` or \
+                 `config.expression` to the value that selects the branch."
+            ));
+        }
+        WorkflowNodeKind::ToolCall if !non_empty("slug") => {
+            problems.push(format!(
+                "{label} is a tool_call but sets no `config.slug` — set `config.slug` to the \
+                 tool to run."
+            ));
+        }
+        _ => {}
+    }
     problems
 }
 
@@ -1368,6 +1469,8 @@ mod tests {
             name = "Export"
             on_error = "continue"
             requires_approval = true
+            [node.config]
+            slug = "csv_export"
             [node.retry]
             max_attempts = 3
             backoff_ms = 100
@@ -1543,6 +1646,8 @@ mod tests {
             kind = "tool_call"
             name = "Call"
             on_error = "route"
+            [node.config]
+            slug = "csv_export"
             [[node]]
             id = "recover"
             kind = "output"
@@ -1575,6 +1680,8 @@ mod tests {
             id = "sw"
             kind = "switch"
             name = "Switch"
+            [node.config]
+            field = "=item.kind"
             [[node]]
             id = "mg"
             kind = "merge"
@@ -1747,6 +1854,8 @@ mod tests {
             id = "sw"
             kind = "switch"
             name = "Switch"
+            [node.config]
+            field = "=item.kind"
             [[node]]
             id = "err_case"
             kind = "output"
@@ -1771,6 +1880,205 @@ mod tests {
             parse_workflow(src).is_ok(),
             "an error-labeled switch case must be valid without on_error = route"
         );
+    }
+
+    // --- Per-kind required config (issue #661) ------------------------------
+
+    /// A `condition` node with no `config.field` is rejected — without it the
+    /// engine tests the whole item and the branch is silently meaningless.
+    #[test]
+    fn condition_without_field_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "gate"
+            kind = "condition"
+            name = "Gate"
+            [[node]]
+            id = "yes_out"
+            kind = "output"
+            name = "Yes"
+            [[node]]
+            id = "no_out"
+            kind = "output"
+            name = "No"
+            [[edge]]
+            from = "start"
+            to = "gate"
+            [[edge]]
+            from = "gate"
+            to = "yes_out"
+            label = "yes"
+            [[edge]]
+            from = "gate"
+            to = "no_out"
+            label = "no"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        assert!(err.to_string().contains("config.field"), "{err}");
+    }
+
+    /// A `condition` branch labeled anything but `yes`/`no` is rejected — an
+    /// off-vocabulary label silently maps onto the `true` port.
+    #[test]
+    fn condition_branch_with_non_yes_no_label_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "gate"
+            kind = "condition"
+            name = "Gate"
+            [node.config]
+            field = "=item.ok"
+            [[node]]
+            id = "a"
+            kind = "output"
+            name = "A"
+            [[node]]
+            id = "b"
+            kind = "output"
+            name = "B"
+            [[edge]]
+            from = "start"
+            to = "gate"
+            [[edge]]
+            from = "gate"
+            to = "a"
+            label = "pass"
+            [[edge]]
+            from = "gate"
+            to = "b"
+            label = "no"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        assert!(err.to_string().contains("labeled `yes` or `no`"), "{err}");
+    }
+
+    /// A well-formed `condition` — a `field` plus `yes`/`no` branches — parses.
+    #[test]
+    fn condition_with_field_and_yes_no_labels_is_valid() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "gate"
+            kind = "condition"
+            name = "Gate"
+            [node.config]
+            field = "=item.approved"
+            [[node]]
+            id = "a"
+            kind = "output"
+            name = "A"
+            [[node]]
+            id = "b"
+            kind = "output"
+            name = "B"
+            [[edge]]
+            from = "start"
+            to = "gate"
+            [[edge]]
+            from = "gate"
+            to = "a"
+            label = "yes"
+            [[edge]]
+            from = "gate"
+            to = "b"
+            label = "no"
+        "#;
+        assert!(parse_workflow(src).is_ok());
+    }
+
+    /// An `http_request` node missing `config.method` / `config.url` is rejected.
+    #[test]
+    fn http_request_without_method_or_url_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "fetch"
+            kind = "http_request"
+            name = "Fetch"
+            [[edge]]
+            from = "start"
+            to = "fetch"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("config.method"), "{message}");
+        assert!(message.contains("config.url"), "{message}");
+    }
+
+    /// A `switch` node with neither `field` nor `expression` is rejected.
+    #[test]
+    fn switch_without_discriminant_is_rejected() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "sw"
+            kind = "switch"
+            name = "Switch"
+            [[node]]
+            id = "case_a"
+            kind = "output"
+            name = "A"
+            [[edge]]
+            from = "start"
+            to = "sw"
+            [[edge]]
+            from = "sw"
+            to = "case_a"
+            label = "a"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        assert!(err.to_string().contains("discriminant"), "{err}");
+    }
+
+    /// On-disk parity (issue #661): a `tool_call` with no `slug` fails at load,
+    /// the same as the console-draft path — so `translate` never has to fall
+    /// back to the node id as a placeholder slug.
+    #[test]
+    fn tool_call_without_slug_is_rejected_on_disk() {
+        let src = r#"
+            id = "wf"
+            name = "WF"
+            [[node]]
+            id = "start"
+            kind = "trigger"
+            name = "Start"
+            [[node]]
+            id = "call"
+            kind = "tool_call"
+            name = "Call"
+            [[edge]]
+            from = "start"
+            to = "call"
+        "#;
+        let err = parse_workflow(src).unwrap_err();
+        assert!(err.to_string().contains("config.slug"), "{err}");
     }
 
     // --- G15: inescapable cycles + reachability (issue #540) ----------------
@@ -1816,7 +2124,7 @@ mod tests {
     }
 
     /// A miniature of the shipped `game_build_pipeline` shape: a `condition`
-    /// guards the loop, with a `pass` branch that leaves it and a `fail` branch
+    /// guards the loop, with a `yes` branch that leaves it and a `no` branch
     /// that loops back. That is a legal bounded retry — it must parse clean.
     #[test]
     fn condition_guarded_loop_is_valid() {
@@ -1836,6 +2144,8 @@ mod tests {
             id = "gate"
             kind = "condition"
             name = "Good enough?"
+            [node.config]
+            field = "=item.good_enough"
             [[node]]
             id = "done"
             kind = "output"
@@ -1849,11 +2159,11 @@ mod tests {
             [[edge]]
             from = "gate"
             to = "done"
-            label = "pass"
+            label = "yes"
             [[edge]]
             from = "gate"
             to = "work"
-            label = "fail"
+            label = "no"
         "#;
         assert!(
             parse_workflow(src).is_ok(),
@@ -1863,7 +2173,7 @@ mod tests {
 
     /// The shipped guarded-retry preset itself must stay valid — its loop
     /// (`gameplay → assets → balance → qa → gate → gameplay`) is escapable
-    /// because `gate` is a `condition` whose `pass` branch leaves the loop.
+    /// because `gate` is a `condition` whose `yes` branch leaves the loop.
     #[test]
     fn the_shipped_guarded_loop_preset_is_valid() {
         const GAME: &str = include_str!(concat!(

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -378,7 +378,11 @@ pub fn parse_workflow(toml_src: &str) -> Result<WorkflowFile> {
         PathBuf::from(format!("{}.toml", raw.id))
     };
 
-    let problems = validate(&raw);
+    // Lenient (issue #682): the read/load path must not hard-fail a saved graph
+    // on the new #661 author-time rules — those are enforced strictly on the
+    // create/update draft path and the seed corpus test. Every structural check
+    // still runs here; only the two #661 rules are skipped.
+    let problems = validate(&raw, false);
     if !problems.is_empty() {
         return Err(OpenCompanyError::DataInvalid { path, problems });
     }
@@ -580,7 +584,20 @@ pub fn list_workflows_union(
 }
 
 /// Collects every validation problem in prosumer language. Empty means valid.
-fn validate(raw: &RawWorkflow) -> Vec<String> {
+///
+/// `strict` picks the severity surface (issue #682). The two NEW #661 author-time
+/// rules — per-kind required `config` ([`required_config_problems`]) and the
+/// `condition` branch `yes`/`no` label rule — run ONLY when `strict` is true.
+/// The read/load path ([`parse_workflow`]) calls this with `strict = false` so a
+/// graph persisted before #661 (a field-less condition, an off-vocabulary branch
+/// label — shapes the console couldn't even emit until this change) still LOADS
+/// and runs with today's behaviour, instead of hard-failing on every read and
+/// vanishing from the console / silently halting a scheduled run. Author-time
+/// enforcement lives on the create/update draft path
+/// ([`validate_draft_against_record`](crate::company::workflow_create)), which
+/// applies these same rules strictly, plus the seed corpus test which runs this
+/// with `strict = true`. Every OTHER structural check here is unconditional.
+pub(crate) fn validate(raw: &RawWorkflow, strict: bool) -> Vec<String> {
     let mut problems = Vec::new();
 
     if raw.id.trim().is_empty() {
@@ -660,13 +677,15 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
             condition_nodes.insert(node.id.as_str());
         }
 
-        // Per-kind required config (issue #661): a broken seed / hand-authored
-        // file that omits a `condition` `field`, an `http_request` `method`/`url`,
-        // a `switch` discriminant, or a `tool_call` `slug` must fail LOUD here
-        // rather than translate into a graph whose runtime behaviour is silently
-        // wrong. Same helper the console-draft path runs, so the two surfaces
-        // reject the same shapes identically.
-        if let Some(kind) = kind {
+        // Per-kind required config (issue #661): a hand-authored file that omits
+        // a `condition` `field`, an `http_request` `method`/`url`, a `switch`
+        // discriminant, or a `tool_call` `slug` translates into a graph whose
+        // runtime behaviour is silently wrong. Enforced ONLY on the strict
+        // author-time surface (issue #682): the read/load path must not hard-fail
+        // a graph persisted before #661, or it would vanish from the console and
+        // silently stop a scheduled run. The console-draft path applies the same
+        // helper strictly, so the two AUTHOR surfaces reject the same shapes.
+        if strict && let Some(kind) = kind {
             problems.extend(required_config_problems(kind, &label, node.config.as_ref()));
         }
 
@@ -922,7 +941,21 @@ fn validate(raw: &RawWorkflow) -> Vec<String> {
         // way — so require every condition branch to read `yes` or `no`. The
         // sole exception is the `error` recovery edge of a condition that is also
         // `on_error = "route"`, already validated by the routing-edge rule above.
-        if condition_nodes.contains(edge.from.as_str()) {
+        //
+        // Enforced ONLY on the strict author-time surface (issue #682): the
+        // read/load path must accept a graph persisted before #661 (a
+        // console-authored condition could not carry `yes`/`no` labels until this
+        // change), where a field-less/label-less condition routed `true` always —
+        // wrong-but-working beats "gone and never fires". The draft path applies
+        // this same rule strictly.
+        //
+        // Intentional asymmetry (do not "fix" one to match the other): the branch
+        // label is lowercased + trimmed before matching `yes`/`no`, so ` YES `
+        // passes — the label is compared, never persisted as a lookup key. By
+        // contrast `validate_tool_call_node` REJECTS a padded `slug`, because that
+        // string is stored and looked up at run time verbatim, so the validated
+        // string must equal the persisted one.
+        if strict && condition_nodes.contains(edge.from.as_str()) {
             let is_route_error =
                 edge.label.as_deref() == Some("error") && route_nodes.contains(edge.from.as_str());
             let is_yes_no = edge
@@ -1164,6 +1197,10 @@ pub(crate) fn required_config_problems(
                 ));
             }
         }
+        // `field` OR `expression` both satisfy a switch — the tinyflows engine
+        // reads `config.expression` first and falls back to `config.field`
+        // (`vendor/tinyagents` `switch.rs`), so either is honoured downstream and
+        // requiring only that ONE is present matches the runtime.
         WorkflowNodeKind::Switch if !non_empty("field") && !non_empty("expression") => {
             problems.push(format!(
                 "{label} is a switch node but names no discriminant — set `config.field` or \
@@ -1884,10 +1921,14 @@ mod tests {
 
     // --- Per-kind required config (issue #661) ------------------------------
 
-    /// A `condition` node with no `config.field` is rejected — without it the
-    /// engine tests the whole item and the branch is silently meaningless.
+    /// A `condition` node with no `config.field` still LOADS on the lenient
+    /// read path (issue #682: pre-#661 saved graphs must keep loading), but the
+    /// STRICT author-time pass reports it — without a field the engine tests the
+    /// whole item and the branch is silently meaningless. This is the regression
+    /// guard: a field-less-condition graph parses via `parse_workflow` yet is
+    /// rejected by `validate(_, true)`.
     #[test]
-    fn condition_without_field_is_rejected() {
+    fn condition_without_field_loads_leniently_but_strict_rejects() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -1919,14 +1960,19 @@ mod tests {
             to = "no_out"
             label = "no"
         "#;
-        let err = parse_workflow(src).unwrap_err();
-        assert!(err.to_string().contains("config.field"), "{err}");
+        // Lenient load path accepts it — a graph persisted before #661 still loads.
+        assert!(parse_workflow(src).is_ok());
+        // Strict author-time pass reports the missing field.
+        let raw: RawWorkflow = toml::from_str(src).expect("the fixture is valid TOML");
+        let problems = validate(&raw, true).join("\n");
+        assert!(problems.contains("config.field"), "{problems}");
     }
 
-    /// A `condition` branch labeled anything but `yes`/`no` is rejected — an
+    /// A `condition` branch labeled anything but `yes`/`no` loads leniently
+    /// (issue #682) but is rejected by the STRICT author-time pass — an
     /// off-vocabulary label silently maps onto the `true` port.
     #[test]
-    fn condition_branch_with_non_yes_no_label_is_rejected() {
+    fn condition_branch_with_non_yes_no_label_loads_leniently_but_strict_rejects() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -1960,8 +2006,12 @@ mod tests {
             to = "b"
             label = "no"
         "#;
-        let err = parse_workflow(src).unwrap_err();
-        assert!(err.to_string().contains("labeled `yes` or `no`"), "{err}");
+        // Lenient load path accepts the off-vocabulary label.
+        assert!(parse_workflow(src).is_ok());
+        // Strict author-time pass reports it.
+        let raw: RawWorkflow = toml::from_str(src).expect("the fixture is valid TOML");
+        let problems = validate(&raw, true).join("\n");
+        assert!(problems.contains("labeled `yes` or `no`"), "{problems}");
     }
 
     /// A well-formed `condition` — a `field` plus `yes`/`no` branches — parses.
@@ -2003,9 +2053,10 @@ mod tests {
         assert!(parse_workflow(src).is_ok());
     }
 
-    /// An `http_request` node missing `config.method` / `config.url` is rejected.
+    /// An `http_request` node missing `config.method` / `config.url` loads
+    /// leniently (issue #682) but the STRICT pass reports BOTH missing keys.
     #[test]
-    fn http_request_without_method_or_url_is_rejected() {
+    fn http_request_without_method_or_url_loads_leniently_but_strict_rejects() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -2021,15 +2072,19 @@ mod tests {
             from = "start"
             to = "fetch"
         "#;
-        let err = parse_workflow(src).unwrap_err();
-        let message = err.to_string();
+        // Lenient load path accepts it.
+        assert!(parse_workflow(src).is_ok());
+        // Strict author-time pass reports both missing config keys at once.
+        let raw: RawWorkflow = toml::from_str(src).expect("the fixture is valid TOML");
+        let message = validate(&raw, true).join("\n");
         assert!(message.contains("config.method"), "{message}");
         assert!(message.contains("config.url"), "{message}");
     }
 
-    /// A `switch` node with neither `field` nor `expression` is rejected.
+    /// A `switch` node with neither `field` nor `expression` loads leniently
+    /// (issue #682) but the STRICT pass reports the missing discriminant.
     #[test]
-    fn switch_without_discriminant_is_rejected() {
+    fn switch_without_discriminant_loads_leniently_but_strict_rejects() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -2053,15 +2108,20 @@ mod tests {
             to = "case_a"
             label = "a"
         "#;
-        let err = parse_workflow(src).unwrap_err();
-        assert!(err.to_string().contains("discriminant"), "{err}");
+        // Lenient load path accepts it.
+        assert!(parse_workflow(src).is_ok());
+        // Strict author-time pass reports the missing discriminant.
+        let raw: RawWorkflow = toml::from_str(src).expect("the fixture is valid TOML");
+        let problems = validate(&raw, true).join("\n");
+        assert!(problems.contains("discriminant"), "{problems}");
     }
 
-    /// On-disk parity (issue #661): a `tool_call` with no `slug` fails at load,
-    /// the same as the console-draft path — so `translate` never has to fall
-    /// back to the node id as a placeholder slug.
+    /// Strict author-time parity (issue #661/#682): a `tool_call` with no `slug`
+    /// loads leniently now, but the STRICT pass reports it — the same shape the
+    /// console-draft path rejects — so `translate` never has to fall back to the
+    /// node id as a placeholder slug once a graph reaches an author surface.
     #[test]
-    fn tool_call_without_slug_is_rejected_on_disk() {
+    fn tool_call_without_slug_loads_leniently_but_strict_rejects() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -2077,8 +2137,12 @@ mod tests {
             from = "start"
             to = "call"
         "#;
-        let err = parse_workflow(src).unwrap_err();
-        assert!(err.to_string().contains("config.slug"), "{err}");
+        // Lenient load path accepts it.
+        assert!(parse_workflow(src).is_ok());
+        // Strict author-time pass reports the missing slug.
+        let raw: RawWorkflow = toml::from_str(src).expect("the fixture is valid TOML");
+        let problems = validate(&raw, true).join("\n");
+        assert!(problems.contains("config.slug"), "{problems}");
     }
 
     // --- G15: inescapable cycles + reachability (issue #540) ----------------
@@ -3063,7 +3127,9 @@ to = "done"
     #[test]
     fn destination_messages_match_the_console() {
         let raw: RawWorkflow = toml::from_str(BAD_DESTINATIONS).expect("the fixture is valid TOML");
-        let problems = validate(&raw).join("\n");
+        // Destination checks are unconditional, so the load-path (`false`) form
+        // surfaces them exactly as `parse_workflow` does.
+        let problems = validate(&raw, false).join("\n");
 
         for tail in [EMAIL_TARGET_TAIL, CHANNEL_TARGET_TAIL] {
             assert!(

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -124,9 +124,10 @@ fn tinyflows_kind(kind: WorkflowNodeKind) -> NodeKind {
 ///    defaults (so an author can override the derived `prompt`, add a
 ///    `tool_call` `slug`/`args`, or shape an `http_request` descriptor).
 /// 3. **First-class fields LAST** — `agent_ref` (bound from `agent`, so config
-///    can never rebind the node to another teammate), the `tool_call` id
-///    placeholder `slug` (only when the overlay carries none), and the
-///    engine-read `on_error` / `retry` / `requires_approval` keys.
+///    can never rebind the node to another teammate) and the engine-read
+///    `on_error` / `retry` / `requires_approval` keys. A `tool_call`'s `slug`
+///    rides in the config overlay (layer 2); author-time validation guarantees
+///    it is present, so translation adds no placeholder (issue #661).
 ///
 /// A legacy node (no `config`, no typed fields) yields exactly the pre-P1
 /// config, so translation of an unchanged file is byte-identical.
@@ -152,13 +153,16 @@ fn translate_node(def: &WorkflowNodeDef) -> Node {
                 config.insert("agent_ref".to_string(), json!(agent));
             }
         }
-        // A `tool_call` needs a `slug` or the engine's node errors; when the
-        // config binds none, fall back to the node id as a stable placeholder.
-        WorkflowNodeKind::ToolCall => {
-            config
-                .entry("slug".to_string())
-                .or_insert_with(|| json!(def.id));
-        }
+        // A `tool_call` needs a `slug` (the config overlay above carries it). The
+        // masking node-id default was removed (issue #661): author-time
+        // validation now rejects a slug-less `tool_call` on BOTH the on-disk seed
+        // path (`workflow_file::validate`) and the console-draft path
+        // (`validate_draft_against_record`), so a validated graph always binds a
+        // real slug. Defaulting to the node id instead pointed the engine's
+        // "missing tool" error at the wrong name and could collide with a real
+        // tool, silently invoking one the author never chose; absent a slug the
+        // engine's `tool_call` node now fails loudly on the missing key.
+        WorkflowNodeKind::ToolCall => {}
         _ => {}
     }
 
@@ -391,7 +395,9 @@ mod tests {
             config("strategist"),
             json!({ "agent_ref": "brand_strategist", "prompt": "Turns the brief into an angle + outline." })
         );
-        assert_eq!(config("gate"), json!({}));
+        // The gate carries its boolean discriminant (issue #661): a condition
+        // node must name the `field` it branches on.
+        assert_eq!(config("gate"), json!({ "field": "=item.needs_research" }));
         assert_eq!(
             config("research"),
             json!({
@@ -410,10 +416,11 @@ mod tests {
         assert_eq!(config("done"), json!({}));
     }
 
-    /// A `tool_call` node whose config binds a `slug` keeps that slug; the
-    /// node-id placeholder is only a fallback when config carries none.
+    /// A `tool_call` node's config `slug` is carried into the engine config
+    /// verbatim (issue #661 removed the node-id placeholder fallback; author-time
+    /// validation now guarantees a real slug is always present).
     #[test]
-    fn config_slug_beats_the_node_id_placeholder() {
+    fn config_slug_is_carried_into_engine_config() {
         let src = r#"
             id = "wf"
             name = "WF"
@@ -486,6 +493,8 @@ mod tests {
             kind = "tool_call"
             name = "Call"
             on_error = "continue"
+            [node.config]
+            slug = "csv_export"
             [node.retry]
             max_attempts = 3
             backoff_ms = 250


### PR DESCRIPTION
## Summary

Part of #661 (workflows module audit) — findings **M1 + M2 + H2**, shipped together because they are coupled: tightening validation without fixing the seeds would make 19 shipped seed workflows fail to load at boot.

**Root cause:** config **validation** and config **derivation** only covered `agent` and `tool_call`. Every other node kind's correctness rested on hand-written `config` that nothing enforced — so graphs saved clean and misbehaved silently at runtime, including the shipped seeds.

- **M1 — enforce required config at author time.** New shared `required_config_problems(kind, label, config)` helper, wired into the on-disk `validate` loop (seed path) and into `validate_draft_against_record` (console/builder draft path): `condition` requires `config.field`, `http_request` requires `method`+`url`, `switch` requires a discriminant. Condition edges must be labeled `yes`/`no` (the `error` route of an `on_error="route"` condition is exempt). A broken workflow now fails **loud at author/load time** with an actionable message instead of silently at runtime.
- **M2 — remove the `tool_call` slug masking default.** `translate_node` defaulted an absent slug to the **node id**, which turned a missing slug into a misleading "`<node-id>` is not a wired tool" error and could silently invoke an unintended tool on an id collision. Removed; a slug-less `tool_call` is now rejected up front (M1) rather than masked.
- **H2 — repair the shipped seeds.** 19 seed TOMLs had field-less `condition` nodes (always routed `true` — the gate decision was never made); 5 labeled branches with non-`yes`/`no` words (both mutually-exclusive branches fired in parallel); `game_studio/game_build_pipeline` was a condition-guarded cycle that **could not compile** (tinyflows `IllegalCycle`). All fixed to parse → validate → translate → **compile** cleanly.

## API Or Behavior Changes

No public API change. Behavior: workflows (seed, console, builder, and REST — all funnel through the shared `validate`) with a `condition` missing a `field`, a `switch` missing a discriminant, an `http_request` missing method/url, or a `condition` with non-`yes`/`no` edge labels are now **rejected at author/load time** instead of misbehaving at runtime. `translate` no longer invents a slug from the node id. The 20 bundled seeds are corrected (see per-seed table in the thread below / commit `dad94887`).

`game_build_pipeline`: kept its QA-fail→rework loop, now bounded by `recursion_limit = 100` on the trigger (OpenCompany has no `loop` node kind; a bounded trigger is tinyflows' sanctioned mechanism for a guarded cycle).

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default + `--features openhuman,tinycortex --no-deps`)
- [x] `cargo build --all-targets` (via `cargo check --all-features --all-targets`)
- [x] `cargo test` (default lib 1985/0; gated `--features openhuman,tinycortex` lib 2964/0)

The seed test (`every_bundled_workflow_is_runnable_against_its_roster`) was extended to push **every** seed through `tinyflows::compiler::compile` — it previously stopped at `translate`, which is why the `game_build` cycle shipped broken. 6 new validation unit tests added.

## Documentation

`translate.rs` doc updated for the removed default. Seed intent (which boolean gate each condition now expresses, and the 5 label normalizations) is documented in the PR thread for reviewer sanity-check.

## Related

Part of #661. Pairs with #677 (create_workflow parity, H1) and #676 (scheduler cap order, H4). Field expressions in seeds are notional template intent (`=item.<name>`) — templates carry no live upstream signal — and express the gate, matching the seeds' documented behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable condition fields for workflow decision points.
  * Added a configuration form requiring a field for condition nodes.
  * Standardized condition branches to use “yes” and “no” labels.
  * Added a recursion limit to gameplay rework cycles.

* **Bug Fixes**
  * Workflows now validate required configuration for conditions, HTTP requests, switches, and tool calls.
  * Tool-based workflow steps now require an explicitly configured identifier.
  * Workflow compilation checks now provide clearer validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->