### PR TITLE
feat(console): author transform.set and connection_ref (#661)

### DIFF
--- a/frontend/src/lib/workflow-node-config.ts
+++ b/frontend/src/lib/workflow-node-config.ts
@@ -12,17 +12,33 @@
 // OpenCompany's `translate.rs` (which lays a node's `config` over the derived
 // defaults verbatim):
 //
-//   tool_call     { slug, args }
-//   http_request  { method, url, headers, body }
+//   tool_call     { slug, args, connection_ref }
+//   http_request  { method, url, headers, body, connection_ref }
 //   switch        { field | expression }        (cases are EDGE labels, not config)
 //   output_parser { schema, auto_fix }
 //   sub_workflow  { workflow_id }
+//   transform     { set }
 //
 // `condition` is a core palette kind (not one of the withheld five), but the
 // host now REQUIRES `config.field` at author time (#661 M1) — the engine
 // truthiness-tests that expression, and without it a condition always routed
 // `true`. So it carries a form too: `condition { field }` (the `yes`/`no`
 // branches are EDGE labels, not config).
+//
+// `transform` is likewise a core palette kind, but its one engine key —
+// `config.set`, a JSON object of field → literal/`=`-expression the engine lays
+// over each item (`nodes/control_flow/transform.rs`) — had no control, so a
+// console-authored transform lowered to a silent identity node. It carries a
+// form now: `transform { set }`. `set` is OPTIONAL — an absent/empty `set` is a
+// valid engine passthrough (what a plain `output` node lowers to), so it is
+// never required. The engine reads `set` only via `as_object`, so a non-object
+// `set` is silently ignored; the `object` shape gate rejects it at author time.
+//
+// `tool_call` and `http_request` also each read an optional `connection_ref`
+// (`cfg.get("connection_ref").and_then(as_str)` in their integration nodes) —
+// an opaque handle to a connected account / credential the host resolves, never
+// a token or secret. It used to survive an edit only by riding the `extra` bag
+// (so it was unauthorable); it is a first-class field on both kinds now.
 //
 // Keys the host REJECTS inside `config` — `on_error`, `retry`,
 // `requires_approval`, `schedule`, `destination`, `agent_ref` — are first-class
@@ -89,6 +105,13 @@ export const NODE_CONFIG_FIELDS: Record<string, readonly ConfigFieldSpec[]> = {
       placeholder: '{ "query": "=item.topic" }',
       hint: "A JSON object of arguments. `=`-expressions resolve per input item at run time.",
     },
+    {
+      key: "connection_ref",
+      label: "Connection",
+      control: "line",
+      placeholder: "composio:slack:acct_1",
+      hint: "Optional. An opaque reference to a connected account or credential the host resolves — never a token or secret. Leave empty to use the default connection.",
+    },
   ],
   http_request: [
     {
@@ -127,6 +150,13 @@ export const NODE_CONFIG_FIELDS: Record<string, readonly ConfigFieldSpec[]> = {
       jsonShape: "object-or-string",
       placeholder: '{ "hello": "world" }',
       hint: "A JSON object sent as the body, or a JSON string like `\"raw text\"`.",
+    },
+    {
+      key: "connection_ref",
+      label: "Connection",
+      control: "line",
+      placeholder: "http:acct_2",
+      hint: "Optional. An opaque reference to a connected account or credential the host resolves — never a token or secret. Leave empty for an unauthenticated request.",
     },
   ],
   switch: [
@@ -173,6 +203,16 @@ export const NODE_CONFIG_FIELDS: Record<string, readonly ConfigFieldSpec[]> = {
       required: true,
       placeholder: "another workflow's id",
       hint: "The id of the workflow to run. It can't be this workflow's own id.",
+    },
+  ],
+  transform: [
+    {
+      key: "set",
+      label: "Set fields",
+      control: "json",
+      jsonShape: "object",
+      placeholder: '{ "greeting": "=item.name" }',
+      hint: "Optional. A JSON object of fields to add or overwrite on each item — each value is a literal or an `=`-expression resolved per item. Leave empty to pass items through unchanged.",
     },
   ],
 };
@@ -233,11 +273,10 @@ function stringifyConfigValue(spec: ConfigFieldSpec, value: unknown): string {
  *
  * Known keys become form strings. **Every other key is preserved verbatim in
  * `extra`** — the anti-data-loss guard: an orchestrator-authored node can carry
- * keys this form has no control for (`connection_ref` on a tool/http node,
- * `execution`/`concurrency`/`inputs` on a sub_workflow), and rebuilding the
- * node from the visible controls alone would silently delete them on the first
- * save. Reserved keys are the one exception — dropped, since the host would
- * reject them anyway.
+ * keys this form has no control for (`execution`/`concurrency`/`inputs` on a
+ * sub_workflow), and rebuilding the node from the visible controls alone would
+ * silently delete them on the first save. Reserved keys are the one exception —
+ * dropped, since the host would reject them anyway.
  */
 export function configDraftFrom(
   kind: string,

--- a/frontend/test/unit/workflow-node-config.test.ts
+++ b/frontend/test/unit/workflow-node-config.test.ts
@@ -27,7 +27,7 @@ import {
  */
 
 describe("hasConfigForm", () => {
-  it("covers the five withheld kinds plus condition (#661 M1)", () => {
+  it("covers the five withheld kinds plus condition (#661 M1) and transform (#661 L3)", () => {
     for (const kind of [
       "tool_call",
       "http_request",
@@ -37,10 +37,14 @@ describe("hasConfigForm", () => {
       // `condition` is a core palette kind, but the host now REQUIRES
       // `config.field` at author time (#661 M1), so it carries a form too.
       "condition",
+      // `transform` is also a core palette kind; its `config.set` map had no
+      // control, so an authored transform lowered to a silent identity node
+      // (#661 L3). It carries a form now.
+      "transform",
     ]) {
       expect(hasConfigForm(kind), kind).toBe(true);
     }
-    for (const kind of ["trigger", "agent", "merge", "transform", "output"]) {
+    for (const kind of ["trigger", "agent", "merge", "output"]) {
       expect(hasConfigForm(kind), kind).toBe(false);
       expect(configFieldSpecs(kind)).toEqual([]);
     }
@@ -51,6 +55,16 @@ describe("hasConfigForm", () => {
     expect(specs).toHaveLength(1);
     expect(specs[0].key).toBe("field");
     expect(specs[0].required).toBe(true);
+  });
+
+  it("transform exposes a single optional object `set` field (#661 L3)", () => {
+    const specs = configFieldSpecs("transform");
+    expect(specs).toHaveLength(1);
+    expect(specs[0].key).toBe("set");
+    // OPTIONAL — an absent/empty `set` is a valid engine passthrough.
+    expect(specs[0].required).toBeFalsy();
+    // The engine reads `set` only via `as_object`, so the shape gate is `object`.
+    expect(specs[0].jsonShape).toBe("object");
   });
 });
 
@@ -118,9 +132,49 @@ describe("configFromDraft — valid drafts emit exactly the engine keys", () => 
     });
   });
 
+  it("transform: set map, empty draft omits config entirely (#661 L3)", () => {
+    expect(configFromDraft("transform", { set: '{ "greeting": "=item.name" }' })).toEqual({
+      set: { greeting: "=item.name" },
+    });
+    // An empty set is a passthrough → the whole config is omitted, never `{}`.
+    expect(configFromDraft("transform", { set: "" })).toBeUndefined();
+    // An explicit empty object is authored through verbatim (still a passthrough).
+    expect(configFromDraft("transform", { set: "{}" })).toEqual({ set: {} });
+  });
+
+  it("tool_call: connection_ref rides alongside slug/args, omitted when blank (#661 M6)", () => {
+    expect(
+      configFromDraft("tool_call", {
+        slug: "slack.post",
+        args: '{ "text": "hi" }',
+        connection_ref: "composio:slack:acct_1",
+      }),
+    ).toEqual({ slug: "slack.post", args: { text: "hi" }, connection_ref: "composio:slack:acct_1" });
+
+    // Whitespace-only connection_ref is trimmed to empty and omitted.
+    expect(
+      configFromDraft("tool_call", { slug: "slack.post", args: "", connection_ref: "  " }),
+    ).toEqual({ slug: "slack.post" });
+  });
+
+  it("http_request: connection_ref rides alongside method/url, omitted when blank (#661 M6)", () => {
+    expect(
+      configFromDraft("http_request", {
+        method: "POST",
+        url: "https://api.test/x",
+        connection_ref: "http:acct_2",
+      }),
+    ).toEqual({ method: "POST", url: "https://api.test/x", connection_ref: "http:acct_2" });
+
+    expect(
+      configFromDraft("http_request", { method: "GET", url: "u", connection_ref: "" }),
+    ).toEqual({ method: "GET", url: "u" });
+  });
+
   it("an all-empty draft serializes to undefined (config omitted from the body)", () => {
     expect(configFromDraft("switch", { field: "", expression: "" })).toBeUndefined();
     expect(configFromDraft("http_request", { method: "", url: "" })).toBeUndefined();
+    expect(configFromDraft("transform", { set: "" })).toBeUndefined();
   });
 });
 
@@ -139,6 +193,19 @@ describe("hydrate → serialize round-trips", () => {
     { kind: "switch", config: { field: "kind" } },
     { kind: "output_parser", config: { schema: { type: "object" }, auto_fix: false } },
     { kind: "sub_workflow", config: { workflow_id: "child-1" } },
+    // `transform` flipping to a config form (#661 L3) means saved transform
+    // configs now decompose → rebuild on every save; that MUST be lossless.
+    { kind: "transform", config: { set: { greeting: "=item.name", tag: "fixed" } } },
+    // connection_ref is a known key now (#661 M6), so it round-trips through the
+    // draft — not the extra bag — on both integration kinds.
+    {
+      kind: "tool_call",
+      config: { slug: "gmail.send", args: { to: "=item.email" }, connection_ref: "acct_9" },
+    },
+    {
+      kind: "http_request",
+      config: { method: "GET", url: "u", connection_ref: "http:acct_2" },
+    },
   ];
 
   for (const { kind, config } of cases) {
@@ -149,15 +216,42 @@ describe("hydrate → serialize round-trips", () => {
   }
 });
 
-describe("unknown-key preservation — the data-loss guard", () => {
-  it("keeps an orchestrator's connection_ref on a tool_call across an edit", () => {
+describe("connection_ref is authorable, not an extra-bag rider (#661 M6)", () => {
+  it("hydrates a tool_call connection_ref into the draft, leaving extra empty", () => {
     const config = { slug: "gmail.send", connection_ref: "acct_42", args: { to: "x" } };
     const { draft, extra } = configDraftFrom("tool_call", config);
-    // The unknown key lands in `extra`, not in a form field.
-    expect(extra).toEqual({ connection_ref: "acct_42" });
+    // Now a known key: it lands in the draft field, NOT the extra bag.
+    expect(draft.connection_ref).toBe("acct_42");
+    expect(extra).toEqual({});
     expect(draft.slug).toBe("gmail.send");
-    // …and rides back out verbatim on serialize.
+    // …and serializes back as a top-level config key.
     expect(configFromDraft("tool_call", draft, extra)).toEqual(config);
+  });
+
+  it("blanking connection_ref on an edit deletes the key", () => {
+    const config = { slug: "gmail.send", connection_ref: "acct_42" };
+    const { draft, extra } = configDraftFrom("tool_call", config);
+    draft.connection_ref = "";
+    expect(configFromDraft("tool_call", draft, extra)).toEqual({ slug: "gmail.send" });
+  });
+
+  it("hydrates an http_request connection_ref into the draft, leaving extra empty", () => {
+    const config = { method: "GET", url: "u", connection_ref: "http:acct_2" };
+    const { draft, extra } = configDraftFrom("http_request", config);
+    expect(draft.connection_ref).toBe("http:acct_2");
+    expect(extra).toEqual({});
+    expect(configFromDraft("http_request", draft, extra)).toEqual(config);
+  });
+});
+
+describe("unknown-key preservation — the data-loss guard", () => {
+  it("keeps an unknown sibling key on a transform across an edit (#661 L3)", () => {
+    // transform gaining a config form must not start dropping unknown siblings.
+    const config = { set: { g: "=item.name" }, mystery: "keep-me" };
+    const { draft, extra } = configDraftFrom("transform", config);
+    expect(draft.set).toBe(JSON.stringify({ g: "=item.name" }, null, 2));
+    expect(extra).toEqual({ mystery: "keep-me" });
+    expect(configFromDraft("transform", draft, extra)).toEqual(config);
   });
 
   it("keeps a sub_workflow's execution/concurrency/inputs", () => {
@@ -242,6 +336,19 @@ describe("configFieldProblem — blur-time JSON check", () => {
       );
     }
   });
+
+  it("rejects a transform set that is valid JSON but not an object (#661 L3)", () => {
+    const setSpec = configFieldSpecs("transform").find((s) => s.key === "set")!;
+    // The engine reads `set` via `as_object`, so arrays/scalars are silently
+    // ignored at run time — the shape gate rejects them at author time instead.
+    for (const bad of ["[]", "42", "true", '"a string"', "null"]) {
+      expect(configFieldProblem(setSpec, bad)).toMatch(/must be a JSON object/);
+    }
+    expect(configFieldProblem(setSpec, "{ not json")).toMatch(/must be valid JSON/);
+    expect(configFieldProblem(setSpec, '{ "greeting": "=item.name" }')).toBeNull();
+    // Empty is never nagged on blur.
+    expect(configFieldProblem(setSpec, "")).toBeNull();
+  });
 });
 
 describe("configDraftProblem — submit-time gate", () => {
@@ -308,6 +415,16 @@ describe("configDraftProblem — submit-time gate", () => {
     expect(configDraftProblem("sub_workflow", "flow-1", { workflow_id: "" })).toMatch(
       /needs the id/,
     );
+  });
+
+  it("rejects a transform set whose shape is wrong at submit (#661 L3)", () => {
+    expect(configDraftProblem("transform", "n1", { set: "[]" })).toMatch(/must be a JSON object/);
+    expect(configDraftProblem("transform", "n1", { set: "{ bad" })).toMatch(/must be valid JSON/);
+    // An empty set is a valid passthrough — never blocked.
+    expect(configDraftProblem("transform", "n1", { set: "" })).toBeNull();
+    expect(
+      configDraftProblem("transform", "n1", { set: '{ "greeting": "=item.name" }' }),
+    ).toBeNull();
   });
 
   it("is a no-op for a kind without a config form", () => {


### PR DESCRIPTION
**Part of #661 — L3 + M6.** (Not `Closes` — #661 is a multi-PR tracker.)

## Summary

The operator console's node authoring table (`frontend/src/lib/workflow-node-config.ts` — the single source of truth both the create dialog and its renderer read) was missing two keys the tinyflows engine actually reads, so two node kinds couldn't be authored faithfully from the console:

- **L3 — `transform`** was on the palette but had no spec entry, so a console-authored transform lowered to a silent identity node. The engine (`nodes/control_flow/transform.rs`) reads `config.set` — a JSON object of `field → literal/=-expression` laid over each item (absent = passthrough). This PR adds a single **optional** `set` field (`json`, `object` shape). `set` is deliberately not required: an absent/empty `set` is a valid engine passthrough (what a plain `output` node lowers to). The engine only reads `set` via `as_object`, so the `object` shape gate rejects an array/scalar `set` at author time — the exact values the engine would otherwise silently ignore.

- **M6 — `connection_ref`** (an opaque connected-account / credential reference the `tool_call` and `http_request` integration nodes resolve via `cfg.get("connection_ref").and_then(as_str)`) was only preserved through an edit by riding the hydrate helper's `extra` bag, so it was unauthorable. This PR appends an **optional** `connection_ref` field to both kinds. Now that it's a known spec key, `configDraftFrom` routes it to the draft (not `extra`) and `configFromDraft` emits it only when non-empty — clearing it on an edit deletes the key.

Every helper in this module is table-driven, so no other frontend code changed: `NodeConfigFields.tsx` already renders `json` + `line` controls and `WorkflowCreateDialog.tsx` is spec-driven. `RESERVED_CONFIG_KEYS` is untouched (neither `set` nor `connection_ref` collides). No Rust changes.

The field hints frame `connection_ref` strictly as an opaque reference the host resolves — never a token or secret to paste.

## API Or Behavior Changes

- Dropping a **transform** node now shows a "Set fields" JSON control; authoring it emits `config.set` instead of an empty/identity config.
- **tool_call** and **http_request** now show an optional "Connection" line; authoring it emits `config.connection_ref`.
- `hasConfigForm("transform")` now returns `true`, so a saved transform's config is decomposed and rebuilt on save. This is covered by a dedicated lossless round-trip test.
- No breaking changes — both new fields are optional; existing saved graphs hydrate and re-serialize identically (the `extra`-bag data-loss guard for unknown keys is preserved and re-tested).

## Tests

Frontend-only change — the Rust checkboxes below are **N/A** (no Rust touched). Commands actually run locally from `frontend/`, all green:

- `npm run typecheck` — exit 0
- `npm run build` — exit 0
- `npx vitest run` — 453 passed (41 in `workflow-node-config.test.ts`, incl. the new cases)
- `./scripts/ci/assert-design-tokens.sh` (repo root) — exit 0

New/updated unit coverage: transform emits exactly `{ set: {...} }`; empty transform draft → config omitted; transform + connection_ref lossless hydrate/serialize round-trips; `set` shape gate (array/scalar/malformed rejected at blur and submit); `connection_ref` emitted alongside `slug`/`args` and `method`/`url` on both kinds; blank/whitespace `connection_ref` omitted; `connection_ref` hydrates into the draft (extra empty) and blanking it on an edit deletes the key; the sub_workflow `extra`-bag test retained as the generic data-loss guard.

Manual UI verification still to do (needs a running console): drop a transform → the "Set fields" control appears and persists; add a "Connection" value on a tool_call / http_request → it persists and clears cleanly.

- [ ] `cargo fmt --all -- --check` — N/A (frontend-only)
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A (frontend-only)
- [ ] `cargo build --all-targets` — N/A (frontend-only)
- [ ] `cargo test` — N/A (frontend-only)

## Documentation

No external docs needed. The module's header comment key-table and the `configDraftFrom` docstring are updated in-file: the `transform { set }` row and `connection_ref` columns are added, and the docstring's canonical extra-bag example (formerly `connection_ref`, now a known key) is switched to a sub_workflow's `execution`/`concurrency`/`inputs`.
