### PR TITLE
fix(store): spare in-flight uploads from the orphan sweep

### DIFF
--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2049,7 +2049,8 @@ const BLOB_BUCKET: &str = "workspace_blobs";
 ///
 /// An hour is far longer than that window and deliberately so. The cost of
 /// being generous is bounded and dull — a genuinely abandoned blob occupies
-/// disk until the next boot an hour later — while the cost of being tight is
+/// disk until the first boot after it becomes old enough, which may be much
+/// later on a long-lived deployment — while the cost of being tight is
 /// destroying a tenant's upload. The asymmetry is the whole argument, so do not
 /// tune this down without one.
 const ORPHAN_BLOB_MIN_AGE_MS: i64 = 60 * 60 * 1000;

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2037,6 +2037,23 @@ impl crate::ports::skills_state::SkillStateStore for MongoStore {
 /// [`MongoStore::blob_filter`].
 const BLOB_BUCKET: &str = "workspace_blobs";
 
+/// How long a blob must have existed before [`MongoStore::sweep_orphan_blobs`]
+/// will treat "no node document" as *abandoned* rather than *in flight*
+/// (issue #664).
+///
+/// The window the sweep must not delete into is between `put_blob` returning
+/// and the `workspace_nodes` insert landing — normally milliseconds, but a
+/// concurrent boot only has to land inside it once to destroy a live upload,
+/// and the damage is permanent: a node whose download 404s and whose `size`
+/// still counts against the quota.
+///
+/// An hour is far longer than that window and deliberately so. The cost of
+/// being generous is bounded and dull — a genuinely abandoned blob occupies
+/// disk until the next boot an hour later — while the cost of being tight is
+/// destroying a tenant's upload. The asymmetry is the whole argument, so do not
+/// tune this down without one.
+const ORPHAN_BLOB_MIN_AGE_MS: i64 = 60 * 60 * 1000;
+
 impl MongoStore {
     /// The workspace payload bucket.
     fn blobs(&self) -> mongodb::gridfs::GridFsBucket {
@@ -2139,6 +2156,32 @@ impl MongoStore {
     /// failure is safe: a sweep that cannot complete is logged and the store is
     /// returned anyway, because refusing to open a company's storage over
     /// reclaimable disk would trade an invisible cost for a total outage.
+    ///
+    /// ## Only blobs older than [`ORPHAN_BLOB_MIN_AGE_MS`] (issue #664)
+    ///
+    /// "No node document" describes an abandoned blob **and** a blob whose
+    /// writer is still running, and the two are indistinguishable by reference
+    /// alone. Without an age bound this sweep deletes live uploads: a second
+    /// process — a rolling deploy, a restarted replica, another tenant's
+    /// container on a shared database — boots between a peer's `put_blob` and
+    /// its node insert, sees a blob with no node, and reclaims it. The peer's
+    /// insert then lands, and the company keeps a node whose download 404s
+    /// forever while its recorded `size` still counts against `tree_quota_gb`.
+    /// Neither half self-heals, because this sweep only ever deletes blobs
+    /// without nodes and never nodes without blobs.
+    ///
+    /// That is the failure the write ordering exists to avoid, reintroduced by
+    /// the thing meant to clean up after it — and the *shared-single-DB* mode
+    /// makes it cross-tenant, since this is the one query in this backend that
+    /// carries no `company_id` (see the multi-tenancy note at the top of this
+    /// module). An age bound closes both: an in-flight upload is young, an
+    /// abandoned one is not, and the filter runs server-side so a young blob is
+    /// never even read.
+    ///
+    /// **Not fixed by reordering the writes.** Node-first would replace an
+    /// invisible orphan with a node whose bytes are absent — the outcome
+    /// `fs_ops::create_binary` rejects in as many words ("only one of those is
+    /// survivable"). The ordering is right; the sweep was wrong.
     async fn sweep_orphan_blobs(&self) -> Result<u64> {
         let live: std::collections::HashSet<(String, String)> = {
             let mut cursor = self
@@ -2156,7 +2199,17 @@ impl MongoStore {
             out
         };
         let bucket = self.blobs();
-        let mut cursor = bucket.find(doc! {}).await.map_err(mongo_err)?;
+        // Server-side, so a blob younger than the bound is never even read —
+        // and so the bound cannot be defeated by a `continue` added later to
+        // the loop below. `uploadDate` is GridFS's own field on the files
+        // document, written when the upload completes.
+        let cutoff = mongodb::bson::DateTime::from_millis(
+            (now_millis() as i64).saturating_sub(ORPHAN_BLOB_MIN_AGE_MS),
+        );
+        let mut cursor = bucket
+            .find(doc! { "uploadDate": { "$lt": cutoff } })
+            .await
+            .map_err(mongo_err)?;
         let mut removed = 0;
         while let Some(file) = cursor.try_next().await.map_err(mongo_err)? {
             let key = file.metadata.as_ref().and_then(|m| {
@@ -2729,6 +2782,24 @@ mod test {
         let _ = store.db.drop().await;
     }
 
+    /// Ages every staged blob past [`ORPHAN_BLOB_MIN_AGE_MS`] (issue #664).
+    ///
+    /// The sweep only reclaims blobs old enough to be abandoned, so a test that
+    /// uploads bytes and reboots in the same millisecond is staging an
+    /// *in-flight* upload, not an orphaned one. Rewriting `uploadDate` is how a
+    /// test says "and then an hour passed" without sleeping for one.
+    async fn age_blobs_past_the_sweep_threshold(store: &MongoStore) {
+        let old = mongodb::bson::DateTime::from_millis(
+            now_millis() as i64 - ORPHAN_BLOB_MIN_AGE_MS - 60_000,
+        );
+        store
+            .db
+            .collection::<Document>(&format!("{BLOB_BUCKET}.files"))
+            .update_many(doc! {}, doc! { "$set": { "uploadDate": old } })
+            .await
+            .expect("backdate staged blobs");
+    }
+
     /// The boot sweep reclaims a payload whose node document never landed.
     ///
     /// This is the crash the write ordering deliberately allows: blob first,
@@ -2786,6 +2857,12 @@ mod test {
             "two orphans and one live payload are staged"
         );
 
+        // The orphans have to be *old* to be orphans (issue #664). Staged
+        // seconds ago they are indistinguishable from a peer's in-flight
+        // upload, and the sweep now spares them for that reason — see
+        // `a_recent_orphan_is_left_alone_because_it_may_be_an_in_flight_upload`.
+        age_blobs_past_the_sweep_threshold(&s).await;
+
         // Constructing a store over the same database runs the sweep.
         let rebooted = MongoStore::from_database(s.db.clone()).await.unwrap();
 
@@ -2815,6 +2892,91 @@ mod test {
             }
         }
         assert_eq!(got, b"live-bytes".to_vec());
+
+        drop_db(&s).await;
+    }
+
+    /// Issue #664: the boot sweep must not delete a concurrent writer's upload.
+    ///
+    /// The state staged here is not a crash — it is the perfectly ordinary
+    /// instant *inside* a healthy `create_binary`, after `put_blob` has
+    /// returned and before the node insert lands. A second process booting then
+    /// (a rolling deploy, a restarted replica, another tenant's container on a
+    /// shared database) sees a blob with no node and, before this fix, reclaimed
+    /// it. The writer's insert would then land on top, leaving a node whose
+    /// download 404s forever and whose `size` still counts against the quota —
+    /// unreclaimable, because the sweep only deletes blobs without nodes and
+    /// never nodes without blobs.
+    ///
+    /// Deliberately *not* backdated: recency is the whole signal.
+    #[tokio::test]
+    async fn a_recent_orphan_is_left_alone_because_it_may_be_an_in_flight_upload() {
+        let Some(s) = store().await else { return };
+        let company = CompanyId::new("inflight-co");
+
+        // Exactly what a concurrent `create_binary` has written so far.
+        s.put_blob(&company, "arriving", "arriving.png", b"in-flight-bytes")
+            .await
+            .unwrap();
+
+        // A second process boots against the same database and sweeps.
+        let rebooted = MongoStore::from_database(s.db.clone()).await.unwrap();
+
+        let files = rebooted
+            .blobs()
+            .find(doc! {})
+            .await
+            .unwrap()
+            .try_collect::<Vec<_>>()
+            .await
+            .unwrap();
+        assert_eq!(
+            files.len(),
+            1,
+            "a blob younger than the threshold is an upload in progress, not an orphan"
+        );
+        assert_eq!(files[0].filename.as_deref(), Some("arriving.png"));
+
+        // And the writer's insert, landing after the sweep, yields a node whose
+        // bytes are actually there — the whole point.
+        let node = crate::ports::workspace::WorkspaceNode {
+            id: "arriving".to_string(),
+            name: "arriving.png".to_string(),
+            kind: crate::ports::workspace::NodeKind::File,
+            parent_id: None,
+            updated_at_millis: now_millis(),
+            created_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+            updated_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+            mime: Some("image/png".to_string()),
+            size: None,
+            sha256: None,
+        };
+        rebooted
+            .collection("workspace_nodes")
+            .insert_one(doc! {
+                "company_id": company.as_ref(),
+                "node_id": &node.id,
+                "node_json": serde_json::to_string(&node).unwrap(),
+                "content": "",
+                "updated_ms": node.updated_at_millis as i64,
+            })
+            .await
+            .unwrap();
+
+        let (_, stream) =
+            crate::ports::workspace::WorkspaceStore::read_bytes(&rebooted, &company, "arriving")
+                .await
+                .unwrap()
+                .expect("the upload that was in flight during the sweep still has its bytes");
+        let mut got = Vec::new();
+        {
+            use futures::StreamExt;
+            let mut stream = stream;
+            while let Some(chunk) = stream.next().await {
+                got.extend_from_slice(&chunk.unwrap());
+            }
+        }
+        assert_eq!(got, b"in-flight-bytes".to_vec());
 
         drop_db(&s).await;
     }


### PR DESCRIPTION
## Summary

Bound the boot-time GridFS orphan sweep by blob age so a concurrent writer's in-flight upload is not reclaimed between `put_blob` completing and the workspace-node document being inserted.

The sweep now filters server-side on GridFS `uploadDate` and only examines blobs older than one hour. The existing orphan test backdates its staged blobs, while a new regression reconstructs the exposed `create_binary` window and proves the blob remains readable after a concurrent store boot.

Closes #664.

## API Or Behavior Changes

- Orphan GridFS blobs younger than one hour are left untouched because they may still be in flight.
- Genuinely abandoned blobs become eligible at the first boot occurring at least one hour after upload; on a long-lived deployment, that may be weeks later.
- No public API shape changes.

## Tests

Prior verification on this exact branch against a local MongoDB instance:

- [x] `store::mongodb` targeted suite — 26 passed.
- [x] Revert-and-check — removing the age bound made the new regression fail while the pre-existing orphan tests still passed (3 passed, 1 failed).
- [x] `git diff --check` — clean in this continuation.

PR checklist commands below are intentionally delegated to CI by the current manager rule in `WORKFLOW-RULES.md`, which prohibits local Rust compilation/test commands on the shared machine:

- [x] `cargo fmt --all -- --check` — N/A locally; CI verification required.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A locally; CI verification required.
- [x] `cargo build --all-targets` — N/A locally; CI verification required.
- [x] `cargo test` — N/A locally; CI verification required.

## Documentation

No external documentation change is needed. The behavioral rationale and threshold tradeoff are documented next to the sweep and its constant.
