### PR TITLE
feat(workspace): let an agent tidy its own folder (#671)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -228,7 +228,8 @@ So the two questions are now separate answers from one declaration
   that can execute arbitrary code (`shell`), reach an arbitrary address
   (`http_request`, `curl`, `web_fetch`, `git_operations`), act through a
   third-party server (`mcp_call_tool`), change the company's shared note tree
-  (`workspace_write`, `workspace_create`), or run a saved workflow; refused for
+  (`workspace_write`, `workspace_create`, `workspace_rename`,
+  `workspace_delete`), or run a saved workflow; refused for
   every named
   consequence — Spend, Send, Sign, Publish, Hire, Identity; and refused for any
   tool nobody has declared.

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -211,7 +211,13 @@ which is fixed at agent-build time and never taken from tool arguments. Agents
 reach the same tree through `workspace_list` / `workspace_search` /
 `workspace_read` / `workspace_create` / `workspace_write`, and a created note has its default home
 in the reserved `Agents/<agent-id>/` folder (#551) — a convention the persona
-brief steers toward, not a boundary the routes enforce. Boot scaffolds the
+brief steers toward, not a boundary the routes enforce. `workspace_rename` and
+`workspace_delete` (#671) are the exception: those two *are* bounded to
+`Agents/<agent-id>/`, checked on the resolved node so an `id` argument refuses
+exactly as its path would. Neither restamps authorship; a delete leaves any
+artifact version that pointed at the node with a dangling `workspaceNodeId`,
+which is the same state the `DELETE` route above produces and is read-guarded
+before reuse. Boot scaffolds the
 `Agents/` root empty; an individual `Agents/<agent-id>/` is minted the first
 time that agent writes into it, and the `Desks/` root is minted whole the first
 time a desk produces something (#645) — so a tree read on a fresh company shows

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -263,20 +263,23 @@ prompt = "Weekly review and operator digest"
     The Usage view surfaces a `Web searches` KPI plus a search status row
     (active / paused at cap 0 / awaiting credential / not granted / not in this
     build).
-  - **`workspace`** (issues #237, #551) grants the company's shared note tree —
+  - **`workspace`** (issues #237, #551, #671) grants the company's shared note tree —
     the `Standards/` / `Playbooks/` / `Product/` documents seeded from
     `companies/<name>/workspace/**`, plus whatever the operator and the agents
     have written since. It is **split**, unlike every other namespace: *reads*
     (`workspace_list`, `workspace_search`, `workspace_read`) follow the
     ordinary rule, so a
     catch-all `*` confers them; *mutations* (`workspace_write`,
-    `workspace_create`) need an **explicit** `workspace` or `workspace.write`
+    `workspace_create`, `workspace_rename`, `workspace_delete`) need an
+    **explicit** `workspace` or `workspace.write`
     entry in `[tools].allow`, because they change a tree every other agent then
     treats as the company's source of truth. `workspace.read` is therefore a
-    genuinely read-only grant. Create and write ride the one flag on purpose:
+    genuinely read-only grant. All four ride the one flag on purpose:
     overwriting an existing standard is strictly more destructive than adding a
-    note beside it, so a grant permitting the first has already permitted the
-    second. `workspace_search` (issue #607) is a read and rides the read side of
+    note beside it, and strictly more destructive than removing or moving
+    something inside the agent's own folder, so a grant permitting the first has
+    already permitted the rest. Issue #671 deliberately added no fifth grant
+    name. `workspace_search` (issue #607) is a read and rides the read side of
     that split — **not** the metered `search` namespace, despite the name.
     `search` is the paid external-credential grant that carries `web_search`;
     reading the company's own notes must not require a billed credential, and
@@ -293,7 +296,20 @@ prompt = "Weekly review and operator digest"
     provisioned at boot. Since issue #552 this call is one of two paths that
     bring it into existence; publishing a deliverable
     (`artifact_mirror::materialize`) is the other, and both go through the same
-    `ensure_agent_folder` seam. Renaming and deleting stay operator-only.
+    `ensure_agent_folder` seam.
+
+    `workspace_rename` and `workspace_delete` (issue #671) are the tidying half.
+    Both act on **one node at a time** and both reach only
+    `Agents/<agent-id>/` — the agent's own folder, never the folder itself,
+    never a teammate's, never shared guidance. `workspace_delete` carries the
+    same required `expected_updated_at` token as `workspace_write` and refuses a
+    folder that still holds anything, so a subtree is removed as N deliberate,
+    individually-parked calls rather than one. `workspace_rename` carries no
+    token, because it destroys nothing: body, id and both authorship stamps
+    survive it. Read the confinement as a division of labour rather than as a
+    security boundary — the same grant already confers *unconfined* overwrite,
+    which reaches further than own-folder lifecycle does. Renaming or deleting
+    anything elsewhere in the tree stays operator-only.
 
     Agent writes are **unconfined**: an agent may create or edit anywhere in its
     company's tree. Confining creation while leaving overwrite free would

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -128,7 +128,8 @@ destroying the diff.
 The Obsidian-style note tree (`src/ports/workspace.rs`), seeded from the
 company's `workspace/**` on first use and thereafter written by both the
 operator (console/REST) and the company's agents (`workspace_create` /
-`workspace_write`).
+`workspace_write`, plus `workspace_rename` / `workspace_delete` within
+`Agents/<agent-id>/` since issue #671).
 
 ```rust
 pub trait WorkspaceStore: Send + Sync {

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -153,6 +153,15 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   workspace_write: "Edit a note in its workspace",
   workspace_read: "Read a note in its workspace",
   workspace_list: "List its workspace notes",
+  // Every workspace mutation parks per call, so each of these reaches an
+  // operator on the approval card and again in the Standing permissions list.
+  // `workspace_create` has been missing since issue #551 and was showing as the
+  // generic "Use one of its tools"; the lifecycle pair (#671) would have
+  // arrived with the same gap. "its own folder" is load-bearing on the last
+  // two — the scope is the whole reason an operator can wave them through.
+  workspace_create: "Add a note to its workspace",
+  workspace_rename: "Rename a note in its own folder",
+  workspace_delete: "Delete a note from its own folder",
   memory_store: "Save something to its memory",
   memory_recall: "Look something up in its memory",
   web_fetch: "Fetch a web page",

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -35,12 +35,14 @@
 //!   the metered `search` one: it reads exactly what `workspace_read` already
 //!   grants, so requiring a billed backend credential for it would price the
 //!   cheap discovery path above the list-then-read crawl it replaces.
-//!   `workspace_write` is added
-//!   only under an **explicit** `workspace` / `workspace.write` grant — a bare
-//!   `*` does not confer it — and is guarded by a required compare-and-swap
-//!   revision token. Unlike the file tools these are scoped by the store, not
-//!   the filesystem: every call resolves through one company-scoped `tree()`
-//!   read, so no host path is ever built from agent input.
+//!   `workspace_create` / `workspace_write` and, since issue #671,
+//!   `workspace_rename` / `workspace_delete` are added only under an
+//!   **explicit** `workspace` / `workspace.write` grant — a bare `*` does not
+//!   confer them. `workspace_write` and `workspace_delete` are each guarded by
+//!   a required compare-and-swap revision token, and the lifecycle pair reaches
+//!   only `Agents/<agent id>/`. Unlike the file tools these are scoped by the
+//!   store, not the filesystem: every call resolves through one company-scoped
+//!   `tree()` read, so no host path is ever built from agent input.
 //! * **Delegation is orchestrator-only.** `query_company` / `spawn_task` /
 //!   `delegate_to_desk` (and the other orchestrator roster/workflow tools) are
 //!   wired only when `is_orchestrator`; a **dispatched** desk/roster agent never
@@ -445,28 +447,35 @@ pub fn build_agent(
     //  1. READS follow the ordinary namespace rule, so a catch-all `*` confers
     //     them — the whole point of #237 is that shared guidance should be
     //     reachable by default.
-    //  2. CREATE + WRITE need an **EXPLICIT** `workspace` (or
-    //     `workspace.write`) grant (`grants_workspace_write_explicit`); `*`
+    //  2. CREATE + WRITE + RENAME + DELETE need an **EXPLICIT** `workspace`
+    //     (or `workspace.write`) grant (`grants_workspace_write_explicit`); `*`
     //     does NOT confer them, mirroring the media/composio precedent, because
-    //     they mutate a tree every other agent then trusts. Both ride the one
-    //     flag: overwriting an existing standard is strictly more destructive
-    //     than adding a note beside it, so a grant that permits the first has
-    //     already permitted the second.
+    //     they mutate a tree every other agent then trusts. All four ride the
+    //     one flag: overwriting an existing standard is strictly more
+    //     destructive than adding a note beside it, and strictly more
+    //     destructive than removing or moving something inside the agent's own
+    //     folder — so a grant that permits the first has already permitted the
+    //     rest, and issue #671 deliberately added no fifth grant name.
     //
     // Unwired-store is fail-closed: with no `deps.workspace` no tool is built
     // and the agent behaves exactly as it did before this cell.
     //
-    // Note what does and does not contain a write here, now that create is
-    // agent-reachable (#551). It is NOT intra-company isolation — an agent may
-    // create and overwrite anywhere in its company's tree, by design. What
-    // holds is: company tenancy (the store is pinned to one `CompanyId` at
-    // build time, and every tool resolves inside a single company-scoped tree
-    // read); the explicit grant above; the write tool's required
-    // `expected_updated_at` CAS token; policy parking, since `workspace_write`
-    // and `workspace_create` are both `Reach::Consequence` and never grantable
-    // standing (`policy::consequence`); and authorship, since every node
-    // records who created it and who last wrote it (#326). Rename and delete
-    // remain operator-only — they are not on this surface at all.
+    // Note what does and does not contain a write here, now that create
+    // (#551) and the lifecycle pair (#671) are agent-reachable. It is NOT
+    // intra-company isolation — an agent may create and overwrite anywhere in
+    // its company's tree, by design. What holds is: company tenancy (the store
+    // is pinned to one `CompanyId` at build time, and every tool resolves
+    // inside a single company-scoped tree read); the explicit grant above; the
+    // required `expected_updated_at` CAS token on `workspace_write` and
+    // `workspace_delete`; policy parking, since all four mutations are
+    // `Reach::Consequence` and never grantable standing
+    // (`policy::consequence`); and authorship, since every node records who
+    // created it and who last wrote it (#326).
+    //
+    // Rename and delete additionally reach only `Agents/<agent id>/`. Read that
+    // as a division of labour, not as a security boundary: the same grant
+    // already confers unconfined overwrite, which is the broader power. See the
+    // `workspace_tools::lifecycle` module docs.
     //
     // Not mapped in `toolbelt::namespace_of`, so these stay intrinsic to the
     // capability filter (the `file_tools` precedent): the reads are free and
@@ -1465,6 +1474,8 @@ mod tests {
             "workspace_read",
             "workspace_search",
             "workspace_write",
+            "workspace_rename",
+            "workspace_delete",
         ] {
             assert!(
                 !unwired.contains(&tool.to_string()),
@@ -1490,17 +1501,26 @@ mod tests {
             wildcard.contains(&"workspace_search".to_string()),
             "a bare `*` must confer workspace search: {wildcard:?}"
         );
-        assert!(
-            !wildcard.contains(&"workspace_write".to_string()),
-            "a bare `*` must NOT confer workspace writes: {wildcard:?}"
-        );
+        for tool in ["workspace_write", "workspace_rename", "workspace_delete"] {
+            assert!(
+                !wildcard.contains(&tool.to_string()),
+                "a bare `*` must NOT confer `{tool}`: {wildcard:?}"
+            );
+        }
 
-        // Explicit `workspace` → reads + write.
+        // Explicit `workspace` → reads + all four mutations. The lifecycle pair
+        // (issue #671) rides this grant rather than a new one: it reaches only
+        // the agent's own folder, which is narrower than the unconfined
+        // overwrite the same grant already confers.
         let explicit = built_tool_names_with_workspace(&["workspace"]);
-        assert!(
-            explicit.contains(&"workspace_write".to_string()),
-            "{explicit:?}"
-        );
+        for tool in [
+            "workspace_create",
+            "workspace_write",
+            "workspace_rename",
+            "workspace_delete",
+        ] {
+            assert!(explicit.contains(&tool.to_string()), "{tool}: {explicit:?}");
+        }
 
         // No workspace grant at all → nothing, even with a store wired.
         let ungranted = built_tool_names_with_workspace(&["web.*"]);
@@ -1509,6 +1529,8 @@ mod tests {
             "workspace_read",
             "workspace_search",
             "workspace_write",
+            "workspace_rename",
+            "workspace_delete",
         ] {
             assert!(
                 !ungranted.contains(&tool.to_string()),
@@ -1529,16 +1551,20 @@ mod tests {
             read_grant.contains(&"workspace_read".to_string()),
             "{read_grant:?}"
         );
-        assert!(
-            !read_grant.contains(&"workspace_write".to_string()),
-            "`workspace.read` must not confer writes: {read_grant:?}"
-        );
+        for tool in ["workspace_write", "workspace_rename", "workspace_delete"] {
+            assert!(
+                !read_grant.contains(&tool.to_string()),
+                "`workspace.read` must not confer `{tool}`: {read_grant:?}"
+            );
+        }
 
         let write_grant = built_tool_names_with_workspace(&["workspace.write"]);
-        assert!(
-            write_grant.contains(&"workspace_write".to_string()),
-            "{write_grant:?}"
-        );
+        for tool in ["workspace_write", "workspace_rename", "workspace_delete"] {
+            assert!(
+                write_grant.contains(&tool.to_string()),
+                "{tool}: {write_grant:?}"
+            );
+        }
     }
 
     /// `workspace_search` rides the `workspace` READ grant and NEVER the

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1266,6 +1266,8 @@ mod tests {
             ("git_operations", serde_json::json!({})),
             ("workspace_write", serde_json::json!({})),
             ("workspace_create", serde_json::json!({})),
+            ("workspace_delete", serde_json::json!({})),
+            ("workspace_rename", serde_json::json!({})),
             ("publish_artifact", serde_json::json!({})),
             ("media_generate_image", serde_json::json!({})),
             ("media_generate_video", serde_json::json!({})),
@@ -1618,18 +1620,20 @@ mod tests {
         );
     }
 
-    /// The company workspace (issues #237, #551): the two read tools reach only
-    /// this company's own note tree and must be allowed in every mode, while
-    /// `workspace_write` (overwrites shared guidance) and `workspace_create`
-    /// (adds to the tree everyone reads) must park under supervised / be denied
+    /// The company workspace (issues #237, #551, #671): the two read tools
+    /// reach only this company's own note tree and must be allowed in every
+    /// mode, while the four mutations — `workspace_write` (overwrites shared
+    /// guidance), `workspace_create` (adds to the tree everyone reads),
+    /// `workspace_delete` and `workspace_rename` (remove and move what the
+    /// agent put in its own folder) — must park under supervised / be denied
     /// under readonly.
     ///
     /// This is the ACTUAL gate on a workspace write. Issue #237 proposed that
     /// declaring `PermissionLevel::Write` would keep the `ApprovalPolicy` as
     /// the per-call gate; it would not — openhuman's `ToolPolicy` surface hands
     /// this bridge only the tool name and args, never the tool's permission
-    /// level, so classification is by name alone. Pinning all three names here
-    /// is what stops a later rename (say `get_workspace_note`, which the
+    /// level, so classification is by name alone. Pinning every one of the six
+    /// names here is what stops a later rename (say `get_workspace_note`, which the
     /// read-only prefix list would silently wave through) from moving a tool
     /// across the gate unnoticed.
     #[tokio::test]
@@ -1644,7 +1648,12 @@ mod tests {
                 "{tool} only reads this company's own workspace and must be allowed"
             );
         }
-        for tool in ["workspace_write", "workspace_create"] {
+        for tool in [
+            "workspace_write",
+            "workspace_create",
+            "workspace_delete",
+            "workspace_rename",
+        ] {
             assert!(
                 matches!(
                     supervised
@@ -1664,7 +1673,12 @@ mod tests {
                 "{tool} must stay available to a read-only desk"
             );
         }
-        for tool in ["workspace_write", "workspace_create"] {
+        for tool in [
+            "workspace_write",
+            "workspace_create",
+            "workspace_delete",
+            "workspace_rename",
+        ] {
             assert!(
                 matches!(
                     readonly.check(&request(tool, serde_json::json!({}))).await,
@@ -1675,11 +1689,18 @@ mod tests {
         }
 
         // Under `full` there is no per-call gate at all — which is precisely
-        // why `workspace_write` carries a required `expected_updated_at`
-        // compare-and-swap token of its own, and why `workspace_create` refuses
-        // a path that already resolves rather than overwriting it.
+        // why `workspace_write` and `workspace_delete` each carry a required
+        // `expected_updated_at` compare-and-swap token of their own, why
+        // `workspace_create` refuses a path that already resolves rather than
+        // overwriting it, and why `workspace_delete` refuses a folder that
+        // still holds anything.
         let full = policy("full", &[], None);
-        for tool in ["workspace_write", "workspace_create"] {
+        for tool in [
+            "workspace_write",
+            "workspace_create",
+            "workspace_delete",
+            "workspace_rename",
+        ] {
             assert_eq!(
                 full.check(&request(tool, serde_json::json!({}))).await,
                 ToolPolicyDecision::Allow,
@@ -3180,6 +3201,8 @@ mod tests {
             "web_fetch",
             "workspace_write",
             "workspace_create",
+            "workspace_delete",
+            "workspace_rename",
             // Anything a remote server chooses to advertise.
             "mcp_registry_tool_call",
             "mcp_call_tool",
@@ -3612,14 +3635,20 @@ mod tests {
         assert!(!grantable("deploy_site", &args));
     }
 
-    /// The two workspace mutations keep their `Other` label on the card — there
-    /// is no consequence word to name — while being refused a standing scope.
+    /// The four workspace mutations keep their `Other` label on the card —
+    /// there is no consequence word to name — while being refused a standing
+    /// scope.
     /// That separation is the point of issue #444: the label and the permission
     /// are different questions.
     #[test]
     fn workspace_mutations_are_labelled_other_and_are_still_not_grantable() {
         let args = serde_json::json!({});
-        for tool in ["workspace_write", "workspace_create"] {
+        for tool in [
+            "workspace_write",
+            "workspace_create",
+            "workspace_delete",
+            "workspace_rename",
+        ] {
             assert_eq!(classify_group(tool, &args), EffectGroup::Other, "{tool}");
             assert!(classify_group(tool, &args).is_unclassified(), "{tool}");
             assert!(!grantable(tool, &args), "{tool}");

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -457,6 +457,23 @@ struct PathIndex {
     /// but the sqlite and mongodb backends do not, so the tool layer stays
     /// closed against them regardless of which backend is wired.
     unaddressable: usize,
+    /// Parent id → how many nodes name it as their parent, counted over
+    /// **every** node the store returned — including the ones excluded from
+    /// `by_path` and `by_id` above.
+    ///
+    /// This exists because "is this folder empty" cannot be answered from the
+    /// path maps. An unaddressable child is absent from both, so a folder
+    /// holding only such children looks empty by every path-shaped measure
+    /// while the port's recursive `delete` would still take them. Counting
+    /// parent ids is structural: it sees a child whether or not that child has
+    /// a renderable path, which is exactly the property the emptiness gate
+    /// needs and the only one that closes the gap.
+    ///
+    /// Direct children only, deliberately — a folder with no direct child has
+    /// no descendants either, so this is sufficient to refuse, and it is exact
+    /// per node id rather than per rendered path (two folders may share a
+    /// path; they never share an id).
+    child_count: HashMap<String, usize>,
 }
 
 impl PathIndex {
@@ -465,6 +482,14 @@ impl PathIndex {
             nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
         let mut index = PathIndex::default();
+        // Counted before the addressability filter below, so a child that is
+        // about to be dropped from both maps is still counted against its
+        // parent. See `child_count`.
+        for node in &nodes {
+            if let Some(parent) = node.parent_id.as_deref() {
+                *index.child_count.entry(parent.to_string()).or_insert(0) += 1;
+            }
+        }
         for node in &nodes {
             match render_path(node, &by_id_raw) {
                 Some(path) => {
@@ -1982,6 +2007,57 @@ mod tests {
         assert_eq!(index.by_id["b"].path, "Standards/Engineering standards.md");
         assert_eq!(index.by_id["c"].path, "README.md");
         assert_eq!(index.unaddressable, 0);
+    }
+
+    /// A child excluded from the path maps must still be counted against its
+    /// parent, because "is this folder empty" decides whether a folder may be
+    /// handed to a port whose `delete` is recursive.
+    ///
+    /// This asserts both measures at once, so the regression is explicit: the
+    /// path-prefix count that `workspace_delete` used to run sees **nothing**
+    /// under the folder, while `child_count` sees the child. A gate reading the
+    /// first would call this folder empty and delete an unbounded subtree that
+    /// was never counted, announced, or named on the approval card — the exact
+    /// outcome the module docs say recursion is refused to prevent.
+    ///
+    /// The shapes here are creatable through the sqlite and mongodb backends;
+    /// only `fs` rejects them at creation (`reject_unsafe_name`), which is why
+    /// the tool layer has to stay closed against them on its own.
+    #[test]
+    fn an_unaddressable_child_is_still_counted_against_its_parent() {
+        let nodes = vec![
+            folder("f", "archive", None),
+            // Name carries a separator: no renderable path, so absent from both
+            // maps by design.
+            file("hidden", "quarterly/report.md", Some("f")),
+        ];
+        let index = PathIndex::build(nodes);
+
+        assert_eq!(index.unaddressable, 1, "the child must be excluded by path");
+        assert!(
+            !index.by_id.contains_key("hidden"),
+            "an unaddressable node must not be reachable by id either"
+        );
+
+        // What the old gate measured: rendered paths beneath the folder.
+        let prefix = format!("{}/", index.by_id["f"].path);
+        let by_path_count: usize = index
+            .by_path
+            .iter()
+            .filter(|(path, _)| path.starts_with(&prefix))
+            .map(|(_, entries)| entries.len())
+            .sum();
+        assert_eq!(
+            by_path_count, 0,
+            "precondition: the path-shaped measure cannot see this child — that is the bug"
+        );
+
+        // What the gate measures now.
+        assert_eq!(
+            index.child_count.get("f").copied().unwrap_or_default(),
+            1,
+            "the structural measure must see a child the path rules exclude"
+        );
     }
 
     #[test]

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -7,7 +7,7 @@
 //! operator could fill `Standards/` with the guidance every agent is supposed
 //! to follow and no agent would ever read a word of it.
 //!
-//! Five tools close that gap:
+//! Seven tools close that gap:
 //!
 //! * [`WORKSPACE_LIST_TOOL`] — the bounded path index (path, kind, id,
 //!   revision), with an optional `prefix` for subtree listing.
@@ -21,6 +21,12 @@
 //!   parent already exists (issue #551).
 //! * [`WORKSPACE_WRITE_TOOL`] — overwrite one existing note, guarded by a
 //!   **required** `expected_updated_at` compare-and-swap token.
+//! * [`WORKSPACE_RENAME_TOOL`] — rename or move one node **inside the agent's
+//!   own folder** (issue #671).
+//! * [`WORKSPACE_DELETE_TOOL`] — remove one node from that same folder, guarded
+//!   by the same required token and refusing a folder that still holds
+//!   anything. See [`lifecycle`] for why that confinement is coherence rather
+//!   than containment.
 //!
 //! Every tool hits the store **live at `execute()` time**. There is no
 //! session cache, so a note edited in the console between two turns changes
@@ -40,9 +46,17 @@
 //! for anything an agent produces and mark shared guidance as something to
 //! touch only on purpose; and every node records who created it and who last
 //! wrote it (issue #326), so a mess is legible and reversible rather than
-//! anonymous. Two irreversible operations, rename and delete, are still absent
-//! from this surface entirely — the operator has a console to undo them in and
-//! the agent does not.
+//! anonymous.
+//!
+//! Issue #671 added the other half of that bargain. An agent that can only
+//! produce leaves every superseded draft in place forever, under whatever name
+//! its first attempt gave it — and since issue #607 each of those competes for
+//! a slot in a bounded search result with the note that replaced it. So rename
+//! and delete are on this surface now, confined to `Agents/<agent id>/`:
+//! tidying your own folder is upkeep, while rearranging anybody else's work is
+//! still the operator's call. That confinement is **not** a security boundary —
+//! the same grant already confers unconfined overwrite — and [`lifecycle`] says
+//! so at length rather than letting the scope be mistaken for one.
 //!
 //! That home folder is minted on first use rather than provisioned at boot, so
 //! [`WorkspaceCreateTool`] makes it on demand when the target sits directly
@@ -180,6 +194,17 @@ use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactStore};
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+// Lifecycle over the agent's own folder (issue #671) — delete and rename. In a
+// child module rather than inline: this file is already the largest in
+// `src/harness/`, and the two tools share a scope gate and a set of refusals
+// with each other rather than with anything above. Nothing here becomes `pub`
+// for its benefit — a child module reaches its ancestors' private items.
+mod lifecycle;
+
+pub use lifecycle::{
+    WORKSPACE_DELETE_TOOL, WORKSPACE_RENAME_TOOL, WorkspaceDeleteTool, WorkspaceRenameTool,
+};
 
 /// Tool name: list the company workspace's path index.
 pub const WORKSPACE_LIST_TOOL: &str = "workspace_list";
@@ -364,6 +389,23 @@ impl CompanyWorkspace {
     /// either, which is what keeps the one-node-per-call rule intact.
     fn is_own_home(&self, segments: &[&str]) -> bool {
         matches!(segments, [root, agent] if *root == AGENTS_ROOT && *agent == self.agent_id)
+    }
+
+    /// Whether `segments` name something **inside** this agent's own home —
+    /// `Agents/<this agent's id>/…` at any depth below the folder itself.
+    ///
+    /// The companion to [`is_own_home`](Self::is_own_home), which is an exact
+    /// match and stays one: create needs "is this precisely the folder I may
+    /// mint?", and the lifecycle tools (issue #671) need "is this something
+    /// inside the folder I already own?". Neither answer implies the other, and
+    /// the home folder itself is deliberately in exactly one of them — it is
+    /// mintable, and it is not deletable.
+    ///
+    /// Compared segment-wise against the id fixed at agent-build time, so a
+    /// teammate's home and everything under it answer `false` no matter what a
+    /// tool argument says.
+    fn is_strictly_inside_own_home(&self, segments: &[&str]) -> bool {
+        segments.len() >= 3 && segments[0] == AGENTS_ROOT && segments[1] == self.agent_id
     }
 
     /// Adopt-or-create this agent's own `Agents/<id>/` folder, returning its id.
@@ -608,16 +650,21 @@ fn fence_nonce() -> String {
 ///
 /// # Why the write half is steering, not a rule the code enforces
 ///
-/// Issue #551 settled that agents write **unconfined** — anywhere in the tree,
-/// create as well as overwrite. There is no prefix gate, and adding one would
-/// be theatre while `{WORKSPACE_WRITE_TOOL}` can already overwrite any note (the
-/// strictly more destructive of the two operations). So what keeps the tree
-/// navigable is this paragraph: name the agent's own folder as the default
-/// home, name shared guidance as something to touch only on purpose, and leave
-/// the irreversible operations (rename, delete) with the operator, who is the
-/// only party with a console to undo them in. The safety net underneath is
-/// attribution — every node records who created it and who last wrote it
-/// (issue #326) — not refusal.
+/// Issue #551 settled that agents *write* **unconfined** — anywhere in the
+/// tree, create as well as overwrite. There is no prefix gate on those two, and
+/// adding one would be theatre while `{WORKSPACE_WRITE_TOOL}` can already
+/// overwrite any note (the strictly more destructive of the two operations). So
+/// what keeps the tree navigable is this paragraph: name the agent's own folder
+/// as the default home, and name shared guidance as something to touch only on
+/// purpose. The safety net underneath is attribution — every node records who
+/// created it and who last wrote it (issue #326) — not refusal.
+///
+/// The lifecycle half (issue #671) is the one place the code *does* draw a
+/// line, and the brief has to state it because it is a different line: rename
+/// and delete reach only `{AGENTS_ROOT}/<agent id>/`. That is a division of
+/// labour rather than containment — tidying your own folder is upkeep the
+/// paragraph above already asks for, while reorganising somebody else's work is
+/// a judgement call the operator has a console for.
 pub fn workspace_brief(can_write: bool) -> String {
     let mut brief = format!(
         "\n\n## Company workspace\n\
@@ -646,8 +693,14 @@ pub fn workspace_brief(can_write: bool) -> String {
              which requires the `expected_updated_at` revision from a `{WORKSPACE_READ_TOOL}` of \
              that same note — so read it, apply your change to the full body you were given, and \
              write the whole body back. Every note records who created it and who last wrote it, \
-             so your edits are attributed to you. Renaming and deleting stay the operator's job, \
-             not yours."
+             so your edits are attributed to you. Keeping your own folder in order is part of \
+             producing work in it: give a note the title it earned with \
+             `{WORKSPACE_RENAME_TOOL}`, and clear away a draft you have replaced with \
+             `{WORKSPACE_DELETE_TOOL}`. Both act on one node at a time and both are confined to \
+             `{AGENTS_ROOT}/<your agent id>/`. Deleting is permanent for anything you simply \
+             created — only a note you published keeps a history anywhere else — so remove what is \
+             genuinely superseded rather than what is merely untidy. Renaming or deleting anything \
+             OUTSIDE your own folder stays the operator's job, not yours."
         ));
     }
     brief
@@ -1271,8 +1324,9 @@ impl Tool for WorkspaceWriteTool {
          must pass `expected_updated_at` — the `rev` from a `workspace_read` of that same note — \
          and the write is refused if the note changed since. This replaces the whole body, so \
          include everything you want kept. NOT for adding a new note (that is \
-         `workspace_create`), NOT for renaming or deleting (operator-only), and NOT for your own \
-         scratch files (use the `file_*` tools)."
+         `workspace_create`), NOT for renaming or deleting one (those are `workspace_rename` and \
+         `workspace_delete`, and only inside your own folder), and NOT for your own scratch files \
+         (use the `file_*` tools)."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1794,16 +1848,19 @@ impl Tool for WorkspaceCreateTool {
 
 /// Build the workspace tool set for one agent.
 ///
-/// `can_write` decides whether [`WORKSPACE_CREATE_TOOL`] and
-/// [`WORKSPACE_WRITE_TOOL`] are included; the caller
+/// `can_write` decides whether the four mutating tools are included; the caller
 /// ([`build_agent`](crate::harness::build::build_agent)) derives it from an
 /// **explicit** `workspace` grant, so a bare `*` yields the three read tools
 /// only.
 ///
-/// Create and write ride the same flag on purpose. Overwriting an existing
-/// operator-owned standard is strictly more destructive than adding a new note
-/// beside it, so any grant that permits the first has already permitted the
-/// second.
+/// All four ride the same flag on purpose, and issue #671 did not add a fifth
+/// grant name for the lifecycle pair. Overwriting an existing operator-owned
+/// standard is strictly more destructive than adding a note beside it — and
+/// strictly more destructive than removing or renaming something inside the
+/// agent's *own* folder, which is all `workspace_delete` and `workspace_rename`
+/// can reach. A grant that already confers unconfined overwrite has by that act
+/// conferred the narrower thing; a separate name would suggest a boundary that
+/// the write tool has already walked past.
 pub fn workspace_tools(
     store: Arc<dyn WorkspaceStore>,
     artifacts: Option<Arc<dyn ArtifactStore>>,
@@ -1823,7 +1880,12 @@ pub fn workspace_tools(
     ];
     if can_write {
         tools.push(Box::new(WorkspaceCreateTool::new(workspace.clone())));
-        tools.push(Box::new(WorkspaceWriteTool::new(workspace)));
+        tools.push(Box::new(WorkspaceWriteTool::new(workspace.clone())));
+        // Issue #671, ordered after the two that add and revise: an agent that
+        // can only produce leaves a mess it may not clean, and one that can
+        // only remove has nothing of its own to remove.
+        tools.push(Box::new(WorkspaceRenameTool::new(workspace.clone())));
+        tools.push(Box::new(WorkspaceDeleteTool::new(workspace)));
     }
     tools
 }
@@ -1837,21 +1899,21 @@ mod tests {
 
     /// The agent every test writes as, so an authorship assertion has a name to
     /// check against.
-    const TEST_AGENT: &str = "ceo";
+    pub(super) const TEST_AGENT: &str = "ceo";
 
     /// A [`CompanyWorkspace`] pinned to `company`, writing as [`TEST_AGENT`].
-    fn ws(store: Arc<dyn WorkspaceStore>, company: CompanyId) -> CompanyWorkspace {
+    pub(super) fn ws(store: Arc<dyn WorkspaceStore>, company: CompanyId) -> CompanyWorkspace {
         CompanyWorkspace::new(store, company, TEST_AGENT.to_string())
     }
 
     /// This agent's origin — what a create or a write must stamp.
-    fn agent_origin() -> WorkspaceOrigin {
+    pub(super) fn agent_origin() -> WorkspaceOrigin {
         WorkspaceOrigin::Agent {
             id: TEST_AGENT.to_string(),
         }
     }
 
-    fn folder(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+    pub(super) fn folder(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
         WorkspaceNode {
             id: id.to_string(),
             name: name.to_string(),
@@ -1866,7 +1928,7 @@ mod tests {
         }
     }
 
-    fn file(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+    pub(super) fn file(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
         WorkspaceNode {
             id: id.to_string(),
             name: name.to_string(),
@@ -1903,7 +1965,7 @@ mod tests {
         (dir, ops)
     }
 
-    fn text(result: &ToolResult) -> String {
+    pub(super) fn text(result: &ToolResult) -> String {
         result.output()
     }
 
@@ -3881,6 +3943,57 @@ mod tests {
         );
     }
 
+    // -- own-home scope (issue #671) ----------------------------------------
+
+    /// The two home predicates answer different questions and must keep
+    /// answering them differently.
+    ///
+    /// `is_own_home` is create's mint-on-demand exception: exactly the folder,
+    /// nothing else. `is_strictly_inside_own_home` is the lifecycle gate: the
+    /// contents, and never the folder itself. Collapsing either into the other
+    /// would either let an agent delete the folder the company finds its work
+    /// in, or refuse it the call that brings that folder into existence.
+    #[test]
+    fn the_two_home_predicates_disagree_exactly_on_the_folder_itself() {
+        let dir = tempfile::tempdir().unwrap();
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        let workspace = ws(store, CompanyId::new("acme"));
+
+        // The folder itself: mintable, never inside.
+        assert!(workspace.is_own_home(&[AGENTS_ROOT, TEST_AGENT]));
+        assert!(!workspace.is_strictly_inside_own_home(&[AGENTS_ROOT, TEST_AGENT]));
+
+        // Inside it, at any depth: never the folder, always inside.
+        for segments in [
+            vec![AGENTS_ROOT, TEST_AGENT, "brief.md"],
+            vec![AGENTS_ROOT, TEST_AGENT, "drafts", "q3", "notes.md"],
+        ] {
+            assert!(!workspace.is_own_home(&segments), "{segments:?}");
+            assert!(
+                workspace.is_strictly_inside_own_home(&segments),
+                "{segments:?}"
+            );
+        }
+
+        // Everything else is neither — a teammate's home and its contents
+        // included, and the `Agents` root itself, which belongs to nobody.
+        for segments in [
+            vec![AGENTS_ROOT],
+            vec![AGENTS_ROOT, "cmo"],
+            vec![AGENTS_ROOT, "cmo", "brief.md"],
+            vec!["Standards", "Engineering standards.md"],
+            // A name that merely starts with the agent's id is a different
+            // folder, because the comparison is segment-wise and not a prefix.
+            vec![AGENTS_ROOT, "ceo-archive", "brief.md"],
+        ] {
+            assert!(!workspace.is_own_home(&segments), "{segments:?}");
+            assert!(
+                !workspace.is_strictly_inside_own_home(&segments),
+                "{segments:?}"
+            );
+        }
+    }
+
     // -- wiring -------------------------------------------------------------
 
     #[test]
@@ -3923,9 +4036,14 @@ mod tests {
                 WORKSPACE_READ_TOOL,
                 WORKSPACE_SEARCH_TOOL,
                 WORKSPACE_CREATE_TOOL,
-                WORKSPACE_WRITE_TOOL
+                WORKSPACE_WRITE_TOOL,
+                // Issue #671. No fifth grant name: the write grant already
+                // confers unconfined overwrite, which reaches further than
+                // own-folder lifecycle does.
+                WORKSPACE_RENAME_TOOL,
+                WORKSPACE_DELETE_TOOL
             ],
-            "create and write ride the same explicit grant"
+            "all four mutations ride the same explicit grant"
         );
     }
 
@@ -3945,17 +4063,35 @@ mod tests {
         assert_eq!(tools[2].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[3].permission_level(), PermissionLevel::Write);
         assert_eq!(tools[4].permission_level(), PermissionLevel::Write);
+        assert_eq!(tools[5].permission_level(), PermissionLevel::Write);
+        assert_eq!(tools[6].permission_level(), PermissionLevel::Write);
+        assert_eq!(tools.len(), 7, "a tool was added without a declared level");
     }
 
     #[test]
     fn the_brief_is_static_and_mentions_writes_only_when_granted() {
         let read_only = workspace_brief(false);
         assert!(read_only.contains(WORKSPACE_LIST_TOOL));
-        assert!(!read_only.contains(WORKSPACE_WRITE_TOOL));
-        assert!(!read_only.contains(WORKSPACE_CREATE_TOOL));
+        // Describing a tool the agent does not hold is how a turn gets spent
+        // calling something that does not exist — so the read-only brief has to
+        // omit every mutation, the lifecycle pair included.
+        for tool in [
+            WORKSPACE_WRITE_TOOL,
+            WORKSPACE_CREATE_TOOL,
+            WORKSPACE_RENAME_TOOL,
+            WORKSPACE_DELETE_TOOL,
+        ] {
+            assert!(!read_only.contains(tool), "{tool}: {read_only}");
+        }
         let writable = workspace_brief(true);
-        assert!(writable.contains(WORKSPACE_WRITE_TOOL));
-        assert!(writable.contains(WORKSPACE_CREATE_TOOL));
+        for tool in [
+            WORKSPACE_WRITE_TOOL,
+            WORKSPACE_CREATE_TOOL,
+            WORKSPACE_RENAME_TOOL,
+            WORKSPACE_DELETE_TOOL,
+        ] {
+            assert!(writable.contains(tool), "{tool}: {writable}");
+        }
         assert!(writable.contains("expected_updated_at"));
     }
 
@@ -3992,9 +4128,13 @@ mod tests {
     /// mechanism and has to be asserted like one.
     ///
     /// The brief must name the agent's own folder as the default home, mark
-    /// shared guidance as conditional rather than forbidden (the tree is
-    /// unconfined — saying "never" here would be a lie the tools do not back),
-    /// and keep rename/delete with the operator.
+    /// shared guidance as conditional rather than forbidden (create and write
+    /// are unconfined — saying "never" here would be a lie those tools do not
+    /// back), and, since issue #671, ask for tidying while keeping the
+    /// lifecycle pair's confinement and permanence explicit. It must NOT still
+    /// say rename and delete are the operator's, full stop: that sentence
+    /// became false the moment the tools shipped, and an agent that believes it
+    /// will never clean up after itself.
     #[test]
     fn the_brief_steers_toward_the_agents_own_folder() {
         let brief = workspace_brief(true);
@@ -4010,13 +4150,22 @@ mod tests {
             "appears the first time you use it",
             "anywhere in the tree",
             "Standards/",
-            "Renaming and deleting",
+            // Issue #671: tidying is asked for, bounded, and honest about what
+            // a delete costs.
+            "part of producing work in it",
+            "one node at a time",
+            "Deleting is permanent",
+            "OUTSIDE your own folder",
         ] {
             assert!(
                 brief.contains(phrase),
                 "the brief dropped {phrase:?}: {brief}"
             );
         }
+        assert!(
+            !brief.contains("Renaming and deleting stay the operator's job"),
+            "the brief still tells agents they cannot tidy their own folder: {brief}"
+        );
     }
 
     // -- binary nodes (issue #553) ------------------------------------------

--- a/src/harness/workspace_tools/lifecycle.rs
+++ b/src/harness/workspace_tools/lifecycle.rs
@@ -345,17 +345,25 @@ impl Tool for WorkspaceDeleteTool {
         // delete is one approval card naming one path that takes an unbounded
         // amount of work with it.
         //
-        // Counted over rendered paths rather than over parent ids so a folder
-        // whose path is shared with another folder (possible — no backend
-        // enforces unique sibling names) is refused rather than half-emptied.
+        // Counted over parent ids, not over rendered paths. A path-prefix count
+        // reads `by_path`, which deliberately omits every node the path rules
+        // exclude — a dangling or cyclic ancestor chain, or a name carrying a
+        // separator, which the sqlite and mongodb backends both accept at
+        // creation. A folder holding only such children therefore looks empty
+        // by every path-shaped measure while the port's recursive delete would
+        // still take them: unnamed on the card, unannounced, and precisely the
+        // nodes this layer made unreachable so no tool could touch them.
+        //
+        // `child_count` is built before that filter, so it sees a child whether
+        // or not the child has a renderable path. It is also exact per node id
+        // rather than per path — two folders may share a path, but never an id,
+        // so this is strictly sharper than the prefix count it replaces.
         if entry.node.kind == NodeKind::Folder {
-            let prefix = format!("{}/", entry.path);
-            let held: usize = index
-                .by_path
-                .iter()
-                .filter(|(path, _)| path.starts_with(&prefix))
-                .map(|(_, entries)| entries.len())
-                .sum();
+            let held = index
+                .child_count
+                .get(&entry.node.id)
+                .copied()
+                .unwrap_or_default();
             if held > 0 {
                 return Ok(ToolResult::error(format!(
                     "Refused: the folder `{shown}` still holds {held} node(s), and nothing was \

--- a/src/harness/workspace_tools/lifecycle.rs
+++ b/src/harness/workspace_tools/lifecycle.rs
@@ -1,0 +1,671 @@
+//! Lifecycle over the agent's **own** workspace folder (issue #671): deleting
+//! and renaming what it put there.
+//!
+//! Since issue #551 an agent can add to the shared tree and overwrite anything
+//! in it, but it could not remove or rename a single node — so the one thing it
+//! could not do was tidy up after itself. Every superseded draft stayed
+//! forever, under whatever name it was given on the first attempt, and issue
+//! #607's search made that cost compound: a stale draft competes for a place in
+//! a bounded result set with the note that replaced it.
+//!
+//! # Why this is coherence, not containment
+//!
+//! The confinement to `Agents/<self>/` here is **not** a security boundary, and
+//! must not be described as one. The same explicit `workspace` grant already
+//! confers [`WORKSPACE_WRITE_TOOL`](super::WORKSPACE_WRITE_TOOL), which can
+//! overwrite any note in the tree with an empty body — strictly broader
+//! destructive reach than deleting one node inside your own folder. The scope
+//! exists because tidying *your own* folder is upkeep the brief already asks
+//! for, while reorganising somebody else's work is a judgement call the
+//! operator has a console for. That is a division of labour, not a wall.
+//!
+//! One thing an overwrite does not do, and this does: a delete removes the
+//! node's authorship record along with its body, so it is marginally worse
+//! forensically than overwriting a note to empty. What narrows that is the
+//! scope (your own folder), the per-call approval parking (both tools are
+//! `Reach::Consequence` and never grantable standing) and the removal
+//! announcement the store emits on the company feed (issue #327).
+//!
+//! # The shape of the two tools
+//!
+//! * [`WorkspaceDeleteTool`] carries a **required** `expected_updated_at`
+//!   compare-and-swap token, exactly like `workspace_write`, and refuses a
+//!   folder that still holds anything. One deliberate node per call, each
+//!   individually announced and individually parked — the same
+//!   one-node-per-call doctrine `workspace_create` follows, applied to the
+//!   destructive direction where it matters more.
+//! * [`WorkspaceRenameTool`] carries **no** token, and the asymmetry is worth
+//!   stating rather than leaving to be noticed. A rename destroys nothing: the
+//!   body, the id and both authorship stamps survive it (the port leaves the
+//!   origins alone on purpose), links are by id rather than by path, and the
+//!   operator can move it straight back. There is nothing for a stale token to
+//!   protect.
+//!
+//! Both checks run against the **resolved** node's path, never the argument, so
+//! passing a raw `id` that names something outside the agent's folder refuses
+//! identically to passing its path.
+//!
+//! # What deliberately stays as it is
+//!
+//! * **A published note is deleted like any other**, and only the wording
+//!   differs. Refusing the published case would invert the risk: a published
+//!   deliverable's history lives on its artifact chain and a re-publish mints
+//!   the node again, so *that* is the recoverable one. A note the agent merely
+//!   created is the one whose deletion is final, and the success message says
+//!   so.
+//! * **The artifact version's `workspace_node_id` is left dangling**, exactly
+//!   as the operator's own DELETE route leaves it today. `materialize`
+//!   read-guards the id before reusing it, and older versions keeping the id of
+//!   the node that actually held them is the stated "honest history" invariant.
+//!   It is a checked tombstone, not a dangling reference.
+//! * **Recursion is refused, not implemented.** The port deletes folders
+//!   recursively, and exposing that would let one agent call remove a subtree
+//!   with a single approval card naming a single path. Refusing a non-empty
+//!   folder turns it into N deliberate calls, each announced and each parked.
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use openhuman_core::openhuman::tools::traits::{PermissionLevel, Tool, ToolResult};
+
+use crate::company::artifact_mirror::published_record_for_node;
+use crate::company::workspace_paths::{is_legal_segment, split_logical_path};
+use crate::company::workspace_scaffold::AGENTS_ROOT;
+use crate::ports::workspace::NodeKind;
+
+use super::{
+    CompanyWorkspace, Entry, PathIndex, WORKSPACE_CREATE_TOOL, WORKSPACE_LIST_TOOL,
+    WORKSPACE_READ_TOOL, WORKSPACE_WRITE_TOOL, echo_path,
+};
+
+/// Tool name: delete one node from the agent's own workspace folder.
+pub const WORKSPACE_DELETE_TOOL: &str = "workspace_delete";
+/// Tool name: rename and/or move one node inside the agent's own folder.
+pub const WORKSPACE_RENAME_TOOL: &str = "workspace_rename";
+
+// ---------------------------------------------------------------------------
+// The shared scope gate
+// ---------------------------------------------------------------------------
+
+/// Refuse `path` unless it names something strictly inside this agent's own
+/// home, returning the agent-facing message when it does not.
+///
+/// `gerund` is `"deleting"` / `"renaming"`, so one gate produces both tools'
+/// refusals and they cannot drift apart.
+///
+/// The home folder gets its own message rather than the generic one because the
+/// reason is different and actionable. `ensure_agent_folder` resolves the home
+/// **by name**, so a home that is deleted or renamed is not merely gone — the
+/// next publish mints a fresh, empty one beside the orphaned contents, and the
+/// company's view of where this agent's work lives silently forks.
+fn refuse_unless_inside_own_home(
+    workspace: &CompanyWorkspace,
+    path: &str,
+    gerund: &str,
+) -> Option<String> {
+    let segments: Vec<&str> = path.split('/').collect();
+    if workspace.is_strictly_inside_own_home(&segments) {
+        return None;
+    }
+    if workspace.is_own_home(&segments) {
+        return Some(format!(
+            "Refused: `{shown}` is your own folder itself, and it is the handle the company uses \
+             to find your work. {Gerund} it would strand everything filed under it and mint a \
+             fresh, empty folder in its place the next time you publish. Act on what is inside it \
+             instead.",
+            shown = echo_path(path),
+            Gerund = capitalize(gerund),
+        ));
+    }
+    Some(format!(
+        "Refused: `{shown}` is outside your own folder `{AGENTS_ROOT}/{agent}/`, and {gerund} is \
+         confined to it. You can still revise a note anywhere in the tree with \
+         `{WORKSPACE_WRITE_TOOL}`; removing or moving one elsewhere is the operator's to do in the \
+         console.",
+        shown = echo_path(path),
+        agent = workspace.agent_id,
+    ))
+}
+
+/// Upper-case the first character of an ASCII word, for a message that starts
+/// with the shared `gerund`.
+fn capitalize(word: &str) -> String {
+    let mut chars = word.chars();
+    match chars.next() {
+        Some(first) => first.to_uppercase().chain(chars).collect(),
+        None => String::new(),
+    }
+}
+
+/// Read `expected_updated_at` in either the integer or the stringified form.
+///
+/// Lifted from [`WorkspaceWriteTool`](super::WorkspaceWriteTool) rather than
+/// re-derived: models stringify numbers constantly, and rejecting `"2000"`
+/// produces an "is required" error for an argument the agent did in fact
+/// supply — a misleading message that costs a whole turn to recover from.
+fn revision_arg(args: &Value) -> Option<u64> {
+    args.get("expected_updated_at").and_then(|value| {
+        value
+            .as_u64()
+            .or_else(|| value.as_str().and_then(|s| s.trim().parse::<u64>().ok()))
+    })
+}
+
+/// Resolve `path` / `id` against a freshly-read index, mapping every failure to
+/// the message the agent should see.
+///
+/// Returns the index alongside the entry: both tools need to keep asking it
+/// questions (what is under this folder, is the target path free) after the
+/// node itself has resolved, and re-reading the tree for each would give two
+/// answers from two snapshots.
+async fn resolve_in_index(
+    workspace: &CompanyWorkspace,
+    path: Option<&str>,
+    id: Option<&str>,
+) -> Result<(PathIndex, Entry), ToolResult> {
+    let index = match workspace.index().await {
+        Ok(index) => index,
+        Err(e) => {
+            return Err(ToolResult::error(format!(
+                "Could not read the company workspace: {e}"
+            )));
+        }
+    };
+    let entry = match index.resolve(path, id) {
+        Ok(entry) => entry.clone(),
+        Err(e) => return Err(ToolResult::error(e.message())),
+    };
+    Ok((index, entry))
+}
+
+/// The `path` / `id` pair, trimmed and with empty strings treated as absent.
+fn target_args(args: &Value) -> (Option<&str>, Option<&str>) {
+    let path = args
+        .get("path")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|p| !p.is_empty());
+    let id = args
+        .get("id")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|i| !i.is_empty());
+    (path, id)
+}
+
+// ---------------------------------------------------------------------------
+// workspace_delete
+// ---------------------------------------------------------------------------
+
+/// What the agent should be told about the permanence of a delete.
+#[derive(Debug, PartialEq, Eq)]
+enum History {
+    /// The node backs a published deliverable, so the artifact chain outlives
+    /// it and a re-publish recreates the path.
+    Published,
+    /// Nothing published points at this node. Removing it is final.
+    Direct,
+    /// No artifact store is wired, or it could not be read — so neither claim
+    /// can honestly be made.
+    Unknown,
+}
+
+impl History {
+    /// The sentence appended to a successful delete.
+    fn note(&self) -> &'static str {
+        match self {
+            Self::Published => {
+                " This note was a published deliverable, so its version history stays in \
+                 Artifacts and publishing it again recreates the path."
+            }
+            Self::Direct => {
+                " Nothing published pointed at it, so this deletion is permanent — there is no \
+                 version history to restore it from."
+            }
+            Self::Unknown => "",
+        }
+    }
+}
+
+/// Deletes one folder or note from the agent's own workspace folder. Wired only
+/// under an explicit `workspace` grant, alongside the other mutating tools.
+pub struct WorkspaceDeleteTool {
+    workspace: CompanyWorkspace,
+}
+
+impl WorkspaceDeleteTool {
+    pub(super) fn new(workspace: CompanyWorkspace) -> Self {
+        Self { workspace }
+    }
+
+    /// Whether this node's removal is recoverable from the artifact chain.
+    ///
+    /// A failed lookup answers [`History::Unknown`] rather than guessing:
+    /// telling an agent a deletion is permanent when it is not (or the reverse)
+    /// is worse than telling it nothing, and neither answer changes what the
+    /// call does.
+    async fn history_of(&self, node_id: &str) -> History {
+        let Some(artifacts) = self.workspace.artifacts.as_ref() else {
+            return History::Unknown;
+        };
+        match published_record_for_node(artifacts.as_ref(), &self.workspace.company, node_id).await
+        {
+            Ok(Some(_)) => History::Published,
+            Ok(None) => History::Direct,
+            Err(e) => {
+                tracing::warn!(
+                    company = %self.workspace.company,
+                    agent = %self.workspace.agent_id,
+                    node = %node_id,
+                    error = %e,
+                    "[workspace] could not tell whether a node being deleted was published; the \
+                     delete proceeds and the agent is told nothing either way"
+                );
+                History::Unknown
+            }
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for WorkspaceDeleteTool {
+    fn name(&self) -> &str {
+        WORKSPACE_DELETE_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Delete ONE folder or note from your own workspace folder `Agents/<your agent id>/`. USE \
+         FOR tidying up after yourself — removing a draft you have replaced, or a working note \
+         that is no longer worth a teammate's time to find. You must pass `expected_updated_at` — \
+         the `rev` from a `workspace_read` of the note, or the `rev=` on its `workspace_list` line \
+         for a folder — and the delete is refused if it changed since. A folder that still holds \
+         anything is refused: empty it one node at a time. NOT for anything outside your own \
+         folder — shared guidance and a teammate's work stay the operator's to remove. NOT for \
+         your own scratch files (use the `file_*` tools)."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The node's path as shown by workspace_list, e.g. \"Agents/ceo/Old draft.md\". Must be inside your own folder."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "The node's id, as an alternative to `path`. It must still resolve to something inside your own folder."
+                },
+                "expected_updated_at": {
+                    "type": "integer",
+                    "description": "The `rev` value you last saw for this node, from workspace_read or its workspace_list line. The delete is refused if it changed since, so re-read rather than guessing."
+                }
+            },
+            "required": ["expected_updated_at"],
+            "additionalProperties": false
+        })
+    }
+
+    /// Honest level for a tool that removes operator-visible content. As with
+    /// the other mutating workspace tools this is not what gates the call — see
+    /// the `workspace_delete` descriptor in
+    /// [`policy::consequence`](crate::policy::consequence).
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let (path, id) = target_args(&args);
+
+        let Some(expected) = revision_arg(&args) else {
+            return Ok(ToolResult::error(format!(
+                "Invalid arguments: `expected_updated_at` is required. Read the note with \
+                 `{WORKSPACE_READ_TOOL}` first (or take a folder's `rev=` from its \
+                 `{WORKSPACE_LIST_TOOL}` line) and pass that back, so something changed since you \
+                 last looked at it is not deleted out from under whoever changed it."
+            )));
+        };
+
+        let (index, entry) = match resolve_in_index(&self.workspace, path, id).await {
+            Ok(pair) => pair,
+            Err(refusal) => return Ok(refusal),
+        };
+
+        // Scope first, and against the resolved path rather than the argument —
+        // a raw `id` naming a teammate's note must refuse exactly as its path
+        // would.
+        if let Some(refusal) =
+            refuse_unless_inside_own_home(&self.workspace, &entry.path, "deleting")
+        {
+            return Ok(ToolResult::error(refusal));
+        }
+
+        // One node per call. The port would happily remove the whole subtree,
+        // which is precisely why this layer must not ask it to: a recursive
+        // delete is one approval card naming one path that takes an unbounded
+        // amount of work with it.
+        //
+        // Counted over rendered paths rather than over parent ids so a folder
+        // whose path is shared with another folder (possible — no backend
+        // enforces unique sibling names) is refused rather than half-emptied.
+        if entry.node.kind == NodeKind::Folder {
+            let prefix = format!("{}/", entry.path);
+            let held: usize = index
+                .by_path
+                .iter()
+                .filter(|(path, _)| path.starts_with(&prefix))
+                .map(|(_, entries)| entries.len())
+                .sum();
+            if held > 0 {
+                return Ok(ToolResult::error(format!(
+                    "Refused: the folder `{shown}` still holds {held} node(s), and nothing was \
+                     deleted. Delete each of them first — one call each, so every removal is \
+                     visible on its own — and then delete the folder. List what is inside it with \
+                     `{WORKSPACE_LIST_TOOL}` and prefix=\"{shown}\".",
+                    shown = echo_path(&entry.path),
+                )));
+            }
+        }
+
+        // The same check-then-act revision guard `workspace_write` carries, and
+        // with the same honesty about it: the tree snapshot above is one
+        // authority on the current revision, so this catches the ordinary case
+        // (the operator edited the note since the agent read it) and narrows
+        // rather than closes the window.
+        if entry.node.updated_at_millis != expected {
+            return Ok(ToolResult::error(format!(
+                "Refused: `{shown}` changed since you last looked at it — you passed \
+                 expected_updated_at={expected}, but its current revision is {current}. Read it \
+                 again with `{WORKSPACE_READ_TOOL}` and decide whether the change you have not \
+                 seen is still worth deleting; do NOT retry with the same expected_updated_at.",
+                shown = echo_path(&entry.path),
+                current = entry.node.updated_at_millis,
+            )));
+        }
+
+        // Asked before the delete, because afterwards the node id is the only
+        // handle left and a lookup failure would be indistinguishable from
+        // "never published".
+        let history = match entry.node.kind {
+            NodeKind::File => self.history_of(&entry.node.id).await,
+            // A folder is never an artifact's node: publishing stamps the file
+            // it materialized, so there is no chain to survive a folder.
+            NodeKind::Folder => History::Unknown,
+        };
+
+        match self
+            .workspace
+            .store
+            .delete(&self.workspace.company, &entry.node.id)
+            .await
+        {
+            Ok(true) => Ok(ToolResult::success(format!(
+                "Deleted the workspace {what} `{shown}` (id={id}).{history}",
+                what = match entry.node.kind {
+                    NodeKind::Folder => "folder",
+                    NodeKind::File => "note",
+                },
+                shown = echo_path(&entry.path),
+                id = entry.node.id,
+                history = history.note(),
+            ))),
+            Ok(false) => Ok(ToolResult::error(format!(
+                "Refused: `{shown}` was already gone by the time the delete ran — somebody removed \
+                 it while you were deciding. Nothing was changed.",
+                shown = echo_path(&entry.path),
+            ))),
+            Err(e) => Ok(ToolResult::error(format!(
+                "Could not delete `{shown}`: {e}",
+                shown = echo_path(&entry.path),
+            ))),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// workspace_rename
+// ---------------------------------------------------------------------------
+
+/// Renames and/or moves one node inside the agent's own workspace folder. Wired
+/// only under an explicit `workspace` grant, alongside the other mutating
+/// tools.
+pub struct WorkspaceRenameTool {
+    workspace: CompanyWorkspace,
+}
+
+impl WorkspaceRenameTool {
+    pub(super) fn new(workspace: CompanyWorkspace) -> Self {
+        Self { workspace }
+    }
+}
+
+#[async_trait]
+impl Tool for WorkspaceRenameTool {
+    fn name(&self) -> &str {
+        WORKSPACE_RENAME_TOOL
+    }
+
+    fn description(&self) -> &str {
+        "Rename and/or move ONE folder or note INSIDE your own workspace folder `Agents/<your \
+         agent id>/`. USE FOR tidying your own folder — giving a draft the title it earned, or \
+         filing notes under a subfolder you made with `workspace_create`. Pass `new_name`, \
+         `new_parent`, or both. The node AND the destination folder must both be inside your own \
+         folder; the destination must already exist. The note keeps its body, its id and its \
+         authorship — to change the body use `workspace_write`. NOT for moving work out of your \
+         folder, and NOT for renaming anything elsewhere in the tree — those stay the operator's."
+    }
+
+    fn parameters_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "The node's path as shown by workspace_list, e.g. \"Agents/ceo/Draft.md\". Must be inside your own folder."
+                },
+                "id": {
+                    "type": "string",
+                    "description": "The node's id, as an alternative to `path`. It must still resolve to something inside your own folder."
+                },
+                "new_name": {
+                    "type": "string",
+                    "description": "The node's new name, one path segment only — no `/`. Include the file extension on a note. Omit to keep the current name."
+                },
+                "new_parent": {
+                    "type": "string",
+                    "description": "The path of an EXISTING folder to move the node into, e.g. \"Agents/ceo/archive\". Must be your own folder or a folder inside it. Omit to leave the node where it is."
+                }
+            },
+            "additionalProperties": false
+        })
+    }
+
+    /// Honest level for a tool that reorganizes operator-visible content. As
+    /// with the other mutating workspace tools this is not what gates the call —
+    /// see the `workspace_rename` descriptor in
+    /// [`policy::consequence`](crate::policy::consequence).
+    fn permission_level(&self) -> PermissionLevel {
+        PermissionLevel::Write
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        let (path, id) = target_args(&args);
+
+        let new_name = args
+            .get("new_name")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|n| !n.is_empty());
+        // Kept even when it trims to nothing, so "move me to the root" can be
+        // told apart from "leave the parent alone" and answered on its merits.
+        let new_parent_arg = args.get("new_parent").and_then(Value::as_str);
+
+        if new_name.is_none() && new_parent_arg.is_none() {
+            return Ok(ToolResult::error(format!(
+                "Invalid arguments: pass `new_name` to rename, `new_parent` to move, or both. To \
+                 change a note's body instead, use `{WORKSPACE_WRITE_TOOL}`."
+            )));
+        }
+
+        if let Some(name) = new_name
+            && !is_legal_segment(name)
+        {
+            return Ok(ToolResult::error(format!(
+                "Invalid `new_name`: `{shown}` is not a single path segment. A name cannot be \
+                 `.` or `..` and cannot contain `/` or `\\` — to move the node into a different \
+                 folder, pass `new_parent` instead.",
+                shown = echo_path(name),
+            )));
+        }
+
+        let (index, entry) = match resolve_in_index(&self.workspace, path, id).await {
+            Ok(pair) => pair,
+            Err(refusal) => return Ok(refusal),
+        };
+
+        if let Some(refusal) =
+            refuse_unless_inside_own_home(&self.workspace, &entry.path, "renaming")
+        {
+            return Ok(ToolResult::error(refusal));
+        }
+
+        // The destination. `None` means "same parent"; anything else has to
+        // resolve to a folder that is the agent's home or sits inside it.
+        //
+        // No mint-on-demand here, unlike `workspace_create`: a node that
+        // resolved inside the home proves the home already exists, so there is
+        // never a home to bring into existence at this point.
+        let destination = match new_parent_arg {
+            None => None,
+            Some(raw) => {
+                // The root is expressible (`""`, `"/"`) and is always outside
+                // the agent's folder, so it gets the scope answer rather than a
+                // parse error that hides the real reason.
+                if raw.trim().trim_matches('/').trim().is_empty() {
+                    return Ok(ToolResult::error(format!(
+                        "Refused: the workspace root is outside your own folder \
+                         `{AGENTS_ROOT}/{agent}/`, so nothing can be moved there. Pass \
+                         `new_parent` as your own folder or a folder inside it, or ask the \
+                         operator to move it in the console.",
+                        agent = self.workspace.agent_id,
+                    )));
+                }
+                let segments = match split_logical_path(raw) {
+                    Ok(segments) => segments,
+                    Err(why) => {
+                        return Ok(ToolResult::error(format!("Invalid `new_parent`: {why}.")));
+                    }
+                };
+                let parent_path = segments.join("/");
+                let parent = match index.by_path.get(&parent_path).map(Vec::as_slice) {
+                    Some([parent]) if parent.node.kind == NodeKind::Folder => parent,
+                    Some([parent]) => {
+                        return Ok(ToolResult::error(format!(
+                            "Refused: `{shown}` is a note, not a folder, so nothing can be moved \
+                             into it.",
+                            shown = echo_path(&parent.path),
+                        )));
+                    }
+                    Some(entries) => {
+                        return Ok(ToolResult::error(format!(
+                            "Refused: the destination `{shown}` is ambiguous — {n} nodes share it. \
+                             Ask the operator to rename one of them in the console.",
+                            shown = echo_path(&parent_path),
+                            n = entries.len(),
+                        )));
+                    }
+                    None => {
+                        return Ok(ToolResult::error(format!(
+                            "Refused: the folder `{shown}` does not exist, so `{node}` has nowhere \
+                             to go. Create it first with `{WORKSPACE_CREATE_TOOL}` and \
+                             kind=\"folder\", then retry this call.",
+                            shown = echo_path(&parent_path),
+                            node = echo_path(&entry.path),
+                        )));
+                    }
+                };
+                let parent_segments: Vec<&str> = parent.path.split('/').collect();
+                if !(self.workspace.is_own_home(&parent_segments)
+                    || self.workspace.is_strictly_inside_own_home(&parent_segments))
+                {
+                    return Ok(ToolResult::error(format!(
+                        "Refused: `{shown}` is outside your own folder `{AGENTS_ROOT}/{agent}/`, \
+                         so nothing can be moved into it. Anything you want the rest of the \
+                         company to own is the operator's to place; what you keep, keep in your \
+                         own folder.",
+                        shown = echo_path(&parent.path),
+                        agent = self.workspace.agent_id,
+                    )));
+                }
+                Some(parent.clone())
+            }
+        };
+
+        // Where this lands, so the "already taken" check below asks about the
+        // path that will actually exist rather than about one of its halves.
+        // The node resolved strictly inside the home, so it always has a parent
+        // segment to fall back on.
+        let parent_path = match &destination {
+            Some(parent) => parent.path.clone(),
+            None => entry
+                .path
+                .rsplit_once('/')
+                .map(|(parent, _)| parent.to_string())
+                .expect("a node inside the home has a parent segment"),
+        };
+        let final_name = new_name.unwrap_or(entry.node.name.as_str());
+        let target_path = format!("{parent_path}/{final_name}");
+
+        if let Some(occupants) = index.by_path.get(&target_path) {
+            if occupants.len() == 1 && occupants[0].node.id == entry.node.id {
+                return Ok(ToolResult::error(format!(
+                    "Refused: `{shown}` is already exactly where you asked to put it, so nothing \
+                     was changed. Pass a `new_name` or a `new_parent` that differs from what it \
+                     has now.",
+                    shown = echo_path(&entry.path),
+                )));
+            }
+            return Ok(ToolResult::error(format!(
+                "Refused: `{shown}` already exists, and nothing was changed. A second node at one \
+                 path makes it ambiguous for every agent from then on. Pick a name that is free, \
+                 or revise the note that is already there with `{WORKSPACE_WRITE_TOOL}`.",
+                shown = echo_path(&target_path),
+            )));
+        }
+
+        match self
+            .workspace
+            .store
+            .rename_move(
+                &self.workspace.company,
+                &entry.node.id,
+                new_name,
+                destination
+                    .as_ref()
+                    .map(|parent| Some(parent.node.id.as_str())),
+            )
+            .await
+        {
+            Ok(node) => Ok(ToolResult::success(format!(
+                "Moved the workspace {what} `{from}` to `{to}` (id={id}). Its body and its \
+                 authorship are unchanged, but the move restamped its revision to rev={rev} — use \
+                 that as `expected_updated_at` if you edit or delete it this turn.",
+                what = match entry.node.kind {
+                    NodeKind::Folder => "folder",
+                    NodeKind::File => "note",
+                },
+                from = echo_path(&entry.path),
+                to = echo_path(&target_path),
+                id = node.id,
+                rev = node.updated_at_millis,
+            ))),
+            Err(e) => Ok(ToolResult::error(format!(
+                "Could not move `{shown}`: {e}",
+                shown = echo_path(&entry.path),
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test;

--- a/src/harness/workspace_tools/lifecycle/test.rs
+++ b/src/harness/workspace_tools/lifecycle/test.rs
@@ -1,0 +1,910 @@
+//! Tests for the own-folder lifecycle tools (issue #671).
+
+use std::sync::Arc;
+
+use super::*;
+use crate::company::workspace_scaffold::{ensure_agent_folder, ensure_workspace_scaffold};
+use crate::harness::workspace_tools::tests::{TEST_AGENT, agent_origin, file, folder, text, ws};
+use crate::ports::artifacts::{ArtifactKind, ArtifactRecord, ArtifactStore};
+use crate::ports::types::CompanyId;
+use crate::ports::workspace::{WorkspaceNode, WorkspaceStore};
+use crate::store::FsOps;
+
+/// The revision [`file`] stamps, and therefore the CAS token every note in
+/// these tests answers to.
+const NOTE_REV: u64 = 2_000;
+/// The revision [`folder`] stamps.
+const FOLDER_REV: u64 = 1_000;
+
+/// A live workspace shaped like the one the lifecycle tools were written for:
+/// the boot scaffold, this agent's own home holding a note and an empty folder,
+/// a teammate's home holding a note, plus `Standards/` and a root `README.md`
+/// to have something outside the agent's reach.
+///
+/// Carries an **artifact store** alongside the workspace store, because
+/// `build_agent` always wires one and `workspace_delete` reads it to decide
+/// whether a removal is recoverable. A fixture without one would exercise only
+/// the [`History::Unknown`] branch and quietly stop checking the sentence the
+/// agent actually reads.
+struct Home {
+    _dir: tempfile::TempDir,
+    store: Arc<dyn WorkspaceStore>,
+    artifacts: Arc<dyn ArtifactStore>,
+    company: CompanyId,
+}
+
+async fn own_home(company: &str) -> Home {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ops = Arc::new(FsOps::new(dir.path()));
+    let store: Arc<dyn WorkspaceStore> = ops.clone();
+    let artifacts: Arc<dyn ArtifactStore> = ops;
+    let id = CompanyId::new(company);
+
+    store
+        .create(&id, &folder("f-standards", "Standards", None), None)
+        .await
+        .expect("folder");
+    store
+        .create(
+            &id,
+            &file("n-eng", "Engineering standards.md", Some("f-standards")),
+            Some("# Engineering\nReview every PR."),
+        )
+        .await
+        .expect("note");
+    store
+        .create(&id, &file("n-readme", "README.md", None), Some("# Root"))
+        .await
+        .expect("readme");
+    ensure_workspace_scaffold(store.as_ref(), &id)
+        .await
+        .unwrap();
+
+    let mine = ensure_agent_folder(store.as_ref(), &id, TEST_AGENT)
+        .await
+        .unwrap();
+    // Agent-authored on purpose: a rename must be provably origin-preserving,
+    // and an operator-stamped fixture could not tell a preserved stamp from a
+    // restamped one.
+    store
+        .create(
+            &id,
+            &WorkspaceNode {
+                created_by: agent_origin(),
+                updated_by: agent_origin(),
+                ..file("n-draft", "Draft.md", Some(&mine))
+            },
+            Some("# Draft"),
+        )
+        .await
+        .unwrap();
+    store
+        .create(&id, &folder("f-archive", "archive", Some(&mine)), None)
+        .await
+        .unwrap();
+
+    let theirs = ensure_agent_folder(store.as_ref(), &id, "cmo")
+        .await
+        .unwrap();
+    store
+        .create(
+            &id,
+            &file("n-mate", "Plan.md", Some(&theirs)),
+            Some("# Plan"),
+        )
+        .await
+        .unwrap();
+
+    Home {
+        _dir: dir,
+        store,
+        artifacts,
+        company: id,
+    }
+}
+
+impl Home {
+    /// The delete tool as the builder wires it: this agent, this company, the
+    /// artifact store attached.
+    fn deleter(&self) -> WorkspaceDeleteTool {
+        WorkspaceDeleteTool::new(
+            ws(self.store.clone(), self.company.clone())
+                .with_artifacts(Some(self.artifacts.clone())),
+        )
+    }
+
+    fn renamer(&self) -> WorkspaceRenameTool {
+        WorkspaceRenameTool::new(ws(self.store.clone(), self.company.clone()))
+    }
+
+    async fn tree(&self) -> Vec<WorkspaceNode> {
+        self.store.tree(&self.company).await.unwrap()
+    }
+
+    /// Whether a node id is still in the tree.
+    async fn has(&self, id: &str) -> bool {
+        self.tree().await.iter().any(|node| node.id == id)
+    }
+
+    async fn read(&self, id: &str) -> (WorkspaceNode, String) {
+        self.store
+            .read(&self.company, id)
+            .await
+            .unwrap()
+            .expect("the node is still there")
+    }
+
+    async fn node(&self, id: &str) -> WorkspaceNode {
+        self.read(id).await.0
+    }
+
+    /// This agent's home folder id, read live.
+    async fn home_id(&self) -> String {
+        self.tree()
+            .await
+            .iter()
+            .find(|n| n.name == TEST_AGENT)
+            .expect("the home folder")
+            .id
+            .clone()
+    }
+
+    /// Add a note directly inside this agent's own folder.
+    async fn add_own(&self, node: WorkspaceNode, content: &str) {
+        let parent = self.home_id().await;
+        self.store
+            .create(
+                &self.company,
+                &WorkspaceNode {
+                    parent_id: Some(parent),
+                    ..node
+                },
+                Some(content),
+            )
+            .await
+            .unwrap();
+    }
+
+    /// Add a binary node directly inside this agent's own folder.
+    async fn add_own_binary(&self, id: &str, name: &str, bytes: &[u8]) {
+        let parent = self.home_id().await;
+        let node = WorkspaceNode {
+            mime: Some("image/png".to_string()),
+            ..file(id, name, Some(&parent))
+        };
+        self.store
+            .create_binary(&self.company, &node, bytes)
+            .await
+            .unwrap();
+    }
+
+    /// Record `node_id` as a published deliverable, so deleting it is the
+    /// recoverable case.
+    async fn publish(&self, artifact_id: &str, node_id: &str, body: &str) {
+        let mut record = ArtifactRecord::new(
+            artifact_id,
+            "t-1",
+            "Launch spec",
+            ArtifactKind::Markdown,
+            body,
+            TEST_AGENT,
+            1,
+        );
+        record.stamp_workspace_node(node_id);
+        self.artifacts.upsert(&self.company, &record).await.unwrap();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// workspace_delete — the happy paths
+// ---------------------------------------------------------------------------
+
+/// The whole point of the issue: an agent can clear a superseded draft out of
+/// its own folder, and is told plainly that nothing will bring it back.
+#[tokio::test]
+async fn deleting_your_own_note_removes_it_and_names_the_loss_as_permanent() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "expected_updated_at": NOTE_REV }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(message.contains("Agents/ceo/Draft.md"), "{message}");
+    assert!(
+        message.contains("permanent"),
+        "a directly-created note's deletion is final and must say so: {message}"
+    );
+    assert!(!home.has("n-draft").await, "the note survived the delete");
+}
+
+/// An empty folder of your own is deletable — which is what makes the
+/// non-empty refusal below an instruction rather than a dead end.
+#[tokio::test]
+async fn an_empty_folder_of_your_own_can_be_deleted() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/archive", "expected_updated_at": FOLDER_REV }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    assert!(text(&out).contains("folder"), "{}", text(&out));
+    assert!(!home.has("f-archive").await);
+}
+
+/// A published note's history lives on its artifact chain, so its deletion is
+/// the **recoverable** case — and the message has to say the opposite of what
+/// it says for an ordinary note, or the agent will treat the two identically.
+#[tokio::test]
+async fn deleting_a_published_note_says_its_history_survives_in_artifacts() {
+    let home = own_home("acme").await;
+    home.publish("art-1", "n-draft", "# Draft").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "id": "n-draft", "expected_updated_at": NOTE_REV }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(message.contains("Artifacts"), "{message}");
+    assert!(
+        !message.contains("permanent"),
+        "a published note is the recoverable case: {message}"
+    );
+    assert!(!home.has("n-draft").await);
+
+    // The chain is untouched, dangling node id and all — the same state the
+    // operator's own DELETE route leaves behind today, and deliberately not
+    // "repaired" here.
+    let stored = home
+        .artifacts
+        .get(&home.company, "art-1")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stored.workspace_node_id(), Some("n-draft"));
+    assert_eq!(stored.versions.len(), 1);
+}
+
+/// The port promises a binary node's payload goes with it (issue #553). This
+/// pins that the agent-facing path reaches that promise rather than refusing
+/// bytes the way `workspace_write` does.
+#[tokio::test]
+async fn a_binary_node_in_your_own_folder_deletes_with_its_payload() {
+    let home = own_home("acme").await;
+    home.add_own_binary("n-own-img", "chart.png", &[0x89, b'P', b'N', b'G'])
+        .await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/chart.png", "expected_updated_at": NOTE_REV }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    assert!(
+        home.store
+            .read_bytes(&home.company, "n-own-img")
+            .await
+            .unwrap()
+            .is_none(),
+        "the payload outlived its node"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// workspace_delete — the scope gate
+// ---------------------------------------------------------------------------
+
+/// Shared guidance is not the agent's to remove, and a refusal must leave it
+/// byte-identical rather than merely un-deleted.
+#[tokio::test]
+async fn a_note_outside_your_own_folder_is_refused_and_left_alone() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({
+            "path": "Standards/Engineering standards.md",
+            "expected_updated_at": NOTE_REV,
+        }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("outside your own folder"),
+        "{}",
+        text(&out)
+    );
+    assert_eq!(
+        home.read("n-eng").await.1,
+        "# Engineering\nReview every PR."
+    );
+}
+
+/// The gate is checked on the **resolved** node, not on the argument — so the
+/// `id` form cannot walk around a `path` form's refusal. This is the bypass the
+/// whole scope argument rests on.
+#[tokio::test]
+async fn an_id_that_names_a_note_outside_your_folder_refuses_like_its_path_would() {
+    let home = own_home("acme").await;
+    let tool = home.deleter();
+
+    for node in ["n-eng", "n-readme", "n-mate"] {
+        let out = tool
+            .execute(json!({ "id": node, "expected_updated_at": NOTE_REV }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "`{node}` was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("outside your own folder"),
+            "`{node}`: {}",
+            text(&out)
+        );
+        assert!(home.has(node).await, "`{node}` was deleted");
+    }
+}
+
+/// A teammate's folder is a teammate's, whichever end of it is named — and the
+/// `Agents` root itself belongs to nobody.
+#[tokio::test]
+async fn a_teammates_home_and_its_contents_are_refused() {
+    let home = own_home("acme").await;
+    let tool = home.deleter();
+
+    for path in ["Agents/cmo", "Agents/cmo/Plan.md", "Agents"] {
+        let out = tool
+            .execute(json!({ "path": path, "expected_updated_at": NOTE_REV }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "`{path}` was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("outside your own folder"),
+            "`{path}`: {}",
+            text(&out)
+        );
+    }
+    assert!(home.has("n-mate").await);
+}
+
+/// The home folder gets a refusal of its own, and it has to explain the actual
+/// consequence: `ensure_agent_folder` resolves the home **by name**, so
+/// deleting it does not merely remove a folder — it makes the next publish mint
+/// a second, empty one and forks the company's view of where this agent's work
+/// lives.
+#[tokio::test]
+async fn your_own_home_folder_gets_its_own_refusal() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo", "expected_updated_at": FOLDER_REV }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(message.contains("your own folder itself"), "{message}");
+    assert!(
+        !message.contains("outside your own folder"),
+        "the home must not get the generic outside-scope message: {message}"
+    );
+    assert!(
+        message.contains("Act on what is inside it"),
+        "the refusal must name the next useful action: {message}"
+    );
+    assert!(home.tree().await.iter().any(|n| n.name == TEST_AGENT));
+}
+
+/// One node per call, in the destructive direction. A recursive delete would be
+/// one approval card naming one path that takes an unbounded amount of work
+/// with it — so a non-empty folder is refused, having changed nothing at all.
+#[tokio::test]
+async fn a_folder_that_still_holds_anything_is_refused_and_deletes_nothing() {
+    let home = own_home("acme").await;
+    home.store
+        .create(
+            &home.company,
+            &file("n-in-archive", "old.md", Some("f-archive")),
+            Some("old"),
+        )
+        .await
+        .unwrap();
+    let before = home.tree().await.len();
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/archive", "expected_updated_at": FOLDER_REV }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(message.contains("still holds 1 node(s)"), "{message}");
+    assert!(
+        message.contains("one call each"),
+        "the refusal must say how to proceed: {message}"
+    );
+    assert_eq!(
+        home.tree().await.len(),
+        before,
+        "a refused folder delete removed something"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// workspace_delete — the revision guard
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn a_delete_without_a_revision_is_refused() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/Draft.md" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(text(&out).contains("expected_updated_at"), "{}", text(&out));
+    assert!(home.has("n-draft").await);
+}
+
+/// A note edited in the console since the agent last read it is not deleted on
+/// the strength of a view that predates the change.
+#[tokio::test]
+async fn a_stale_revision_is_refused_and_names_the_current_one() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "expected_updated_at": 1 }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(message.contains(&NOTE_REV.to_string()), "{message}");
+    assert!(
+        message.contains("do NOT retry with the same expected_updated_at"),
+        "{message}"
+    );
+    assert!(home.has("n-draft").await);
+}
+
+/// Models stringify numbers constantly. `workspace_write` learned this the
+/// expensive way; the same leniency is inherited rather than re-litigated.
+#[tokio::test]
+async fn a_revision_is_accepted_as_a_number_or_a_string() {
+    for revision in [json!(NOTE_REV), json!(NOTE_REV.to_string())] {
+        let home = own_home("acme").await;
+        let out = home
+            .deleter()
+            .execute(json!({
+                "path": "Agents/ceo/Draft.md",
+                "expected_updated_at": revision,
+            }))
+            .await
+            .unwrap();
+        assert!(!out.is_error, "{revision}: {}", text(&out));
+        assert!(!home.has("n-draft").await, "{revision}");
+    }
+
+    // A string that is not a number is still not a revision.
+    let home = own_home("acme").await;
+    let out = home
+        .deleter()
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "expected_updated_at": "latest" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(home.has("n-draft").await);
+}
+
+/// The tenancy argument the module rests on, applied to the destructive tool: a
+/// node id borrowed from another company is simply absent from this company's
+/// index, so the store is never asked about it.
+#[tokio::test]
+async fn tenancy_a_borrowed_node_id_cannot_be_deleted_by_another_company() {
+    let home = own_home("acme").await;
+    let intruder = WorkspaceDeleteTool::new(
+        ws(home.store.clone(), CompanyId::new("other"))
+            .with_artifacts(Some(home.artifacts.clone())),
+    );
+
+    let out = intruder
+        .execute(json!({ "id": "n-draft", "expected_updated_at": NOTE_REV }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("No workspace note matches"),
+        "{}",
+        text(&out)
+    );
+    assert!(home.has("n-draft").await);
+}
+
+// ---------------------------------------------------------------------------
+// workspace_rename
+// ---------------------------------------------------------------------------
+
+/// A rename is content-, id- and authorship-preserving. All three matter: the
+/// id is what every artifact record points at, and the origins are what keep an
+/// agent's work attributed after somebody tidies it.
+#[tokio::test]
+async fn renaming_your_own_note_keeps_its_body_id_and_authorship() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .renamer()
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "new_name": "Q3 launch brief.md" }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    let message = text(&out);
+    assert!(
+        message.contains("Agents/ceo/Q3 launch brief.md"),
+        "{message}"
+    );
+    assert!(
+        message.contains("rev="),
+        "the move restamps the revision, so it has to hand the new one back: {message}"
+    );
+
+    let (node, body) = home.read("n-draft").await;
+    assert_eq!(node.name, "Q3 launch brief.md");
+    assert_eq!(body, "# Draft");
+    assert_eq!(node.created_by, agent_origin());
+    assert_eq!(node.updated_by, agent_origin());
+}
+
+/// Filing a note under a subfolder you made is the other half of tidying, and
+/// the destination may be either the home itself or anything inside it.
+#[tokio::test]
+async fn a_note_can_be_moved_into_and_back_out_of_a_subfolder_of_your_own() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    let out = tool
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "new_parent": "Agents/ceo/archive" }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    assert_eq!(
+        home.node("n-draft").await.parent_id.as_deref(),
+        Some("f-archive")
+    );
+
+    // …and back up into the home itself, which is a legal *destination* even
+    // though it is never a legal target for a delete or a rename.
+    let out = tool
+        .execute(json!({ "id": "n-draft", "new_parent": "Agents/ceo" }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    assert_eq!(
+        home.node("n-draft").await.parent_id,
+        Some(home.home_id().await)
+    );
+}
+
+/// A rename and a move in one call, since the tool advertises both.
+#[tokio::test]
+async fn a_name_and_a_parent_can_change_in_one_call() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .renamer()
+        .execute(json!({
+            "path": "Agents/ceo/Draft.md",
+            "new_name": "superseded.md",
+            "new_parent": "Agents/ceo/archive",
+        }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("Agents/ceo/archive/superseded.md"),
+        "{}",
+        text(&out)
+    );
+    let node = home.node("n-draft").await;
+    assert_eq!(node.name, "superseded.md");
+    assert_eq!(node.parent_id.as_deref(), Some("f-archive"));
+}
+
+/// A binary node renames like any other — the port moves the payload with it.
+#[tokio::test]
+async fn a_binary_node_can_be_renamed_and_keeps_its_payload() {
+    let home = own_home("acme").await;
+    home.add_own_binary("n-own-img", "chart.png", &[0x89, b'P', b'N', b'G'])
+        .await;
+
+    let out = home
+        .renamer()
+        .execute(json!({ "path": "Agents/ceo/chart.png", "new_name": "q3-chart.png" }))
+        .await
+        .unwrap();
+    assert!(!out.is_error, "{}", text(&out));
+    let (node, _) = home
+        .store
+        .read_bytes(&home.company, "n-own-img")
+        .await
+        .unwrap()
+        .expect("the payload survived the rename");
+    assert_eq!(node.name, "q3-chart.png");
+    assert_eq!(node.size, Some(4));
+}
+
+/// The scope gate is the one delete uses, checked on the resolved node — so
+/// both argument forms refuse identically outside the agent's folder.
+#[tokio::test]
+async fn renaming_anything_outside_your_own_folder_is_refused() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    for args in [
+        json!({ "path": "Standards/Engineering standards.md", "new_name": "mine.md" }),
+        json!({ "id": "n-eng", "new_name": "mine.md" }),
+        json!({ "path": "Agents/cmo/Plan.md", "new_name": "mine.md" }),
+        json!({ "id": "n-mate", "new_parent": "Agents/ceo" }),
+        json!({ "path": "README.md", "new_name": "mine.md" }),
+    ] {
+        let out = tool.execute(args.clone()).await.unwrap();
+        assert!(out.is_error, "{args} was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("outside your own folder"),
+            "{args}: {}",
+            text(&out)
+        );
+    }
+    assert_eq!(home.node("n-eng").await.name, "Engineering standards.md");
+    assert_eq!(home.node("n-mate").await.name, "Plan.md");
+}
+
+/// The home folder is the agent's identity anchor for renames too, and for the
+/// sharper reason: its name **is** the lookup key.
+#[tokio::test]
+async fn your_own_home_folder_cannot_be_renamed() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .renamer()
+        .execute(json!({ "path": "Agents/ceo", "new_name": "chief-exec" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("your own folder itself"),
+        "{}",
+        text(&out)
+    );
+    assert!(home.tree().await.iter().any(|n| n.name == TEST_AGENT));
+}
+
+/// Moving to the workspace root is always refused, and gets the scope answer
+/// rather than the parse error an empty path would otherwise produce — the
+/// reason is that the root is not the agent's, not that `""` is malformed.
+#[tokio::test]
+async fn moving_to_the_workspace_root_is_refused_with_the_scope_reason() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    for root in ["", "/", "  ", "//"] {
+        let out = tool
+            .execute(json!({ "path": "Agents/ceo/Draft.md", "new_parent": root }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "`{root}` was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("workspace root is outside your own folder"),
+            "`{root}`: {}",
+            text(&out)
+        );
+    }
+    assert_eq!(
+        home.node("n-draft").await.parent_id,
+        Some(home.home_id().await),
+        "a refused move relocated the note anyway"
+    );
+}
+
+/// A destination outside the agent's folder is refused even when the node
+/// itself is inside it — otherwise "confined to your own folder" would only be
+/// half true, and the escape would be a one-call move.
+#[tokio::test]
+async fn moving_your_own_note_out_of_your_folder_is_refused() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    for parent in ["Standards", "Agents", "Agents/cmo"] {
+        let out = tool
+            .execute(json!({ "path": "Agents/ceo/Draft.md", "new_parent": parent }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "`{parent}` was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("outside your own folder"),
+            "`{parent}`: {}",
+            text(&out)
+        );
+    }
+    assert_eq!(
+        home.node("n-draft").await.parent_id,
+        Some(home.home_id().await),
+        "a refused move relocated the note anyway"
+    );
+}
+
+/// The `fs` backend rejects an unsafe name, but sqlite and mongodb do not — so
+/// the tool layer validates rather than relying on whichever backend is wired.
+#[tokio::test]
+async fn a_new_name_that_is_not_a_single_segment_is_refused() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    for name in ["..", ".", "a/b", "a\\b", "sub/dir/note.md"] {
+        let out = tool
+            .execute(json!({ "path": "Agents/ceo/Draft.md", "new_name": name }))
+            .await
+            .unwrap();
+        assert!(out.is_error, "`{name}` was allowed: {}", text(&out));
+        assert!(
+            text(&out).contains("single path segment"),
+            "`{name}`: {}",
+            text(&out)
+        );
+    }
+    assert_eq!(home.node("n-draft").await.name, "Draft.md");
+}
+
+/// Two nodes at one path make it ambiguous for every agent from then on — the
+/// argument `workspace_create` refuses on, applied to the other way of reaching
+/// the same state.
+#[tokio::test]
+async fn a_rename_onto_an_occupied_path_is_refused_and_changes_nothing() {
+    let home = own_home("acme").await;
+    home.add_own(file("n-other", "Notes.md", None), "notes")
+        .await;
+
+    let out = home
+        .renamer()
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "new_name": "Notes.md" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(text(&out).contains("already exists"), "{}", text(&out));
+    assert_eq!(home.node("n-draft").await.name, "Draft.md");
+    assert_eq!(
+        home.read("n-other").await.1,
+        "notes",
+        "the note that was already there must be untouched"
+    );
+}
+
+/// A rename that names no change is a refusal rather than a silent success —
+/// the store would answer `Ok` and announce nothing, which reads to the agent
+/// as "the move happened" when nothing moved.
+#[tokio::test]
+async fn a_rename_that_changes_nothing_says_so() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    for args in [
+        json!({ "path": "Agents/ceo/Draft.md", "new_name": "Draft.md" }),
+        json!({ "path": "Agents/ceo/Draft.md", "new_parent": "Agents/ceo" }),
+    ] {
+        let out = tool.execute(args.clone()).await.unwrap();
+        assert!(out.is_error, "{args}: {}", text(&out));
+        assert!(
+            text(&out).contains("already exactly where you asked to put it"),
+            "{args}: {}",
+            text(&out)
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_destination_that_is_missing_or_is_a_note_is_refused_with_what_to_do() {
+    let home = own_home("acme").await;
+    let tool = home.renamer();
+
+    let out = tool
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "new_parent": "Agents/ceo/nope" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(text(&out).contains("does not exist"), "{}", text(&out));
+    assert!(
+        text(&out).contains(WORKSPACE_CREATE_TOOL),
+        "the refusal must name the tool that fixes it: {}",
+        text(&out)
+    );
+
+    home.add_own(file("n-other", "Notes.md", None), "notes")
+        .await;
+    let out = tool
+        .execute(json!({ "path": "Agents/ceo/Draft.md", "new_parent": "Agents/ceo/Notes.md" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("is a note, not a folder"),
+        "{}",
+        text(&out)
+    );
+}
+
+#[tokio::test]
+async fn a_rename_needs_at_least_one_of_new_name_and_new_parent() {
+    let home = own_home("acme").await;
+
+    let out = home
+        .renamer()
+        .execute(json!({ "path": "Agents/ceo/Draft.md" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(text(&out).contains("new_name"), "{}", text(&out));
+    assert!(text(&out).contains("new_parent"), "{}", text(&out));
+}
+
+#[tokio::test]
+async fn tenancy_a_borrowed_node_id_cannot_be_renamed_by_another_company() {
+    let home = own_home("acme").await;
+    let intruder = WorkspaceRenameTool::new(ws(home.store.clone(), CompanyId::new("other")));
+
+    let out = intruder
+        .execute(json!({ "id": "n-draft", "new_name": "mine.md" }))
+        .await
+        .unwrap();
+    assert!(out.is_error, "{}", text(&out));
+    assert!(
+        text(&out).contains("No workspace note matches"),
+        "{}",
+        text(&out)
+    );
+    assert_eq!(home.node("n-draft").await.name, "Draft.md");
+}
+
+// ---------------------------------------------------------------------------
+// The declared surface
+// ---------------------------------------------------------------------------
+
+/// Both tools are honest about what they do, and both answer a refusal as a
+/// readable `ToolResult` rather than as an `Err` the harness renders as a
+/// crash.
+#[tokio::test]
+async fn both_tools_declare_write_and_answer_refusals_as_results() {
+    let home = own_home("acme").await;
+    let delete = home.deleter();
+    let rename = home.renamer();
+
+    assert_eq!(delete.name(), WORKSPACE_DELETE_TOOL);
+    assert_eq!(rename.name(), WORKSPACE_RENAME_TOOL);
+    assert_eq!(delete.permission_level(), PermissionLevel::Write);
+    assert_eq!(rename.permission_level(), PermissionLevel::Write);
+
+    // Neither `path` nor `id`: the resolver's own message, delivered as a
+    // result.
+    for out in [
+        delete
+            .execute(json!({ "expected_updated_at": NOTE_REV }))
+            .await
+            .unwrap(),
+        rename.execute(json!({ "new_name": "x.md" })).await.unwrap(),
+    ] {
+        assert!(out.is_error, "{}", text(&out));
+        assert!(text(&out).contains("Invalid arguments"), "{}", text(&out));
+    }
+
+    // The schemas name only the arguments each tool actually reads.
+    let delete_schema = delete.parameters_schema();
+    assert_eq!(delete_schema["required"], json!(["expected_updated_at"]));
+    assert_eq!(delete_schema["additionalProperties"], json!(false));
+    let rename_schema = rename.parameters_schema();
+    assert!(rename_schema["properties"]["new_parent"].is_object());
+    assert_eq!(rename_schema["additionalProperties"], json!(false));
+}

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -383,6 +383,24 @@ const DECLARED: &[Declared] = &[
     d("workspace_search", EffectGroup::Other, Reach::Nothing),
     d("workspace_create", EffectGroup::Other, Reach::Consequence),
     d("workspace_write", EffectGroup::Other, Reach::Consequence),
+    // `workspace_delete` and `workspace_rename` (issue #671) take the same
+    // classification, and again by re-deriving it rather than by copying.
+    //
+    // Both are confined to the agent's own `Agents/<self>/` folder, which is
+    // narrower than either tool above — so the temptation is to price them
+    // lower. That would be backwards. Reach here is about what a call costs the
+    // company, and a delete removes a node **and its authorship record** from a
+    // tree the operator and every teammate read; a rename moves what somebody
+    // may have linked to by path. Neither is undone by the agent that did it,
+    // and the operator's undo is a console session, not a retry. `Consequence`
+    // is what "the operator would want to have seen this" means.
+    //
+    // `PerCall` follows for the same reason it does above, with one more: a
+    // standing grant on deletion is precisely the shape that turns one bad turn
+    // into a folder that is quietly empty by the end of it. Per-call parking
+    // makes each removal its own card naming its own path.
+    d("workspace_delete", EffectGroup::Other, Reach::Consequence),
+    d("workspace_rename", EffectGroup::Other, Reach::Consequence),
     // ---- Publishing --------------------------------------------------------
     // Externally visible and not reversible by the company alone.
     d("publish_artifact", EffectGroup::Publish, Reach::Consequence),
@@ -887,6 +905,8 @@ mod tests {
             "http_request",
             "git_operations",
             "workspace_write",
+            "workspace_delete",
+            "workspace_rename",
             "publish_artifact",
             "media_generate_image",
             "media_generate_video",
@@ -961,6 +981,8 @@ mod tests {
             "web_fetch",
             "workspace_create",
             "workspace_write",
+            "workspace_delete",
+            "workspace_rename",
             "git_operations",
             "run_workflow",
             "mcp_call_tool",
@@ -1482,6 +1504,8 @@ mod tests {
             workspace_tools::WORKSPACE_SEARCH_TOOL,
             workspace_tools::WORKSPACE_CREATE_TOOL,
             workspace_tools::WORKSPACE_WRITE_TOOL,
+            workspace_tools::WORKSPACE_RENAME_TOOL,
+            workspace_tools::WORKSPACE_DELETE_TOOL,
             crate::harness::composio_catalog::LIST_TOOLS_TOOL,
             crate::harness::composio_catalog::LIST_TOOLKITS_TOOL,
         ] {


### PR DESCRIPTION
## Summary

An agent had five workspace tools — list, read, write, create, search — and **no way to delete, rename or move anything**. Lifecycle was operator-only, and the brief said so outright. That was coherent while agents could only overwrite existing notes; it stopped being coherent when #551 let them create. An agent can make a mess it is forbidden from cleaning up: stale drafts, misnamed files, near-duplicates from task retries. Only an operator can tidy any of it, so in practice nobody does.

**#607 gave that a cost.** Before search, junk was invisible until you opened a folder. Now every stale draft is a candidate in every search, competing for a bounded 50-result set against the file someone actually wants — so the tree degrades exactly as it gets used.

This adds `workspace_delete` and `workspace_rename`, confined to `Agents/<agent id>/`.

Closes #671.

## API Or Behavior Changes

**Both tools ride the existing `workspace.write` grant — no fifth grant name.** An agent that cannot write has no business deleting; an agent that can write can already destroy a note's contents by overwriting it. Own-home lifecycle is *narrower* reach on the same power.

**This is coherence, not containment, and the PR does not claim otherwise.** Agents write unconfined across the whole tree by deliberate product decision — authorship (`created_by`/`updated_by`, #326) is the accountability mechanism, not a boundary. Anything an agent could destroy by deleting, it can already destroy by overwriting. The own-home scope exists because *"tidy up after yourself"* is a capability with an obvious correct use, while *"delete anything in the company"* is not — no task needs it, and a prompt-injected agent handed it does more damage per mistake.

**One honest caveat**: delete removes the node **and its authorship record**, which is marginally worse forensically than overwrite-to-empty. Mitigated by the scope, by per-call approval (both tools are `Reach::Consequence`, so every call parks), and by the removal announcement. The CAS check is check-then-act — it narrows the race, it does not close it.

**Scope is enforced on the resolved node, not the argument.** Both tools accept `path` or `id`; the gate runs after resolution, so an `id` naming a node outside the home refuses identically to a path. Without that, `id` is a trivial walk-around.

**`workspace_delete`** requires `expected_updated_at` (the same stale-refusal shape as `workspace_write`). Three refusals, each with its own message: outside the agent's home; **the home folder itself** — `ensure_agent_folder` resolves the home *by name*, so deleting it forks where the company looks for that agent's work; and **non-empty folders**. Refusing recursion is deliberate: it turns a subtree wipe into N deliberate, individually-announced, individually-parked deletions, and dissolves the "teammate's published deliverable sits under my home" case that #552's `Agents/<agent>/<task-id>/` layout creates.

**Deleting a published note and deleting a private one are different acts, so the success message differs.** A published note is mirrored from an artifact whose version history is authoritative — the content survives and re-publishing recreates the path. A note the agent created directly has no backstop: the deletion is final, and the message says so. (My first instinct was to *refuse* on published nodes; that inverts the risk — the published one is the recoverable one.)

**`workspace_rename`** takes no CAS token, and the reasoning changed during implementation — see below. Both endpoints must be under `Agents/<self>/`: in-place rename allowed, reparent only into the home or inside it, **move-to-root always refused**.

**The dangling `ArtifactVersion.workspace_node_id` is left alone, deliberately.** The operator DELETE route produces this exact state today, and every reader re-verifies before use — `materialize` read-guards, `artifacts.rs` re-checks, `brain.rs` re-adopts by path. It is a checked tombstone, not the #553 "sha256 with no bytes" class.

## Four places the plan was wrong

Recorded because two of them would have shipped as defects:

1. **`rename_move` restamps `updated_at_millis`.** The plan justified skipping the CAS token by calling rename "content- and origin-preserving". Origins yes — the revision no; `FsOps::rename_move` sets `now_millis()`. The no-token decision still stands (nothing is destroyed), but the success message now hands the new `rev` back. Without that, an agent's very next write in the same turn is refused as stale — an intermittent, baffling failure.

2. **"No frontend change is expected" was wrong, and the fix predates this issue.** True of the tree UI. But both tools park on every call, and `frontend/src/lib/language.ts`'s `TOOL_LABELS` had no entry, so the approval card and the Standing-permissions list would render the raw tool identifier through the generic fallback — exactly the #372 bug. Found while grepping to *confirm* the plan's claim rather than to check it. **`workspace_create` has been in that broken state since #551**, so every approval prompt for an agent creating a note has shown a raw identifier; fixed here rather than left as the one unnamed sibling.

3. **Doc drift the plan did not list.** `docs/spec/runtime/manifest.md` asserted "Renaming and deleting stay operator-only" — false as of this branch. Three further spec files enumerate the mutation set. All updated, all still under the 500-line cap.

4. **"Nothing becomes `pub`" holds for production items only.** A child module reaches its ancestors' private items, so `CompanyWorkspace` / `PathIndex` / `echo_path` needed nothing — but the parent's `#[cfg(test)] mod tests` is *not* an ancestor of `lifecycle::test`, so six test helpers took `pub(super)`. Test-only, zero production surface.

Also: **move-to-root is not expressible as a path.** `""` and `"/"` fail `split_logical_path` as a *parse* error, which would have buried the real reason behind a syntax complaint. It is detected before parsing and given the scope answer; the port is never handed `Some(None)`.

## Tests

Every gate, exit codes captured directly rather than through a pipe:

- [x] `cargo fmt --all -- --check` — 0
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — 0
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings` — 0
- [x] `cargo build --all-targets` (via `cargo check --locked --all-features --all-targets`) — 0
- [x] `cargo test --locked` — **1979 passed**, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **2987 passed**, 0 failed
- [x] `frontend`: `npm run typecheck` 0, `npm run build` 0, **`./scripts/ci/assert-design-tokens.sh` 0**

28 new lifecycle tests (99 in `workspace_tools` total). Coverage includes: scope refusals including the **by-id bypass** and a teammate's home; the home-folder refusal; non-empty folder refused **and nothing deleted**; CAS required / stale / string-form; duplicate-target rename refused; move-to-root refused; reparent into and out of the home; binary node delete and rename (pinning the port's post-#553 behaviour); published-note vs permanent-note messages; tenancy mirrors. Grant tests cover read / explicit / `workspace.read` / `workspace.write` / bare `*` / unwired.

## Documentation

Brief write-half rewritten — tidying your own folder is expected upkeep, delete is permanent for direct-created notes, and rename/delete **outside** your folder stays the operator's. The phrasing is pinned by a test, as #570 and #607 both did, because the brief is what actually steers behaviour. Module docs, the `workspace_write` description, and four spec files updated.

## Related

- #551 — agents create in the shared tree; the change that made this asymmetric, and the source of the `workspace_create` label bug fixed here
- #326 — authorship, the accountability mechanism that stands in for a write boundary
- #552 — publish mirroring; why deleting a published note differs from deleting a private one, and why `Agents/<agent>/<task-id>/` makes recursive delete sharp
- #607 — search; stale files now compete for a bounded result set, which is what gave accumulation a cost
- #372 — the raw-identifier-on-the-approval-card bug this re-fixes for `workspace_create`
