### PR TITLE
feat(chat): link the member pane out to the org chart (#485)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -984,7 +984,19 @@ export function AppShell({
           {view === "overview" && (
             <Overview client={client} company={company} />
           )}
-          {view === "company" && <OrgChartView client={client} company={company} />}
+          {view === "company" && (
+            <OrgChartView
+              client={client}
+              company={company}
+              // Issue #485: chat's member pane links in at a desk
+              // (`#/company/<deskId>`), which needs the hash's second segment
+              // to reach this view at all — it was dropped here, so the chart
+              // had no per-desk address to link to. `useHashView` hands the
+              // segment back unvalidated, so the chart resolves an unknown id
+              // itself rather than this shell guessing which desks exist.
+              focusDeskId={sub}
+            />
+          )}
           {view === "chat" && (
             <ChatView
               client={client}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -878,6 +878,28 @@ export function ChatView({
               }}
               onAdd={() => setAddOpen(true)}
               onMessage={(m) => selectChannel(dmChannelId(m))}
+              /**
+               * The way from this channel to the desk it is (issue #485).
+               *
+               * Only for a host-backed desk channel. A DM is not a desk, and a
+               * fallback desk (`lib/desks.ts`) carries no `memberIds` because
+               * the host has no desks surface at all — the chart would have
+               * nothing to open. Both simply get no link rather than one that
+               * lands nowhere.
+               *
+               * A desk's channel id **is** its desk id (`deskFromDto`), so
+               * there is no mapping to keep in step. Written to the hash rather
+               * than routed through a callback, as `ArtifactsTab`'s "Open in
+               * workspace" does: this is a cross-view address, and the shell
+               * only hands chat a chat-scoped navigate.
+               */
+              onManageDesk={
+                active.kind === "channel" && active.memberIds
+                  ? () => {
+                      window.location.hash = `/company/${active.id}`;
+                    }
+                  : undefined
+              }
               canEditBudget={isAdmin && fromHost}
               onEditBudget={setBudgetFor}
               onRemoveCap={(m) => void applyBudget(m, null)}

--- a/frontend/src/views/chat/MembersPane.tsx
+++ b/frontend/src/views/chat/MembersPane.tsx
@@ -50,6 +50,19 @@ interface Props {
   onAdd: () => void;
   onMessage: (member: TeamMember) => void;
   /**
+   * Open this channel's desk on the org chart (issue #485). Absent for a DM and
+   * for a fallback desk — neither is a desk the chart draws.
+   *
+   * A link, deliberately, and not an editor bolted on here. This pane *drops* a
+   * member id that resolves to no roster teammate (see `channelMembers`), which
+   * is right for a chat — you cannot message nobody. But that ghost seat is
+   * precisely the one an operator most needs to remove, and an editor on this
+   * pane could not offer it without breaking the drop rule the pane is built
+   * on. Membership editing therefore stays on the surface that keeps ghost
+   * seats visible and badged: the chart.
+   */
+  onManageDesk?: () => void;
+  /**
    * Whether to offer the daily-budget controls at all (issue #360, ported
    * from the retired Team page): admin-only, and only for a host-backed
    * teammate — a starter-roster row is a local placeholder with no budget
@@ -88,6 +101,7 @@ export function MembersPane({
   onRemove,
   onAdd,
   onMessage,
+  onManageDesk,
   canEditBudget,
   onEditBudget,
   onRemoveCap,
@@ -158,12 +172,28 @@ export function MembersPane({
 
             return (
               <>
-                <SectionLabel className="text-foreground">In this channel</SectionLabel>
+                <div className="flex items-baseline justify-between gap-2">
+                  <SectionLabel className="text-foreground">In this channel</SectionLabel>
+                  {onManageDesk && (
+                    <ManageDeskLink onClick={onManageDesk}>Manage on the org chart</ManageDeskLink>
+                  )}
+                </div>
                 {channelMembers.length > 0 ? (
                   rows(channelMembers)
                 ) : (
+                  // An empty desk is the strongest case for reaching the
+                  // editor, so the copy carries the way there rather than
+                  // leaving the operator to find the header link.
                   <p className="px-2 py-1.5 text-xs text-muted-foreground">
                     Nobody is on this desk yet.
+                    {onManageDesk && (
+                      <>
+                        {" "}
+                        <ManageDeskLink onClick={onManageDesk} inline>
+                          Staff it on the org chart
+                        </ManageDeskLink>
+                      </>
+                    )}
                   </p>
                 )}
 
@@ -179,6 +209,37 @@ export function MembersPane({
         )}
       </div>
     </aside>
+  );
+}
+
+/**
+ * The way out to the org chart (issue #485).
+ *
+ * Quiet by design — a link, not a button. Editing membership is a different
+ * surface's job, and dressing the way there as an action here would suggest
+ * this pane could do it.
+ */
+function ManageDeskLink({
+  onClick,
+  inline,
+  children,
+}: {
+  onClick: () => void;
+  /** Sits inside a sentence rather than beside a heading. */
+  inline?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline",
+        inline ? "underline" : "shrink-0 px-2 pb-1",
+      )}
+    >
+      {children}
+    </button>
   );
 }
 

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -82,6 +82,32 @@ pane renders one plain list. The rest of the company is always one section
 below, so adding a teammate or opening somebody's DM never needs a different
 surface.
 
+### Editing it is somewhere else, on purpose (#485)
+
+The pane **links** to the org chart — "Manage on the org chart" beside "In this
+channel", "Staff it on the org chart" when the desk is empty — and grows no
+membership controls of its own. The link opens `#/company/<deskId>`, which the
+chart scrolls to and focuses. A desk's channel id *is* its desk id
+(`deskFromDto`), so nothing maps between them.
+
+The reason is the pane's own rule. `channelMembers` **drops** a member id that
+resolves to no roster teammate: you cannot message nobody, so no row is drawn
+for one. The chart does the opposite and **badges** it "Not on the roster". A
+membership editor has to show every seat, and that ghost seat is exactly the one
+an operator most needs to remove — so an editor here would either break the drop
+rule this pane is built on or be unable to remove ghosts. Editing lives where
+ghosts are visible. Keep the two behaviours as they are; the divergence is what
+makes the split coherent rather than arbitrary.
+
+The link is offered only for a **host-backed desk channel**. A DM is not a desk,
+and a fallback desk names one the host does not have — the chart would open on
+nothing, so neither gets a link. There is no admin gate, because the chart has
+none either (its controls are gated by provenance).
+
+The channel rail stays flat, and #485 settled that too: it already is the org
+chart's desk level, since no desk can name a parent desk. See
+`views/company/README.md`.
+
 ## Files
 
 | | |

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -44,11 +44,25 @@ import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
+  /**
+   * A desk to bring into view on arrival — the second segment of
+   * `#/company/<deskId>`, which the chat member pane links to (issue #485).
+   *
+   * Best-effort on purpose. `useHashView` hands the segment back unvalidated,
+   * this chart loads over the network, and a link outlives the desk it names —
+   * so an id this chart does not draw is a **silent no-op**, never an error. A
+   * stale bookmark should show the company, not a banner about it.
+   *
+   * The hash is never rewritten from here either: `#/company/<deskId>` is a
+   * shareable address, and canonicalising it away would break the link the
+   * operator just followed.
+   */
+  focusDeskId?: string | null;
 }
 
 type Load = "loading" | "ready" | "error";
 
-export function OrgChartView({ client, company }: Props) {
+export function OrgChartView({ client, company, focusDeskId }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [tree, setTree] = useState<OrgTree | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
@@ -57,6 +71,11 @@ export function OrgChartView({ client, company }: Props) {
   // A generation token so a response for a company we have navigated away from
   // cannot overwrite the one on screen. Same guard `SkillsView` uses.
   const gen = useRef(0);
+  /** Which desk id the arriving link has already been honoured for. */
+  const focused = useRef<string | null>(null);
+  /** The desk currently wearing the arrival ring, if any. */
+  const [focusMark, setFocusMark] = useState<string | null>(null);
+  const chartRef = useRef<HTMLDivElement | null>(null);
 
   const boot = useCallback(async () => {
     const mine = ++gen.current;
@@ -103,6 +122,57 @@ export function OrgChartView({ client, company }: Props) {
   }, [boot]);
 
   /**
+   * Bring the linked-to desk into view, once per id.
+   *
+   * Once, because every write here refetches the whole chart: re-running this
+   * on each refetch would yank the page back to the linked desk while the
+   * operator is editing a different one. `focused` records the id already
+   * honoured rather than a boolean, so following a second link still works.
+   *
+   * The desk is also given DOM focus, not just a scroll position. A ring is
+   * invisible to a screen reader, and "where did that link land me" is exactly
+   * the question focus answers; `preventScroll` keeps `scrollIntoView`'s
+   * centring rather than letting the browser re-scroll to its own idea of
+   * visible.
+   *
+   * An id with no node — a deleted desk, a typo, a chart that 404'd — falls
+   * through without marking itself honoured, so a desk that appears later
+   * (created in another tab, or a refetch that finally succeeds) is still
+   * caught.
+   */
+  useEffect(() => {
+    if (load !== "ready" || !focusDeskId || focused.current === focusDeskId) return;
+    const node = chartRef.current?.querySelector<HTMLElement>(
+      `[data-desk-id="${CSS.escape(focusDeskId)}"]`,
+    );
+    if (!node) return;
+    focused.current = focusDeskId;
+    node.scrollIntoView({ block: "center", behavior: "smooth" });
+    node.focus({ preventScroll: true });
+    setFocusMark(focusDeskId);
+  }, [load, focusDeskId, tree]);
+
+  /**
+   * Drop the ring on the operator's first move, rather than after a guessed
+   * number of milliseconds.
+   *
+   * A timer has to be picked against a chart that loads over the network: too
+   * short and the ring expires before a slow load painted it, too long and it
+   * outstays the moment it was drawn for. A click or a keypress is the actual
+   * signal that the desk has been found.
+   */
+  useEffect(() => {
+    if (!focusMark) return;
+    const clear = () => setFocusMark(null);
+    window.addEventListener("pointerdown", clear, { once: true });
+    window.addEventListener("keydown", clear, { once: true });
+    return () => {
+      window.removeEventListener("pointerdown", clear);
+      window.removeEventListener("keydown", clear);
+    };
+  }, [focusMark]);
+
+  /**
    * Run a write, then re-read the whole chart.
    *
    * Refetch rather than patch in place: every write here changes something the
@@ -124,7 +194,7 @@ export function OrgChartView({ client, company }: Props) {
   }
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div ref={chartRef} className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-6">
         <div className="flex items-start justify-between gap-4">
           <div className="space-y-1">
@@ -174,6 +244,7 @@ export function OrgChartView({ client, company }: Props) {
               <Chart
                 tree={tree}
                 busy={busy}
+                focusMark={focusMark}
                 onCreate={() => setCreateOpen(true)}
                 onAdd={(desk, agentId) =>
                   void mutate(`${desk.id}:${agentId}`, () =>
@@ -223,6 +294,7 @@ export function OrgChartView({ client, company }: Props) {
 function Chart({
   tree,
   busy,
+  focusMark,
   onCreate,
   onAdd,
   onRemove,
@@ -231,6 +303,8 @@ function Chart({
 }: {
   tree: OrgTree;
   busy: string | null;
+  /** The desk a `#/company/<deskId>` link landed on, ringed until first input. */
+  focusMark: string | null;
   onCreate: () => void;
   onAdd: (desk: OrgDesk, agentId: string) => void;
   onRemove: (desk: OrgDesk, agentId: string) => void;
@@ -262,6 +336,7 @@ function Chart({
                 desk={desk}
                 addable={addableTo(tree, desk)}
                 busy={busy}
+                focused={focusMark === desk.id}
                 onAdd={(agentId) => onAdd(desk, agentId)}
                 onRemove={(agentId) => onRemove(desk, agentId)}
                 onMove={(index, direction) => onMove(desk, index, direction)}
@@ -280,6 +355,7 @@ function DeskNode({
   desk,
   addable,
   busy,
+  focused,
   onAdd,
   onRemove,
   onMove,
@@ -288,6 +364,8 @@ function DeskNode({
   desk: OrgDesk;
   addable: { id: string; name: string }[];
   busy: string | null;
+  /** This desk is the one a `#/company/<deskId>` link asked for. */
+  focused: boolean;
   onAdd: (agentId: string) => void;
   onRemove: (agentId: string) => void;
   onMove: (index: number, direction: "up" | "down") => void;
@@ -295,7 +373,26 @@ function DeskNode({
 }) {
   const locked = busy !== null;
   return (
-    <div role="treeitem" aria-level={2} aria-expanded="true" aria-selected="false">
+    <div
+      role="treeitem"
+      aria-level={2}
+      aria-expanded="true"
+      aria-selected="false"
+      // The desk's anchor for `#/company/<deskId>` (issue #485). A data
+      // attribute rather than an `id`: the desk id is the host's, and minting
+      // document-wide ids from it would collide with anything else on the page
+      // that names the same desk.
+      data-desk-id={desk.id}
+      data-desk-focused={focused ? "true" : undefined}
+      // Programmatically focusable, not tab-reachable: the arrival focus is
+      // how a screen reader is told where the link landed, but a desk wrapper
+      // is not a control and does not belong in the tab order.
+      tabIndex={-1}
+      className={cn(
+        "scroll-mt-4 rounded-xl outline-none",
+        focused && "ring-2 ring-primary ring-offset-2 ring-offset-background",
+      )}
+    >
       <div className="rounded-xl border">
         <div className="flex items-start justify-between gap-2 px-3 py-2.5">
           <div className="min-w-0">

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -140,6 +140,24 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
    * (created in another tab, or a refetch that finally succeeds) is still
    * caught.
    */
+  /**
+   * Forget the honoured id when the route target itself changes.
+   *
+   * `focused` exists to survive a *refetch* (same target, new tree), not a
+   * *navigation*. Without this, leaving `#/company/<id>` for the bare chart or
+   * a stale id and then coming back to the same desk hits the `focused.current
+   * === focusDeskId` guard and the link silently does nothing the second time.
+   * Clearing the mark here also stops an unknown target from inheriting the
+   * previous desk's ring.
+   *
+   * Keyed on the target only — `tree` is deliberately absent, so a refetch
+   * still cannot yank the operator back to the linked desk mid-edit.
+   */
+  useEffect(() => {
+    focused.current = null;
+    setFocusMark(null);
+  }, [company, focusDeskId]);
+
   useEffect(() => {
     if (load !== "ready" || !focusDeskId || focused.current === focusDeskId) return;
     const node = chartRef.current?.querySelector<HTMLElement>(

--- a/frontend/src/views/company/README.md
+++ b/frontend/src/views/company/README.md
@@ -60,6 +60,43 @@ handled the opposite way: it stays, badged "Not on the roster". The chat member
 pane drops such an id, which is right for a chat — you cannot message nobody.
 Here it is a fact about the structure that only the operator can fix.
 
+That divergence is **load-bearing**, not incidental: it is the reason membership
+editing lives here and not on the member pane. See below.
+
+## How chat reaches this surface (#485)
+
+`#/company/<deskId>` opens the chart with that desk scrolled to, focused, and
+ringed until the operator's first click or keypress. The chat member pane links
+in at exactly that address — "Manage on the org chart" beside "In this channel",
+or "Staff it on the org chart" when the desk is empty.
+
+Three decisions #485 settled, so they are not re-argued:
+
+**The channel rail stays flat.** It already *is* this tree's desk level. A desk
+cannot name a parent desk, so nesting is unrepresentable (see above), and both
+surfaces render the same `GET {scope}/desks` in the same host order. "A desk
+thread becomes a view of the org chart" is satisfied by the two surfaces being
+the same list with a link between them — not by restructuring the rail into a
+tree it has no data to draw.
+
+**DMs are untouched.** Under a flat rail the question does not arise. Recorded
+for a future attempt: if grouping were ever adopted, DMs would be a separate
+flat section *below* the tree — they are not desks, and hanging them off one
+would invent the same structure `Not on a desk` exists to avoid.
+
+**Membership editing stays here; the pane only links.** The member pane drops an
+id that resolves to no roster teammate. A membership editor must show every
+seat, and the ghost seat is precisely the one an operator most needs to remove —
+so an editor on that pane would either violate the pane's documented drop rule
+or knowingly be unable to remove ghosts. Editing belongs on the surface that
+keeps ghosts visible. No admin gate on the link: this chart has none either,
+because its controls are gated by provenance instead.
+
+An unknown or deleted desk id in the hash is a **silent no-op** — the chart
+renders normally. `useHashView` hands the second segment back unvalidated, and a
+stale bookmark deserves the company, not a banner. The hash is never rewritten:
+`#/company/<deskId>` is a shareable address.
+
 ## Files
 
 | | |
@@ -78,7 +115,7 @@ reload against a stateful stub.
 
 ## Deliberately not here
 
-- **Chat alignment** — whether a desk thread becomes a view of this tree
-  (#311's third open question). Filed as #485.
+- **A nested channel rail** — #485 settled that the rail already is this tree's
+  desk level, and that a fourth level is unrepresentable. See above.
 - **The Overview graph's invented departments** — replacing them with this real
   structure belongs with the replacement, not the foundation. Filed as #486.

--- a/frontend/test/e2e/chat-channel-membership.spec.ts
+++ b/frontend/test/e2e/chat-channel-membership.spec.ts
@@ -257,6 +257,65 @@ test("#370 a broken /desks is a retryable error, not invented channels", async (
   await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
 });
 
+/** The way out to the org chart, added by #485. */
+const manageLink = (page: Page) =>
+  pane(page).getByRole("button", { name: "Manage on the org chart" });
+
+const chart = (page: Page) => page.getByRole("tree", { name: "Company org chart" });
+
+test("#485 a desk channel links out to its own desk on the org chart", async ({ page }) => {
+  await mockApi(page, () => "ok");
+  await openChannel(page, "engineering");
+  await openPane(page);
+
+  await expect(manageLink(page)).toBeVisible();
+  await manageLink(page).click();
+
+  // A desk's channel id *is* its desk id (`deskFromDto`), so the link needs no
+  // mapping — and the address it lands on names the desk, not just the chart.
+  await expect.poll(() => page.url()).toContain("#/company/engineering");
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+
+  const desk = chart(page)
+    .locator('[role="treeitem"][aria-level="2"]')
+    .filter({ hasText: "Engineering" });
+  await expect(desk).toBeVisible();
+  // Landed *on the desk*, not merely on the chart: the arrival ring and DOM
+  // focus are what make a link into a nine-desk company useful.
+  await expect(desk).toHaveAttribute("data-desk-focused", "true");
+  await expect(desk).toBeFocused();
+});
+
+test("#485 a DM has no desk to manage", async ({ page }) => {
+  await mockApi(page, () => "ok");
+  await openChannel(page, "engineering");
+  await openPane(page);
+  // The positive control, in the same run: the link is offered here, so its
+  // absence below is about DMs and not about the link never rendering.
+  await expect(manageLink(page)).toBeVisible();
+
+  await pane(page).getByText("Agent 4", { exact: true }).click();
+  await expect(page.getByPlaceholder("Message Agent 4")).toBeVisible();
+
+  // A DM still gets the "In this channel" section — it has a membership of
+  // exactly one — but it is not a desk, so the chart has nothing to open.
+  await expect(pane(page).getByRole("heading", { name: "In this channel" })).toBeVisible();
+  await expect(manageLink(page)).toHaveCount(0);
+});
+
+test("#485 a fallback desk offers no link to a desk the host doesn't have", async ({ page }) => {
+  await mockApi(page, () => "404");
+  await openChannel(page, "general");
+  await openPane(page);
+
+  // No `.../desks` route at all, so these channels come from `lib/desks.ts` and
+  // name desks the org chart cannot draw. Linking to one would land on an empty
+  // chart, so no link is offered — the same reasoning that makes this pane fall
+  // back to the whole roster here.
+  await expect(pane(page).getByRole("heading", { name: "In this channel" })).toHaveCount(0);
+  await expect(manageLink(page)).toHaveCount(0);
+});
+
 test("the send path and the thread id it addresses are undisturbed", async ({ page }) => {
   sentChats.length = 0;
   await mockApi(page, () => "ok");

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -464,6 +464,54 @@ test("#485 a desk id the chart doesn't have is a silent no-op", async ({ page })
     .toBe("true");
 });
 
+test("#485 following the same desk link twice still lands on it", async ({ page }) => {
+  await mockApi(page);
+
+  // Every hop here is an in-app hash change, never `page.goto`: a full
+  // navigation remounts the chart and resets the very state this pins, so it
+  // would pass whether or not the bug exists.
+  await page.goto("/#/company/growth");
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(deskNode(page, "Growth")).toHaveAttribute("data-desk-focused", "true");
+
+  // Off to the bare chart. The view stays mounted, so whatever it remembers
+  // about the last honoured id survives.
+  await page.evaluate(() => {
+    window.location.hash = "#/company";
+  });
+  await expect(chart(page)).toBeVisible();
+  // The previous desk must not keep wearing the ring once it is no longer the
+  // route's target.
+  await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(0);
+
+  // Back to the same desk. This is the case that regressed: the id matched the
+  // one already honoured, so the arrival was skipped and the link did nothing.
+  await page.evaluate(() => {
+    window.location.hash = "#/company/growth";
+  });
+  const growth = deskNode(page, "Growth");
+  await expect(growth).toHaveAttribute("data-desk-focused", "true");
+  await expect(growth).toBeFocused();
+  await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(1);
+});
+
+test("#485 a stale id does not leave the previous desk wearing the ring", async ({ page }) => {
+  await mockApi(page);
+
+  await page.goto("/#/company/growth");
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(deskNode(page, "Growth")).toHaveAttribute("data-desk-focused", "true");
+
+  // An id the chart does not have is a no-op for *arrival*, but it must still
+  // retire the previous target's mark — otherwise the ring claims a desk the
+  // address no longer names.
+  await page.evaluate(() => {
+    window.location.hash = "#/company/deleted-last-week";
+  });
+  await expect(chart(page)).toBeVisible();
+  await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(0);
+});
+
 test("#485 a membership edit on the chart is there when you get back to chat", async ({ page }) => {
   await mockApi(page);
 

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -220,6 +220,25 @@ async function openChart(page: Page) {
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
 }
 
+/**
+ * The chat member pane — the channel rail is the other `complementary` on
+ * screen, so the pane is always the last one.
+ */
+const memberPane = (page: Page) => page.getByRole("complementary").last();
+
+/**
+ * Open the chat member pane if it is shut.
+ *
+ * Its open state lives in `ChatView`, which unmounts when the operator steps
+ * into another view — so this has to be re-run after a round trip through the
+ * chart, and a blind click would close what a previous call opened.
+ */
+async function openMemberPane(page: Page) {
+  const toggle = page.getByRole("button", { name: /members$/i });
+  if ((await toggle.getAttribute("aria-pressed")) !== "true") await toggle.click();
+  await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();
+}
+
 test.beforeEach(reset);
 
 test("#311 the org chart is reachable, which it was not before", async ({ page }) => {
@@ -393,6 +412,87 @@ test("#311 blueprint structure offers no control the host would refuse", async (
   await page.reload();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
   await expect(deskNode(page, "Growth")).toHaveCount(0);
+});
+
+test("#485 #/company/<deskId> lands on that desk, not just on the chart", async ({ page }) => {
+  await mockApi(page);
+
+  // The chat member pane's "Manage on the org chart" writes exactly this
+  // address. Before #485 the shell dropped the hash's second segment on the
+  // way into this view, so the chart had no per-desk address at all.
+  await page.goto("/#/company/growth");
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+
+  const growth = deskNode(page, "Growth");
+  await expect(growth).toHaveAttribute("data-desk-focused", "true");
+  // Focus, not only a ring: a ring says nothing to a screen reader, and "where
+  // did that link put me" is the question focus answers.
+  await expect(growth).toBeFocused();
+  // Nobody else is marked — arriving at one desk must not light up the chart.
+  await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(1);
+
+  // The address survives, so the link the operator followed stays shareable.
+  await expect.poll(() => page.url()).toContain("#/company/growth");
+
+  // And the ring is not sticky: it clears on the first move rather than on a
+  // timer nobody can pick correctly against a chart that loads over a network.
+  await page.keyboard.press("Escape");
+  await expect(growth).not.toHaveAttribute("data-desk-focused", "true");
+});
+
+test("#485 a desk id the chart doesn't have is a silent no-op", async ({ page }) => {
+  await mockApi(page);
+
+  // `useHashView` hands the second segment back unvalidated, and a link can
+  // outlive the desk it names. A stale bookmark gets the company, not a banner.
+  await page.goto("/#/company/deleted-last-week");
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(chart(page).locator('[role="treeitem"][aria-level="2"]')).toHaveCount(2);
+  await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(0);
+  await expect(page.getByRole("alert")).toHaveCount(0);
+  // Not rewritten either: only this view knows which desk ids exist, so the
+  // shell has no business canonicalising a segment it cannot judge.
+  await expect.poll(() => page.url()).toContain("#/company/deleted-last-week");
+
+  // The teeth on the assertions above: focus is not simply broken. Point the
+  // same chart at a desk it *does* have and the marker appears.
+  await page.goto("/#/company/engineering");
+  await expect
+    .poll(() => deskNode(page, "Engineering").getAttribute("data-desk-focused"), {
+      timeout: 30_000,
+    })
+    .toBe("true");
+});
+
+test("#485 a membership edit on the chart is there when you get back to chat", async ({ page }) => {
+  await mockApi(page);
+
+  // The round trip #485 is actually for: read the desk in chat, notice it is
+  // short a person, fix that where it can be fixed, come back.
+  await page.goto("/#/chat/engineering");
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+  await openMemberPane(page);
+  await expect(memberPane(page)).toContainText("Grace");
+  await expect(memberPane(page).locator("ul").first()).not.toContainText("Turing");
+
+  await memberPane(page).getByRole("button", { name: "Manage on the org chart" }).click();
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+
+  const engineering = deskNode(page, "Engineering");
+  await engineering.getByRole("button", { name: "Add teammate" }).click();
+  await page.getByRole("menuitem", { name: "Turing" }).click();
+  await expect(engineering.locator('[role="treeitem"][aria-level="3"]')).toHaveCount(3);
+
+  // Back the way we came — a hash navigation, so Back is the operator's own
+  // route home and not a reload.
+  await page.goBack();
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+  await openMemberPane(page);
+  // Chat re-reads the desks when it remounts, so no reload is needed for the
+  // edit to show. The two surfaces stay separate reads of one host list —
+  // there is no shared client cache to keep in step, and adding one would put
+  // the pane's drop rule and the chart's badge rule on the same data path.
+  await expect(memberPane(page).locator("ul").first()).toContainText("Turing");
 });
 
 test("#311 a seat naming nobody on the roster is shown, not hidden", async ({ page }) => {


### PR DESCRIPTION
## Summary

Closes #485.

#485 asked three questions. Two of them dissolve once you look at the data, and the third has a correctness answer rather than a taste answer.

**Does the channel rail become a view of the tree?** It already is one. A desk cannot name a parent desk — neither `GroupChat` nor `OverlayDesk` has such a field, so nesting is unrepresentable — and the rail and the chart render the same `GET {scope}/desks` in the same host order. The rail *is* the tree's desk level. Restructuring it would move DOM around to express something the data already guarantees, so the rail is unchanged and the identity is recorded in the READMEs instead.

**What happens to DMs?** Under a flat rail, nothing. The question only bites if grouping is adopted, so the answer it would need (DMs as a separate flat section — nesting them under desks gives a two-desk teammate two rows for one `dm:<id>` channel, and an unplaced teammate no row at all) is written down rather than left to be re-derived later.

**Does the member pane grow membership controls, or link out?** It links out, and the reason is a correctness trap rather than a preference. `channelMembers` deliberately *drops* member ids that resolve to no roster teammate; `buildOrgTree` deliberately *badges* them "Not on the roster". An editor must show every seat, and the ghost seat is precisely the one an operator needs to remove — so an in-pane editor would either violate the documented drop rule or knowingly be unable to remove ghosts. Membership editing belongs on the surface that keeps ghosts visible. That makes the divergence load-bearing, and this PR restates it next to the new link on both sides so it cannot drift unnoticed.

What this gives up, deliberately: no in-place staffing edits from chat. Reaching the editor is one hash navigation.

## API Or Behavior Changes

Console-only. **No backend change** — no route, schema, or resolver is touched.

- `#/company/<deskId>` is now a real address. The hash's second segment reached this view and was dropped; the chart now scrolls that desk into view, focuses it, and rings it. Unknown or deleted ids are a silent no-op (the owning view validates its own `sub`, per `use-hash-view.ts`), and the hash is never rewritten — the URL stays shareable.
- The chat member pane shows "Manage on the org chart" beside **In this channel**, and "Staff it on the org chart" in the empty-desk copy. Shown only for host-backed desk channels. DMs and fallback desks never get it, by construction: the link's predicate is `active.kind === "channel" && active.memberIds`, the same condition that decides whether the section renders at all, so the two can't disagree.
- No admin gate — the chart has none either; its controls are provenance-gated.

**One deviation from the plan, made during implementation.** The arrival highlight clears on the operator's first interaction rather than on a timer. A timer must be guessed against a chart that loads over the network — too short and it expires before a slow load has painted it — and it makes the e2e assertion inherently racy. The desk also takes DOM focus, so arrival is announced to a screen reader instead of only drawn. Focus is one-shot per id, so a refetch after a write cannot yank the page back while the operator is editing elsewhere.

## Tests

Rust gates are N/A — this branch changes no Rust. Frontend gates, all run in this worktree:

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` — 441/441
- [x] `npm run build`
- [x] `bash scripts/ci/assert-design-tokens.sh`
- [x] `npm run e2e` — **108 passed, 8 skipped, 0 failed** against a real host binary (the 8 skips are the pre-existing `PW_LIVE_BRAIN` specs)
- [x] N/A: `cargo fmt` / `cargo clippy` / `cargo build` / `cargo test` — no Rust changed in this branch

**The new assertions were proven to have teeth.** With the four source files reverted to `9af6d672` and the new specs kept, five of the six go red:

```
chat-channel-membership — waiting for getByRole('complementary').last()
  .getByRole('button', { name: 'Manage on the org chart' })   (timeout)
org-tree — expect(growth).toHaveAttribute("data-desk-focused", "true")
  Expected: "true"   Received: null
```

The sixth ("a fallback desk offers no link") is a pure-absence guard-rail with nothing to assert pre-change; its teeth come from the positive control asserted in the same file. Coverage: link present on a host-backed desk, absent on a DM, absent on a fallback desk, click lands on `#/company/<deskId>`; deep-link focuses and highlights; a garbage `sub` renders the chart normally; and the full round trip — edit membership on the chart, Back to chat, pane reflects it.

## Documentation

- `frontend/src/views/company/README.md` and `frontend/src/views/chat/README.md` record all three decisions, with the drop-vs-badge divergence restated adjacent to the new link on both sides — the rule this design depends on, placed where a future editor will read it.
- The DM fallback answer is recorded so a later grouping attempt inherits it rather than re-deferring the question.

**Known, pre-existing, not fixed here** (out of scope, named so it isn't discovered in review): the shell's desk-thread map effect is keyed `[client, company]`, so a desk *created* mid-session doesn't route SSE/approvals until company reload. That is true today for anyone using the chart directly. Adding a member to an existing desk — what this flow actually does — is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added links from eligible chat channels to manage memberships on the corresponding company org-chart desk.
  - Company desk links now open the org chart, scroll to the selected desk, and highlight it for easier identification.
  - Membership changes remain synchronized when navigating between chat and the org chart.
  - Invalid or outdated desk links are handled without errors.

- **Bug Fixes**
  - Preserved desk-specific navigation instead of discarding route information.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->