### PR TITLE
workspace: never serve a blob as a document a browser will execute (#667)

### DIFF
--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -229,6 +229,34 @@ including a 17 MiB case that proves the BSON cap is not in play. Over HTTP:
 decode as UTF-8 is stored as a note instead, so an uploaded `.md` keeps its
 editor and backlinks.
 
+**A stored `mime` does not decide how the blob route serves it (#667).** That
+value is the uploader's declared `Content-Type`, or `mime_guess` on a published
+deliverable's filename — a claim, not a property of the bytes — and the route is
+same-origin with the console's `SameSite=Lax` session cookie, which a top-level
+navigation sends. So `read_blob` classifies against a **closed list** instead:
+
+| stored mime | served as | disposition |
+| --- | --- | --- |
+| raster image (`png`, `jpeg`, `gif`, `webp`, `avif`, `bmp`, `tiff`, `apng`, icon) or `application/pdf` | unchanged | `inline` |
+| `image/svg+xml` | unchanged | `attachment` |
+| anything else, including absent | `application/octet-stream` | `attachment` |
+
+Every response also carries `X-Content-Type-Options: nosniff`, without which the
+forced type is a suggestion. SVG is split out rather than folded into either
+neighbour because it is an image *and* a document: an `<img>` will not decode it
+without `image/svg+xml`, and inside an `<img>` the SVG spec's secure static mode
+runs no script — but the same bytes at the top of a tab are a scripted document
+on this origin. Keeping the type and forcing `attachment` serves both.
+
+This lives on the **read** path deliberately. Sanitising on upload would leave
+every payload already stored under a caller-chosen mime exploitable; classifying
+at serve time covers those too. The console is unaffected either way — it fetches
+blobs through `getBlob` and wraps them in an object URL, and `fetch` ignores
+`Content-Disposition` entirely.
+
+A repo-wide Content-Security-Policy is **not** part of this and is still absent;
+its lack is not specific to this route and closing this one does not close that.
+
 **Authorship (#326).** Every `WorkspaceNode` carries `created_by` and
 `updated_by`, both a `WorkspaceOrigin` ∈ `seed | operator | agent{id}`. `write`
 takes the author and stamps `updated_by`; `create` receives a fully-formed node

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -431,9 +431,22 @@ async fn search(
 ///
 /// `ETag` is the payload's sha256 — the digest the store computed from the
 /// bytes it holds, so a conditional request is answered by the thing itself
-/// rather than by a timestamp that a rename would move. `Content-Disposition`
-/// is `inline`: the console renders images in place, and a browser opening the
-/// URL directly should show the file rather than be forced to download it.
+/// rather than by a timestamp that a rename would move.
+///
+/// # A stored `mime` is a caller's claim, so it does not decide the disposition
+///
+/// `node.mime` comes from the upload's declared `Content-Type` (or from
+/// `mime_guess` on a published deliverable's filename), which means it is
+/// influenced by whoever produced the file rather than derived from the bytes.
+/// Serving that value back with `Content-Disposition: inline` handed an
+/// uploader the ability to run script on the console's own origin, with the
+/// operator's `SameSite=Lax` session cookie attached — a top-level navigation
+/// sends it (issue #667).
+///
+/// So the mime no longer selects the disposition; [`serving_for`] does, from a
+/// closed list. Nothing about *storage* changed, which is the point: a payload
+/// already sitting in the tree under a mime some caller chose is neutralised the
+/// next time it is served, rather than only on uploads that happen after this.
 async fn read_blob(
     company: ScopedCompany,
     Path(NodePath { node_id }): Path<NodePath>,
@@ -448,19 +461,22 @@ async fn read_blob(
             "workspace blob {node_id}"
         ))));
     };
-    let mime = node
-        .mime
-        .unwrap_or_else(|| "application/octet-stream".to_string());
+    let serving = serving_for(node.mime.as_deref());
     let mut response = Response::builder()
         .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, mime)
+        .header(header::CONTENT_TYPE, serving.content_type)
+        // Without this, a browser is free to disregard the type above and sniff
+        // the bytes — which would make forcing `application/octet-stream` a
+        // suggestion rather than a decision.
+        .header(header::X_CONTENT_TYPE_OPTIONS, "nosniff")
         // Quoted per RFC 9110, and escaped defensively: a node name never
         // reaches this header, but a digest that somehow did would break the
         // response rather than the parse.
         .header(
             header::CONTENT_DISPOSITION,
             format!(
-                "inline; filename=\"{}\"",
+                "{}; filename=\"{}\"",
+                serving.disposition,
                 node.name.replace('"', "").replace(['\r', '\n'], "")
             ),
         );
@@ -475,6 +491,83 @@ async fn read_blob(
             "blob response failed: {e}"
         )))
     })
+}
+
+/// The media types a browser may render as a **document** on this origin.
+///
+/// Every entry is a format a browser decodes into pixels or into a viewer of its
+/// own, not one it parses into a DOM with a script context. `image/*` as a
+/// prefix rule would be the obvious way to write this and would be wrong:
+/// `image/svg+xml` is an XML *document* format whose `<script>` executes, so it
+/// is deliberately absent here and handled below instead.
+///
+/// `application/pdf` is included because a browser renders a PDF in a viewer
+/// that has no reach into the embedding origin's DOM or cookies, and because
+/// "open the URL, see the file" is the whole reason the route serves anything
+/// inline. Dropping it would be the more conservative choice — it would cost
+/// only direct navigation, since the console has never previewed a PDF — and is
+/// a one-line change if the tradeoff is ever judged differently.
+const INLINE_RENDERABLE: &[&str] = &[
+    "image/apng",
+    "image/avif",
+    "image/bmp",
+    "image/gif",
+    "image/jpeg",
+    "image/png",
+    "image/tiff",
+    "image/vnd.microsoft.icon",
+    "image/webp",
+    "image/x-icon",
+    "application/pdf",
+];
+
+/// Types the console may preview but no browser may open as a document.
+///
+/// SVG is both at once. In an `<img>` element it renders in the SVG spec's
+/// *secure static mode* — no script, no external references — which is why the
+/// console's image preview of one is safe, and why the type has to survive this
+/// far to reach it: an `<img>` will not decode SVG bytes without
+/// `image/svg+xml`. At the top of a tab the same bytes are a full document on
+/// this origin. Keeping the type and forcing `attachment` separates the two,
+/// where a single allow-list would have had to sacrifice one for the other.
+const PREVIEW_ONLY: &[&str] = &["image/svg+xml"];
+
+/// How [`read_blob`] will serve one stored payload.
+struct BlobServing {
+    content_type: String,
+    disposition: &'static str,
+}
+
+/// Decides a payload's response type and disposition from its stored mime.
+///
+/// Three outcomes, and the default is the safe one: a type nobody vouched for
+/// is served as opaque bytes the browser is told to download. That is what makes
+/// this a closed list rather than a blocklist — a media type invented after this
+/// was written lands in the last arm, not in the first.
+fn serving_for(stored: Option<&str>) -> BlobServing {
+    // The essence only: `image/png; charset=binary` is `image/png`, and a
+    // comparison against the raw value would miss it and downgrade a legitimate
+    // image to a download.
+    let essence = stored
+        .map(|m| m.split(';').next().unwrap_or(m).trim().to_ascii_lowercase())
+        .unwrap_or_default();
+
+    if INLINE_RENDERABLE.contains(&essence.as_str()) {
+        BlobServing {
+            content_type: essence,
+            disposition: "inline",
+        }
+    } else if PREVIEW_ONLY.contains(&essence.as_str()) {
+        BlobServing {
+            content_type: essence,
+            disposition: "attachment",
+        }
+    } else {
+        BlobServing {
+            content_type: "application/octet-stream".to_string(),
+            disposition: "attachment",
+        }
+    }
 }
 
 /// Names a multipart failure for what it actually was (issue #647).
@@ -834,5 +927,76 @@ async fn delete_node(
         Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
             "workspace node {node_id}"
         ))))
+    }
+}
+
+#[cfg(test)]
+mod serving_test {
+    use super::serving_for;
+
+    /// The classification table, stated once so the arms cannot drift apart.
+    #[test]
+    fn a_stored_mime_maps_to_exactly_one_serving() {
+        let cases: &[(Option<&str>, &str, &str)] = &[
+            // Renderable: the type survives and the browser shows it.
+            (Some("image/png"), "image/png", "inline"),
+            (Some("image/jpeg"), "image/jpeg", "inline"),
+            (Some("image/gif"), "image/gif", "inline"),
+            (Some("image/webp"), "image/webp", "inline"),
+            (Some("application/pdf"), "application/pdf", "inline"),
+            // Previewable but never a document.
+            (Some("image/svg+xml"), "image/svg+xml", "attachment"),
+            // Everything else is opaque bytes, whatever the caller called it.
+            (Some("text/html"), "application/octet-stream", "attachment"),
+            (
+                Some("application/xhtml+xml"),
+                "application/octet-stream",
+                "attachment",
+            ),
+            (Some("text/plain"), "application/octet-stream", "attachment"),
+            (
+                Some("application/zip"),
+                "application/octet-stream",
+                "attachment",
+            ),
+            (None, "application/octet-stream", "attachment"),
+        ];
+        for (stored, content_type, disposition) in cases {
+            let serving = serving_for(*stored);
+            assert_eq!(
+                (serving.content_type.as_str(), serving.disposition),
+                (*content_type, *disposition),
+                "stored mime {stored:?}"
+            );
+        }
+    }
+
+    /// A mime reaches this function from more than one writer, and only the
+    /// upload route normalises before storing — `capture_body` stores whatever
+    /// `mime_guess` produced, and a payload written straight through the port
+    /// stores whatever its caller passed. So the essence is matched here too,
+    /// or a parameterised or upper-cased `image/png` would be downgraded to a
+    /// download and the console's preview would break for it.
+    #[test]
+    fn the_essence_is_matched_not_the_raw_header_value() {
+        for stored in [
+            "image/png; charset=binary",
+            "  image/png  ",
+            "IMAGE/PNG",
+            "Image/Png ;q=1",
+        ] {
+            let serving = serving_for(Some(stored));
+            assert_eq!(serving.content_type, "image/png", "stored mime {stored:?}");
+            assert_eq!(serving.disposition, "inline", "stored mime {stored:?}");
+        }
+    }
+
+    /// The list is closed, not a blocklist: a type nobody has considered is
+    /// downloaded rather than rendered.
+    #[test]
+    fn an_unknown_type_falls_to_the_safe_arm() {
+        let serving = serving_for(Some("application/x-invented-2031"));
+        assert_eq!(serving.content_type, "application/octet-stream");
+        assert_eq!(serving.disposition, "attachment");
     }
 }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -7083,6 +7083,196 @@ async fn the_text_and_blob_reads_refuse_each_others_nodes() {
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
 
+// ---------------------------------------------------------------------------
+// The blob route never hands a browser a document (issue #667)
+// ---------------------------------------------------------------------------
+
+/// `GET …/workspace/blob/{id}` as a browser navigating to it would.
+async fn blob_response(state: &AppState, id: &str) -> axum::response::Response {
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/api/v1/company/workspace/blob/{id}"))
+        .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+        .body(Body::empty())
+        .unwrap();
+    router(state.clone()).oneshot(request).await.unwrap()
+}
+
+/// The header triple a response must show before it can be called inert:
+/// a type that is not a document, a browser told not to second-guess it, and a
+/// disposition that downloads rather than renders.
+fn assert_not_executable(response: &axum::response::Response, context: &str) {
+    let content_type = response.headers()["content-type"].to_str().unwrap();
+    let disposition = response.headers()["content-disposition"].to_str().unwrap();
+    let nosniff = response
+        .headers()
+        .get("x-content-type-options")
+        .map(|v| v.to_str().unwrap().to_string());
+
+    assert!(
+        disposition.starts_with("attachment;"),
+        "{context}: a browser must download this, not render it — got {disposition:?}"
+    );
+    assert_eq!(
+        nosniff.as_deref(),
+        Some("nosniff"),
+        "{context}: without nosniff the type below is a suggestion"
+    );
+    for executable in [
+        "text/html",
+        "image/svg+xml",
+        "application/xhtml+xml",
+        "text/xml",
+    ] {
+        assert!(
+            !content_type.starts_with(executable),
+            "{context}: served as {content_type:?}, which a browser parses into a \
+             document with a script context"
+        );
+    }
+}
+
+/// The vector in #667, end to end: a payload stored under a document media type
+/// is not servable as a document.
+///
+/// The bytes carry a trailing `0xff` so the upload takes the **binary** branch —
+/// a valid-UTF-8 `text/html` upload is stored as a prose note and never reaches
+/// this route at all. That byte is not a contrivance to reach the branch: a
+/// browser decoding these bytes substitutes U+FFFD for it and runs the script
+/// exactly the same, so this is the real shape of the attack.
+///
+/// The assertion that matters is the one about the *stored* mime: it is still
+/// `text/html` afterwards. The fix is on the read path precisely so that every
+/// payload already sitting in a tree under a caller's chosen mime is covered,
+/// which an upload-side sanitiser would not have been.
+#[tokio::test]
+async fn a_blob_stored_as_html_cannot_be_served_as_a_document() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let payload = b"<script>fetch('/api/v1/company/team')</script>\xff";
+    let (status, node) = upload_file(&state, "payload.png", Some("text/html"), payload, None).await;
+    assert_eq!(status, StatusCode::OK, "{node}");
+    assert_eq!(
+        node["mime"], "text/html",
+        "the stored mime is untouched — the read path is what neutralises it"
+    );
+    let id = node["id"].as_str().unwrap().to_string();
+
+    let response = blob_response(&state, &id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()["content-type"],
+        "application/octet-stream",
+        "a type nobody vouched for is served as opaque bytes"
+    );
+    assert_not_executable(&response, "an html-typed payload");
+
+    // Neutralised, not corrupted: an operator who downloads it still gets the
+    // file they stored.
+    let got = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(got.to_vec(), payload.to_vec());
+}
+
+/// SVG is why an `image/*` prefix rule would not have closed this.
+///
+/// It is an image the console previews and a document a browser executes, so the
+/// two halves are answered separately: the type survives (an `<img>` will not
+/// decode SVG without it, and inside an `<img>` the SVG spec's secure static
+/// mode means no script runs), and the disposition becomes `attachment` so the
+/// same bytes at the top of a tab are downloaded instead of rendered.
+#[tokio::test]
+async fn an_svg_keeps_its_type_for_the_console_but_is_never_rendered_as_a_document() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let svg = br#"<svg xmlns="http://www.w3.org/2000/svg"><script>fetch('/api/v1/company/team')</script></svg>"#;
+    let (status, node) = upload_file(&state, "logo.svg", Some("image/svg+xml"), svg, None).await;
+    assert_eq!(status, StatusCode::OK, "{node}");
+    let id = node["id"].as_str().unwrap().to_string();
+
+    let response = blob_response(&state, &id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()["content-type"],
+        "image/svg+xml",
+        "the console's <img> preview needs this exact type to decode the bytes"
+    );
+    let disposition = response.headers()["content-disposition"]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        disposition.starts_with("attachment;"),
+        "a top-level navigation must download an SVG, not render it: {disposition:?}"
+    );
+    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+}
+
+/// An arbitrary caller-declared type — one nobody has ever vetted — is opaque.
+/// This is the closed-list half of the fix: the default arm is the safe one, so
+/// a media type invented after this was written is downloaded, not rendered.
+#[tokio::test]
+async fn an_unrecognised_stored_type_is_served_as_opaque_bytes() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    for (name, declared) in [
+        ("doc.xhtml", "application/xhtml+xml"),
+        ("sheet.xml", "text/xml"),
+        ("archive.zip", "application/zip"),
+    ] {
+        let (status, node) =
+            upload_file(&state, name, Some(declared), &[0x50, 0x4b, 0xff], None).await;
+        assert_eq!(status, StatusCode::OK, "{node}");
+        let id = node["id"].as_str().unwrap().to_string();
+        let response = blob_response(&state, &id).await;
+        assert_eq!(
+            response.headers()["content-type"],
+            "application/octet-stream",
+            "{declared} is not on the inline list"
+        );
+        assert_not_executable(&response, declared);
+    }
+}
+
+/// The behaviour #611 built, pinned so the fix above cannot quietly cost it: an
+/// image still arrives with its own type and `inline`, which is what makes the
+/// console's preview and a direct navigation both show the picture.
+#[tokio::test]
+async fn an_image_still_renders_inline_with_its_own_type() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, node) = upload_file(
+        &state,
+        "hero.png",
+        Some("image/png"),
+        &[0x89, b'P', b'N', b'G', 0xff],
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{node}");
+    let id = node["id"].as_str().unwrap().to_string();
+
+    let response = blob_response(&state, &id).await;
+    assert_eq!(response.headers()["content-type"], "image/png");
+    assert_eq!(response.headers()["x-content-type-options"], "nosniff");
+    let disposition = response.headers()["content-disposition"]
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(
+        disposition.starts_with("inline;"),
+        "an image must still render in place: {disposition:?}"
+    );
+    assert!(disposition.contains("hero.png"));
+}
+
 /// An upload lands under the folder it names, like any other node.
 #[tokio::test]
 async fn an_upload_can_target_a_parent_folder() {


### PR DESCRIPTION
## Summary

`read_blob` served `node.mime` verbatim with `Content-Disposition: inline`, and
`node.mime` is the uploader's declared `Content-Type` — or `mime_guess` on a
published deliverable's filename — rather than anything derived from the bytes.
`resolve_mime` rejects only `application/octet-stream`, so any other value a
caller declares is stored and replayed.

The route is same-origin with the operator console. Its session cookie is
`SameSite=Lax` (`src/server/graphql/auth.rs:13`), which **is** sent on a
top-level navigation, and `ScopedCompany` → `CompanyAuth` → `resolve_session`
accepts it. So opening `…/workspace/blob/{id}` in a tab authenticated and
rendered attacker-authored markup as a document on the console's own origin,
with the operator's session attached to anything it then requested.

`serving_for()` now decides the response from a **closed list** instead:

| stored mime | served as | disposition |
| --- | --- | --- |
| raster image (`png`, `jpeg`, `gif`, `webp`, `avif`, `bmp`, `tiff`, `apng`, icon) or `application/pdf` | unchanged | `inline` |
| `image/svg+xml` | unchanged | `attachment` |
| anything else, **including absent** | `application/octet-stream` | `attachment` |

Every response also carries `X-Content-Type-Options: nosniff`, without which the
forced type is a suggestion rather than a decision.

Closes tinyhumansai/opencompany#667.

### Why the read path and not the upload path

Both would close the vector for *future* uploads. Only the read path closes it
for the payloads **already stored** under a mime some caller chose, and those are
the ones that exist right now. The test asserts this directly: the stored mime is
still `text/html` after the fix, and the response is inert anyway.

It also keeps the diff off `upload`/`resolve_mime`, which #665/#666 are actively
changing.

### Why SVG is its own arm rather than folded into either neighbour

An `image/*` prefix rule is the obvious way to write the allow-list and is the
wrong one — `image/svg+xml` is an XML *document* format whose `<script>` runs.
But SVG is genuinely both things at once:

- Inside an `<img>` element it renders in the SVG spec's **secure static mode**:
  no script, no external references. The console previews it there
  (`BinaryNodeView` gates on `node.mime.startsWith("image/")`), and an `<img>`
  will not decode SVG bytes at all without `image/svg+xml` — so the type has to
  survive.
- At the top of a tab the same bytes are a full scripted document on this origin.

Keeping the type and forcing `attachment` serves both. A single allow-list would
have had to sacrifice one of them.

### The PDF call, stated so it is cheap to overrule

I put `application/pdf` on the inline list. The case **against**, which is real:
the console has never previewed a PDF — `BinaryNodeView`'s own comment says it
deliberately shows metadata and a download instead — so excluding PDF would cost
only direct navigation, and would drop pdf.js / plugin surface from a same-origin
path. The case **for**, which I took: `inline` exists so that opening the URL
shows the file, and a browser renders a PDF in a viewer with no reach into the
embedding origin's DOM or cookies. It is a one-line change either way and the
code comment says so.

## API Or Behavior Changes

**The console is unaffected.** It never sees `Content-Disposition`: `fetchBlobUrl`
→ `client.getBlob` → `fetch` → `URL.createObjectURL`, and `fetch` ignores the
header entirely. The Download button is `<a download>` on a `blob:` URL. Image
preview is unchanged because images keep their type; SVG preview is unchanged for
the same reason. No frontend change was needed and none is included.

**What does change** is a direct browser navigation to `…/workspace/blob/{id}`
for a non-image, non-PDF payload: it now downloads under the node's own name
instead of rendering. For the media types this route actually holds — zips,
office documents, video — that is what a browser did anyway. For `text/html`,
`application/xhtml+xml` and SVG it is the fix.

**Out of scope, and named rather than half-done: there is still no
Content-Security-Policy anywhere in `src/` or `frontend/`.** That gap is
repo-wide, not specific to this route, and closing this route does not close it.
I did not build one and this PR should not be read as having addressed it.

Two things I checked and did **not** change:

- `read_blob` is the only non-test caller of `read_bytes` in `src/server/`, so
  this closes the class rather than one door.
- `task_export.rs` is the other HTML-emitting route and is clean: it escapes via
  `escape()` at `:619`, has tests pinning `&lt;script&gt;`, and already serves
  `attachment`.

## Tests

Run on `upstream/main` @ `a90f70f` with submodules populated (verified by
`Cargo.toml` existence, not `submodule status`).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo build --all-targets` — ran as `cargo check --locked --all-features --all-targets`, which is strictly wider (it is also the lane that catches the MongoDB/SQLite row-construction paths neither default nor gated features compile)
- [x] `cargo test --locked` — **1986 + 10 + 1 passed, 0 failed**
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **2965 + 10 + 1 + 11 + 2 passed, 0 failed**
- [x] N/A — `--features acp`: this diff touches nothing under `src/server/acp/*`.
- [x] N/A — `--features mongodb` / `sqlite` lanes: the change is one HTTP handler and a pure function; it reads `node.mime` off a value every backend already returns and stores nothing. The `--all-features` check above still compiles both backends.
- [x] N/A — frontend: no `frontend/` file is touched, for the reason given under *Behavior Changes* (the console never sees the header that changed).

### New coverage — 7 tests, and both reverts were checked

Four over HTTP in `write_test.rs`, three unit tests on the classifier in
`workspace.rs`.

**Reaching the vector honestly.** A valid-UTF-8 `text/html` upload is stored as a
prose *note* by `text_body` and never reaches `read_blob` at all, so the HTML
payload carries one trailing `0xff` to take the binary branch. That is not a
contrivance to reach the branch: a browser substitutes U+FFFD for that byte and
runs the script identically. `image/svg+xml` and `application/xhtml+xml` are not
"texty" to `text_body`, so they reach the route with no trick whatsoever.

**Revert-and-check, in two parts so each failure is attributable.** A single
revert would not have distinguished them, and deleting `serving_for` outright
would have failed the unit tests by *compile error*, which proves nothing.

*Part A* — route reverted to `node.mime` + `inline`, classifier left in place:
**0 passed, 4 failed.** Each for its own reason, not a shared one:

```
a_blob_stored_as_html_cannot_be_served_as_a_document
    left: "text/html"   right: "application/octet-stream"
an_svg_keeps_its_type_..._never_rendered_as_a_document
    a top-level navigation must download an SVG: "inline; filename=\"logo.svg\""
an_unrecognised_stored_type_is_served_as_opaque_bytes
    left: "application/xhtml+xml"   right: "application/octet-stream"
an_image_still_renders_inline_with_its_own_type
    no entry found for key "x-content-type-options"
```

*Part B* — classifier gutted to the pre-fix passthrough rule: **0 passed, 3
failed** — `("image/svg+xml", "inline")` vs `attachment`,
`"application/x-invented-2031"` vs `octet-stream`, `"image/png; charset=binary"`
vs `image/png`.

Restored: **7 passed, 0 failed.**

**One test's revert-failure is narrower than its name suggests, so I am saying so
rather than letting the green row imply more.**
`an_image_still_renders_inline_with_its_own_type` fails under revert on the
*missing `nosniff` header* — its `image/png` and `inline` assertions were already
true before this change. It is a regression guard for #611's behaviour plus one
new assertion, and only the new assertion is what its revert-failure proves.

## Documentation

`docs/spec/runtime/ports-console.md` — the classification table, why the fix is
on the read path, why SVG is split out, that the console is unaffected, and an
explicit note that a repo-wide CSP is still absent and this does not close it.
The file is 384 lines, under the 500-line guideline in `AGENTS.md`.

## Related

- #611 / #553 — the PR and issue that added this route and its inline image
  rendering, which this preserves.
- #665 / #666 — the upload path. Untouched here on purpose.
