### PR TITLE
feat(approvals): redact approval payload and amount for non-admins (#618)

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -337,6 +337,20 @@ export interface ApprovalSummary {
    */
   payload?: unknown;
   /**
+   * Whether {@link payload} and {@link amount_usd} were withheld from **this
+   * reader** because of their role (#618).
+   *
+   * Membership decides whether you may know an approval exists; role decides
+   * whether you may read its contents. An admin never sees this set.
+   *
+   * The console must not treat a withheld approval as an empty one. `payload`
+   * being absent already means "the effect carries no arguments", so without
+   * this flag a hidden payment and a no-argument tool call are the same bytes —
+   * and a member would read "nothing to show" where the truth is "not shown to
+   * you". Render the difference; see `ApprovalPayload`.
+   */
+  contents_hidden?: boolean;
+  /**
    * The chat thread this approval was raised in (#379) — the **host** thread id,
    * which is a desk id for a channel and a roster agent id for a direct message.
    * Resolve it to a console channel id with `channelIdForThread`.

--- a/frontend/src/components/approval-card.tsx
+++ b/frontend/src/components/approval-card.tsx
@@ -20,6 +20,7 @@ import {
   ChevronDown,
   ChevronUp,
   CreditCard,
+  EyeOff,
   FileSignature,
   FileText,
   Globe,
@@ -89,6 +90,15 @@ export function ApprovalHeadline({
         <p className="font-medium">{approvalAction(a)}</p>
         {a.amount_usd != null && (
           <p className="text-xs font-medium text-muted-foreground">{money(a.amount_usd)}</p>
+        )}
+        {/*
+         * #618: an absent amount normally means "this effect involves no
+         * money". When it was withheld it means the opposite could be true, and
+         * a member reading a hidden payment as a free action is exactly the
+         * misreading the flag exists to prevent.
+         */}
+        {a.amount_usd == null && a.contents_hidden && (
+          <p className="text-xs font-medium text-muted-foreground italic">Amount hidden</p>
         )}
       </div>
       {actions && <div className="flex shrink-0 gap-2">{actions}</div>}
@@ -163,6 +173,23 @@ export function ApprovalMeta({
 export function ApprovalPayload({ approval }: { approval: ApprovalSummary }) {
   const lines = useMemo(() => payloadLines(approval), [approval]);
   const [expanded, setExpanded] = useState(false);
+
+  // Withheld by role (#618) — say so. Returning `null` here would be the one
+  // wrong answer: it is what an approval with no arguments renders as, so a
+  // member would read a hidden payment as an ordinary empty card. The point of
+  // the flag is that "nothing to show" and "not shown to you" must not look
+  // alike.
+  if (approval.contents_hidden) {
+    return (
+      <div className="flex items-center gap-2 rounded-lg border border-dashed bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <EyeOff className="size-3.5 shrink-0" />
+        <span>
+          Details hidden by your role. An admin can see what this approval will do and decide it.
+        </span>
+      </div>
+    );
+  }
+
   if (lines.length === 0) return null;
 
   const clampable =

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1730,6 +1730,12 @@ impl CompanyRuntime {
                 // which matters for `composio_execute`, where the same tool is
                 // grantable reading a repository and not grantable sending mail.
                 broadly_grantable: p.effect.agent.is_some() && p.effect.may_be_granted_standing(),
+                // Always false here. Whether a *reader* may see the contents is
+                // a property of who is asking, and this projection is
+                // deliberately principal-free (issue #618) — the redaction
+                // happens at the edge, in `server::approval_visibility`, so
+                // per-role logic stays out of the domain layer.
+                contents_hidden: false,
             })
             .collect()
     }

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -194,6 +194,27 @@ pub struct ApprovalSummary {
     /// approve-once behaviour by construction.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub broadly_grantable: bool,
+    /// Whether [`payload`](Self::payload) and [`amount_usd`](Self::amount_usd)
+    /// were withheld from *this reader* because of their role (issue #618).
+    ///
+    /// Set at the edge by
+    /// [`approval_visibility`](crate::server::approval_visibility), never by
+    /// the projection — the runtime does not know who is asking, and this is
+    /// deliberately the only place that does.
+    ///
+    /// **The reason this flag exists rather than just blanking the fields:**
+    /// `payload: None` already means "the effect carries no arguments". Without
+    /// a separate signal, a withheld payment and a no-argument tool call are
+    /// the same bytes on the wire, and a console cannot tell "there is nothing
+    /// to show" from "you may not see it". The first renders as an ordinary
+    /// empty card; the second has to say *hidden by your role*, or a Member is
+    /// quietly misled about what they are looking at.
+    ///
+    /// Skipped when `false`, so an admin's response — and every response
+    /// produced before this field existed — serializes byte-identically to
+    /// before, and a console that reads no such field is unaffected.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub contents_hidden: bool,
 }
 
 #[cfg(test)]

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -134,7 +134,10 @@ mod tests {
     #[test]
     fn a_member_gets_the_approval_without_its_contents() {
         let out = for_principal(&principal(UserRole::Member), vec![summary()]);
-        assert!(out[0].payload.is_none(), "the recipient must not reach a member");
+        assert!(
+            out[0].payload.is_none(),
+            "the recipient must not reach a member"
+        );
         assert!(out[0].amount_usd.is_none(), "nor the amount");
         assert!(
             out[0].contents_hidden,

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -1,0 +1,176 @@
+//! Who may read an approval's *contents* (issue #618).
+//!
+//! Membership decides whether you may know an approval **exists**. It does not
+//! decide whether you may read what it is about. `payload` carries
+//! recipient-bearing tool arguments and `amount_usd` carries money; the rest of
+//! [`ApprovalSummary`] — the id, the kind, who asked, which task, when — is what
+//! makes stalled work visible, and every member needs it.
+//!
+//! This is the product's **first per-resource, per-role field restriction**.
+//! Everywhere else, role decides whether you may *act* (see
+//! [`AdminScopedCompany`](crate::server::ops::scope::AdminScopedCompany)); here
+//! it decides which fields of a read you receive. That is a new shape and worth
+//! knowing before it is copied.
+//!
+//! ## Why the split lands here and not on the whole route
+//!
+//! Refusing the route to non-admins was the obvious alternative and is worse: a
+//! Member would lose sight of *why* their work is stalled. Issue #468
+//! deliberately keeps a "waiting on approval" indicator on the task card, and
+//! that indicator has to survive for the people doing the work, not only for
+//! the people who can sign it off.
+//!
+//! ## Hidden is not absent
+//!
+//! Redaction does **not** simply blank the fields. `payload: None` already
+//! means "this effect carries no arguments", so blanking would make a withheld
+//! payment indistinguishable from a no-argument tool call — the console would
+//! render an approval that looks empty rather than one it may not show. So a
+//! redacted summary sets [`ApprovalSummary::contents_hidden`], and the console
+//! says "hidden by your role" instead of showing nothing.
+
+use crate::runtime::types::ApprovalSummary;
+use crate::server::graphql::auth::GqlAuth;
+
+/// May this principal read an approval's payload and amount?
+///
+/// Both arms are written out. `GqlAuth` has exactly two, and a wildcard here
+/// would silently grant contents to any arm added later — which is how a role
+/// guard decays into a deny-list.
+pub(crate) fn may_read_approval_contents(auth: &GqlAuth) -> bool {
+    match auth {
+        // The role already rides on the principal the route resolved, so
+        // nothing has to be threaded down into the domain layer to ask this.
+        GqlAuth::User(user) => user.may_administer(),
+        // **Fail closed, deliberately.** A platform bearer is the hosting
+        // control plane — it provisions and suspends containers and is not a
+        // person in the company. It has no need for a tenant's message bodies
+        // or payment amounts, and "the machine credential sees everything" is
+        // the assumption worth not making. This costs nothing today: the
+        // console authenticates as a user, and a prosumer deployment has no
+        // platform credential at all (`resolve_claims` requires
+        // `platform_auth` to be configured), so no human loses anything.
+        //
+        // If the hosting layer ever genuinely needs contents, that is a
+        // deliberate scope to add here, not a default to inherit.
+        GqlAuth::Platform(_) => false,
+    }
+}
+
+/// Applies [`may_read_approval_contents`] to a projection on its way out.
+///
+/// Takes the whole list rather than one summary because every caller has a
+/// list, and because doing it per-item at three call sites is three chances to
+/// forget one.
+pub(crate) fn for_principal(
+    auth: &GqlAuth,
+    mut approvals: Vec<ApprovalSummary>,
+) -> Vec<ApprovalSummary> {
+    if may_read_approval_contents(auth) {
+        return approvals;
+    }
+    for approval in &mut approvals {
+        hide_contents(approval);
+    }
+    approvals
+}
+
+/// Strips the two contents fields and records that it happened.
+///
+/// `contents_hidden` is what keeps this honest — see the module note.
+pub(crate) fn hide_contents(approval: &mut ApprovalSummary) {
+    approval.payload = None;
+    approval.amount_usd = None;
+    approval.contents_hidden = true;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ports::types::{ApprovalId, CompanyId};
+    use crate::ports::{SessionKind, UserRole};
+    use crate::server::graphql::auth::UserPrincipal;
+    use crate::server::platform_auth::PlatformClaims;
+
+    fn principal(role: UserRole) -> GqlAuth {
+        GqlAuth::User(UserPrincipal {
+            company: CompanyId::new("acme"),
+            user_id: "u-1".to_string(),
+            email: "who@example.test".to_string(),
+            role,
+            must_change_password: false,
+            session_token_hash: "hash".to_string(),
+            credential: SessionKind::Browser,
+        })
+    }
+
+    /// A summary with both contents fields populated — the only interesting
+    /// input, since redaction is a no-op on an approval that carries neither.
+    fn summary() -> ApprovalSummary {
+        ApprovalSummary {
+            id: ApprovalId::new("appr-1"),
+            kind: "email.send".to_string(),
+            amount_usd: Some(2400.0),
+            at_millis: 1_000,
+            task: None,
+            agent: Some("ops".to_string()),
+            payload: Some(serde_json::json!({ "to": "board@example.test" })),
+            thread: None,
+            broadly_grantable: false,
+            contents_hidden: false,
+        }
+    }
+
+    #[test]
+    fn an_admin_reads_the_contents_unchanged() {
+        let out = for_principal(&principal(UserRole::Admin), vec![summary()]);
+        assert!(out[0].payload.is_some(), "an admin decides the sign-off");
+        assert_eq!(out[0].amount_usd, Some(2400.0));
+        assert!(!out[0].contents_hidden);
+    }
+
+    /// The case the issue exists for. Membership still gets the row — that is
+    /// #468's stalled-work signal — but not what is inside it.
+    #[test]
+    fn a_member_gets_the_approval_without_its_contents() {
+        let out = for_principal(&principal(UserRole::Member), vec![summary()]);
+        assert!(out[0].payload.is_none(), "the recipient must not reach a member");
+        assert!(out[0].amount_usd.is_none(), "nor the amount");
+        assert!(
+            out[0].contents_hidden,
+            "and the console must be able to say so, rather than render an empty card"
+        );
+        // Everything that makes stalled work legible survives.
+        assert_eq!(out[0].kind, "email.send");
+        assert_eq!(out[0].agent.as_deref(), Some("ops"));
+        assert_eq!(out[0].at_millis, 1_000);
+    }
+
+    /// Issue #618's stated trap: a platform bearer carries no `UserRole`, and
+    /// whatever it gets must be a decision rather than a fallthrough. It is
+    /// **fail-closed** — see the comment on `may_read_approval_contents`.
+    #[test]
+    fn a_platform_bearer_is_refused_the_contents_explicitly() {
+        let claims = PlatformClaims {
+            tenant: "tenant:hosting".to_string(),
+            scopes: std::collections::HashSet::new(),
+            companies: None,
+        };
+        let out = for_principal(&GqlAuth::Platform(claims), vec![summary()]);
+        assert!(out[0].payload.is_none());
+        assert!(out[0].amount_usd.is_none());
+        assert!(out[0].contents_hidden);
+    }
+
+    /// Redaction must not invent contents where there were none: a no-argument
+    /// approval read by an admin still reports `contents_hidden == false`, so
+    /// "nothing to show" and "not shown to you" stay distinguishable.
+    #[test]
+    fn an_absent_payload_is_not_reported_as_hidden() {
+        let mut bare = summary();
+        bare.payload = None;
+        bare.amount_usd = None;
+        let out = for_principal(&principal(UserRole::Admin), vec![bare]);
+        assert!(!out[0].contents_hidden);
+    }
+}

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -72,12 +72,13 @@ impl CompanyGql {
     /// the whole boundary reachable through one GraphQL field.
     async fn approvals(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<ApprovalGql>> {
         let auth = ctx.data::<GqlAuth>()?;
-        Ok(
-            crate::server::approval_visibility::for_principal(auth, self.runtime.pending_approvals())
-                .into_iter()
-                .map(ApprovalGql::from)
-                .collect(),
+        Ok(crate::server::approval_visibility::for_principal(
+            auth,
+            self.runtime.pending_approvals(),
         )
+        .into_iter()
+        .map(ApprovalGql::from)
+        .collect())
     }
 
     /// The company roster: manifest teammates plus operator-added overlays.

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -65,12 +65,19 @@ impl CompanyGql {
     }
 
     /// The approvals currently awaiting the operator for this company.
-    async fn approvals(&self) -> Vec<ApprovalGql> {
-        self.runtime
-            .pending_approvals()
-            .into_iter()
-            .map(ApprovalGql::from)
-            .collect()
+    ///
+    /// Contents are role-gated exactly as on the REST list (issue #618). This
+    /// is the surface that made the question worth asking: it maps the same
+    /// projection, so a redaction applied only to the REST handlers would leave
+    /// the whole boundary reachable through one GraphQL field.
+    async fn approvals(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<ApprovalGql>> {
+        let auth = ctx.data::<GqlAuth>()?;
+        Ok(
+            crate::server::approval_visibility::for_principal(auth, self.runtime.pending_approvals())
+                .into_iter()
+                .map(ApprovalGql::from)
+                .collect(),
+        )
     }
 
     /// The company roster: manifest teammates plus operator-added overlays.
@@ -341,6 +348,12 @@ pub struct ApprovalGql {
     /// Epoch-millis the effect was parked. `Float` round-trips the full u64
     /// range that would overflow GraphQL's `Int`.
     pub at_millis: f64,
+    /// Whether `amountUsd` was withheld from this reader by their role (#618).
+    ///
+    /// Carried for the same reason it is on the REST summary: a `null` amount
+    /// otherwise means "this effect involves no money", and a Member looking at
+    /// a withheld payment would read it as a free action.
+    pub contents_hidden: bool,
 }
 
 impl From<crate::runtime::types::ApprovalSummary> for ApprovalGql {
@@ -350,6 +363,7 @@ impl From<crate::runtime::types::ApprovalSummary> for ApprovalGql {
             kind: summary.kind,
             amount_usd: summary.amount_usd,
             at_millis: summary.at_millis as f64,
+            contents_hidden: summary.contents_hidden,
         }
     }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -34,6 +34,14 @@ type Approval {
 	range that would overflow GraphQL's `Int`.
 	"""
 	atMillis: Float!
+	"""
+	Whether `amountUsd` was withheld from this reader by their role (#618).
+	
+	Carried for the same reason it is on the REST summary: a `null` amount
+	otherwise means "this effect involves no money", and a Member looking at
+	a withheld payment would read it as a free action.
+	"""
+	contentsHidden: Boolean!
 }
 
 """
@@ -98,6 +106,11 @@ type Company {
 	pendingApprovals: Int!
 	"""
 	The approvals currently awaiting the operator for this company.
+	
+	Contents are role-gated exactly as on the REST list (issue #618). This
+	is the surface that made the question worth asking: it maps the same
+	projection, so a redaction applied only to the REST handlers would leave
+	the whole boundary reachable through one GraphQL field.
 	"""
 	approvals: [Approval!]!
 	"""

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "tinyplace")]
 pub mod a2a;
+pub(crate) mod approval_visibility;
 /// The Agent Client Protocol surface (the `acp` feature).
 ///
 /// The module's own docs reason about "a build without the feature"; this is

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "tinyplace")]
 pub mod a2a;
-pub(crate) mod approval_visibility;
 /// The Agent Client Protocol surface (the `acp` feature).
 ///
 /// The module's own docs reason about "a build without the feature"; this is
@@ -9,6 +8,7 @@ pub(crate) mod approval_visibility;
 /// console shell.
 #[cfg(feature = "acp")]
 pub mod acp;
+pub(crate) mod approval_visibility;
 pub mod chat_history;
 pub mod cors;
 mod error;

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1699,7 +1699,12 @@ async fn list_approvals(
         return Err(resp);
     }
     let runtime = lookup(&state, &id).map_err(IntoResponse::into_response)?;
-    Ok(Json(runtime.pending_approvals()))
+    // Membership got you the list; role decides whether you may read what is in
+    // it (issue #618).
+    Ok(Json(crate::server::approval_visibility::for_principal(
+        &auth,
+        runtime.pending_approvals(),
+    )))
 }
 
 /// `GET /api/v1/company/approvals` (single-company alias).
@@ -1713,7 +1718,13 @@ async fn list_approvals_single(
     if let Some(resp) = authorize_address(&state, &auth, runtime.id()) {
         return Err(resp);
     }
-    Ok(Json(runtime.pending_approvals()))
+    // Same contents rule as the `{id}` form (issue #618) — the two handlers are
+    // the same read behind two addressing forms, and a redaction applied to one
+    // of them would be a hole rather than a boundary.
+    Ok(Json(crate::server::approval_visibility::for_principal(
+        &auth,
+        runtime.pending_approvals(),
+    )))
 }
 
 /// The operator's resolution of a parked approval.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -3760,6 +3760,117 @@ mod test {
         }
     }
 
+    /// Issue #618: membership gets you the approval, role gets you its
+    /// contents.
+    ///
+    /// **The two-account part is the point.** The harness signs every request
+    /// in as an admin, so a redaction verified only as an admin passes
+    /// identically against no redaction at all — the test would prove nothing
+    /// while looking like coverage. This seeds a second, Member-role account
+    /// and drives the same route with both.
+    #[tokio::test]
+    async fn a_member_sees_the_approval_but_not_its_payload_or_amount() {
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        let effect = crate::ports::types::Effect {
+            kind: "payment.send".into(),
+            group: crate::ports::types::EffectGroup::Spend,
+            amount_usd: Some(2400.0),
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({ "to": "board@example.test", "memo": "Q3 retainer" }),
+            agent: Some("ceo".into()),
+            run_id: None,
+        };
+        runtime
+            .journal
+            .record_parked(
+                &crate::ports::types::ApprovalId::new("appr-618"),
+                &effect,
+                1_000,
+                TaskLink::Unlinked,
+                ApprovalConversation::default(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let app = router(state);
+
+        async fn approvals_as(app: &axum::Router, cookie: String) -> serde_json::Value {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/api/v1/company/approvals")
+                        .header("cookie", cookie)
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice(&bytes).unwrap()
+        }
+
+        // The admin decides the sign-off, so the admin sees what it will do.
+        let as_admin = approvals_as(&app, crate::server::test_support::fixed_cookie("acme")).await;
+        let admin_row = &as_admin.as_array().unwrap()[0];
+        assert_eq!(admin_row["amount_usd"].as_f64(), Some(2400.0));
+        assert_eq!(admin_row["payload"]["to"], "board@example.test");
+        assert!(
+            admin_row.get("contents_hidden").is_none(),
+            "an admin is not told anything was hidden: {admin_row}"
+        );
+
+        let as_member =
+            approvals_as(&app, crate::server::test_support::member_cookie("acme")).await;
+        let member_row = &as_member.as_array().unwrap()[0];
+
+        // Still visible: everything that makes stalled work legible. This half
+        // is what #468 depends on — a member must keep seeing that work is
+        // waiting and what kind of call it is.
+        assert_eq!(member_row["id"], "appr-618");
+        assert_eq!(member_row["kind"], "payment.send");
+        assert_eq!(member_row["agent"], "ceo");
+        assert_eq!(member_row["at_millis"].as_u64(), Some(1_000));
+
+        // Withheld: the recipient and the money.
+        assert!(
+            member_row.get("payload").is_none(),
+            "the recipient must not reach a member: {member_row}"
+        );
+        // `null`, not absent: unlike `payload`, `amount_usd` carries no
+        // `skip_serializing_if`, so it stays on the wire as an explicit null.
+        // Both read as "no value" to the console (`a.amount_usd != null`
+        // covers either), and changing the wire shape as a side effect of a
+        // redaction would be a worse trade than asserting the shape that is
+        // actually there.
+        assert!(
+            member_row["amount_usd"].is_null(),
+            "nor the amount: {member_row}"
+        );
+        assert_eq!(
+            member_row["contents_hidden"], true,
+            "and the console must be able to say so rather than render an empty card: {member_row}"
+        );
+
+        // Belt and braces: the recipient string must appear nowhere in the
+        // member's response, however the shape changes later.
+        let raw = serde_json::to_string(&as_member).unwrap();
+        assert!(
+            !raw.contains("board@example.test") && !raw.contains("Q3 retainer"),
+            "payload content leaked to a member: {raw}"
+        );
+    }
+
     /// The dotted kind the stalled brain parks once its follow-up turn gets
     /// past the barrier. Parking journals durably (`record_parked`), so its
     /// presence in `pending_approvals()` is proof the continuation reached the

--- a/src/server/test_support.rs
+++ b/src/server/test_support.rs
@@ -132,6 +132,72 @@ pub(crate) async fn seed_fixed_admin(state: &AppState, company: &str) {
         .expect("seed_fixed_admin: create session");
 }
 
+/// A second fixed session token, for a **Member** rather than an admin.
+///
+/// Same safety property as [`FIXED_TEST_TOKEN`]: only its hash is stored.
+pub(crate) const FIXED_MEMBER_TEST_TOKEN: &str = "fixed-test-member-session-token-not-a-secret";
+
+/// Seeds a non-admin user whose session uses [`FIXED_MEMBER_TEST_TOKEN`].
+///
+/// Exists because the harness signs every request in as an admin
+/// ([`seed_fixed_admin`]), which is the wrong account for testing anything
+/// role-gated: a redaction verified only as an admin passes identically against
+/// no redaction at all. Issue #618 is the first per-role *field* restriction in
+/// the product, so proving it needs the account that is supposed to be denied.
+pub(crate) async fn seed_fixed_member(state: &AppState, company: &str) {
+    let id = CompanyId::new(company);
+    let runtime = state
+        .registry()
+        .get(&id)
+        .expect("seed_fixed_member: company is not registered");
+    let now = now_millis();
+    let user_id = generate_id();
+    runtime
+        .users()
+        .upsert_user(
+            &id,
+            &UserRecord {
+                id: user_id.clone(),
+                email: "harness-member@example.test".to_string(),
+                display_name: None,
+                role: UserRole::Member,
+                status: UserStatus::Active,
+                password_hash: None,
+                must_change_password: false,
+                created_at_millis: now,
+                last_seen_at_millis: None,
+                updated_at_millis: now,
+            },
+        )
+        .await
+        .expect("seed_fixed_member: upsert user");
+    runtime
+        .sessions()
+        .create(
+            &id,
+            &SessionRecord {
+                id: generate_id(),
+                token_hash: sha256_hex(FIXED_MEMBER_TEST_TOKEN),
+                user_id,
+                created_at_millis: now,
+                expires_at_millis: now + 60 * 60 * 1000,
+                user_agent: None,
+                kind: crate::ports::SessionKind::Browser,
+                label: None,
+            },
+        )
+        .await
+        .expect("seed_fixed_member: create session");
+}
+
+/// The `Cookie` header for [`seed_fixed_member`]'s session in `company`.
+pub(crate) fn member_cookie(company: &str) -> String {
+    format!(
+        "{}={FIXED_MEMBER_TEST_TOKEN}",
+        session_cookie_name(&CompanyId::new(company)).expect("cookie-safe company id")
+    )
+}
+
 /// The `Cookie` header for [`seed_fixed_admin`]'s session in `company`.
 pub(crate) fn fixed_cookie(company: &str) -> String {
     format!(


### PR DESCRIPTION
## Summary

Closes #618, implementing @oxoxDev's **option 3**: membership still decides whether you may know an approval exists; it no longer decides whether you may read its contents. `payload` and `amount_usd` are withheld from a Member and visible to an Admin.

**This is the product's first per-resource, per-role field restriction.** Everywhere else role decides whether you may *act* (`AdminScopedCompany` / `require_admin`); here it decides which fields of a read you receive. That is a new shape and worth knowing before it is copied — stated here rather than left to be inferred from the diff, as the issue asked.

## Problem

`GET …/approvals` returned every field of `ApprovalSummary` to any authenticated company member. `authorize_address` gates the route on `user.company == *id` and nothing else; `UserPrincipal` carries `role` and it was simply not consulted. So a Member could read the recipient and body of an email a teammate's agent was waiting to send, and the amount of a payment awaiting sign-off.

Option 2 (role-gate the whole route) was rejected in the issue **because it would blank #468's stalled-work indicator** — a Member has to keep seeing that work is waiting and on what. This change keeps that and removes only the two fields where "any authenticated member" was doing real work.

## Solution

A new `server::approval_visibility` applies the rule **at the edge**. `CompanyRuntime::pending_approvals()` stays principal-free — it does not know who is asking, and per-role logic stays out of the domain layer, which was the design objection recorded on the issue.

### Hidden is not absent — why there is a new field

Blanking `payload` and `amount_usd` would have failed the issue's own requirement that a redacted approval "read as *hidden by your role*, not as an empty or missing approval". `payload: None` **already means** "this effect carries no arguments", and a null `amount_usd` already means "no money involved". Without a separate signal, a withheld payment and a no-argument tool call are the same bytes, and the console cannot tell "nothing to show" from "not shown to you" — a Member would read a hidden $2,400 payment as a free action.

So `ApprovalSummary` gains `contents_hidden`, set only at the edge, skipped when false. An admin's response and every response produced before this change serialize byte-identically to before.

### Two deviations from the issue's implementation notes

Both deliberate; flagging them because a reviewer comparing this diff against those notes would otherwise read one as missed.

1. **Three consumers, not four.** The notes list `list_approvals`, `list_approvals_single`, `ApprovalGql`, and the task-card read in `ops/tasks.rs`. The task card needs no redaction: #629 (merged earlier today) shrank `TaskApproval` to `id` / `at_millis` / `status`, so neither sensitive field reaches that response any more. I verified rather than assumed — it consumes `pending_approvals()` but projects none of it.
2. **The `contents_hidden` flag**, above, which the notes did not anticipate.

### `GqlAuth::Platform` — fail-closed, explicitly

The issue warned that a platform bearer carries no `UserRole` and that defaulting it by falling through a match is how a role guard becomes a deny-list. Both arms are written out, with no wildcard, so a third arm added later is a compile error rather than a silent grant.

It is **fail-closed**: a platform bearer is the hosting control plane, not a person in the company, and has no need for a tenant's message bodies. This costs nothing today — the console authenticates as a user, and `resolve_claims` requires `platform_auth` to be configured, so a self-hosted deployment has no platform credential at all and no human loses anything. I checked that specifically before choosing, because fail-closed would have been wrong if a prosumer's only principal were `Platform`.

### Console

All three surfaces route through two shared spots in `approval-card.tsx`, so both are covered at once:

- `ApprovalPayload` renders "Details hidden by your role" instead of returning `null` — returning `null` is precisely what a no-argument approval renders as.
- The header renders "Amount hidden" when the amount is absent *and* withheld.

**Naming asymmetry, deliberate:** async-graphql camelCases the field to `contentsHidden`, while the REST summary stays `contents_hidden` (`ApprovalSummary` has no `rename_all`, and the console's TS mirror is snake_case throughout). Each surface keeps its own convention; please don't "fix" one to match the other.

## API Or Behavior Changes

- `GET /api/v1/companies/{id}/approvals` and `/api/v1/company/approvals`: for a **Member**, `payload` is omitted and `amount_usd` is `null`, with `contents_hidden: true`. Unchanged for an Admin.
- GraphQL `Company.approvals`: same rule; `ApprovalGql` gains `contentsHidden: Boolean!`. SDL snapshot regenerated via the documented `cargo test -- --ignored regenerate_sdl_snapshot`; the diff is +13 lines and contains nothing but this field and its docs.
- A platform bearer now receives redacted contents. Behaviour change for machine credentials, called out above.
- Nothing about how approvals are *decided* changes.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs this lane: `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, exit 0. (`--no-deps` is required locally or it fails on two pre-existing `large_enum_variant` lints in `vendor/tinyagents`; CI passes it — `ci.yml:434`.)
- [x] `cargo build --all-targets` — ran `cargo check --features openhuman,tinycortex --all-targets`, exit 0. Gated lane, covers `examples/`.
- [x] `cargo test` — ran `cargo test --features openhuman,tinycortex`: **2963 passed, 0 failed**.

Console: `npm run typecheck`, `typecheck:e2e`, `typecheck:unit` all exit 0.

**The two-account test is the one that matters.** The harness signs every request in as an admin, so a redaction verified only as an admin passes identically against no redaction at all — it would look like coverage and prove nothing. `a_member_sees_the_approval_but_not_its_payload_or_amount` seeds a second Member-role account (new `seed_fixed_member` / `member_cookie` helpers) and drives the same route as both principals: the admin sees the recipient and the amount; the member sees `id`, `kind`, `agent`, `at_millis` and `contents_hidden: true`, and the response is additionally asserted to contain the recipient string nowhere at all.

Plus four unit tests on the rule itself, including the `Platform` arm and one asserting that an approval which genuinely has no payload is **not** reported as hidden — so "nothing to show" and "not shown to you" stay distinguishable in both directions.

**Revert-and-check**, run rather than reasoned about. With `may_read_approval_contents` forced to `true` for everyone, the two-account test fails with the member's response printed in full:

```
the recipient must not reach a member: {"id":"appr-618","kind":"payment.send",
"amount_usd":2400.0,...,"payload":{"to":"board@example.test","memo":"Q3 retainer"}}
```

That failure message is the exposure this issue exists to close.

Worth recording: the two-account test caught two errors in my own work before it tested the feature — I had assumed `ApprovalSummary` was camelCase (it has no `rename_all`), and that a redacted `amount_usd` would be absent (it has no `skip_serializing_if`, so it is an explicit `null`). I asserted the shape that is actually on the wire rather than changing the wire as a side effect of a redaction.

## Documentation

Rationale lives at the definition sites, as this codebase does it: the module doc on `approval_visibility` explains why the split is per-field rather than per-route and why hidden ≠ absent; `ApprovalSummary::contents_hidden` and the TS mirror each carry the "must not render as empty" instruction.

**Not verified:** no live two-account run against a deployed console. Per the issue's note, `e2e_harness` names exactly one admin, so that would need a Member invited first. The redaction itself is proven at the HTTP boundary by the test above; what is unproven is only how the three console surfaces *look* to a real Member. Happy to do that if you want it before merge.

## Related

- Closes #618
- Adjacent and deliberately **not** in scope: `IrreversibleEffect.amount_usd` in the task-detail read also shows a money amount to any member. Different DTO, executed effects rather than parked approvals, so it is outside this issue's question. Flagging rather than widening the diff — say the word and I will file it.
