### PR TITLE
docs(workflows): node-kind vocabulary honesty — headers + contract (#661)

### DIFF
--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -39,6 +39,10 @@ Supporting docs:
   `workflow`-deliverable card builds a proposed graph that lands In Review for
   approval before it exists, then apply/reject; host-authority conversion and
   the one authoring path
+- [workflow-vocabulary.md](workflow-vocabulary.md) — the node-kind authoring
+  contract: the 12 kinds an author may write and what each lowers to, the
+  engine-only kinds (`code` / `memory` / `dedup` / `loop`) OpenCompany refuses
+  at parse and why, and the builder ⊂ parser ⊂ engine nesting
 - [rebuild.md](rebuild.md) — replacing a registered runtime in place (quiesce →
   hand over → swap), so a first-time inference config needs no restart
 - [api.md](api.md) — HTTP routes and auth

--- a/docs/spec/runtime/workflow-build.md
+++ b/docs/spec/runtime/workflow-build.md
@@ -58,7 +58,9 @@ uses, on `updated_at_millis`).
 
 The direction is inverted exactly as in [Planning](planning.md): the **host**
 gathers the roster (which teammates an `agent` node may name), the node-kind
-vocabulary, and the names of the workflows that already exist, and hands the
+vocabulary (the builder emits within `BUILDER_NODE_KINDS`, a subset of the
+authoring set — see [workflow-vocabulary.md](workflow-vocabulary.md)), and the
+names of the workflows that already exist, and hands the
 model a complete picture. The model runs with **no tools** and only synthesizes
 — so collisions and unknown-agent references are rare by construction, and a
 builder pass can no more act on the world than a planning pass can.

--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -1,0 +1,112 @@
+# Workflow node-kind vocabulary
+
+Three node-kind sets sit behind a company workflow, and they are deliberately
+**not** the same size. This document is the authoring contract: which node
+kinds an author may write, what each one becomes when it runs, and — just as
+importantly — which engine kinds OpenCompany refuses on purpose and why.
+
+## The authoring contract is `workflow_file.rs`, not the vendored catalog
+
+The tinyflows engine defines a catalog of node kinds in its own source
+(`NODE_KINDS` in the vendored `tinyflows/src/catalog.rs`). That catalog is the
+*engine's* vocabulary, not OpenCompany's. The set an author may actually write
+is the narrower `WORKFLOW_NODE_KINDS` in
+[`src/company/workflow_file.rs`](../../../src/company/workflow_file.rs): the
+parser accepts exactly those kinds and rejects everything else at parse time,
+listing the accepted set in the error. Reading the vendored catalog to learn
+"what a workflow may contain" gives the wrong answer — always read
+`WORKFLOW_NODE_KINDS`.
+
+The relationship is a strict nesting:
+
+```
+builder (BUILDER_NODE_KINDS)  ⊂  parser (WORKFLOW_NODE_KINDS)  ⊂  engine (NODE_KINDS)
+        4 kinds                          12 kinds                       15 kinds
+```
+
+Each layer is a superset of the one to its left. An author writes within the
+parser set; the host's automatic builder emits within an even narrower set (see
+[The builder tier is narrower still](#the-builder-tier-is-narrower-still)); the
+engine can run more than either accepts.
+
+## The 12 accepted kinds and what each lowers to
+
+`translate()` in
+[`src/workflows/translate.rs`](../../../src/workflows/translate.rs) maps every
+accepted kind onto a tinyflows engine kind. Eleven are identity mappings — the
+on-disk kind and the engine kind are the same string. The one exception is
+`output`, which the engine has no kind for, so it lowers to a bare
+`transform`.
+
+| OpenCompany kind | Lowers to (tinyflows) | Note |
+| --- | --- | --- |
+| `trigger` | `trigger` | identity |
+| `agent` | `agent` | identity; `agent_ref` routes to the company `HarnessPool` |
+| `tool_call` | `tool_call` | identity; runs a real toolbelt tool, fail-closed on `[tools].allow` |
+| `http_request` | `http_request` | identity; routes through the SSRF-guarded `GuardedHttpClient` |
+| `condition` | `condition` | identity; edge labels map to `true`/`false` ports |
+| `output` | `transform` | **not identity** — see below |
+| `switch` | `switch` | identity |
+| `merge` | `merge` | identity |
+| `split_out` | `split_out` | identity |
+| `transform` | `transform` | identity |
+| `output_parser` | `output_parser` | identity |
+| `sub_workflow` | `sub_workflow` | identity |
+
+`tool_call` and `http_request` are fully wired and execute for real (see
+[`src/workflows/caps/mod.rs`](../../../src/workflows/caps/mod.rs)); they are not
+structural placeholders.
+
+## `output` lowering and host-side delivery
+
+tinyflows has no `output` kind. An `output` node lowers to a `transform` node
+with no `set` config — a pure pass-through, which is exactly the terminal
+"report back" semantics: its predecessors' items flow through unchanged.
+
+An `output` node may also carry a `destination` (`owner` / `email` / `channel`,
+from `WORKFLOW_DESTINATION_KINDS`). That destination is **deliberately not
+translated** into the engine graph. Delivery runs host-side, after the engine
+returns, in [`src/workflows/delivery.rs`](../../../src/workflows/delivery.rs);
+the engine has no use for a `destination` key and it would be inert cargo in
+node config. A destination-bearing `output` node therefore lowers to the same
+bare pass-through `transform` as one without a destination — pinned by the
+`an_output_destination_never_reaches_the_engine_graph` test in `translate.rs`.
+
+## The engine-only kinds OpenCompany rejects
+
+The engine catalog carries four kinds the parser does **not** accept:
+`code`, `memory`, `dedup`, and `loop`. A workflow file naming any of them fails
+at parse with the usual unknown-kind error — they never reach `translate()`.
+Each is left out for a specific, recorded reason (rationale lives in
+[`src/workflows/caps/mod.rs`](../../../src/workflows/caps/mod.rs)):
+
+| Engine-only kind | Why it is rejected |
+| --- | --- |
+| `code` | The `CodeRunner` capability is an explicit loud-failure stub (`UnwiredCode`): code execution for company workflows is not built, so the capability returns a clear error rather than a silent no-op. Accepting the kind would only let an author author a node that can never run. |
+| `memory` | Deliberately undecided, not merely unbuilt. A `MemoryProvider` would give a workflow read **and write** access to agent memory, and which scopes a workflow may touch has not been settled. The capability is left `None` and pinned by `the_memory_capability_is_left_unwired_on_purpose`, so the answer must be given rather than defaulted into. |
+| `dedup` | A tinyflows 0.6 catalog addition (arrived with the #499 pin bump) that OpenCompany has not adopted into the authoring set. |
+| `loop` | A tinyflows 0.6 catalog addition (arrived with the #499 pin bump) that OpenCompany has not adopted into the authoring set. |
+
+Rejection happens **at parse**, before translation — an author cannot smuggle
+one of these into a running graph. Widening the parser to accept any of them is
+a deliberate feature decision (settling the memory-scope policy, building the
+code runner, or adopting the 0.6 additions), out of scope for this contract.
+
+## The builder tier is narrower still
+
+The host's automatic workflow builder — the plan → workflow bridge in
+[`workflow-build.md`](workflow-build.md) — emits an even smaller set,
+`BUILDER_NODE_KINDS` in
+[`src/harness/workflow_build.rs`](../../../src/harness/workflow_build.rs):
+`trigger`, `agent`, `condition`, `output`. A graph the builder proposes stays
+inside those four kinds; a human author editing the file directly may use the
+full 12-kind parser set. This is the strict nesting from the top of this
+document: builder ⊂ parser ⊂ engine.
+
+## Provenance
+
+The engine-side counts and the specific 0.6-only kinds above are true **as of
+the tinyflows 0.6.x pin (#499)**. When that pin is bumped, re-verify this
+document against the new `NODE_KINDS` and re-decide whether any newly added
+engine kind should be adopted into `WORKFLOW_NODE_KINDS`. Grep this file for
+"#499" when bumping the pin.

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -20,11 +20,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{OpenCompanyError, Result};
 
-/// The node kinds a workflow graph may use, mirroring the tinyflows model. The
-/// first six are the original OpenCompany set; the trailing six (P2) complete
-/// the tinyflows node catalog: data-shape nodes (`switch` / `merge` /
-/// `split_out` / `transform` / `output_parser`) and `sub_workflow` composition.
-/// Each string is tinyflows' snake_case wire kind verbatim.
+/// The node kinds a workflow graph may use — the OpenCompany authoring
+/// contract. The first six are the original set; the trailing six (P2) add the
+/// data-shape nodes (`switch` / `merge` / `split_out` / `transform` /
+/// `output_parser`) and `sub_workflow` composition. Each string is tinyflows'
+/// snake_case wire kind verbatim, but this set is deliberately *narrower* than
+/// tinyflows' full engine catalog (`tinyflows`'s `NODE_KINDS`): the engine-only
+/// kinds are refused at parse. The accepted-vs-rejected contract, and why each
+/// engine-only kind is left out, is documented in
+/// `docs/spec/runtime/workflow-vocabulary.md`.
 pub const WORKFLOW_NODE_KINDS: &[&str] = &[
     "trigger",
     "agent",

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -2,9 +2,11 @@
 //!
 //! A company's workflow graphs live on disk as
 //! [`WorkflowFile`](crate::company::workflow_file::WorkflowFile)s — a data-only
-//! node/edge model with six node kinds (trigger / agent / tool_call /
-//! http_request / condition / output). This module runs one directly on the
-//! embedded [`tinyflows`] engine, with **agent** nodes routed to the company's
+//! node/edge model whose accepted node kinds are
+//! [`WORKFLOW_NODE_KINDS`](crate::company::workflow_file::WORKFLOW_NODE_KINDS)
+//! (the authoring contract; see `docs/spec/runtime/workflow-vocabulary.md`).
+//! This module runs one directly on the embedded [`tinyflows`] engine, with
+//! **agent** nodes routed to the company's
 //! [`HarnessPool`](crate::harness::HarnessPool) so a step inherits the roster's
 //! persona / model / memory / approval policy / metering (never a second pool).
 //!

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -1,10 +1,15 @@
 //! Translate a company [`WorkflowFile`] into a tinyflows
 //! [`WorkflowGraph`](tinyflows::model::WorkflowGraph).
 //!
-//! OpenCompany's on-disk model is a validated six-kind node/edge graph (see
-//! [`crate::company::workflow_file`]); tinyflows' runnable model is a
-//! twelve-kind graph. The mapping is mostly one-to-one, with two deliberate
-//! choices:
+//! OpenCompany's on-disk model is a validated node/edge graph whose accepted
+//! node kinds are the
+//! [`WORKFLOW_NODE_KINDS`](crate::company::workflow_file::WORKFLOW_NODE_KINDS)
+//! authoring set (see [`crate::company::workflow_file`]); tinyflows' runnable
+//! model carries the wider `NODE_KINDS` engine catalog. Every accepted kind
+//! lowers into that catalog, but the parser deliberately refuses the
+//! engine-only kinds — the authoring contract and the rejected set are spelled
+//! out in `docs/spec/runtime/workflow-vocabulary.md`. The mapping is mostly
+//! one-to-one, with two deliberate choices:
 //!
 //! * **`output` → [`Transform`](tinyflows::model::NodeKind::Transform)** —
 //!   tinyflows has no `output` kind. A `transform` node with no `set` config is
@@ -29,10 +34,10 @@
 //! node config, which the engine's `agent` node routes to the injected
 //! `AgentRunner` — that is how a step lands on the harness pool (see
 //! [`super::caps`]). `tool_call` and `http_request` nodes are mapped
-//! structurally; executing them end-to-end (real tool/HTTP semantics) is a
-//! documented follow-on — [`super::caps`] wires them to explicit "not yet wired"
-//! capabilities so an unreached node is inert and a reached one fails loudly
-//! rather than silently.
+//! structurally and both execute for real: a `tool_call` node runs a Cell A
+//! toolbelt tool, fail-closed on the company's `[tools].allow` grants, and an
+//! `http_request` node routes through the SSRF-guarded `GuardedHttpClient` —
+//! both wired in [`super::caps`].
 
 use std::collections::HashSet;
 


### PR DESCRIPTION
## Summary

**Part of #661 — L7 + L4** (workflows follow-up; this is a multi-PR tracker, so *not* `Closes`).

Docs and comments only — **no behavior change, and the parser is deliberately not widened.**

- **L7 (comment honesty):** the module headers on `src/workflows/translate.rs` and `src/workflows/mod.rs` claimed OpenCompany was a "six-kind" model and tinyflows a "twelve-kind" one, and that `tool_call` / `http_request` were "not yet wired." All three are stale/false against the current pin. Rewrote the headers to anchor counts on the **named constants** (`WORKFLOW_NODE_KINDS`, tinyflows `NODE_KINDS`) instead of literals, and to state plainly that both `tool_call` (real toolbelt tool, fail-closed on `[tools].allow`) and `http_request` (SSRF-guarded `GuardedHttpClient`) execute for real — cross-referencing `super::caps`. Accurate parts (`output`→`Transform`, condition→`true`/`false` ports, destination-not-translated, `agent`→`HarnessPool`) were preserved.
- **L4 (authoring contract doc):** added `docs/spec/runtime/workflow-vocabulary.md` — the first doc to state which kinds the OpenCompany **parser** accepts versus the wider engine catalog, and *why* the engine-only kinds are refused.

### Verified live against the pinned tinyflows (v0.6.0 / `8054646`, via #499)

| Set | Constant | Count |
|-----|----------|-------|
| Engine catalog | `NODE_KINDS` (`vendor/.../tinyflows/src/catalog.rs`) | **15** |
| OC authoring / parser | `WORKFLOW_NODE_KINDS` (`src/company/workflow_file.rs`) | **12** (11 identity + `output`→`Transform`) |
| Auto-builder tier | `BUILDER_NODE_KINDS` (`src/harness/workflow_build.rs`) | **4** |

Nesting: **builder ⊂ parser ⊂ engine**. The four engine-only kinds the parser rejects at parse time are `code`, `memory`, `dedup`, `loop` — each documented with the rationale from `src/workflows/caps/mod.rs` (code = loud-failure stub; memory = policy deliberately undecided/test-pinned; dedup/loop = 0.6 additions not adopted). Widening the parser to accept any of them is a feature decision, out of scope here.

## API Or Behavior Changes

None. Documentation and doc-comments only. The parser's accepted-kind set is untouched.

## Tests

No new tests: a header comment has nothing to unit-test, and the doc's claims are already pinned by existing tests — `an_output_destination_never_reaches_the_engine_graph` (`translate.rs`), `the_memory_capability_is_left_unwired_on_purpose` (`caps/mod.rs`), and the unknown-kind parse tests in `workflow_file.rs`.

Gates run locally (green):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex -- -D warnings`
- [x] `cargo check --locked --features openhuman` (the workflows module compiles only under `openhuman`)
- [x] `wc -l` ≤ 500 on every touched Markdown file
- [x] manual accuracy diff of the doc's tables against `WORKFLOW_NODE_KINDS`, the pinned `catalog.rs` (15), and `caps/mod.rs`

## Documentation

- New: `docs/spec/runtime/workflow-vocabulary.md` (112 lines).
- Index bullet added in `docs/spec/runtime/README.md`; one link added from `docs/spec/runtime/workflow-build.md`.
- `#[doc]` pointer added on `WORKFLOW_NODE_KINDS` in `src/company/workflow_file.rs` (pointer only; parser logic untouched), and the now-stale "completes the tinyflows catalog" phrase corrected to "deliberately narrower than the engine catalog."

## Related

Part of #661 (L7 + L4).