### PR TITLE
publish: tell the truth about a stored payload, and record its digest

### DIFF
--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -125,7 +125,24 @@ pub enum MirrorPayload<'a> {
     },
 }
 
-/// Put `target`'s body into the shared tree and return the node id holding it.
+/// What a publish left in the tree: the node holding it, and — for bytes — the
+/// digest **the store computed** while writing it (issue #668).
+///
+/// The digest is `None` for prose, whose version body is the content itself, so
+/// there is nothing a hash would add. For bytes it is the only thing that tells
+/// two versions of one deliverable apart, and it comes back from
+/// [`WorkspaceStore::create_binary`] / [`write_binary`](WorkspaceStore::write_binary)
+/// rather than being computed here — see those methods for why the provenance
+/// matters more than the value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mirrored {
+    /// The workspace node now holding the deliverable.
+    pub node_id: String,
+    /// The store's `sha256` of the bytes it wrote, when the payload was bytes.
+    pub sha256: Option<String>,
+}
+
+/// Put `target`'s body into the shared tree and return what it left there.
 ///
 /// The layout is `Agents/<agent-id>/<task-id>/<source…>`. The agent's folder is
 /// minted on demand by
@@ -161,7 +178,7 @@ pub async fn materialize(
     workspace: &dyn WorkspaceStore,
     company: &CompanyId,
     target: PublishTarget<'_>,
-) -> Result<String> {
+) -> Result<Mirrored> {
     // The cheap path, and the common one on a re-publish: the node from last
     // time still exists, so revise it in place and keep every reference to it
     // (the console's deep link, an operator's bookmark) working.
@@ -178,8 +195,11 @@ pub async fn materialize(
         && node.kind == NodeKind::File
         && node.is_binary() == matches!(target.payload, MirrorPayload::Bytes { .. })
     {
-        write_payload(workspace, company, existing, target).await?;
-        return Ok(existing.to_string());
+        let sha256 = write_payload(workspace, company, existing, target).await?;
+        return Ok(Mirrored {
+            node_id: existing.to_string(),
+            sha256,
+        });
     }
 
     let segments = split_source(target.source)?;
@@ -231,8 +251,11 @@ pub async fn materialize(
                 workspace.delete(company, &id).await?;
                 return create_payload(workspace, company, Some(parent), filename, target).await;
             }
-            write_payload(workspace, company, &id, target).await?;
-            Ok(id)
+            let sha256 = write_payload(workspace, company, &id, target).await?;
+            Ok(Mirrored {
+                node_id: id,
+                sha256,
+            })
         }
         None => create_payload(workspace, company, Some(parent), filename, target).await,
     }
@@ -244,20 +267,21 @@ async fn write_payload(
     company: &CompanyId,
     node_id: &str,
     target: PublishTarget<'_>,
-) -> Result<()> {
+) -> Result<Option<String>> {
     match target.payload {
         MirrorPayload::Text(body) => {
             workspace
                 .write(company, node_id, body, origin(target.agent_id))
                 .await?;
+            Ok(None)
         }
         MirrorPayload::Bytes { bytes, mime } => {
-            workspace
+            let node = workspace
                 .write_binary(company, node_id, bytes, Some(mime), origin(target.agent_id))
                 .await?;
+            Ok(node.sha256)
         }
     }
-    Ok(())
 }
 
 /// Creates a fresh node of the right kind holding `target`'s payload.
@@ -267,7 +291,7 @@ async fn create_payload(
     parent: Option<String>,
     filename: &str,
     target: PublishTarget<'_>,
-) -> Result<String> {
+) -> Result<Mirrored> {
     let mut node = WorkspaceNode {
         id: crate::ports::generate_id(),
         name: filename.to_string(),
@@ -283,13 +307,20 @@ async fn create_payload(
     match target.payload {
         MirrorPayload::Text(body) => {
             workspace.create(company, &node, Some(body)).await?;
+            Ok(Mirrored {
+                node_id: node.id,
+                sha256: None,
+            })
         }
         MirrorPayload::Bytes { bytes, mime } => {
             node.mime = Some(mime.to_string());
-            workspace.create_binary(company, &node, bytes).await?;
+            let stamped = workspace.create_binary(company, &node, bytes).await?;
+            Ok(Mirrored {
+                node_id: stamped.id,
+                sha256: stamped.sha256,
+            })
         }
     }
-    Ok(node.id)
 }
 
 /// Record an edit to `node_id` on the artifact chain that owns it, when one
@@ -578,7 +609,8 @@ mod test {
 
         let id = materialize(ws, &co, target("launch.md", "# Launch"))
             .await
-            .expect("materialize");
+            .expect("materialize")
+            .node_id;
 
         assert_eq!(
             path_of(ws, &co, &id).await,
@@ -620,7 +652,8 @@ mod test {
             },
         )
         .await
-        .expect("materialize");
+        .expect("materialize")
+        .node_id;
 
         assert_eq!(
             path_of(ws, &co, &id).await,
@@ -665,7 +698,8 @@ mod test {
 
         let first = materialize(ws, &co, target("report.md", "# Draft"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         let second = materialize(
             ws,
             &co,
@@ -679,7 +713,8 @@ mod test {
             },
         )
         .await
-        .expect("a shape change must not fail the publish");
+        .expect("a shape change must not fail the publish")
+        .node_id;
 
         let (node, _) = ws
             .read_bytes(&co, &second)
@@ -708,10 +743,12 @@ mod test {
 
         let spec = materialize(ws, &co, target("specs/a.md", "spec body"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         let doc = materialize(ws, &co, target("docs/a.md", "doc body"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
 
         assert_ne!(spec, doc, "one node for two paths would lose a deliverable");
         assert_eq!(
@@ -736,7 +773,8 @@ mod test {
 
         let first = materialize(ws, &co, target("launch.md", "draft one"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         let before = ws.tree(&co).await.unwrap().len();
 
         let again = materialize(
@@ -748,7 +786,8 @@ mod test {
             },
         )
         .await
-        .unwrap();
+        .unwrap()
+        .node_id;
 
         assert_eq!(again, first, "a re-publish must not open a rival node");
         assert_eq!(ws.tree(&co).await.unwrap().len(), before, "nothing created");
@@ -765,7 +804,8 @@ mod test {
 
         let first = materialize(ws, &co, target("launch.md", "draft one"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         assert!(ws.delete(&co, &first).await.unwrap());
 
         let again = materialize(
@@ -777,7 +817,8 @@ mod test {
             },
         )
         .await
-        .unwrap();
+        .unwrap()
+        .node_id;
 
         assert_ne!(again, first, "a deleted node must not be resurrected by id");
         assert_eq!(
@@ -799,11 +840,13 @@ mod test {
 
         let first = materialize(ws, &co, target("launch.md", "draft one"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
         // `existing_node_id: None` is exactly what a pre-#552 artifact carries.
         let again = materialize(ws, &co, target("launch.md", "draft two"))
             .await
-            .unwrap();
+            .unwrap()
+            .node_id;
 
         assert_eq!(again, first, "the node already at the path must be adopted");
         assert_eq!(ws.read(&co, &first).await.unwrap().unwrap().1, "draft two");
@@ -819,7 +862,10 @@ mod test {
 
         // Publish once to lay down `Agents/cmo/t-1/`, then put a folder where
         // the next publish's note wants to be.
-        let sibling = materialize(ws, &co, target("other.md", "x")).await.unwrap();
+        let sibling = materialize(ws, &co, target("other.md", "x"))
+            .await
+            .unwrap()
+            .node_id;
         let parent = ws
             .read(&co, &sibling)
             .await

--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -585,7 +585,7 @@ impl WorkspaceStore for FixedTree {
         _company: &CompanyId,
         _node: &WorkspaceNode,
         _bytes: &[u8],
-    ) -> crate::Result<()> {
+    ) -> crate::Result<WorkspaceNode> {
         unreachable!("search never creates")
     }
     async fn write_binary(

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1584,42 +1584,99 @@ impl HarnessBrain {
                 match artifact_mirror::materialize(workspace.as_ref(), &self.record.id, target)
                     .await
                 {
-                    Ok(node_id) => {
-                        // A second write only when the link actually changed:
-                        // a fresh publish (nothing was inherited) or a
-                        // re-publish whose node the operator deleted, which
-                        // `materialize` replaces with a new one. The ordinary
-                        // re-publish reuses its node and stores once.
-                        if record.workspace_node_id() != Some(node_id.as_str()) {
+                    Ok(mirrored) => {
+                        let node_id = mirrored.node_id;
+                        // Issue #663/#668: the version body was composed before
+                        // the store was asked, so it describes an outcome that
+                        // had not happened. Now it has — say what it was, and
+                        // record the digest the STORE computed so two versions
+                        // of one binary can be told apart.
+                        //
+                        // Always re-composed, never conditional on the link
+                        // having changed: an ordinary re-publish reuses its node
+                        // and would otherwise keep the previous version's
+                        // digest, which is precisely the "identical string"
+                        // failure #668 describes.
+                        let stored = pending.payload.artifact_body_for(
+                            crate::harness::publish::PayloadStorage::Stored {
+                                sha256: mirrored.sha256.as_deref(),
+                            },
+                        );
+                        // Only when it actually says something new. Prose is its
+                        // own body, so a text re-publish composes the identical
+                        // string and still stores once — the contract
+                        // `an_ordinary_republish_writes_the_artifact_once`
+                        // pins. A binary's body gains the store's digest, so it
+                        // differs and is worth the second write: without it the
+                        // version would keep the PREVIOUS digest, which is the
+                        // indistinguishable-versions defect (#668) with an extra
+                        // step.
+                        let body_changed =
+                            record.latest().is_some_and(|latest| latest.body != stored);
+                        if body_changed {
+                            record.amend_latest_body(stored);
+                        }
+                        let relinked = record.workspace_node_id() != Some(node_id.as_str());
+                        if relinked {
                             record.stamp_workspace_node(&node_id);
-                            // Warn rather than `?`: at this point BOTH surfaces
-                            // already hold this body and only the pointer
-                            // between them is missing, so failing the batch
-                            // would discard the remaining publishes' records to
-                            // report a link that heals on the next publish —
-                            // `materialize` finds an existing node by path and
-                            // re-adopts it rather than duplicating.
-                            if let Err(err) = artifacts.upsert(&self.record.id, &record).await {
-                                tracing::warn!(
-                                    task_id = %card.id,
-                                    source = %pending.source,
-                                    node = %node_id,
-                                    error = %err,
-                                    "[publish] the deliverable and its note are both stored but \
-                                     could not be linked; the next publish of this source \
-                                     re-adopts the note and repairs it"
-                                );
-                            }
+                        }
+                        // A second write only when the record actually changed:
+                        // a fresh publish, a re-publish whose node the operator
+                        // deleted, or a body that now carries an outcome it did
+                        // not before. Warn rather than `?` for the unchanged
+                        // reason — BOTH surfaces already hold this body and only
+                        // the record's copy is stale, so failing the batch would
+                        // discard the remaining publishes' records to report
+                        // something the next publish repairs.
+                        if (body_changed || relinked)
+                            && let Err(err) = artifacts.upsert(&self.record.id, &record).await
+                        {
+                            tracing::warn!(
+                                task_id = %card.id,
+                                source = %pending.source,
+                                node = %node_id,
+                                error = %err,
+                                "[publish] the deliverable and its note are both stored but the \
+                                 record could not be updated; the next publish of this source \
+                                 re-adopts the note and repairs it"
+                            );
                         }
                     }
-                    Err(err) => tracing::error!(
-                        task_id = %card.id,
-                        agent = %author,
-                        source = %pending.source,
-                        error = %err,
-                        "[publish] could not put the published file into the company workspace; \
-                         it is still recorded as an artifact"
-                    ),
+                    Err(err) => {
+                        // Issue #663. The record already claimed this file was
+                        // filed into the workspace. It was not, so the claim is
+                        // withdrawn rather than left standing — an operator who
+                        // opens the artifact and reads "open it there" and finds
+                        // nothing is the dangling-record failure #553 set out to
+                        // remove, arriving through the error path.
+                        //
+                        // The store's error is logged and NOT written to the
+                        // record: a version body is permanent and a backend
+                        // error can name host paths.
+                        tracing::error!(
+                            task_id = %card.id,
+                            agent = %author,
+                            source = %pending.source,
+                            error = %err,
+                            "[publish] could not put the published file into the company \
+                             workspace; the artifact record says so rather than promising a \
+                             file that is not there"
+                        );
+                        record.amend_latest_body(
+                            pending.payload.artifact_body_for(
+                                crate::harness::publish::PayloadStorage::Refused,
+                            ),
+                        );
+                        if let Err(err) = artifacts.upsert(&self.record.id, &record).await {
+                            tracing::error!(
+                                task_id = %card.id,
+                                source = %pending.source,
+                                error = %err,
+                                "[publish] the workspace refused the file AND the record could \
+                                 not be corrected; it still claims the file is stored"
+                            );
+                        }
+                    }
                 }
             }
             written.push(TaskOutputArtifact {

--- a/src/harness/publish.rs
+++ b/src/harness/publish.rs
@@ -543,6 +543,27 @@ pub enum PublishPayload {
     },
 }
 
+/// What the workspace did with a published payload, as the artifact version has
+/// to describe it (issues #663, #668).
+///
+/// Three states rather than a `bool` because "not stored yet" and "refused" are
+/// different things to tell an operator, and collapsing them is how a record
+/// came to assert storage that never happened.
+#[derive(Debug, Clone, Copy)]
+pub enum PayloadStorage<'a> {
+    /// The store has not been asked yet — the body composed before the mirror.
+    Pending,
+    /// The store wrote it, and returned this digest (`None` for prose, or a
+    /// backend that recorded none).
+    Stored {
+        /// The `sha256` **the store** computed. Never hashed on this side; see
+        /// [`WorkspaceStore::create_binary`](crate::ports::workspace::WorkspaceStore::create_binary).
+        sha256: Option<&'a str>,
+    },
+    /// The store refused it. The reason is logged, never written to the record.
+    Refused,
+}
+
 impl PublishPayload {
     /// What the artifact chain records as this version's body.
     ///
@@ -557,13 +578,55 @@ impl PublishPayload {
     /// writes the node, and a second hash on this path would be a second
     /// opportunity for the two to disagree about what was published.
     pub fn artifact_body(&self) -> String {
+        self.artifact_body_for(PayloadStorage::Pending)
+    }
+
+    /// The version body for a payload whose storage outcome is `storage`
+    /// (issues #663, #668).
+    ///
+    /// One function for all three wordings so they cannot drift into
+    /// contradicting each other, which is the defect #663 is about: the body
+    /// used to assert "stored as a file in the company workspace"
+    /// unconditionally, and was composed *before* the store was asked. When the
+    /// workspace refused the file, the record went on saying it was there.
+    ///
+    /// Prose ignores `storage` entirely: for text the version **is** the
+    /// content, so it is complete whatever the tree does.
+    pub fn artifact_body_for(&self, storage: PayloadStorage<'_>) -> String {
         match self {
             Self::Text(text) => text.clone(),
-            Self::Bytes { bytes, mime } => format!(
-                "{mime}, {} bytes — stored as a file in the company workspace. Open it there; \
-                 this record is the version history, not the content.",
-                bytes.len()
-            ),
+            Self::Bytes { bytes, mime } => {
+                let head = format!("{mime}, {} bytes", bytes.len());
+                match storage {
+                    // Written before the store is asked, and true at that
+                    // instant. It survives only if the process dies mid-drain;
+                    // otherwise the outcome below replaces it.
+                    PayloadStorage::Pending => format!(
+                        "{head} — a binary payload being filed into the company workspace. This \
+                         record is the version history, not the content."
+                    ),
+                    PayloadStorage::Stored { sha256: Some(sha) } => format!(
+                        "{head}, sha256 {sha} — stored as a file in the company workspace. Open \
+                         it there; this record is the version history, not the content."
+                    ),
+                    // A store that returned no digest: say so rather than
+                    // implying the version is identified when it is not.
+                    PayloadStorage::Stored { sha256: None } => format!(
+                        "{head} — stored as a file in the company workspace, with no digest \
+                         recorded. Open it there; this record is the version history, not the \
+                         content."
+                    ),
+                    // Deliberately does NOT carry the store's error text. This
+                    // string is permanent, and a backend error can name host
+                    // paths; the operator needs to know the file is not there,
+                    // and the diagnosis belongs in the log.
+                    PayloadStorage::Refused => format!(
+                        "{head} — NOT stored: the company workspace refused this file, so there \
+                         is nothing to open there. This record is the version history, not the \
+                         content."
+                    ),
+                }
+            }
         }
     }
 

--- a/src/harness/publish/test.rs
+++ b/src/harness/publish/test.rs
@@ -306,6 +306,109 @@ fn a_binary_version_records_a_description_and_not_the_bytes() {
     assert!(body.contains("company workspace"), "{body}");
 }
 
+/// Issue #663. The body composed **before** the store is asked must not assert
+/// that the file is there — that claim was unconditional, and it survived a
+/// workspace refusal, leaving the record promising a file that does not exist.
+#[test]
+fn a_pending_binary_version_does_not_claim_the_file_is_stored() {
+    let payload = PublishPayload::Bytes {
+        bytes: vec![0u8; 16],
+        mime: "image/png".to_string(),
+    };
+    let body = payload.artifact_body_for(PayloadStorage::Pending);
+    assert!(
+        !body.contains("stored as a file"),
+        "nothing has been stored yet: {body}"
+    );
+    assert!(
+        !body.contains("Open it there"),
+        "and the operator must not be sent to look for it: {body}"
+    );
+}
+
+/// Issue #668. A stored version carries the digest **the store** computed, which
+/// is what lets a reader tell two versions apart and see whether a re-publish
+/// changed anything.
+#[test]
+fn a_stored_binary_version_records_the_stores_digest() {
+    let payload = PublishPayload::Bytes {
+        bytes: vec![0u8; 16],
+        mime: "image/png".to_string(),
+    };
+    let body = payload.artifact_body_for(PayloadStorage::Stored {
+        sha256: Some("abc123"),
+    });
+    assert!(body.contains("sha256 abc123"), "{body}");
+    assert!(body.contains("stored as a file"), "{body}");
+}
+
+/// The defect #668 describes in one assertion: two versions of one binary that
+/// coincide in mime and length used to be **literally equal strings**, so the
+/// history could not say which was which. The digest is what separates them.
+#[test]
+fn two_binary_versions_of_the_same_length_differ_by_their_digest() {
+    let payload = PublishPayload::Bytes {
+        bytes: vec![0u8; 120_000],
+        mime: "image/png".to_string(),
+    };
+    let v1 = payload.artifact_body_for(PayloadStorage::Stored {
+        sha256: Some("1111111111111111"),
+    });
+    let v2 = payload.artifact_body_for(PayloadStorage::Stored {
+        sha256: Some("2222222222222222"),
+    });
+    assert_ne!(
+        v1, v2,
+        "two versions of one deliverable must not be the same sentence"
+    );
+
+    // The control: without a digest they collapse back into one string, which
+    // is exactly the state this issue is about.
+    let bare = payload.artifact_body_for(PayloadStorage::Stored { sha256: None });
+    assert_eq!(
+        bare,
+        payload.artifact_body_for(PayloadStorage::Stored { sha256: None }),
+        "the no-digest body is the indistinguishable case, and it says so"
+    );
+    assert!(
+        bare.contains("no digest recorded"),
+        "a backend that recorded none must say so rather than imply identity: {bare}"
+    );
+}
+
+/// Issue #663's other half: when the workspace refuses the file, the record
+/// withdraws the claim instead of leaving it standing.
+///
+/// It must also NOT carry the store's error text — a version body is permanent
+/// and a backend error can name host paths.
+#[test]
+fn a_refused_binary_version_withdraws_the_storage_claim() {
+    let payload = PublishPayload::Bytes {
+        bytes: vec![0u8; 16],
+        mime: "image/png".to_string(),
+    };
+    let body = payload.artifact_body_for(PayloadStorage::Refused);
+    assert!(body.contains("NOT stored"), "{body}");
+    assert!(
+        !body.contains("Open it there"),
+        "the operator must not be sent to a file that is not there: {body}"
+    );
+}
+
+/// Prose is unaffected by any of this: for text the version IS the content, so
+/// it is complete whatever the tree did.
+#[test]
+fn a_prose_version_is_its_content_whatever_the_store_did() {
+    let payload = PublishPayload::Text("# Spec".to_string());
+    for storage in [
+        PayloadStorage::Pending,
+        PayloadStorage::Stored { sha256: None },
+        PayloadStorage::Refused,
+    ] {
+        assert_eq!(payload.artifact_body_for(storage), "# Spec");
+    }
+}
+
 // ── The tool ──────────────────────────────────────────────────────────────
 
 #[tokio::test]

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2854,7 +2854,7 @@ mod tests {
             _company: &CompanyId,
             _node: &WorkspaceNode,
             _bytes: &[u8],
-        ) -> crate::Result<()> {
+        ) -> crate::Result<WorkspaceNode> {
             unreachable!("the listing never creates")
         }
         async fn write_binary(

--- a/src/ports/artifacts.rs
+++ b/src/ports/artifacts.rs
@@ -328,6 +328,28 @@ impl ArtifactRecord {
         }
     }
 
+    /// Rewrites the newest revision's body — the reconciliation a publish owes
+    /// when the storage outcome it described turns out differently (#663).
+    ///
+    /// # Why amending is right here, and only here
+    ///
+    /// The chain is the authoritative version history, so rewriting a recorded
+    /// body is not something to do casually. This is confined to the drain that
+    /// *created* the version: the body was composed before the workspace was
+    /// asked (the ordering is deliberate — the record is written first so a node
+    /// is never created for an unrecorded deliverable), so the version spends a
+    /// moment describing an outcome that has not happened yet. Amending it is
+    /// how that moment ends with the truth rather than with a claim.
+    ///
+    /// It is **not** a general edit path: an operator revision is a new version,
+    /// with its own authorship, which is what `human_edit_diff` reads. A no-op
+    /// on an empty record.
+    pub fn amend_latest_body(&mut self, body: impl Into<String>) {
+        if let Some(latest) = self.versions.last_mut() {
+            latest.body = body.into();
+        }
+    }
+
     /// The workspace node the newest revision was mirrored into, if any.
     ///
     /// The re-publish and console-edit paths both ask this question — "is there

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -342,12 +342,26 @@ pub trait WorkspaceStore: Send + Sync {
     /// `bytes` is a slice rather than a stream on purpose: the quota decorator
     /// has to know the full size before anything is written, so that a refused
     /// write leaves no partial blob and no node behind. See [`BlobStream`].
+    ///
+    /// # Returns the **stamped** node, and that is the point (issue #668)
+    ///
+    /// The node handed back is the one [`stamped_binary`] produced, carrying the
+    /// `size` and `sha256` the store computed from `bytes` — not the node the
+    /// caller passed in. [`write_binary`](Self::write_binary) already returned
+    /// its updated node; this makes the pair symmetric.
+    ///
+    /// It exists so a caller that needs the digest — the publish drain, which
+    /// records it on the artifact version — can only ever obtain it **from the
+    /// store**. Hashing the same bytes caller-side would give one algorithm
+    /// called twice, and two calls can disagree if the bytes differ between
+    /// them; a returned node makes the digest's provenance structural, so a
+    /// future backend cannot quietly substitute its own.
     async fn create_binary(
         &self,
         company: &CompanyId,
         node: &WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()>;
+    ) -> Result<WorkspaceNode>;
     /// Replaces a binary node's payload, returning the updated node.
     ///
     /// The binary twin of [`write`](Self::write), and the reason re-publishing a

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -177,10 +177,10 @@ impl WorkspaceStore for WorkspaceAnnouncer {
         company: &CompanyId,
         node: &WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()> {
-        self.inner.create_binary(company, node, bytes).await?;
+    ) -> Result<WorkspaceNode> {
+        let stamped = self.inner.create_binary(company, node, bytes).await?;
         self.announce(company, &node.id, CHANGE_OPENED).await;
-        Ok(())
+        Ok(stamped)
     }
 
     /// Replaces a payload through, then announces `updated` — unconditionally,

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -299,7 +299,7 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
         company: &CompanyId,
         node: &WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()> {
+    ) -> Result<WorkspaceNode> {
         self.admit(company, &node.name, bytes.len() as u64, None)
             .await?;
         self.inner.create_binary(company, node, bytes).await

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2374,13 +2374,38 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
     ws.create(&alpha, &folder_node("shots", "Shots"), None)
         .await
         .unwrap();
-    ws.create_binary(
-        &alpha,
-        &node("img", "hero.png", Some("image/png"), Some("shots")),
-        &png,
-    )
-    .await
-    .unwrap();
+    let stamped = ws
+        .create_binary(
+            &alpha,
+            &node("img", "hero.png", Some("image/png"), Some("shots")),
+            &png,
+        )
+        .await
+        .unwrap();
+
+    // -- The create RETURNS the stamped node (issue #668) ------------------
+    //
+    // Asserted with populated values, never `None`: a `None` here would pass
+    // against a backend that dropped the field entirely, which is the one thing
+    // this is meant to catch. The digest is the reason the signature returns a
+    // node at all — a caller that records it must be unable to obtain it from
+    // anywhere but the store.
+    let (expected_size, expected_sha) = crate::ports::workspace::blob_metadata(&png);
+    assert_eq!(
+        stamped.sha256.as_deref(),
+        Some(expected_sha.as_str()),
+        "create_binary must hand back the digest it computed, not an empty field"
+    );
+    assert_eq!(
+        stamped.size,
+        Some(expected_size),
+        "and the size it computed with it"
+    );
+    assert_eq!(
+        stamped.id, "img",
+        "the returned node is the one just created"
+    );
+    assert_eq!(stamped.mime.as_deref(), Some("image/png"));
 
     // -- Metadata is computed, not accepted -------------------------------
     let (meta, stream) = ws.read_bytes(&alpha, "img").await.unwrap().unwrap();
@@ -2390,7 +2415,6 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
         Some(png.len() as u64),
         "size must come from the bytes, not from the caller's claim"
     );
-    let (_, expected_sha) = crate::ports::workspace::blob_metadata(&png);
     assert_eq!(
         meta.sha256.as_deref(),
         Some(expected_sha.as_str()),

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1123,7 +1123,7 @@ impl WorkspaceStore for FsOps {
         company: &CompanyId,
         node: &WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()> {
+    ) -> Result<WorkspaceNode> {
         let node = crate::ports::workspace::stamped_binary(node, bytes)?;
         reject_unsafe_name(&node.name)?;
         let bundle = self.bundle(company);
@@ -1165,7 +1165,10 @@ impl WorkspaceStore for FsOps {
         tokio::fs::write(&physical, bytes)
             .await
             .map_err(|e| io_err(&physical, e))?;
-        self.save_index(company, &index).await
+        self.save_index(company, &index).await?;
+        // The stamped node, so the digest a caller records can only have come
+        // from the store (issue #668).
+        Ok(node)
     }
 
     async fn write_binary(

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2345,7 +2345,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         company: &CompanyId,
         node: &crate::ports::workspace::WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()> {
+    ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let node = crate::ports::workspace::stamped_binary(node, bytes)?;
         let nodes = self.workspace_nodes(company).await?;
@@ -2381,7 +2381,9 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             })
             .await
             .map_err(mongo_err)?;
-        Ok(())
+        // The stamped node, so the digest a caller records can only have come
+        // from the store (issue #668).
+        Ok(node)
     }
 
     async fn write_binary(

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2409,7 +2409,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         company: &CompanyId,
         node: &crate::ports::workspace::WorkspaceNode,
         bytes: &[u8],
-    ) -> Result<()> {
+    ) -> Result<crate::ports::workspace::WorkspaceNode> {
         use crate::ports::workspace::NodeKind;
         let node = crate::ports::workspace::stamped_binary(node, bytes)?;
         let conn = self.conn();
@@ -2447,7 +2447,9 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ],
         )
         .map_err(sql_err)?;
-        Ok(())
+        // The stamped node, so the digest a caller records can only have come
+        // from the store (issue #668).
+        Ok(node)
     }
 
     async fn write_binary(


### PR DESCRIPTION
## Summary

Closes #663 and #668. Two defects, one mechanism — which is why they are one PR: #668's fix, done the way its own issue asks ("record the `sha256` the store already computes"), is only reachable once #663's ordering question is answered.

**#663** — a published binary's artifact version asserted *"stored as a file in the company workspace. Open it there"* **unconditionally**, and was composed **before** the store was asked. When the workspace refused the file, the claim stood and the refusal was only `tracing::error!`d. The operator opens the artifact, reads "open it there", goes there, finds nothing — the dangling record #553 set out to remove, returning through the error path.

**#668** — the same body carried no digest, so two versions of one binary that coincided in mime and length were *literally equal strings*. Superseded versions were both unrecoverable and unidentifiable.

The body is now composed **from the outcome**. `PayloadStorage` names which of three states it describes — `Pending`, `Stored { sha256 }`, `Refused` — so all three wordings live in one function and cannot drift into contradicting each other. After the mirror, the drain amends the version: on success with the digest, on failure withdrawing the claim.

### The ordering was the real question, and I did not reverse it

#663 suggests "the workspace write has to be attempted before either is composed". That would invert `artifact_mirror`'s deliberate chain-first ordering, whose own doc says writing the record first is what stops *"a node in the tree with no artifact behind it at all"*. So this takes #663's other branch — **reconcile the record after the write** — which keeps that invariant and is also where the store's digest becomes available. One mechanism, both issues, no ordering regression.

### The digest can only come from the store

`create_binary` now returns the stamped node, exactly as `write_binary` already did — the port was **asymmetric**, and this makes it consistent rather than wider. Hashing the same bytes caller-side would be one algorithm called twice, and two calls can disagree if the bytes differ between them. Returning the node makes provenance structural: a future backend cannot quietly substitute its own digest.

Blast radius was bounded as scoped — 3 backends, 2 thin decorators, 2 test stubs, and **no** unrelated caller broke.

### One thing deliberately not in the record

A store error is **never** written to the artifact body. A version is permanent and a backend error can name host paths; the operator needs to know the file is not there, and the diagnosis belongs in the log. (Directly applying the lesson from #614's review, where a URL's userinfo reached the durable approval journal.)

### A narrowing of #663

#663's first bullet says the tool tells the agent the file was "captured in full" before anything is written. Having read it: the payload genuinely **is** captured in full at that point — into the queue — and the receipt tail says *"It appears on this task's Artifacts tab when the run finishes"*, which is future tense and never claims workspace storage. So the tool's message is defensible and is unchanged. **The false claim lived entirely in the artifact body**, and that is what this fixes. Flagged rather than silently doing half the issue.

## API Or Behavior Changes

- `WorkspaceStore::create_binary` returns `Result<WorkspaceNode>` (was `Result<()>`) — the stamped node, carrying the store's `size` and `sha256`.
- `artifact_mirror::materialize` returns `Mirrored { node_id, sha256 }` (was `Result<String>`).
- New `PublishPayload::artifact_body_for(PayloadStorage)`; `artifact_body()` remains as the `Pending` case.
- New `ArtifactRecord::amend_latest_body`, documented as confined to the drain that created the version — an operator revision is still a new version, so `human_edit_diff` is untouched.
- The post-mirror upsert now runs when the **body** changed as well as when the link did. A *text* re-publish composes an identical body and still stores once, so `an_ordinary_republish_writes_the_artifact_once` holds unchanged; a binary's body gains the digest, so it pays one extra write. That test caught an earlier, broader version of this change — see Tests.

## Tests

Gated lane, plus the all-features check. Exit codes from unpiped redirects to a session-private path.

- [x] `cargo fmt --all -- --check` — `EXIT:0`.
- [x] `cargo clippy --all-targets -- -D warnings` — CI's form, `--locked --no-deps --features openhuman,tinycortex --all-targets`, `EXIT:0`.
- [x] `cargo build --all-targets` — **`cargo check --locked --all-features --all-targets`, `EXIT:0`.** Run deliberately: this PR changes a port signature all three backends implement, and `mongodb.rs` is compiled by neither the default nor the gated lane.
- [x] `cargo test` — `cargo test --features openhuman,tinycortex`: **2963 passed, 0 failed**, `EXIT:0`.

New tests:

- `a_pending_binary_version_does_not_claim_the_file_is_stored` — the body composed before the store is asked must not assert storage.
- `a_stored_binary_version_records_the_stores_digest` — #668's payoff.
- `two_binary_versions_of_the_same_length_differ_by_their_digest` — #668's defect in one assertion, plus a control showing the no-digest body is the indistinguishable case and says so.
- `a_refused_binary_version_withdraws_the_storage_claim` — and asserts the body does **not** send the operator to look for the file.
- `a_prose_version_is_its_content_whatever_the_store_did` — the control: prose is storage-independent, so a change that made every body outcome-dependent would fail here.
- Conformance (`assert_workspace_store`): `create_binary`'s returned node is asserted with **populated** `sha256`, `size`, `id` and `mime` — never `None`, which would pass against a backend that dropped the field.

**Revert-and-check.** With the old unconditional body restored, **51 tests ran** (47 passed, 4 failed): the four outcome-dependent tests fail, and the prose control plus the pre-existing description test pass. Non-zero count quoted deliberately — a filter that matches nothing reports `0 passed; 0 failed` and exits 0.

**An existing test caught me.** My first version made the post-mirror upsert unconditional, and `an_ordinary_republish_writes_the_artifact_once` failed. It was right: a text re-publish gains nothing from a second write. Narrowed to "only when the body actually changed", which keeps that contract and pays the cost only where the digest makes it necessary.

## Documentation

`create_binary`'s doc explains why it returns the node and why provenance matters more than the value; `PayloadStorage` documents why three states rather than a bool; `amend_latest_body` documents why amending is confined to the creating drain.
