### PR TITLE
fix(connections): one provider grid, one source of truth (#582)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -334,6 +334,41 @@ there is **no Slack provider** at all (the backend's only Slack credential is an
 internal alerting bot), so Slack has no hosted route except Composio, which runs
 its own OAuth.
 
+### One connection status, for one console list (issue #582)
+
+`GET …/connections` is the **only** answer to "what is connected". It reconciles
+the native `oauth/{provider}` catalog with a live Composio probe into one row per
+provider, marking which namespaces reported it in `via` — and the console renders
+exactly one provider grid from it (`frontend/src/lib/provider-grid.ts`).
+
+That took removing a gate. `composio_view` used to discard the Composio half
+unless the company explicitly granted the `composio` tool namespace, while
+`GET …/composio/connections` — which the console's *other* provider list read —
+never consulted the grant. The two lists therefore disagreed by construction, not
+by timing: 13 of the 21 shipped companies grant no `composio`, so for most of
+them one screen said both "connected" and "not connected" about the same account,
+and the second list's Connect button was actionable.
+
+The grant governs whether **agents receive Composio tools**. It never governed
+whether a handshake completes — `resolve_tenant` reads the credential and the
+toolkit allowlist and nothing else, so the sign-in the gate hid worked perfectly
+well from the surface that ignored it. It is now reported (`granted` on
+`GET …/composio`) and stated as a caveat next to the connected badge, rather than
+silently deciding what the page may show.
+
+Two consequences worth knowing:
+
+- The probe now runs for any company holding a credential, not only granting
+  ones. It stays bounded by `COMPOSIO_PROBE_TIMEOUT` and still degrades to
+  `unverified` rather than to a confident "not connected".
+- `reconcile` is split from `project_connections` purely as a test seam: the
+  probe is a network call with no injection point, and the removed gate lived on
+  the far side of it, which is how it survived unasserted.
+
+No host route releases a Composio connection — `…/connections/{provider}/disconnect`
+blanks this host's own secret — so the console offers Disconnect only for a row
+whose `via` includes `native`.
+
 ## tiny.place A2A inbound + discovery (`tinyplace` feature)
 
 Behind the `tinyplace` feature the server mounts the agent-to-agent surface

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -207,14 +207,25 @@ it. Responses mirror the TypeScript models in `src/lib/*` and `src/api/types.ts`
   revenue, byCategory, transactions). **Caveat:** the inference-cost component
   of spend is `0` until openhuman#4940 (as with Usage).
 
-### Connections — `src/views/ConnectionsView.tsx`, `src/lib/connections.ts`
-- OAuth catalog with connect/disconnect and connected-account state.
+### Connections — `src/views/ConnectionsView.tsx`, `src/lib/provider-grid.ts`
+- **One** provider grid with connect/disconnect and connected-account state,
+  plus the credential sections above it (MCP, inference, company key, Composio
+  token, channels).
 - **Source:** ✅ real (feature `oauth`) — `Company.connections` (GraphQL) reads
   manifest intent (`[[connection]]`) + live OAuth status; `POST
   …/connections/{provider}/start` returns the authorize URL,
   `…/disconnect` drops tokens, and `GET /api/v1/oauth/callback` completes the
   flow. Without the `oauth` feature the write routes `404 not_wired` and the
   console shows the read-only catalog.
+- **One list, one answer (issue #582).** The page used to render two provider
+  lists — `ComposioSection`'s grid off `GET …/composio/connections`, and a
+  categorised grid of eleven hardcoded tiles off `GET …/connections` — which
+  applied different rules to the same Composio state and so disagreed on screen.
+  Now: `GET …/connections` is the sole status source, the backend's Composio
+  catalog is the sole list of what can be connected, `src/lib/connections.ts` is
+  native-route metadata rather than a list, and `src/lib/provider-grid.ts` merges
+  the three into the rows `ProvidersSection` renders. `ComposioSection` keeps
+  only the credential layer.
 
 ### Domain & Email (Settings) — `src/components/domain-settings.tsx`, `src/lib/domain.ts`
 - Custom domain with generated DNS records (verification TXT, CNAME, DKIM, SPF)

--- a/frontend/src/lib/composio-catalog.ts
+++ b/frontend/src/lib/composio-catalog.ts
@@ -416,10 +416,10 @@ export function availableCategories(rows: readonly ProviderRow[]): ProviderCateg
  * cleared the chip would be the more common design and the more annoying one:
  * it throws away half of what the operator already told us.
  */
-export function filterByCategory(
-  rows: readonly ProviderRow[],
+export function filterByCategory<T extends ProviderRow>(
+  rows: readonly T[],
   category: ProviderCategory,
-): ProviderRow[] {
+): T[] {
   if (category === "All") return [...rows];
   return rows.filter((row) => row.category === category);
 }
@@ -433,7 +433,10 @@ export function filterByCategory(
  * types "invoices" and should still reach Stripe. That third case is new with
  * #600 — before it, there was no description on the wire to match against.
  */
-export function filterProviderRows(rows: readonly ProviderRow[], query: string): ProviderRow[] {
+export function filterProviderRows<T extends ProviderRow>(
+  rows: readonly T[],
+  query: string,
+): T[] {
   const q = query.trim().toLowerCase();
   if (!q) return [...rows];
   return rows.filter(
@@ -455,11 +458,11 @@ export function filterProviderRows(rows: readonly ProviderRow[], query: string):
  * button that stood between the operator and the catalog is gone rather than
  * relabelled.
  */
-export function visibleProviderRows(
-  rows: readonly ProviderRow[],
+export function visibleProviderRows<T extends ProviderRow>(
+  rows: readonly T[],
   category: ProviderCategory,
   query: string,
-): ProviderRow[] {
+): T[] {
   return filterProviderRows(filterByCategory(rows, category), query);
 }
 

--- a/frontend/src/lib/connections.ts
+++ b/frontend/src/lib/connections.ts
@@ -1,6 +1,19 @@
-// The catalog of third-party accounts a company can act through. This is the
-// console's view of what *can* be connected; whether a host can actually run
-// the OAuth handshake depends on its `/connections` surface (see the client).
+// Metadata for the providers this console knows natively, and the rule that
+// decides how a tile's button behaves.
+//
+// ## Not the page's provider list (issue #582)
+//
+// It used to be one, rendered as a categorised grid of eleven tiles *alongside*
+// a second grid built from the backend's live Composio catalog — two lists, two
+// status routes, and a page that could say a provider was both connected and
+// not connected. The page now renders one grid (`lib/provider-grid.ts`), whose
+// membership is the backend catalog and whose status is `GET …/connections`.
+//
+// What `CONNECTION_PROVIDERS` still owns is what only the console can know:
+// which ids the host's `well_known` table can run a native handshake for, the
+// Composio slug each maps to, and the brand colours. It also supplies the tiles
+// on a host with no Composio at all, where the backend catalog comes back empty
+// and these eleven are the whole page.
 //
 // ## Two routes, one tile (issue #599)
 //
@@ -248,7 +261,14 @@ export function connectionStateFor<T extends { provider: string; connected?: boo
 export interface ComposioReach {
   /** Whether the `composio` feature is compiled into this build. */
   inBuild: boolean;
-  /** Whether the company explicitly grants `composio`. */
+  /**
+   * Whether the company explicitly grants the `composio` tool namespace.
+   *
+   * **Not part of the routing decision** (issue #582) — carried so the grid can
+   * caveat a connection the agents cannot use yet. See
+   * {@link composioCanAuthorize} for why gating on it was the page's
+   * contradiction rather than a safeguard.
+   */
   granted: boolean;
   /**
    * Whether a credential of **any** tier resolves; `none` means there is
@@ -277,9 +297,27 @@ export interface ComposioReach {
  * it would just move the 400 from one backend to the other. In open mode the
  * effective list is a *display* list, not a limit — any slug the backend permits
  * is reachable — so it is deliberately not consulted (issue #397).
+ *
+ * ## The `composio` grant is deliberately not consulted (issue #582)
+ *
+ * It used to be, and that was half of the page's self-contradiction. The grant
+ * governs whether **agents receive Composio tools** — it is not a property of
+ * whether a sign-in can complete. `POST …/composio/authorize` never checked it
+ * (`resolve_tenant` in `src/server/ops/composio.rs` reads the credential and the
+ * toolkit allowlist, and nothing else), so the sign-in this predicate refused to
+ * offer worked perfectly well from the provider list that ignored the grant.
+ * One surface said "connect me", the other said "no route" — for the same
+ * account, on the same screen.
+ *
+ * Reinstating the gate on the other surface instead would have been the wrong
+ * repair: it would take away a sign-in operators use today and leave them no
+ * way to connect an account before granting the namespace. So the grant stops
+ * being a route decision and becomes what it always described — a caveat the
+ * grid states plainly ("connected, but agents will not receive its tools until
+ * `composio` is granted"), sourced from {@link ComposioReach.granted}.
  */
 export function composioCanAuthorize(reach: ComposioReach | null, toolkit: string): boolean {
-  if (!reach || !reach.inBuild || !reach.granted || !reach.hasCredential) return false;
+  if (!reach || !reach.inBuild || !reach.hasCredential) return false;
   if (reach.openMode) return true;
   const wanted = toolkitSlug(toolkit);
   return reach.effectiveToolkits.some((slug) => toolkitSlug(slug) === wanted);
@@ -342,7 +380,11 @@ export type ConnectRoute =
  * Connect — which is exactly the outcome #599 is about.
  */
 export function connectRoute(
-  provider: ConnectionProvider,
+  // Only the toolkit slug is read, and the merged grid (issue #582) routes tiles
+  // that have no `ConnectionProvider` entry at all — every provider the backend
+  // catalog offers, not just the eleven with local metadata. Narrowing the
+  // parameter to what the rule actually uses is what lets one rule serve both.
+  provider: Pick<ConnectionProvider, "toolkit">,
   state: { credentialSource?: string } | undefined,
   reach: ComposioReach | null,
 ): ConnectRoute {

--- a/frontend/src/lib/provider-grid.ts
+++ b/frontend/src/lib/provider-grid.ts
@@ -1,0 +1,214 @@
+// The Connections page's ONE provider grid (issue #582).
+//
+// ## What this replaces
+//
+// The page used to render two provider lists and neither consulted the other:
+//
+//  1. `ComposioSection`'s tile grid, built from the backend's live Composio
+//     catalog and its own `GET …/composio/connections` probe;
+//  2. a categorised grid built from the eleven hardcoded `CONNECTION_PROVIDERS`
+//     tiles, whose status came from `GET …/connections`.
+//
+// So Gmail appeared twice on one screen — connected in one grid, offering a
+// Connect button in the other — and the lower grid's button was actionable, so
+// an operator who trusted it would start a second sign-in for an account
+// already connected.
+//
+// The two grids disagreeing was not a rendering accident. Each read a
+// *different* route, and the two routes applied different rules to the same
+// underlying Composio state: `GET …/connections` discarded it entirely unless
+// the company explicitly granted the `composio` tool namespace, while
+// `GET …/composio/connections` never consulted the grant. 13 of the 21 shipped
+// companies grant no `composio`, so for most of them the contradiction was the
+// steady state rather than a race. That gate is gone (see `composio_view` in
+// `src/server/ops/connections_read.rs`), which is what makes one grid possible:
+// `GET …/connections` is now a complete answer to "what is connected", across
+// both namespaces, for every provider — not just the ones a manifest declared.
+//
+// ## The division of labour, now that there is one grid
+//
+//  - **What is connected** comes from `GET …/connections` alone. It is the only
+//    route that reconciles the native `oauth/{provider}` catalog with Composio,
+//    and it is the answer an agent's tool belt is built from.
+//  - **What can be connected** comes from the backend's Composio catalog, plus
+//    the local `CONNECTION_PROVIDERS` tiles for the native-only hatch.
+//  - **How to connect it** is `connectRoute`, unchanged and still the single
+//    rule the tile renders and the click calls.
+//
+// `CONNECTION_PROVIDERS` is consequently no longer a *list* — the backend
+// catalog is. It is metadata for the native route: which ids the host's
+// `well_known` table can run an OAuth handshake for, and the brand colours for
+// tiles the backend catalog does not cover.
+
+import type { ComposioToolkitEntry } from "@/api/composio";
+import type { ConnectionState } from "@/api/types";
+import {
+  buildProviderRows,
+  type ProviderRow,
+} from "@/lib/composio-catalog";
+import {
+  CONNECTION_PROVIDERS,
+  connectRoute,
+  toolkitSlug,
+  type ComposioReach,
+  type ConnectRoute,
+  type ConnectionProvider,
+} from "@/lib/connections";
+
+/** One tile in the merged grid: what to draw, and what a click does. */
+export interface GridProvider extends ProviderRow {
+  /**
+   * The id the *host* knows this provider by — what `startConnection` and
+   * `disconnectConnection` are called with, and what a manifest declares.
+   *
+   * Distinct from {@link ProviderRow.slug}, which is Composio's spelling and
+   * what `POST …/composio/authorize` takes. They differ for every hyphenated
+   * tile (`google-calendar` / `googlecalendar`) and outright for `x` /
+   * `twitter`, so collapsing them into one field would silently send one
+   * namespace's key to the other's route. Falls back to the slug for a provider
+   * the local catalog has no tile for — which is most of them, and is correct:
+   * a provider with no native metadata has no native route to name.
+   */
+  providerId: string;
+  /** How this tile's button behaves — rendered from and acted on identically. */
+  route: ConnectRoute;
+  /** The namespaces reporting it connected. Empty when it is not. */
+  via: ("native" | "composio")[];
+  /**
+   * A Composio path exists but could not be read, so `connected: false` means
+   * "unknown", not "no". The tile must say so rather than painting a confident
+   * disconnected state over an unanswered probe.
+   */
+  unverified: boolean;
+  /** The connected account label, when the host knows one. Never a credential. */
+  account?: string;
+  /**
+   * Whether a local Disconnect can actually do anything.
+   *
+   * `DELETE …/connections/{provider}` blanks the host's own `oauth/{provider}`
+   * secret and best-effort revokes it upstream. It does **not** touch a Composio
+   * connection, and there is no host route that does. So a tile connected only
+   * through Composio must not offer a Disconnect: it would blank a secret that
+   * was never there, report success, and leave the tile connected on the next
+   * refresh — the same "the page says two things" failure in a different place.
+   */
+  canDisconnect: boolean;
+}
+
+/** The local tile for a Composio slug, when the console has metadata for one. */
+function nativeTileFor(slug: string): ConnectionProvider | undefined {
+  return CONNECTION_PROVIDERS.find((p) => toolkitSlug(p.toolkit) === slug);
+}
+
+/**
+ * Collapse the host's connection rows into `slug -> connected`.
+ *
+ * Normalized and OR-ed rather than indexed, because the host can emit two rows
+ * for one provider when an id and its Composio slug do not normalize alike: a
+ * manifest declaring `provider = "x"` yields a disconnected `x` row while
+ * Composio's connected state arrives separately as `twitter`. Both must land on
+ * the same tile, and connected must win — the union the host already performs
+ * within a row, extended across the alias it cannot see.
+ */
+function connectedBySlug(
+  states: Readonly<Record<string, ConnectionState>>,
+): Record<string, boolean> {
+  const out: Record<string, boolean> = {};
+  for (const state of Object.values(states)) {
+    const key = toolkitSlug(state.provider);
+    // Fold the alias too, so a `twitter` row also marks the `x` tile connected
+    // for a console that keys the tile by its id rather than its slug.
+    const tile = CONNECTION_PROVIDERS.find(
+      (p) => toolkitSlug(p.id) === key || toolkitSlug(p.toolkit) === key,
+    );
+    for (const alias of new Set([key, tile ? toolkitSlug(tile.toolkit) : key])) {
+      out[alias] = out[alias] === true || state.connected;
+    }
+  }
+  return out;
+}
+
+/**
+ * Every host row that speaks about one tile, most-informative first.
+ *
+ * A connected row wins over a disconnected one for the alias reason above; among
+ * equals the row carrying `via`/`account` is preferred, so a tile does not lose
+ * its account label to an empty duplicate.
+ */
+function statesFor(
+  row: { slug: string; providerId: string },
+  states: Readonly<Record<string, ConnectionState>>,
+): ConnectionState[] {
+  const wanted = new Set([toolkitSlug(row.slug), toolkitSlug(row.providerId)]);
+  return Object.values(states)
+    .filter((s) => wanted.has(toolkitSlug(s.provider)))
+    .sort((a, b) => {
+      if (a.connected !== b.connected) return a.connected ? -1 : 1;
+      return (b.via?.length ?? 0) - (a.via?.length ?? 0);
+    });
+}
+
+/**
+ * Build the page's single provider grid.
+ *
+ * `catalog` is the backend's Composio catalog (or the manifest allowlist, or a
+ * flagged fallback — the host already decided which, and re-deciding here is how
+ * the two lists drifted apart in the first place). `extra` carries slugs
+ * connected through the by-slug escape hatch this session. `states` is
+ * `GET …/connections`, the sole authority on connected. `reach` and
+ * `platformManaged` feed `connectRoute`.
+ *
+ * The tail is the point of the union: `CONNECTION_PROVIDERS` tiles whose toolkit
+ * the catalog did not offer are appended anyway. A host with Composio switched
+ * off returns an empty catalog, and without this the page would render nothing
+ * at all rather than the eleven native tiles a self-hoster can genuinely use.
+ */
+export function buildGridProviders(
+  catalog: readonly ComposioToolkitEntry[],
+  extra: readonly string[],
+  states: Readonly<Record<string, ConnectionState>>,
+  reach: ComposioReach | null,
+  platformManaged: boolean,
+): GridProvider[] {
+  const offered = new Set(catalog.map((entry) => toolkitSlug(entry.slug)));
+  const nativeOnly: ComposioToolkitEntry[] = CONNECTION_PROVIDERS.filter(
+    (p) => !offered.has(toolkitSlug(p.toolkit)),
+  ).map((p) => ({
+    slug: p.toolkit,
+    name: p.name,
+    description: p.description,
+    logo: null,
+    categories: [],
+  }));
+
+  const rows = buildProviderRows(
+    [...catalog, ...nativeOnly],
+    extra,
+    connectedBySlug(states),
+  );
+
+  return rows.map((row) => {
+    const tile = nativeTileFor(row.slug);
+    const providerId = tile?.id ?? row.slug;
+    const matched = statesFor({ slug: row.slug, providerId }, states);
+    const state = matched[0];
+    // A tile the host said nothing about still inherits the instance-level
+    // `attested` fact — it is a property of the pod, not of one provider.
+    const effective =
+      state ?? (platformManaged ? ({ credentialSource: "attested" } as const) : undefined);
+    // Union across every row that speaks about this tile: the host reconciles
+    // within a row, and the alias split means there can be two.
+    const via = [...new Set(matched.flatMap((s) => s.via ?? []))];
+    return {
+      ...row,
+      providerId,
+      route: connectRoute({ toolkit: row.slug }, effective, reach),
+      via,
+      // Only unknown if nothing already answered yes: a provider we know is
+      // connected needs no second opinion.
+      unverified: !row.connected && matched.some((s) => s.unverified === true),
+      account: matched.find((s) => s.account)?.account,
+      canDisconnect: row.connected && via.includes("native"),
+    };
+  });
+}

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Check, Info, Loader2, Plug, ShieldCheck } from "lucide-react";
+import { Info, ShieldCheck } from "lucide-react";
 import { toast } from "sonner";
 
 import { me as fetchMe } from "@/api/auth";
@@ -8,28 +8,20 @@ import {
   getComposioStatus,
   listComposioConnections,
   startComposioAuthorize,
+  type ComposioStatus,
 } from "@/api/composio";
 import type { ConnectionState } from "@/api/types";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent } from "@/components/ui/card";
-import { Skeleton } from "@/components/ui/skeleton";
-import {
-  CONNECTION_CATEGORY_ORDER,
-  CONNECTION_PROVIDERS,
-  connectionStateFor,
-  connectRoute,
-  type ComposioReach,
-  type ConnectionProvider,
-  type ConnectRoute,
-} from "@/lib/connections";
-import { cn } from "@/lib/utils";
+import { catalogWarning } from "@/lib/composio-catalog";
+import { type ComposioReach } from "@/lib/connections";
+import { buildGridProviders, type GridProvider } from "@/lib/provider-grid";
 import { armTourResume } from "@/tour/state";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { McpServersSection } from "@/views/connections/McpServersSection";
 import { CompanyCredentialCard } from "@/views/connections/CompanyCredentialCard";
 import { ComposioSection } from "@/views/connections/ComposioSection";
+import { ProvidersSection } from "@/views/connections/ProvidersSection";
 import { ChannelsSection } from "./connections/ChannelsSection";
 import { useLocalScope } from "@/connections/ConnectionContext";
 
@@ -69,10 +61,17 @@ export function ConnectionsView({ client, company }: Props) {
   // particularly poor greeting, since the failure arrives only after they have
   // pasted a live credential into a form that could never submit it.
   const [canManage, setCanManage] = useState(false);
-  // What Composio offers here, or `null` while unknown / not reachable. This is
-  // the hosted connect route for every tile (issue #599), so the grid cannot
-  // decide what a Connect does without it.
-  const [reach, setReach] = useState<ComposioReach | null>(null);
+  // The host's Composio answer, or `null` while unknown / not reachable.
+  //
+  // The whole status, not just the routing facts it used to be narrowed to: the
+  // page's one provider grid is built from `effectiveCatalog` (issue #582), and
+  // the catalog's honesty markers (`catalogSource`, `catalogNotice`) travel with
+  // it. Narrowing here and re-fetching the same call elsewhere for the rest is
+  // how the page ended up with two lists.
+  const [status, setStatus] = useState<ComposioStatus | null>(null);
+  // Slugs connected through the by-slug escape hatch this session, so they keep
+  // a tile instead of vanishing after a successful sign-in (issue #397).
+  const [extraToolkits, setExtraToolkits] = useState<string[]>([]);
   // Whether this instance carries a platform-projected identity, as Composio
   // reports it. A second witness for the same host-level fact the connection
   // rows carry — and the only one available when the manifest declares no
@@ -116,28 +115,17 @@ export function ConnectionsView({ client, company }: Props) {
         // connection and never answers would hold the page on skeletons
         // forever. Losing the race is not an error, it is "no Composio route
         // we can confirm", which is what a null `reach` already means.
-        const status = await Promise.race([
+        const probed = await Promise.race([
           getComposioStatus(client, company),
           new Promise<null>((resolve) => window.setTimeout(() => resolve(null), COMPOSIO_PROBE_TIMEOUT_MS)),
         ]);
         if (!live) return;
-        if (!status) {
-          setReach(null);
-          setAttested(false);
-          return;
-        }
-        setReach({
-          inBuild: status.inBuild,
-          granted: status.granted,
-          hasCredential: status.credentialSource !== "none",
-          openMode: status.openMode,
-          effectiveToolkits: status.effectiveToolkits,
-        });
-        setAttested(status.credentialSource === "attested");
+        setStatus(probed);
+        setAttested(probed?.credentialSource === "attested");
       } catch {
         // No Composio surface on this host — not an error for this page.
         if (live) {
-          setReach(null);
+          setStatus(null);
           setAttested(false);
         }
       } finally {
@@ -180,8 +168,8 @@ export function ConnectionsView({ client, company }: Props) {
   }, [client, company]);
 
   /** The self-hosted hatch: navigate the document to the host's authorize URL. */
-  async function connectNative(p: ConnectionProvider) {
-    const { url } = await client.startConnection(p.id, company);
+  async function connectNative(p: GridProvider) {
+    const { url } = await client.startConnection(p.providerId, company);
     // Unlike the Composio sign-in below (which opens a tab and survives), this
     // navigates the whole document away — taking the product tour's
     // in-memory step state with it. Arm a resume marker so the operator comes
@@ -203,12 +191,12 @@ export function ConnectionsView({ client, company }: Props) {
    * finished when the tab opens, and clearing early would offer a second Connect
    * for a sign-in already in flight.
    */
-  async function connectComposio(p: ConnectionProvider, toolkit: string) {
+  async function connectComposio(p: { providerId: string; label: string }, toolkit: string) {
     // A sign-in for this toolkit is already polling (it can have been started
     // from a different tile sharing the slug). Clear the flag we just set rather
     // than leaving this tile spinning on someone else's flow.
     if (pollTimers.current[toolkit] !== undefined) {
-      setBusy((b) => (b === p.id ? null : b));
+      setBusy((b) => (b === p.providerId ? null : b));
       return;
     }
     const { connectUrl } = await startComposioAuthorize(client, company, toolkit);
@@ -226,21 +214,24 @@ export function ConnectionsView({ client, company }: Props) {
     // wrong trade on a tab we hand an OAuth URL to. `ComposioSection.signIn`
     // opens the same URL the same way and likewise does not check.
     window.open(connectUrl, "_blank", "noopener,noreferrer");
-    toast.message(`Complete ${p.name} sign-in in the new tab.`);
+    toast.message(`Complete ${p.label} sign-in in the new tab.`);
     const deadline = Date.now() + 120_000;
     const poll = async () => {
       delete pollTimers.current[toolkit];
       if (Date.now() > deadline) {
-        setBusy((b) => (b === p.id ? null : b));
-        toast.message(`${p.name} sign-in timed out. Try again if it didn't complete.`);
+        setBusy((b) => (b === p.providerId ? null : b));
+        toast.message(`${p.label} sign-in timed out. Try again if it didn't complete.`);
         return;
       }
       try {
         const rows = await listComposioConnections(client, company);
         if (rows.some((r) => r.toolkit.toLowerCase() === toolkit.toLowerCase() && r.connected)) {
-          setBusy((b) => (b === p.id ? null : b));
-          toast.success(`Connected ${p.name}.`);
-          // Re-read the host's reconciled view so the tile flips to Disconnect.
+          setBusy((b) => (b === p.providerId ? null : b));
+          toast.success(`Connected ${p.label}.`);
+          // Re-read the host's reconciled view so the tile flips to connected.
+          // This is the page's only status source now (issue #582), so one
+          // refresh updates everything that speaks about this provider — there
+          // is no second list left to go stale behind it.
           await refresh();
           return;
         }
@@ -252,15 +243,15 @@ export function ConnectionsView({ client, company }: Props) {
     pollTimers.current[toolkit] = window.setTimeout(() => void poll(), 2_000);
   }
 
-  async function connect(p: ConnectionProvider, route: ConnectRoute) {
+  async function connect(p: GridProvider) {
     if (busy) return;
-    setBusy(p.id);
+    setBusy(p.providerId);
     try {
-      if (route.kind === "composio") {
-        await connectComposio(p, route.toolkit);
+      if (p.route.kind === "composio") {
+        await connectComposio(p, p.route.toolkit);
         return;
       }
-      if (route.kind === "native") {
+      if (p.route.kind === "native") {
         await connectNative(p);
         return;
       }
@@ -268,26 +259,53 @@ export function ConnectionsView({ client, company }: Props) {
       // would be a rendering bug rather than an operator action.
       setBusy(null);
     } catch {
-      toast.error(`Couldn't start the ${p.name} connection.`);
+      toast.error(`Couldn't start the ${p.label} connection.`);
       setBusy(null);
     }
   }
 
-  async function disconnect(p: ConnectionProvider) {
-    if (busy) return;
-    setBusy(p.id);
+  /**
+   * Sign in to a toolkit typed into the by-slug hatch.
+   *
+   * It has no tile until the host reports it, so it is added to `extraToolkits`
+   * first — `buildGridProviders` gives it one from local metadata, and the
+   * refresh after a successful poll then fills in the real status.
+   */
+  async function connectSlug(slug: string) {
+    if (busy || !slug) return;
+    setExtraToolkits((t) => (t.includes(slug) ? t : [...t, slug]));
+    setBusy(slug);
     try {
-      await client.disconnectConnection(p.id, company);
-      toast.success(`Disconnected ${p.name}.`);
+      await connectComposio({ providerId: slug, label: slug }, slug);
+    } catch {
+      toast.error(`Couldn't start the ${slug} connection.`);
+      setBusy(null);
+    }
+  }
+
+  /**
+   * Release a connection this host actually holds.
+   *
+   * Only offered for a tile whose `via` includes `native` (see
+   * `GridProvider.canDisconnect`): this route blanks the host's own
+   * `oauth/{provider}` secret, and no host route can release a Composio
+   * connection. Offering it on a Composio-only tile would report success and
+   * leave the tile connected on the next refresh.
+   */
+  async function disconnect(p: GridProvider) {
+    if (busy) return;
+    setBusy(p.providerId);
+    try {
+      await client.disconnectConnection(p.providerId, company);
+      toast.success(`Disconnected ${p.label}.`);
       await refresh();
     } catch {
-      toast.error(`Couldn't disconnect ${p.name}.`);
+      toast.error(`Couldn't disconnect ${p.label}.`);
     } finally {
       setBusy(null);
     }
   }
 
-  const connectedCount = Object.values(states).filter((s) => s.connected).length;
   // `attested` is a property of the *instance*, not of one provider: it means
   // this pod carries a platform-minted identity, so every connection is the
   // platform's to run. One row reporting it is therefore enough to say so once
@@ -302,20 +320,41 @@ export function ConnectionsView({ client, company }: Props) {
     load === "ready" &&
     (Object.values(states).some((s) => s.credentialSource === "attested") || attested);
 
-  // One decision per tile, made once and used for both the button and the click,
-  // so what is rendered and what is called can never disagree.
-  const routes = useMemo(() => {
-    const out = new Map<string, { state?: ConnectionState; route: ConnectRoute }>();
-    for (const provider of CONNECTION_PROVIDERS) {
-      const state = connectionStateFor(provider, states);
-      // A tile the host said nothing about still inherits the instance-level
-      // `attested` fact — it is a property of the pod, not of one provider.
-      const effective =
-        state ?? (platformManaged ? ({ credentialSource: "attested" } as const) : undefined);
-      out.set(provider.id, { state, route: connectRoute(provider, effective, reach) });
-    }
-    return out;
-  }, [states, reach, platformManaged]);
+  // The routing facts, narrowed out of the status the page already holds.
+  const reach: ComposioReach | null = useMemo(
+    () =>
+      status
+        ? {
+            inBuild: status.inBuild,
+            granted: status.granted,
+            hasCredential: status.credentialSource !== "none",
+            openMode: status.openMode,
+            effectiveToolkits: status.effectiveToolkits,
+          }
+        : null,
+    [status],
+  );
+
+  // The page's one provider list. Status, route and metadata resolved together,
+  // once, so nothing on this screen can answer differently from anything else
+  // on it (issue #582).
+  const providers = useMemo(
+    () =>
+      buildGridProviders(
+        status?.effectiveCatalog ?? [],
+        extraToolkits,
+        states,
+        reach,
+        platformManaged,
+      ),
+    [status?.effectiveCatalog, extraToolkits, states, reach, platformManaged],
+  );
+
+  // Counted off the rendered grid, not off the raw host rows. The badge used to
+  // count every row `GET …/connections` returned while the grid below drew only
+  // the eleven tiles the console had metadata for — so the header could read "3
+  // connected" above a grid showing none of them (issue #582).
+  const connectedCount = providers.filter((p) => p.connected).length;
 
   return (
     <div className="flex-1 overflow-y-auto">
@@ -390,205 +429,29 @@ export function ConnectionsView({ client, company }: Props) {
           client={client}
           company={company}
           canManage={canManage}
+          onChanged={() => setCredentialGeneration((n) => n + 1)}
         />
 
         <ChannelsSection client={client} company={company} canManage={canManage} />
 
-        {load === "ready" && (
-          <Alert data-testid="connections-catalog-advisory">
-            <Info className="size-4" />
-            <AlertTitle>Agents reach these providers through Composio</AlertTitle>
-            <AlertDescription>
-              Connecting below records the account against this company, but the tool belt your
-              agents actually run on is wired in the Composio section above — that is where a
-              connection becomes something an agent can do. Connect Gmail, GitHub or Slack there
-              first (issue #396).
-            </AlertDescription>
-          </Alert>
-        )}
-
-        {load === "loading" || !reachSettled ? (
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-            {Array.from({ length: 6 }).map((_, i) => (
-              <Skeleton key={i} className="h-28 rounded-xl" />
-            ))}
-          </div>
-        ) : (
-          CONNECTION_CATEGORY_ORDER.map((category) => {
-            const providers = CONNECTION_PROVIDERS.filter((p) => p.category === category);
-            if (providers.length === 0) return null;
-            return (
-              <section key={category} className="space-y-3">
-                <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                  {category}
-                </h3>
-                <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-                  {providers.map((p) => {
-                    const { state, route } = routes.get(p.id) ?? { route: { kind: "unavailable" as const } };
-                    return (
-                      <ConnectionCard
-                        key={p.id}
-                        provider={p}
-                        state={state}
-                        route={route}
-                        disabled={load === "unavailable" || !canManage}
-                        busy={busy === p.id}
-                        onConnect={() => void connect(p, route)}
-                        onDisconnect={() => void disconnect(p)}
-                      />
-                    );
-                  })}
-                </div>
-              </section>
-            );
-          })
-        )}
+        {/* The page's one provider list (issue #582). It used to be two — this
+            grid and a categorised grid of eleven hardcoded tiles below it — and
+            they disagreed by construction, so a provider could show as connected
+            in one and offer a Connect button in the other on the same screen. */}
+        <ProvidersSection
+          providers={providers}
+          canManage={canManage && load !== "unavailable"}
+          busy={busy}
+          noCredential={status?.credentialSource === "none"}
+          granted={status?.granted !== false}
+          openMode={status?.openMode === true}
+          degraded={status ? catalogWarning(status) : null}
+          loading={load === "loading" || !reachSettled}
+          onConnect={(p) => void connect(p)}
+          onDisconnect={(p) => void disconnect(p)}
+          onConnectSlug={(slug) => void connectSlug(slug)}
+        />
       </div>
-    </div>
-  );
-}
-
-/**
- * One provider tile.
- *
- * The unconnected foot of the card renders whatever {@link connectRoute}
- * decided, so the button an operator sees is the call the click makes:
- *
- * - `native` — this host holds a registered provider application for it (or the
- *   company already stored a token): the self-hosted hatch. The Connect button,
- *   exactly as before.
- * - `composio` — the hosted route. Also a Connect button, but it opens
- *   Composio's own OAuth in a tab rather than navigating this document.
- * - `managed` — a platform identity runs connections for this instance and
- *   there is no Composio route; nothing to set up locally.
- * - `unavailable` — no route can succeed, so the tile says so rather than
- *   offering a button that 400s. This is the state issue #599 reports missing:
- *   every undeclared tile fell through to a Connect that could never work.
- *
- * The connected foot offers **Disconnect only when there is something local to
- * revoke** — i.e. `via` includes `native`. A Composio-only connection has no
- * disconnect route on the host at all (`/composio` exposes status, token,
- * authorize and connections, and nothing else), so a Disconnect button there
- * would call `…/connections/{id}/disconnect`, blank a secret that was never
- * set, report success and change nothing. Naming where the connection lives is
- * the honest answer until a Composio disconnect route exists.
- */
-function ConnectionCard({
-  provider,
-  state,
-  route,
-  disabled,
-  busy,
-  onConnect,
-  onDisconnect,
-}: {
-  provider: ConnectionProvider;
-  state?: ConnectionState;
-  route: ConnectRoute;
-  disabled: boolean;
-  busy: boolean;
-  onConnect: () => void;
-  onDisconnect: () => void;
-}) {
-  const connected = Boolean(state?.connected);
-  const managedByPlatform = route.kind === "managed";
-  const noRoute = route.kind === "unavailable";
-  // Which namespace actually backs this connection. `native` alone means the
-  // credential sits in the host's catalog, which no agent tool reads yet — worth
-  // distinguishing from a Composio connection, which is a live capability.
-  const via = state?.via ?? [];
-  const nativeOnly = connected && via.length > 0 && !via.includes("composio");
-  // Only a native credential can be revoked from here; see the doc above.
-  // An empty `via` is "this host predates the field" (it is optional on the
-  // wire), not "Composio owns it" — withholding Disconnect there would strip
-  // the control from every connection on an older host, so the affordance is
-  // withheld only when the host affirmatively named Composio and nothing else.
-  const canDisconnect = connected && (via.length === 0 || via.includes("native"));
-  const unverified = state?.unverified === true;
-  return (
-    <Card className={cn(connected && "border-primary/30")}>
-      <CardContent className="flex h-full flex-col gap-3 py-4">
-        <div className="flex items-start gap-3">
-          <Monogram provider={provider} />
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              <p className="truncate font-medium">{provider.name}</p>
-              {connected && (
-                <span className="inline-flex items-center gap-1 text-xs font-medium text-status-done-text">
-                  <Check className="size-3" /> Connected
-                </span>
-              )}
-            </div>
-            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
-              {connected && state?.account ? state.account : provider.description}
-            </p>
-            {connected && via.length > 0 && (
-              <p className="mt-0.5 text-xs text-muted-foreground" data-testid={`connection-via-${provider.id}`}>
-                via {via.join(" + ")}
-                {nativeOnly && " — stored here; agents use the Composio connection"}
-              </p>
-            )}
-            {!connected && unverified && (
-              <p className="mt-0.5 text-xs text-status-blocked-text">
-                Couldn&apos;t check the Composio connection — state unknown.
-              </p>
-            )}
-          </div>
-        </div>
-        <div className="mt-auto">
-          {canDisconnect ? (
-            <Button variant="outline" size="sm" className="w-full" disabled={busy} onClick={onDisconnect}>
-              {busy ? <Loader2 className="size-4 animate-spin" /> : null}
-              Disconnect
-            </Button>
-          ) : connected ? (
-            <p
-              className="text-xs text-muted-foreground"
-              data-testid={`connection-composio-managed-${provider.id}`}
-            >
-              Connected through Composio — manage it in the Composio section above.
-            </p>
-          ) : managedByPlatform ? (
-            <p
-              className="inline-flex items-center gap-1 text-xs text-status-done-text"
-              data-testid={`connection-managed-${provider.id}`}
-            >
-              <ShieldCheck className="size-3" /> Managed by the platform — nothing to set up here
-            </p>
-          ) : noRoute ? (
-            <p
-              className="text-xs text-muted-foreground"
-              data-testid={`connection-unavailable-${provider.id}`}
-            >
-              Not available on this host.
-            </p>
-          ) : (
-            <Button
-              variant={disabled ? "outline" : "default"}
-              size="sm"
-              className="w-full"
-              disabled={disabled || busy}
-              onClick={onConnect}
-            >
-              {busy ? <Loader2 className="size-4 animate-spin" /> : <Plug className="size-4" />}
-              Connect
-            </Button>
-          )}
-        </div>
-      </CardContent>
-    </Card>
-  );
-}
-
-function Monogram({ provider }: { provider: ConnectionProvider }) {
-  const label = provider.glyph ?? provider.name.charAt(0);
-  return (
-    <div
-      className="flex size-10 shrink-0 items-center justify-center rounded-lg text-sm font-semibold text-white"
-      style={{ backgroundColor: provider.color }}
-      aria-hidden
-    >
-      {label}
     </div>
   );
 }

--- a/frontend/src/views/connections/ComposioSection.tsx
+++ b/frontend/src/views/connections/ComposioSection.tsx
@@ -1,26 +1,9 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import {
-  AlertTriangle,
-  Check,
-  KeyRound,
-  Loader2,
-  LogIn,
-  Plug,
-  Save,
-  Search,
-  ShieldCheck,
-  Trash2,
-} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, KeyRound, Loader2, Plug, Save, ShieldCheck, Trash2 } from "lucide-react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import {
-  getComposioStatus,
-  listComposioConnections,
-  setComposioToken,
-  startComposioAuthorize,
-  type ComposioStatus,
-} from "@/api/composio";
+import { getComposioStatus, setComposioToken, type ComposioStatus } from "@/api/composio";
 import { ApiError } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -28,54 +11,6 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
-import { cn } from "@/lib/utils";
-import {
-  availableCategories,
-  buildProviderRows,
-  catalogWarning,
-  permissionHint,
-  toolkitLabel,
-  visibleProviderRows,
-  type ProviderCategory,
-  type ProviderRow,
-} from "@/lib/composio-catalog";
-
-/**
- * A provider's branded logo, degrading to a monogram.
- *
- * The URL is best-effort by construction: the backend publishes one for most
- * catalog entries, and every other tile falls back to a slug-derived guess at
- * Composio's logo CDN. A guess that 404s must look like a plain tile, never a
- * broken-image glyph — so the error is caught and swapped rather than left to
- * the browser.
- */
-function ProviderLogo({ row }: { row: ProviderRow }) {
-  const [failed, setFailed] = useState(false);
-  // A company can repoint at a different backend, which re-keys the logo. Reset
-  // on URL change so one dead image does not poison the slot for good.
-  useEffect(() => setFailed(false), [row.logoUrl]);
-
-  if (failed) {
-    return (
-      <span
-        aria-hidden="true"
-        className="flex size-8 items-center justify-center rounded-lg bg-muted text-xs font-semibold text-muted-foreground"
-      >
-        {row.label.charAt(0).toUpperCase()}
-      </span>
-    );
-  }
-  return (
-    <img
-      src={row.logoUrl}
-      alt=""
-      aria-hidden="true"
-      loading="lazy"
-      className="size-8 rounded-lg object-contain"
-      onError={() => setFailed(true)}
-    />
-  );
-}
 
 interface Props {
   client: OpenCompanyClient;
@@ -86,99 +21,58 @@ interface Props {
    * they act through.
    *
    * **Courtesy, not enforcement.** The host refuses both writes with a 403
-   * whatever this says. What it prevents is offering a Sign in button that
-   * cannot complete, or a token field whose Save is refused only after the
-   * operator has already pasted a live credential into it.
+   * whatever this says. What it prevents is offering a token field whose Save is
+   * refused only after the operator has already pasted a live credential into
+   * it.
    */
   canManage: boolean;
+  /**
+   * Called after the stored token changes.
+   *
+   * The provider grid's status and routing are downstream of which credential
+   * this company reaches Composio with — setting or clearing a token here flips
+   * `credentialSource`, and every tile's route with it. Without this the grid
+   * would keep rendering the old answer while this section reported the new one:
+   * the same two-surfaces-disagreeing failure #582 is about, arriving through
+   * the credential rather than through the connection list.
+   */
+  onChanged: () => void;
 }
 
 /**
- * Per-tenant Composio connection management (issue #110, Cell D).
+ * Which credential this company reaches Composio with (issue #110, Cell D).
  *
- * Two layers, and they are independent:
+ * **Only that.** This section used to carry a second thing — a per-provider
+ * "Sign in per provider" grid — and that grid was one of the two provider lists
+ * issue #582 collapsed. The page now has a single grid, `ProvidersSection`,
+ * built from the reconciled `GET …/connections` status; what is left here is the
+ * credential layer, which is genuinely independent of it:
  *
- * 1. **Which credential this company reaches Composio with**, reported as
- *    `credentialSource`:
- *    - `attested` (hosted) — the instance already holds a platform identity, so
- *      there is nothing to paste and nothing stored here. A company that wants
- *      to use its OWN Composio account can still override.
- *    - `company` (issue #586) — this company's own TinyHumans credential, set
- *      by its admin. Composio is brokered through it, so there is nothing to
- *      paste here either: the one key already authorizes this. The override
- *      still exists for a company that wants its own Composio account.
- *    - `static` — a Composio token this company pasted, or a static instance key.
- *    - `none` — no credential can be obtained, so there is nothing to authorize
- *      against and agents get no Composio tools.
- * 2. **Which providers are connected**, via a per-provider OAuth "Sign in" list
- *    driven by the granted toolkits. Composio runs the hosted OAuth; we open it
- *    in a tab and poll until the toolkit reports connected.
+ * - `attested` (hosted) — the instance already holds a platform identity, so
+ *   there is nothing to paste and nothing stored here. A company that wants to
+ *   use its OWN Composio account can still override.
+ * - `company` (issue #586) — this company's own TinyHumans credential, set by
+ *   its admin. Composio is brokered through it, so there is nothing to paste
+ *   here either. The override still exists for a company that wants its own
+ *   Composio account.
+ * - `static` — a Composio token this company pasted, or a static instance key.
+ * - `none` — no credential can be obtained, so there is nothing to authorize
+ *   against and agents get no Composio tools.
  *
  * The pasted token is WRITE-ONLY: stored and never shown again. A set/clear
  * takes effect on the agents' next turn, no restart. Hidden entirely when the
  * feature is not in the build.
  */
-export function ComposioSection({ client, company, canManage }: Props) {
+export function ComposioSection({ client, company, canManage, onChanged }: Props) {
   const [load, setLoad] = useState<"loading" | "ready" | "unavailable">("loading");
   const [status, setStatus] = useState<ComposioStatus | null>(null);
   const [token, setToken] = useState("");
   const [busy, setBusy] = useState<"save" | "clear" | null>(null);
-  // toolkit slug -> connected. Absent = unknown / not yet fetched.
-  const [connected, setConnected] = useState<Record<string, boolean>>({});
-  // toolkit slug currently mid-sign-in (open tab + poll).
-  const [signingIn, setSigningIn] = useState<string | null>(null);
-  // Only meaningful in the attested state, where the paste card is an override
-  // rather than the way in.
+  // Only meaningful in the credentialled states, where the paste card is an
+  // override rather than the way in.
   const [showOverride, setShowOverride] = useState(false);
-  // Open mode only: a slug typed into the "connect by slug" field. It is now an
-  // escape hatch rather than the way to reach the tail — the rows above are the
-  // backend's real catalog — but it still earns its place: it is the only way to
-  // connect a provider when the catalog could not be fetched, and the only way
-  // to reach one the catalog happens to omit (issue #397).
-  const [otherToolkit, setOtherToolkit] = useState("");
-  // Slugs connected through that field this session, so they get a row of their
-  // own instead of vanishing after a successful sign-in.
-  const [extraToolkits, setExtraToolkits] = useState<string[]>([]);
-  // Provider search. In open mode the host now hands over the backend's real
-  // catalog — roughly a hundred toolkits — so finding one by scrolling stopped
-  // being reasonable (issue #397).
-  const [query, setQuery] = useState("");
-  // The selected category chip. Composed with the search rather than replacing
-  // it, so an operator can look for "invoices" inside Platform (issue #600).
-  const [category, setCategory] = useState<ProviderCategory>("All");
 
   const requestGeneration = useRef(0);
-  const pollTimers = useRef<Record<string, number>>({});
-
-  // Clear any in-flight poll timers on unmount / company switch.
-  useEffect(() => {
-    const timers = pollTimers.current;
-    return () => {
-      Object.values(timers).forEach((id) => window.clearTimeout(id));
-      pollTimers.current = {};
-    };
-  }, [company]);
-
-  const refreshConnections = useCallback(
-    async (s: ComposioStatus) => {
-      // Listing connections needs *a* credential — any tier. With none there is
-      // nothing to authorize against, and the call 409s. Keyed off the
-      // EFFECTIVE list, not the manifest one: in open mode the manifest list is
-      // empty precisely because everything is allowed (issue #397).
-      if (s.credentialSource === "none" || s.effectiveToolkits.length === 0) {
-        setConnected({});
-        return;
-      }
-      try {
-        const rows = await listComposioConnections(client, company);
-        setConnected(Object.fromEntries(rows.map((r) => [r.toolkit.toLowerCase(), r.connected])));
-      } catch {
-        // Non-fatal: leave the provider rows in their "sign in" state.
-        setConnected({});
-      }
-    },
-    [client, company],
-  );
 
   const refresh = useCallback(async () => {
     const generation = ++requestGeneration.current;
@@ -188,21 +82,15 @@ export function ComposioSection({ client, company, canManage }: Props) {
       setStatus(s);
       // Hide the whole section when the feature is not compiled into this build.
       setLoad(s.inBuild ? "ready" : "unavailable");
-      if (s.inBuild) void refreshConnections(s);
     } catch {
       if (generation !== requestGeneration.current) return;
       setLoad("unavailable");
     }
-  }, [client, company, refreshConnections]);
+  }, [client, company]);
 
   useEffect(() => {
     setStatus(null);
-    setConnected({});
     setShowOverride(false);
-    setOtherToolkit("");
-    setExtraToolkits([]);
-    setQuery("");
-    setCategory("All");
     setLoad("loading");
     void refresh();
   }, [refresh]);
@@ -215,7 +103,7 @@ export function ComposioSection({ client, company, canManage }: Props) {
       setStatus(res.status);
       setToken("");
       toast.success(res.note);
-      void refreshConnections(res.status);
+      onChanged();
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Could not save the token.");
     } finally {
@@ -229,85 +117,16 @@ export function ComposioSection({ client, company, canManage }: Props) {
       const res = await setComposioToken(client, company, "");
       setStatus(res.status);
       setToken("");
-      setConnected({});
-      // Clearing an override falls back to whatever tier remains — re-probe
-      // rather than assuming there is no credential left.
+      // Clearing an override falls back to whatever tier remains — the status
+      // the host just returned says which, and the grid re-probes for itself.
       toast.success("Composio token cleared.");
-      void refreshConnections(res.status);
+      onChanged();
     } catch (err) {
       toast.error(err instanceof ApiError ? err.message : "Could not clear the token.");
     } finally {
       setBusy(null);
     }
   }
-
-  // Per-provider OAuth: open Composio's hosted connect URL in a new tab, then
-  // poll the connection list every 2s up to ~2 minutes until this toolkit flips
-  // to connected (Composio completes the OAuth on its side — no local callback).
-  async function signIn(toolkit: string) {
-    // Guard the shared flag AND a poll already in flight for this toolkit.
-    if (signingIn || pollTimers.current[toolkit] !== undefined) return;
-    setSigningIn(toolkit);
-    const label = toolkitLabel(toolkit);
-    try {
-      const { connectUrl } = await startComposioAuthorize(client, company, toolkit);
-      window.open(connectUrl, "_blank", "noopener,noreferrer");
-      toast.message(`Complete ${label} sign-in in the new tab.`);
-      const deadline = Date.now() + 120_000;
-      const poll = async () => {
-        delete pollTimers.current[toolkit];
-        if (Date.now() > deadline) {
-          setSigningIn((t) => (t === toolkit ? null : t));
-          toast.message(`${label} sign-in timed out. Try again if it didn't complete.`);
-          return;
-        }
-        try {
-          const rows = await listComposioConnections(client, company);
-          const map = Object.fromEntries(rows.map((r) => [r.toolkit.toLowerCase(), r.connected]));
-          setConnected(map);
-          if (map[toolkit.toLowerCase()]) {
-            setSigningIn((t) => (t === toolkit ? null : t));
-            toast.success(`Connected ${label}.`);
-            return;
-          }
-        } catch {
-          // Ignore transient probe errors while the operator finishes sign-in.
-        }
-        pollTimers.current[toolkit] = window.setTimeout(() => void poll(), 2_000);
-      };
-      pollTimers.current[toolkit] = window.setTimeout(() => void poll(), 2_000);
-    } catch (err) {
-      setSigningIn((t) => (t === toolkit ? null : t));
-      toast.error(err instanceof ApiError ? err.message : `Couldn't start ${label} sign-in.`);
-    }
-  }
-
-  // Ordered once per status/connection change: connected first, then the
-  // handful everyone reaches for, then the tail alphabetically. Ordering,
-  // bucketing and filtering live in `@/lib/composio-catalog` so they are
-  // testable without a document — see `vitest.config.ts` on where the line sits.
-  //
-  // Built from `effectiveCatalog`, not `effectiveToolkits`: the slug list is
-  // still the wire contract every host call uses, but it is the catalog entries
-  // that carry the name, description, logo and categories this grid is made of
-  // (issue #600).
-  const rows = useMemo(
-    () => buildProviderRows(status?.effectiveCatalog ?? [], extraToolkits, connected),
-    [status?.effectiveCatalog, extraToolkits, connected],
-  );
-  const categories = useMemo(() => availableCategories(rows), [rows]);
-  const visible = useMemo(
-    () => visibleProviderRows(rows, category, query),
-    [rows, category, query],
-  );
-  const degraded = status ? catalogWarning(status) : null;
-
-  // A chip can go away under the operator — a company narrows its manifest, or
-  // a refresh returns a shorter catalog. Falling back to All beats leaving them
-  // staring at an empty grid filtered by a bucket that no longer exists.
-  useEffect(() => {
-    if (!categories.includes(category)) setCategory("All");
-  }, [categories, category]);
 
   if (load === "unavailable") return null;
 
@@ -317,14 +136,6 @@ export function ComposioSection({ client, company, canManage }: Props) {
   // paste?" — the difference is whose identity it is, which the copy states.
   const companyKey = status?.credentialSource === "company";
   const byoToken = status?.credentialSource === "static";
-  // No credential of any tier: there is nothing to authorize a provider against.
-  const noCredential = status?.credentialSource === "none";
-  // Issue #397: gate on the EFFECTIVE list. The old gate read
-  // `toolkits.length > 0`, and an empty manifest list means "defer to the
-  // backend allowlist" — allow everything — so the one value meaning *every
-  // provider* rendered *no* providers on 19 of 20 shipped templates.
-  const showProviders = load === "ready" && status !== null && status.effectiveToolkits.length > 0;
-  const openMode = status?.openMode === true;
   // In the attested state the paste card is a deliberate override; everywhere
   // else it is the only way to connect, so it is always on screen.
   // Issue #403: the credential card is an admin's. A member still sees the
@@ -341,17 +152,17 @@ export function ComposioSection({ client, company, canManage }: Props) {
       <div className="flex items-center gap-2">
         <Plug className="size-4 text-muted-foreground" />
         <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-          Composio (Gmail / Slack / GitHub)
+          Composio credential
         </h3>
       </div>
       <p className="text-sm text-muted-foreground">
         {!canManage
           ? "Your agents reach Gmail, Slack & GitHub through Composio. Which account they act through belongs to the company, so an admin manages it — this is what is wired today."
           : attested
-          ? "Give your agents Gmail, Slack & GitHub via Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Sign in per provider below."
-          : companyKey
-          ? "Give your agents Gmail, Slack & GitHub via Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Sign in per provider below; every agent in the company can then use what you connect."
-          : "Give your agents Gmail, Slack & GitHub via Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then sign in per provider below. A change takes effect on the next turn, no restart."}
+            ? "Your agents reach providers through Composio. This company is linked through this instance's own cluster identity — there is no key to copy and nothing stored here. Connect providers in the grid below."
+            : companyKey
+              ? "Your agents reach providers through Composio. This company's own TinyHumans credential already authorizes it — there is no separate Composio token to paste and no provider app to register. Connect providers in the grid below; every agent in the company can then use what you connect."
+              : "Your agents reach providers through Composio. Paste this company's Composio OAuth token — it is the identity the backend bills and isolates, stored securely and never shown again — then connect providers in the grid below. A change takes effect on the next turn, no restart."}
       </p>
 
       {load === "loading" ? (
@@ -387,231 +198,6 @@ export function ComposioSection({ client, company, canManage }: Props) {
               namespace, so agents will not receive Composio tools even once connected. Add
               <span className="font-mono"> composio</span> to the company&apos;s tool grants first.
             </p>
-          )}
-
-          {showProviders && status && (
-            <Card>
-              <CardContent className="space-y-2 py-4">
-                <p className="text-xs font-medium text-muted-foreground">Sign in per provider</p>
-                {/* Branches on `canManage` like the intro above it. A member has
-                    neither the credential field nor the paste card, so telling
-                    them to "set the credential or paste a token below" points at
-                    controls that are not on their screen. */}
-                {noCredential && (
-                  <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                    {canManage
-                      ? "No credential is available for this company yet, so there is nothing to authorize against. Set the company's TinyHumans credential — one key authorizes the providers the platform brokers — or paste a Composio token below to use a Composio account of your own."
-                      : "No credential is available for this company yet, so there is nothing to authorize against. An admin has to set the company's credential before providers can be connected."}
-                  </p>
-                )}
-                {degraded ? (
-                  // The host could not read Composio's catalog. Say so — a
-                  // built-in list rendered like a fetched one is a claim we
-                  // cannot back (issue #397).
-                  <p className="flex items-start gap-2 rounded-md bg-status-blocked-soft p-2 text-xs text-status-blocked-text">
-                    <AlertTriangle className="mt-px size-3 shrink-0" />
-                    <span>{degraded}</span>
-                  </p>
-                ) : (
-                  openMode && (
-                    <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                      This company allows <span className="font-medium">any</span> provider Composio
-                      offers — {rows.length} in total, connected first. Filter by category or
-                      search by name, slug, or what a provider does.
-                    </p>
-                  )
-                )}
-                {rows.length > 8 && (
-                  <div className="relative">
-                    <Search className="absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
-                    <Input
-                      aria-label="Search providers"
-                      autoComplete="off"
-                      className="pl-7"
-                      placeholder={`Search ${rows.length} providers by name or what they do…`}
-                      value={query}
-                      onChange={(e) => setQuery(e.target.value)}
-                    />
-                  </div>
-                )}
-                {categories.length > 2 && (
-                  // Chips only earn their row when there is more than one real
-                  // bucket to choose between — `availableCategories` always
-                  // includes "All", so two means one bucket, which is not a
-                  // choice. A two-provider manifest list gets the grid without
-                  // a filter that can only ever do nothing.
-                  <div
-                    role="group"
-                    aria-label="Filter providers by category"
-                    className="flex gap-1.5 overflow-x-auto pb-1"
-                  >
-                    {categories.map((c) => (
-                      <Button
-                        key={c}
-                        type="button"
-                        size="sm"
-                        variant={c === category ? "secondary" : "ghost"}
-                        aria-pressed={c === category}
-                        className={cn(
-                          "h-7 shrink-0 rounded-full px-3 text-xs",
-                          c !== category && "text-muted-foreground",
-                        )}
-                        onClick={() => setCategory(c)}
-                      >
-                        {c}
-                      </Button>
-                    ))}
-                  </div>
-                )}
-                {/*
-                  A dense tile grid, not rows (issue #600). 123 full-width rows
-                  are unreadable at any scroll depth, which is why the old list
-                  hid all but twelve behind a "show all" button — the cut was a
-                  workaround for the layout. Compact branded tiles fit the whole
-                  catalog on a screen or two, so the button is gone rather than
-                  relabelled.
-                */}
-                <ul
-                  className="grid gap-2"
-                  style={{
-                    // Uniform rows so a grid of 123 tiles reads as a grid and
-                    // not as ragged masonry — the tile is a fixed slot, and the
-                    // label clamps to fit it.
-                    gridTemplateColumns: "repeat(auto-fill, minmax(8.5rem, 1fr))",
-                    gridAutoRows: "5.5rem",
-                  }}
-                >
-                  {visible.map((row) => {
-                    const isSigningIn = signingIn === row.slug;
-                    // The whole tile is the affordance. An 8.5rem tile has no
-                    // room for a label AND a button, and a tile that looks
-                    // clickable but is not would be worse than either.
-                    const actionable = canManage && !row.connected;
-                    // Named `state`, not `status` — `status` is the component's
-                    // ComposioStatus, and shadowing it here would be a quiet
-                    // trap for the next edit.
-                    const state = row.connected
-                      ? "connected"
-                      : isSigningIn
-                        ? "signing in"
-                        : "not connected";
-                    const shell = cn(
-                      "flex size-full flex-col items-start justify-between gap-1 rounded-lg border p-2.5 text-left",
-                      row.connected
-                        ? "border-status-done/30 bg-status-done-soft"
-                        : "border-border bg-card",
-                    );
-                    const body = (
-                      <>
-                        <div className="flex w-full items-start justify-between gap-1">
-                          <ProviderLogo row={row} />
-                          {row.connected ? (
-                            <Check className="size-3.5 shrink-0 text-status-done-text" />
-                          ) : isSigningIn ? (
-                            <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
-                          ) : actionable ? (
-                            <LogIn className="size-3.5 shrink-0 text-muted-foreground" />
-                          ) : null}
-                        </div>
-                        <div className="w-full min-w-0">
-                          <span className="line-clamp-2 text-xs leading-tight font-medium">
-                            {row.label}
-                          </span>
-                          <span
-                            className={cn(
-                              "block text-3xs",
-                              row.connected
-                                ? "text-status-done-text"
-                                : "text-muted-foreground",
-                            )}
-                          >
-                            {state}
-                          </span>
-                        </div>
-                      </>
-                    );
-                    return (
-                      <li key={row.slug} className="min-w-0">
-                        {actionable ? (
-                          <button
-                            type="button"
-                            disabled={signingIn !== null || noCredential}
-                            onClick={() => void signIn(row.slug)}
-                            title={row.description || undefined}
-                            aria-label={`Sign in to ${row.label}. ${state}. Authorises: ${permissionHint(row.category)}.`}
-                            className={cn(
-                              shell,
-                              "transition-colors hover:border-foreground/20 hover:bg-accent",
-                              "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
-                              "disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border disabled:hover:bg-card",
-                            )}
-                          >
-                            {body}
-                          </button>
-                        ) : (
-                          // Connected, or a viewer who cannot manage: there is
-                          // nothing to click. Rendered as a div rather than a
-                          // disabled button so it stays in the reading order —
-                          // "Gmail, connected" is exactly what a member opened
-                          // this panel to learn, and a disabled button is
-                          // unfocusable.
-                          <div
-                            className={shell}
-                            title={row.description || undefined}
-                            aria-label={`${row.label}. ${state}.`}
-                          >
-                            {body}
-                          </div>
-                        )}
-                      </li>
-                    );
-                  })}
-                </ul>
-                {visible.length === 0 && (
-                  <p className="py-2 text-xs text-muted-foreground">
-                    {query.trim() !== "" ? (
-                      <>
-                        No provider matches “{query.trim()}”
-                        {category !== "All" && <> in {category}</>}. Composio&apos;s slug may differ
-                        from the product name — try another category, or connect it by slug below.
-                      </>
-                    ) : (
-                      <>No provider in {category}.</>
-                    )}
-                  </p>
-                )}
-                {openMode && canManage && (
-                  <div className="flex items-end gap-2 border-t border-border pt-3">
-                    <div className="flex-1 space-y-1">
-                      <Label htmlFor="composio-other-toolkit" className="text-xs">
-                        Connect by slug
-                      </Label>
-                      <Input
-                        id="composio-other-toolkit"
-                        autoComplete="off"
-                        placeholder="composio toolkit slug, e.g. hubspot"
-                        value={otherToolkit}
-                        disabled={noCredential}
-                        onChange={(e) => setOtherToolkit(e.target.value)}
-                      />
-                    </div>
-                    <Button
-                      variant="outline"
-                      disabled={signingIn !== null || noCredential || !otherToolkit.trim()}
-                      onClick={() => {
-                        const slug = otherToolkit.trim().toLowerCase();
-                        setOtherToolkit("");
-                        setExtraToolkits((t) => (t.includes(slug) ? t : [...t, slug]));
-                        void signIn(slug);
-                      }}
-                    >
-                      <LogIn className="size-4" />
-                      Sign in
-                    </Button>
-                  </div>
-                )}
-              </CardContent>
-            </Card>
           )}
 
           {/* Gated on `credentialed`, not `attested`: a company brokered through

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -1,0 +1,453 @@
+import { useEffect, useMemo, useState } from "react";
+import { AlertTriangle, Check, Loader2, LogIn, Search, Unplug } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  availableCategories,
+  permissionHint,
+  visibleProviderRows,
+  type ProviderCategory,
+} from "@/lib/composio-catalog";
+import type { GridProvider } from "@/lib/provider-grid";
+import { cn } from "@/lib/utils";
+
+interface Props {
+  /** Every provider this company can reach, connected first (issue #582). */
+  providers: GridProvider[];
+  /** Whether this viewer may change what the company connects through (#403). */
+  canManage: boolean;
+  /** The `providerId` whose connect/disconnect is in flight, if any. */
+  busy: string | null;
+  /** Nothing to authorize against — no credential of any tier resolves. */
+  noCredential: boolean;
+  /**
+   * Whether the company grants the `composio` tool namespace.
+   *
+   * A caveat, never a gate (issue #582). A connection made without it is real —
+   * the account is linked and the tile is honest to say so — but no agent
+   * receives its tools until the grant exists, and the operator has to be told
+   * that where they can see the connected badge, not only in a section above.
+   */
+  granted: boolean;
+  /** Open mode: any slug the backend permits is reachable, so offer the hatch. */
+  openMode: boolean;
+  /** Why the catalog on screen is not the backend's real one, when it is not. */
+  degraded: string | null;
+  /** The host has not answered yet. */
+  loading: boolean;
+  onConnect: (provider: GridProvider) => void;
+  onDisconnect: (provider: GridProvider) => void;
+  onConnectSlug: (slug: string) => void;
+}
+
+/**
+ * The Connections page's one provider grid (issue #582).
+ *
+ * The page used to carry two: this tile grid (then inside `ComposioSection`,
+ * fed by `GET …/composio/connections`) and a categorised grid of eleven
+ * hardcoded tiles fed by `GET …/connections`. They disagreed — routinely and by
+ * construction, not as a race — so Gmail could show "connected" in one and an
+ * actionable Connect button in the other, on one screen.
+ *
+ * What survives is this grid, because it is the one that was already right: the
+ * providers come from the backend's live catalog rather than a list compiled
+ * into the console, and #600 gave it the names, logos, descriptions and
+ * categories that made the hardcoded tiles worth keeping in the first place.
+ * What it gained is the other grid's job — the reconciled status from
+ * `GET …/connections`, the native self-hosted route, and Disconnect — so the
+ * page has one list and that list has one answer.
+ *
+ * Presentational on purpose: it owns the filter chips and the search box, and
+ * nothing else. Connected state, the route decision and both writes belong to
+ * `ConnectionsView`, which holds the host state they are derived from. A tile
+ * that decided its own status is how the page came to have two of them.
+ */
+export function ProvidersSection({
+  providers,
+  canManage,
+  busy,
+  noCredential,
+  granted,
+  openMode,
+  degraded,
+  loading,
+  onConnect,
+  onDisconnect,
+  onConnectSlug,
+}: Props) {
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState<ProviderCategory>("All");
+  const [otherToolkit, setOtherToolkit] = useState("");
+
+  const categories = useMemo(() => availableCategories(providers), [providers]);
+  const visible = useMemo(
+    () => visibleProviderRows(providers, category, query),
+    [providers, category, query],
+  );
+
+  // A chip can go away under the operator — a company narrows its manifest, or a
+  // refresh returns a shorter catalog. Falling back to All beats leaving them
+  // staring at an empty grid filtered by a bucket that no longer exists.
+  useEffect(() => {
+    if (!categories.includes(category)) setCategory("All");
+  }, [categories, category]);
+
+  const connectedCount = providers.filter((p) => p.connected).length;
+
+  if (loading) {
+    return (
+      <section className="space-y-3">
+        <SectionHeading count={null} />
+        <Skeleton className="h-64 rounded-xl" />
+      </section>
+    );
+  }
+
+  return (
+    <section className="space-y-3">
+      <SectionHeading count={connectedCount} />
+      <Card>
+        <CardContent className="space-y-2 py-4">
+          {noCredential && (
+            <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+              {canManage
+                ? "No credential is available for this company yet, so there is nothing to authorize against. Set the company's TinyHumans credential — one key authorizes the providers the platform brokers — or paste a Composio token below to use a Composio account of your own."
+                : "No credential is available for this company yet, so there is nothing to authorize against. An admin has to set the company's credential before providers can be connected."}
+            </p>
+          )}
+          {!granted && connectedCount > 0 && (
+            // Stated here rather than only in the credential section above,
+            // because this is where the connected badges are: the operator
+            // reading "connected" is the one who needs to know their agents
+            // still cannot use it. The connection itself is real — the grant
+            // governs the tool belt, not the handshake (issue #582).
+            <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+              <AlertTriangle className="mt-px size-3 shrink-0" />
+              <span>
+                These accounts are connected, but this company does not grant the{" "}
+                <span className="font-mono">composio</span> tool namespace, so its agents will not
+                receive their tools yet. Add <span className="font-mono">composio</span> to the
+                company&apos;s tool grants.
+              </span>
+            </p>
+          )}
+          {degraded && (
+            // The host could not read Composio's catalog. Say so — a built-in
+            // list rendered like a fetched one is a claim we cannot back (#397).
+            <p className="flex items-start gap-2 rounded-md bg-status-blocked-soft p-2 text-xs text-status-blocked-text">
+              <AlertTriangle className="mt-px size-3 shrink-0" />
+              <span>{degraded}</span>
+            </p>
+          )}
+          {!degraded && openMode && (
+            <p className="rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+              This company allows <span className="font-medium">any</span> provider Composio offers
+              — {providers.length} in total, connected first. Filter by category or search by name,
+              slug, or what a provider does.
+            </p>
+          )}
+
+          {providers.length > 8 && (
+            <div className="relative">
+              <Search className="absolute top-1/2 left-2 size-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                aria-label="Search providers"
+                autoComplete="off"
+                className="pl-7"
+                placeholder={`Search ${providers.length} providers by name or what they do…`}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+            </div>
+          )}
+
+          {categories.length > 2 && (
+            // Chips only earn their row when there is more than one real bucket
+            // to choose between — `availableCategories` always includes "All",
+            // so two means one bucket, which is not a choice.
+            <div
+              role="group"
+              aria-label="Filter providers by category"
+              className="flex gap-1.5 overflow-x-auto pb-1"
+            >
+              {categories.map((c) => (
+                <Button
+                  key={c}
+                  type="button"
+                  size="sm"
+                  variant={c === category ? "secondary" : "ghost"}
+                  aria-pressed={c === category}
+                  className={cn(
+                    "h-7 shrink-0 rounded-full px-3 text-xs",
+                    c !== category && "text-muted-foreground",
+                  )}
+                  onClick={() => setCategory(c)}
+                >
+                  {c}
+                </Button>
+              ))}
+            </div>
+          )}
+
+          <ul
+            className="grid gap-2"
+            style={{
+              // Uniform rows so a grid of 123 tiles reads as a grid and not as
+              // ragged masonry — the tile is a fixed slot, and the label clamps.
+              gridTemplateColumns: "repeat(auto-fill, minmax(8.5rem, 1fr))",
+              gridAutoRows: "5.5rem",
+            }}
+          >
+            {visible.map((row) => (
+              <ProviderTile
+                key={row.slug}
+                row={row}
+                canManage={canManage}
+                busy={busy === row.providerId}
+                anyBusy={busy !== null}
+                noCredential={noCredential}
+                onConnect={() => onConnect(row)}
+                onDisconnect={() => onDisconnect(row)}
+              />
+            ))}
+          </ul>
+
+          {visible.length === 0 && (
+            <p className="py-2 text-xs text-muted-foreground">
+              {query.trim() !== "" ? (
+                <>
+                  No provider matches “{query.trim()}”
+                  {category !== "All" && <> in {category}</>}. Composio&apos;s slug may differ from
+                  the product name — try another category, or connect it by slug below.
+                </>
+              ) : (
+                <>No provider in {category}.</>
+              )}
+            </p>
+          )}
+
+          {openMode && canManage && (
+            <div className="flex items-end gap-2 border-t border-border pt-3">
+              <div className="flex-1 space-y-1">
+                <Label htmlFor="providers-other-toolkit" className="text-xs">
+                  Connect by slug
+                </Label>
+                <Input
+                  id="providers-other-toolkit"
+                  autoComplete="off"
+                  placeholder="composio toolkit slug, e.g. hubspot"
+                  value={otherToolkit}
+                  disabled={noCredential}
+                  onChange={(e) => setOtherToolkit(e.target.value)}
+                />
+              </div>
+              <Button
+                variant="outline"
+                disabled={busy !== null || noCredential || !otherToolkit.trim()}
+                onClick={() => {
+                  const slug = otherToolkit.trim().toLowerCase();
+                  setOtherToolkit("");
+                  onConnectSlug(slug);
+                }}
+              >
+                <LogIn className="size-4" />
+                Sign in
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </section>
+  );
+}
+
+function SectionHeading({ count }: { count: number | null }) {
+  return (
+    <div className="space-y-1">
+      <h3 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+        Providers
+      </h3>
+      <p className="text-sm text-muted-foreground">
+        Every account this company can act through, and which are wired.
+        {count !== null && count > 0 && ` ${count} connected.`}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * One tile.
+ *
+ * The whole tile is the affordance when there is exactly one thing to do with
+ * it. An 8.5rem tile has no room for a label AND a button, and a tile that looks
+ * clickable but is not would be worse than either.
+ *
+ * Connected tiles are the exception: the click target moves to a small
+ * Disconnect control in the glyph slot, so the destructive action is never the
+ * whole surface an operator brushes past while scanning.
+ */
+function ProviderTile({
+  row,
+  canManage,
+  busy,
+  anyBusy,
+  noCredential,
+  onConnect,
+  onDisconnect,
+}: {
+  row: GridProvider;
+  canManage: boolean;
+  busy: boolean;
+  anyBusy: boolean;
+  noCredential: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}) {
+  // `managed` and `unavailable` render no action at all — that is the whole
+  // point of routing the tile (issue #599): a button that could only 400 is
+  // never drawn.
+  const connectable =
+    canManage && !row.connected && (row.route.kind === "composio" || row.route.kind === "native");
+  const state = row.connected
+    ? row.via.length > 0
+      ? `connected via ${row.via.join(" + ")}`
+      : "connected"
+    : busy
+      ? "signing in"
+      : row.unverified
+        ? "could not check"
+        : row.route.kind === "managed"
+          ? "managed by the platform"
+          : row.route.kind === "unavailable"
+            ? "not available here"
+            : "not connected";
+
+  const shell = cn(
+    "flex size-full flex-col items-start justify-between gap-1 rounded-lg border p-2.5 text-left",
+    row.connected ? "border-status-done/30 bg-status-done-soft" : "border-border bg-card",
+  );
+
+  const glyph = row.connected ? (
+    canManage && row.canDisconnect ? (
+      <button
+        type="button"
+        disabled={anyBusy}
+        onClick={onDisconnect}
+        title={`Disconnect ${row.label}`}
+        aria-label={`Disconnect ${row.label}`}
+        className={cn(
+          "shrink-0 rounded p-0.5 text-status-done-text",
+          "hover:bg-status-done/20 hover:text-foreground",
+          "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+        )}
+      >
+        {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Unplug className="size-3.5" />}
+      </button>
+    ) : (
+      <Check
+        className="size-3.5 shrink-0 text-status-done-text"
+        // Composio holds this connection and no host route can release it —
+        // `DELETE …/connections/{provider}` only blanks a local secret this
+        // provider never had. Saying where it lives beats a button that
+        // reports success and changes nothing.
+        aria-hidden="true"
+      />
+    )
+  ) : busy ? (
+    <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+  ) : connectable ? (
+    <LogIn className="size-3.5 shrink-0 text-muted-foreground" />
+  ) : null;
+
+  const body = (
+    <>
+      <div className="flex w-full items-start justify-between gap-1">
+        <ProviderLogo row={row} />
+        {glyph}
+      </div>
+      <div className="w-full min-w-0">
+        <span className="line-clamp-2 text-xs leading-tight font-medium">{row.label}</span>
+        <span
+          className={cn(
+            "block truncate text-3xs",
+            row.connected ? "text-status-done-text" : "text-muted-foreground",
+          )}
+        >
+          {row.account ?? state}
+        </span>
+      </div>
+    </>
+  );
+
+  const title =
+    row.connected && !row.canDisconnect
+      ? `${row.label} is connected through Composio; manage or revoke it there.`
+      : row.description || undefined;
+
+  return (
+    // Keyed by the Composio slug, which is what the host calls it and what every
+    // other surface in this issue reconciles on — so a spec that names a tile
+    // names the same thing the backend does.
+    <li className="min-w-0" data-testid={`provider-${row.slug}`}>
+      {connectable ? (
+        <button
+          type="button"
+          disabled={anyBusy || (row.route.kind === "composio" && noCredential)}
+          onClick={onConnect}
+          title={row.description || undefined}
+          aria-label={`Connect ${row.label}. ${state}. Authorises: ${permissionHint(row.category)}.`}
+          className={cn(
+            shell,
+            "transition-colors hover:border-foreground/20 hover:bg-accent",
+            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+            "disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-border disabled:hover:bg-card",
+          )}
+        >
+          {body}
+        </button>
+      ) : (
+        // Connected, unroutable, or a viewer who cannot manage: the tile itself
+        // is not a control. Rendered as a div rather than a disabled button so
+        // it stays in the reading order — "Gmail, connected" is exactly what a
+        // member opened this page to learn, and a disabled button is
+        // unfocusable.
+        <div className={shell} title={title} aria-label={`${row.label}. ${state}.`}>
+          {body}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function ProviderLogo({ row }: { row: GridProvider }) {
+  const [failed, setFailed] = useState(false);
+  // A company can repoint at a different backend, which re-keys the logo. Reset
+  // on URL change so one dead image does not poison the slot for good.
+  useEffect(() => setFailed(false), [row.logoUrl]);
+
+  if (failed) {
+    return (
+      <span
+        aria-hidden="true"
+        className="flex size-8 items-center justify-center rounded-lg bg-muted text-xs font-semibold text-muted-foreground"
+      >
+        {row.label.charAt(0).toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    <img
+      src={row.logoUrl}
+      alt=""
+      aria-hidden="true"
+      loading="lazy"
+      className="size-8 rounded-lg object-contain"
+      onError={() => setFailed(true)}
+    />
+  );
+}

--- a/frontend/test/e2e/connections-one-list.spec.ts
+++ b/frontend/test/e2e/connections-one-list.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #582 — the Connections page must say one thing about a provider.
+ *
+ * The page carried two provider lists fed by two routes that applied different
+ * rules to the same Composio state, so Gmail could render as connected in one
+ * and offer an actionable Connect button in the other, on one screen. An
+ * operator who trusted the second one would start a sign-in for an account
+ * already connected — the shape #396 had to clean up once.
+ *
+ * ## What this spec can and cannot prove here
+ *
+ * The acceptance criteria are structural, and two of the three are checkable
+ * against any host: a provider appears exactly once, and no connect action is
+ * offered for one already connected. Those are asserted below over whatever the
+ * host actually serves, so they hold for a harness with no Composio and for a
+ * tenant with a full catalogue alike.
+ *
+ * The third — that the *status* comes from one place — is the half that needed a
+ * live Composio to exercise, because the contradiction was between
+ * `GET …/connections` (which discarded Composio state unless the company granted
+ * the `composio` namespace) and `GET …/composio/connections` (which never
+ * consulted the grant). The harness binary carries no `composio` feature, so
+ * that divergence cannot be reproduced from here at all. It is pinned where it
+ * is decidable instead: `test/unit/provider-grid.test.ts` for the merge, and
+ * `src/server/ops/connections_read.rs` for the gate itself.
+ *
+ * Drives a running host (see `playwright.config.ts` — the harness brings it up,
+ * there is no `webServer`). CI does not run Playwright.
+ */
+
+type Page = import("@playwright/test").Page;
+
+async function openConnections(page: Page): Promise<void> {
+  await page.goto("/#/settings/connections");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  if (await skip.isVisible().catch(() => false)) await skip.click();
+  await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible({ timeout: 30_000 });
+}
+
+test("a provider appears exactly once on the page", async ({ page }) => {
+  await openConnections(page);
+
+  const slugs = await page.locator("[data-testid^='provider-']").evaluateAll((nodes) =>
+    nodes.map((n) => n.getAttribute("data-testid") ?? ""),
+  );
+  expect(slugs.length, "the page should render provider tiles").toBeGreaterThan(0);
+
+  const duplicated = slugs.filter((slug, i) => slugs.indexOf(slug) !== i);
+  expect(duplicated, `these providers rendered more than one tile: ${duplicated.join(", ")}`).toEqual(
+    [],
+  );
+});
+
+test("the page holds one provider grid, not two", async ({ page }) => {
+  await openConnections(page);
+
+  // The second grid was a categorised one whose sections were headings named
+  // after the category. Categories survive as filter chips on the one grid, so a
+  // *heading* by that name means the old grid came back.
+  await expect(page.getByRole("heading", { name: "Providers" })).toHaveCount(1);
+  for (const category of ["Communication", "Productivity", "Developer", "Finance", "Storage"]) {
+    await expect(
+      page.getByRole("heading", { name: category, exact: true }),
+      `"${category}" is rendered as a section heading — the categorised second grid is back`,
+    ).toHaveCount(0);
+  }
+});
+
+test("no connect action is offered for an already-connected provider", async ({ page }) => {
+  await openConnections(page);
+
+  // The tile is the affordance only when there is something to do with it, so a
+  // connected tile must not be a button. This holds vacuously on a host with
+  // nothing connected, which is the honest outcome — it is an invariant over
+  // whatever is connected, not a claim that something is.
+  const connectable = page.locator("[data-testid^='provider-'] button[aria-label^='Connect ']");
+  for (const tile of await connectable.all()) {
+    await expect(tile).not.toHaveAttribute("aria-label", /\. connected/i);
+  }
+});

--- a/frontend/test/e2e/connections-one-list.spec.ts
+++ b/frontend/test/e2e/connections-one-list.spec.ts
@@ -32,10 +32,28 @@ import { expect, test } from "@playwright/test";
 
 type Page = import("@playwright/test").Page;
 
+/**
+ * Open the page with the first-run tour out of the way.
+ *
+ * The dismissal is not cosmetic and the wait is not padding: the welcome dialog
+ * is a Radix dialog, so while it is open every other element is `aria-hidden`
+ * and therefore invisible to `getByRole`. It also mounts a beat *after* the
+ * navigation resolves — so an `isVisible()` check taken immediately races it and
+ * usually wins, leaving the dialog to open over the assertions that follow.
+ * Every spec here starts from the same shared storage state, which was captured
+ * before any tour was skipped, so this happens once per test rather than once
+ * per run.
+ */
 async function openConnections(page: Page): Promise<void> {
   await page.goto("/#/settings/connections");
   const skip = page.getByRole("button", { name: "Skip for now" });
-  if (await skip.isVisible().catch(() => false)) await skip.click();
+  await skip
+    .waitFor({ state: "visible", timeout: 10_000 })
+    .then(() => skip.click())
+    .catch(() => {
+      /* already dismissed in this context — nothing to close */
+    });
+  await expect(skip).toBeHidden({ timeout: 10_000 });
   await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible({ timeout: 30_000 });
 }
 

--- a/frontend/test/e2e/oauth-onboarding-resume.spec.ts
+++ b/frontend/test/e2e/oauth-onboarding-resume.spec.ts
@@ -56,7 +56,12 @@ test("a cancelled handshake lands back in the console, not on a dead page", asyn
 
   // The grid is rendered and usable — the failure was a bounce-back, not a
   // terminal state.
-  await expect(page.getByRole("heading", { name: "Communication" })).toBeVisible();
+  //
+  // Issue #582 collapsed the page's two provider lists into one, so this asserts
+  // the surviving grid's heading rather than a category section heading from the
+  // catalogue grid that used to sit below it. The categories did not go away —
+  // they are filter chips on the one grid now.
+  await expect(page.getByRole("heading", { name: "Providers" })).toBeVisible();
 
   // Issue #599: this used to assert `getByRole("button", { name: "Connect" })`
   // was enabled. That button was only there because of the bug — this harness
@@ -65,7 +70,7 @@ test("a cancelled handshake lands back in the console, not on a dead page", asyn
   // complete and clicking it 400'd with "provider is not enabled on this host".
   // A tile with no route now says so instead, which is what makes the retry
   // offer honest rather than merely present.
-  await expect(page.getByTestId("connection-unavailable-slack")).toBeVisible();
+  await expect(page.getByTestId("provider-slack")).toContainText(/not available here/i);
 });
 
 test("an unknown failure code still produces a usable message", async ({ page }) => {

--- a/frontend/test/unit/connection-route.test.ts
+++ b/frontend/test/unit/connection-route.test.ts
@@ -106,9 +106,22 @@ describe("composioCanAuthorize", () => {
   it("is false without a reachable Composio", () => {
     expect(composioCanAuthorize(null, "slack")).toBe(false);
     expect(composioCanAuthorize({ ...OPEN, inBuild: false }, "slack")).toBe(false);
-    expect(composioCanAuthorize({ ...OPEN, granted: false }, "slack")).toBe(false);
     // `credentialSource: "none"` — nothing to authorize against.
     expect(composioCanAuthorize({ ...OPEN, hasCredential: false }, "slack")).toBe(false);
+  });
+
+  // Issue #582. This assertion used to read `false`, and that was half of the
+  // page's self-contradiction: `POST …/composio/authorize` never consulted the
+  // grant (`resolve_tenant` reads the credential and the toolkit allowlist and
+  // nothing else), so the sign-in this predicate refused to offer worked fine
+  // from the provider list that ignored the grant. One surface said "connect
+  // me", the other said "no route", for the same account on the same screen.
+  //
+  // The grant governs whether AGENTS receive Composio tools, which is a caveat
+  // the grid states next to the connected badge — not a reason to withhold a
+  // handshake that completes.
+  it("offers a route without the composio grant, which gates tools and not the handshake", () => {
+    expect(composioCanAuthorize({ ...OPEN, granted: false }, "slack")).toBe(true);
   });
 
   it("allows any toolkit in open mode, where the backend allowlist governs", () => {

--- a/frontend/test/unit/provider-grid.test.ts
+++ b/frontend/test/unit/provider-grid.test.ts
@@ -1,0 +1,217 @@
+// The Connections page's one provider grid (issue #582).
+//
+// The bug these pin: the page rendered two provider lists from two routes that
+// applied different rules to the same Composio state, so Gmail could show as
+// connected in one and offer an actionable Connect button in the other, on one
+// screen. These tests are about the merge that leaves one list — that a provider
+// appears exactly once, that its connected state has a single source, and that
+// no action is offered which the host cannot carry out.
+
+import { describe, expect, it } from "vitest";
+
+import type { ComposioToolkitEntry } from "@/api/composio";
+import type { ConnectionState } from "@/api/types";
+import { buildGridProviders } from "@/lib/provider-grid";
+import { CONNECTION_PROVIDERS, type ComposioReach } from "@/lib/connections";
+
+/** A host where Composio is live and everything is reachable (open mode). */
+const OPEN: ComposioReach = {
+  inBuild: true,
+  granted: true,
+  hasCredential: true,
+  openMode: true,
+  effectiveToolkits: [],
+};
+
+function entry(slug: string, over: Partial<ComposioToolkitEntry> = {}): ComposioToolkitEntry {
+  return { slug, name: "", description: "", logo: null, categories: [], ...over };
+}
+
+function states(...rows: ConnectionState[]): Record<string, ConnectionState> {
+  return Object.fromEntries(rows.map((r) => [r.provider, r]));
+}
+
+function bySlug(providers: ReturnType<typeof buildGridProviders>, slug: string) {
+  const found = providers.filter((p) => p.slug === slug);
+  expect(found.length, `expected exactly one ${slug} tile, got ${found.length}`).toBe(1);
+  return found[0];
+}
+
+describe("buildGridProviders", () => {
+  it("renders a provider exactly once even when the host reports it twice", () => {
+    // The host emits two rows for one provider whenever an id and its Composio
+    // slug do not normalize alike: a manifest declaring `x` yields a
+    // disconnected `x` row while Composio's connected state arrives as
+    // `twitter`. Two rows must still be one tile — this is acceptance criterion
+    // 1, and the failure it guards is the whole issue.
+    const providers = buildGridProviders(
+      [entry("twitter")],
+      [],
+      states(
+        { provider: "x", connected: false },
+        { provider: "twitter", connected: true, via: ["composio"] },
+      ),
+      OPEN,
+      false,
+    );
+    const tile = bySlug(providers, "twitter");
+    expect(tile.connected).toBe(true);
+    expect(tile.via).toEqual(["composio"]);
+  });
+
+  it("takes connected from the host's reconciled rows, not from a second probe", () => {
+    const providers = buildGridProviders(
+      [entry("gmail"), entry("slack")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"], account: "ops@acme.test" }),
+      OPEN,
+      false,
+    );
+    expect(bySlug(providers, "gmail").connected).toBe(true);
+    expect(bySlug(providers, "gmail").account).toBe("ops@acme.test");
+    // Absent from `/connections` means not connected — the single answer, with
+    // no second list to contradict it.
+    expect(bySlug(providers, "slack").connected).toBe(false);
+  });
+
+  it("offers no connect action for an already-connected provider", () => {
+    // Acceptance criterion 3. A connected tile is not a Connect affordance, so
+    // an operator cannot start a second sign-in for one account — the shape
+    // #396 had to clean up once.
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+    );
+    expect(bySlug(providers, "gmail").connected).toBe(true);
+  });
+
+  it("matches a hyphenated console id to its Composio slug", () => {
+    const providers = buildGridProviders(
+      [entry("googlecalendar")],
+      [],
+      states({ provider: "googlecalendar", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+    );
+    const tile = bySlug(providers, "googlecalendar");
+    expect(tile.connected).toBe(true);
+    // The host id stays distinct from the Composio slug: one is what
+    // `startConnection`/`disconnectConnection` take, the other is what
+    // `composio/authorize` takes, and sending either to the other's route fails.
+    expect(tile.providerId).toBe("google-calendar");
+  });
+
+  it("keeps every local tile when the host offers no Composio catalog", () => {
+    // A self-hoster with Composio switched off gets an empty catalog. Without
+    // the union the page would render nothing at all rather than the tiles they
+    // can genuinely connect natively.
+    const providers = buildGridProviders([], [], {}, null, false);
+    for (const local of CONNECTION_PROVIDERS) {
+      expect(
+        providers.some((p) => p.slug === local.toolkit),
+        `${local.id} lost its tile with no Composio catalog`,
+      ).toBe(true);
+    }
+  });
+
+  it("does not duplicate a local tile the backend catalog also offers", () => {
+    const providers = buildGridProviders([entry("gmail", { name: "Gmail" })], [], {}, OPEN, false);
+    expect(providers.filter((p) => p.slug === "gmail")).toHaveLength(1);
+  });
+
+  it("offers Disconnect only where the host holds something to release", () => {
+    // `DELETE …/connections/{provider}` blanks the host's own `oauth/{provider}`
+    // secret; no host route releases a Composio connection. A Disconnect on a
+    // Composio-only tile would report success and leave it connected on the next
+    // refresh — the same contradiction in a different place.
+    const providers = buildGridProviders(
+      [entry("gmail"), entry("slack")],
+      [],
+      states(
+        { provider: "gmail", connected: true, via: ["composio"] },
+        { provider: "slack", connected: true, via: ["native"] },
+      ),
+      OPEN,
+      false,
+    );
+    expect(bySlug(providers, "gmail").canDisconnect).toBe(false);
+    expect(bySlug(providers, "slack").canDisconnect).toBe(true);
+  });
+
+  it("reports an unread Composio probe as unknown rather than disconnected", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: false, unverified: true }),
+      OPEN,
+      false,
+    );
+    expect(bySlug(providers, "gmail").unverified).toBe(true);
+  });
+
+  it("does not call a connected provider unverified", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states(
+        { provider: "gmail", connected: true, via: ["native"] },
+        { provider: "gmail-alias", connected: false, unverified: true },
+      ),
+      OPEN,
+      false,
+    );
+    expect(bySlug(providers, "gmail").unverified).toBe(false);
+  });
+
+  it("routes an undeclared provider through Composio on a platform-managed host", () => {
+    // Issue #599's case, carried over: `GET …/connections` answers only for
+    // declared providers, so a tenant declaring none leaves every tile with no
+    // row of its own. The instance-level `attested` fact still applies.
+    const providers = buildGridProviders([entry("gmail")], [], {}, OPEN, true);
+    expect(bySlug(providers, "gmail").route).toEqual({ kind: "composio", toolkit: "gmail" });
+  });
+
+  it("says a platform-managed tile is managed when Composio cannot reach it", () => {
+    const providers = buildGridProviders([entry("gmail")], [], {}, null, true);
+    expect(bySlug(providers, "gmail").route).toEqual({ kind: "managed" });
+  });
+
+  it("gives a slug from the by-slug hatch a tile of its own", () => {
+    const providers = buildGridProviders([], ["hubspot"], {}, OPEN, false);
+    expect(bySlug(providers, "hubspot").route).toEqual({ kind: "composio", toolkit: "hubspot" });
+  });
+
+  it("orders connected providers first", () => {
+    const providers = buildGridProviders(
+      [entry("zendesk"), entry("gmail"), entry("stripe")],
+      [],
+      states({ provider: "stripe", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+    );
+    expect(providers[0].slug).toBe("stripe");
+  });
+
+  it("connects a provider whose company does not grant the composio namespace", () => {
+    // The heart of #582 on this side of the wire. The grant governs whether
+    // agents receive Composio tools; it never governed whether a sign-in can
+    // complete. Gating the route on it — while the other list did not — is what
+    // made one page say both things.
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      { ...OPEN, granted: false },
+      false,
+    );
+    const tile = bySlug(providers, "gmail");
+    expect(tile.connected).toBe(true);
+    expect(bySlug(buildGridProviders([entry("slack")], [], {}, { ...OPEN, granted: false }, false), "slack").route).toEqual({
+      kind: "composio",
+      toolkit: "slack",
+    });
+  });
+});

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -271,10 +271,23 @@ pub(crate) struct ProviderConnection {
 
 /// Ask Composio which toolkits this company has connected.
 ///
-/// Best-effort by construction: a company that does not grant `composio`, a
-/// build without the feature, or a missing credential all yield
-/// [`ComposioView::NotApplicable`], and a live probe that errors yields
-/// [`ComposioView::Unavailable`]. Nothing here can fail the connections page.
+/// Best-effort by construction: a build without the feature or a missing
+/// credential yields [`ComposioView::NotApplicable`], and a live probe that
+/// errors yields [`ComposioView::Unavailable`]. Nothing here can fail the
+/// connections page.
+///
+/// **Not gated on the `composio` tool grant** (issue #582). It used to be, and
+/// that gate was the page's contradiction: `GET …/composio/connections` — which
+/// the console's provider list reads — has never consulted the grant, so a
+/// company holding a credential without an explicit `composio` grant got
+/// "connected" from one route and "not connected" from this one, for the same
+/// account, on the same screen. 13 of the 21 shipped companies grant no
+/// `composio`, so this was the steady state rather than a race.
+///
+/// The grant answers a *different* question — whether agents receive Composio
+/// tools — and the console states that separately from the `granted` flag on
+/// `GET …/composio`. Discarding a real connection here never answered it; it
+/// only made the page disagree with itself.
 ///
 /// **Bounded on purpose.** This is a network call on a page-load path, so a
 /// backend that stops answering must degrade the Composio half of one row — not
@@ -282,10 +295,7 @@ pub(crate) struct ProviderConnection {
 /// lands in [`ComposioView::Unavailable`], which the console renders as "could
 /// not check" rather than as a confident disconnected state.
 #[cfg(feature = "composio")]
-async fn composio_view(runtime: &CompanyRuntime, granted: bool) -> ComposioView {
-    if !granted {
-        return ComposioView::NotApplicable;
-    }
+async fn composio_view(runtime: &CompanyRuntime) -> ComposioView {
     let Ok(config) = super::composio::resolve_tenant(runtime).await else {
         // No credential of any tier resolves, so there is no Composio path to
         // reconcile against — not a failure to report.
@@ -322,7 +332,7 @@ const COMPOSIO_PROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_se
 /// Without the `composio` feature there is no second namespace to reconcile
 /// against, so every provider's answer is the native one alone.
 #[cfg(not(feature = "composio"))]
-async fn composio_view(_runtime: &CompanyRuntime, _granted: bool) -> ComposioView {
+async fn composio_view(_runtime: &CompanyRuntime) -> ComposioView {
     ComposioView::NotApplicable
 }
 
@@ -335,14 +345,25 @@ async fn composio_view(_runtime: &CompanyRuntime, _granted: bool) -> ComposioVie
 pub(crate) async fn project_connections(
     runtime: &CompanyRuntime,
 ) -> Result<Vec<ProviderConnection>, crate::error::OpenCompanyError> {
+    reconcile(runtime, composio_view(runtime).await).await
+}
+
+/// [`project_connections`] over an already-resolved [`ComposioView`].
+///
+/// Split out purely as a test seam, and worth one: the probe is a network call
+/// with no injection point, so before this the *reconciliation* — which is the
+/// part that decides what the console shows — could only be exercised through
+/// the `NotApplicable` arm. The gate that issue #582 removed lived on the far
+/// side of that line, which is how it survived: nothing could assert that a
+/// company granting no `composio` still gets its Composio-connected providers,
+/// because no test could produce a [`ComposioView::Known`] to assert it with.
+async fn reconcile(
+    runtime: &CompanyRuntime,
+    composio: ComposioView,
+) -> Result<Vec<ProviderConnection>, crate::error::OpenCompanyError> {
     let Some(record) = runtime.store().load(runtime.id()).await? else {
         return Ok(Vec::new());
     };
-    let composio = composio_view(
-        runtime,
-        crate::company::grants_composio_explicit(&record.manifest.tools.allow),
-    )
-    .await;
     // Host-level, so resolved once rather than per connection below.
     let host = HostConnectRoutes::from_env();
 
@@ -957,6 +978,87 @@ mod tests {
                  different key"
             );
         }
+    }
+
+    /// Issue #582: the Composio half of a row does **not** depend on the
+    /// `composio` tool grant.
+    ///
+    /// This is the contradiction the Connections page reported. `GET
+    /// …/connections` used to discard every Composio connection unless the
+    /// company explicitly granted the `composio` namespace, while `GET
+    /// …/composio/connections` — which the console's provider list reads —
+    /// never consulted the grant. 13 of the 21 shipped companies grant no
+    /// `composio`, so for most of them "connected here, not connected there"
+    /// was the steady state rather than a race.
+    ///
+    /// The manifest below grants nothing at all, which is the case that used to
+    /// return an empty list: no `[[connection]]` to project natively, and a
+    /// Composio view thrown away before it was read.
+    #[tokio::test]
+    async fn composio_state_survives_a_company_that_does_not_grant_composio() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n",
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        let rows = super::reconcile(
+            runtime.as_ref(),
+            super::ComposioView::Known(
+                [("gmail".to_string(), true), ("slack".to_string(), false)]
+                    .into_iter()
+                    .collect(),
+            ),
+        )
+        .await
+        .expect("reconcile");
+
+        let gmail = rows
+            .iter()
+            .find(|row| row.provider == "gmail")
+            .expect("a Composio-connected provider must reach the console even with no grant");
+        assert!(
+            gmail.connected,
+            "gmail should be connected: {:?}",
+            gmail.via
+        );
+        assert_eq!(gmail.via, vec!["composio"]);
+        // A toolkit Composio knows but has not connected is not a row: the page
+        // lists what is connected plus what the catalog offers, and the catalog
+        // is the other route's job.
+        assert!(
+            !rows.iter().any(|row| row.provider == "slack"),
+            "a disconnected toolkit should not become a connection row"
+        );
+    }
+
+    /// An unread probe is reported as unknown, not as disconnected — the
+    /// distinction the console renders as "could not check".
+    #[tokio::test]
+    async fn an_unreadable_composio_probe_is_unverified_not_disconnected() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(
+            &home,
+            "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+             [[connection]]\nprovider = \"gmail\"\n",
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        let rows = super::reconcile(runtime.as_ref(), super::ComposioView::Unavailable)
+            .await
+            .expect("reconcile");
+
+        let gmail = rows.iter().find(|row| row.provider == "gmail").unwrap();
+        assert!(!gmail.connected);
+        assert!(
+            gmail.unverified,
+            "an unanswered probe must not read as 'no'"
+        );
     }
 
     /// A company with no `[[connection]]` entries returns an empty list (200),


### PR DESCRIPTION
Closes #582.

## The RCA differs from the issue, and it matters for review

Three of the five things #582 describes were **already fixed on main** by #599, #586 and #600. Reviewers should not re-litigate them:

- **Slug aliasing** — fixed by #599. Each tile carries an explicit `toolkit` slug and `connectionStateFor` matches across both spellings, connected-wins, including the `x`→`twitter` alias a normalizer cannot derive.
- **Dead Connect buttons** — fixed by #599. `connectRoute` picks native/composio/managed/unavailable per tile, so a button that could only 400 is no longer rendered.
- **Grid staleness after a sign-in started in the grid** — fixed. `connectComposio` re-reads `GET …/connections` after its poll.

The issue's stated cause — "a hardcoded catalog with no knowledge of what Composio reports" — is therefore not the bug. Since #316 the backend reconciles both namespaces and the grid rendered that live state. Two things actually remained.

### 1. A gate asymmetry between two routes (the root cause)

`composio_view` in `src/server/ops/connections_read.rs` discarded **all** Composio state unless the company explicitly granted the `composio` tool namespace. `GET …/composio/connections` — which the console's other provider list read — never consulted the grant.

**13 of the 21 shipped companies grant no `composio`**, so for most of them "connected here, not connected there" was the steady state, not a race. The console mirrored the split: `composioCanAuthorize` required `reach.granted` while `ComposioSection`'s `showProviders` ignored it entirely.

The grant governs whether **agents receive Composio tools**. It never governed whether a handshake completes — `resolve_tenant` reads the credential and the toolkit allowlist and nothing else — so the sign-in the gate refused to offer worked perfectly well from the surface that ignored it. Reinstating the gate on the *other* surface would have been the wrong repair: it would remove a sign-in operators use today and leave no way to connect an account before granting the namespace. So the grant is now reported (`granted` on `GET …/composio`) and rendered as a caveat beside the connected badge.

### 2. Two lists still rendered

`ComposioSection`'s tile grid and the categorised grid of eleven hardcoded tiles. #600 made this sharper rather than softer: the Composio grid is now a branded tile grid with logos, category chips and search over the backend's ~123-provider catalog, so the two were visually near-identical.

Also fixed: the header badge counted every `/connections` row while the grid drew only the eleven tiles the console had metadata for, so it could read "3 connected" above a grid showing none of them.

## The change

**Which grid survives.** The Composio grid, because it was already the better one: its membership is the backend's live catalog rather than a list compiled into the console, and #600 gave it the names, logos, descriptions and categories that made the hardcoded tiles worth keeping. It absorbs the other grid's job — reconciled status from `GET …/connections`, the native self-hosted route, and Disconnect.

- `frontend/src/lib/provider-grid.ts` (new) merges catalog + native metadata + host status into the rendered rows.
- `frontend/src/views/connections/ProvidersSection.tsx` (new) draws them.
- `frontend/src/lib/connections.ts` stops being a list and becomes native-route metadata: the ids with a `well_known` key, their Composio slugs, brand colours, and the tiles a host with no Composio falls back to.
- `ComposioSection` keeps only the credential layer it documents itself as, and notifies the page on token change so the grid re-probes.
- `reconcile` is split out of `project_connections` as a test seam — the probe is a network call with no injection point, and the removed gate lived on the far side of it, which is how it survived unasserted.

Net **−340 lines**.

## One deliberate behaviour change

**Disconnect is now offered only where `via` includes `native`.** No host route releases a Composio connection (`/composio` exposes status, token, authorize and connections, and nothing else), so the old button called `…/connections/{id}/disconnect`, blanked a secret that was never set, reported success, and left the tile connected on the next refresh. A Composio-only tile now names where the connection lives instead.

## Acceptance

- ✅ A provider appears exactly once on the page.
- ✅ Its connected state comes from one place — `GET …/connections`, which reconciles both namespaces and is what an agent's tool belt is built from.
- ✅ No Connect is offered for an already-connected provider.

## Commands run

```
cargo fmt --all -- --check
cargo clippy --all-targets -- -D warnings
cargo test                                  # 2038 lib tests, 0 failed
cargo +1.96.1 check --features composio -p opencompany --all-targets
cd frontend && npx tsc -b && npm test        # 434 tests, 0 failed
# real host serving the production bundle, real browser:
PW_BASE_URL=… PW_STORAGE_STATE=… npx playwright test   # 100 passed, 8 skipped, 0 failed
```

Also verified manually against a running host with the console bundle: 13 tiles, zero duplicates, zero connected-tiles-offering-Connect, zero leftover category headings, no console errors.

## What the tests do NOT prove

**The grant-gate divergence itself is not reproduced end-to-end.** It needs a `--features composio` host *and* live Composio credentials for a company that does not grant `composio` — the e2e harness binary is a default-feature build, so `inBuild` is false and the divergence cannot arise there. It is pinned where it is decidable instead:

- `src/server/ops/connections_read.rs` — `composio_state_survives_a_company_that_does_not_grant_composio`
- `frontend/test/unit/provider-grid.test.ts` — the merge, 14 cases

`frontend/test/e2e/connections-one-list.spec.ts` asserts only the structural criteria, and says so in its header.

One existing assertion in `connection-route.test.ts` was **inverted deliberately**: it pinned `composioCanAuthorize(..., granted: false) === false`, which is the exact gate that caused the bug.

## Follow-up

#404 ("a provider as an openable, manageable object") should read from the single source this establishes. Doing it on top of two lists would bake the split in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
