### PR TITLE
workspace: mint a shape-changed deliverable before deleting the old one

### DIFF
--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -236,11 +236,9 @@ pub async fn materialize(
         // for every agent.
         Some(id) => {
             // The same shape guard as above: a node already at this path whose
-            // kind disagrees with what is being published is deleted and
-            // replaced, because no write can turn one into the other. Deleting
-            // is safe here in a way it is not above — the path is the
-            // deliverable's identity, so this node IS the thing being
-            // superseded, and its history lives on the artifact chain.
+            // kind disagrees with what is being published cannot be revised,
+            // because no write path converts one kind into the other (and the
+            // store refuses if asked). It has to be replaced.
             let replace = match workspace.read(company, &id).await? {
                 Some((node, _)) => {
                     node.is_binary() != matches!(target.payload, MirrorPayload::Bytes { .. })
@@ -248,8 +246,7 @@ pub async fn materialize(
                 None => false,
             };
             if replace {
-                workspace.delete(company, &id).await?;
-                return create_payload(workspace, company, Some(parent), filename, target).await;
+                return replace_payload(workspace, company, &parent, filename, &id, target).await;
             }
             let sha256 = write_payload(workspace, company, &id, target).await?;
             Ok(Mirrored {
@@ -282,6 +279,104 @@ async fn write_payload(
             Ok(node.sha256)
         }
     }
+}
+
+/// Replaces the node at a path with one of the **other** kind — prose becoming
+/// bytes, or the reverse — without a window in which the deliverable does not
+/// exist (issue #662).
+///
+/// # Why not delete-then-create
+///
+/// That is what this used to do, and it turned a *refused* publish into a
+/// destructive one. `create_payload` fails for designed reasons — over
+/// `max_blob_mb`, over `tree_quota_gb`, a store error — and quota refusal is an
+/// intended outcome of the same work that introduced this path. When it failed,
+/// the old deliverable had already been deleted and nothing restored it: the
+/// operator was left with an artifact record pointing at a node id that no
+/// longer resolved, and the previous deliverable — which was fine — destroyed by
+/// a publish that did not succeed.
+///
+/// The old code argued the deletion was safe because "its history lives on the
+/// artifact chain". That holds when the replacement lands and not otherwise, and
+/// nothing distinguished the two. It is also **false for a binary**, whose
+/// artifact version records neither content nor digest (issue #668) — so the
+/// chain recovers nothing. Minting first removes the need for that argument
+/// rather than working around it.
+///
+/// # Why the replacement is staged under another name
+///
+/// The obvious create-then-delete — mint the replacement at the final path,
+/// then remove the old node — briefly puts **two** nodes at one path, and if the
+/// delete then fails they stay there. [`resolve_file`] answers a duplicated name
+/// with `Conflict`, so that state does not decay: it refuses every future
+/// publish to that path, for every agent. Staging under a name nothing resolves
+/// keeps the path unambiguous at every instant.
+///
+/// # What each failure leaves behind
+///
+/// * **The create fails** — the common case, and the one this issue is about.
+///   Nothing has changed: the old deliverable is intact, the path still resolves
+///   to it, and the error propagates. Publishing is refused rather than
+///   destructive.
+/// * **The delete fails** — the old deliverable is still intact. The staged node
+///   is removed so the workspace is left exactly as it was found, and the
+///   original error propagates.
+/// * **The rename fails** — the only arm that loses the old node, and the
+///   replacement survives it: the new payload is durable under the staging name,
+///   the path is free rather than ambiguous, and the error names the node so it
+///   can be found. Strictly better than the old behaviour, which lost the
+///   payload outright.
+async fn replace_payload(
+    workspace: &dyn WorkspaceStore,
+    company: &CompanyId,
+    parent: &str,
+    filename: &str,
+    superseded: &str,
+    target: PublishTarget<'_>,
+) -> Result<String> {
+    // A name no publish can produce and `resolve_file` will never match, so the
+    // path keeps resolving to exactly one node while the swap is in flight.
+    let staged_name = format!("{filename}.publishing-{}", crate::ports::generate_id());
+    let staged = create_payload(
+        workspace,
+        company,
+        Some(parent.to_string()),
+        &staged_name,
+        target,
+    )
+    .await?;
+
+    if let Err(err) = workspace.delete(company, superseded).await {
+        // The old deliverable is still there, so the only thing to undo is the
+        // node just staged. A failure to clean it up is logged rather than
+        // returned: the caller's error is the one that explains the publish.
+        if let Err(cleanup) = workspace.delete(company, &staged).await {
+            tracing::warn!(
+                company = %company,
+                staged = %staged,
+                error = %cleanup,
+                "[publish] could not remove a staged replacement after a failed supersede; it \
+                 remains in the workspace under its staging name"
+            );
+        }
+        return Err(err);
+    }
+
+    workspace
+        .rename_move(company, &staged, Some(filename), None)
+        .await
+        .map_err(|err| {
+            tracing::error!(
+                company = %company,
+                staged = %staged,
+                name = %staged_name,
+                error = %err,
+                "[publish] the replacement was stored but could not be renamed onto the \
+                 deliverable's path; it is in the workspace under its staging name"
+            );
+            err
+        })?;
+    Ok(staged)
 }
 
 /// Creates a fresh node of the right kind holding `target`'s payload.
@@ -568,6 +663,106 @@ mod test {
         (dir, ops, CompanyId::new("mirror-co"))
     }
 
+    /// A store that delegates everything to a real backend but **refuses every
+    /// create**, which is the shape a quota refusal takes here.
+    ///
+    /// A wrapper rather than a configured quota because the assertion is about
+    /// what `materialize` does when the create fails, not about which limit
+    /// produced the failure — and a real limit would tie the test to whichever
+    /// cap happens to be tunable.
+    struct RefusingCreate(Arc<FsOps>);
+
+    #[async_trait::async_trait]
+    impl WorkspaceStore for RefusingCreate {
+        async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
+            WorkspaceStore::tree(&*self.0, company).await
+        }
+        async fn read(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, String)>> {
+            WorkspaceStore::read(&*self.0, company, id).await
+        }
+        async fn write(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            content: &str,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write(&*self.0, company, id, content, author).await
+        }
+        async fn create(
+            &self,
+            company: &CompanyId,
+            node: &WorkspaceNode,
+            content: Option<&str>,
+        ) -> Result<()> {
+            // Folders still have to be creatable: the scaffold mints the agent
+            // and task folders on the way in, and refusing those would fail the
+            // publish before it ever reaches the replacement.
+            if node.kind == NodeKind::Folder {
+                return WorkspaceStore::create(&*self.0, company, node, content).await;
+            }
+            Err(OpenCompanyError::InvalidRequest("over quota".to_string()))
+        }
+        async fn create_binary(
+            &self,
+            _company: &CompanyId,
+            _node: &WorkspaceNode,
+            _bytes: &[u8],
+        ) -> Result<()> {
+            Err(OpenCompanyError::InvalidRequest("over quota".to_string()))
+        }
+        async fn write_binary(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            bytes: &[u8],
+            mime: Option<&str>,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write_binary(&*self.0, company, id, bytes, mime, author).await
+        }
+        async fn read_bytes(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, crate::ports::workspace::BlobStream)>> {
+            WorkspaceStore::read_bytes(&*self.0, company, id).await
+        }
+        async fn rename_move(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            name: Option<&str>,
+            parent: Option<Option<&str>>,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::rename_move(&*self.0, company, id, name, parent).await
+        }
+        async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
+            WorkspaceStore::delete(&*self.0, company, id).await
+        }
+        async fn is_empty(&self, company: &CompanyId) -> Result<bool> {
+            WorkspaceStore::is_empty(&*self.0, company).await
+        }
+    }
+
+    /// Every node id in the workspace, sorted — the set, which is what `tree`
+    /// actually promises.
+    async fn sorted_ids(ws: &dyn WorkspaceStore, company: &CompanyId) -> Vec<String> {
+        let mut ids: Vec<String> = ws
+            .tree(company)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id)
+            .collect();
+        ids.sort();
+        ids
+    }
+
     /// A node's rendered path, so an assertion reads as a path rather than a
     /// ULID.
     async fn path_of(ws: &dyn WorkspaceStore, company: &CompanyId, id: &str) -> String {
@@ -730,6 +925,147 @@ mod test {
         assert!(
             ws.read(&co, &first).await.unwrap().is_none(),
             "the superseded node is gone, not left beside its replacement"
+        );
+    }
+
+    /// Issue #662. A shape-changing publish whose replacement **fails** must
+    /// leave the previous deliverable exactly where it was.
+    ///
+    /// This is the defect: the old code deleted first, so a refused create —
+    /// over `max_blob_mb`, over `tree_quota_gb`, any store error — destroyed a
+    /// deliverable that was fine, and left the artifact record pointing at a
+    /// node id that no longer resolved. Quota refusal is a *designed* outcome of
+    /// this path, so the window was never theoretical.
+    #[tokio::test]
+    async fn a_failed_replacement_leaves_the_previous_deliverable_intact() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("report.md", "# Draft"))
+            .await
+            .unwrap();
+        let before = path_of(ws, &co, &first).await;
+
+        // The same publish as the test above, but the store refuses to create
+        // the binary node — the shape every quota refusal takes here.
+        let refusing = RefusingCreate(ops.clone());
+        let err = materialize(
+            &refusing,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x25, 0x50, 0x44, 0x46],
+                    mime: "application/pdf",
+                },
+                existing_node_id: Some(&first),
+                ..target("report.md", "")
+            },
+        )
+        .await
+        .expect_err("the refused create must fail the publish");
+        assert!(
+            err.to_string().contains("over quota"),
+            "the store's own refusal must reach the caller: {err}"
+        );
+
+        let (node, body) = ws
+            .read(&co, &first)
+            .await
+            .unwrap()
+            .expect("the previous deliverable must still exist");
+        assert_eq!(body, "# Draft", "its content is untouched");
+        assert_eq!(node.name, "report.md");
+        assert_eq!(
+            path_of(ws, &co, &first).await,
+            before,
+            "and it still sits at the deliverable's path"
+        );
+    }
+
+    /// The other half: a refused replacement must not leave the staged node
+    /// behind either. The workspace has to look exactly as it did before the
+    /// publish was attempted — one node at the path, and nothing beside it.
+    #[tokio::test]
+    async fn a_failed_replacement_leaves_no_staged_node_behind() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("report.md", "# Draft"))
+            .await
+            .unwrap();
+        // Sorted: `tree` promises the set, not an order, so comparing raw
+        // sequences would fail on a reshuffle that changed nothing.
+        let before = sorted_ids(ws, &co).await;
+
+        let refusing = RefusingCreate(ops.clone());
+        let _ = materialize(
+            &refusing,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x25, 0x50, 0x44, 0x46],
+                    mime: "application/pdf",
+                },
+                existing_node_id: Some(&first),
+                ..target("report.md", "")
+            },
+        )
+        .await;
+
+        let after = sorted_ids(ws, &co).await;
+        assert_eq!(
+            before, after,
+            "a refused publish must change nothing at all"
+        );
+    }
+
+    /// The success path still ends with exactly ONE node at the path — the
+    /// staging name is an implementation detail that must never survive.
+    ///
+    /// Without this, the staged replacement could silently ship under
+    /// `report.md.publishing-<id>` and every assertion about the failure paths
+    /// would still pass.
+    #[tokio::test]
+    async fn a_successful_replacement_leaves_one_node_at_the_path() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("report.md", "# Draft"))
+            .await
+            .unwrap();
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x25, 0x50, 0x44, 0x46],
+                    mime: "application/pdf",
+                },
+                existing_node_id: Some(&first),
+                ..target("report.md", "")
+            },
+        )
+        .await
+        .expect("the replacement lands");
+
+        let nodes = ws.tree(&co).await.unwrap();
+        let parent = nodes
+            .iter()
+            .find(|n| n.id == second)
+            .and_then(|n| n.parent_id.clone())
+            .expect("the replacement has a parent");
+        let named: Vec<&WorkspaceNode> = nodes
+            .iter()
+            .filter(|n| n.parent_id.as_deref() == Some(parent.as_str()))
+            .collect();
+        assert_eq!(
+            named.iter().filter(|n| n.name == "report.md").count(),
+            1,
+            "exactly one node carries the deliverable's name: {named:?}"
+        );
+        assert!(
+            !named.iter().any(|n| n.name.contains(".publishing-")),
+            "no staging name may survive a successful publish: {named:?}"
         );
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -281,6 +281,25 @@ async fn write_payload(
     }
 }
 
+/// Removes a staged replacement that will not be used, leaving the workspace as
+/// it was found.
+///
+/// Best-effort and never returns: every caller already has an error that
+/// explains the publish, and a cleanup failure must not replace it with a less
+/// informative one. The staged name is logged so an operator can find the node
+/// if the removal did fail.
+async fn discard_staged(workspace: &dyn WorkspaceStore, company: &CompanyId, staged: &str) {
+    if let Err(cleanup) = workspace.delete(company, staged).await {
+        tracing::warn!(
+            company = %company,
+            staged = %staged,
+            error = %cleanup,
+            "[publish] could not remove a staged replacement that will not be used; it remains \
+             in the workspace under its staging name"
+        );
+    }
+}
+
 /// Replaces the node at a path with one of the **other** kind — prose becoming
 /// bytes, or the reverse — without a window in which the deliverable does not
 /// exist (issue #662).
@@ -346,20 +365,33 @@ async fn replace_payload(
     )
     .await?;
 
-    if let Err(err) = workspace.delete(company, superseded).await {
-        // The old deliverable is still there, so the only thing to undo is the
-        // node just staged. A failure to clean it up is logged rather than
-        // returned: the caller's error is the one that explains the publish.
-        if let Err(cleanup) = workspace.delete(company, &staged).await {
-            tracing::warn!(
-                company = %company,
-                staged = %staged,
-                error = %cleanup,
-                "[publish] could not remove a staged replacement after a failed supersede; it \
-                 remains in the workspace under its staging name"
-            );
+    match workspace.delete(company, superseded).await {
+        Ok(true) => {}
+        // `delete` reports *whether a node was removed*, and "already gone" is
+        // `Ok(false)`, not an error. Reading only the `Err` arm would let a
+        // second publish that superseded this same path while ours was staging
+        // go undetected — and then BOTH renames land on `filename`, which is the
+        // two-nodes-one-path `Conflict` this staging exists to prevent, reached
+        // through the one return value the code did not read.
+        //
+        // Not hypothetical: workflow runs are spawned rather than serialized
+        // behind the cycle lock, and `materialize` is reached from the publish
+        // drain rather than from a `company_write_lock`ed write plane, so two
+        // publishes of one path genuinely overlap.
+        Ok(false) => {
+            discard_staged(workspace, company, &staged).await;
+            return Err(OpenCompanyError::Conflict(format!(
+                "the deliverable at `{filename}` was replaced by another publish while this one \
+                 was being prepared; nothing was overwritten — publish again"
+            )));
         }
-        return Err(err);
+        Err(err) => {
+            // The old deliverable is still there, so the only thing to undo is
+            // the node just staged. A failure to clean it up is logged rather
+            // than returned: the caller's error explains the publish.
+            discard_staged(workspace, company, &staged).await;
+            return Err(err);
+        }
     }
 
     workspace
@@ -925,6 +957,137 @@ mod test {
         assert!(
             ws.read(&co, &first).await.unwrap().is_none(),
             "the superseded node is gone, not left beside its replacement"
+        );
+    }
+
+    /// A store that delegates everything but reports **no node removed** from
+    /// `delete` — the state a concurrent publish leaves behind when it
+    /// supersedes the same path first.
+    struct VanishingDelete(Arc<FsOps>);
+
+    #[async_trait::async_trait]
+    impl WorkspaceStore for VanishingDelete {
+        async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
+            WorkspaceStore::tree(&*self.0, company).await
+        }
+        async fn read(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, String)>> {
+            WorkspaceStore::read(&*self.0, company, id).await
+        }
+        async fn write(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            content: &str,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write(&*self.0, company, id, content, author).await
+        }
+        async fn create(
+            &self,
+            company: &CompanyId,
+            node: &WorkspaceNode,
+            content: Option<&str>,
+        ) -> Result<()> {
+            WorkspaceStore::create(&*self.0, company, node, content).await
+        }
+        async fn create_binary(
+            &self,
+            company: &CompanyId,
+            node: &WorkspaceNode,
+            bytes: &[u8],
+        ) -> Result<()> {
+            WorkspaceStore::create_binary(&*self.0, company, node, bytes).await
+        }
+        async fn write_binary(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            bytes: &[u8],
+            mime: Option<&str>,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write_binary(&*self.0, company, id, bytes, mime, author).await
+        }
+        async fn read_bytes(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, crate::ports::workspace::BlobStream)>> {
+            WorkspaceStore::read_bytes(&*self.0, company, id).await
+        }
+        async fn rename_move(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            name: Option<&str>,
+            parent: Option<Option<&str>>,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::rename_move(&*self.0, company, id, name, parent).await
+        }
+        /// The whole point: the node is really removed, but the caller is told
+        /// nothing was — exactly what the loser of a concurrent supersede sees.
+        async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
+            WorkspaceStore::delete(&*self.0, company, id).await?;
+            Ok(false)
+        }
+        async fn is_empty(&self, company: &CompanyId) -> Result<bool> {
+            WorkspaceStore::is_empty(&*self.0, company).await
+        }
+    }
+
+    /// A `delete` that reports `Ok(false)` means somebody else already
+    /// superseded this path. Renaming onto it anyway would put TWO nodes on one
+    /// name — and `resolve_file` answers a duplicate with `Conflict`, so that
+    /// state never decays: every future publish to the deliverable is refused,
+    /// for every agent.
+    ///
+    /// The staging design exists to make that state unreachable, and reading
+    /// only `delete`'s `Err` arm would have reopened it through its return
+    /// value.
+    #[tokio::test]
+    async fn a_delete_that_removed_nothing_refuses_rather_than_duplicating_the_path() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(ws, &co, target("report.md", "# Draft"))
+            .await
+            .unwrap();
+
+        let racing = VanishingDelete(ops.clone());
+        let err = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x25, 0x50, 0x44, 0x46],
+                    mime: "application/pdf",
+                },
+                existing_node_id: Some(&first),
+                ..target("report.md", "")
+            },
+        )
+        .await
+        .expect_err("a superseded path must refuse rather than rename onto it");
+        assert!(
+            err.to_string().contains("another publish"),
+            "the refusal must say what happened: {err}"
+        );
+
+        // The invariant this protects: at most one node carries the name.
+        let nodes = ws.tree(&co).await.unwrap();
+        let named: Vec<&WorkspaceNode> = nodes.iter().filter(|n| n.name == "report.md").collect();
+        assert!(
+            named.len() <= 1,
+            "the path must never carry two nodes: {named:?}"
+        );
+        // And no staged node is left behind under its staging name.
+        assert!(
+            !nodes.iter().any(|n| n.name.contains(".publishing-")),
+            "a refused supersede must not leak its staged node: {nodes:?}"
         );
     }
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -281,25 +281,6 @@ async fn write_payload(
     }
 }
 
-/// Removes a staged replacement that will not be used, leaving the workspace as
-/// it was found.
-///
-/// Best-effort and never returns: every caller already has an error that
-/// explains the publish, and a cleanup failure must not replace it with a less
-/// informative one. The staged name is logged so an operator can find the node
-/// if the removal did fail.
-async fn discard_staged(workspace: &dyn WorkspaceStore, company: &CompanyId, staged: &str) {
-    if let Err(cleanup) = workspace.delete(company, staged).await {
-        tracing::warn!(
-            company = %company,
-            staged = %staged,
-            error = %cleanup,
-            "[publish] could not remove a staged replacement that will not be used; it remains \
-             in the workspace under its staging name"
-        );
-    }
-}
-
 /// Replaces the node at a path with one of the **other** kind — prose becoming
 /// bytes, or the reverse — without a window in which the deliverable does not
 /// exist (issue #662).
@@ -331,20 +312,19 @@ async fn discard_staged(workspace: &dyn WorkspaceStore, company: &CompanyId, sta
 /// publish to that path, for every agent. Staging under a name nothing resolves
 /// keeps the path unambiguous at every instant.
 ///
-/// # What each failure leaves behind
+/// # The store owns the compare-and-swap
 ///
 /// * **The create fails** — the common case, and the one this issue is about.
 ///   Nothing has changed: the old deliverable is intact, the path still resolves
 ///   to it, and the error propagates. Publishing is refused rather than
 ///   destructive.
-/// * **The delete fails** — the old deliverable is still intact. The staged node
-///   is removed so the workspace is left exactly as it was found, and the
-///   original error propagates.
-/// * **The rename fails** — the only arm that loses the old node, and the
-///   replacement survives it: the new payload is durable under the staging name,
-///   the path is free rather than ambiguous, and the error names the node so it
-///   can be found. Strictly better than the old behaviour, which lost the
-///   payload outright.
+/// * **Another publisher wins** — [`WorkspaceStore::swap_files`] consumes this
+///   publisher's staging node and returns `None`; the caller receives a conflict
+///   and the final path still names exactly the winner.
+/// * **The store fails** — the old node remains the compare-and-swap authority.
+///   The staging id is logged rather than blindly deleted: a distributed store
+///   error can be an indeterminate response to a committed write, and deleting
+///   that id could destroy the successful replacement.
 async fn replace_payload(
     workspace: &dyn WorkspaceStore,
     company: &CompanyId,
@@ -352,7 +332,7 @@ async fn replace_payload(
     filename: &str,
     superseded: &str,
     target: PublishTarget<'_>,
-) -> Result<String> {
+) -> Result<Mirrored> {
     // A name no publish can produce and `resolve_file` will never match, so the
     // path keeps resolving to exactly one node while the swap is in flight.
     let staged_name = format!("{filename}.publishing-{}", crate::ports::generate_id());
@@ -365,50 +345,30 @@ async fn replace_payload(
     )
     .await?;
 
-    match workspace.delete(company, superseded).await {
-        Ok(true) => {}
-        // `delete` reports *whether a node was removed*, and "already gone" is
-        // `Ok(false)`, not an error. Reading only the `Err` arm would let a
-        // second publish that superseded this same path while ours was staging
-        // go undetected — and then BOTH renames land on `filename`, which is the
-        // two-nodes-one-path `Conflict` this staging exists to prevent, reached
-        // through the one return value the code did not read.
-        //
-        // Not hypothetical: workflow runs are spawned rather than serialized
-        // behind the cycle lock, and `materialize` is reached from the publish
-        // drain rather than from a `company_write_lock`ed write plane, so two
-        // publishes of one path genuinely overlap.
-        Ok(false) => {
-            discard_staged(workspace, company, &staged).await;
-            return Err(OpenCompanyError::Conflict(format!(
-                "the deliverable at `{filename}` was replaced by another publish while this one \
-                 was being prepared; nothing was overwritten — publish again"
-            )));
-        }
-        Err(err) => {
-            // The old deliverable is still there, so the only thing to undo is
-            // the node just staged. A failure to clean it up is logged rather
-            // than returned: the caller's error explains the publish.
-            discard_staged(workspace, company, &staged).await;
-            return Err(err);
-        }
-    }
-
-    workspace
-        .rename_move(company, &staged, Some(filename), None)
+    match workspace
+        .swap_files(company, superseded, &staged.node_id, filename)
         .await
-        .map_err(|err| {
+    {
+        Ok(Some(node)) => Ok(Mirrored {
+            node_id: node.id,
+            sha256: node.sha256,
+        }),
+        Ok(None) => Err(OpenCompanyError::Conflict(format!(
+            "the deliverable at `{filename}` was replaced by another publish while this one \
+             was being prepared; nothing was overwritten — publish again"
+        ))),
+        Err(err) => {
             tracing::error!(
                 company = %company,
-                staged = %staged,
+                staged = %staged.node_id,
                 name = %staged_name,
                 error = %err,
-                "[publish] the replacement was stored but could not be renamed onto the \
-                 deliverable's path; it is in the workspace under its staging name"
+                "[publish] the store could not decide the staged replacement; its id is logged \
+                 for recovery rather than deleted after an indeterminate write"
             );
-            err
-        })?;
-    Ok(staged)
+            Err(err)
+        }
+    }
 }
 
 /// Creates a fresh node of the right kind holding `target`'s payload.
@@ -744,7 +704,7 @@ mod test {
             _company: &CompanyId,
             _node: &WorkspaceNode,
             _bytes: &[u8],
-        ) -> Result<()> {
+        ) -> Result<WorkspaceNode> {
             Err(OpenCompanyError::InvalidRequest("over quota".to_string()))
         }
         async fn write_binary(
@@ -772,6 +732,15 @@ mod test {
             parent: Option<Option<&str>>,
         ) -> Result<WorkspaceNode> {
             WorkspaceStore::rename_move(&*self.0, company, id, name, parent).await
+        }
+        async fn swap_files(
+            &self,
+            company: &CompanyId,
+            expected_id: &str,
+            replacement_id: &str,
+            name: &str,
+        ) -> Result<Option<WorkspaceNode>> {
+            WorkspaceStore::swap_files(&*self.0, company, expected_id, replacement_id, name).await
         }
         async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
             WorkspaceStore::delete(&*self.0, company, id).await
@@ -960,13 +929,57 @@ mod test {
         );
     }
 
-    /// A store that delegates everything but reports **no node removed** from
-    /// `delete` — the state a concurrent publish leaves behind when it
-    /// supersedes the same path first.
-    struct VanishingDelete(Arc<FsOps>);
+    /// The reverse shape change is equally important: a generated payload can
+    /// later be republished as editable prose without asking either write API
+    /// to violate its type guard.
+    #[tokio::test]
+    async fn republishing_a_payload_as_a_note_replaces_the_node() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        let first = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x25, 0x50, 0x44, 0x46],
+                    mime: "application/pdf",
+                },
+                ..target("report.md", "")
+            },
+        )
+        .await
+        .unwrap()
+        .node_id;
+        let second = materialize(
+            ws,
+            &co,
+            PublishTarget {
+                existing_node_id: Some(&first),
+                ..target("report.md", "# Editable")
+            },
+        )
+        .await
+        .expect("a binary-to-text shape change must succeed")
+        .node_id;
+
+        let (node, body) = ws.read(&co, &second).await.unwrap().unwrap();
+        assert_eq!(body, "# Editable");
+        assert!(!node.is_binary());
+        assert_eq!(
+            path_of(ws, &co, &second).await,
+            format!("{AGENTS_ROOT}/cmo/t-1/report.md")
+        );
+        assert!(ws.read_bytes(&co, &first).await.unwrap().is_none());
+    }
+
+    /// A real store whose swap boundary pauses until two publishers have both
+    /// staged their payloads. This makes the race deterministic without
+    /// replacing the compare-and-swap implementation under test.
+    struct PausedSwap(Arc<FsOps>, Arc<tokio::sync::Barrier>);
 
     #[async_trait::async_trait]
-    impl WorkspaceStore for VanishingDelete {
+    impl WorkspaceStore for PausedSwap {
         async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
             WorkspaceStore::tree(&*self.0, company).await
         }
@@ -999,7 +1012,7 @@ mod test {
             company: &CompanyId,
             node: &WorkspaceNode,
             bytes: &[u8],
-        ) -> Result<()> {
+        ) -> Result<WorkspaceNode> {
             WorkspaceStore::create_binary(&*self.0, company, node, bytes).await
         }
         async fn write_binary(
@@ -1028,37 +1041,40 @@ mod test {
         ) -> Result<WorkspaceNode> {
             WorkspaceStore::rename_move(&*self.0, company, id, name, parent).await
         }
-        /// The whole point: the node is really removed, but the caller is told
-        /// nothing was — exactly what the loser of a concurrent supersede sees.
+        async fn swap_files(
+            &self,
+            company: &CompanyId,
+            expected_id: &str,
+            replacement_id: &str,
+            name: &str,
+        ) -> Result<Option<WorkspaceNode>> {
+            self.1.wait().await;
+            WorkspaceStore::swap_files(&*self.0, company, expected_id, replacement_id, name).await
+        }
         async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
-            WorkspaceStore::delete(&*self.0, company, id).await?;
-            Ok(false)
+            WorkspaceStore::delete(&*self.0, company, id).await
         }
         async fn is_empty(&self, company: &CompanyId) -> Result<bool> {
             WorkspaceStore::is_empty(&*self.0, company).await
         }
     }
 
-    /// A `delete` that reports `Ok(false)` means somebody else already
-    /// superseded this path. Renaming onto it anyway would put TWO nodes on one
-    /// name — and `resolve_file` answers a duplicate with `Conflict`, so that
-    /// state never decays: every future publish to the deliverable is refused,
-    /// for every agent.
-    ///
-    /// The staging design exists to make that state unreachable, and reading
-    /// only `delete`'s `Err` arm would have reopened it through its return
-    /// value.
+    /// Two publishers can prepare the same shape-changing path concurrently.
+    /// Both must reach the real store's swap boundary before either proceeds;
+    /// exactly one wins, and the loser cannot create a duplicate final path or
+    /// leak its staging node.
     #[tokio::test]
-    async fn a_delete_that_removed_nothing_refuses_rather_than_duplicating_the_path() {
+    async fn concurrent_shape_changes_have_one_winner_and_no_duplicate_path() {
         let (_dir, ops, co) = stores();
         let ws: &dyn WorkspaceStore = ops.as_ref();
 
         let first = materialize(ws, &co, target("report.md", "# Draft"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
 
-        let racing = VanishingDelete(ops.clone());
-        let err = materialize(
+        let racing = PausedSwap(ops.clone(), Arc::new(tokio::sync::Barrier::new(2)));
+        let left = materialize(
             &racing,
             &co,
             PublishTarget {
@@ -1069,25 +1085,45 @@ mod test {
                 existing_node_id: Some(&first),
                 ..target("report.md", "")
             },
-        )
-        .await
-        .expect_err("a superseded path must refuse rather than rename onto it");
+        );
+        let right = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                payload: MirrorPayload::Bytes {
+                    bytes: &[0x89, b'P', b'N', b'G'],
+                    mime: "image/png",
+                },
+                existing_node_id: Some(&first),
+                ..target("report.md", "")
+            },
+        );
+        let (left, right) = tokio::join!(left, right);
+        let outcomes = [left, right];
+        assert_eq!(
+            outcomes.iter().filter(|result| result.is_ok()).count(),
+            1,
+            "exactly one compare-and-swap must win: {outcomes:?}"
+        );
+        let loser = outcomes
+            .iter()
+            .find_map(|result| result.as_ref().err())
+            .expect("one publisher loses");
         assert!(
-            err.to_string().contains("another publish"),
-            "the refusal must say what happened: {err}"
+            loser.to_string().contains("another publish"),
+            "the refusal must say what happened: {loser}"
         );
 
-        // The invariant this protects: at most one node carries the name.
         let nodes = ws.tree(&co).await.unwrap();
         let named: Vec<&WorkspaceNode> = nodes.iter().filter(|n| n.name == "report.md").collect();
-        assert!(
-            named.len() <= 1,
-            "the path must never carry two nodes: {named:?}"
+        assert_eq!(
+            named.len(),
+            1,
+            "the final path must continuously have one winner: {named:?}"
         );
-        // And no staged node is left behind under its staging name.
         assert!(
             !nodes.iter().any(|n| n.name.contains(".publishing-")),
-            "a refused supersede must not leak its staged node: {nodes:?}"
+            "the losing compare-and-swap must consume its staged node: {nodes:?}"
         );
     }
 
@@ -1106,7 +1142,8 @@ mod test {
 
         let first = materialize(ws, &co, target("report.md", "# Draft"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         let before = path_of(ws, &co, &first).await;
 
         // The same publish as the test above, but the store refuses to create
@@ -1155,7 +1192,8 @@ mod test {
 
         let first = materialize(ws, &co, target("report.md", "# Draft"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         // Sorted: `tree` promises the set, not an order, so comparing raw
         // sequences would fail on a reshuffle that changed nothing.
         let before = sorted_ids(ws, &co).await;
@@ -1195,7 +1233,8 @@ mod test {
 
         let first = materialize(ws, &co, target("report.md", "# Draft"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         let second = materialize(
             ws,
             &co,
@@ -1209,7 +1248,8 @@ mod test {
             },
         )
         .await
-        .expect("the replacement lands");
+        .expect("the replacement lands")
+        .node_id;
 
         let nodes = ws.tree(&co).await.unwrap();
         let parent = nodes

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -296,6 +296,21 @@ async fn write_payload(
 /// longer resolved, and the previous deliverable — which was fine — destroyed by
 /// a publish that did not succeed.
 ///
+/// # The staging window costs quota, and that changes who succeeds
+///
+/// The replacement is minted while the superseded node still exists, so both
+/// payloads are charged against `tree_quota_gb` until the swap. Delete-first
+/// freed the old bytes before asking for the new ones. A company close to its
+/// quota republishing a large deliverable is therefore **refused where it
+/// previously succeeded** — the end state of a successful publish is unchanged,
+/// but which publishes succeed is not.
+///
+/// That is the right trade, and it is the same one the rest of this doc argues:
+/// a refusal leaves the previous deliverable intact and is recoverable by
+/// raising the quota or deleting something, where the old behaviour destroyed
+/// it. Recorded here because the operator-visible symptom — a quota error on a
+/// republish of something that already fits — is otherwise unexplainable.
+///
 /// The old code argued the deletion was safe because "its history lives on the
 /// artifact chain". That holds when the replacement lands and not otherwise, and
 /// nothing distinguished the two. It is also **false for a binary**, whose
@@ -971,6 +986,30 @@ mod test {
             format!("{AGENTS_ROOT}/cmo/t-1/report.md")
         );
         assert!(ws.read_bytes(&co, &first).await.unwrap().is_none());
+
+        // …and the staging name does not survive. The text side stages through
+        // plain `create` rather than `create_binary`, so it is a different pair
+        // of store calls from the text→bytes case above: a swap that promoted
+        // the node but left a sibling behind would satisfy every assertion
+        // before this one.
+        let nodes = ws.tree(&co).await.unwrap();
+        let parent = node
+            .parent_id
+            .clone()
+            .expect("the replacement has a parent");
+        let siblings: Vec<&WorkspaceNode> = nodes
+            .iter()
+            .filter(|n| n.parent_id.as_deref() == Some(parent.as_str()))
+            .collect();
+        assert_eq!(
+            siblings.iter().filter(|n| n.name == "report.md").count(),
+            1,
+            "exactly one node carries the deliverable's name: {siblings:?}"
+        );
+        assert!(
+            !siblings.iter().any(|n| n.name.contains(".publishing-")),
+            "no staging name may survive a successful publish: {siblings:?}"
+        );
     }
 
     /// A real store whose swap boundary pauses until two publishers have both

--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -614,6 +614,15 @@ impl WorkspaceStore for FixedTree {
     ) -> crate::Result<WorkspaceNode> {
         unreachable!("search never renames")
     }
+    async fn swap_files(
+        &self,
+        _company: &CompanyId,
+        _expected_id: &str,
+        _replacement_id: &str,
+        _name: &str,
+    ) -> crate::Result<Option<WorkspaceNode>> {
+        unreachable!("search never swaps files")
+    }
     async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
         unreachable!("search never deletes")
     }

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2984,6 +2984,15 @@ mod tests {
         ) -> crate::Result<WorkspaceNode> {
             unreachable!("the listing never renames")
         }
+        async fn swap_files(
+            &self,
+            _company: &CompanyId,
+            _expected_id: &str,
+            _replacement_id: &str,
+            _name: &str,
+        ) -> crate::Result<Option<WorkspaceNode>> {
+            unreachable!("the listing never swaps files")
+        }
         async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
             unreachable!("the listing never deletes")
         }

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -409,6 +409,29 @@ pub trait WorkspaceStore: Send + Sync {
         name: Option<&str>,
         parent: Option<Option<&str>>,
     ) -> Result<WorkspaceNode>;
+    /// Atomically promotes a staged file over the file it supersedes.
+    ///
+    /// Both ids must name files under the same parent. `replacement_id` is
+    /// renamed to `name` as part of the swap; `expected_id` is removed. The
+    /// operation is conditional on `expected_id` still naming the node being
+    /// replaced, so concurrent publishers cannot both win the same path.
+    ///
+    /// Returns the promoted node on success. If the expected node has already
+    /// gone, returns `None` **and consumes the staged replacement**, including
+    /// any binary payload. That cleanup is part of the port contract: a caller
+    /// losing the compare-and-swap must not leak its private staging node.
+    ///
+    /// Backends must make the logical tree transition without an observable
+    /// delete-then-rename gap. This is deliberately a store primitive rather
+    /// than two existing calls: a process-local lock cannot protect MongoDB
+    /// when two server instances publish concurrently.
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<WorkspaceNode>>;
     /// Deletes a node; folders are removed recursively. Returns whether a node
     /// was removed.
     ///

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -239,6 +239,34 @@ impl WorkspaceStore for WorkspaceAnnouncer {
         Ok(node)
     }
 
+    /// Promotes a staged file and emits the same logical changes the former
+    /// delete-plus-rename sequence emitted, but only after the atomic store
+    /// operation has decided its winner.
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<WorkspaceNode>> {
+        let promoted = self
+            .inner
+            .swap_files(company, expected_id, replacement_id, name)
+            .await?;
+        match &promoted {
+            Some(node) => {
+                self.announce(company, expected_id, CHANGE_REMOVED).await;
+                self.announce(company, &node.id, CHANGE_UPDATED).await;
+            }
+            None => {
+                // `create(_binary)` announced the private staging node as
+                // opened; the losing swap consumed it, so close that loop.
+                self.announce(company, replacement_id, CHANGE_REMOVED).await;
+            }
+        }
+        Ok(promoted)
+    }
+
     /// Deletes through, and announces only when a node was actually removed —
     /// a delete of an id the tree never held changed nothing.
     ///

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -341,6 +341,22 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
         self.inner.rename_move(company, id, name, parent).await
     }
 
+    /// The staged create has already paid the only quota charge this shape
+    /// change can add. Workspace quota counts binary payloads only, and a
+    /// shape-changing swap has exactly one binary side, so forwarding the swap
+    /// cannot transiently double-count two blobs.
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<WorkspaceNode>> {
+        self.inner
+            .swap_files(company, expected_id, replacement_id, name)
+            .await
+    }
+
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         self.inner.delete(company, id).await
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2609,6 +2609,61 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
         "…and byte-exactly"
     );
 
+    // -- Atomic staged-file swap -----------------------------------------
+    let old = WorkspaceNode {
+        mime: None,
+        size: None,
+        sha256: None,
+        ..node("swap-old", "report.md", None, None)
+    };
+    ws.create(&alpha, &old, Some("# old")).await.unwrap();
+    ws.create_binary(
+        &alpha,
+        &node(
+            "swap-new",
+            "report.md.publishing-test",
+            Some("application/pdf"),
+            None,
+        ),
+        b"new-payload",
+    )
+    .await
+    .unwrap();
+    let promoted = ws
+        .swap_files(&alpha, "swap-old", "swap-new", "report.md")
+        .await
+        .unwrap()
+        .expect("the expected node is still current");
+    assert_eq!(promoted.id, "swap-new");
+    assert_eq!(promoted.name, "report.md");
+    assert!(ws.read(&alpha, "swap-old").await.unwrap().is_none());
+    let (_, stream) = ws.read_bytes(&alpha, "swap-new").await.unwrap().unwrap();
+    assert_eq!(drain(stream).await, b"new-payload".to_vec());
+
+    // A stale compare-and-swap loses and consumes its private stage, payload
+    // included. This is what prevents two concurrent publishers from leaving
+    // either a duplicate final path or quota-charging garbage behind.
+    ws.create_binary(
+        &alpha,
+        &node(
+            "swap-loser",
+            "report.md.publishing-loser",
+            Some("application/pdf"),
+            None,
+        ),
+        b"loser",
+    )
+    .await
+    .unwrap();
+    assert!(
+        ws.swap_files(&alpha, "already-gone", "swap-loser", "report.md")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(ws.read(&alpha, "swap-loser").await.unwrap().is_none());
+    assert!(ws.read_bytes(&alpha, "swap-loser").await.unwrap().is_none());
+
     // -- A binary node must carry a mime ----------------------------------
     assert!(
         ws.create_binary(&alpha, &node("nomime", "x.bin", None, None), b"x")

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1297,6 +1297,70 @@ impl WorkspaceStore for FsOps {
         Ok(node)
     }
 
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<WorkspaceNode>> {
+        reject_unsafe_name(name)?;
+        let path = self.bundle(company).workspace_index_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut index = self.load_index(company).await?;
+        let Some(replacement) = index.get(replacement_id).cloned() else {
+            return Err(OpenCompanyError::CompanyNotFound(format!(
+                "workspace node {replacement_id}"
+            )));
+        };
+        if replacement.kind != NodeKind::File {
+            return Err(OpenCompanyError::InvalidRequest(
+                "only files can be promoted from a staging path".to_string(),
+            ));
+        }
+
+        let expected = index.get(expected_id).cloned();
+        let still_current = expected.as_ref().is_some_and(|node| {
+            node.kind == NodeKind::File
+                && node.name == name
+                && node.parent_id == replacement.parent_id
+        });
+        if !still_current {
+            // The compare-and-swap lost. The staging node is private to this
+            // operation, so consume it while the same index lock is held.
+            let physical = self.physical_path(company, &index, replacement_id)?;
+            if tokio::fs::try_exists(&physical).await.unwrap_or(false) {
+                tokio::fs::remove_file(&physical)
+                    .await
+                    .map_err(|e| io_err(&physical, e))?;
+            }
+            index.remove(replacement_id);
+            self.save_index(company, &index).await?;
+            return Ok(None);
+        }
+
+        let expected = expected.expect("still_current requires an expected node");
+        let old_physical = self.physical_path(company, &index, expected_id)?;
+        let staged_physical = self.physical_path(company, &index, replacement_id)?;
+        let mut promoted = replacement;
+        promoted.name = name.to_string();
+        promoted.updated_at_millis = now_millis();
+
+        // `rename` is the filesystem compare-and-swap boundary: on the
+        // supported Unix server platforms it replaces the destination in one
+        // operation, so a payload reader sees either the old bytes or the new
+        // bytes and never an absent final path. If it fails, the index is still
+        // untouched and the old deliverable remains authoritative.
+        tokio::fs::rename(&staged_physical, &old_physical)
+            .await
+            .map_err(|e| io_err(&old_physical, e))?;
+        index.remove(&expected.id);
+        index.insert(promoted.id.clone(), promoted.clone());
+        self.save_index(company, &index).await?;
+        Ok(Some(promoted))
+    }
+
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).workspace_index_json();
         let lock = path_lock(&path);

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2543,6 +2543,137 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         Ok(node)
     }
 
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<crate::ports::workspace::WorkspaceNode>> {
+        use crate::ports::workspace::NodeKind;
+
+        let nodes = self.collection("workspace_nodes");
+        let Some(staged_doc) = nodes
+            .find_one(doc! {
+                "company_id": company.as_ref(),
+                "node_id": replacement_id,
+            })
+            .await
+            .map_err(mongo_err)?
+        else {
+            return Err(OpenCompanyError::CompanyNotFound(format!(
+                "workspace node {replacement_id}"
+            )));
+        };
+        let staged_json = get_str(&staged_doc, "node_json")?.to_string();
+        let replacement: crate::ports::workspace::WorkspaceNode =
+            serde_json::from_str(&staged_json)?;
+        if replacement.kind != NodeKind::File {
+            return Err(OpenCompanyError::InvalidRequest(
+                "only files can be promoted from a staging path".to_string(),
+            ));
+        }
+
+        let expected_doc = nodes
+            .find_one(doc! {
+                "company_id": company.as_ref(),
+                "node_id": expected_id,
+            })
+            .await
+            .map_err(mongo_err)?;
+        let expected = expected_doc
+            .as_ref()
+            .map(
+                |document| -> Result<crate::ports::workspace::WorkspaceNode> {
+                    let json = get_str(document, "node_json")?;
+                    Ok(serde_json::from_str(json)?)
+                },
+            )
+            .transpose()?;
+        let still_current = expected.as_ref().is_some_and(|node| {
+            node.kind == NodeKind::File
+                && node.name == name
+                && node.parent_id == replacement.parent_id
+        });
+
+        // Detach the private staging document before changing the expected
+        // document's id: `(company_id, node_id)` is unique. The GridFS payload
+        // deliberately stays in place, already keyed by `replacement_id`.
+        // A crash here leaves the old deliverable intact and, at worst, an
+        // orphan the boot sweep reclaims.
+        let detached = nodes
+            .delete_one(doc! {
+                "company_id": company.as_ref(),
+                "node_id": replacement_id,
+                "node_json": &staged_json,
+            })
+            .await
+            .map_err(mongo_err)?;
+        if detached.deleted_count != 1 {
+            return Err(OpenCompanyError::Conflict(
+                "the staged workspace replacement changed before it could be promoted".to_string(),
+            ));
+        }
+
+        if !still_current {
+            self.drop_blobs(company, replacement_id, None).await?;
+            return Ok(None);
+        }
+
+        let expected_doc = expected_doc.expect("still_current requires an expected document");
+        let expected_json = get_str(&expected_doc, "node_json")?.to_string();
+        let expected_content = expected_doc
+            .get("content")
+            .cloned()
+            .unwrap_or_else(|| mongodb::bson::Bson::String(String::new()));
+        let staged_content = staged_doc
+            .get("content")
+            .cloned()
+            .unwrap_or_else(|| mongodb::bson::Bson::String(String::new()));
+        let mut promoted = replacement;
+        promoted.name = name.to_string();
+        promoted.updated_at_millis = now_millis();
+
+        // One document update is the compare-and-swap. Including the complete
+        // old JSON and content makes an in-place writer count as a competing
+        // revision even if two timestamps happen to share a millisecond.
+        let swapped = nodes
+            .update_one(
+                doc! {
+                    "company_id": company.as_ref(),
+                    "node_id": expected_id,
+                    "node_json": &expected_json,
+                    "content": expected_content,
+                },
+                doc! {"$set": {
+                    "node_id": replacement_id,
+                    "node_json": serde_json::to_string(&promoted)?,
+                    "content": staged_content,
+                    "updated_ms": promoted.updated_at_millis as i64,
+                }},
+            )
+            .await
+            .map_err(mongo_err)?;
+        if swapped.matched_count == 0 {
+            self.drop_blobs(company, replacement_id, None).await?;
+            return Ok(None);
+        }
+
+        // The new document already points at durable replacement bytes. Old
+        // bytes are now unreachable; a cleanup failure must not turn a
+        // successful atomic swap into a reported publish failure, because the
+        // boot orphan sweep can safely finish this work later.
+        if let Err(err) = self.drop_blobs(company, expected_id, None).await {
+            tracing::warn!(
+                company = %company,
+                node_id = %expected_id,
+                error = %err,
+                "workspace file swap succeeded but old GridFS payload cleanup was deferred"
+            );
+        }
+        Ok(Some(promoted))
+    }
+
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let nodes = self.workspace_nodes(company).await?;
         if !nodes.contains_key(id) {

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2586,7 +2586,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             .map(
                 |document| -> Result<crate::ports::workspace::WorkspaceNode> {
                     let json = get_str(document, "node_json")?;
-                    Ok(serde_json::from_str(json)?)
+                    Ok(serde_json::from_str(&json)?)
                 },
             )
             .transpose()?;

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -29,7 +29,7 @@ use std::sync::{Arc, Mutex as StdMutex, MutexGuard};
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use rusqlite::{Connection, OptionalExtension, params};
+use rusqlite::{Connection, OptionalExtension, TransactionBehavior, params};
 use tokio::sync::broadcast;
 
 use crate::Result;
@@ -2578,6 +2578,73 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         )
         .map_err(sql_err)?;
         Ok(node)
+    }
+
+    async fn swap_files(
+        &self,
+        company: &CompanyId,
+        expected_id: &str,
+        replacement_id: &str,
+        name: &str,
+    ) -> Result<Option<crate::ports::workspace::WorkspaceNode>> {
+        use crate::ports::workspace::NodeKind;
+
+        let mut conn = self.conn();
+        // Acquire the write reservation before reading either row. Two
+        // SqliteStore instances can point at the same database; an immediate
+        // transaction serializes their compare-and-swap decisions rather than
+        // letting both read the same expected node first.
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let nodes = self.workspace_nodes(&tx, company)?;
+        let Some(replacement) = nodes.get(replacement_id).cloned() else {
+            return Err(OpenCompanyError::CompanyNotFound(format!(
+                "workspace node {replacement_id}"
+            )));
+        };
+        if replacement.kind != NodeKind::File {
+            return Err(OpenCompanyError::InvalidRequest(
+                "only files can be promoted from a staging path".to_string(),
+            ));
+        }
+
+        let still_current = nodes.get(expected_id).is_some_and(|node| {
+            node.kind == NodeKind::File
+                && node.name == name
+                && node.parent_id == replacement.parent_id
+        });
+        if !still_current {
+            tx.execute(
+                "DELETE FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
+                params![company.as_ref(), replacement_id],
+            )
+            .map_err(sql_err)?;
+            tx.commit().map_err(sql_err)?;
+            return Ok(None);
+        }
+
+        let mut promoted = replacement;
+        promoted.name = name.to_string();
+        promoted.updated_at_millis = now_millis();
+        tx.execute(
+            "DELETE FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
+            params![company.as_ref(), expected_id],
+        )
+        .map_err(sql_err)?;
+        tx.execute(
+            "UPDATE workspace_nodes SET node_json = ?1, updated_ms = ?2 \
+             WHERE company_id = ?3 AND id = ?4",
+            params![
+                serde_json::to_string(&promoted)?,
+                promoted.updated_at_millis as i64,
+                company.as_ref(),
+                replacement_id
+            ],
+        )
+        .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
+        Ok(Some(promoted))
     }
 
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {


### PR DESCRIPTION
## Summary

Closes #662. A shape-changing publish (text to binary, or binary to text) used to delete the existing workspace node before creating its replacement. A quota or store refusal therefore destroyed a valid deliverable even though the publish failed.

The replacement is now created under a private staging name first, then promoted with a store-level conditional swap. The old node remains authoritative until the swap succeeds. If another publisher already replaced it, the loser is refused and its staging node, including any GridFS payload, is consumed. The final path never passes through a delete-then-rename gap and cannot acquire two winners from concurrent shape-changing publishes.

The swap boundary is implemented per durable backend:

- FsOps holds the workspace index lock and replaces the final file with one rename before publishing the new index.
- SQLite uses an immediate transaction, so multiple connections serialize the compare-and-swap decision.
- MongoDB detaches the private staging document and conditionally changes the expected document in one atomic update. The filter includes the expected metadata and content, making concurrent writes lose the comparison; GridFS cleanup follows only after the winner is durable.

The change is rebased over #688 and returns its `Mirrored { node_id, sha256 }` unchanged, so a shape-changing binary publish records the digest computed by the store.

## API Or Behavior Changes

- Adds `WorkspaceStore::swap_files`, the atomic staged-file promotion primitive. Decorators forward it and preserve quota/event behavior.
- A replacement create failure leaves the old deliverable untouched.
- A concurrent loser returns `Conflict` and leaves the winning final path unambiguous.
- Workspace quota does not double-count the staging window: quota counts binary payloads only, and a shape-changing replacement has exactly one binary side. Text-to-binary admission charges the staged binary while the old text is unmetered; binary-to-text adds no charged payload.

## Tests

- [x] `cargo fmt --all -- --check` — passed locally.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A locally per fleet rule; Rust validation runs in CI.
- [x] `cargo build --all-targets` — N/A locally per fleet rule; Rust validation runs in CI.
- [x] `cargo test` — N/A locally per fleet rule; Rust validation runs in CI.

Added coverage:

- A deterministic two-publisher barrier test: both payloads stage before either swap runs, exactly one wins, the loser reports conflict, one final-path node remains, and no staging node leaks.
- Binary-to-text replacement succeeds, preserves the final path, removes the old binary node, and returns a text node.
- The shared binary-store conformance suite now validates successful promotion and stale-winner cleanup for FsOps, SQLite, and MongoDB, including payload cleanup.
- Existing refusal tests continue to require the previous deliverable and workspace node set to remain unchanged when staging fails.

Rust compilation and tests are intentionally left to CI under the repository workflow rule that prohibits local Rust test-target builds on the shared machine.

## Documentation

Updated the `WorkspaceStore` contract and `replace_payload` failure/atomicity documentation. Backend comments explain each atomic boundary, Mongo crash ordering, quota accounting, and deferred orphan cleanup.
