### PR TITLE
feat(team): give runtime-added teammates a readable roster id (#686)

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -223,6 +223,32 @@ is never rewritten. Overlay teammates are addressable: since issue #71 the
 harness builds a real agent for each one, with the company-wide tool grant, no
 cognition tier, and never the orchestrator.
 
+`POST …/team` and the orchestrator's `add_agent` tool both **derive the roster
+id from the display name** (issue #686): "Dana Designer" becomes
+`dana_designer`, in the same snake_case grammar the manifest validator enforces
+on a hand-authored `[[agent]].id`. They used to mint an opaque
+`{millis}-{counter}` id, which #570/#552/#607 render as a workspace folder and
+in search-hit paths — so half a company's tree read as
+`Agents/019fad5ada20-000000000003/` beside `Agents/backend_engineer/`.
+
+- **Collisions suffix, they do not refuse.** A slug already held by a manifest
+  agent, another teammate, a desk id or name, or a reserved word (`operator`,
+  `Agents`, `Desks`) becomes `<slug>_2`, `_3`, … Duplicate display names have
+  always been accepted here, and an unsuffixed collision with a *manifest* id is
+  worse than a refusal: the roster build skips it, so the teammate would persist
+  and never materialise.
+- **Minted once, never re-minted.** `PATCH …/team/{agentId}` renames a teammate
+  and leaves the id alone; a name-keyed id would orphan its workspace folder,
+  budget row, desk memberships and inbox on every correction.
+- **Removal frees the slug**, so re-adding the same name takes the id back and
+  **adopts the old `Agents/<slug>/` folder** — the intended remedy for a typo'd
+  name, and not a way to get a clean slate.
+
+Teammates carrying generated ids are **not migrated**: rewriting them would
+rewrite the `WorkspaceOrigin` stamps issue #326 keeps honest, and every path
+into their folders. They keep working, reachable by display name through
+`crate::runtime::assignee`.
+
 `GET …/team/{agentId}` is the **agent detail** read (issue #264). `GET …/team`
 answers "who is on the roster"; this answers "what is this agent", and before it
 existed neither the console nor any other client could reach an agent's tier,

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -386,7 +386,7 @@ impl CompanyManifest {
 
 /// True when `id` is non-empty, starts with a lowercase letter, and contains
 /// only lowercase letters, digits, and underscores.
-fn is_snake_case(id: &str) -> bool {
+pub(crate) fn is_snake_case(id: &str) -> bool {
     let mut chars = id.chars();
     match chars.next() {
         Some(first) if first.is_ascii_lowercase() => {}

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -72,6 +72,7 @@ pub use credentials::{Credential, CredentialSource, TinyhumansTokenSource, Token
 /// The roster-id grammar check, shared with the runtime id minter so a slug and
 /// a hand-authored `[[agent]].id` are held to one rule (issue #686). Not `pub`:
 /// outside the crate the validator speaks through `CompanyManifest::validate`.
+#[cfg(test)]
 pub(crate) use manifest::is_snake_case;
 pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -69,6 +69,10 @@ pub mod workspace_seed;
 use std::path::Path;
 
 pub use credentials::{Credential, CredentialSource, TinyhumansTokenSource, TokenTier};
+/// The roster-id grammar check, shared with the runtime id minter so a slug and
+/// a hand-authored `[[agent]].id` are held to one rule (issue #686). Not `pub`:
+/// outside the crate the validator speaks through `CompanyManifest::validate`.
+pub(crate) use manifest::is_snake_case;
 pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};
 pub use types::{

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2423,6 +2423,78 @@ description = "Builds the product."
         );
     }
 
+    /// Issue #686, end to end: the orchestrator adds a teammate whose display
+    /// name slugs onto a **manifest** agent's id, and the teammate still shows
+    /// up in the built roster.
+    ///
+    /// This is the failure the suffix exists to prevent, and it only became
+    /// reachable when ids started coming from names. `add_agent`'s duplicate
+    /// guard compares overlay *names*, so "Engineer" sails past it; an
+    /// unsuffixed `engineer` would then be skipped by
+    /// [`build_roster`](super::build_roster) as already claimed by the manifest
+    /// — saved to the record, never materialised, no error anywhere.
+    #[tokio::test]
+    async fn a_tool_added_teammate_colliding_with_a_manifest_id_still_joins_the_roster() {
+        use openhuman_core::openhuman::tools::Tool;
+
+        use crate::harness::orchestrator::AddAgentTool;
+
+        /// A `CompanyStore` that actually holds the record, unlike
+        /// `RecordingStore` — `add_agent` has to load what it saves.
+        struct SeededStore(StdMutex<CompanyRecord>);
+
+        #[async_trait]
+        impl CompanyStore for SeededStore {
+            async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+                Ok(Some(self.0.lock().unwrap().clone()))
+            }
+            async fn save(&self, record: &CompanyRecord) -> crate::Result<()> {
+                *self.0.lock().unwrap() = record.clone();
+                Ok(())
+            }
+            async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+                Ok(Vec::new())
+            }
+            async fn append_ledger(
+                &self,
+                _id: &CompanyId,
+                _entry: LedgerEntry,
+            ) -> crate::Result<()> {
+                Ok(())
+            }
+        }
+
+        let fx = fixture();
+        let company = CompanyId::new("acme");
+        let store = Arc::new(SeededStore(StdMutex::new(record())));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(serde_json::json!({ "name": "Engineer", "role": "Platform" }))
+            .await
+            .expect("execute");
+        assert!(
+            !result.is_error,
+            "the name guard compares overlay names only"
+        );
+        assert!(
+            result.text().contains("engineer_2"),
+            "the orchestrator has to learn the id it can address: {}",
+            result.text()
+        );
+
+        let saved = store.load(&company).await.unwrap().expect("record");
+        assert_eq!(saved.overlay_agents[0].id, "engineer_2");
+
+        let roster = build_roster(&saved, &fx.deps, &[]).expect("roster builds");
+        let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec!["ceo", "engineer", "engineer_2"],
+            "a suffixed id materialises; an unsuffixed one would vanish here"
+        );
+    }
+
     /// Issue #551: a roster rebuild writes nothing to the workspace.
     ///
     /// This used to be the feature's second provisioning seam — a teammate

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -76,7 +76,7 @@ use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
 use crate::ports::tasks::{TaskOutputAction, TaskOutputWorkflow};
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, OverlayAgent};
-use crate::ports::{CompanyStore, WorkflowRun, WorkflowRunner, generate_id};
+use crate::ports::{CompanyStore, WorkflowRun, WorkflowRunner};
 
 /// The manifest cognition-tier that marks the orchestrator agent.
 ///
@@ -1626,7 +1626,11 @@ impl Tool for AddAgentTool {
         // existing overlay teammate, so a trigger-happy orchestrator can't
         // accumulate indistinguishable duplicates. Matching on name alone is
         // intentional — the orchestrator supplies display names, and an id
-        // collision with a manifest agent is handled by `build_roster`.
+        // collision with a manifest agent is handled by `mint_agent_id` below.
+        //
+        // It does not subsume that check: this compares overlay *names*, so a
+        // call naming "Backend Engineer" on a company whose manifest declares
+        // `backend_engineer` passes here and still needs a suffixed id.
         let name_lower = name.to_ascii_lowercase();
         if record
             .overlay_agents
@@ -1637,8 +1641,12 @@ impl Tool for AddAgentTool {
                 "A teammate named \"{name}\" already exists. Pick a different name, or remove the existing one first."
             )));
         }
+        // Same readable-id rule as the console route (issue #686), under the
+        // same per-company write lock, so the two minting sites cannot hand out
+        // one id twice.
+        let id = record.mint_agent_id(&name);
         let agent = OverlayAgent {
-            id: generate_id(),
+            id: id.clone(),
             name: name.clone(),
             role: role.clone(),
             description,
@@ -1646,8 +1654,13 @@ impl Tool for AddAgentTool {
         record.overlay_agents.push(agent);
         self.store.save(&record).await?;
 
+        // The id is in the result because the orchestrator has to be able to
+        // address the teammate it just created — delegating to it, or putting it
+        // on a desk, takes the id, not the display name. The console gets the
+        // same answer from `TeamMemberDto.id`; before this the agent-facing half
+        // had no way to learn it at all.
         Ok(ToolResult::success(format!(
-            "Added {name} as {role} to the team. They'll be reachable as a teammate starting next turn."
+            "Added {name} (id `{id}`) as {role} to the team. They'll be reachable as a teammate starting next turn."
         )))
     }
 }
@@ -4301,6 +4314,92 @@ name = "Morning"
             Some("Owns acquisition experiments.")
         );
         assert!(!added.id.is_empty(), "a stable id must be minted");
+    }
+
+    /// Issue #686 — the tool mints the same readable, name-derived id the
+    /// console route does, and hands it back in the result so the orchestrator
+    /// can delegate to the teammate it just created.
+    #[tokio::test]
+    async fn add_agent_tool_mints_a_readable_id_and_reports_it() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({ "name": "Dana Designer", "role": "Designer" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+        assert!(
+            result.text().contains("`dana_designer`"),
+            "the id must be in the result, not only in the record: {}",
+            result.text()
+        );
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert_eq!(record.overlay_agents[0].id, "dana_designer");
+    }
+
+    /// The name guard still fires, and it fires *before* minting — so a
+    /// duplicate display name is refused rather than quietly given a `_2` id.
+    /// Two teammates the orchestrator cannot tell apart is the thing that guard
+    /// exists to stop, and readable ids do not make it less true.
+    #[tokio::test]
+    async fn add_agent_tool_still_refuses_a_duplicate_display_name() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        for _ in 0..1 {
+            let first = tool
+                .execute(json!({ "name": "Dana Designer", "role": "Designer" }))
+                .await
+                .expect("execute");
+            assert!(!first.is_error, "{}", first.text());
+        }
+
+        let second = tool
+            .execute(json!({ "name": "dana designer", "role": "Illustrator" }))
+            .await
+            .expect("execute");
+        assert!(second.is_error, "{}", second.text());
+        assert!(
+            second.text().contains("already exists"),
+            "{}",
+            second.text()
+        );
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert_eq!(
+            record.overlay_agents.len(),
+            1,
+            "the refusal must not have persisted a `dana_designer_2`"
+        );
+    }
+
+    /// A name colliding with a **manifest** agent's id passes the name guard —
+    /// it compares overlay names — and is caught by the minter instead. The
+    /// roster-level consequence is pinned in `harness::tests`.
+    #[tokio::test]
+    async fn add_agent_tool_suffixes_past_a_manifest_agent_id() {
+        let company = CompanyId::new("acme");
+        let mut record = seeded_record(&company);
+        record.manifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"backend_engineer\"\nrole = \"Backend Engineer\"\n",
+        )
+        .expect("valid manifest");
+        let store = Arc::new(MemStore::seeded(record));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({ "name": "Backend Engineer", "role": "Platform" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert_eq!(record.overlay_agents[0].id, "backend_engineer_2");
     }
 
     #[tokio::test]

--- a/src/ports/ids.rs
+++ b/src/ports/ids.rs
@@ -51,6 +51,75 @@ pub fn generate_id() -> String {
     format!("{millis:012x}-{counter:012x}")
 }
 
+/// The stem [`agent_slug`] falls back to when a display name yields nothing a
+/// roster id may legally be.
+pub const AGENT_SLUG_FALLBACK: &str = "teammate";
+
+/// The longest slug [`agent_slug`] will return, in bytes (all ASCII, so also in
+/// characters). A roster id becomes a workspace folder name and a path segment
+/// in every search hit that quotes it; a name pasted from a paragraph should not
+/// turn into a path nobody can read across.
+const AGENT_SLUG_MAX: usize = 64;
+
+/// Derives a readable, snake_case roster id from a teammate's display name.
+///
+/// `"Dana Designer"` becomes `dana_designer` — the same grammar the manifest
+/// validator enforces on hand-authored `[[agent]].id`s (lowercase letters,
+/// digits and underscores, starting with a letter), so a runtime-added teammate
+/// and a blueprint one name their `Agents/<id>/` folder the same way. Before
+/// this, runtime teammates took [`generate_id`] and read as
+/// `Agents/019fad5ada20-000000000003/` (issue #686).
+///
+/// Deliberately **underscores, not hyphens** — unlike
+/// [`company_id_from_name`](crate::runtime::company_id_from_name), whose output
+/// is a company slug and answers to no such validator. The roster id grammar is
+/// already set by the manifest, and a hyphen dialect would make a third id shape
+/// to reason about rather than one fewer.
+///
+/// # Not unique on its own
+///
+/// This is pure normalization: two teammates named "Designer" both slug to
+/// `designer`. Nothing should call it to *mint* an id —
+/// [`CompanyRecord::mint_agent_id`](crate::ports::types::CompanyRecord::mint_agent_id)
+/// is the minting entry point, and it resolves collisions against the roster
+/// the slug has to be unique within.
+///
+/// # Degenerate names
+///
+/// A name with no ASCII letter to start on — `"***"`, `""`, `"24/7 Support"`,
+/// an all-non-ASCII name — has no readable slug in it, and no transliteration is
+/// attempted. Those return [`AGENT_SLUG_FALLBACK`], which mints as `teammate`,
+/// `teammate_2`, … exactly like any other stem. That is the same trade
+/// `company_id_from_name` makes with `"company"`.
+pub fn agent_slug(display_name: &str) -> String {
+    let mut slug = String::with_capacity(display_name.len().min(AGENT_SLUG_MAX));
+    let mut prev_underscore = false;
+    for ch in display_name.chars() {
+        if ch.is_ascii_alphanumeric() {
+            slug.push(ch.to_ascii_lowercase());
+            prev_underscore = false;
+        } else if !prev_underscore {
+            // Every other run of characters — spaces, punctuation, emoji, CJK —
+            // collapses to a single separator rather than one per character.
+            slug.push('_');
+            prev_underscore = true;
+        }
+    }
+    // Trim first, then cap: the cap must not be spent on separators that were
+    // going to be dropped anyway. Every pushed character is ASCII, so slicing
+    // by byte index can never split one.
+    let trimmed = slug.trim_matches('_');
+    let capped = trimmed[..trimmed.len().min(AGENT_SLUG_MAX)].trim_end_matches('_');
+    // A slug that does not start with a lowercase letter would fail the
+    // manifest's own `is_snake_case` check, so it is not a legal roster id at
+    // all — digit-leading names land here alongside empty ones.
+    if capped.starts_with(|c: char| c.is_ascii_lowercase()) {
+        capped.to_string()
+    } else {
+        AGENT_SLUG_FALLBACK.to_string()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -62,5 +131,90 @@ mod test {
         assert_ne!(a, b);
         // Zero-padded fixed-width hex makes lexicographic order match mint order.
         assert!(b > a, "expected {b} > {a}");
+    }
+
+    #[test]
+    fn agent_slug_lowercases_and_joins_words_with_underscores() {
+        assert_eq!(agent_slug("Dana Designer"), "dana_designer");
+        assert_eq!(agent_slug("Backend Engineer"), "backend_engineer");
+        assert_eq!(agent_slug("QA2"), "qa2");
+    }
+
+    #[test]
+    fn agent_slug_collapses_and_trims_separator_runs() {
+        assert_eq!(agent_slug("Designer!!"), "designer");
+        assert_eq!(agent_slug("  Head   of   Ops  "), "head_of_ops");
+        assert_eq!(agent_slug("__Dana--Designer__"), "dana_designer");
+        assert_eq!(agent_slug("Ana Maria (Growth)"), "ana_maria_growth");
+    }
+
+    /// A name with no ASCII letter to start on has no readable slug in it, and
+    /// none is invented — it takes the shared stem instead.
+    #[test]
+    fn agent_slug_falls_back_for_names_with_no_legal_stem() {
+        for name in ["***", "", "   ", "24/7 Support", "設計者", "🙂", "7", "_"] {
+            assert_eq!(
+                agent_slug(name),
+                AGENT_SLUG_FALLBACK,
+                "expected the fallback stem for {name:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn agent_slug_caps_length_without_a_trailing_separator() {
+        // The cap is a hard byte cap, not a word boundary: a word straddling it
+        // is truncated rather than dropped, which keeps the rule one sentence.
+        let long = "Chief ".repeat(40);
+        let slug = agent_slug(&long);
+        assert_eq!(slug.len(), AGENT_SLUG_MAX);
+        assert!(slug.starts_with("chief_chief_"), "{slug}");
+        assert!(
+            !slug.ends_with('_'),
+            "cap left a dangling separator: {slug}"
+        );
+
+        // When the cap lands exactly on a separator, that separator goes with
+        // it — a roster id never ends in `_`.
+        let aligned = "abcdefg ".repeat(20);
+        let slug = agent_slug(&aligned);
+        assert_eq!(slug.len(), AGENT_SLUG_MAX - 1, "{slug}");
+        assert!(slug.ends_with("abcdefg"), "{slug}");
+
+        let dense = "a".repeat(100);
+        assert_eq!(agent_slug(&dense).len(), AGENT_SLUG_MAX);
+    }
+
+    /// The one property that matters: whatever comes out is something the
+    /// manifest validator would accept as a roster id. Coupled to the real
+    /// `is_snake_case` rather than a copy of its rules, so a change to the
+    /// grammar fails here instead of shipping ids the validator rejects.
+    #[test]
+    fn every_slug_satisfies_the_manifest_id_grammar() {
+        let mut names: Vec<String> = [
+            "Dana Designer",
+            "Designer!!",
+            "***",
+            "",
+            "24/7 Support",
+            "設計者",
+            "🙂 Growth 🙂",
+            "O'Brien-Smith, Jr.",
+            "___",
+            "9Lives",
+            "a",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+        names.push("Chief ".repeat(40));
+        names.push("a".repeat(100));
+        for name in &names {
+            let slug = agent_slug(name);
+            assert!(
+                crate::company::is_snake_case(&slug),
+                "slug {slug:?} from name {name:?} is not a legal roster id"
+            );
+        }
     }
 }

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -46,7 +46,7 @@ pub use context::ContextStore;
 pub use economy::AgentEconomy;
 pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_prune};
 pub use facts::{FactKind, FactRecord, FactStore};
-pub use ids::{generate_id, now_millis};
+pub use ids::{AGENT_SLUG_FALLBACK, agent_slug, generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2707,11 +2707,19 @@ impl CompanyRecord {
     /// `name_key` case-insensitively.
     ///
     /// The companion to [`Self::resolve_roster_agent_id`] for the half of the
-    /// roster that has no typable id. `server::ops::team` mints an overlay
-    /// teammate with `id: generate_id()`, so an operator who adds "Shane" never
-    /// sees anything but the name — matching on ids alone made every teammate
-    /// they added unassignable, on a board whose Assignee field is free text
-    /// with no picker. Manifest agents keep their id-only namespace: their ids
+    /// roster that has no typable id. `server::ops::team` minted an overlay
+    /// teammate with `id: generate_id()` before #686, so an operator who added
+    /// "Shane" never saw anything but the name — matching on ids alone made
+    /// every teammate they added unassignable, on a board whose Assignee field
+    /// is free text with no picker.
+    ///
+    /// A teammate added since #686 carries a readable slug and resolves by id,
+    /// but this stays load-bearing: records written before it keep their
+    /// generated ids (nothing migrates them), and
+    /// [`Self::mint_agent_id`] deliberately does not re-mint on a rename, so a
+    /// renamed teammate's current name is reachable only here.
+    ///
+    /// Manifest agents keep their id-only namespace: their ids
     /// (`ceo`, `engineer`) are human-authored and typable, and
     /// [`Self::resolve_roster_agent_id`] is tried first, so a display name can
     /// never shadow a real id.

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -14,7 +14,7 @@ use std::ops::Range;
 use serde::{Deserialize, Serialize};
 
 use crate::company::CompanyManifest;
-use crate::ports::ids::{generate_id, now_millis};
+use crate::ports::ids::{agent_slug, generate_id, now_millis};
 use crate::ports::workflow_runner::DeliveryReport;
 
 // ---------------------------------------------------------------------------
@@ -2384,6 +2384,20 @@ impl OverlayBlob {
     }
 }
 
+/// Ids [`CompanyRecord::mint_agent_id`] will never hand to a teammate, however
+/// free the roster leaves them: the always-present operator channel and the two
+/// workspace system roots.
+///
+/// Held as references to the real constants rather than re-typed literals, so a
+/// rename of any of the three moves this list with it instead of quietly
+/// unreserving a name. Compared case-insensitively, which is why `Agents` and
+/// `Desks` cover a minted (always-lowercase) `agents` / `desks`.
+pub const RESERVED_AGENT_IDS: [&str; 3] = [
+    crate::runtime::OPERATOR_CHANNEL,
+    crate::company::workspace_scaffold::AGENTS_ROOT,
+    crate::company::workspace_scaffold::DESKS_ROOT,
+];
+
 /// A durable company record: charter/roster (manifest) plus ledger and
 /// lifecycle state.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -2572,6 +2586,96 @@ impl CompanyRecord {
     pub fn is_roster_agent(&self, agent_id: &str) -> bool {
         self.manifest.agents.iter().any(|a| a.id == agent_id)
             || self.overlay_agents.iter().any(|a| a.id == agent_id)
+    }
+
+    /// Mints the roster id for a teammate about to be added under
+    /// `display_name`: [`agent_slug`] of the name, suffixed `_2`, `_3`, … until
+    /// it collides with nothing this record already routes on (issue #686).
+    ///
+    /// **The only way a write path should name a new overlay teammate.** Both
+    /// minting sites — the console `POST …/team` route and the orchestrator's
+    /// `add_agent` tool — call it under the shared per-company write lock, so
+    /// the check and the save that follows it cannot interleave.
+    ///
+    /// # Why a suffix rather than a refusal
+    ///
+    /// An unsuffixed id colliding with a **manifest** agent would be silently
+    /// dropped: `build_roster` skips any overlay id a manifest agent already
+    /// claims, so the teammate would persist in the record, never materialise,
+    /// and report no error. Refusing instead would take away a capability that
+    /// exists today — `POST …/team` accepts duplicate display names — and would
+    /// leave the tool's caller with a failed call and no human to recover it.
+    ///
+    /// # What counts as taken
+    ///
+    /// Every namespace a key typed into an Assignee field or a chat address can
+    /// land in, compared case-insensitively:
+    ///
+    /// * manifest and overlay teammate ids ([`Self::resolve_roster_agent_id`]);
+    /// * desk ids **and desk display names** — [`assignee::resolve`] tries desks
+    ///   first and [`Self::resolve_desk_id`] matches a desk name ignoring case,
+    ///   so a teammate id equal to a desk's name would be unaddressable. The
+    ///   comparison is against the name **as written**, not its slug: nothing
+    ///   routes on the slug of a desk name, so a desk called "Content Desk"
+    ///   leaves `content_desk` free while one called "Content" does not;
+    /// * [`RESERVED_AGENT_IDS`] — the operator channel and the two workspace
+    ///   system roots.
+    ///
+    /// [`assignee::resolve`]: crate::runtime::assignee::resolve
+    ///
+    /// # The id is minted once and never follows a rename
+    ///
+    /// `PATCH …/team/{agent_id}` edits a teammate's name, role and description
+    /// and deliberately leaves the id alone. A name-keyed id would orphan
+    /// everything already filed under the old one — the teammate's
+    /// `Agents/<id>/` folder, its `WorkspaceOrigin::Agent` stamps, its budget
+    /// override row, its desk memberships, its inbox — which is the same trap
+    /// name-keyed DM ids sprang on the console's chat journals (issue #364).
+    /// So a slug records what a teammate was called when it was created, and
+    /// nothing more; the display name is the thing that stays current.
+    ///
+    /// # Removing a teammate frees its slug again
+    ///
+    /// `DELETE …/team/{agent_id}` drops the overlay row (and its budget
+    /// override), after which re-adding the same name mints the same bare slug.
+    /// The new teammate then **adopts the old one's `Agents/<slug>/` folder**,
+    /// and that folder's `Agent` origin stamps re-attribute to it. That is the
+    /// intended remedy for a typo'd name — the same human, correcting
+    /// themselves, keeping the work — but it does mean remove-plus-re-add is not
+    /// a way to give a teammate a clean slate. `Agents/<slug>/` is a folder
+    /// named for a seat, not a chain of custody for whoever last sat in it.
+    pub fn mint_agent_id(&self, display_name: &str) -> String {
+        let stem = agent_slug(display_name);
+        if !self.roster_id_taken(&stem) {
+            return stem;
+        }
+        (2usize..)
+            .map(|n| format!("{stem}_{n}"))
+            .find(|candidate| !self.roster_id_taken(candidate))
+            .expect("an unbounded suffix sweep always reaches a free id")
+    }
+
+    /// Whether `candidate` already names something this record routes on, so
+    /// [`Self::mint_agent_id`] must step past it. See that method for why each
+    /// namespace counts.
+    fn roster_id_taken(&self, candidate: &str) -> bool {
+        if RESERVED_AGENT_IDS
+            .iter()
+            .any(|reserved| candidate.eq_ignore_ascii_case(reserved))
+        {
+            return true;
+        }
+        if self.resolve_roster_agent_id(candidate).is_some() {
+            return true;
+        }
+        self.manifest
+            .group_chats
+            .iter()
+            .map(|c| (&c.id, &c.name))
+            .chain(self.overlay_desks.iter().map(|d| (&d.id, &d.name)))
+            .any(|(id, name)| {
+                id.eq_ignore_ascii_case(candidate) || name.eq_ignore_ascii_case(candidate)
+            })
     }
 
     /// Resolves an operator-typed teammate key to its canonical roster id,
@@ -3856,6 +3960,139 @@ mod test {
         assert!(record.is_roster_agent("ceo"));
         assert!(record.is_roster_agent("nova"));
         assert!(!record.is_roster_agent("ghost"));
+    }
+
+    /// A record with one manifest agent and no desks, for the minting tests.
+    fn mint_record() -> CompanyRecord {
+        desk_record(
+            "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"backend_engineer\"\nrole = \"Backend Engineer\"\n",
+            Vec::new(),
+        )
+    }
+
+    fn add_overlay(record: &mut CompanyRecord, id: &str, name: &str) {
+        record.overlay_agents.push(OverlayAgent {
+            id: id.into(),
+            name: name.into(),
+            role: "Worker".into(),
+            description: None,
+        });
+    }
+
+    /// A free slug is minted bare — the whole point of issue #686 is that the
+    /// common case reads as `Agents/dana_designer/`.
+    #[test]
+    fn mint_agent_id_takes_the_bare_slug_when_it_is_free() {
+        let record = mint_record();
+        assert_eq!(record.mint_agent_id("Dana Designer"), "dana_designer");
+        assert_eq!(record.mint_agent_id("Designer!!"), "designer");
+        assert_eq!(record.mint_agent_id("24/7 Support"), "teammate");
+    }
+
+    /// The collision that matters: an overlay id equal to a **manifest** id is
+    /// skipped by `build_roster`, so the teammate would save and never
+    /// materialise. Suffixing is what keeps it reachable.
+    #[test]
+    fn mint_agent_id_suffixes_past_a_manifest_agent() {
+        let record = mint_record();
+        assert_eq!(
+            record.mint_agent_id("Backend Engineer"),
+            "backend_engineer_2"
+        );
+    }
+
+    /// Repeated adds of one name walk `_2`, `_3`, … in order, so the ids a
+    /// company ends up with are a function of its roster and not of arrival
+    /// timing.
+    #[test]
+    fn mint_agent_id_walks_suffixes_deterministically() {
+        let mut record = mint_record();
+        let first = record.mint_agent_id("Designer");
+        assert_eq!(first, "designer");
+        add_overlay(&mut record, &first, "Designer");
+
+        let second = record.mint_agent_id("Designer");
+        assert_eq!(second, "designer_2");
+        add_overlay(&mut record, &second, "Designer");
+
+        assert_eq!(record.mint_agent_id("Designer"), "designer_3");
+
+        // A degenerate name is not a special case — it suffixes like any other.
+        add_overlay(&mut record, "teammate", "***");
+        assert_eq!(record.mint_agent_id("🙂"), "teammate_2");
+    }
+
+    /// Case is not a difference: an overlay id typed with capitals still blocks
+    /// the lowercase slug, because `resolve_roster_agent_id` folds case and two
+    /// teammates one capital apart would be one unroutable key.
+    #[test]
+    fn mint_agent_id_treats_a_case_variant_id_as_taken() {
+        let mut record = mint_record();
+        add_overlay(&mut record, "Dana_Designer", "Dana Designer");
+        assert_eq!(record.mint_agent_id("Dana Designer"), "dana_designer_2");
+    }
+
+    /// Desks resolve *before* teammates in `assignee::resolve`, by id and by
+    /// case-insensitive display name — so a minted id equal to either would be
+    /// unreachable, and both are stepped past.
+    #[test]
+    fn mint_agent_id_steps_past_desk_ids_and_desk_names() {
+        let manifest = "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+             [[group_chat]]\nid = \"growth\"\nname = \"Content\"\nmembers = [\"ceo\"]\n";
+        let mut record = desk_record(manifest, Vec::new());
+
+        // By desk id.
+        assert_eq!(record.mint_agent_id("Growth"), "growth_2");
+        // By desk display name, which `resolve_desk_id` matches ignoring case.
+        assert_eq!(record.mint_agent_id("content"), "content_2");
+
+        // A desk name that is not itself slug-shaped is *not* reserved: nothing
+        // routes on the slug of a desk name, only on the name as written, so
+        // `content_desk` shadows no key that "Content Desk" answers to.
+        record.overlay_desks.push(OverlayDesk {
+            id: "design".into(),
+            name: "Design Studio".into(),
+            description: None,
+            members: Vec::new(),
+        });
+        assert_eq!(record.mint_agent_id("Design Studio"), "design_studio");
+        // …while the overlay desk's id is reserved exactly like a manifest one.
+        assert_eq!(record.mint_agent_id("Design"), "design_2");
+    }
+
+    /// The operator channel and the workspace system roots are never handed to
+    /// a teammate, on an otherwise empty roster.
+    #[test]
+    fn mint_agent_id_never_returns_a_reserved_id() {
+        let record = desk_record("[company]\nname = \"Acme\"\n", Vec::new());
+        assert_eq!(record.mint_agent_id("Operator"), "operator_2");
+        assert_eq!(record.mint_agent_id("Agents"), "agents_2");
+        assert_eq!(record.mint_agent_id("desks"), "desks_2");
+        assert_eq!(RESERVED_AGENT_IDS, ["operator", "Agents", "Desks"]);
+    }
+
+    /// Whatever is minted is a legal roster id, suffix included — the same
+    /// grammar the manifest validator holds a hand-authored id to.
+    #[test]
+    fn every_minted_id_satisfies_the_manifest_id_grammar() {
+        let mut record = mint_record();
+        for name in [
+            "Dana Designer",
+            "Backend Engineer",
+            "***",
+            "24/7 Support",
+            "Operator",
+            "設計者",
+        ] {
+            let id = record.mint_agent_id(name);
+            assert!(
+                crate::company::is_snake_case(&id),
+                "minted id {id:?} from {name:?} is not a legal roster id"
+            );
+            add_overlay(&mut record, &id, name);
+        }
     }
 
     /// The persisted overlay blob reads both the current object form and the

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -166,10 +166,16 @@ pub fn resolve(record: &CompanyRecord, assignee: &str) -> AssigneeResolution {
         return AssigneeResolution::Agent(id);
     }
     // Then operator-added teammates by display name. Tried only after the id
-    // namespace so a display name can never shadow a real id. `ops::team` mints
-    // these with `id: generate_id()`, so the name is the only string the
-    // operator ever sees — matching ids alone made every teammate they added
-    // unassignable on a free-text Assignee field (#214 review).
+    // namespace so a display name can never shadow a real id. `ops::team` used
+    // to mint these with `id: generate_id()`, making the name the only string
+    // the operator ever saw — matching ids alone left every teammate they added
+    // unassignable on a free-text Assignee field (#214 review). Since #686 the
+    // id is a readable slug, so the typical new teammate now resolves on the
+    // line above; this arm still earns its keep for the two cases a slug does
+    // not cover — teammates added before #686, which keep their generated ids
+    // forever, and any teammate renamed since (the id is minted once and never
+    // follows a rename, so the current display name may be the *only* string
+    // the operator recognises).
     let by_name = record.overlay_agent_ids_by_name(key);
     match by_name.len() {
         0 => AssigneeResolution::Unknown(key.to_string()),
@@ -396,9 +402,11 @@ members = ["ceo"]
     }
 
     /// An operator-added teammate is reachable by the only string the operator
-    /// ever sees. `server::ops::team` mints these with `id: generate_id()`, so
-    /// an id-only match made every teammate the operator added unassignable on
-    /// a free-text Assignee field with no picker (#214 review).
+    /// may recognise. `server::ops::team` minted these with `id: generate_id()`
+    /// before #686, so an id-only match made every teammate the operator added
+    /// unassignable on a free-text Assignee field with no picker (#214 review).
+    /// The fixture keeps a generated-shaped id deliberately: those records still
+    /// exist and are never migrated, so this arm must keep working for them.
     #[test]
     fn an_operator_added_teammate_resolves_by_display_name() {
         let mut record = acme();

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -43,9 +43,9 @@ use crate::AppState;
 use crate::company::dns::DomainStatus;
 use crate::error::OpenCompanyError;
 use crate::ports::inbox::InboxMeta;
+use crate::ports::now_millis;
 use crate::ports::store::company_write_lock;
 use crate::ports::types::{Actor, ActorKind, BudgetOverride, CompanyRecord, OverlayAgent};
-use crate::ports::{generate_id, now_millis};
 use crate::server::error::ApiError;
 use crate::server::ops::language;
 use crate::server::ops::{DOMAIN_KEY, ScopedCompany, scoped};
@@ -415,7 +415,13 @@ async fn add_member(
 
     let mut record = load_record(&company).await?;
     let agent = OverlayAgent {
-        id: generate_id(),
+        // A readable id derived from the name, unique against the roster this
+        // record already holds (issue #686). Minted here rather than pushed and
+        // renamed later: the id names the teammate's `Agents/<id>/` folder and
+        // stamps every artifact it authors, so it has to be right on the first
+        // save. The surrounding write lock is what makes the uniqueness check
+        // and the save below one atomic step.
+        id: record.mint_agent_id(&body.name),
         name: body.name,
         role: body.role,
         description: body.description,
@@ -504,10 +510,14 @@ async fn remove_member(
             "teammate {agent_id}"
         ))));
     }
-    // Drop the teammate's budget override with it (issue #343). Overlay ids are
-    // generated, so a future teammate will not collide with this one — but a
-    // record that accumulated dead override rows would grow without bound and
-    // make the roster read scan entries for teammates that no longer exist.
+    // Drop the teammate's budget override with it (issue #343). Since #686 the
+    // id is a slug of the display name rather than a generated one, so removing
+    // a teammate *frees its id*: re-adding the same name mints the same slug and
+    // the new teammate adopts the old one's `Agents/<slug>/` folder. Clearing
+    // the override here is therefore load-bearing, not just hygiene — a row left
+    // behind would silently cap whoever next takes the seat. See
+    // `CompanyRecord::mint_agent_id` for why the reuse is the intended remedy
+    // for a typo'd name rather than a hazard to design around.
     record.overlay_budgets.retain(|b| b.agent_id != agent_id);
     company.runtime.store().save(&record).await?;
     Ok(StatusCode::NO_CONTENT)
@@ -1315,6 +1325,176 @@ mod tests {
             record.overlay_budgets.is_empty(),
             "the removed teammate's override went with it: {:?}",
             record.overlay_budgets
+        );
+    }
+
+    /// Issue #686 — a console-added teammate gets a readable snake_case id
+    /// derived from its name, so its workspace folder reads
+    /// `Agents/dana_designer/` rather than `Agents/019fad5ada20-…/`.
+    ///
+    /// A second teammate with the same name suffixes rather than being refused:
+    /// duplicate display names were always accepted here, and taking that away
+    /// would be a capability regression dressed as a bug fix.
+    #[tokio::test]
+    async fn a_console_added_teammate_gets_a_readable_id() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let add = async |name: &str| {
+            let (status, created) = send(
+                &state,
+                "POST",
+                "/api/v1/company/team",
+                Some(json!({"name": name, "role": "Designer"})),
+                Some(&admin_cookie()),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{created}");
+            created["id"].as_str().unwrap().to_string()
+        };
+
+        assert_eq!(add("Dana Designer").await, "dana_designer");
+        assert_eq!(add("Dana Designer").await, "dana_designer_2");
+        // A name colliding with a manifest agent's id steps past it — an
+        // unsuffixed `writer` would be dropped by `build_roster` and the
+        // teammate would save without ever materialising.
+        assert_eq!(add("Writer").await, "writer_2");
+        // A name with no legal stem in it takes the shared fallback.
+        assert_eq!(add("24/7").await, "teammate");
+    }
+
+    /// The slug is a seat name, not a chain of custody: removing a teammate
+    /// frees its id, and re-adding the same name takes it back — which is what
+    /// makes remove-plus-re-add the remedy for a typo'd name, since the new
+    /// teammate adopts the old `Agents/<slug>/` folder.
+    ///
+    /// Pinned rather than left implicit because it is the one consequence of
+    /// name-derived ids that a generated id did not have.
+    #[tokio::test]
+    async fn removing_a_teammate_frees_its_slug_for_reuse() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (_, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Dana Designer", "role": "Designer"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(created["id"], "dana_designer");
+
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            "/api/v1/company/team/dana_designer",
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NO_CONTENT);
+
+        let (_, again) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Dana Designer", "role": "Designer"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(
+            again["id"], "dana_designer",
+            "the freed slug comes back rather than suffixing past a ghost: {again}"
+        );
+    }
+
+    /// The id is minted once. `PATCH …/team/{id}` renames the teammate and
+    /// leaves the id alone — a name-keyed id would orphan the teammate's
+    /// workspace folder, its budget row and its desk memberships on every
+    /// correction (the trap name-keyed DM ids sprang in issue #364).
+    #[tokio::test]
+    async fn renaming_a_teammate_does_not_remint_its_id() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (_, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Dana Designer", "role": "Designer"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(created["id"], "dana_designer");
+
+        let (status, edited) = send(
+            &state,
+            "PATCH",
+            "/api/v1/company/team/dana_designer",
+            Some(json!({"name": "Dana Diaz"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{edited}");
+        assert_eq!(edited["name"], "Dana Diaz");
+        assert_eq!(
+            edited["id"], "dana_designer",
+            "the id records what the teammate was called at creation: {edited}"
+        );
+
+        // And the per-teammate routes still answer on the original slug.
+        let (status, _) = put_budget(&state, "dana_designer", json!({"budgetUsdDaily": 3.0})).await;
+        assert_eq!(status, StatusCode::OK);
+        let row = team_row(&state, "dana_designer").await;
+        assert_eq!(row["budgetUsdDaily"], 3.0, "{row}");
+        assert_eq!(row["name"], "Dana Diaz", "{row}");
+    }
+
+    /// Every teammate route keyed on `{agent_id}` keeps working when that id is
+    /// a slug — the inbox toggle alongside the budget pair, since the slug now
+    /// travels in a URL path where a generated id used to.
+    #[tokio::test]
+    async fn slug_ids_work_across_the_per_teammate_routes() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (_, created) = send(
+            &state,
+            "POST",
+            "/api/v1/company/team",
+            Some(json!({"name": "Ana Maria (Growth)", "role": "Growth"})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        let id = created["id"].as_str().unwrap().to_string();
+        assert_eq!(id, "ana_maria_growth");
+
+        let (status, _) = send(
+            &state,
+            "PUT",
+            &format!("/api/v1/company/team/{id}/inbox"),
+            Some(json!({"enabled": true})),
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(team_row(&state, &id).await["inboxEnabled"], true);
+
+        let (status, _) = put_budget(&state, &id, json!({"budgetUsdDaily": 1.5})).await;
+        assert_eq!(status, StatusCode::OK);
+        let (status, _) = send(
+            &state,
+            "DELETE",
+            &format!("/api/v1/company/team/{id}/budget"),
+            None,
+            Some(&admin_cookie()),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert!(
+            team_row(&state, &id).await.get("budgetUsdDaily").is_none(),
+            "the reset came back through the slug-keyed route"
         );
     }
 


### PR DESCRIPTION
## Summary

A teammate added at runtime got a ULID as its roster id, so its workspace folder was named after the ULID. Observed live on the `smoke1` staging tenant — of 17 folders under `Agents/`, **8 read like this**:

```
Agents/019fa75dbc9b-000000000005/     ← added at runtime
Agents/019fad5ada20-000000000003/
Agents/backend_engineer/              ← from the manifest
Agents/product_manager/
```

Two minting policies for the same concept, and only one produced something a human can read. Runtime-added teammates now get a snake_case slug derived from their display name.

Closes #686.

## The bug this actually prevents

The cosmetics are the symptom. **`build_roster` skips an overlay id that a manifest agent already claims** — so once ids come from names, adding a teammate called "Backend Engineer" to a company with a manifest `backend_engineer` would have **saved a teammate that never materialises**, erroring nowhere. It would sit in the record, absent from the roster, silently doing nothing.

That was unreachable while ids were generated (ULIDs never collide) and became reachable the moment ids came from names. The existing duplicate-*name* guard does not catch it: it compares overlay names only, and the collision here is against a *manifest id*. Suffixing is what makes name-derived ids safe, not what makes them tidy.

## API Or Behavior Changes

**`agent_slug(display_name)`** (`src/ports/ids.rs`) — lowercase, keep ASCII alphanumerics, collapse every other run to a single `_`, trim, cap at 64. Returns the stem `teammate` when the result would not start with a lowercase letter, mirroring `company_id_from_name`'s `"company"` fallback. **Snake_case with underscores, not that function's hyphens**: the roster-id grammar is set by the manifest validator and by every existing agent (`backend_engineer`), and a hyphen dialect would be a third id shape in one system.

**`CompanyRecord::mint_agent_id()`** (`src/ports/types.rs`) — bare slug when free, else the smallest `_2`, `_3`, … Free means not colliding (case-insensitively) with manifest ids, overlay ids, desk ids, or the reserved set. `RESERVED_AGENT_IDS` is built from the real `OPERATOR_CHANNEL` / `AGENTS_ROOT` / `DESKS_ROOT` constants rather than re-typed literals, so a rename upstream cannot silently unreserve a name.

**Both minting sites** — `add_member` (`src/server/ops/team.rs`) and `AddAgentTool` (`src/harness/orchestrator.rs`) — mint through it, inside the shared per-company write lock they already held, so check-then-save is race-safe between the console and the tool.

**`add_agent` now reports the minted id** in its success text. That was the one end-to-end gap this change owed: without it the orchestrator creates a teammate and cannot address it afterwards. The console already had the id in its DTO.

**Existing ULID-id agents are untouched.** No migration, deliberately: it would have to rewrite `WorkspaceOrigin::Agent` authorship stamps — the records #326 exists to keep honest — plus every workspace path. **Zero existing test bodies were modified**, and the ULID-shaped fixtures stayed green untouched; that is the back-compat proof, not an assertion.

## Three places the plan was wrong

1. **A rename route already exists.** The plan stated none did, and asked for a doc comment describing the minted-once policy "for when one arrives". `PATCH …/team/{agent_id}` (`team_agent.rs::edit_agent`) has been writing `agent.name` and leaving the id alone all along. So the policy is **pinned by a test**, not just described — and the practical consequence is that a typo'd name is fixable today, while the folder keeps the original slug.
2. **Reserving desk *display names* would have been superstition.** The plan asked for it. But comparing a minted slug against a raw desk name only bites when the name is already slug-shaped modulo case: a desk called "Content" blocks `content`, while "Content Desk" leaves `content_desk` free, because nothing routes on the slug of a desk name. Not reserved; both directions pinned.
3. **`is_snake_case` was private**, so the grammar sweep needed a visibility change (`pub(crate)`) — the one file outside the planned list. Worth it: the sweep now couples to the real validator instead of a copy of its rules.

Two claims verified by reading rather than asserted by omission: **nothing parses a roster id by shape**, and the frontend uses `agent.id` in exactly three places (equality, avatar-tone hash, rendering) — **no frontend change is owed**.

## Tests

Every gate, exit codes captured directly rather than through a pipe:

- [x] `cargo fmt --all -- --check` — 0
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` — 0
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings` — 0
- [x] `cargo build --all-targets` (via `cargo check --locked --all-features --all-targets`) — 0
- [x] `cargo test --locked` — **1995 passed**, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **2978 passed**, 0 failed

20 new tests: slug normalisation including all-punctuation, empty, non-ASCII and digit-leading names → `teammate`; the 64-char cap; a sweep asserting **every** output satisfies the real `is_snake_case` grammar; `"Backend Engineer"` against a manifest `backend_engineer` → `backend_engineer_2` **and present in the built roster** (the silent-drop pin); deterministic `_2`/`_3` ordering; desk-id and reserved-name collisions; the rename route leaving the id alone; and route/tool coverage at both minting sites.

No frontend gates — no frontend file is touched.

## Documentation

`docs/spec/runtime/api.md` describes name-derived ids, the suffix rule, and the minted-once policy.

**Flagged, not fixed**: that file is now **532 lines against the repo's 500-line Markdown cap**. It was **already 506 on `main`**, so this inherits a violation rather than creating one; the addition was tightened from 33 lines to 26 rather than splitting the file, which is separate work.

## Related

- #570 — member folders minted on first use; the change that put the roster id into a path
- #552 — deliverables land at `Agents/<id>/<task-id>/`, so the id is in every artifact's path
- #607 — search renders those paths to agents and operators alike, which is what made this visible
- #326 — `WorkspaceOrigin::Agent { id }`; the authorship stamps a migration would have to rewrite, and the reason there is no migration here
- #71 — the `add_agent` tool, one of the two minting sites
