### PR TITLE
feat(connections): make a Composio connection an object with accounts, and let one be revoked (#404)

### DIFF
--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -263,10 +263,58 @@ fn slug_toolkit(slug: &str) -> String {
     slug.split('_').next().unwrap_or("").to_ascii_lowercase()
 }
 
+/// One connected Composio account, projected for the console (issue #404).
+///
+/// Composio models a connection as an **account**, not as a boolean: a company
+/// can hold two Gmail connections, and telling them apart is the entire point of
+/// a detail view. [`list_connection_states`] deliberately folds this down to one
+/// `(toolkit, connected)` pair per toolkit for the tile grid and the
+/// reconciliation probe, both of which only ever ask "is this provider wired".
+/// Everything that needs to *manage* a connection reads these rows instead.
+///
+/// **Non-secret projection.** Composio returns no token material on this route,
+/// and nothing here is derived from the tenant bearer. The [`id`](Self::id) is a
+/// Composio-side handle, not a credential: it is the argument
+/// [`delete_connection`] takes, and it is useless without the bearer that scopes
+/// it to this company.
+///
+/// Always compiled, so the console DTO that mirrors it (`ops::composio`) can be
+/// defined in a build without the `composio` feature — only the functions that
+/// produce these rows are gated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComposioConnectionRow {
+    /// Composio's connection id — what [`delete_connection`] revokes.
+    pub id: String,
+    /// Toolkit slug, normalized (`gmail`, `googlecalendar`).
+    pub toolkit: String,
+    /// Composio's raw status string (`ACTIVE`, `INITIATED`, `EXPIRED`, …).
+    ///
+    /// Forwarded verbatim rather than reduced to [`connected`](Self::connected),
+    /// because "connected: false" reads as *not set up* while an expired
+    /// connection was set up and needs re-authorizing — a different sentence and
+    /// a different button. The console maps the vocabulary; the host does not
+    /// pretend to know every value Composio may add.
+    pub status: String,
+    /// Whether this connection is usable — `ACTIVE` or `CONNECTED`,
+    /// case-insensitively, matching the vendored client's own `is_active`.
+    pub connected: bool,
+    /// When Composio recorded the connection, ISO-8601, when it says.
+    pub created_at: Option<String>,
+    /// The account label this connection acts as, when the provider published
+    /// one: the account email, else a workspace/team name, else a handle.
+    ///
+    /// Derived here rather than in the console so the precedence is stated once
+    /// and tested once — it mirrors OpenHuman's `deriveConnectionLabel`, which
+    /// is the experience this issue ports. `None` is honest: plenty of toolkits
+    /// publish no identity at all, and inventing one from the slug would render
+    /// as a fact the operator cannot check.
+    pub account: Option<String>,
+}
+
 #[cfg(feature = "composio")]
 pub use live::{
-    ComposioMetering, authorize_connect_url, composio_tools, list_catalog_toolkits,
-    list_connection_states,
+    ComposioMetering, authorize_connect_url, composio_tools, delete_connection,
+    list_catalog_toolkits, list_connection_states, list_connections_detailed,
 };
 
 #[cfg(feature = "composio")]
@@ -449,36 +497,116 @@ mod live {
         }
     }
 
-    /// The per-toolkit connected state the console renders as provider rows: one
-    /// `(toolkit, connected)` pair per toolkit that has at least one connection,
-    /// with `connected == true` when **any** connection for that toolkit is
-    /// active. Backs the console's `GET …/composio/connections` route.
+    /// Every connected account this company holds, one row per **connection**
+    /// rather than per toolkit (issue #404). Backs the console's provider detail
+    /// view and the disconnect it offers.
     ///
-    /// Filtered to the tenant allowlist (mirrors the `composio_list_connections`
-    /// agent tool) so a connection outside the company's grant is never
-    /// surfaced. Sorted by toolkit for a stable render order. Any upstream error
-    /// is scrubbed of the tenant bearer before it bubbles.
-    pub async fn list_connection_states(config: &TenantComposio) -> Result<Vec<(String, bool)>> {
-        tracing::debug!(allowlist = ?config.toolkits, "[composio] ops list_connections");
+    /// Filtered to the tenant allowlist exactly as [`list_connection_states`] is
+    /// — the two share this call, so a connection outside the company's grant is
+    /// invisible to both, and cannot be reached by guessing its id either (see
+    /// [`delete_connection`]). Sorted by `(toolkit, id)` for a stable render
+    /// order. Any upstream error is scrubbed of the tenant bearer before it
+    /// bubbles.
+    pub async fn list_connections_detailed(
+        config: &TenantComposio,
+    ) -> Result<Vec<ComposioConnectionRow>> {
+        tracing::debug!(allowlist = ?config.toolkits, "[composio] ops list_connections_detailed");
         let (client, secrets) = live_call(config).await?;
         let resp = match client.list_connections().await {
             Ok(resp) => resp,
             Err(err) => return Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
         };
+        let mut rows: Vec<ComposioConnectionRow> = resp
+            .connections
+            .into_iter()
+            .filter_map(|conn| {
+                let toolkit = conn.normalized_toolkit();
+                if !toolkit_allowed(&config.toolkits, &toolkit) {
+                    return None;
+                }
+                let connected = conn.is_active();
+                Some(ComposioConnectionRow {
+                    id: conn.id,
+                    toolkit,
+                    status: conn.status,
+                    connected,
+                    created_at: conn.created_at,
+                    // Same precedence as OpenHuman's `deriveConnectionLabel`:
+                    // email, then workspace, then handle. A field present but
+                    // blank is treated as absent — a whitespace label would
+                    // render as an empty parenthetical, which reads as a bug.
+                    account: [conn.account_email, conn.workspace, conn.username]
+                        .into_iter()
+                        .flatten()
+                        .map(|v| v.trim().to_string())
+                        .find(|v| !v.is_empty()),
+                })
+            })
+            .collect();
+        rows.sort_by(|a, b| a.toolkit.cmp(&b.toolkit).then_with(|| a.id.cmp(&b.id)));
+        Ok(rows)
+    }
+
+    /// The per-toolkit connected state the console renders as provider tiles: one
+    /// `(toolkit, connected)` pair per toolkit that has at least one connection,
+    /// with `connected == true` when **any** connection for that toolkit is
+    /// active. Backs the console's `GET …/composio/connections` route and the
+    /// reconciliation probe in `ops::connections_read`.
+    ///
+    /// A projection over [`list_connections_detailed`] rather than a second call
+    /// shape: one network round-trip, one allowlist filter, one scrub. The fold
+    /// is what the tile grid wants and all the probe can use — both ask only
+    /// "is this provider wired" — but it is lossy, so anything that manages a
+    /// connection reads the rows instead.
+    pub async fn list_connection_states(config: &TenantComposio) -> Result<Vec<(String, bool)>> {
+        let rows = list_connections_detailed(config).await?;
         let mut states: std::collections::BTreeMap<String, bool> =
             std::collections::BTreeMap::new();
-        for conn in resp.connections {
-            let toolkit = conn.normalized_toolkit();
-            if !toolkit_allowed(&config.toolkits, &toolkit) {
-                continue;
-            }
-            let active = conn.is_active();
+        for row in rows {
             states
-                .entry(toolkit)
-                .and_modify(|c| *c = *c || active)
-                .or_insert(active);
+                .entry(row.toolkit)
+                .and_modify(|c| *c = *c || row.connected)
+                .or_insert(row.connected);
         }
         Ok(states.into_iter().collect())
+    }
+
+    /// Revoke one connected account by its Composio connection id (issue #404).
+    /// Backs the console's `DELETE …/composio/connections/{id}`.
+    ///
+    /// **The id is checked against this tenant's own filtered list first**, and
+    /// an unknown one fails before any delete is attempted. Two reasons, and the
+    /// second is the load-bearing one:
+    ///
+    /// * The backend scopes a delete to the caller's bearer, so another
+    ///   company's connection was never reachable — but a connection belonging
+    ///   to *this* company under a toolkit its manifest does **not** allow is
+    ///   reachable by that bearer, and is deliberately invisible to every read
+    ///   here. Letting an id delete what no read will show would make the
+    ///   allowlist a display filter rather than a boundary.
+    /// * It turns "already disconnected" into a clear answer instead of whatever
+    ///   the upstream returns for a stale id.
+    ///
+    /// Returns `Ok(())` on a completed revoke. A refusal (`deleted: false`) is an
+    /// error rather than a silent success: the console's next line tells the
+    /// operator the account is gone, and it must not say so on the strength of a
+    /// call the backend declined.
+    pub async fn delete_connection(config: &TenantComposio, connection_id: &str) -> Result<()> {
+        let connection_id = connection_id.trim();
+        if connection_id.is_empty() {
+            anyhow::bail!("composio disconnect: connection id must not be empty");
+        }
+        let known = list_connections_detailed(config).await?;
+        if !known.iter().any(|row| row.id == connection_id) {
+            anyhow::bail!("no such connection for this company");
+        }
+        tracing::debug!(connection_id = %connection_id, "[composio] ops delete_connection");
+        let (client, secrets) = live_call(config).await?;
+        match client.delete_connection(connection_id).await {
+            Ok(resp) if resp.deleted => Ok(()),
+            Ok(_) => anyhow::bail!("Composio declined to delete the connection"),
+            Err(err) => Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+        }
     }
 
     /// The backend's live Composio toolkit catalog — every slug it will let
@@ -1556,13 +1684,26 @@ mod ops_helper_tests {
     /// Mock `GET /agent-integrations/composio/connections` — gmail has one
     /// active + one pending row (→ connected), slack only pending (→ not
     /// connected), notion active (filtered out unless allowlisted).
+    ///
+    /// The identity fields exercise each arm of the account-label precedence
+    /// (issue #404): `c1` publishes an email, `c2` only a blank one plus a
+    /// workspace, `c3` only a username, `c4` nothing at all.
     async fn connections_handler() -> axum::Json<Value> {
         axum::Json(json!({
             "success": true,
             "data": { "connections": [
-                { "id": "c1", "toolkit": "gmail", "status": "ACTIVE" },
-                { "id": "c2", "toolkit": "gmail", "status": "INITIATED" },
-                { "id": "c3", "toolkit": "slack", "status": "INITIATED" },
+                {
+                    "id": "c1", "toolkit": "gmail", "status": "ACTIVE",
+                    "createdAt": "2026-08-01T10:00:00Z",
+                    "accountEmail": " ops@acme.test ",
+                    "username": "ignored-when-an-email-is-present"
+                },
+                {
+                    "id": "c2", "toolkit": "gmail", "status": "INITIATED",
+                    "accountEmail": "   ",
+                    "workspace": "Acme Workspace"
+                },
+                { "id": "c3", "toolkit": "slack", "status": "INITIATED", "username": "acme-bot" },
                 { "id": "c4", "toolkit": "notion", "status": "ACTIVE" }
             ] }
         }))
@@ -1678,6 +1819,131 @@ mod ops_helper_tests {
             states,
             vec![("gmail".to_string(), true), ("slack".to_string(), false)],
             "gmail active (one ACTIVE row), slack pending only, notion filtered out"
+        );
+    }
+
+    /// Issue #404: the detail view needs the account behind a connection, not
+    /// just that one exists. Pins the whole projection — per-connection rows
+    /// (two for gmail, where the fold gives one), the raw status, the account
+    /// label precedence, and the `(toolkit, id)` order — against the same
+    /// allowlist filter the fold applies.
+    #[tokio::test]
+    async fn list_connections_detailed_projects_each_account_with_its_identity() {
+        let url = spawn_backend().await;
+        let rows = list_connections_detailed(&config(&url, vec!["gmail".into(), "slack".into()]))
+            .await
+            .expect("list connections");
+
+        // Compared as whole rows rather than as a tuple projection, so a field
+        // added to `ComposioConnectionRow` later cannot slip past this
+        // assertion unexamined.
+        let expect = |id: &str,
+                      toolkit: &str,
+                      status: &str,
+                      connected: bool,
+                      created_at: Option<&str>,
+                      account: Option<&str>| ComposioConnectionRow {
+            id: id.to_string(),
+            toolkit: toolkit.to_string(),
+            status: status.to_string(),
+            connected,
+            created_at: created_at.map(str::to_string),
+            account: account.map(str::to_string),
+        };
+        assert_eq!(
+            rows,
+            vec![
+                // Email wins over the username the same row carries, and is
+                // trimmed.
+                expect(
+                    "c1",
+                    "gmail",
+                    "ACTIVE",
+                    true,
+                    Some("2026-08-01T10:00:00Z"),
+                    Some("ops@acme.test"),
+                ),
+                // A blank email is not an email: falls through to the workspace.
+                // Kept as its own row rather than folded into c1 — this is the
+                // "two Gmail accounts" case a disconnect has to tell apart.
+                expect(
+                    "c2",
+                    "gmail",
+                    "INITIATED",
+                    false,
+                    None,
+                    Some("Acme Workspace"),
+                ),
+                // Username is the last resort.
+                expect("c3", "slack", "INITIATED", false, None, Some("acme-bot")),
+            ],
+            "one row per connection, sorted by (toolkit, id); notion filtered out \
+             by the allowlist exactly as the fold filters it"
+        );
+    }
+
+    /// The fold the tile grid and the reconciliation probe read must keep
+    /// meaning what it meant before #404 widened the call underneath it —
+    /// `connected` is still "any account active", not "the first one".
+    #[tokio::test]
+    async fn the_per_toolkit_fold_still_summarises_the_detailed_rows() {
+        let url = spawn_backend().await;
+        let cfg = config(&url, vec!["gmail".into(), "slack".into()]);
+        let rows = list_connections_detailed(&cfg).await.expect("rows");
+        let states = list_connection_states(&cfg).await.expect("states");
+
+        let folded: std::collections::BTreeMap<String, bool> =
+            rows.into_iter().fold(Default::default(), |mut acc, r| {
+                let e = acc.entry(r.toolkit).or_insert(false);
+                *e = *e || r.connected;
+                acc
+            });
+        assert_eq!(
+            states,
+            folded.into_iter().collect::<Vec<_>>(),
+            "the states route is exactly the OR-fold of the detailed rows"
+        );
+    }
+
+    /// Issue #404 + #403: an id this company's own reads will not show must not
+    /// be deletable by naming it. The mock serves no DELETE route at all, so a
+    /// request that got as far as dialling would fail loudly rather than pass —
+    /// the refusal has to come from the guard, before the call.
+    #[tokio::test]
+    async fn disconnect_refuses_an_id_outside_this_companys_visible_connections() {
+        let url = spawn_backend().await;
+        // `c4` (notion) is a real, active connection upstream — but this
+        // company's manifest does not grant notion, so no read here surfaces
+        // it. That is the case the guard exists for: the bearer *could* delete
+        // it, and the allowlist must be a boundary rather than a display filter.
+        let err = delete_connection(&config(&url, vec!["gmail".into()]), "c4")
+            .await
+            .expect_err("a connection outside the grant is not deletable");
+        assert!(
+            err.to_string().contains("no such connection"),
+            "unexpected error: {err}"
+        );
+
+        // And an id that exists nowhere at all fails the same way.
+        let err = delete_connection(&config(&url, vec!["gmail".into()]), "nope")
+            .await
+            .expect_err("an unknown id is not deletable");
+        assert!(
+            err.to_string().contains("no such connection"),
+            "unexpected error: {err}"
+        );
+    }
+
+    /// An empty / whitespace id is refused before the list is even fetched.
+    #[tokio::test]
+    async fn disconnect_refuses_a_blank_id_before_any_network_call() {
+        // Unreachable backend — the argument check must fire first.
+        let err = delete_connection(&config("http://127.0.0.1:1", vec!["gmail".into()]), "  ")
+            .await
+            .expect_err("a blank id is refused");
+        assert!(
+            err.to_string().contains("must not be empty"),
+            "unexpected error: {err}"
         );
     }
 

--- a/src/harness/composio.rs
+++ b/src/harness/composio.rs
@@ -311,6 +311,33 @@ pub struct ComposioConnectionRow {
     pub account: Option<String>,
 }
 
+/// Why a disconnect did not happen.
+///
+/// Two variants because they are two different sentences to an operator, and —
+/// caught by running the route rather than by a test — two different HTTP
+/// statuses. Collapsing both into one error type reported a refused id as
+/// `502 Bad Gateway`: "the provider is down", about a call that was never made,
+/// for an id the guard rejected locally. The caller cannot re-derive the
+/// distinction from an error string, so the type carries it.
+#[derive(Debug)]
+pub enum DisconnectError {
+    /// The id names nothing this company can see, so there is nothing to
+    /// revoke. A client mistake, not an outage.
+    NotFound(String),
+    /// The call reached Composio, and Composio failed or declined it. Already
+    /// scrubbed of the tenant bearer.
+    Upstream(anyhow::Error),
+}
+
+impl std::fmt::Display for DisconnectError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotFound(message) => f.write_str(message),
+            Self::Upstream(err) => write!(f, "{err}"),
+        }
+    }
+}
+
 #[cfg(feature = "composio")]
 pub use live::{
     ComposioMetering, authorize_connect_url, composio_tools, delete_connection,
@@ -591,21 +618,35 @@ mod live {
     /// error rather than a silent success: the console's next line tells the
     /// operator the account is gone, and it must not say so on the strength of a
     /// call the backend declined.
-    pub async fn delete_connection(config: &TenantComposio, connection_id: &str) -> Result<()> {
+    pub async fn delete_connection(
+        config: &TenantComposio,
+        connection_id: &str,
+    ) -> std::result::Result<(), DisconnectError> {
         let connection_id = connection_id.trim();
         if connection_id.is_empty() {
-            anyhow::bail!("composio disconnect: connection id must not be empty");
+            return Err(DisconnectError::NotFound(
+                "a connection id is required".to_string(),
+            ));
         }
-        let known = list_connections_detailed(config).await?;
+        let known = list_connections_detailed(config)
+            .await
+            .map_err(DisconnectError::Upstream)?;
         if !known.iter().any(|row| row.id == connection_id) {
-            anyhow::bail!("no such connection for this company");
+            return Err(DisconnectError::NotFound(
+                "no such connection for this company".to_string(),
+            ));
         }
         tracing::debug!(connection_id = %connection_id, "[composio] ops delete_connection");
-        let (client, secrets) = live_call(config).await?;
+        let (client, secrets) = live_call(config).await.map_err(DisconnectError::Upstream)?;
         match client.delete_connection(connection_id).await {
             Ok(resp) if resp.deleted => Ok(()),
-            Ok(_) => anyhow::bail!("Composio declined to delete the connection"),
-            Err(err) => Err(anyhow::anyhow!(scrub(&format!("{err}"), &secrets))),
+            Ok(_) => Err(DisconnectError::Upstream(anyhow::anyhow!(
+                "Composio declined to delete the connection"
+            ))),
+            Err(err) => Err(DisconnectError::Upstream(anyhow::anyhow!(scrub(
+                &format!("{err}"),
+                &secrets
+            )))),
         }
     }
 
@@ -1919,9 +1960,12 @@ mod ops_helper_tests {
         let err = delete_connection(&config(&url, vec!["gmail".into()]), "c4")
             .await
             .expect_err("a connection outside the grant is not deletable");
+        // The *variant* is the assertion, not the message: it is what decides
+        // the status code the console sees, and asserting only on the string
+        // is what let a refusal ship as a `502`.
         assert!(
-            err.to_string().contains("no such connection"),
-            "unexpected error: {err}"
+            matches!(err, DisconnectError::NotFound(_)),
+            "a refused id must be NotFound, not an upstream failure: {err:?}"
         );
 
         // And an id that exists nowhere at all fails the same way.
@@ -1929,21 +1973,24 @@ mod ops_helper_tests {
             .await
             .expect_err("an unknown id is not deletable");
         assert!(
-            err.to_string().contains("no such connection"),
-            "unexpected error: {err}"
+            matches!(err, DisconnectError::NotFound(_)),
+            "unexpected error: {err:?}"
         );
     }
 
-    /// An empty / whitespace id is refused before the list is even fetched.
+    /// An empty / whitespace id is refused before the list is even fetched —
+    /// and as a client mistake, not as an unreachable backend.
     #[tokio::test]
     async fn disconnect_refuses_a_blank_id_before_any_network_call() {
-        // Unreachable backend — the argument check must fire first.
+        // Unreachable backend — the argument check must fire first. If it did
+        // not, this would surface as `Upstream`, which is what the assertion
+        // below rules out.
         let err = delete_connection(&config("http://127.0.0.1:1", vec!["gmail".into()]), "  ")
             .await
             .expect_err("a blank id is refused");
         assert!(
-            err.to_string().contains("must not be empty"),
-            "unexpected error: {err}"
+            matches!(err, DisconnectError::NotFound(_)),
+            "unexpected error: {err:?}"
         );
     }
 

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -62,7 +62,8 @@
 
 use axum::Json;
 use axum::Router;
-use axum::routing::{get, post, put};
+use axum::extract::Path;
+use axum::routing::{delete, get, post, put};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -221,16 +222,21 @@ async fn fetch_catalog(_runtime: &CompanyRuntime) -> Result<Vec<CatalogEntry>, S
 ///
 /// The read/write-token plane (`GET …/composio`, `PUT …/composio/token`) is
 /// always present. The per-provider OAuth sign-in plane (`POST
-/// …/composio/authorize`, `GET …/composio/connections`) is **also** always
-/// present in the route table — mirroring how `get_status` stays wired and
-/// reports `inBuild:false` rather than `#[cfg]`-ing itself out — but its
-/// handlers only reach the live Composio client under the `composio` feature;
-/// otherwise they answer `409 Conflict` "not in this build".
+/// …/composio/authorize`, `GET …/composio/connections`, `DELETE
+/// …/composio/connections/{connection_id}`) is **also** always present in the
+/// route table — mirroring how `get_status` stays wired and reports
+/// `inBuild:false` rather than `#[cfg]`-ing itself out — but its handlers only
+/// reach the live Composio client under the `composio` feature; otherwise they
+/// answer `409 Conflict` "not in this build".
 pub fn router() -> Router<AppState> {
     scoped("/composio", get(get_status))
         .merge(scoped("/composio/token", put(set_token)))
         .merge(scoped("/composio/authorize", post(authorize)))
         .merge(scoped("/composio/connections", get(connections)))
+        .merge(scoped(
+            "/composio/connections/{connection_id}",
+            delete(disconnect),
+        ))
 }
 
 /// The company's Composio status as the console renders it. **Never** carries the
@@ -346,11 +352,50 @@ struct AuthorizeDto {
 /// One per-toolkit connected state in the `GET …/composio/connections`
 /// response: `connected` is true when the company has at least one active
 /// connection for that toolkit.
+///
+/// [`accounts`](Self::accounts) was added for the provider detail view (issue
+/// #404) **additively**: `toolkit` and `connected` keep their exact previous
+/// meaning, so the tile grid and the post-authorize poll that read only those
+/// two are untouched by it. A detail view therefore needs no second route and
+/// no second round-trip — the call the page already makes now carries enough to
+/// open a provider.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ConnectionDto {
     toolkit: String,
     connected: bool,
+    /// Every connection this company holds for the toolkit, oldest id first.
+    ///
+    /// Usually one. Composio permits several accounts per toolkit, and a company
+    /// that connected Gmail twice needs to see which is which before revoking
+    /// one — the concrete reason `connected: bool` alone could not back a
+    /// disconnect.
+    accounts: Vec<ConnectedAccountDto>,
+}
+
+/// One connected account inside a [`ConnectionDto`] (issue #404).
+///
+/// A non-secret projection of
+/// [`ComposioConnectionRow`](crate::harness::composio::ComposioConnectionRow) —
+/// see its docs for why the id is safe to hand the console.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ConnectedAccountDto {
+    /// Composio's connection id — the path segment `DELETE …/connections/{id}`
+    /// takes.
+    id: String,
+    /// Composio's raw status string, forwarded verbatim so the console can tell
+    /// "never set up" from "set up and expired".
+    status: String,
+    /// Whether this individual account is usable.
+    connected: bool,
+    /// When Composio recorded the connection, when it says.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    created_at: Option<String>,
+    /// The account label, when the provider published one. Omitted rather than
+    /// guessed — see the row type's docs.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    account: Option<String>,
 }
 
 /// Which tier a company's Composio credential comes from.
@@ -597,7 +642,7 @@ async fn authorize_impl(
 #[cfg(feature = "composio")]
 async fn connections_impl(runtime: &CompanyRuntime) -> Result<Json<Vec<ConnectionDto>>, ApiError> {
     let config = resolve_tenant(runtime).await?;
-    let states = crate::harness::composio::list_connection_states(&config)
+    let rows = crate::harness::composio::list_connections_detailed(&config)
         .await
         .map_err(|err| {
             ApiError(crate::error::OpenCompanyError::TinyHumans {
@@ -605,12 +650,108 @@ async fn connections_impl(runtime: &CompanyRuntime) -> Result<Json<Vec<Connectio
                 message: err.to_string(),
             })
         })?;
-    Ok(Json(
-        states
-            .into_iter()
-            .map(|(toolkit, connected)| ConnectionDto { toolkit, connected })
-            .collect(),
-    ))
+    Ok(Json(group_by_toolkit(rows)))
+}
+
+/// Fold per-connection rows into the per-toolkit response shape.
+///
+/// `connected` is `true` when **any** account for the toolkit is active — the
+/// same rule the pre-#404 route applied, kept here so the boolean the tile grid
+/// reads cannot drift from what it meant before the accounts were added.
+///
+/// A `BTreeMap` gives the toolkit ordering the route has always had; the rows
+/// arrive already sorted by `(toolkit, id)`, so the per-toolkit account order is
+/// stable too. Split out from the handler so it is testable without a live
+/// Composio backend.
+#[cfg(feature = "composio")]
+fn group_by_toolkit(
+    rows: Vec<crate::harness::composio::ComposioConnectionRow>,
+) -> Vec<ConnectionDto> {
+    let mut by_toolkit: std::collections::BTreeMap<String, ConnectionDto> =
+        std::collections::BTreeMap::new();
+    for row in rows {
+        let entry = by_toolkit
+            .entry(row.toolkit.clone())
+            .or_insert_with(|| ConnectionDto {
+                toolkit: row.toolkit.clone(),
+                connected: false,
+                accounts: Vec::new(),
+            });
+        entry.connected = entry.connected || row.connected;
+        entry.accounts.push(ConnectedAccountDto {
+            id: row.id,
+            status: row.status,
+            connected: row.connected,
+            created_at: row.created_at,
+            account: row.account,
+        });
+    }
+    by_toolkit.into_values().collect()
+}
+
+/// `DELETE …/composio/connections/{id}` — revoke one connected account
+/// (issue #404).
+///
+/// **Admin-only** (issue #403), for the same reason `authorize` is: the
+/// connection belongs to the company, so removing the account its agents act
+/// through is a decision made on the company's behalf. Journaled on success
+/// only, alongside the connect it reverses.
+///
+/// What this does and does not revoke matters, and the console says so before
+/// asking: it removes the connection **at Composio**, so agents lose the
+/// capability on their next turn. It does not sign the company out of the
+/// provider, and it does not touch the native `oauth/{provider}` catalog entry,
+/// which is a separate credential this plane has never owned.
+async fn disconnect(
+    company: AdminScopedCompany,
+    Path(ConnectionPath { connection_id }): Path<ConnectionPath>,
+) -> Result<Json<DisconnectDto>, ApiError> {
+    let dto = disconnect_impl(company.runtime.as_ref(), &connection_id).await?;
+    journal(&company, "provider_disconnected", None).await?;
+    Ok(dto)
+}
+
+/// The sub-resource path (`connection_id`); the scope `id` is consumed by the
+/// extractor.
+#[derive(Debug, Deserialize)]
+struct ConnectionPath {
+    connection_id: String,
+}
+
+/// `DELETE …/composio/connections/{id}` response. A body rather than a bare 204
+/// so the console can state what happened in the same words the host used.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct DisconnectDto {
+    /// Plain-language confirmation, scoped to what was actually revoked.
+    note: String,
+}
+
+#[cfg(feature = "composio")]
+async fn disconnect_impl(
+    runtime: &CompanyRuntime,
+    connection_id: &str,
+) -> Result<Json<DisconnectDto>, ApiError> {
+    let config = resolve_tenant(runtime).await?;
+    crate::harness::composio::delete_connection(&config, connection_id)
+        .await
+        .map_err(|err| {
+            ApiError(crate::error::OpenCompanyError::TinyHumans {
+                code: "composio_disconnect".to_string(),
+                message: err.to_string(),
+            })
+        })?;
+    Ok(Json(DisconnectDto {
+        note: "Disconnected at Composio. Agents lose these tools on their next turn.".to_string(),
+    }))
+}
+
+#[cfg(not(feature = "composio"))]
+async fn disconnect_impl(
+    _runtime: &CompanyRuntime,
+    _connection_id: &str,
+) -> Result<Json<DisconnectDto>, ApiError> {
+    Err(not_in_build())
 }
 
 /// A `409 Conflict` "Composio is not in this build" — the OAuth plane's off-state
@@ -1570,5 +1711,77 @@ mod tests {
             send(&state, "GET", "/api/v1/company/composio/connections", None).await;
         assert_eq!(status, StatusCode::CONFLICT, "{raw}");
         assert_eq!(body["code"], "conflict", "{body}");
+    }
+
+    /// The disconnect added for #404 is wired on the same terms as the rest of
+    /// the OAuth plane: present in the route table whatever the build, and a
+    /// `409` — never a `404` — when there is no usable client. A `404` here
+    /// would read as "no such connection", which is a claim about the company's
+    /// accounts that this build cannot make.
+    #[tokio::test]
+    async fn disconnect_route_conflicts_without_build_or_token() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n[tools]\nallow = [\"composio\"]\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        )
+        .await;
+
+        let (status, body, raw) = send(
+            &state,
+            "DELETE",
+            "/api/v1/company/composio/connections/conn-1",
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::CONFLICT, "{raw}");
+        assert_eq!(body["code"], "conflict", "{body}");
+    }
+
+    /// Issue #404: the per-toolkit shape the tile grid reads is a fold over the
+    /// per-connection rows, and the fold must not lose an account or flip a
+    /// boolean. Pure — no live backend needed.
+    #[cfg(feature = "composio")]
+    #[test]
+    fn grouping_keeps_every_account_and_ors_their_connected_state() {
+        use crate::harness::composio::ComposioConnectionRow;
+
+        let row = |id: &str, toolkit: &str, connected: bool, account: Option<&str>| {
+            ComposioConnectionRow {
+                id: id.to_string(),
+                toolkit: toolkit.to_string(),
+                status: if connected { "ACTIVE" } else { "INITIATED" }.to_string(),
+                connected,
+                created_at: None,
+                account: account.map(str::to_string),
+            }
+        };
+
+        let out = super::group_by_toolkit(vec![
+            row("c1", "gmail", false, Some("a@acme.test")),
+            row("c2", "gmail", true, Some("b@acme.test")),
+            row("c3", "slack", false, None),
+        ]);
+
+        assert_eq!(out.len(), 2, "one entry per toolkit");
+        assert_eq!(out[0].toolkit, "gmail");
+        assert!(
+            out[0].connected,
+            "a toolkit is connected when ANY of its accounts is — the second row \
+             here, which a first-row-wins fold would have missed"
+        );
+        assert_eq!(
+            out[0]
+                .accounts
+                .iter()
+                .map(|a| (a.id.as_str(), a.connected))
+                .collect::<Vec<_>>(),
+            vec![("c1", false), ("c2", true)],
+            "both accounts survive, in the order the rows arrived"
+        );
+        assert_eq!(out[1].toolkit, "slack");
+        assert!(!out[1].connected, "no active account, so not connected");
+        assert_eq!(out[1].accounts.len(), 1);
     }
 }

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -732,14 +732,26 @@ async fn disconnect_impl(
     runtime: &CompanyRuntime,
     connection_id: &str,
 ) -> Result<Json<DisconnectDto>, ApiError> {
+    use crate::harness::composio::DisconnectError;
+
     let config = resolve_tenant(runtime).await?;
     crate::harness::composio::delete_connection(&config, connection_id)
         .await
-        .map_err(|err| {
-            ApiError(crate::error::OpenCompanyError::TinyHumans {
-                code: "composio_disconnect".to_string(),
-                message: err.to_string(),
-            })
+        // An id this company cannot see is a `404`, not a `502`. Both were the
+        // latter until the route was actually run: the console would have told
+        // an operator the provider was unreachable about a call that never left
+        // the host, and a retry — the obvious response to a bad gateway — would
+        // fail identically forever.
+        .map_err(|err| match err {
+            DisconnectError::NotFound(message) => {
+                ApiError(crate::error::OpenCompanyError::NotFound(message))
+            }
+            DisconnectError::Upstream(err) => {
+                ApiError(crate::error::OpenCompanyError::TinyHumans {
+                    code: "composio_disconnect".to_string(),
+                    message: err.to_string(),
+                })
+            }
         })?;
     Ok(Json(DisconnectDto {
         note: "Disconnected at Composio. Agents lose these tools on their next turn.".to_string(),

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -5969,6 +5969,14 @@ async fn a_member_cannot_change_what_the_company_reaches_the_world_as() {
             "/api/v1/company/composio/authorize",
             Some(json!({ "toolkit": "gmail" })),
         ),
+        // Revoking one of those accounts is the same decision as choosing it
+        // (issue #404) — a member who cannot connect must not be able to
+        // disconnect either.
+        (
+            "DELETE",
+            "/api/v1/company/composio/connections/conn-1",
+            None,
+        ),
         // The model every agent thinks with, and the key it is billed against.
         (
             "PUT",


### PR DESCRIPTION
## Summary

Server groundwork for #404. **This does not close it** — nothing an operator sees has changed yet; the detail view itself is a follow-up. What it removes is the reason that view could not be built.

#404 reads as a console issue, but the blocker was one layer lower: the host destroyed the data a detail view needs before the console ever saw it. The vendored Composio client returns `id`, `status`, `createdAt`, `accountEmail`, `workspace`, `username` per connection (`vendor/openhuman/.../composio/types.rs`). `list_connection_states` folded all of it into `Vec<(String, bool)>`, and `GET …/composio/connections` shipped `{toolkit, connected}`. A connection reached the UI as a boolean, so there was nothing to open — and no amount of frontend work could have changed that.

Second, there was no way to disconnect a Composio connection at all. The router was four routes, none of them a DELETE, while `delete_connection` sat unused in the vendored client. The page's only Disconnect revokes the **native** credential — the one #396 established nothing reads — so the connection agents actually run on could not be revoked, and the one that could be revoked does nothing.

**What this changes**

- `list_connections_detailed` returns one row per connection. `list_connection_states` becomes a projection over it: one network call, one allowlist filter, one scrub, and the per-toolkit OR-fold the tile grid and the `connections_read` probe consume is unchanged in meaning.
- `GET …/composio/connections` gains `accounts[]` per toolkit — **additively**. `toolkit` and `connected` keep their exact previous meaning, so the tile grid and the post-authorize poll are untouched, and the detail view needs no second route and no second round-trip.
- `DELETE …/composio/connections/{connection_id}`, admin-only (#403) on the same grounds as `authorize`: revoking the account the company acts through is a decision made on the company's behalf. It joins the `a_member_cannot_change_what_the_company_reaches_the_world_as` table rather than getting a bespoke test, which is what that table is for.

**Two judgement calls worth reviewing**

*The delete guard is a boundary, not politeness.* The id is checked against this company's own filtered list before dialling. The tenant bearer **can** reach a connection whose toolkit the manifest does not grant, and every read here deliberately hides those; letting an id revoke what no read will show would demote the allowlist to a display filter. Proven end-to-end below.

*The account label is derived server-side* (email → workspace → handle, blank treated as absent), mirroring OpenHuman's `deriveConnectionLabel`, so the precedence is stated and tested once rather than re-derived in the console.

**Not in scope, deliberately**

Per-connection usage. It turns out no server work is needed: `byProvider` on the existing usage route is already keyed by toolkit slug and fed by an `OauthCall` sample per successful `composio_execute`, so the detail view can show honest call counts for Composio. Nothing meters MCP or native, and per #404 those must say so on screen rather than render a plausible zero.

#582 (two sources of truth on one page) is still open and still the sequencing risk it names: whichever list the detail view opens from should be the single source that issue establishes.

## API Or Behavior Changes

- `GET …/composio/connections` — **additive**. New `accounts[]` per toolkit: `{ id, status, connected, createdAt?, account? }`. Existing `toolkit` / `connected` fields unchanged in shape and meaning; no console change is required by this PR.
- `DELETE …/composio/connections/{connection_id}` — **new**. Admin-only. `200 {note}` on success; `404` for an id this company cannot see; `502` when Composio itself fails; `409` on a build without the `composio` feature (never `404`, which would read as "no such connection" — a claim about the company's accounts that such a build cannot make).
- Journals one `ToolAccessChanged { change: "provider_disconnected" }` on success only, attributed to the admin.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default build; and `--features composio` on 1.96.1, clean for this crate — the `-D warnings` failures you'll see workspace-wide are pre-existing `large_enum_variant` lints in vendored `tinyagents`)
- [x] `cargo build --bin opencompany --features composio`
- [x] `cargo test --features composio --lib composio` — **102 passed, 1 failed**

The one failure is `server::ops::composio::tests::an_admin_is_unaffected`. It is **pre-existing and environment-dependent**: it dials the real `api.tinyhumans.ai` on the *authorize* route and gets `502` instead of `409`. Reproduced identically on clean `upstream/main` with this branch's changes stashed. This branch does not touch `authorize`.

Six new tests: the account projection (label precedence, allowlist filter, `(toolkit, id)` order), fold-equivalence with the detailed rows, both disconnect guards, the grouping fold, and the route's not-in-build conflict.

**Driven end-to-end against a mock Composio backend** (real host, real magic-link auth, real router), which is what the unit tests could not prove:

- A company with two Gmail accounts renders both, distinguishable by email — the case a boolean structurally could not express.
- Slack reports `connected: false` with `status: "INITIATED"` preserved, so "pending" is distinguishable from "never set up".
- `DELETE conn-gmail-1` → `200`, gone from the next read, `gmail` still `connected: true` via the surviving account, one attributed audit entry.
- A connection outside the allowlist (`notion`, genuinely connected upstream) → `404`, and the mock's request log shows **no DELETE ever left the host**; it survives upstream.

That run also caught a bug the tests missed: both refusals originally returned `502`, because every failure mapped to `OpenCompanyError::TinyHumans`. So a locally-rejected id reported as "the provider is unreachable", and a retry — the obvious response to a bad gateway — would have failed identically forever. Fixed with a typed `DisconnectError` (`NotFound` → 404, `Upstream` → 502); the tests now assert the variant rather than the message, since the variant is what picks the status and the message assertion is exactly what let it through.

## Documentation

Rustdoc on the changed surfaces carries the reasoning: why the fold is lossy and what still reads it, why the delete guard is a boundary rather than politeness, and why the not-in-build answer is `409` rather than `404`. No `docs/` page describes this route's response shape, so none needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
