### PR TITLE
workspace: a binary node is not an empty note on GraphQL, and replaced bytes refetch (#669)

### DIFF
--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -369,6 +369,33 @@ export async function fetchBlobUrl(
   return URL.createObjectURL(blob);
 }
 
+/**
+ * Identifies the *bytes* a binary node currently holds (issue #669).
+ *
+ * The viewer fetches a payload once and holds an object URL for it, so it needs
+ * to know when that URL has gone stale. The node id alone cannot say: a
+ * re-publish overwrites a payload **in place** and deliberately keeps the id, so
+ * an operator watching an image while an agent regenerated it kept seeing — and
+ * downloading — the old bytes until they navigated away and back.
+ *
+ * `sha256` is the answer because it *is* "these are different bytes", which is
+ * also why the blob route serves it as the `ETag`. The two obvious alternatives
+ * are both wrong in a way that shows up rarely enough to be nasty: `size` misses
+ * a same-length rewrite, and `updatedAtMillis` moves on a rename that changed no
+ * bytes at all, forcing a needless refetch of a payload that may be 60 MB.
+ *
+ * This exists as a named function rather than as entries in a `useEffect`
+ * dependency array because a dependency array is exactly the kind of thing a
+ * later edit shortens without noticing, and because the rule above is worth
+ * asserting in a test.
+ *
+ * A node with no digest falls back to the id, which is the pre-#553 behaviour
+ * and correct: nothing here can detect a change the host did not report.
+ */
+export function blobCacheKey(node: Pick<FsNode, "id" | "sha256">): string {
+  return node.sha256 ? `${node.id}:${node.sha256}` : node.id;
+}
+
 /** A human-readable size, for the metadata a binary node shows instead of a body. */
 export function formatBytes(bytes: number | undefined): string {
   if (bytes === undefined) return "unknown size";

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -24,6 +24,7 @@ import { toast } from "sonner";
 import { ApiError } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import {
+  blobCacheKey,
   createNode,
   deleteNode as deleteNodeApi,
   fetchBlobUrl,
@@ -1494,6 +1495,7 @@ function BinaryNodeView({
   const [url, setUrl] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const isImage = (node.mime ?? "").startsWith("image/");
+  const blobKey = blobCacheKey(node);
 
   useEffect(() => {
     let revoked = false;
@@ -1519,7 +1521,10 @@ function BinaryNodeView({
       revoked = true;
       if (current) URL.revokeObjectURL(current);
     };
-  }, [client, company, node.id]);
+    // `blobKey`, not `node.id`, is what makes a re-publish visible: it folds in
+    // the digest, so bytes replaced in place re-fetch (issue #669). The rule
+    // lives in `blobCacheKey` and is asserted there.
+  }, [client, company, node.id, blobKey]);
 
   return (
     <div className="mx-auto max-w-3xl px-6 py-6" data-testid="workspace-binary">

--- a/frontend/test/unit/workspace-binary.test.ts
+++ b/frontend/test/unit/workspace-binary.test.ts
@@ -10,7 +10,14 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { OpenCompanyClient } from "@/api/client";
-import { fetchTree, formatBytes, isBinary, uploadFile, type FsNode } from "@/api/workspace";
+import {
+  blobCacheKey,
+  fetchTree,
+  formatBytes,
+  isBinary,
+  uploadFile,
+  type FsNode,
+} from "@/api/workspace";
 
 function client(handler: (req: { method: string; url: string; body?: string }) => unknown) {
   const transport = {
@@ -57,6 +64,39 @@ describe("formatBytes", () => {
 
   it("keeps zero a real answer, not a missing one", () => {
     expect(formatBytes(0)).toBe("0 B");
+  });
+});
+
+describe("blobCacheKey", () => {
+  /**
+   * The defect in #669: a re-publish overwrites a payload in place, keeping the
+   * node id and changing the digest. Keying the viewer's fetch on the id alone
+   * meant the operator kept seeing — and downloading — the old bytes.
+   */
+  it("changes when the bytes change, even though the node id does not", () => {
+    const before = { id: "n-img", sha256: "aaa" };
+    const after = { id: "n-img", sha256: "bbb" };
+    expect(blobCacheKey(after)).not.toBe(blobCacheKey(before));
+  });
+
+  it("is stable when nothing about the payload changed", () => {
+    expect(blobCacheKey({ id: "n-img", sha256: "aaa" })).toBe(
+      blobCacheKey({ id: "n-img", sha256: "aaa" }),
+    );
+  });
+
+  it("still separates two different nodes that happen to hold identical bytes", () => {
+    // Two uploads of the same file share a digest. They are different nodes and
+    // must not share a cache entry, or opening one would show the other's name.
+    expect(blobCacheKey({ id: "n-a", sha256: "same" })).not.toBe(
+      blobCacheKey({ id: "n-b", sha256: "same" }),
+    );
+  });
+
+  it("falls back to the id when the host reported no digest", () => {
+    // Nothing here can detect a change the host did not report, so the honest
+    // answer is the pre-#553 behaviour rather than a key that churns.
+    expect(blobCacheKey({ id: "n-img", sha256: undefined })).toBe("n-img");
   });
 });
 

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -378,6 +378,36 @@ type FsNode {
 	Who last wrote the node's content (a rename or move does not change it).
 	"""
 	updatedBy: WorkspaceOrigin!
+	"""
+	The payload's media type — **set only on a binary node** (issue #553),
+	and null on a folder or a prose note.
+	
+	Its presence is the whole test for "this node holds bytes, not text", and
+	without it no GraphQL consumer could discover that binaries exist at all:
+	a payload's text `read` is an empty body by contract, so a 4 MB PNG and a
+	genuinely empty note were the same answer on this surface (issue #669).
+	The REST `FsNode` has carried these three since #553; this is the field
+	set catching up, not a new concept.
+	"""
+	mime: String
+	"""
+	The payload's length in bytes; null unless `mime` is set.
+	
+	`Float`, not `Int`, because the store's `size` is a `u64` and GraphQL's
+	`Int` is 32-bit — the same choice `usage` and `Approval.atMillis` made,
+	for the same reason. Today's 64 MiB per-write cap fits in an `Int`; the
+	cap is configurable and the field should not be the thing that stops it
+	being raised.
+	"""
+	size: Float
+	"""
+	The payload's sha256, the same digest the blob route serves as its
+	`ETag`; null unless `mime` is set.
+	
+	This is what makes "the bytes changed" observable to a consumer that
+	cannot see the bytes — a re-publish keeps the node id and changes this.
+	"""
+	sha256: String
 }
 
 type Inbox {
@@ -1126,9 +1156,9 @@ type WorkspaceOrigin {
 One workspace search hit (issue #607).
 
 The node is nested rather than flattened: `FsNode` is already the projection
-every other workspace read hands back, and re-declaring its seven fields here
-would be a second copy to keep in step. What search adds is the two things
-only a search knows — where the node sits, and why it came back.
+every other workspace read hands back, and re-declaring its fields here would
+be a second copy to keep in step. What search adds is the two things only a
+search knows — where the node sits, and why it came back.
 """
 type WorkspaceSearchHit {
 	"""

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -1473,3 +1473,160 @@ fn regenerate_sdl_snapshot() {
         std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/server/graphql/schema.graphql");
     std::fs::write(&path, super::sdl()).unwrap();
 }
+
+// ---------------------------------------------------------------------------
+// A binary node is not a note, on either read surface (issue #669)
+// ---------------------------------------------------------------------------
+
+/// Mints a real binary node in the store, the way an upload or a publish does.
+async fn given_a_binary_node(state: &AppState, name: &str, mime: &str, bytes: &[u8]) -> String {
+    let id = CompanyId::new("acme");
+    let workspace = state.registry().get(&id).unwrap().workspace().clone();
+    let node = crate::ports::workspace::WorkspaceNode {
+        id: crate::ports::generate_id(),
+        name: name.to_string(),
+        kind: crate::ports::workspace::NodeKind::File,
+        parent_id: None,
+        updated_at_millis: 1_700_000_000_000,
+        created_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+        updated_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+        mime: Some(mime.to_string()),
+        size: None,
+        sha256: None,
+    };
+    workspace.create_binary(&id, &node, bytes).await.unwrap();
+    node.id
+}
+
+/// The headline of #669: `workspaceFile` reported a payload as an ordinary note
+/// with no content, so a 4 MB PNG and a genuinely empty note were the same
+/// response — on the surface whose entire job is to be unambiguous.
+///
+/// Asserted against the REST twin in the same test rather than in isolation.
+/// The two are documented as differing only in timestamp shape, and the bug was
+/// precisely that they disagreed about something much larger than that; a test
+/// that pinned only the GraphQL half would not notice them drifting apart again
+/// in the other direction.
+#[tokio::test]
+async fn graphql_and_rest_agree_that_a_binary_node_holds_no_text() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let png: &[u8] = &[0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff];
+    let id = given_a_binary_node(&state, "hero.png", "image/png", png).await;
+
+    // GraphQL: an error naming the route that does serve the bytes, and no
+    // `content: ""` masquerading as an empty note.
+    let value = query(
+        router(state.clone()),
+        &format!(
+            r#"{{"query":"{{ company(id:\"acme\"){{ workspaceFile(id:\"{id}\"){{ name content }} }} }}"}}"#
+        ),
+    )
+    .await;
+    let errors = value["errors"]
+        .as_array()
+        .unwrap_or_else(|| panic!("a payload must not resolve as a note: {value}"));
+    let message = errors[0]["message"].as_str().unwrap();
+    assert!(
+        message.contains("image/png") && message.contains("workspace/blob/"),
+        "the refusal must name the type and the route that works: {message}"
+    );
+    assert!(
+        value["data"]["company"]["workspaceFile"].is_null(),
+        "no half-answer alongside the error: {value}"
+    );
+
+    // REST, the twin, for the same node: the same refusal.
+    let response = router(state)
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(format!("/api/v1/company/workspace/file/{id}"))
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let rest = String::from_utf8(bytes.to_vec()).unwrap();
+    assert!(
+        rest.contains("image/png") && rest.contains("workspace/blob/"),
+        "REST must still refuse the same way: {rest}"
+    );
+}
+
+/// The other half of #669, and the reason refusing above is not merely a harder
+/// `null`: the tree now carries the three fields that let a consumer discover a
+/// binary exists **before** it asks for text it cannot have.
+///
+/// Without these the refusal would be a dead end — a GraphQL client would have
+/// no way to reach a payload at all, because nothing in the schema said payloads
+/// were a thing. The REST `FsNode` has carried them since #553.
+#[tokio::test]
+async fn the_tree_projects_a_binary_nodes_mime_size_and_digest() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let png: &[u8] = &[0x89, b'P', b'N', b'G', 0xff];
+    given_a_binary_node(&state, "hero.png", "image/png", png).await;
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { name mime size sha256 } } }"}"#,
+    )
+    .await;
+    assert!(value["errors"].is_null(), "{value}");
+    let tree = value["data"]["company"]["workspaceTree"]
+        .as_array()
+        .unwrap();
+    let image = tree
+        .iter()
+        .find(|node| node["name"] == serde_json::json!("hero.png"))
+        .unwrap_or_else(|| panic!("the binary node is in the tree: {value}"));
+
+    assert_eq!(image["mime"], "image/png");
+    assert_eq!(
+        image["size"].as_f64().unwrap(),
+        png.len() as f64,
+        "the size the store computed, not the None this test sent in"
+    );
+    let sha = image["sha256"]
+        .as_str()
+        .unwrap_or_else(|| panic!("a digest is projected: {image}"));
+    assert_eq!(sha.len(), 64, "the store's sha256, hex-encoded");
+}
+
+/// A prose note leaves all three null. The console reads `mime`'s **presence**
+/// as "render or download this instead of editing it", so a projection that
+/// invented an empty string here would put every note behind a download card.
+#[tokio::test]
+async fn a_prose_note_projects_no_binary_metadata() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let id = CompanyId::new("acme");
+    let workspace = state.registry().get(&id).unwrap().workspace().clone();
+    crate::company::workspace_scaffold::ensure_agent_folder(workspace.as_ref(), &id, "maya")
+        .await
+        .unwrap();
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { name mime size sha256 } } }"}"#,
+    )
+    .await;
+    assert!(value["errors"].is_null(), "{value}");
+    let tree = value["data"]["company"]["workspaceTree"]
+        .as_array()
+        .unwrap_or_else(|| panic!("the tree resolves: {value}"));
+    let folder = tree
+        .iter()
+        .find(|node| node["name"] == serde_json::json!("maya"))
+        .unwrap();
+    assert!(folder["mime"].is_null(), "{folder}");
+    assert!(folder["size"].is_null(), "{folder}");
+    assert!(folder["sha256"].is_null(), "{folder}");
+}

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -1599,9 +1599,15 @@ async fn the_tree_projects_a_binary_nodes_mime_size_and_digest() {
     assert_eq!(sha.len(), 64, "the store's sha256, hex-encoded");
 }
 
-/// A prose note leaves all three null. The console reads `mime`'s **presence**
-/// as "render or download this instead of editing it", so a projection that
-/// invented an empty string here would put every note behind a download card.
+/// A folder and a prose note both leave all three null. The console reads
+/// `mime`'s **presence** as "render or download this instead of editing it", so
+/// a projection that invented an empty string here would put every note behind
+/// a download card.
+///
+/// Both are asserted because only one of them is a real test of the rule: a
+/// folder can never carry a payload, so its nulls are structural, whereas a note
+/// is a `File` exactly like the binary above and `mime` is the single field
+/// telling them apart.
 #[tokio::test]
 async fn a_prose_note_projects_no_binary_metadata() {
     let home_dir = home();
@@ -1613,20 +1619,54 @@ async fn a_prose_note_projects_no_binary_metadata() {
         .await
         .unwrap();
 
+    // A folder is the easy half. The note is the half that matters: it is a
+    // `File` like the payload above, so `mime`'s absence is the *only* thing
+    // separating the two, and a projection that reached for a default here
+    // would put every note in the company behind a download card.
+    let note = crate::ports::workspace::WorkspaceNode {
+        id: crate::ports::generate_id(),
+        name: "Charter.md".to_string(),
+        kind: crate::ports::workspace::NodeKind::File,
+        parent_id: None,
+        updated_at_millis: 1_700_000_000_000,
+        created_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+        updated_by: crate::ports::workspace::WorkspaceOrigin::Operator,
+        mime: None,
+        size: None,
+        sha256: None,
+    };
+    workspace
+        .create(&id, &note, Some("# Charter\n\nprose, not bytes.\n"))
+        .await
+        .unwrap();
+
     let value = query(
         router(state),
-        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { name mime size sha256 } } }"}"#,
+        r#"{"query":"{ company(id:\"acme\"){ workspaceTree { name kind mime size sha256 } } }"}"#,
     )
     .await;
     assert!(value["errors"].is_null(), "{value}");
     let tree = value["data"]["company"]["workspaceTree"]
         .as_array()
         .unwrap_or_else(|| panic!("the tree resolves: {value}"));
-    let folder = tree
-        .iter()
-        .find(|node| node["name"] == serde_json::json!("maya"))
-        .unwrap();
+    let find = |name: &str| {
+        tree.iter()
+            .find(|node| node["name"] == serde_json::json!(name))
+            .unwrap_or_else(|| panic!("`{name}` is in the tree: {value}"))
+            .clone()
+    };
+
+    let folder = find("maya");
     assert!(folder["mime"].is_null(), "{folder}");
     assert!(folder["size"].is_null(), "{folder}");
     assert!(folder["sha256"].is_null(), "{folder}");
+
+    let note = find("Charter.md");
+    assert_eq!(
+        note["kind"], "file",
+        "a note is a file, not a folder: {note}"
+    );
+    assert!(note["mime"].is_null(), "{note}");
+    assert!(note["size"].is_null(), "{note}");
+    assert!(note["sha256"].is_null(), "{note}");
 }

--- a/src/server/graphql/workspace.rs
+++ b/src/server/graphql/workspace.rs
@@ -66,6 +66,30 @@ pub struct FsNodeGql {
     pub created_by: WorkspaceOriginGql,
     /// Who last wrote the node's content (a rename or move does not change it).
     pub updated_by: WorkspaceOriginGql,
+    /// The payload's media type — **set only on a binary node** (issue #553),
+    /// and null on a folder or a prose note.
+    ///
+    /// Its presence is the whole test for "this node holds bytes, not text", and
+    /// without it no GraphQL consumer could discover that binaries exist at all:
+    /// a payload's text `read` is an empty body by contract, so a 4 MB PNG and a
+    /// genuinely empty note were the same answer on this surface (issue #669).
+    /// The REST `FsNode` has carried these three since #553; this is the field
+    /// set catching up, not a new concept.
+    pub mime: Option<String>,
+    /// The payload's length in bytes; null unless `mime` is set.
+    ///
+    /// `Float`, not `Int`, because the store's `size` is a `u64` and GraphQL's
+    /// `Int` is 32-bit — the same choice `usage` and `Approval.atMillis` made,
+    /// for the same reason. Today's 64 MiB per-write cap fits in an `Int`; the
+    /// cap is configurable and the field should not be the thing that stops it
+    /// being raised.
+    pub size: Option<f64>,
+    /// The payload's sha256, the same digest the blob route serves as its
+    /// `ETag`; null unless `mime` is set.
+    ///
+    /// This is what makes "the bytes changed" observable to a consumer that
+    /// cannot see the bytes — a re-publish keeps the node id and changes this.
+    pub sha256: Option<String>,
 }
 
 impl From<WorkspaceNode> for FsNodeGql {
@@ -82,6 +106,9 @@ impl From<WorkspaceNode> for FsNodeGql {
             updated_at: iso8601(node.updated_at_millis),
             created_by: node.created_by.into(),
             updated_by: node.updated_by.into(),
+            mime: node.mime,
+            size: node.size.map(|bytes| bytes as f64),
+            sha256: node.sha256,
         }
     }
 }
@@ -109,9 +136,9 @@ pub struct WorkspaceFileGql {
 /// One workspace search hit (issue #607).
 ///
 /// The node is nested rather than flattened: `FsNode` is already the projection
-/// every other workspace read hands back, and re-declaring its seven fields here
-/// would be a second copy to keep in step. What search adds is the two things
-/// only a search knows — where the node sits, and why it came back.
+/// every other workspace read hands back, and re-declaring its fields here would
+/// be a second copy to keep in step. What search adds is the two things only a
+/// search knows — where the node sits, and why it came back.
 #[derive(SimpleObject)]
 #[graphql(name = "WorkspaceSearchHit")]
 pub struct WorkspaceSearchHitGql {
@@ -151,6 +178,24 @@ pub(crate) async fn resolve_tree(
 /// [`file_with_backlinks`](crate::company::workspace_links::file_with_backlinks),
 /// shared with the REST `GET …/workspace/file/{id}` route the console reads, so
 /// the two surfaces can never report different backlinks for the same note.
+///
+/// # A binary node is refused here, exactly as it is over REST (issue #669)
+///
+/// The port's honest answer to a prose-shaped read of a payload is `""`, and
+/// this resolver used to pass that straight through — so a 4 MB PNG and an
+/// empty note were the same response, on a surface whose whole job is to be
+/// unambiguous about what a node contains. The REST twin has always refused,
+/// naming the route that does serve the bytes; `WorkspaceFileBody` and
+/// `WorkspaceFileGql` are documented as differing only in timestamp shape, and
+/// answering differently about a node's *kind* is a much larger divergence than
+/// the one that documentation permits.
+///
+/// Adding `mime` to this type instead was the alternative, and it is the wrong
+/// one: it would make the twins differ in field set rather than in timestamps,
+/// and it would leave `content: ""` sitting in the response for a client to
+/// misread. Discovery belongs on the tree, where [`FsNodeGql`] now carries
+/// `mime`/`size`/`sha256` — so a consumer learns a node is binary *before*
+/// asking for its text, which is the order that avoids the error entirely.
 pub(crate) async fn resolve_file(
     runtime: &Arc<CompanyRuntime>,
     id: &str,
@@ -160,6 +205,14 @@ pub(crate) async fn resolve_file(
     else {
         return Ok(None);
     };
+
+    if let Some(mime) = &node.mime {
+        return Err(async_graphql::Error::new(format!(
+            "`{}` holds {mime} data, not text; fetch it from \
+             `…/workspace/blob/{}` instead",
+            node.name, node.id
+        )));
+    }
 
     Ok(Some(WorkspaceFileGql {
         id: ID(node.id),


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#669.

Two halves of one omission — the places that consume the workspace port's "a
binary node yields an empty body" contract for a node that might be binary.

**Backend.** The REST read route refuses a payload and names the blob route; the
GraphQL `resolve_file` passed the empty body straight through, so a 4 MB PNG and
a genuinely empty note were the same response. `resolve_file` now refuses the
same way. Discovery moves to the tree instead: `FsNodeGql` gains `mime`, `size`
and `sha256`, which the REST `FsNode` has carried since #553 — so a consumer
learns a node is binary *before* asking for text it cannot have. `size` is
`Float`, following the convention `usage` and `Approval.atMillis` set for `u64`
against GraphQL's 32-bit `Int`. `schema.graphql` regenerated.

Adding `mime` to `WorkspaceFileGql` was the alternative and is worse: the two
file DTOs are documented as differing only in timestamp shape, and it would have
left `content: ""` in the response for a client to misread.

**Frontend.** `BinaryNodeView` refetched only when the node id changed, so a
re-publish that overwrites a payload in place — keeping the id, changing the
digest — left the operator viewing and downloading stale bytes. The staleness
rule is now `blobCacheKey()` in `api/workspace.ts`, keyed on `sha256`, and the
effect depends on that. A named function rather than entries in a dependency
array because `vitest.config.ts` confines unit tests to pure functions, and an
array is the kind of thing a later edit shortens without noticing.

## API Or Behavior Changes

- **Breaking for one previously-nonsensical case:** `Company.workspaceFile(id)`
  on a **binary** node now returns a GraphQL error naming the blob route,
  instead of a `WorkspaceFile` with `content: ""`. This matches what the REST
  twin `GET …/workspace/file/{id}` has always done (400). A client that was
  reading `content` for a payload was reading an empty string, never the bytes.
- **Additive:** `FsNode` (GraphQL) gains `mime: String`, `size: Float`,
  `sha256: String`, all null unless the node is binary. `schema.graphql` is
  regenerated accordingly.
- No REST changes. No changes to the workspace port or any store.

## Tests

Commands run locally, all from the repo root:

- `cargo fmt --all -- --check` — exit 0
- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman,tinycortex` — exit 0, **3131 passed, 0 failed**, 3 ignored
- `frontend`: `pnpm typecheck` — exit 0; `pnpm build` — exit 0;
  `pnpm vitest run test/unit/workspace-binary.test.ts` — 12 passed

Each new assertion was proven to fail with its fix reverted, and every
revert-check was re-run **after** the rebase onto current `main`:

| Reverted | Observed |
| --- | --- |
| the `resolve_file` refusal | 1 ran, **1 failed** — `a payload must not resolve as a note: {"name":"hero.png","content":""}` |
| `FsNodeGql`'s `mime`/`size`/`sha256` | 2 ran, **2 failed** — `Unknown field "mime"/"size"/"sha256" on type "FsNode"` |
| `blobCacheKey` → `return node.id` | 12 ran, **1 failed** — `expected 'n-img' not to be 'n-img'` |

Second commit strengthens one of the new tests:
`a_prose_note_projects_no_binary_metadata` was named for a prose note but only
asserted against the `maya` agent **folder**. A folder can never carry a payload,
so its nulls are structural and prove nothing about the rule the console depends
on — `mime`'s presence is what routes a node to the download path, and a note is
a `File` exactly like the binary beside it. It now creates a real text node and
asserts all three stay null for it, plus `kind: "file"` so the case cannot
quietly degrade into a second folder assertion.

Pre-existing and unrelated: a full `pnpm vitest run` has 45 failures across
`tour-resume`, `desktop-bridge` and `connection-registry`, all
`window.localStorage.clear is not a function`. This branch touches none of those
files and no vitest config or setup.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run as the gated lane: `--locked --no-deps --features openhuman,tinycortex --all-targets`)
- [x] `cargo build --all-targets` (N/A as spelled — covered by `cargo check --locked --all-features --all-targets`, the stricter lane, since `CompanyRecord` is built from a row in `mongodb.rs`/`sqlite.rs` and is invisible to the default and gated lanes)
- [x] `cargo test` (run as `cargo test --features openhuman,tinycortex`)

## Documentation

Rustdoc on the changed surfaces carries the reasoning: `FsNodeGql`'s three new
fields explain why they are nullable and why `size` is `Float`, and
`resolve_file` documents why a binary node is refused here rather than given a
`mime` field of its own. `blobCacheKey` documents why `sha256` and not `size` or
`updatedAtMillis`. `src/server/graphql/schema.graphql` is regenerated, and being
committed is itself the read-contract documentation for this surface.

No file in `docs/` describes the GraphQL workspace field set, so nothing there
went stale; the REST/GraphQL parity this restores is the behaviour
`docs/spec/runtime/api.md` already describes.
