### PR TITLE
workspace: bound an upload by its size, not its encoding, and stop two names aliasing one file (#665, #666)

### DIFF
--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -230,6 +230,17 @@ including a 17 MiB case that proves the BSON cap is not in play. Over HTTP:
 decode as UTF-8 is stored as a note instead, so an uploaded `.md` keeps its
 editor and backlinks.
 
+An upload is still bounded by the company's `max_blob_mb` before that
+text/binary choice (#665). The bound is a property of bytes entering through
+the upload route, not their eventual representation; ordinary text writes stay
+unmetered and text nodes still do not contribute to `tree_quota_gb`.
+
+The filesystem backend mirrors logical names as real paths, so it refuses a
+create, rename, or move that would duplicate a sibling name (#666). The check
+runs under the workspace-index lock: a refused upload leaves the existing node,
+payload, size, and digest unchanged. Id-keyed database backends can continue to
+represent duplicate sibling names without aliasing payloads.
+
 **A stored `mime` does not decide how the blob route serves it (#667).** That
 value is the uploader's declared `Content-Type`, or `mime_guess` on a published
 deliverable's filename — a claim, not a property of the bytes — and the route is

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -236,10 +236,14 @@ the upload route, not their eventual representation; ordinary text writes stay
 unmetered and text nodes still do not contribute to `tree_quota_gb`.
 
 The filesystem backend mirrors logical names as real paths, so it refuses a
-create, rename, or move that would duplicate a sibling name (#666). The check
-runs under the workspace-index lock: a refused upload leaves the existing node,
-payload, size, and digest unchanged. Id-keyed database backends can continue to
-represent duplicate sibling names without aliasing payloads.
+create, rename, or move that would land on a path another node already holds
+(#666). It compares the whole resolved name chain rather than the sibling name,
+because a tree can legitimately hold two folders under one name — the scaffold
+finds such roots, declines to resolve them and leaves them standing — and their
+equally-named children are not siblings by `parent_id` yet still resolve to one
+path. The check runs under the workspace-index lock: a refused upload leaves the
+existing node, payload, size, and digest unchanged. Id-keyed database backends
+can continue to represent duplicate names without aliasing payloads.
 
 **A stored `mime` does not decide how the blob route serves it (#667).** That
 value is the uploader's declared `Content-Type`, or `mime_guess` on a published

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -357,6 +357,54 @@ mod tests {
         (dir, ops)
     }
 
+    /// Seeds root folders that share `name` by writing the workspace index
+    /// directly.
+    ///
+    /// The filesystem store refuses to *create* two siblings under one name,
+    /// because on that backend they would resolve to one path (issue #666).
+    /// The trees below are the ones that check what the scaffold does when it
+    /// nevertheless *finds* an ambiguous root — an index written before that
+    /// refusal existed, or one an id-keyed backend can still represent legally.
+    /// So the state is written rather than requested: going through `create`
+    /// would only re-assert the store's refusal and never reach the scaffold.
+    async fn seed_duplicate_roots(
+        dir: &std::path::Path,
+        company: &CompanyId,
+        name: &str,
+        ids: &[&str],
+    ) {
+        let index: std::collections::HashMap<String, WorkspaceNode> = ids
+            .iter()
+            .map(|id| {
+                (
+                    (*id).to_string(),
+                    WorkspaceNode {
+                        id: (*id).to_string(),
+                        name: name.to_string(),
+                        kind: NodeKind::Folder,
+                        parent_id: None,
+                        updated_at_millis: 1,
+                        created_by: WorkspaceOrigin::Operator,
+                        updated_by: WorkspaceOrigin::Operator,
+                        mime: None,
+                        size: None,
+                        sha256: None,
+                    },
+                )
+            })
+            .collect();
+        let bundle = crate::store::Bundle::new(dir.to_path_buf(), company);
+        tokio::fs::create_dir_all(bundle.workspace_dir())
+            .await
+            .expect("workspace dir");
+        tokio::fs::write(
+            bundle.workspace_index_json(),
+            serde_json::to_vec(&index).expect("index json"),
+        )
+        .await
+        .expect("seed index");
+    }
+
     /// A node's rendered `parent/child` path, for readable assertions.
     fn path_of(nodes: &[WorkspaceNode], node: &WorkspaceNode) -> String {
         match &node.parent_id {
@@ -529,28 +577,9 @@ mod tests {
     /// shape: adding a third would make it worse, so nothing is created.
     #[tokio::test]
     async fn several_nodes_sharing_a_root_name_are_left_alone() {
-        let (_dir, ws) = store().await;
+        let (dir, ws) = store().await;
         let company = CompanyId::new("acme");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(
-                &company,
-                &WorkspaceNode {
-                    id: id.to_string(),
-                    name: AGENTS_ROOT.to_string(),
-                    kind: NodeKind::Folder,
-                    parent_id: None,
-                    updated_at_millis: 1,
-                    created_by: WorkspaceOrigin::Operator,
-                    updated_by: WorkspaceOrigin::Operator,
-                    mime: None,
-                    size: None,
-                    sha256: None,
-                },
-                None,
-            )
-            .await
-            .unwrap();
-        }
+        seed_duplicate_roots(dir.path(), &company, AGENTS_ROOT, &["dup-a", "dup-b"]).await;
 
         ensure_workspace_scaffold(ws.as_ref(), &company)
             .await
@@ -867,28 +896,9 @@ mod tests {
     /// root it *does* manage still provisions beside them.
     #[tokio::test]
     async fn duplicate_desks_nodes_do_not_disturb_the_scaffold() {
-        let (_dir, ws) = store().await;
+        let (dir, ws) = store().await;
         let company = CompanyId::new("acme");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(
-                &company,
-                &WorkspaceNode {
-                    id: id.to_string(),
-                    name: DESKS_ROOT.to_string(),
-                    kind: NodeKind::Folder,
-                    parent_id: None,
-                    updated_at_millis: 1,
-                    created_by: WorkspaceOrigin::Operator,
-                    updated_by: WorkspaceOrigin::Operator,
-                    mime: None,
-                    size: None,
-                    sha256: None,
-                },
-                None,
-            )
-            .await
-            .unwrap();
-        }
+        seed_duplicate_roots(dir.path(), &company, DESKS_ROOT, &["dup-a", "dup-b"]).await;
 
         ensure_workspace_scaffold(ws.as_ref(), &company)
             .await

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -288,6 +288,32 @@ pub fn rebind_binary(
 /// [`WorkspaceNode::is_binary`] and say something better.
 #[async_trait]
 pub trait WorkspaceStore: Send + Sync {
+    /// May a payload of `len` bytes be accepted for storage under `name`,
+    /// whatever it will end up being stored *as* (issue #665)?
+    ///
+    /// # Why this exists next to the write methods that already check
+    ///
+    /// The quota decorator meters binary payloads and deliberately leaves prose
+    /// notes uncounted — see
+    /// [`QuotaEnforcedWorkspace`](crate::runtime::QuotaEnforcedWorkspace), whose
+    /// premise is that "a note is bounded by what a model will emit into a tool
+    /// call". That premise holds for every writer it covers and fails for
+    /// exactly one caller: the multipart upload route, where arbitrary
+    /// operator-supplied bytes enter the tree and are classified as prose purely
+    /// because they happen to decode as UTF-8.
+    ///
+    /// So this is the route **asking the store to judge**, rather than the route
+    /// applying a limit of its own. That distinction is what keeps policy where
+    /// the quota module insists it belongs: a caller cannot know a company's
+    /// configured cap — routers are built once, before any company exists — and
+    /// a limit re-derived at the call site would be the global default, silently
+    /// wrong for any company that raised or lowered its own.
+    ///
+    /// Defaults to admitting everything, so a backend that stores no quota — and
+    /// every test double — is unaffected.
+    async fn admit_upload(&self, _company: &CompanyId, _name: &str, _len: u64) -> Result<()> {
+        Ok(())
+    }
     /// Returns every node in the tree (order unspecified; callers build the
     /// tree from `parent_id`).
     async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>>;

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -123,6 +123,14 @@ impl WorkspaceAnnouncer {
 
 #[async_trait]
 impl WorkspaceStore for WorkspaceAnnouncer {
+    /// Delegated, not defaulted (issue #665). This wrapper sits *outside* the
+    /// quota decorator, so taking the trait's permissive default here would
+    /// answer "yes" for every upload and hide the only implementation that knows
+    /// the company's cap.
+    async fn admit_upload(&self, company: &CompanyId, name: &str, len: u64) -> Result<()> {
+        self.inner.admit_upload(company, name, len).await
+    }
+
     async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
         self.inner.tree(company).await
     }

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -222,6 +222,25 @@ impl QuotaEnforcedWorkspace {
             .sum())
     }
 
+    /// The per-file half of the quota, on its own.
+    ///
+    /// Written once and called twice — by [`admit`](Self::admit) and by
+    /// [`admit_upload`](WorkspaceStore::admit_upload) — for the reason
+    /// [`human`] is shared: an operator who hits the same cap through the
+    /// upload route and through a binary write is hitting one limit, and two
+    /// copies of the sentence are two chances for the two paths to start
+    /// describing it differently.
+    fn admit_single(&self, name: &str, len: u64) -> Result<()> {
+        if len > self.quota.max_blob_bytes {
+            return Err(OpenCompanyError::WorkspaceQuota(format!(
+                "`{name}` is {}, over the {} limit for a single file. Nothing was stored.",
+                human(len),
+                human(self.quota.max_blob_bytes),
+            )));
+        }
+        Ok(())
+    }
+
     /// Refuses `len` bytes when either limit would be broken.
     ///
     /// Runs before any call into the inner store, which is what makes a refusal
@@ -233,13 +252,7 @@ impl QuotaEnforcedWorkspace {
         len: u64,
         replacing: Option<&str>,
     ) -> Result<()> {
-        if len > self.quota.max_blob_bytes {
-            return Err(OpenCompanyError::WorkspaceQuota(format!(
-                "`{name}` is {}, over the {} limit for a single file. Nothing was stored.",
-                human(len),
-                human(self.quota.max_blob_bytes),
-            )));
-        }
+        self.admit_single(name, len)?;
         let Some(limit) = self.quota.tree_quota_bytes else {
             return Ok(());
         };
@@ -270,14 +283,7 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
     /// measured against it. That is the documented narrowing above, unchanged —
     /// this bounds a single upload, it does not start counting notes.
     async fn admit_upload(&self, _company: &CompanyId, name: &str, len: u64) -> Result<()> {
-        if len > self.quota.max_blob_bytes {
-            return Err(OpenCompanyError::WorkspaceQuota(format!(
-                "`{name}` is {}, over the {} limit for a single file. Nothing was stored.",
-                human(len),
-                human(self.quota.max_blob_bytes),
-            )));
-        }
-        Ok(())
+        self.admit_single(name, len)
     }
 
     async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -261,6 +261,25 @@ impl QuotaEnforcedWorkspace {
 
 #[async_trait]
 impl WorkspaceStore for QuotaEnforcedWorkspace {
+    /// The upload route's question, answered with this company's own limits
+    /// (issue #665).
+    ///
+    /// Only [`admit`](Self::admit)'s per-file half applies: `tree_quota_bytes`
+    /// totals `size`, which only a binary node carries, so a payload about to be
+    /// stored as prose contributes nothing to the tree total and must not be
+    /// measured against it. That is the documented narrowing above, unchanged —
+    /// this bounds a single upload, it does not start counting notes.
+    async fn admit_upload(&self, _company: &CompanyId, name: &str, len: u64) -> Result<()> {
+        if len > self.quota.max_blob_bytes {
+            return Err(OpenCompanyError::WorkspaceQuota(format!(
+                "`{name}` is {}, over the {} limit for a single file. Nothing was stored.",
+                human(len),
+                human(self.quota.max_blob_bytes),
+            )));
+        }
+        Ok(())
+    }
+
     async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
         self.inner.tree(company).await
     }
@@ -525,6 +544,30 @@ mod test {
             .write(&co, "note", &"y".repeat(9_000), WorkspaceOrigin::Operator)
             .await
             .expect("nor is an overwrite");
+    }
+
+    /// The upload-only admission seam uses the company's configured per-file
+    /// cap without applying the binary-tree total to prose that remains
+    /// deliberately uncounted.
+    #[tokio::test]
+    async fn upload_admission_uses_the_custom_cap_but_not_the_tree_total() {
+        let (_dir, store, co) = wired(WorkspaceQuota {
+            max_blob_bytes: 64,
+            tree_quota_bytes: Some(1),
+        });
+
+        store
+            .admit_upload(&co, "at.csv", 64)
+            .await
+            .expect("exactly at the configured per-file cap is admitted");
+        let err = store
+            .admit_upload(&co, "over.csv", 65)
+            .await
+            .expect_err("one byte over the configured cap is refused");
+        let message = err.to_string();
+        assert!(message.contains("over.csv"), "{message}");
+        assert!(message.contains("65 bytes"), "{message}");
+        assert!(message.contains("64 bytes"), "{message}");
     }
 
     /// The digest is the store's, not the caller's — the decorator forwards

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -690,6 +690,27 @@ async fn upload(
         .to_string();
     let mime = resolve_mime(&name, declared.as_deref());
 
+    // Issue #665: a file uploaded as a file is bounded as a file, whatever its
+    // encoding turns out to be. Asked **here, before the text/binary branch**
+    // below, because that branch decides how the payload is *stored* and must
+    // not also decide whether a limit applies.
+    //
+    // The store is asked rather than a limit applied here: a route cannot know a
+    // company's configured cap — routers are built once, before any company
+    // exists — so a check written inline would silently enforce the global
+    // default against a company that raised or lowered its own.
+    //
+    // This is not the per-writer check `workspace_quota` argues against. That
+    // argument is about writers *forgetting*; the decorator's narrowing rests on
+    // "a note is bounded by what a model will emit into a tool call", which is
+    // true of every writer it covers and false here — this route is where
+    // arbitrary operator-supplied bytes enter the tree.
+    company
+        .runtime
+        .workspace()
+        .admit_upload(company.id(), &name, bytes.len() as u64)
+        .await?;
+
     let mut node = WorkspaceNode {
         id: generate_id(),
         name,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1226,6 +1226,62 @@ async fn workspace_create_write_move_and_cycle_rejection() {
     assert_eq!(status, StatusCode::NO_CONTENT);
 }
 
+/// Issue #666 applies to every way the filesystem path can change, not only to
+/// creates. A rename that could alias a sibling is refused before either the
+/// index or either file body moves.
+#[tokio::test]
+async fn workspace_rename_cannot_claim_a_siblings_physical_path() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (_, first) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "first.md", "kind": "file", "content": "first body"})),
+    )
+    .await;
+    let first_id = first["id"].as_str().unwrap().to_string();
+    let (_, second) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "second.md", "kind": "file", "content": "second body"})),
+    )
+    .await;
+    let second_id = second["id"].as_str().unwrap().to_string();
+
+    let (status, refusal) = send(
+        &state,
+        "PATCH",
+        &format!("/api/v1/company/workspace/{second_id}"),
+        Some(json!({"name": "first.md"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::CONFLICT, "{refusal}");
+    assert_eq!(refusal["code"], "conflict", "{refusal}");
+
+    for (id, name, content) in [
+        (&first_id, "first.md", "first body"),
+        (&second_id, "second.md", "second body"),
+    ] {
+        let (status, file) = send(
+            &state,
+            "GET",
+            &format!("/api/v1/company/workspace/file/{id}"),
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{file}");
+        assert_eq!(file["name"], name, "the refused rename changed metadata");
+        assert_eq!(
+            file["content"], content,
+            "the refused rename moved or overwrote a sibling body"
+        );
+    }
+}
+
 /// The read plane the console's Workspace tab runs on (issue #177): the tree
 /// `GET` reflects writes, and the file `GET` carries content plus
 /// server-computed backlinks.
@@ -6977,6 +7033,88 @@ async fn an_uploaded_image_round_trips_through_the_blob_route() {
     assert_eq!(got.to_vec(), png, "the bytes must survive the round trip");
 }
 
+/// Issue #666: the filesystem backend derives payload paths from sibling
+/// names, so accepting the same name twice used to leave two ids pointing at
+/// one file. The second upload overwrote the first while the first node kept
+/// its old length and digest.
+///
+/// Refusing the colliding create is the filesystem backend's honest answer: it
+/// preserves the first payload and prevents the blob route from serving bytes
+/// under metadata computed for a different file.
+#[tokio::test]
+async fn a_same_name_upload_is_refused_without_overwriting_the_first_blob() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let first_bytes = vec![0x89, b'P', b'N', b'G', 0xff];
+    let (status, first) =
+        upload_file(&state, "chart.png", Some("image/png"), &first_bytes, None).await;
+    assert_eq!(status, StatusCode::OK, "{first}");
+    let first_id = first["id"].as_str().unwrap().to_string();
+    let first_sha = first["sha256"].as_str().unwrap().to_string();
+
+    let second_bytes = vec![0x89, b'P', b'N', b'G', 1, 2, 3, 0xff];
+    let (status, refusal) =
+        upload_file(&state, "chart.png", Some("image/png"), &second_bytes, None).await;
+    assert_eq!(status, StatusCode::CONFLICT, "{refusal}");
+    assert_eq!(refusal["code"], "conflict", "{refusal}");
+    assert!(
+        refusal["error"]
+            .as_str()
+            .is_some_and(|message| message.contains("chart.png")),
+        "the operator can identify the occupied name: {refusal}"
+    );
+
+    let response = blob_response(&state, &first_id).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers()["content-length"],
+        first_bytes.len().to_string(),
+        "the surviving node still describes its own payload"
+    );
+    assert_eq!(response.headers()["etag"], format!("\"{first_sha}\""));
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    assert_eq!(
+        body.as_ref(),
+        first_bytes.as_slice(),
+        "the refused upload must not overwrite the first file"
+    );
+
+    let (status, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        tree.as_array()
+            .unwrap()
+            .iter()
+            .filter(|node| node["name"] == "chart.png")
+            .count(),
+        1,
+        "a rejected collision must not leave a second metadata row"
+    );
+
+    // The physical paths differ when the parent differs, so this is not a
+    // workspace-wide filename ban.
+    let (_, folder) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "Archive", "kind": "folder"})),
+    )
+    .await;
+    let folder_id = folder["id"].as_str().unwrap();
+    let (status, nested) = upload_file(
+        &state,
+        "chart.png",
+        Some("image/png"),
+        &second_bytes,
+        Some(folder_id),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{nested}");
+    assert_eq!(nested["parentId"], folder_id);
+}
+
 /// A Markdown upload stays a **note**, not a payload. Storing it as bytes would
 /// silently cost it the editor, the diff-free text read, backlinks and search —
 /// so the decision is asserted rather than left to whichever branch ran.
@@ -7437,6 +7575,96 @@ async fn a_file_over_the_per_file_cap_is_refused_as_too_large_not_as_malformed()
     );
 
     assert_eq!(tree_names(&state).await, before, "and nothing was stored");
+}
+
+/// A file part declared as a texty type, so the upload takes the **text**
+/// branch rather than the binary one.
+fn text_file_part_prefix(filename: &str) -> Vec<u8> {
+    format!(
+        "--{OVERSIZE_BOUNDARY}\r\nContent-Disposition: form-data; name=\"file\"; \
+         filename=\"{filename}\"\r\nContent-Type: text/csv\r\n\r\n"
+    )
+    .into_bytes()
+}
+
+/// Issue #665: an over-cap upload is refused even when its bytes are valid
+/// UTF-8.
+///
+/// The store's quota decorator meters **binary payloads only**, and that is a
+/// deliberate narrowing — `src/runtime/workspace_quota.rs` says so, on the
+/// grounds that "a note is bounded by what a model will emit into a tool call".
+/// That premise holds for every writer the decorator covers and is false for
+/// this route, which is where arbitrary operator-supplied bytes enter the tree.
+///
+/// So a 65 MiB `.csv` — valid UTF-8, therefore classified as prose — used to be
+/// stored with **no size check at all**, while the byte-identical payload under
+/// a binary content type was refused. Same request, same size, opposite answer,
+/// decided by whether the bytes happened to decode.
+///
+/// The narrowing itself is untouched: an agent's note is still unmetered, and
+/// `tree_quota_gb` still counts binary payloads alone.
+#[tokio::test]
+async fn an_over_cap_upload_is_refused_even_when_its_bytes_are_valid_utf8() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let before = tree_names(&state).await;
+
+    // NUL bytes: valid UTF-8, so `text_body` decodes them and the upload takes
+    // the text branch. One megabyte over the 64 MiB default cap.
+    let oversize = 65 * 1024 * 1024;
+    let (status, body) = post_upload(
+        &state,
+        streamed_multipart(
+            text_file_part_prefix("export.csv"),
+            oversize,
+            format!("\r\n--{OVERSIZE_BOUNDARY}--\r\n").into_bytes(),
+        ),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::PAYLOAD_TOO_LARGE, "{body}");
+    assert_eq!(body["code"], "workspace_quota_exceeded", "{body}");
+    let message = body["error"].as_str().expect("an error message");
+    assert!(message.contains("export.csv"), "names the file: {message}");
+    assert!(message.contains("65.0 MiB"), "names its size: {message}");
+    assert!(message.contains("64.0 MiB"), "names the limit: {message}");
+    assert!(message.contains("Nothing was stored"), "{message}");
+
+    assert_eq!(tree_names(&state).await, before, "and nothing was stored");
+}
+
+/// The other half of #665, and the reason the fix is a cap rather than a
+/// reclassification: an *under*-cap text upload is still stored as prose.
+///
+/// Refusing large text must not turn ordinary text uploads into opaque blobs — a
+/// `.csv` an operator uploads is meant to stay searchable, backlinkable and
+/// editable in the console. If this ever fails, the fix has started deciding
+/// storage representation instead of bounding size.
+#[tokio::test]
+async fn an_under_cap_text_upload_is_still_stored_as_prose() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+
+    let (status, node) = upload_file(
+        &state,
+        "notes.csv",
+        Some("text/csv"),
+        b"a,b,c\n1,2,3\n",
+        None,
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{node}");
+    assert_eq!(
+        node["content"], "a,b,c\n1,2,3\n",
+        "a text upload keeps its body: {node}"
+    );
+    assert!(
+        node.get("mime").is_none() || node["mime"].is_null(),
+        "and is a prose note, not a binary payload: {node}"
+    );
 }
 
 /// The route's own backstop is classified too, and it fires while *skipping* a

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -15,8 +15,8 @@
 //! - workspace → real folders + Markdown files under `workspace/`, indexed by
 //!   `.workspace-index.json` (ULID → node metadata; physical paths derive from
 //!   the folder/name tree so a rename physically relocates the subtree). The
-//!   filesystem store therefore refuses duplicate sibling names: two ids may
-//!   never alias the same on-disk path (issue #666).
+//!   filesystem store therefore refuses a write whose resolved path another
+//!   node already holds: two ids may never alias one on-disk path (issue #666).
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -14,7 +14,9 @@
 //! - skills → `skills.json` (operator deltas)
 //! - workspace → real folders + Markdown files under `workspace/`, indexed by
 //!   `.workspace-index.json` (ULID → node metadata; physical paths derive from
-//!   the folder/name tree so a rename physically relocates the subtree)
+//!   the folder/name tree so a rename physically relocates the subtree). The
+//!   filesystem store therefore refuses duplicate sibling names: two ids may
+//!   never alias the same on-disk path (issue #666).
 
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
@@ -1086,6 +1088,7 @@ impl WorkspaceStore for FsOps {
                 }
             }
         }
+        reject_sibling_name_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
         index.insert(node.id.clone(), node.clone());
         let physical = self.physical_path(company, &index, &node.id)?;
         match node.kind {
@@ -1153,6 +1156,7 @@ impl WorkspaceStore for FsOps {
                 }
             }
         }
+        reject_sibling_name_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
         index.insert(node.id.clone(), node.clone());
         // The same sanitized derivation the text path uses, so a binary node
         // cannot reach a path a note could not.
@@ -1268,6 +1272,10 @@ impl WorkspaceStore for FsOps {
                 ));
             }
         }
+        let current = index.get(id).expect("node present");
+        let target_name = name.unwrap_or(&current.name);
+        let target_parent = parent.unwrap_or(current.parent_id.as_deref());
+        reject_sibling_name_collision(&index, id, target_name, target_parent)?;
         let old_physical = self.physical_path(company, &index, id)?;
         {
             let node = index.get_mut(id).expect("node present");
@@ -1468,6 +1476,35 @@ fn descendants(index: &HashMap<String, WorkspaceNode>, id: &str) -> HashSet<Stri
         }
     }
     out
+}
+
+/// Refuses two siblings whose logical names would resolve to one physical path.
+///
+/// Node ids are the workspace's durable identity, but the filesystem backend
+/// intentionally mirrors the operator-visible folder/name tree on disk. That
+/// representation cannot safely carry duplicate sibling names: the second
+/// create would overwrite the first node's bytes while leaving both metadata
+/// rows behind, and a later read would serve one payload under the other row's
+/// size and digest (issue #666).
+///
+/// The check runs while the workspace-index lock is held by every caller, so
+/// two concurrent creates cannot both observe an available name. `self_id` is
+/// ignored so a no-op rename remains valid.
+fn reject_sibling_name_collision(
+    index: &HashMap<String, WorkspaceNode>,
+    self_id: &str,
+    name: &str,
+    parent: Option<&str>,
+) -> Result<()> {
+    if index
+        .values()
+        .any(|node| node.id != self_id && node.parent_id.as_deref() == parent && node.name == name)
+    {
+        return Err(OpenCompanyError::Conflict(format!(
+            "workspace already contains `{name}` in that folder"
+        )));
+    }
+    Ok(())
 }
 
 /// Rejects a node name that contains a path separator or a parent-dir hop, so a

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1088,7 +1088,7 @@ impl WorkspaceStore for FsOps {
                 }
             }
         }
-        reject_sibling_name_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
+        reject_path_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
         index.insert(node.id.clone(), node.clone());
         let physical = self.physical_path(company, &index, &node.id)?;
         match node.kind {
@@ -1156,7 +1156,7 @@ impl WorkspaceStore for FsOps {
                 }
             }
         }
-        reject_sibling_name_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
+        reject_path_collision(&index, &node.id, &node.name, node.parent_id.as_deref())?;
         index.insert(node.id.clone(), node.clone());
         // The same sanitized derivation the text path uses, so a binary node
         // cannot reach a path a note could not.
@@ -1275,7 +1275,7 @@ impl WorkspaceStore for FsOps {
         let current = index.get(id).expect("node present");
         let target_name = name.unwrap_or(&current.name);
         let target_parent = parent.unwrap_or(current.parent_id.as_deref());
-        reject_sibling_name_collision(&index, id, target_name, target_parent)?;
+        reject_path_collision(&index, id, target_name, target_parent)?;
         let old_physical = self.physical_path(company, &index, id)?;
         {
             let node = index.get_mut(id).expect("node present");
@@ -1478,28 +1478,89 @@ fn descendants(index: &HashMap<String, WorkspaceNode>, id: &str) -> HashSet<Stri
     out
 }
 
-/// Refuses two siblings whose logical names would resolve to one physical path.
+/// The workspace-relative chain of names a node resolves to, or would.
+///
+/// This is [`FsOps::physical_path`]'s derivation with the constant
+/// `workspace/` prefix left off, and it exists separately because the check
+/// below needs the path of a node that is *not in the index yet*. Two nodes
+/// alias exactly when their chains are equal, so comparing chains and
+/// comparing the paths they build is the same question.
+fn name_chain(
+    index: &HashMap<String, WorkspaceNode>,
+    name: &str,
+    parent: Option<&str>,
+) -> Result<Vec<String>> {
+    let mut names = vec![name.to_string()];
+    let mut cursor = parent.map(str::to_string);
+    let mut guard = 0;
+    while let Some(node_id) = cursor {
+        let node = index.get(&node_id).ok_or_else(|| {
+            OpenCompanyError::Store(format!("dangling workspace parent {node_id}"))
+        })?;
+        names.push(node.name.clone());
+        cursor = node.parent_id.clone();
+        guard += 1;
+        if guard > 10_000 {
+            return Err(OpenCompanyError::Store(
+                "workspace cycle detected".to_string(),
+            ));
+        }
+    }
+    names.reverse();
+    Ok(names)
+}
+
+/// Refuses a name/parent that would resolve to a physical path another node
+/// already holds.
 ///
 /// Node ids are the workspace's durable identity, but the filesystem backend
 /// intentionally mirrors the operator-visible folder/name tree on disk. That
-/// representation cannot safely carry duplicate sibling names: the second
-/// create would overwrite the first node's bytes while leaving both metadata
-/// rows behind, and a later read would serve one payload under the other row's
-/// size and digest (issue #666).
+/// representation cannot safely carry two nodes on one path: the second create
+/// would overwrite the first node's bytes while leaving both metadata rows
+/// behind, and a later read would serve one payload under the other row's size
+/// and digest (issue #666).
+///
+/// # Why the whole path, and not the sibling name
+///
+/// Matching on `(parent_id, name)` catches the ordinary case and misses the one
+/// that is already in the field. A tree may hold **duplicate-named folders** —
+/// [`crate::company::workspace_scaffold`] finds them, refuses to resolve them
+/// and deliberately leaves them standing, and an index written before this
+/// check existed can carry them. Two nodes under two roots both named `Desks`
+/// are not siblings by `parent_id`, and their paths are nevertheless the same
+/// string. Comparing the resolved chain closes that, and subsumes the sibling
+/// case: equal parents plus equal names is equal chains.
+///
+/// # Why only the moved node's own path is checked
+///
+/// Renaming a folder moves its whole subtree, but a chain is determined by its
+/// prefix: if a descendant's new chain equalled some other node's chain, their
+/// prefixes would be equal too — which is a collision on the renamed node's own
+/// chain, and is refused here. So a descendant cannot collide unless its
+/// ancestor already does.
+///
+/// A node whose own chain cannot be derived (a dangling parent in a damaged
+/// index) is skipped rather than propagated: it resolves to no path, so it can
+/// alias nothing, and one unreachable row must not make every write fail.
 ///
 /// The check runs while the workspace-index lock is held by every caller, so
-/// two concurrent creates cannot both observe an available name. `self_id` is
-/// ignored so a no-op rename remains valid.
-fn reject_sibling_name_collision(
+/// two concurrent creates cannot both observe an available path. `self_id` is
+/// excluded so a no-op rename remains valid.
+fn reject_path_collision(
     index: &HashMap<String, WorkspaceNode>,
     self_id: &str,
     name: &str,
     parent: Option<&str>,
 ) -> Result<()> {
-    if index
+    let candidate = name_chain(index, name, parent)?;
+    let taken = index
         .values()
-        .any(|node| node.id != self_id && node.parent_id.as_deref() == parent && node.name == name)
-    {
+        .filter(|node| node.id != self_id)
+        .any(|node| {
+            name_chain(index, &node.name, node.parent_id.as_deref())
+                .is_ok_and(|chain| chain == candidate)
+        });
+    if taken {
         return Err(OpenCompanyError::Conflict(format!(
             "workspace already contains `{name}` in that folder"
         )));
@@ -1621,6 +1682,174 @@ mod test {
             .prefix("opencompany-fsops-")
             .tempdir()
             .expect("tempdir")
+    }
+
+    fn workspace_node(id: &str, name: &str, kind: NodeKind, parent: Option<&str>) -> WorkspaceNode {
+        WorkspaceNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            parent_id: parent.map(str::to_string),
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Operator,
+            updated_by: WorkspaceOrigin::Operator,
+            mime: None,
+            size: None,
+            sha256: None,
+        }
+    }
+
+    /// A file node carrying the mime a binary write requires; `size` and
+    /// `sha256` are the store's to compute.
+    fn binary_node(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+        WorkspaceNode {
+            mime: Some("application/pdf".to_string()),
+            ..workspace_node(id, name, NodeKind::File, parent)
+        }
+    }
+
+    async fn collect_stream(stream: crate::ports::workspace::BlobStream) -> Vec<u8> {
+        use futures::StreamExt;
+        let mut stream = stream;
+        let mut out = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            out.extend_from_slice(&chunk.expect("chunk"));
+        }
+        out
+    }
+
+    /// Two root folders under one name, written straight to the index.
+    ///
+    /// `create` refuses to *make* this shape now (issue #666), but it is
+    /// reachable in the field: an index written before that refusal existed
+    /// carries it, and `workspace_scaffold` finds such roots, declines to
+    /// resolve them and deliberately leaves them standing. So the state is
+    /// seeded rather than requested.
+    async fn seed_duplicate_roots(ops: &FsOps, company: &CompanyId) {
+        let mut index = HashMap::new();
+        for id in ["root-a", "root-b"] {
+            index.insert(
+                id.to_string(),
+                workspace_node(id, "Desks", NodeKind::Folder, None),
+            );
+        }
+        ops.bundle(company)
+            .ensure_dirs()
+            .await
+            .expect("bundle dirs");
+        ops.save_index(company, &index).await.expect("seed index");
+    }
+
+    /// Issue #666, one level below the sibling case: nodes under two
+    /// same-named folders are not siblings by `parent_id`, and still resolve to
+    /// one path. A check keyed on `(parent_id, name)` admits the second and
+    /// lets it overwrite the first node's bytes.
+    #[tokio::test]
+    async fn equal_names_under_duplicate_roots_cannot_claim_one_path() {
+        let root_dir = tmp_root();
+        let ops = FsOps::new(root_dir.path());
+        let company = CompanyId::new("acme");
+        seed_duplicate_roots(&ops, &company).await;
+
+        ops.create_binary(
+            &company,
+            &binary_node("first", "report.pdf", Some("root-a")),
+            b"the first payload",
+        )
+        .await
+        .expect("the first child of the first root is fine");
+
+        let err = ops
+            .create_binary(
+                &company,
+                &binary_node("second", "report.pdf", Some("root-b")),
+                b"a different payload entirely",
+            )
+            .await
+            .expect_err("the second root's child resolves to the same path");
+        assert!(
+            matches!(err, OpenCompanyError::Conflict(_)),
+            "a path already in use is a conflict, not a store error: {err:?}"
+        );
+
+        let (node, stream) = ops
+            .read_bytes(&company, "first")
+            .await
+            .expect("read")
+            .expect("the first node still exists");
+        assert_eq!(
+            collect_stream(stream).await,
+            b"the first payload",
+            "the refused create must not have overwritten the first payload"
+        );
+        assert_eq!(
+            node.size,
+            Some("the first payload".len() as u64),
+            "nor left the surviving node describing bytes it no longer holds"
+        );
+        assert!(
+            ops.tree(&company)
+                .await
+                .expect("tree")
+                .iter()
+                .all(|n| n.id != "second"),
+            "a refused create must not leave a metadata row behind"
+        );
+    }
+
+    /// The same path, reached by moving rather than creating.
+    #[tokio::test]
+    async fn a_move_cannot_claim_a_path_held_under_a_duplicate_root() {
+        let root_dir = tmp_root();
+        let ops = FsOps::new(root_dir.path());
+        let company = CompanyId::new("acme");
+        seed_duplicate_roots(&ops, &company).await;
+
+        ops.create_binary(
+            &company,
+            &binary_node("first", "report.pdf", Some("root-a")),
+            b"the first payload",
+        )
+        .await
+        .expect("create under the first root");
+        ops.create_binary(
+            &company,
+            &binary_node("mover", "draft.pdf", Some("root-b")),
+            b"a different payload entirely",
+        )
+        .await
+        .expect("a differently-named child of the second root is fine");
+
+        let err = ops
+            .rename_move(&company, "mover", Some("report.pdf"), None)
+            .await
+            .expect_err("renaming it onto the other root's path is refused");
+        assert!(
+            matches!(err, OpenCompanyError::Conflict(_)),
+            "expected a conflict: {err:?}"
+        );
+
+        let (_, stream) = ops
+            .read_bytes(&company, "first")
+            .await
+            .expect("read")
+            .expect("the node whose path was targeted still exists");
+        assert_eq!(
+            collect_stream(stream).await,
+            b"the first payload",
+            "the refused move must not have overwritten it"
+        );
+        let (moved, stream) = ops
+            .read_bytes(&company, "mover")
+            .await
+            .expect("read")
+            .expect("and the mover still exists");
+        assert_eq!(moved.name, "draft.pdf", "under its original name");
+        assert_eq!(
+            collect_stream(stream).await,
+            b"a different payload entirely",
+            "with its own bytes"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Two separate defects that meet on one code path: the multipart upload route.

**#665 — a limit that depended on the encoding.** The route classifies a payload as
prose when its bytes happen to decode as UTF-8, and that classification also decided
whether any size limit applied. A 65 MiB `.csv` was stored unchecked, while the
byte-identical payload under a binary content type was refused. Same request, same
size, opposite answer.

Adds `WorkspaceStore::admit_upload`, defaulted to permit, implemented by
`QuotaEnforcedWorkspace` and **delegated** by `WorkspaceAnnouncer` — the announcer
wraps the quota decorator, so a defaulted method there would answer "yes" to every
upload and hide the only implementation that knows the company's cap. The route asks
the store *before* the text/binary branch, so the company's own `max_blob_mb` applies
rather than the global default a route-local check would have had to guess at (routers
are built once, before any company exists).

**#666 — two ids, one file.** On the filesystem backend a node's on-disk path is
derived from the chain of sibling names, with no uniqueness check. Two files uploaded
under one name into one folder resolved to a single path: the second overwrote the
first, while the first node kept its own `size` and `sha256`, so the blob route served
B's bytes under A's `Content-Length` and `ETag`, and a conditional request against A's
ETag was answered as fresh.

Adds `reject_path_collision`, wired at the three paths that can move a node onto
another's physical path: `create`, `create_binary` and `rename_move`. It compares the
**resolved name chain**, not `(parent_id, name)` — a tree can legitimately hold two
folders under one name (the scaffold finds such roots, declines to resolve them and
leaves them standing), and their equally-named children are not siblings by `parent_id`
yet still resolve to one path. Comparing chains subsumes the sibling case: equal parents
plus equal names is equal chains.

Only the created/moved node's own chain is checked, because a chain is determined by its
prefix: a descendant's new chain could only collide if its ancestor's did, which is
refused here. A node whose own chain cannot be derived (a dangling parent in a damaged
index) is skipped rather than propagated — it resolves to no path, so it can alias
nothing.

It runs under the workspace-index lock every caller already holds, so two concurrent
creates cannot both observe a free path, and a refusal leaves the existing node, payload,
size and digest untouched. `write_binary` never changes a name and `swap_files` removes
the node holding the name before inserting the promoted one, so neither needs the check.

### Scope: what #665 does *not* fix

`tree_quota_gb` still bounds binary payloads alone. It totals `node.size`, which only a
binary node carries, so an upload stored as prose contributes nothing to that total —
measuring one against a total it never joins would be arbitrary, and enough under-cap
text uploads still add up. Closing that half means giving text nodes a `size`, which
breaks the documented "`mime`, `size` and `sha256` are all `Some` or none is" invariant
and goes stale on every subsequent text edit. `src/runtime/workspace_quota.rs` already
names that as its own follow-up ("if notes ever become the pressure, `size` on a text
node is the thing to add"), and it is a maintainer's call rather than a drive-by. The
per-file bypass — the one an operator setting `max_blob_mb` is actually buying — is
closed here.

Backend scope for #666 is the filesystem store only: id-keyed database backends do not
derive paths from names and can continue to represent duplicate sibling names without
aliasing a payload.

Two scaffold tests built their fixture by asking the fs store to create duplicate root
names — the state #666 now forbids. They now seed the index directly, which is also the
honest shape of the case they cover: an index written before the refusal existed, or one
an id-keyed backend can still represent legally. Their assertions are unchanged.

Closes tinyhumansai/opencompany#665
Closes tinyhumansai/opencompany#666

## API Or Behavior Changes

- **New port method** `WorkspaceStore::admit_upload(company, name, len)`, with a
  permissive default body — no backend or test double is required to change.
- **`POST /api/v1/company/workspace/upload`** now answers `413` with
  `workspace_quota_exceeded` for a payload over `max_blob_mb` regardless of encoding.
  Previously only non-UTF-8 payloads were refused.
- **`409 conflict`** from the filesystem backend when a create, rename or move would
  put two siblings under one name. Previously accepted, silently aliasing one file.
  Under-cap text uploads are still stored as prose, and agent notes stay unmetered.

## Tests

Lanes run locally, all on the pushed tree:

- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman,tinycortex` — **3089 + 10 + 1 + 11 + 2 = 3113 passed, 0 failed**
- `cargo test` (default features) — **2059 passed, 0 failed**

Every new test was re-run with its own hunk reverted, each selecting exactly one test:

| Hunk reverted | Test | Result |
|---|---|---|
| `create` + `create_binary` collision calls | `a_same_name_upload_is_refused_without_overwriting_the_first_blob` | 1 selected, 1 FAILED |
| `rename_move` collision call | `workspace_rename_cannot_claim_a_siblings_physical_path` | 1 selected, 1 FAILED |
| route's `admit_upload` call | `an_over_cap_upload_is_refused_even_when_its_bytes_are_valid_utf8` | 1 selected, 1 FAILED |
| `WorkspaceAnnouncer` delegation | (same test) | 1 selected, 1 FAILED |
| `QuotaEnforcedWorkspace::admit_upload` | `upload_admission_uses_the_custom_cap_but_not_the_tree_total` | 1 selected, 1 FAILED |
| path-chain comparison, back to `(parent_id, name)` | `equal_names_under_duplicate_roots_cannot_claim_one_path`, `a_move_cannot_claim_a_path_held_under_a_duplicate_root` | 2 selected, 2 FAILED |

`an_under_cap_text_upload_is_still_stored_as_prose` passes on `main` as well — it is a
guard against the fix over-reaching into storage representation, not a proof of the fix,
and is not counted as one.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `--locked --no-deps --features openhuman,tinycortex --all-targets`; `--no-deps` keeps pre-existing `vendor/tinyagents` lints out, which CI does not see either
- [x] `cargo build --all-targets`
- [x] `cargo test` — plus the gated `--features openhuman,tinycortex` lane

## Documentation

`docs/spec/runtime/ports-console.md` records both: that an upload is bounded by
`max_blob_mb` before the text/binary choice and that text nodes still do not contribute
to `tree_quota_gb`, and that the filesystem backend refuses a write landing on a path
another node holds — comparing the whole resolved chain, and why — while id-keyed
backends need not. `src/store/fs_ops.rs`'s module header notes that two ids may never
alias one on-disk path.
