### PR TITLE
feat(delivery,harness): standing-admin owner delivery + per-agent tool grants (#661 M8+L5)

### DIFF
--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -283,6 +283,11 @@ fn company_builder(
     .with_default_mcp_servers(state.config().default_mcp_servers.clone())
     .with_host_base_url(state.config().host_base_url())
     .with_workspace_quota(state.config().workspace_quota)
+    // Issue #661 / M8: the deployment's standing bootstrap admin, normalized,
+    // so a fresh tenant's `owner` report reaches its creator before that first
+    // sign-in mints a user record. `None` (self-hosted, no injected address) is
+    // a no-op. BootRebuilder reuses this builder, so the grant survives rebuild.
+    .with_bootstrap_admin(state.config().bootstrap_admin())
     .with_skills_registry(state.shared_skill_registry()?)
     .with_id(company_id.clone());
     if let Some(source_dir) = source_dir {

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -4597,6 +4597,7 @@ members = ["engineer"]
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         tasks
             .upsert(&CompanyId::new("acme"), &card("t1", "nova"))
@@ -4925,6 +4926,7 @@ members = ["eng1", "eng2"]
                 name: "Cto".to_string(),
                 role: "CTO".to_string(),
                 description: None,
+                tools: Vec::new(),
             }],
             overlay_desk_members: vec![crate::ports::types::OverlayDeskMember {
                 desk_id: "eng".to_string(),

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1867,6 +1867,13 @@ fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
         agent.name.hash(&mut hasher);
         agent.role.hash(&mut hasher);
         agent.description.hash(&mut hasher);
+        // Issue #661 / L5: a grant edit changes the roster the harness must
+        // build, so it has to move this fingerprint — otherwise a re-grant would
+        // persist and be silently ignored until the next process restart, the
+        // same staleness the tier/skill fingerprints exist to prevent. Hashed in
+        // order (an operator's own list), length folded in first via the slice
+        // length above so `["a","b"]` cannot collide with `["ab"]`.
+        agent.tools.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -2146,7 +2153,12 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         role: overlay.role.clone(),
         description: overlay.description.clone(),
         tier: None,
-        tools: Vec::new(),
+        // Issue #661 / L5: carry the overlay's own per-teammate grant. An empty
+        // list here is unchanged behaviour — `agent_effective_grants` reads it as
+        // the standard company-wide grant, exactly as the hardcoded empty did.
+        // A non-empty list is intersected with `[tools].allow` by that same
+        // function below (narrow-only, never a widen).
+        tools: overlay.tools.clone(),
         budget_usd_daily: None,
     }
 }
@@ -2239,6 +2251,89 @@ mod tests {
         let split = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec!["a", "b"]))));
         let joined = policy_fingerprint(Some(&fp_entry(Some("auto"), Some(vec!["ab"]))));
         assert_ne!(split, joined);
+    }
+
+    /// Issue #661 / L5: an overlay teammate's own `tools` grant flows into the
+    /// manifest shape `build_agent` consumes, and is INTERSECTED with the company
+    /// allow-list — narrow-only, never a widen. An empty grant is the standard
+    /// company-wide grant, exactly as the pre-L5 hardcoded empty was.
+    #[test]
+    fn overlay_agent_to_manifest_carries_the_tool_grant() {
+        let allow = vec!["docs.*".to_string(), "web".to_string()];
+
+        // A scoped overlay teammate: the grant is carried, then narrowed to what
+        // the company already allows. `payment.send` is NOT in `allow`, so the
+        // overlay cannot escalate to it — the security invariant.
+        let scoped = OverlayAgent {
+            id: "scoped".into(),
+            name: "Scoped".into(),
+            role: "Researcher".into(),
+            description: None,
+            tools: vec!["docs.*".into(), "payment.send".into()],
+        };
+        let manifest = overlay_agent_to_manifest(&scoped);
+        assert_eq!(
+            manifest.tools,
+            vec!["docs.*".to_string(), "payment.send".to_string()],
+            "the overlay's own grant must reach the manifest shape"
+        );
+        assert_eq!(
+            agent_effective_grants(&allow, &manifest.tools),
+            vec!["docs.*".to_string()],
+            "narrow-only: the un-allowed `payment.send` is intersected out"
+        );
+
+        // An empty overlay grant is the standard company-wide grant, unchanged.
+        let standard = OverlayAgent {
+            id: "std".into(),
+            name: "Std".into(),
+            role: "Generalist".into(),
+            description: None,
+            tools: Vec::new(),
+        };
+        let manifest = overlay_agent_to_manifest(&standard);
+        assert!(manifest.tools.is_empty());
+        assert_eq!(
+            agent_effective_grants(&allow, &manifest.tools),
+            allow,
+            "an empty grant falls back to the full company allow-list"
+        );
+    }
+
+    /// Issue #661 / L5: a grant edit changes the roster the harness must build, so
+    /// it has to move the overlay fingerprint — otherwise a re-grant would
+    /// persist, render as applied, and be silently ignored until the process
+    /// restarted, the same staleness the tier/skill fingerprints guard against.
+    #[test]
+    fn overlay_fingerprint_moves_on_a_tools_only_edit() {
+        let one = |tools: Vec<String>| {
+            vec![OverlayAgent {
+                id: "a".into(),
+                name: "A".into(),
+                role: "r".into(),
+                description: None,
+                tools,
+            }]
+        };
+        let standard = one(Vec::new());
+        let scoped = one(vec!["docs.*".into()]);
+        let scoped_more = one(vec!["docs.*".into(), "email".into()]);
+
+        assert_ne!(
+            overlay_fingerprint(&standard),
+            overlay_fingerprint(&scoped),
+            "adding a grant must move the fingerprint or the re-grant is ignored until restart"
+        );
+        assert_ne!(
+            overlay_fingerprint(&scoped),
+            overlay_fingerprint(&scoped_more),
+            "widening the grant list must move it too"
+        );
+        // Identical grants → identical fingerprint (no spurious rebuild).
+        assert_eq!(
+            overlay_fingerprint(&scoped),
+            overlay_fingerprint(&one(vec!["docs.*".into()]))
+        );
     }
 
     /// Attribution is deliberately NOT hashed.
@@ -2585,6 +2680,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: Some("Owns acquisition experiments.".into()),
+            tools: Vec::new(),
         });
 
         let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
@@ -2608,6 +2704,7 @@ description = "Builds the product."
             name: "Impostor".into(),
             role: "Shadow CEO".into(),
             description: None,
+            tools: Vec::new(),
         });
 
         let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
@@ -2731,6 +2828,7 @@ description = "Builds the product."
             name: "Dana".into(),
             role: "Designer".into(),
             description: None,
+            tools: Vec::new(),
         });
         pool.ensure(&rec, &fx.deps).await.expect("second ensure");
 
@@ -3765,6 +3863,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: None,
+            tools: Vec::new(),
         });
         live_store.save(&updated).await.unwrap();
 
@@ -4595,6 +4694,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: None,
+            tools: Vec::new(),
         });
         let live_store = Arc::new(LiveStore::default());
         live_store.save(&rec).await.unwrap();

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1769,7 +1769,7 @@ impl Tool for AddAgentTool {
     }
 
     fn description(&self) -> &str {
-        "Add a new teammate to the company. Provide a `name`, a `role` (job title), and an optional `description` of their mandate. The teammate becomes a real, addressable member of the roster starting next turn."
+        "Add a new teammate to the company. Provide a `name`, a `role` (job title), an optional `description` of their mandate, and an optional `tools` grant. The teammate becomes a real, addressable member of the roster starting next turn."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1778,7 +1778,12 @@ impl Tool for AddAgentTool {
             "properties": {
                 "name": { "type": "string", "description": "The new teammate's display name." },
                 "role": { "type": "string", "description": "The new teammate's job title." },
-                "description": { "type": "string", "description": "An optional description of the teammate's mandate." }
+                "description": { "type": "string", "description": "An optional description of the teammate's mandate." },
+                "tools": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional per-teammate tool grant, as a list of tool-namespace globs (e.g. \"docs.*\", \"email\"). These are INTERSECTED with the company's allowed tools: the grant can only NARROW this teammate below the company-wide allow-list, never widen or escalate it past what the company already permits. Omit or leave empty to give the standard company-wide grant."
+                }
             },
             "required": ["name", "role"],
             "additionalProperties": false
@@ -1810,6 +1815,30 @@ impl Tool for AddAgentTool {
             .map(str::trim)
             .filter(|d| !d.is_empty())
             .map(str::to_string);
+        // Issue #661 / L5: an optional per-teammate tool grant. The globs are
+        // INTERSECTED with the company's `[tools].allow` at roster-build time
+        // (`agent_effective_grants`), so this can only narrow the new teammate
+        // below the company grant — never widen or escalate it. Omitted, `null`,
+        // or empty means the standard company-wide grant, exactly like a manifest
+        // agent with no `tools` line. A non-string item is a clean argument
+        // error, the same shape as a missing `name`/`role`.
+        let tools = match args.get("tools") {
+            None | Some(Value::Null) => Vec::new(),
+            Some(Value::Array(items)) => {
+                let mut globs = Vec::with_capacity(items.len());
+                for item in items {
+                    let glob = item
+                        .as_str()
+                        .ok_or_else(|| anyhow::anyhow!("`tools` must be an array of strings"))?
+                        .trim();
+                    if !glob.is_empty() {
+                        globs.push(glob.to_string());
+                    }
+                }
+                globs
+            }
+            Some(_) => return Err(anyhow::anyhow!("`tools` must be an array of strings")),
+        };
 
         // Serialize per-company writes so the orchestrator's add_agent and the
         // console `POST .../team` route can never clobber each other's
@@ -1853,6 +1882,7 @@ impl Tool for AddAgentTool {
             name: name.clone(),
             role: role.clone(),
             description,
+            tools,
         };
         record.overlay_agents.push(agent);
         self.store.save(&record).await?;
@@ -4722,6 +4752,7 @@ name = "Morning"
             name: "Fact Fetcher".to_string(),
             role: "Researcher".to_string(),
             description: None,
+            tools: Vec::new(),
         });
         let store: Arc<dyn CompanyStore> = Arc::new(MemStore::seeded(record));
 
@@ -4860,6 +4891,87 @@ name = "Morning"
             Some("Owns acquisition experiments.")
         );
         assert!(!added.id.is_empty(), "a stable id must be minted");
+        // No `tools` given → the standard company-wide grant (empty list).
+        assert!(
+            added.tools.is_empty(),
+            "an add with no `tools` is the standard grant, not an empty shelf"
+        );
+    }
+
+    /// Issue #661 / L5: `add_agent` carries a per-teammate tool grant onto the
+    /// overlay record, trimming and dropping blank globs. The grant is narrowed
+    /// against `[tools].allow` later (at roster build); persistence keeps the
+    /// authored list verbatim so the Team tab and the roster read the same thing.
+    #[tokio::test]
+    async fn add_agent_tool_persists_a_tool_grant() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({
+                "name": "Ravi",
+                "role": "Researcher",
+                "tools": ["docs.*", "   ", "email"]
+            }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert_eq!(
+            record.overlay_agents[0].tools,
+            vec!["docs.*".to_string(), "email".to_string()],
+            "blanks are dropped and globs trimmed"
+        );
+    }
+
+    /// An empty `tools` array is the standard grant, not "no tools" — the same
+    /// as omitting the field entirely.
+    #[tokio::test]
+    async fn add_agent_tool_empty_tools_is_the_standard_grant() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({ "name": "Ravi", "role": "Researcher", "tools": [] }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "{}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert!(record.overlay_agents[0].tools.is_empty());
+    }
+
+    /// A non-string `tools` item is a clean argument error, the same shape as a
+    /// missing `name`/`role` — a malformed grant must not persist a half-parsed
+    /// teammate.
+    #[tokio::test]
+    async fn add_agent_tool_rejects_a_non_string_tool() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = AddAgentTool::new(company.clone(), store.clone());
+
+        assert!(
+            tool.execute(json!({ "name": "Ravi", "role": "Researcher", "tools": [123] }))
+                .await
+                .is_err(),
+            "a non-string tool glob must be rejected"
+        );
+        // Also rejects a non-array `tools`.
+        assert!(
+            tool.execute(json!({ "name": "Ravi", "role": "Researcher", "tools": "docs.*" }))
+                .await
+                .is_err(),
+            "a non-array `tools` must be rejected"
+        );
+
+        let record = store.load(&company).await.unwrap().expect("record");
+        assert!(
+            record.overlay_agents.is_empty(),
+            "a rejected add must not persist a teammate"
+        );
     }
 
     /// Issue #686 — the tool mints the same readable, name-derived id the

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -421,6 +421,7 @@ async fn an_overlay_teammate_added_at_runtime_writes_on_its_first_turn() {
         name: "Analyst".to_string(),
         role: "Analyst".to_string(),
         description: Some("Reads the numbers.".to_string()),
+        tools: Vec::new(),
     };
 
     let (script, workspace) = run_write_turn(dir.path(), OVERLAY_AGENT, vec![overlay]).await;

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -126,6 +126,7 @@ mod tests {
             name: "Creative studio (renamed)".into(),
             role: "Creative".into(),
             description: None,
+            tools: Vec::new(),
         }];
         let map = roster_display_names(&agents, &overlay);
         assert_eq!(map.get("strategy").unwrap(), "Strategy desk");

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2176,6 +2176,19 @@ pub struct OverlayAgent {
     /// An optional description of the teammate's mandate.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// The per-teammate tool grant: a manifest `[[agent]].tools`-style glob list,
+    /// **intersected** with the company's `[tools].allow` at roster-build time
+    /// (issue #661 / L5). An **empty** list is the standard company-wide grant
+    /// (every allowed tool), exactly as an omitted manifest `tools` line is —
+    /// never "no tools". The intersection is narrow-only: this can restrict a
+    /// teammate below the company grant, never widen it past it.
+    ///
+    /// `#[serde(default)]` keeps every overlay record written before this field
+    /// existed deserializing unchanged (as an empty list → standard grant), and
+    /// `skip_serializing_if` keeps the common empty case out of the persisted
+    /// JSON so a standard-grant teammate serializes exactly as it did before.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
 }
 
 /// An operator-added desk membership that the version-controlled manifest does
@@ -4210,10 +4223,43 @@ mod test {
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert!(record.is_roster_agent("ceo"));
         assert!(record.is_roster_agent("nova"));
         assert!(!record.is_roster_agent("ghost"));
+    }
+
+    /// Issue #661 / L5 serde: the new per-teammate `tools` grant is optional and
+    /// empty-by-default on the wire, so an overlay record written before the
+    /// field existed deserializes unchanged, and a standard-grant teammate
+    /// serializes exactly as it did before (no `tools` key).
+    #[test]
+    fn overlay_agent_tools_defaults_empty_and_skips_when_empty() {
+        // An old record with no `tools` key deserializes to an empty grant.
+        let legacy: OverlayAgent =
+            serde_json::from_str(r#"{"id":"a","name":"A","role":"r"}"#).expect("legacy overlay");
+        assert!(legacy.tools.is_empty());
+
+        // An empty grant is omitted from the serialized form — a standard-grant
+        // teammate is byte-for-byte what it was before this field existed.
+        let value = serde_json::to_value(&legacy).unwrap();
+        assert!(
+            value.get("tools").is_none(),
+            "an empty grant must not serialize a `tools` key: {value}"
+        );
+
+        // A non-empty grant round-trips in order.
+        let scoped = OverlayAgent {
+            id: "s".into(),
+            name: "S".into(),
+            role: "r".into(),
+            description: None,
+            tools: vec!["docs.*".into(), "email".into()],
+        };
+        let round: OverlayAgent =
+            serde_json::from_str(&serde_json::to_string(&scoped).unwrap()).unwrap();
+        assert_eq!(round.tools, vec!["docs.*".to_string(), "email".to_string()]);
     }
 
     /// A record with one manifest agent and no desks, for the minting tests.
@@ -4231,6 +4277,7 @@ mod test {
             name: name.into(),
             role: "Worker".into(),
             description: None,
+            tools: Vec::new(),
         });
     }
 
@@ -4668,6 +4715,7 @@ mod test {
             name: "Shane".to_string(),
             role: "Growth".to_string(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(record.effective_budget("shane"), None);
 

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -150,7 +150,10 @@ pub enum DeliveryStatus {
 pub enum DeliveryReason {
     /// This build wired no delivery ports at all, so nothing could be sent.
     NotWired,
-    /// An `owner` report reached the company's admin mailbox.
+    /// An `owner` report reached one of the company's admin mailboxes — an
+    /// active admin from the user store, or a standing admin invite (a manifest
+    /// `[users] admins` entry or the deployment's bootstrap admin) not yet signed
+    /// in (issue #661 / M8).
     OwnerEmailed,
     /// An `email` report reached the named recipient on an established thread.
     RecipientEmailed,
@@ -160,8 +163,10 @@ pub enum DeliveryReason {
     /// `owner` had no mailbox to send from, so the report went to the operator
     /// channel instead.
     OwnerFellBackNoMailbox,
-    /// `owner` had a mailbox but no active admin with an address, so the report
-    /// went to the operator channel instead.
+    /// `owner` had a mailbox but no admin address to send to — no active admin
+    /// in the user store and no standing admin invite (manifest `[users] admins`
+    /// or the deployment's bootstrap admin) either (issue #661 / M8) — so the
+    /// report went to the operator channel instead.
     OwnerFellBackNoAdminAddress,
     /// `owner`'s operator-channel fallback itself failed, so nothing was sent.
     OwnerFallbackFailed,

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -280,6 +280,7 @@ members = []
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "nova"),
@@ -313,6 +314,7 @@ members = []
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         record.overlay_desk_members.push(OverlayDeskMember {
             desk_id: "empty".into(),
@@ -416,6 +418,7 @@ members = ["ceo"]
             name: "Shane".into(),
             role: "Support".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "Shane"),
@@ -440,6 +443,7 @@ members = ["ceo"]
             name: "engineer".into(),
             role: "Support".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "engineer"),
@@ -460,6 +464,7 @@ members = ["ceo"]
                 name: "Shane".into(),
                 role: "Support".into(),
                 description: None,
+                tools: Vec::new(),
             });
         }
         let resolution = resolve(&record, "Shane");

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -281,6 +281,13 @@ pub struct RuntimeBuilder {
     secrets: Option<Arc<dyn SecretStore>>,
     inbox: Option<Arc<dyn InboxStore>>,
     mail: Option<CompanyMail>,
+    /// The deployment's standing bootstrap-admin address
+    /// (`AppConfig::bootstrap_admin`), pre-normalized, when the platform injects
+    /// one (issue #661 / M8). Threaded onto the workflow delivery bundle so an
+    /// `owner` report on a fresh tenant reaches the company's creator before
+    /// their first sign-in mints a user record. `None` everywhere but the hosted
+    /// serve path.
+    bootstrap_admin: Option<String>,
     tasks: Option<Arc<dyn TaskStore>>,
     workspace: Option<Arc<dyn WorkspaceStore>>,
     /// Issue #553: the byte limits the workspace is held to. Defaults to a
@@ -379,6 +386,7 @@ impl RuntimeBuilder {
             secrets: None,
             inbox: None,
             mail: None,
+            bootstrap_admin: None,
             tasks: None,
             workspace: None,
             workspace_quota: crate::runtime::WorkspaceQuota::default(),
@@ -798,6 +806,15 @@ impl RuntimeBuilder {
     /// (email send is opt-in / hosted-only).
     pub fn with_mail(mut self, mail: CompanyMail) -> Self {
         self.mail = Some(mail);
+        self
+    }
+
+    /// Wires the deployment's standing bootstrap-admin address (issue #661 / M8),
+    /// pre-normalized by `AppConfig::bootstrap_admin`. Absent by default: only
+    /// the hosted serve path injects one, and `None` is a clean no-op that leaves
+    /// `owner` delivery resolving admins from the user store alone.
+    pub fn with_bootstrap_admin(mut self, bootstrap_admin: Option<String>) -> Self {
+        self.bootstrap_admin = bootstrap_admin;
         self
     }
 
@@ -1800,6 +1817,12 @@ impl RuntimeBuilder {
                                     mail: self.mail.clone(),
                                     inbox: inbox.clone(),
                                     users: ops.users.clone(),
+                                    // Issue #661 / M8: the deployment's standing
+                                    // bootstrap admin, so an `owner` report on a
+                                    // fresh tenant reaches the company's creator
+                                    // before their first sign-in mints a user
+                                    // record. `None` off the hosted serve path.
+                                    bootstrap_admin: self.bootstrap_admin.clone(),
                                     channels: channels.clone(),
                                     // Issue #227: the same gate and journal the
                                     // runtime gets below — one approvals queue,

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -246,6 +246,7 @@ async fn team_reports_the_effective_cap_and_its_attribution() {
         name: "Jamie".to_string(),
         role: "Growth".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     let admin = Actor {
         kind: ActorKind::User,
@@ -329,12 +330,14 @@ async fn team_keeps_zero_explicit_null_and_manifest_only_caps_distinct() {
         name: "Zeroed".to_string(),
         role: "Growth".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     record.overlay_agents.push(OverlayAgent {
         id: "uncapped".to_string(),
         name: "Uncapped".to_string(),
         role: "Ops".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     let admin = Actor {
         kind: ActorKind::User,

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -175,6 +175,13 @@ struct AddMember {
     /// member exactly as before, so adding the field takes no permission away.
     #[serde(default)]
     budget_usd_daily: Option<f64>,
+    /// An optional per-teammate tool grant (issue #661 / L5): tool-namespace
+    /// globs INTERSECTED with the company's `[tools].allow` at roster-build time
+    /// — narrow-only, never a widen. Omitted or empty gives the standard
+    /// company-wide grant, so adding the field takes no permission away: it can
+    /// only restrict the new teammate below what the company already allows.
+    #[serde(default)]
+    tools: Vec<String>,
 }
 
 /// The set-budget body.
@@ -413,6 +420,14 @@ async fn add_member(
     let write_lock = company_write_lock(company.id());
     let _lock = write_lock.lock().await;
 
+    // Issue #661 / L5: trim + drop blank globs, mirroring the orchestrator
+    // `add_agent` parse. Empty stays empty → the standard company-wide grant.
+    let tools: Vec<String> = body
+        .tools
+        .into_iter()
+        .map(|glob| glob.trim().to_string())
+        .filter(|glob| !glob.is_empty())
+        .collect();
     let mut record = load_record(&company).await?;
     let agent = OverlayAgent {
         // A readable id derived from the name, unique against the roster this
@@ -425,6 +440,9 @@ async fn add_member(
         name: body.name,
         role: body.role,
         description: body.description,
+        // Issue #661 / L5: the teammate's own grant, intersected with the
+        // company allow-list by the shared reads/roster build. Empty = standard.
+        tools,
     };
     record.overlay_agents.push(agent.clone());
     let attribution = author.map(|admin| BudgetOverride {

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -177,12 +177,15 @@ pub(super) struct AgentDeskDto {
 
 /// The tool globs an agent *asks* for, resolved identically for every reader.
 ///
-/// A manifest teammate's `[[agent]].tools` line; an **empty** list for an
-/// overlay teammate, which mirrors `harness::overlay_agent_to_manifest` — and
-/// which means "the company's standard grant", not "no tools".
+/// A manifest teammate's `[[agent]].tools` line, or — for an overlay teammate —
+/// its own [`OverlayAgent::tools`](crate::ports::types::OverlayAgent::tools)
+/// grant (issue #661 / L5), which mirrors `harness::overlay_agent_to_manifest`.
+/// An **empty** list from either source means "the company's standard grant",
+/// not "no tools", so the Team tab shows the teammate's real effective grant
+/// rather than the full company allow-list for every overlay member.
 ///
 /// Its callers have already established that `agent_id` is on the roster, so a
-/// miss here can only be the overlay half.
+/// miss in the manifest half can only be the overlay half.
 pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<String> {
     record
         .manifest
@@ -190,6 +193,13 @@ pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<St
         .iter()
         .find(|agent| agent.id == agent_id)
         .map(|agent| agent.tools.clone())
+        .or_else(|| {
+            record
+                .overlay_agents
+                .iter()
+                .find(|agent| agent.id == agent_id)
+                .map(|agent| agent.tools.clone())
+        })
         .unwrap_or_default()
 }
 
@@ -562,6 +572,63 @@ members = ["writer", "ceo"]
             .prefix("oc-agent-detail-")
             .tempdir()
             .expect("tempdir")
+    }
+
+    /// Issue #661 / L5: `requested_grants` reads a manifest agent's `tools` line,
+    /// falls back to an overlay teammate's own grant, and reads an empty grant
+    /// (from either source, and for an unknown id) as the standard company-wide
+    /// grant — so the Team tab shows an overlay teammate's real grant instead of
+    /// the full company allow-list.
+    #[test]
+    fn requested_grants_reads_overlay_then_manifest_then_empty() {
+        use crate::ports::types::OverlayAgent;
+
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n\
+             [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\ntools = [\"workspace.read\"]\n",
+        )
+        .unwrap();
+        let mut record = CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents: Vec::new(),
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        };
+        record.overlay_agents.push(OverlayAgent {
+            id: "scoped".to_string(),
+            name: "Scoped".to_string(),
+            role: "Researcher".to_string(),
+            description: None,
+            tools: vec!["docs.*".to_string()],
+        });
+        record.overlay_agents.push(OverlayAgent {
+            id: "standard".to_string(),
+            name: "Standard".to_string(),
+            role: "Generalist".to_string(),
+            description: None,
+            tools: Vec::new(),
+        });
+
+        // A manifest agent's own line.
+        assert_eq!(
+            super::requested_grants(&record, "ceo"),
+            vec!["workspace.read"]
+        );
+        // An overlay teammate's own grant (the L5 read side).
+        assert_eq!(super::requested_grants(&record, "scoped"), vec!["docs.*"]);
+        // An overlay teammate with no grant → empty (the standard grant).
+        assert!(super::requested_grants(&record, "standard").is_empty());
+        // An unknown id → empty, as before.
+        assert!(super::requested_grants(&record, "nobody").is_empty());
     }
 
     async fn state_with_manifest(home: &std::path::Path, manifest_toml: &str) -> AppState {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2792,6 +2792,7 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
         name: "Helper".to_string(),
         role: "Assistant".to_string(),
         description: None,
+        tools: Vec::new(),
     };
     let state = state_with_manifest_and_overlays(&home, manifest, vec![overlay]).await;
 

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1329,6 +1329,7 @@ mod test {
             name: "Dana Designer".into(),
             role: "Design".into(),
             description: Some("Owns the brand".into()),
+            tools: Vec::new(),
         }];
         // That teammate added to the `eng` desk through the membership overlay.
         let desk_members = vec![OverlayDeskMember {

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -143,7 +143,8 @@ use crate::ports::types::{
 };
 use crate::ports::{
     ApprovalGate, ChannelAdapter, DeliveryReason, DeliveryReport, DeliveryStatus, EmailRecord,
-    EventLog, InboxStore, UserRole, UserStatus, UserStore, generate_id, now_millis,
+    EventLog, InboxStore, UserRole, UserStatus, UserStore, generate_id, normalize_email,
+    now_millis,
 };
 use crate::runtime::cycle::EMAIL_SEND_KIND;
 use crate::runtime::journal::{ApprovalConversation, RuntimeJournal};
@@ -183,6 +184,22 @@ pub struct WorkflowDeliveryDeps {
     /// The company's user directory: how an `owner` destination resolves to
     /// actual addresses, server-side.
     pub users: Arc<dyn UserStore>,
+    /// The deployment's standing bootstrap-admin address
+    /// ([`AppConfig::bootstrap_admin`](crate::app::AppConfig::bootstrap_admin)),
+    /// pre-normalized, when the platform injected one (issue #661 / M8).
+    ///
+    /// A platform-provisioned company has nobody in its manifest and nobody in
+    /// the [`UserStore`](Self::users) until the creator first signs in, so on a
+    /// fresh tenant an `owner` report used to find no admin address and fall
+    /// back to the operator channel — the one human who could act on it never
+    /// heard about it. This is the same standing invite the login path honours
+    /// (`server::users::bootstrap_admins`), threaded here so `owner` reaches it
+    /// before that first sign-in. `None` — the only value every non-production
+    /// construction site sets — is a clean no-op.
+    ///
+    /// The `Debug` impl prints its presence only, never the address, the same
+    /// stance the mail handle takes.
+    pub bootstrap_admin: Option<String>,
     /// Every wired channel adapter, including the always-present `operator`.
     pub channels: Vec<Arc<dyn ChannelAdapter>>,
     /// What a cold `email` recipient is parked on (issue #227). `None` fails
@@ -232,6 +249,9 @@ impl std::fmt::Debug for WorkflowDeliveryDeps {
         // whose derived `Debug` prints the password (see `mailer::test`).
         f.debug_struct("WorkflowDeliveryDeps")
             .field("mail", &self.mail.is_some())
+            // Presence only: a bootstrap-admin address is a real person's email
+            // and must never reach a log line, exactly like the mail handle.
+            .field("bootstrap_admin", &self.bootstrap_admin.is_some())
             .field("parking", &self.parking.is_some())
             .field(
                 "channels",
@@ -537,7 +557,13 @@ async fn deliver_one(
     match destination.kind.trim() {
         // --- owner: resolved server-side; the graph names nobody -------------
         "owner" => {
-            let admins = admin_emails(delivery.users.as_ref(), &record.id).await;
+            let admins = owner_recipients(
+                delivery.users.as_ref(),
+                &record.id,
+                record,
+                delivery.bootstrap_admin.as_deref(),
+            )
+            .await;
             match (&delivery.mail, admins.is_empty()) {
                 (Some(mail), false) => {
                     for address in admins {
@@ -573,7 +599,7 @@ async fn deliver_one(
                         )
                     } else {
                         (
-                            "no active admin has an email address",
+                            "no active admin or standing admin invite has an email address",
                             DeliveryReason::OwnerFellBackNoAdminAddress,
                         )
                     };
@@ -972,24 +998,106 @@ impl DeliveryParking {
     }
 }
 
-/// The active admins' email addresses, in store order. An unreadable user store
-/// yields none (which routes `owner` to the operator-channel fallback) rather
-/// than failing the run.
-async fn admin_emails(users: &dyn UserStore, company: &CompanyId) -> Vec<String> {
+/// The addresses an `owner` report is emailed to: the company's active admins,
+/// unioned with its **standing admin invites** — the manifest's `[users]
+/// admins` and the deployment's [`bootstrap_admin`](WorkflowDeliveryDeps::bootstrap_admin)
+/// (issue #661 / M8) — that have not yet signed in.
+///
+/// # Why the union, and why the "no user record" restriction
+///
+/// A platform-provisioned company names nobody in its manifest and has nobody
+/// in the [`UserStore`] until the creator redeems their first login link. The
+/// pre-M8 resolver read only the store, so on a fresh tenant an owner report
+/// found no admin address and fell back to the operator channel — the one human
+/// who could act on it never got it. The standing invites are exactly the
+/// addresses the login path (`server::users::eligibility` /
+/// [`bootstrap_admins`](crate::server::users)) already treats as admins-in-waiting,
+/// so `owner` mails them for the same reason they can log in.
+///
+/// A **user record wins** over a standing invite for the same address, mirroring
+/// `eligibility`: a standing invite is only mailed when the address holds *no*
+/// record at all. Two consequences fall out of that one rule —
+///
+/// * a bootstrap admin who has since signed in **and been suspended** is not
+///   mailed (their record wins, and a suspended admin is not an active one), and
+/// * an address named both as an active admin and as a standing invite is
+///   mailed **once** (the active-admin arm sends it; the standing copy is
+///   dropped as "already has a record").
+///
+/// # Store-error stance: still mail the standing invites
+///
+/// An unreadable user store yields the standing invites **anyway**, not an empty
+/// list. The store failing is precisely when dropping the only humans the
+/// company is known to have is worst — that silent drop back to the operator
+/// channel is the M8 bug. The read failure is logged; the standing invites,
+/// which come from the manifest and the injected config and need no store read,
+/// are still mailed. An empty result (no admins, no standing invites) routes
+/// `owner` to the operator-channel fallback exactly as before.
+async fn owner_recipients(
+    users: &dyn UserStore,
+    company: &CompanyId,
+    record: &CompanyRecord,
+    bootstrap_admin: Option<&str>,
+) -> Vec<String> {
+    // The standing admin invites: the manifest's `[users] admins` plus the
+    // platform-injected bootstrap admin, normalized the same way the login path
+    // normalizes them so `Grace@ACME.test` and `grace@acme.test` are one
+    // address here and there. `bootstrap_admin` arrives already normalized (the
+    // `AppConfig` accessor did it), but normalizing again is idempotent and
+    // keeps this function honest against a caller that passes a raw value.
+    let mut standing: Vec<String> = record
+        .manifest
+        .users
+        .admins
+        .iter()
+        .map(|a| normalize_email(a))
+        .collect();
+    if let Some(email) = bootstrap_admin {
+        let email = normalize_email(email);
+        if !email.is_empty() && !standing.contains(&email) {
+            standing.push(email);
+        }
+    }
+
     match users.list_users(company).await {
-        Ok(list) => list
-            .into_iter()
-            .filter(|u| u.role == UserRole::Admin && u.status == UserStatus::Active)
-            .map(|u| u.email)
-            .filter(|email| email.contains('@'))
-            .collect(),
+        Ok(list) => {
+            // Every address that holds a record, whatever its role or status.
+            // These win: a standing invite for such an address is dropped, so a
+            // suspended admin is not resurrected through a leftover invite and a
+            // double-listed address is mailed once.
+            let has_record: std::collections::HashSet<String> =
+                list.iter().map(|u| normalize_email(&u.email)).collect();
+            // The send-eligible records: active admins with a real mailbox.
+            let mut recipients: Vec<String> = list
+                .iter()
+                .filter(|u| u.role == UserRole::Admin && u.status == UserStatus::Active)
+                .map(|u| u.email.clone())
+                .filter(|email| email.contains('@'))
+                .collect();
+            // Standing invites with no record yet, and a real mailbox.
+            for email in standing {
+                if !has_record.contains(&email)
+                    && email.contains('@')
+                    && !recipients.contains(&email)
+                {
+                    recipients.push(email);
+                }
+            }
+            recipients
+        }
         Err(err) => {
             tracing::warn!(
                 company = %company,
                 error = %err,
-                "workflow delivery: could not read the user directory; falling back to the operator channel"
+                "workflow delivery: could not read the user directory; emailing the standing admin \
+                 invites only (dropping them would silence the owner report entirely)"
             );
-            Vec::new()
+            // Still mail the standing invites — they are the only humans the
+            // company is known to have, and this drop is the M8 bug.
+            standing
+                .into_iter()
+                .filter(|email| email.contains('@'))
+                .collect()
         }
     }
 }
@@ -1372,6 +1480,7 @@ allow = [{allow}]
                     }),
                     inbox: inbox.clone(),
                     users: users.clone(),
+                    bootstrap_admin: None,
                     channels,
                     parking: None,
                 },
@@ -1384,6 +1493,37 @@ allow = [{allow}]
                 journal: None,
                 events,
             }
+        }
+
+        /// Sets the deployment's standing bootstrap-admin address (M8), the same
+        /// value the production builder threads from `AppConfig::bootstrap_admin`.
+        fn with_bootstrap_admin(mut self, email: &str) -> Self {
+            self.deps.bootstrap_admin = Some(email.to_string());
+            self
+        }
+
+        /// Sets the company record's manifest so a test can name `[users] admins`
+        /// standing invites. Rebuilt from TOML rather than mutated field-by-field
+        /// so the parse mirrors a real manifest load.
+        fn manifest_with_admins(admins: &[&str]) -> crate::company::CompanyManifest {
+            let list = admins
+                .iter()
+                .map(|a| format!("\"{a}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            toml::from_str(&format!(
+                r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[users]
+admins = [{list}]
+"#
+            ))
+            .expect("valid manifest with [users] admins")
         }
 
         /// Wires the approvals queue the production builder wires: a real
@@ -1540,6 +1680,64 @@ allow = [{allow}]
             _company: &CompanyId,
         ) -> futures::stream::BoxStream<'static, crate::ports::types::StoredEvent> {
             Box::pin(futures::stream::empty())
+        }
+    }
+
+    /// A [`UserStore`] whose `list_users` always errors — the M8 store-error
+    /// path. Every other method is unreachable for these tests (the `owner`
+    /// resolver reads only `list_users`) and panics if a future caller leans on
+    /// it, rather than quietly returning an empty result that would hide a bug.
+    struct FailingUserStore;
+
+    #[async_trait]
+    impl UserStore for FailingUserStore {
+        async fn list_users(&self, _company: &CompanyId) -> crate::Result<Vec<UserRecord>> {
+            Err(OpenCompanyError::Config(
+                "user directory is unreadable".into(),
+            ))
+        }
+        async fn get_user(
+            &self,
+            _company: &CompanyId,
+            _id: &str,
+        ) -> crate::Result<Option<UserRecord>> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn find_user_by_email(
+            &self,
+            _company: &CompanyId,
+            _email: &str,
+        ) -> crate::Result<Option<UserRecord>> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn upsert_user(&self, _company: &CompanyId, _user: &UserRecord) -> crate::Result<()> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn delete_user(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn list_invites(
+            &self,
+            _company: &CompanyId,
+        ) -> crate::Result<Vec<crate::ports::InviteRecord>> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn find_invite_by_email(
+            &self,
+            _company: &CompanyId,
+            _email: &str,
+        ) -> crate::Result<Option<crate::ports::InviteRecord>> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn upsert_invite(
+            &self,
+            _company: &CompanyId,
+            _invite: &crate::ports::InviteRecord,
+        ) -> crate::Result<()> {
+            unreachable!("owner delivery reads only list_users")
+        }
+        async fn delete_invite(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+            unreachable!("owner delivery reads only list_users")
         }
     }
 
@@ -1700,6 +1898,215 @@ allow = [{allow}]
         assert_eq!(reports.len(), 1, "{reports:?}");
         assert_eq!(reports[0].status, DeliveryStatus::Failed);
         assert!(reports[0].detail.contains("operator"), "{reports:?}");
+    }
+
+    // --- owner: standing admin invites (issue #661 / M8) ---------------------
+
+    /// **The M8 headline.** A fresh platform-provisioned tenant has nobody in
+    /// its manifest and nobody in the user store yet, but the platform injected
+    /// a bootstrap admin. An `owner` report must reach that address — not fall
+    /// back to the operator channel, which is the one human who could act on it
+    /// never hearing about it.
+    #[tokio::test]
+    async fn owner_emails_the_standing_bootstrap_admin_on_a_fresh_tenant() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_bootstrap_admin("founder@acme.test");
+        // No admins in the store, no `[users] admins` in the manifest.
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(reports[0].reason, DeliveryReason::OwnerEmailed);
+        assert_eq!(reports[0].target.as_deref(), Some("founder@acme.test"));
+        assert_eq!(h.mail.sent().len(), 1);
+        assert_eq!(h.mail.sent()[0].1.to, "founder@acme.test");
+        // The operator channel must be untouched — the whole bug is that the
+        // report fell back to it.
+        assert!(
+            h.channel.sent().is_empty(),
+            "the standing admin was mailed, so nothing goes to the operator channel"
+        );
+        // The send is mirrored into the inbox as outbound, and journaled.
+        let outbound: Vec<_> = h
+            .inbox_messages()
+            .await
+            .into_iter()
+            .filter(|m| m.outbound)
+            .collect();
+        assert_eq!(outbound.len(), 1, "the send must leave an audit record");
+        let journaled = h.journaled_deliveries().await;
+        assert_eq!(journaled.len(), 1, "{journaled:?}");
+    }
+
+    /// A manifest `[users] admins` entry is a standing invite too, and is mailed
+    /// the same way — even before that person has ever signed in.
+    #[tokio::test]
+    async fn owner_emails_a_manifest_admin_standing_invite() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        let mut rec = record(&[]);
+        rec.manifest = Harness::manifest_with_admins(&["grace@acme.test"]);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &rec,
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(reports[0].reason, DeliveryReason::OwnerEmailed);
+        assert_eq!(h.mail.sent().len(), 1);
+        assert_eq!(h.mail.sent()[0].1.to, "grace@acme.test");
+    }
+
+    /// **User-record-wins.** A bootstrap admin who has since signed in and been
+    /// *suspended* is not mailed through the leftover standing invite: their
+    /// record wins, and a suspended admin is not an active one. `owner` then has
+    /// nowhere to send and falls back to the operator channel with the M8
+    /// wording.
+    #[tokio::test]
+    async fn owner_does_not_email_a_suspended_bootstrap_admin() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_bootstrap_admin("founder@acme.test");
+        // The bootstrap admin signed in, then was suspended: a record exists.
+        h.users
+            .upsert_user(
+                &h.company,
+                &UserRecord {
+                    id: "founder".to_string(),
+                    email: "founder@acme.test".to_string(),
+                    display_name: None,
+                    role: UserRole::Admin,
+                    status: UserStatus::Suspended,
+                    password_hash: None,
+                    must_change_password: false,
+                    created_at_millis: 1,
+                    last_seen_at_millis: None,
+                    updated_at_millis: 1,
+                },
+            )
+            .await
+            .unwrap();
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(
+            reports[0].reason,
+            DeliveryReason::OwnerFellBackNoAdminAddress
+        );
+        assert!(
+            reports[0].detail.contains("standing admin invite"),
+            "the fallback wording must name standing invites now: {reports:?}"
+        );
+        assert!(
+            h.mail.sent().is_empty(),
+            "a suspended admin must not be mailed, invite or not"
+        );
+        assert_eq!(h.channel.sent().len(), 1, "the report went to the operator");
+    }
+
+    /// **Dedupe.** An address named both as an active admin and as the bootstrap
+    /// admin is one person, and is mailed exactly once.
+    #[tokio::test]
+    async fn owner_dedupes_an_active_admin_that_is_also_the_bootstrap_admin() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true).with_bootstrap_admin("ada@acme.test");
+        h.add_admin("u1", "ada@acme.test").await;
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "one recipient, one row: {reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(h.mail.sent().len(), 1, "mailed once, not twice");
+        assert_eq!(h.mail.sent()[0].1.to, "ada@acme.test");
+    }
+
+    /// A manifest admin address is normalized the same way the login path
+    /// normalizes it, so `Grace@ACME.test` and `grace@acme.test` are one address
+    /// — the send goes to the normalized form.
+    #[tokio::test]
+    async fn owner_normalizes_a_manifest_admin_address() {
+        let dir = tempfile::tempdir().unwrap();
+        let h = Harness::new(dir.path(), true, true);
+        let mut rec = record(&[]);
+        rec.manifest = Harness::manifest_with_admins(&["Grace@ACME.test"]);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &rec,
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(h.mail.sent()[0].1.to, "grace@acme.test");
+    }
+
+    /// **Store-error stance (the M8 bug's worst case).** When the user store
+    /// cannot be read, the standing invites are mailed anyway — dropping the only
+    /// humans the company is known to have back to the operator channel is
+    /// exactly the silent drop M8 fixes.
+    #[tokio::test]
+    async fn owner_still_emails_standing_invites_when_the_user_store_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut h = Harness::new(dir.path(), true, true).with_bootstrap_admin("founder@acme.test");
+        h.deps.users = Arc::new(FailingUserStore);
+
+        let reports = deliver_outputs(
+            Some(&h.deps),
+            &record(&[]),
+            &graph("owner", None),
+            "run-1",
+            &reached_output(),
+            &[],
+        )
+        .await;
+
+        assert_eq!(reports.len(), 1, "{reports:?}");
+        assert_eq!(
+            reports[0].status,
+            DeliveryStatus::Sent,
+            "an unreadable store must still mail the standing invite: {reports:?}"
+        );
+        assert_eq!(reports[0].reason, DeliveryReason::OwnerEmailed);
+        assert_eq!(h.mail.sent().len(), 1);
+        assert_eq!(h.mail.sent()[0].1.to, "founder@acme.test");
     }
 
     // --- email ---------------------------------------------------------------

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -227,6 +227,7 @@ pub(super) fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc
             mail: None,
             inbox: Arc::new(FsInboxStore::new(dir)),
             users: Arc::new(FsOps::new(dir)),
+            bootstrap_admin: None,
             channels: Vec::new(),
             parking: Some(DeliveryParking {
                 approvals: gate,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1351,6 +1351,7 @@ to = "done"
             mail: None,
             inbox: Arc::new(crate::store::FsInboxStore::new(dir.path())),
             users: Arc::new(FsOps::new(dir.path())),
+            bootstrap_admin: None,
             channels: vec![Arc::new(channel.clone())],
             // This case delivers to a channel, which never parks.
             parking: None,
@@ -2371,6 +2372,7 @@ to = "done"
             mail: None,
             inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
             users: Arc::new(crate::store::FsOps::new(dir)),
+            bootstrap_admin: None,
             channels: Vec::new(),
             parking: Some(super::super::delivery::DeliveryParking {
                 approvals: gate,
@@ -2663,6 +2665,7 @@ to = "gate"
             }),
             inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
             users,
+            bootstrap_admin: None,
             channels: Vec::new(),
             parking: Some(super::super::delivery::DeliveryParking {
                 approvals: Arc::new(crate::policy::ManifestApprovalGate::new(policy)),
@@ -2786,6 +2789,7 @@ to = "gate"
             mail: None,
             inbox: Arc::new(crate::store::FsInboxStore::new(dir)),
             users: Arc::new(FsOps::new(dir)),
+            bootstrap_admin: None,
             channels: vec![Arc::new(channel)],
             parking: None,
             events,
@@ -3873,6 +3877,7 @@ to = "done"
             mail: None,
             inbox: Arc::new(crate::store::FsInboxStore::new(dir.path())),
             users: Arc::new(FsOps::new(dir.path())),
+            bootstrap_admin: None,
             channels: vec![Arc::new(channel.clone())],
             parking: None,
             events: events.clone(),
@@ -3932,6 +3937,7 @@ to = "done"
             mail: None,
             inbox: Arc::new(crate::store::FsInboxStore::new(dir.path())),
             users: Arc::new(FsOps::new(dir.path())),
+            bootstrap_admin: None,
             channels: vec![Arc::new(channel.clone())],
             parking: None,
             events: events.clone(),


### PR DESCRIPTION
## Summary

**Part of #661 — M8 + L5** (two independent fixes to delivery + roster fidelity; not a full close of #661).

**M8 — owner delivery reaches the standing admin invite on a fresh tenant.**
An `owner` workflow report used to resolve recipients from the `UserStore` alone. A platform-provisioned company names nobody in its manifest and has nobody in the store until the creator first signs in, so on a fresh tenant the report found no admin address and fell back to the operator channel — the one human who could act on it never heard about it. Owner recipients are now the active `UserStore` admins **unioned** with the company's standing admin invites (manifest `[users].admins` + the deployment's `OPENCOMPANY_ADMIN_EMAIL` bootstrap admin), restricted to addresses with no user record so a **user record always wins** (a suspended admin is not mailed via a leftover invite; an address in both is mailed once). A pre-normalized `bootstrap_admin` is threaded onto `WorkflowDeliveryDeps` (Debug prints presence only, never the address) via `RuntimeBuilder::with_bootstrap_admin`, wired in `company_builder`; `BootRebuilder` reuses that builder so the grant survives an in-place rebuild.

**L5 — `add_agent` can carry per-agent tool grants.**
`AddAgentTool` took only name/role/description and `overlay_agent_to_manifest` hardcoded `tools: Vec::new()`, so every operator/orchestrator-added teammate received the **full** company `[tools].allow`. `OverlayAgent` gains an optional `tools` glob list (serde `default` + skip-if-empty, so old records deserialize unchanged and a standard-grant teammate serializes exactly as before). `AddAgentTool` and the console `POST …/team` route accept an optional `tools` array; the grant flows through `overlay_agent_to_manifest`, is hashed in `overlay_fingerprint` (so a grant edit rebuilds the roster), and the Team-tab read side (`requested_grants`) reflects the real per-agent grant.

**Security invariant (add_agent narrows-only):** the per-agent grant is **intersected** with the company `[tools].allow` at roster build (`agent_effective_grants`), so it can only NARROW a teammate below the company grant — never widen or escalate. `tier` stays out of scope (add_agent must not mint orchestrators); the #686 write-lock/mint path is untouched. Empty/omitted `tools` = the standard company-wide grant.

**Deliberate widening (M8 store-error):** when the user store cannot be read, the standing invites are mailed *anyway* rather than dropped — dropping the only humans the company is known to have back to the operator channel is exactly the silent-drop bug M8 fixes.

## API Or Behavior Changes

- `owner` workflow reports now email standing admin invites (manifest `[users].admins` + `OPENCOMPANY_ADMIN_EMAIL`) that have not yet signed in — previously they fell back to the operator channel on a fresh tenant.
- `OverlayAgent` gains an optional `tools` field; `AddAgentTool` and `POST {scope}/team` accept an optional `tools` array (intersected with `[tools].allow`, narrow-only). Backward-compatible on the wire: absent/empty is the standard grant and old overlay records deserialize unchanged.
- `DeliveryReason::OwnerFellBackNoAdminAddress` / `OwnerEmailed` serde tokens are unchanged (doc-comment updates only). No frontend change.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (and `--features openhuman,tinycortex`)
- [x] `cargo check --locked --all-targets` (and `--all-features --all-targets`, and `--features openhuman,tinycortex --all-targets`)
- [x] `cargo test --locked` (and `cargo test --locked --features openhuman,tinycortex --tests` — 3141 lib + integration targets, 0 failed)

New tests: fresh-tenant bootstrap-admin emailed (operator channel untouched, outbound mirrored, `WorkflowReportDelivered` journaled); manifest `[users].admins` invite emailed; suspended bootstrap admin **not** emailed (fallback fires, new wording); dedupe (active admin == bootstrap admin → one mail); manifest normalization (`Grace@ACME.test`); store-error still mails invites. L5: grants persist + trim/drop-blanks + reject non-string, empty = standard grant, `overlay_agent_to_manifest` carries + intersects (narrow-only), `overlay_fingerprint` moves on a tools-only edit, `requested_grants` overlay/manifest/empty, serde default + skip-if-empty.

## Documentation

Doc-comments updated in-code (`WorkflowDeliveryDeps`, `owner_recipients`, `DeliveryReason` variants, `OverlayAgent.tools`, `requested_grants`, `AddAgentTool` schema). No spec/module doc changes needed — behavior is described where it lives.
