### PR TITLE
approvals: tell the operator when a workflow run discarded gated calls

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -341,6 +341,19 @@ export interface WorkflowRunOutcome {
    * and absent must read as "not cancelled".
    */
   cancelled?: boolean;
+  /**
+   * System notices raised about this run (issue #638) — today, that a node
+   * gated more tool calls than the per-batch cap allows and the excess was
+   * discarded.
+   *
+   * NOT a failure. A run that overflowed the cap still succeeded: its nodes
+   * ran and its output is valid. Render it as a warning beside the outcome,
+   * never as an error, or a run that worked reads as one that broke.
+   *
+   * Omitted on the wire for the overwhelming majority of runs, which raise
+   * nothing — so absent must read as "nothing to tell you", not "unknown".
+   */
+  notices?: string[];
 }
 
 export function listWorkflows(

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -144,6 +144,12 @@ export type CompanyStreamEvent =
        * just pressed Cancel that the run finished fine.
        */
       cancelled?: boolean;
+      /**
+       * System notices raised about the run (issue #638), e.g. that gated tool
+       * calls past the per-batch cap were discarded. Absent on the vast
+       * majority of runs. Not a failure — see `WorkflowRunOutcome.notices`.
+       */
+      notices?: string[];
     }
   // Issue #371/#382: the live per-node progress trail. A run announces itself,
   // then brackets each non-trigger node with a *started* frame as it begins and

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -308,11 +308,18 @@ function RunHistoryRow({
 
           Deliberately not a destructive Alert: nothing failed. It is the same
           tone as the cancelled line — something happened that you need to know,
-          not something that went wrong. */}
+          not something that went wrong.
+
+          Coloured with `--status-blocked-text` rather than a palette amber:
+          that token is the console's "needs your attention, nothing is broken"
+          state, it is the one a gated call already reads as elsewhere, and it
+          themes for both schemes on its own — which the `dark:` pair it
+          replaced had to restate by hand. `text-2xs` is the same 11px rung the
+          sibling lines above use, by name. */}
       {(run.notices ?? []).map((notice, i) => (
         <p
           key={i}
-          className="text-[11px] text-amber-600 dark:text-amber-500"
+          className="text-2xs text-[var(--status-blocked-text)]"
           data-testid="workflow-run-notice"
         >
           {notice}

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -300,6 +300,24 @@ function RunHistoryRow({
           Finished — this run routed no reports.
         </p>
       )}
+      {/* Issue #638. Rendered ALONGSIDE the outcome above rather than as one
+          more branch of it, because a notice is not a terminal state — a run
+          can succeed, be stopped, or fail and still have discarded gated calls
+          the operator needs to know about. Folding it into the chain would have
+          made it invisible for every outcome except the one branch it sat in.
+
+          Deliberately not a destructive Alert: nothing failed. It is the same
+          tone as the cancelled line — something happened that you need to know,
+          not something that went wrong. */}
+      {(run.notices ?? []).map((notice, i) => (
+        <p
+          key={i}
+          className="text-[11px] text-amber-600 dark:text-amber-500"
+          data-testid="workflow-run-notice"
+        >
+          {notice}
+        </p>
+      ))}
     </div>
   );
 }

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -629,6 +629,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         };
 
         let wired = wire_event(7, &event);
@@ -667,6 +668,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: true,
+            notices: Vec::new(),
         };
 
         let wired = wire_event(7, &event);

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -3214,6 +3214,7 @@ mod tests {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         });
 
         assert!(!summary.contains(RECIPIENT), "{summary}");
@@ -3240,6 +3241,7 @@ mod tests {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: true,
+            notices: Vec::new(),
         });
 
         assert!(summary.contains("stopped"), "{summary}");
@@ -4672,6 +4674,7 @@ name = "Morning"
                 deliveries: Vec::new(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             })
         }
     }
@@ -4769,6 +4772,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         });
         let calls = runner_impl.calls.clone();
         let runner: Arc<dyn WorkflowRunner> = Arc::new(runner_impl);
@@ -4812,6 +4816,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -4910,6 +4915,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: true,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -4944,6 +4950,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -5144,6 +5151,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -5209,6 +5217,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -5284,6 +5293,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -5382,6 +5392,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -5997,6 +6008,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         };
         let md = summarize_run(&file, &run, "run-xyz", RunOutputStored::Stored);
         assert!(md.contains("last of 3 items — third"), "{md}");
@@ -6010,6 +6022,7 @@ name = "Morning"
             deliveries: Vec::new(),
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
         };
         let md = summarize_run(&file, &run_one, "run-1", RunOutputStored::Stored);
         assert!(md.contains("1 item(s) — only"), "{md}");
@@ -6045,6 +6058,7 @@ name = "Morning"
                 deliveries: Vec::new(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -6072,6 +6086,7 @@ name = "Morning"
                 deliveries: Vec::new(),
                 cancelled: true,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cancel_cache.clone(),
@@ -6106,6 +6121,7 @@ name = "Morning"
                 deliveries: Vec::new(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -6166,6 +6182,7 @@ name = "Morning"
                 deliveries: Vec::new(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -332,17 +332,29 @@ impl DrainedRequests {
     /// and that assertion is #561's real guarantee — the cap quoted is the one
     /// the drain was taken against, never a constant the call site had lying
     /// around. Rewording around it beat loosening it.
+    ///
+    /// # Agreement
+    ///
+    /// Every countable word in the sentence branches on `n`, verbs and pronouns
+    /// included — a single discard reads "1 further gated tool call was not
+    /// raised … It was not run". Only the nouns branched at first, so the one
+    /// case an operator is most likely to hit read as "1 … call **were** not
+    /// raised". The sentence exists to be believed; ungrammatical is a reason
+    /// not to believe it.
     pub fn overflow_notice(&self) -> Option<String> {
         (self.discarded > 0).then(|| {
             let n = self.discarded;
             let cap = self.cap;
             let calls = if n == 1 { "call" } else { "calls" };
             let them = if n == 1 { "it" } else { "them" };
+            let were = if n == 1 { "was" } else { "were" };
+            let they = if n == 1 { "It" } else { "They" };
+            let they_are = if n == 1 { "it is" } else { "they are" };
             format!(
-                "Heads up: {n} further gated tool {calls} were not raised for approval. One \
+                "Heads up: {n} further gated tool {calls} {were} not raised for approval. One \
                  batch can raise at most {cap}, and {n} more needed your sign-off than that. \
-                 They were **not** run and they are **not** on the Approvals page — ask the \
-                 agent again to get {them} back."
+                 {they} {were} **not** run and {they_are} **not** on the Approvals page — ask \
+                 the agent again to get {them} back."
             )
         })
     }
@@ -2289,12 +2301,40 @@ mod tests {
     }
 
     /// One dropped request reads as one, not as "1 calls".
+    ///
+    /// The nouns agreed from the start; the verbs and pronouns did not, so a
+    /// single discard read "1 further gated tool call **were** not raised …
+    /// **They were** not run and **they are** not on the Approvals page". The
+    /// whole sentence has to agree, not the countable nouns in it — an operator
+    /// reading a confidently-worded, ungrammatical notice has cause to wonder
+    /// what else about it is stale.
     #[test]
     fn the_overflow_notice_is_singular_for_a_single_dropped_request() {
         let drained = DrainedRequests::new(Vec::new(), 1, 8);
         let notice = drained.overflow_notice().expect("one is still an overflow");
         assert!(notice.contains("1 further gated tool call "), "{notice}");
         assert!(!notice.contains("calls"), "{notice}");
+        assert!(notice.contains("call was not raised"), "{notice}");
+        assert!(notice.contains("It was **not** run"), "{notice}");
+        assert!(notice.contains("it is **not** on the"), "{notice}");
+        assert!(!notice.contains("were"), "{notice}");
+        assert!(!notice.contains("they"), "{notice}");
+        assert!(!notice.contains("They"), "{notice}");
+    }
+
+    /// …and the plural is untouched: the agreement fix must not singularise the
+    /// case that was already right.
+    #[test]
+    fn the_overflow_notice_stays_plural_for_several_dropped_requests() {
+        let drained = DrainedRequests::new(Vec::new(), 3, 8);
+        let notice = drained.overflow_notice().expect("three is an overflow");
+        assert!(
+            notice.contains("3 further gated tool calls were not"),
+            "{notice}"
+        );
+        assert!(notice.contains("They were **not** run"), "{notice}");
+        assert!(notice.contains("they are **not** on the"), "{notice}");
+        assert!(!notice.contains(" was "), "{notice}");
     }
 
     /// The notice names the cap the drain was actually taken against, not one a

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -980,6 +980,24 @@ pub enum CompanyEvent {
         /// non-cancelled run's line byte-identical to what it was.
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         cancelled: bool,
+        /// System notices raised about this run (issue #638) — today, that a
+        /// node's turn gated more tool calls than the per-batch cap allows and
+        /// the excess was discarded.
+        ///
+        /// The run-side counterpart of the operator bubble the chat path pushes
+        /// (#561). A run has no conversation to speak on, so without this the
+        /// operator sees the first `cap` cards on the Approvals page and no
+        /// indication that any more were gated.
+        ///
+        /// Separate from [`error`](Self::WorkflowRunFinished::error) on purpose:
+        /// a run that overflowed the cap **succeeded**, and putting this there
+        /// would mark it failed and inflate the failure count.
+        ///
+        /// `#[serde(default)]` + `skip_serializing_if` so a pre-#638 line
+        /// replays and an ordinary run's event serializes byte-for-byte as it
+        /// did before — which is every run that did not overflow.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        notices: Vec<String>,
     },
     /// A workflow run began (issue #371) — the opening bracket of a run's
     /// per-node progress trail.
@@ -4535,6 +4553,7 @@ mod test {
             pending_approvals: vec!["review".to_string()],
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -4551,6 +4570,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: Some("agent node `worker` had no inference source".to_string()),
             cancelled: false,
+            notices: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -4579,6 +4599,7 @@ mod test {
                 pending_approvals: Vec::new(),
                 error: None,
                 cancelled: false,
+                notices: Vec::new(),
             }
         );
         // …and serializing it back emits nothing extra.
@@ -4610,6 +4631,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: true,
+            notices: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
 
@@ -4722,6 +4744,7 @@ mod test {
                 pending_approvals: vec!["review".to_string()],
                 error: None,
                 cancelled: false,
+                notices: Vec::new(),
             }
         );
     }

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -71,6 +71,30 @@ pub struct WorkflowRun {
     /// written before this field existed still loads, as an empty list.
     #[serde(default)]
     pub nodes: Vec<WorkflowRunNodeRow>,
+    /// System notices raised *about* this run that the operator needs and that
+    /// no other field can carry (issue #638).
+    ///
+    /// Today there is exactly one producer: a node whose turn gated more tool
+    /// calls than [`MAX_APPROVAL_REQUESTS_PER_TURN`](crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN)
+    /// allows, whose excess is discarded. The chat path says that out loud as
+    /// its own bubble (#561); a run has no conversation to speak on, so before
+    /// this the only trace was a `tracing::warn!` — and a log line is not the
+    /// operator learning anything.
+    ///
+    /// **Deliberately not `error`.** A run that overflowed the cap did not
+    /// fail: its nodes ran, its output is valid, and marking it failed would
+    /// inflate the failure count and hide a real failure among them. Same
+    /// reasoning [`cancelled`](Self::cancelled) is a flag rather than an error
+    /// string.
+    ///
+    /// **And not a `DeliveryReport` row**, which is per-`output`-node and per
+    /// delivery attempt: a run with no `output` node produces no rows at all,
+    /// and this notice is about the run, not about a delivery.
+    ///
+    /// `#[serde(default)]` so a payload written before this field existed still
+    /// loads, as empty — and empty is the overwhelmingly common case.
+    #[serde(default)]
+    pub notices: Vec<String>,
 }
 
 /// One node's structural outcome inside a run (issue #542).

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -88,19 +88,30 @@ pub async fn record_run_finished(
     // by an operator — the stop signal resolves *into* an `Ok(cancelled)`, never
     // into an `Err` — so the error arm is unambiguously a failure or the boot
     // sweep's synthetic one.
-    let (deliveries, pending_approvals, error, cancelled): (
+    // Issue #638: `notices` rides the Ok arm for the same reason `cancelled`
+    // does — a run that never returned produced no notices, and an `Err` is
+    // already fully described by `error`.
+    let (deliveries, pending_approvals, error, cancelled, notices): (
         Vec<DeliveryReport>,
         Vec<String>,
         Option<String>,
         bool,
+        Vec<String>,
     ) = match outcome {
         Ok(run) => (
             run.deliveries.clone(),
             run.pending_approvals.clone(),
             None,
             run.cancelled,
+            run.notices.clone(),
         ),
-        Err(err) => (Vec::new(), Vec::new(), Some(err.to_string()), false),
+        Err(err) => (
+            Vec::new(),
+            Vec::new(),
+            Some(err.to_string()),
+            false,
+            Vec::new(),
+        ),
     };
 
     let event = CompanyEvent::WorkflowRunFinished {
@@ -114,6 +125,7 @@ pub async fn record_run_finished(
         pending_approvals,
         error,
         cancelled,
+        notices,
     };
 
     if let Err(err) = events.append(company, event).await {
@@ -369,6 +381,62 @@ mod test {
             deliveries,
             cancelled: false,
             nodes: Vec::new(),
+            notices: Vec::new(),
+        }
+    }
+
+    /// Issue #638: a run's notices survive onto the journaled outcome, which is
+    /// the row the console's history panel reads.
+    ///
+    /// The point of the assertion is the **round trip**, not the assignment: the
+    /// event is written to a real JSONL log and read back, so a field that
+    /// serialized but did not deserialize — or one `skip_serializing_if` dropped
+    /// on the way out — fails here rather than in front of an operator.
+    #[tokio::test]
+    async fn a_runs_notices_reach_the_journaled_outcome() {
+        let (_dir, events) = log();
+        let company = CompanyId::new("acme");
+        let notice = "Heads up: 3 further gated tool calls were not raised for approval.";
+        let run = WorkflowRun {
+            notices: vec![notice.to_string()],
+            ..run_with(Vec::new(), Vec::new())
+        };
+
+        record_run_finished(&events, &company, "wf", false, "run-1", Ok(&run)).await;
+
+        let journaled = journaled(&events, &company).await;
+        let CompanyEvent::WorkflowRunFinished { notices, error, .. } = journaled
+            .iter()
+            .find(|e| matches!(e, CompanyEvent::WorkflowRunFinished { .. }))
+            .expect("the outcome was journaled")
+        else {
+            unreachable!("matched above")
+        };
+        assert_eq!(notices, &vec![notice.to_string()]);
+        assert!(
+            error.is_none(),
+            "a run that raised a notice did not fail — putting this in `error` \
+             would inflate the failure count and hide a real failure among them",
+        );
+    }
+
+    /// The other direction, and the one that keeps the field honest: a run with
+    /// nothing to say carries an empty list, and a *failed* run carries none at
+    /// all rather than inheriting whatever the Ok arm would have had.
+    #[tokio::test]
+    async fn an_ordinary_run_and_a_failed_run_carry_no_notices() {
+        let (_dir, events) = log();
+        let company = CompanyId::new("acme");
+
+        let ok = run_with(Vec::new(), Vec::new());
+        record_run_finished(&events, &company, "wf", false, "run-ok", Ok(&ok)).await;
+        record_run_finished(&events, &company, "wf", false, "run-bad", Err("boom")).await;
+
+        for event in journaled(&events, &company).await {
+            let CompanyEvent::WorkflowRunFinished { notices, .. } = event else {
+                continue;
+            };
+            assert!(notices.is_empty(), "nothing to say means an empty list");
         }
     }
 
@@ -678,6 +746,7 @@ mod test {
                     pending_approvals: Vec::new(),
                     error: None,
                     cancelled: false,
+                    notices: Vec::new(),
                 },
             )
             .await

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1137,6 +1137,7 @@ mod decide_tests {
                 deliveries: Vec::new(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             })
         }
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1152,6 +1152,7 @@ mod test {
                             deliveries: Vec::new(),
                             cancelled: true,
                             nodes: Vec::new(),
+                            notices: Vec::new(),
                         });
                     }
                 }
@@ -1163,6 +1164,7 @@ mod test {
                 deliveries: self.deliveries.clone(),
                 cancelled: false,
                 nodes: Vec::new(),
+                notices: Vec::new(),
             })
         }
     }
@@ -2008,6 +2010,7 @@ to = "done"
                 pending_approvals,
                 error,
                 cancelled,
+                notices: _,
             } = event
             else {
                 unreachable!("filtered above")

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -905,6 +905,7 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             pending_approvals,
             error,
             cancelled,
+            notices,
         } => {
             let mut o = envelope("workflow_run_finished");
             o["workflowId"] = json!(workflow_id);
@@ -925,6 +926,13 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             // operator who just pressed Cancel would get "ran successfully".
             if *cancelled {
                 o["cancelled"] = json!(true);
+            }
+            // Issue #638: same presence-check discipline again. Omitted on the
+            // overwhelming majority of runs, which raise nothing — so a console
+            // that checks for the key gets "was there anything to tell me?"
+            // without having to compare against an empty list.
+            if !notices.is_empty() {
+                o["notices"] = json!(notices);
             }
             o
         }
@@ -4945,6 +4953,7 @@ mod test {
             pending_approvals: vec!["review".into()],
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["type"], "workflow_run_finished");
@@ -4987,6 +4996,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: Some("no inference source for agent node `worker`".into()),
             cancelled: false,
+            notices: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["error"], "no inference source for agent node `worker`");
@@ -5098,6 +5108,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         }))
         .expect("projected");
         assert_eq!(with_id["runId"], "run-9");
@@ -5110,6 +5121,7 @@ mod test {
             pending_approvals: Vec::new(),
             error: None,
             cancelled: false,
+            notices: Vec::new(),
         }))
         .expect("projected");
         assert!(legacy.get("runId").is_none(), "{legacy}");

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1584,6 +1584,16 @@ struct WorkflowRunOutcome {
     /// when false, like `running`.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     cancelled: bool,
+    /// System notices raised about this run (issue #638) — today, that a node
+    /// gated more tool calls than the per-batch cap allows and the excess was
+    /// discarded.
+    ///
+    /// Not an `error`: the run succeeded. The history panel renders these as a
+    /// warning rather than a failure, so a run that overflowed still reads as
+    /// the success it was, with something the operator needs to know attached.
+    /// Omitted when empty, like `nodes` — which is nearly every run.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    notices: Vec<String>,
 }
 
 /// One node's outcome inside a run (issue #371).
@@ -1702,6 +1712,7 @@ async fn list_runs(
                     // whose signal has already been fired, because it has not
                     // wound down yet.
                     cancelled: false,
+                    notices: Vec::new(),
                 });
             }
             CompanyEvent::WorkflowNodeFinished {
@@ -1733,6 +1744,7 @@ async fn list_runs(
                 pending_approvals,
                 error,
                 cancelled,
+                notices,
             } => {
                 if !matches(&workflow_id) {
                     continue;
@@ -1750,6 +1762,7 @@ async fn list_runs(
                     entry.error = error;
                     entry.running = false;
                     entry.cancelled = cancelled;
+                    entry.notices = notices;
                     continue;
                 }
                 // …else stand alone. Two ways to get here, both legitimate: a
@@ -1770,6 +1783,7 @@ async fn list_runs(
                     started_at_millis: None,
                     running: false,
                     cancelled,
+                    notices,
                 });
             }
             _ => {}
@@ -2864,6 +2878,7 @@ mod tests {
                         pending_approvals: Vec::new(),
                         error: error.map(str::to_string),
                         cancelled: false,
+                        notices: Vec::new(),
                     },
                 )
                 .await
@@ -3097,6 +3112,7 @@ mod tests {
                         pending_approvals: Vec::new(),
                         error: error.map(str::to_string),
                         cancelled: false,
+                        notices: Vec::new(),
                     },
                 )
                 .await
@@ -4231,6 +4247,7 @@ mod tests {
                             deliveries: Vec::new(),
                             cancelled: true,
                             nodes: Vec::new(),
+                            notices: Vec::new(),
                         });
                     }
                 }
@@ -4241,6 +4258,7 @@ mod tests {
                     deliveries: Vec::new(),
                     cancelled: false,
                     nodes: Vec::new(),
+                    notices: Vec::new(),
                 })
             }
         }
@@ -4867,6 +4885,7 @@ label = "ok"
                         status: crate::ports::types::WorkflowNodeStatus::Ok,
                         elapsed_ms: 3,
                     }],
+                    notices: Vec::new(),
                 })
             }
         }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -83,6 +83,27 @@ type EffectSlots = (
     Option<Arc<dyn AgentRunner>>,
 );
 
+/// What one run needs the capability bundle to know about *itself*.
+///
+/// Bundled rather than passed as five more parameters (issue #638 added the
+/// fifth and tipped `build_capabilities` over clippy's arity limit). They
+/// genuinely travel together — every one is scoped to this run and meaningless
+/// without the others — so a struct is the honest shape rather than a way of
+/// making the lint quiet.
+pub struct RunContext<'a> {
+    /// The workflow being run.
+    pub workflow_id: &'a str,
+    /// This run's id (issue #395), the key its approvals are stamped with.
+    pub run_id: &'a str,
+    /// The operator's topic for this run (issue #154), threaded to the agent
+    /// capability so a node's turn carries what was actually asked.
+    pub run_request: Option<String>,
+    /// Issue #542: stub every effectful slot and journal nothing.
+    pub dry_run: bool,
+    /// Where an agent node leaves an operator-facing notice (issue #638).
+    pub notices: RunNotices,
+}
+
 /// Assembles the [`Capabilities`] bundle for a run of `workflow_id`.
 ///
 /// `record` carries everything the outside-world capabilities need: the company
@@ -116,11 +137,15 @@ pub async fn build_capabilities(
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
     record: &CompanyRecord,
-    workflow_id: &str,
-    run_id: &str,
-    run_request: Option<String>,
-    dry_run: bool,
+    run: RunContext<'_>,
 ) -> Capabilities {
+    let RunContext {
+        workflow_id,
+        run_id,
+        run_request,
+        dry_run,
+        notices,
+    } = run;
     let company = record.id.clone();
     let mode = PolicyMode::parse(&record.manifest.policy.mode);
     let grants = record.manifest.tools.allow.clone();
@@ -234,6 +259,7 @@ pub async fn build_capabilities(
             company.clone(),
             run_id.to_string(),
             run_request,
+            notices,
         ));
         (Arc::new(tools), Arc::new(http), state, Some(agent))
     };
@@ -329,6 +355,39 @@ pub struct HarnessAgentRunner {
     /// run, so without this the run's topic never reaches the teammate doing the
     /// work — the agent would run, find no subject, and ask for one.
     run_request: Option<String>,
+    /// Where this node leaves an operator-facing notice (issue #638).
+    notices: RunNotices,
+}
+
+/// Where an agent node leaves a notice for the operator (issue #638).
+///
+/// A shared handle rather than a return value because there is nowhere to
+/// return it to: `AgentRunner::run_agent` hands the engine a `Value` that
+/// becomes the node's output, and a system notice is emphatically not node
+/// output — it would ride into a downstream `=item` binding and into the run's
+/// persisted output snapshot. So the notice goes sideways, out to the runner
+/// that owns the run, and lands on [`WorkflowRun::notices`].
+///
+/// Cheap to clone; every clone appends to the same list, which is what lets one
+/// run's several agent nodes each contribute.
+#[derive(Clone, Default)]
+pub struct RunNotices {
+    inner: Arc<std::sync::Mutex<Vec<String>>>,
+}
+
+impl RunNotices {
+    /// Records one notice.
+    pub fn push(&self, notice: String) {
+        self.inner
+            .lock()
+            .expect("run notices poisoned")
+            .push(notice);
+    }
+
+    /// Takes everything recorded so far, leaving the collector empty.
+    pub fn take(&self) -> Vec<String> {
+        std::mem::take(&mut *self.inner.lock().expect("run notices poisoned"))
+    }
 }
 
 impl HarnessAgentRunner {
@@ -341,6 +400,7 @@ impl HarnessAgentRunner {
         company: CompanyId,
         run_id: String,
         run_request: Option<String>,
+        notices: RunNotices,
     ) -> Self {
         Self {
             pool,
@@ -348,6 +408,7 @@ impl HarnessAgentRunner {
             company,
             run_id,
             run_request,
+            notices,
         }
     }
 
@@ -436,10 +497,33 @@ impl HarnessAgentRunner {
         // count, a run that flooded the gate looks identical to one that did
         // not.
         let drained = queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN);
+        let notice = drained.overflow_notice();
         let discarded = drained.discarded;
         let requests = drained.requests;
         if requests.is_empty() {
             return;
+        }
+
+        // Issue #638: told to the operator, not only logged. Raised BEFORE the
+        // parking guard below, and that ordering is a fix in itself — the guard
+        // `return`s, so on a runtime with no approvals gate the overflow was
+        // not even reaching the log. The notice is about calls that were
+        // *discarded*, which is true whether or not the survivors could be
+        // parked; if anything it matters more when they could not.
+        if let Some(notice) = notice {
+            // `overflow_notice` rather than a sentence of our own: the wording
+            // lives on `DrainedRequests` (#561) precisely so the chat path and
+            // this one cannot tell an operator the same thing two ways.
+            self.notices.push(notice);
+        }
+        if discarded > 0 {
+            tracing::warn!(
+                company = %self.company,
+                run_id = %self.run_id,
+                discarded,
+                "workflow agent node: more gated tool calls than one run may park; the excess \
+                 was discarded"
+            );
         }
 
         let Some(parking) = self
@@ -460,24 +544,6 @@ impl HarnessAgentRunner {
             return;
         };
 
-        if discarded > 0 {
-            // Bounded exactly as the cycle drain is: a model that keeps
-            // re-trying a blocked tool must not be able to flood the queue.
-            //
-            // Issue #638: the chat path now *tells* the operator when it
-            // discards (#561, `DrainedRequests::overflow_notice`); this one
-            // still only logs. Less bad than the chat path was — the count
-            // exists somewhere — but a log line is not the operator learning
-            // anything. Fixing it needs a surface a run can speak on, which is
-            // why it is tracked separately rather than done here.
-            tracing::warn!(
-                company = %self.company,
-                run_id = %self.run_id,
-                discarded,
-                "workflow agent node: more gated tool calls than one run may park; the excess \
-                 was discarded"
-            );
-        }
         for request in requests {
             // The delivery precedent: a workflow run has no board card behind it
             // and no conversation to raise the request in, so it is recorded
@@ -655,6 +721,116 @@ impl CodeRunner for UnwiredCode {
 mod tests {
     use super::*;
 
+    /// Issue #638: a node that gates more calls than the cap allows leaves the
+    /// operator a **notice**, not only a log line.
+    ///
+    /// Asserted on `RunNotices` — the value that becomes `WorkflowRun::notices`
+    /// and then the journaled outcome the history panel reads — rather than on
+    /// a log, which is what the issue asks for and what the chat path already
+    /// had via #561.
+    #[tokio::test]
+    async fn an_overflowing_node_leaves_the_operator_a_notice() {
+        let over = MAX_APPROVAL_REQUESTS_PER_TURN + 3;
+        let (notices, queue) = overflowing_runner_notices(over, true).await;
+
+        assert_eq!(notices.len(), 1, "one notice for one overflow: {notices:?}");
+        let notice = &notices[0];
+        assert!(
+            notice.contains(&format!("at most {MAX_APPROVAL_REQUESTS_PER_TURN}")),
+            "it must quote the cap that did the discarding: {notice}"
+        );
+        assert!(notice.contains('3'), "…and how many went past it: {notice}");
+        assert_eq!(
+            queue.drain(MAX_APPROVAL_REQUESTS_PER_TURN).requests.len(),
+            0,
+            "the drain already emptied this run's scope"
+        );
+    }
+
+    /// The ordering fix that rides with it. The `parking`-is-`None` guard
+    /// `return`s, and it used to sit **above** the overflow branch — so on a
+    /// runtime with no approvals gate the discard was not even reaching the
+    /// log, let alone the operator.
+    ///
+    /// That is the worst case, not a corner: the survivors could not be parked
+    /// either, so the notice is the *only* thing the operator can be told.
+    #[tokio::test]
+    async fn the_notice_survives_a_runtime_with_no_approvals_gate() {
+        let over = MAX_APPROVAL_REQUESTS_PER_TURN + 2;
+        let (notices, _) = overflowing_runner_notices(over, false).await;
+        assert_eq!(
+            notices.len(),
+            1,
+            "no gate to park into is exactly when the operator most needs telling: {notices:?}"
+        );
+    }
+
+    /// A node that stayed under the cap says nothing — the notice must be the
+    /// exception, not a line on every run.
+    #[tokio::test]
+    async fn a_node_within_the_cap_raises_no_notice() {
+        let (notices, _) = overflowing_runner_notices(MAX_APPROVAL_REQUESTS_PER_TURN, true).await;
+        assert!(notices.is_empty(), "nothing was discarded: {notices:?}");
+    }
+
+    /// Queues `count` gated calls in a run's scope, drains them through
+    /// `park_gated_calls`, and returns whatever the run was told.
+    ///
+    /// `with_gate` selects whether a `parking` sink is wired, which is the axis
+    /// the guard-order test needs.
+    async fn overflowing_runner_notices(
+        count: usize,
+        with_gate: bool,
+    ) -> (Vec<String>, crate::harness::policy::ApprovalRequestQueue) {
+        use crate::harness::policy::{ApprovalRequest, ApprovalScope};
+        use crate::ports::types::{Effect, EffectGroup};
+
+        let dir = tempfile::Builder::new()
+            .prefix("oc-638-")
+            .tempdir()
+            .expect("tempdir");
+        let (mut deps, _journal) =
+            crate::workflows::gated_tool_turn_test::deps(String::new(), dir.path());
+        if !with_gate {
+            deps.delivery = None;
+        }
+        let queue = deps.approval_requests.clone();
+        let notices = RunNotices::default();
+        let runner = HarnessAgentRunner::new(
+            Arc::new(HarnessPool::new()),
+            deps,
+            CompanyId::new("acme"),
+            "run-1".to_string(),
+            None,
+            notices.clone(),
+        );
+
+        // Pushed inside the run's own scope, exactly as its turn would.
+        let claim = queue.claim(ApprovalScope::Run("run-1".to_string()));
+        claim
+            .scoped(async {
+                for i in 0..count {
+                    queue.push(ApprovalRequest {
+                        tool: "shell".to_string(),
+                        reason: "gated".to_string(),
+                        effect: Effect {
+                            kind: "shell".to_string(),
+                            group: EffectGroup::Other,
+                            amount_usd: None,
+                            established_thread: false,
+                            first_time_counterparty: false,
+                            payload: json!({ "n": i }),
+                            agent: Some("ceo".to_string()),
+                            run_id: None,
+                        },
+                    });
+                }
+            })
+            .await;
+        claim.scoped(runner.park_gated_calls()).await;
+        (notices.take(), queue)
+    }
+
     #[test]
     fn message_prefers_prompt_then_input_then_message() {
         assert_eq!(
@@ -804,10 +980,13 @@ mod tests {
             Arc::new(HarnessPool::new()),
             deps,
             &record,
-            "wf",
-            "run:1",
-            None,
-            false,
+            RunContext {
+                workflow_id: "wf",
+                run_id: "run:1",
+                run_request: None,
+                dry_run: false,
+                notices: RunNotices::default(),
+            },
         )
         .await;
 
@@ -843,10 +1022,13 @@ mod tests {
             Arc::new(HarnessPool::new()),
             deps,
             &record,
-            "wf",
-            "run:1",
-            None,
-            true, // dry
+            RunContext {
+                workflow_id: "wf",
+                run_id: "run:1",
+                run_request: None,
+                dry_run: true,
+                notices: RunNotices::default(),
+            },
         )
         .await;
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -260,14 +260,21 @@ async fn run_workflow_inner(
     // durable effect around the engine — the started/finished/node journal
     // writes, the delivery dispatch, and gate parking. Read once here.
     let dry_run = ctx.dry_run;
+    // Issue #638: where an agent node leaves an operator-facing notice. Owned
+    // here, by the run, because that is the only scope that outlives the nodes
+    // and reaches `WorkflowRun`.
+    let notices = super::caps::RunNotices::default();
     let capabilities = super::caps::build_capabilities(
         pool,
         deps,
         record,
-        &workflow.id,
-        &run_id,
-        run_request,
-        dry_run,
+        super::caps::RunContext {
+            workflow_id: &workflow.id,
+            run_id: &run_id,
+            run_request,
+            dry_run,
+            notices: notices.clone(),
+        },
     )
     .await;
 
@@ -533,6 +540,11 @@ async fn run_workflow_inner(
             deliveries: Vec::new(),
             cancelled: true,
             nodes,
+            // A stopped run still reports what its completed nodes had to say
+            // — a discarded-overflow notice describes calls that were already
+            // refused before the stop, and withholding it would leave the
+            // operator with fewer cards than were gated and no explanation.
+            notices: notices.take(),
         });
     }
 
@@ -549,6 +561,7 @@ async fn run_workflow_inner(
             deliveries,
             cancelled: false,
             nodes,
+            notices: notices.take(),
         });
     }
 
@@ -652,6 +665,10 @@ async fn run_workflow_inner(
         deliveries,
         cancelled: false,
         nodes,
+        // Issue #638: whatever the nodes had to tell the operator. Empty for
+        // every run that did not overflow the approval cap, which is nearly all
+        // of them.
+        notices: notices.take(),
     })
 }
 
@@ -900,6 +917,9 @@ fn cancelled_run() -> WorkflowRun {
         // (the drain runs before this returns), so "how far did it get?" is
         // answered by the history, not by this settled body.
         nodes: Vec::new(),
+        // Nothing to say: this constructor is the pre-engine stop path, so no
+        // node ran and no node raised anything.
+        notices: Vec::new(),
     }
 }
 


### PR DESCRIPTION
## Summary

A workflow node whose turn gates more tool calls than `MAX_APPROVAL_REQUESTS_PER_TURN`
allows discards the excess. Until now the only trace was a `tracing::warn!` — the
operator was never told. The chat path already says it out loud (#561,
`DrainedRequests::overflow_notice`); a run has no conversation to speak on, so this adds
the surface a run can speak on.

Closes tinyhumansai/opencompany#638

**How it works.** `RunNotices` is a cheap-to-clone shared handle owned by the run. An
agent node pushes onto it sideways rather than returning a notice, because
`AgentRunner::run_agent` hands the engine a `Value` that becomes the node's *output* — a
system notice riding that channel would land in a downstream `=item` binding and in the
run's persisted output snapshot. The run drains it onto `WorkflowRun::notices`, which is
journaled onto `WorkflowRunFinished` and rendered by `RunHistoryPanel` as an amber line
beside the outcome.

Three deliberate choices, each pinned by a test:

- **Not `error`.** A run that overflowed the cap did not fail — its nodes ran and its
  output is valid. Marking it failed would inflate the failure count and hide real
  failures among them. Same reasoning as `cancelled` being a flag.
- **Rendered alongside the outcome, not as one more branch of it.** A run can succeed, be
  stopped, *or* fail and still have discarded gated calls. Folding it into the outcome
  chain would make it invisible for every outcome but the one branch it sat in.
- **An ordering fix rides along.** The overflow branch now runs *before* the
  `parking`-is-`None` guard. That guard `return`s, so on a runtime with no approvals gate
  the discard was not reaching even the log. That is the worst case, not a corner: the
  survivors could not be parked either, so the notice is the only thing the operator can
  be told.

### Also in here: number agreement in the overflow notice

`overflow_notice` branched its *nouns* on the count but not its verbs or pronouns, so a
single discard read "1 further gated tool call **were** not raised … **They were** not
run and **they are** not on the Approvals page". This was raised on #672, which merged
with the bug still in it, so it is live on `main` today; `overflow_notice` is this PR's
surface, so it is fixed here.

Fixing only the first verb would produce "They **was** not run", so the pronouns move
with it. n=1 now reads: "…1 further gated tool call **was** not raised … **It was** not
run and **it is** not on the Approvals page." Both directions are pinned — one test that
fails if it stays plural, one that fails if the fix over-corrects the plural case.

## API Or Behavior Changes

- **`WorkflowRun` gains `notices: Vec<String>`** and `CompanyEvent::WorkflowRunFinished`
  gains the matching field. Both `#[serde(default)]`, so payloads written before the
  field existed still load — as empty, which is the overwhelmingly common case.
- **`WorkflowRunOutcome.notices?: string[]`** on the console API. Absent means "nothing
  to tell you", never "unknown". It is a warning, never an error.
- **`build_capabilities` signature**: its five per-run arguments are now bundled into a
  new `pub struct RunContext<'a>`, taking it from 8 parameters to 4. Issue #638 added the
  fifth and tipped it over clippy's arity limit; the five genuinely travel together, so a
  struct is the honest shape rather than a way of quieting the lint. Three call sites
  updated (1 production, 2 tests).
- The operator-facing overflow sentence now agrees in number for a single discard. No
  change for the plural case, which was already correct.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
      (`--no-deps` keeps pre-existing `vendor/tinyagents` lints, which CI never sees, from
      masking the result). Exit 0, zero errors.
- [x] `cargo build --all-targets` — exit 0.
- [x] `cargo test` — run as `cargo test --features openhuman,tinycortex`. Exit 0:
      **3088 passed, 0 failed, 3 ignored** in the lib target, all other targets green.

Also run: `cargo check --locked --all-features --all-targets` (exit 0). `--all-features`
matters here because `mongodb.rs` / `sqlite.rs` build `CompanyRecord` from a row rather
than a struct literal, which the default and gated lanes cannot see.

**Test count is accounted for exactly.** Lib tests at the base commit: 3085. At this
branch: 3091. A name-diff of the two `--list` outputs (not just a net count, which could
hide a rename) shows **6 added, 0 removed** — the 5 this feature adds plus 1 for the
grammar fix.

**Every new test was verified to fail with its mechanism reverted** (7 mutations; each
run exited non-zero with the rest of the set still passing, so none was a silent no-op):

| Mutation | Test that failed |
| --- | --- |
| Undo the number-agreement fix | `the_overflow_notice_is_singular_for_a_single_dropped_request` |
| Over-singularise (always "was") | `the_overflow_notice_stays_plural_for_several_dropped_requests` |
| Suppress `notices.push` | `an_overflowing_node_leaves_the_operator_a_notice` **and** `the_notice_survives_a_runtime_with_no_approvals_gate` |
| Move the notice back below the parking guard | `the_notice_survives_a_runtime_with_no_approvals_gate` (alone — the ordering fix is pinned on its own, not riding on the push) |
| Fire the notice unconditionally | `a_node_within_the_cap_raises_no_notice` |
| Ok arm drops `notices` | `a_runs_notices_reach_the_journaled_outcome` |
| Err arm carries `notices` | `an_ordinary_run_and_a_failed_run_carry_no_notices` |

### Console lane

Run in full locally, all green: `npm run typecheck`, `typecheck:e2e`, `typecheck:unit`,
`npm test` (**426 passed, 38 files**), `npm run build`, and
`./scripts/ci/assert-design-tokens.sh`.

The design-tokens gate caught a real violation in the first push of this branch, now
fixed. The notice line was written as `text-[11px] text-amber-600 dark:text-amber-500` —
an arbitrary font size *and* a raw palette colour, two of the three things that script
forbids. The gate postdates the code: it arrived on `main` while this work was in
progress, so the rebase is what brought the two together. It now reads
`text-2xs text-[var(--status-blocked-text)]` — the same named 11px rung the sibling lines
in this component already use, and the console's "needs your attention, nothing is
broken" state token, which themes for both schemes on its own rather than restating
itself in a `dark:` variant.

Note for anyone reproducing locally: the unit suite must run on **Node 22**, as CI does.
On Node 23+ it fails 45 tests across 3 files with `window.localStorage.clear is not a
function` — newer Node ships a native `globalThis.localStorage` global that collides with
jsdom's. That is a local-environment artifact only; the suite is green on `main` and
green here.

## Documentation

The new field and its constraints are documented where they are declared, which is where
a reader meets them: `WorkflowRun::notices` in `src/ports/workflow_runner.rs` carries the
reasoning for not being `error` and not being a `DeliveryReport` row, and
`WorkflowRunOutcome.notices` in `frontend/src/api/workflows.ts` carries the
render-as-warning-never-error contract. `overflow_notice` gains an `# Agreement` section
explaining why every countable word in the sentence branches on the count.

No `docs/` change: this adds a field to an existing journaled outcome and a line to an
existing panel rather than changing architecture or expected usage. No new UI string
literal is introduced — the panel renders backend-supplied text — so there is no `useT()`
key and no locale files to update.
