### PR TITLE
approvals: make always_approve gate what it claims, and default it to empty

### DIFF
--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -70,7 +70,15 @@ enabled = true
 
 [policy]
 mode = "supervised"
-always_approve = ["payment.send", "filing.submit", "external.publish"]
+# `always_approve` names the thing to gate the way the runtime names it: a tool
+# name, or a dotted effect kind a brain emits. This template used to list
+# `payment.send` / `filing.submit` / `external.publish`, none of which is a tool
+# this company can run — so the fence it advertised gated nothing on the harness
+# path (issue #684). `publish_artifact` is a real one, and it is the entry worth
+# demonstrating: under `supervised` the gate already parks every publish, so
+# this changes nothing today and keeps holding if the studio is ever moved to
+# `auto` or `full`.
+always_approve = ["publish_artifact"]
 auto_approve_under_usd = 1.0
 
 [place]

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -347,24 +347,25 @@ a leading dotted segment (`payment` gates `payment.send`, never
 `payroll.export`). They previously held two matchers with two rules, so one
 operator list meant different things depending on which brain was running.
 
-An entry must **resolve**: name a declared tool, or carry a consequence word so
-that a brain emitting it produces a gateable group. One that does neither stops
-the company loading, because a fence that can never fire is worse than no fence
-— it reads as protection. That check is exact for tool names (a closed set) and
-heuristic for effect kinds (open by specification: the Medulla wire types
-`kind` as a free string, so the brain names its own effects and there is no set
-to check against).
+Operator-authored entries are intentionally not restricted to the declared tool
+table. Native effect kinds are open by specification: the Medulla wire carries
+`kind` as a free string, and a hosted brain may emit one this repository has
+never seen. The gate checks `always_approve` before its `EffectGroup` fallback,
+so even an otherwise-unclassified custom kind can be exactly the one the
+operator meant to stop. Treating the classifier as a registry would turn a
+working fence into a load error.
 
-That limit is why **the default is empty**. A default the runtime cannot prove
-will ever fire must not ship as though it were protection: the shipped default
-used to be `payment.send` / `filing.submit` / `external.publish`, none of which
-named a tool, so every company running it believed payments and publishing were
-gated on the harness path and none were. Two of the three name capabilities the
-product does not have; the real name behind the third is `publish_artifact`,
-which must not be defaulted because `full` publishing unattended is the ruling
-on issue #658. Under the default `supervised` mode the checkpoint taxonomy
-parks every `Spend` / `Sign` / `Publish` effect anyway, so the empty default
-costs no protection that was ever real.
+The **default is empty** because shipped defaults can and should meet a stricter
+standard than open operator input. The old default was `payment.send` /
+`filing.submit` / `external.publish`; none named a tool, so every company using
+the harness path believed payments and publishing were gated and none were. Two
+of the three name capabilities the product does not have; the real name behind
+the third is `publish_artifact`, which must not be defaulted because `full`
+publishing unattended is the ruling on issue #658. Under the default
+`supervised` mode the checkpoint taxonomy parks every `Spend` / `Sign` /
+`Publish` effect anyway, so the empty default costs no protection that was ever
+real. A drift test requires every future default entry to name its intended,
+declared tool target explicitly.
 
 ### Precedence at the tool gate
 

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -335,6 +335,37 @@ with actor and timestamps, but each admitted call writes no journal record.
 Defensible because a standing grant only ever admits tools declared grantable
 and never a priced call; a per-use record is additive later.
 
+### What an `always_approve` entry names (issue #684)
+
+One namespace, not two. An entry is an **effect kind**, and a **tool name is an
+effect kind** — the harness projects a flagged tool call onto an `Effect` by
+making the tool name the kind verbatim, so `publish_artifact` is the
+single-segment case of the same thing `payment.send` is the two-segment case of.
+Both approval paths — the native-effect gate and the harness tool policy — read
+one matcher, `policy::always_approve::matches`, which matches the exact entry or
+a leading dotted segment (`payment` gates `payment.send`, never
+`payroll.export`). They previously held two matchers with two rules, so one
+operator list meant different things depending on which brain was running.
+
+An entry must **resolve**: name a declared tool, or carry a consequence word so
+that a brain emitting it produces a gateable group. One that does neither stops
+the company loading, because a fence that can never fire is worse than no fence
+— it reads as protection. That check is exact for tool names (a closed set) and
+heuristic for effect kinds (open by specification: the Medulla wire types
+`kind` as a free string, so the brain names its own effects and there is no set
+to check against).
+
+That limit is why **the default is empty**. A default the runtime cannot prove
+will ever fire must not ship as though it were protection: the shipped default
+used to be `payment.send` / `filing.submit` / `external.publish`, none of which
+named a tool, so every company running it believed payments and publishing were
+gated on the harness path and none were. Two of the three name capabilities the
+product does not have; the real name behind the third is `publish_artifact`,
+which must not be defaulted because `full` publishing unattended is the ruling
+on issue #658. Under the default `supervised` mode the checkpoint taxonomy
+parks every `Spend` / `Sign` / `Publish` effect anyway, so the empty default
+costs no protection that was ever real.
+
 ### Precedence at the tool gate
 
 A tool call is decided in this order:
@@ -449,8 +480,10 @@ Prosumers adjust the fence in plain language, which compiles to policy:
 - "Auto-approve spending under $5" → `auto_approve_under_usd = 5.0`
 - "Never contact my customers directly" → `never_do` → `Deny` on
   `dm.external` matching the customer list
-- "You can post to the blog without asking" → remove `external.publish`
-  from `always_approve` for that channel
+- "You can post to the blog without asking" → remove `publish_artifact` from
+  `always_approve` for that channel. Nothing to remove unless the operator put
+  it there: `always_approve` defaults to empty, and under `supervised` it is
+  the checkpoint taxonomy — not the list — that parks a publish
 
 Standing-rule changes are themselves Charter edits with provenance and audit
 ([charter.md](charter.md)); loosening a rule takes effect for *future*

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -71,9 +71,8 @@ search_daily_calls = 200           # per-company daily web_search cap (0 = pause
 
 [policy]                           # see company-brain/approvals.md
 mode = "supervised"                # readonly | supervised (default) | auto | full
-always_approve = ["publish_artifact"]   # default []; names a tool or an effect
-                                   # kind — see approvals.md. An entry that
-                                   # matches neither is a validation error
+always_approve = ["publish_artifact"]   # default []; names a tool or an open
+                                   # effect kind — see approvals.md
 auto_approve_under_usd = 1.0
 
 [place]                            # see company-as-agent/
@@ -202,11 +201,12 @@ prompt = "Weekly review and operator digest"
   `auto_approve_under_usd` lets small spends through. **A tool name is an
   effect kind** — the harness projects one onto the other — so
   `["publish_artifact"]` and `["payment.send"]` are the same syntax at
-  different segment counts, and an entry matching neither a declared tool nor a
-  consequence-bearing kind is a validation error rather than a silent
-  no-match (issue #684). The default is **empty**: `supervised` already parks
-  every money / publish / filing effect through the checkpoint taxonomy, so the
-  conservative default is the mode, not the list.
+  different segment counts (issue #684). Operator-authored effect kinds remain
+  open-ended because a hosted brain may emit a kind this repository has never
+  seen; the shared matcher runs before the checkpoint taxonomy. The default is
+  **empty**: `supervised` already parks every money / publish / filing effect
+  through that taxonomy, so the conservative default is the mode, not the
+  list.
 - **`[place]`** drives the [going-public flow](../company-as-agent/README.md).
   `skills` feed Agent Card generation; prices are decimal strings (USDC).
 - **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -71,7 +71,9 @@ search_daily_calls = 200           # per-company daily web_search cap (0 = pause
 
 [policy]                           # see company-brain/approvals.md
 mode = "supervised"                # readonly | supervised (default) | auto | full
-always_approve = ["payment.send", "filing.submit", "external.publish"]
+always_approve = ["publish_artifact"]   # default []; names a tool or an effect
+                                   # kind — see approvals.md. An entry that
+                                   # matches neither is a validation error
 auto_approve_under_usd = 1.0
 
 [place]                            # see company-as-agent/
@@ -197,8 +199,14 @@ prompt = "Weekly review and operator digest"
   outward reads run unattended, anything that leaves the company or spends on
   submit still parks). `always_approve` lists effect kinds that park for
   approval regardless of amount and wins over every tier including `full`;
-  `auto_approve_under_usd` lets small spends through. Defaults are
-  conservative: `supervised`, with all money/publish/filing effects gated.
+  `auto_approve_under_usd` lets small spends through. **A tool name is an
+  effect kind** — the harness projects one onto the other — so
+  `["publish_artifact"]` and `["payment.send"]` are the same syntax at
+  different segment counts, and an entry matching neither a declared tool nor a
+  consequence-bearing kind is a validation error rather than a silent
+  no-match (issue #684). The default is **empty**: `supervised` already parks
+  every money / publish / filing effect through the checkpoint taxonomy, so the
+  conservative default is the mode, not the list.
 - **`[place]`** drives the [going-public flow](../company-as-agent/README.md).
   `skills` feed Agent Card generation; prices are decimal strings (USDC).
 - **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -243,20 +243,6 @@ impl CompanyManifest {
             problems.push(one_of("`[policy].mode`", POLICY_MODES, &self.policy.mode));
         }
 
-        // `always_approve` wins over every tier including `full`, so an entry
-        // that can never match is not a harmless dead string — it is a control
-        // the operator believes is protecting them (issue #684). Fail closed:
-        // a name this build cannot produce stops the company loading, rather
-        // than silently gating nothing.
-        for entry in crate::policy::always_approve::unresolved(&self.policy.always_approve) {
-            problems.push(format!(
-                "`[policy].always_approve` lists `{entry}`, which is neither a tool this company \
-                 can run nor an effect kind its brain can emit — it would never park anything. \
-                 Write a tool name (for example `publish_artifact` or `web_search`) or a dotted \
-                 effect kind naming a real consequence (for example `payment.send`)."
-            ));
-        }
-
         if let Some(under) = self.policy.auto_approve_under_usd
             && under < 0.0
         {
@@ -477,29 +463,6 @@ mod tests {
             manifest.policy.always_approve.is_empty(),
             "the default always-approve list is empty on purpose — see \
              DEFAULT_ALWAYS_APPROVE"
-        );
-    }
-
-    /// The fence an operator writes is honoured, and one they cannot have meant
-    /// is refused rather than silently ignored (issue #684).
-    #[test]
-    fn an_always_approve_entry_that_could_never_fire_is_a_validation_error() {
-        let good = parse(
-            "[company]\nname = \"Solo\"\n\n[policy]\nalways_approve = [\"publish_artifact\", \"payment.send\"]\n",
-        );
-        assert!(good.validate().is_empty(), "{:?}", good.validate());
-
-        // A mistyped *tool name* — the error this check reliably catches, and
-        // the common one, since a tool name has to be spelled exactly. A
-        // mistyped effect *kind* usually still resolves; see
-        // `the_effect_kind_half_of_the_check_is_a_low_floor`.
-        let typo = parse(
-            "[company]\nname = \"Solo\"\n\n[policy]\nalways_approve = [\"pubish_artifact\"]\n",
-        );
-        let problems = typo.validate();
-        assert!(
-            problems.iter().any(|p| p.contains("pubish_artifact")),
-            "a fence that can never fire must be loud, got {problems:?}"
         );
     }
 
@@ -928,36 +891,21 @@ mod tests {
                 skill.id
             );
         }
-        // A supervised policy with a defined always-approve fence — and every
-        // entry in it names something this build can actually gate. Asserting
+        // A supervised policy with a defined always-approve fence. Asserting
         // only `!is_empty()` is what let the template ship three entries that
-        // matched nothing (issue #684): a list's length says nothing about
-        // whether it fires.
+        // matched nothing on its harness path (issue #684): a list's length
+        // says nothing about whether it fires.
         assert_eq!(manifest.policy.mode, "supervised");
         assert!(!manifest.policy.always_approve.is_empty());
-        for entry in &manifest.policy.always_approve {
-            assert!(
-                crate::policy::always_approve::resolves(entry),
-                "the template's fence lists `{entry}`, which would never park anything"
-            );
-        }
-        // `resolves` alone is too weak to guard this template, and saying so
-        // costs nothing: the three entries it used to ship (`payment.send` /
-        // `filing.submit` / `external.publish`) all resolve as effect kinds, so
-        // the loop above would have passed on the broken version unchanged.
-        //
-        // What was actually wrong is that none of them named a tool, and the
-        // template's brain is the openhuman harness — so the fence it
-        // advertised could only ever have fired for a hosted brain the template
-        // does not use. A shipped template must demonstrate a gate that works
-        // on its own path.
+        // What was actually wrong is that none of the old entries named a tool,
+        // and the template runs the openhuman harness. A shipped template must
+        // demonstrate a gate that works on its own path, not merely a plausible
+        // effect-kind string.
         assert!(
-            manifest
-                .policy
-                .always_approve
-                .iter()
-                .any(|entry| crate::policy::consequence::declared_tools()
-                    .any(|tool| tool == entry)),
+            crate::policy::always_approve::matches(
+                &manifest.policy.always_approve,
+                "publish_artifact"
+            ),
             "the template's fence names no declared tool, so nothing in it can \
              park a harness tool call — the shape of issue #684"
         );

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -243,6 +243,20 @@ impl CompanyManifest {
             problems.push(one_of("`[policy].mode`", POLICY_MODES, &self.policy.mode));
         }
 
+        // `always_approve` wins over every tier including `full`, so an entry
+        // that can never match is not a harmless dead string — it is a control
+        // the operator believes is protecting them (issue #684). Fail closed:
+        // a name this build cannot produce stops the company loading, rather
+        // than silently gating nothing.
+        for entry in crate::policy::always_approve::unresolved(&self.policy.always_approve) {
+            problems.push(format!(
+                "`[policy].always_approve` lists `{entry}`, which is neither a tool this company \
+                 can run nor an effect kind its brain can emit — it would never park anything. \
+                 Write a tool name (for example `publish_artifact` or `web_search`) or a dotted \
+                 effect kind naming a real consequence (for example `payment.send`)."
+            ));
+        }
+
         if let Some(under) = self.policy.auto_approve_under_usd
             && under < 0.0
         {
@@ -453,9 +467,39 @@ mod tests {
         assert_eq!(manifest.tools.provider, "openhuman");
         assert_eq!(manifest.policy.mode, "supervised");
         assert!(!manifest.place.discoverable);
-        assert_eq!(
-            manifest.policy.always_approve,
-            vec!["payment.send", "filing.submit", "external.publish"]
+        // Issue #684: this asserted the three-string default verbatim, which is
+        // how the defect survived — the list's *contents* were pinned and its
+        // *effect* never was, so a list that matched nothing passed. It is
+        // empty now, and what makes the defaults prosumer-safe is the
+        // `supervised` mode asserted above: `evaluate_supervised` parks every
+        // Spend / Sign / Publish effect on its own.
+        assert!(
+            manifest.policy.always_approve.is_empty(),
+            "the default always-approve list is empty on purpose — see \
+             DEFAULT_ALWAYS_APPROVE"
+        );
+    }
+
+    /// The fence an operator writes is honoured, and one they cannot have meant
+    /// is refused rather than silently ignored (issue #684).
+    #[test]
+    fn an_always_approve_entry_that_could_never_fire_is_a_validation_error() {
+        let good = parse(
+            "[company]\nname = \"Solo\"\n\n[policy]\nalways_approve = [\"publish_artifact\", \"payment.send\"]\n",
+        );
+        assert!(good.validate().is_empty(), "{:?}", good.validate());
+
+        // A mistyped *tool name* — the error this check reliably catches, and
+        // the common one, since a tool name has to be spelled exactly. A
+        // mistyped effect *kind* usually still resolves; see
+        // `the_effect_kind_half_of_the_check_is_a_low_floor`.
+        let typo = parse(
+            "[company]\nname = \"Solo\"\n\n[policy]\nalways_approve = [\"pubish_artifact\"]\n",
+        );
+        let problems = typo.validate();
+        assert!(
+            problems.iter().any(|p| p.contains("pubish_artifact")),
+            "a fence that can never fire must be loud, got {problems:?}"
         );
     }
 
@@ -884,9 +928,39 @@ mod tests {
                 skill.id
             );
         }
-        // A supervised policy with a defined always-approve fence.
+        // A supervised policy with a defined always-approve fence — and every
+        // entry in it names something this build can actually gate. Asserting
+        // only `!is_empty()` is what let the template ship three entries that
+        // matched nothing (issue #684): a list's length says nothing about
+        // whether it fires.
         assert_eq!(manifest.policy.mode, "supervised");
         assert!(!manifest.policy.always_approve.is_empty());
+        for entry in &manifest.policy.always_approve {
+            assert!(
+                crate::policy::always_approve::resolves(entry),
+                "the template's fence lists `{entry}`, which would never park anything"
+            );
+        }
+        // `resolves` alone is too weak to guard this template, and saying so
+        // costs nothing: the three entries it used to ship (`payment.send` /
+        // `filing.submit` / `external.publish`) all resolve as effect kinds, so
+        // the loop above would have passed on the broken version unchanged.
+        //
+        // What was actually wrong is that none of them named a tool, and the
+        // template's brain is the openhuman harness — so the fence it
+        // advertised could only ever have fired for a hosted brain the template
+        // does not use. A shipped template must demonstrate a gate that works
+        // on its own path.
+        assert!(
+            manifest
+                .policy
+                .always_approve
+                .iter()
+                .any(|entry| crate::policy::consequence::declared_tools()
+                    .any(|tool| tool == entry)),
+            "the template's fence names no declared tool, so nothing in it can \
+             park a harness tool call — the shape of issue #684"
+        );
         // The weekly opportunity loop is a schedule.
         assert!(!manifest.schedules.is_empty());
     }

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -87,10 +87,10 @@ pub const KNOWN_CHANNELS: &[&str] = &["operator", "email", "slack", "sms", "web"
 ///   the default configuration; they only ever mattered under `auto` and
 ///   `full`, tiers an operator opts into for unattended operation.
 ///
-/// An operator who wants a specific gate still writes one, and now a name that
-/// could never fire is a manifest validation error instead of a silent
-/// no-match. See [`crate::policy::always_approve`] for what can and cannot be
-/// validated, and why.
+/// An operator who wants a specific gate still writes one. Operator-authored
+/// effect kinds remain open-ended because a hosted brain may emit a kind this
+/// repository has never seen; see [`crate::policy::always_approve`] for why a
+/// registry-based validator would reject working custom fences.
 pub const DEFAULT_ALWAYS_APPROVE: &[&str] = &[];
 
 /// Priorities a company may assign to a prioritized `[[connection]]`.
@@ -651,8 +651,8 @@ pub struct Policy {
     /// so `["publish_artifact"]` and `["payment.send"]` are the same syntax at
     /// different segment counts. Matched by
     /// [`always_approve::matches`](crate::policy::always_approve::matches) on
-    /// both approval paths; an entry that could never match is a validation
-    /// error rather than a silent no-match (issue #684).
+    /// both approval paths (issue #684). Native effect kinds are open-ended, so
+    /// configured entries are not restricted to this build's declared tools.
     ///
     /// Defaults to [`DEFAULT_ALWAYS_APPROVE`], which is empty — see there for
     /// why.

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -57,8 +57,41 @@ pub const POLICY_MODES: &[&str] = &["readonly", "supervised", "auto", "full"];
 /// Channels the runtime knows how to enable under `[channels.*]`.
 pub const KNOWN_CHANNELS: &[&str] = &["operator", "email", "slack", "sms", "web", "telegram"];
 
-/// Effect kinds gated for approval by default under a `supervised` policy.
-pub const DEFAULT_ALWAYS_APPROVE: &[&str] = &["payment.send", "filing.submit", "external.publish"];
+/// Effect kinds gated for approval by default — **empty on purpose** (issue
+/// #684).
+///
+/// This shipped as `["payment.send", "filing.submit", "external.publish"]`, and
+/// the promise it read as was not one the runtime kept. `always_approve` wins
+/// over every tier including `full`, so a company shipping the default believed
+/// payments, filings and publishing were gated. On the **harness** path —
+/// the one every company using the openhuman toolbelt runs — the list is
+/// matched against the tool name, and none of those three names a tool, so
+/// nothing was gated at all.
+///
+/// The list is now matched by one shared rule on both paths
+/// ([`always_approve::matches`](crate::policy::always_approve::matches)), and it
+/// ships empty rather than being repaired, for three reasons:
+///
+/// * **Two of the three name capabilities this product does not have.** There
+///   is no payment tool and no `Sign`-group tool in the declaration table, and
+///   nothing outside test code emits either kind. A default cannot gate a
+///   capability that does not exist.
+/// * **The third must not be defaulted.** The real name behind
+///   `external.publish` is `publish_artifact`, and issue #658 ruled that `full`
+///   publishes unattended — an operator who wants otherwise writes
+///   `always_approve = ["publish_artifact"]`. Defaulting it would overturn that
+///   ruling silently.
+/// * **It costs no protection.** The default mode is `supervised`, and
+///   `ManifestApprovalGate::evaluate_supervised` already parks every `Spend`,
+///   `Sign` and `Publish` effect on its own. The three entries added nothing to
+///   the default configuration; they only ever mattered under `auto` and
+///   `full`, tiers an operator opts into for unattended operation.
+///
+/// An operator who wants a specific gate still writes one, and now a name that
+/// could never fire is a manifest validation error instead of a silent
+/// no-match. See [`crate::policy::always_approve`] for what can and cannot be
+/// validated, and why.
+pub const DEFAULT_ALWAYS_APPROVE: &[&str] = &[];
 
 /// Priorities a company may assign to a prioritized `[[connection]]`.
 pub const CONNECTION_PRIORITIES: &[&str] = &["low", "medium", "high"];
@@ -611,7 +644,18 @@ pub struct Policy {
     /// decision rather than a rider on adding the tier.
     #[serde(default = "default_policy_mode")]
     pub mode: String,
-    /// Effect kinds that always park for approval regardless of amount.
+    /// Effect kinds that always park for approval regardless of amount, and
+    /// regardless of tier — this list wins over `full`.
+    ///
+    /// A tool name is an effect kind (the harness projects one onto the other),
+    /// so `["publish_artifact"]` and `["payment.send"]` are the same syntax at
+    /// different segment counts. Matched by
+    /// [`always_approve::matches`](crate::policy::always_approve::matches) on
+    /// both approval paths; an entry that could never match is a validation
+    /// error rather than a silent no-match (issue #684).
+    ///
+    /// Defaults to [`DEFAULT_ALWAYS_APPROVE`], which is empty — see there for
+    /// why.
     #[serde(default = "default_always_approve")]
     pub always_approve: Vec<String>,
     /// Spends strictly under this many USD skip approval.

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -762,13 +762,23 @@ impl ApprovalPolicy {
         self.budget_usd_daily
     }
 
-    /// Whether `kind` is in the manifest's `always_approve` list. Matches either
-    /// the exact dotted kind or a leading segment (so `payment` matches
-    /// `payment.send`).
+    /// Whether `kind` is in the manifest's `always_approve` list.
+    ///
+    /// Delegates to [`always_approve::matches`](crate::policy::always_approve::matches)
+    /// so this path and the native-effect gate
+    /// ([`ManifestApprovalGate`](crate::policy::ManifestApprovalGate)) read one
+    /// rule. They used to hold two: this one matched the exact kind or a
+    /// leading segment, the gate matched exactly — so `always_approve =
+    /// ["payment"]` gated a tool call here and silently missed the
+    /// identically-named native effect there (issue #684).
+    ///
+    /// `kind` is the tool name on this path, which is not a coincidence to
+    /// paper over: [`effect_for`](Self::effect_for) below projects a flagged
+    /// call onto an [`Effect`] by making the tool name the effect kind
+    /// verbatim, so the two namespaces the issue describes are one namespace
+    /// read twice.
     fn always_requires_approval(&self, kind: &str) -> bool {
-        self.always_approve
-            .iter()
-            .any(|entry| entry == kind || kind.starts_with(&format!("{entry}.")))
+        crate::policy::always_approve::matches(&self.always_approve, kind)
     }
 
     /// Best-effort USD amount carried by a tool call's arguments, from either an
@@ -1456,6 +1466,102 @@ mod tests {
                 .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
+    }
+
+    /// The two approval paths must decide the same operator list the same way
+    /// (issue #684).
+    ///
+    /// This is the assertion whose absence let the defect ship. Each path had
+    /// its own matcher and its own tests, and each path's tests passed: the
+    /// native gate matched dotted kinds exactly, this one matched tool names
+    /// with a leading-segment rule, and nothing anywhere compared them. So
+    /// `always_approve = ["payment"]` parked here and waved through there, and
+    /// the shipped default — three dotted kinds, no tool names — was live on
+    /// the gate and inert on the harness, which is the path a company using the
+    /// openhuman toolbelt actually runs.
+    ///
+    /// It asserts agreement rather than a fixed verdict per path deliberately.
+    /// Pinning "the harness parks `payment`" would go green again the moment
+    /// the two implementations drifted apart in the other direction.
+    #[tokio::test]
+    async fn both_approval_paths_agree_on_the_same_always_approve_list() {
+        use crate::policy::ManifestApprovalGate;
+        use crate::ports::approvals::ApprovalGate;
+        use crate::ports::types::PolicyDecision;
+
+        // A leading segment, an exact dotted kind, a bare tool name, a
+        // near-miss that must NOT be gated, and a case variant.
+        //
+        // Every name here is one the tier itself has no opinion about under
+        // `full`, so the only thing that can make the two paths disagree is the
+        // fence. A priced name like `web_search` would drag the harness's
+        // metered-read and budget arms into a comparison that is not about
+        // `always_approve`, so it is deliberately absent.
+        let fence = &["payment", "filing.submit", "publish_artifact"];
+        let names = [
+            "payment.send",
+            "payment",
+            "filing.submit",
+            "publish_artifact",
+            "PUBLISH_ARTIFACT",
+            "payroll.export",
+        ];
+
+        // `full` on both sides, so the tier decides nothing and any parking
+        // observed is the override's doing.
+        let harness = policy("full", fence, None);
+        let gate = ManifestApprovalGate::new(Policy {
+            mode: "full".to_string(),
+            always_approve: fence.iter().map(|s| s.to_string()).collect(),
+            auto_approve_under_usd: None,
+        });
+
+        let mut agreed = 0;
+        for name in names {
+            let harness_parks = matches!(
+                harness.check(&request(name, serde_json::json!({}))).await,
+                ToolPolicyDecision::RequireApproval { .. }
+            );
+            let effect = Effect {
+                kind: name.to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::Value::Null,
+                agent: None,
+                run_id: None,
+            };
+            let gate_parks = matches!(
+                gate.evaluate(&CompanyId::new("acme"), &effect)
+                    .await
+                    .unwrap(),
+                PolicyDecision::RequireApproval
+            );
+            assert_eq!(
+                harness_parks, gate_parks,
+                "`{name}` parks on one approval path and not the other — \
+                 one operator list, two answers (issue #684)"
+            );
+            agreed += 1;
+        }
+        assert_eq!(agreed, names.len(), "every name must have been compared");
+
+        // Non-vacuity: the comparison above is only worth something if the
+        // fence actually separates these names. Two paths that both allowed
+        // everything would agree perfectly and prove nothing.
+        assert!(matches!(
+            harness
+                .check(&request("payment.send", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(
+            harness
+                .check(&request("payroll.export", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::Allow
+        );
     }
 
     /// Issue #560's contract, stated as the operator reads it: the agent works

--- a/src/policy/always_approve.rs
+++ b/src/policy/always_approve.rs
@@ -40,51 +40,22 @@
 //! sites read it. Both syntaxes keep working, because they were always one
 //! syntax.
 //!
-//! ## What can and cannot be validated (and why the default is empty)
+//! ## Why configured entries are not validated against a registry
 //!
-//! [`resolves`] answers "can this entry ever match anything this build
-//! produces?", so [`Manifest::validate`](crate::company::Manifest) can reject a
-//! typo loudly instead of handing back a list that silently gates nothing.
+//! Tool names are a closed set, but native effect kinds are deliberately open:
+//! `effect_from_frame` copies the brain's `frame.kind` verbatim. That means a
+//! company may legitimately gate a kind this repository has never seen. The
+//! gate consults this matcher **before** its `EffectGroup` fallback, so even an
+//! otherwise-unclassified kind can be exactly the one an operator meant to
+//! stop.
 //!
-//! It is **exact on one half of the namespace and heuristic on the other**, and
-//! that asymmetry is a property of the system rather than a shortcut here:
-//!
-//! * Tool names are a **closed** set — [`declared_tools`] enumerates every one
-//!   the crate can wire, and a coverage test fails if a live tool is missing
-//!   from it. An entry naming a tool can be checked exactly.
-//! * Effect kinds are **open by specification**. `docs/spec/integrations/medulla.md`
-//!   types the wire field as `"string(1..64)"`, and `effect_from_frame` copies
-//!   `frame.kind` verbatim, so the brain names its own effects. There is no set
-//!   to check against, and there cannot be one without breaking every
-//!   legitimate hosted-brain configuration that gates a kind this repo has
-//!   never heard of.
-//!
-//! The best available check on that half is `effect_group_for`: a kind carrying
-//! no recognised consequence word classifies as
-//! [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), which
-//! `evaluate_supervised` waves through — so it cannot be the thing an operator
-//! meant to gate.
-//!
-//! **It is a floor, and a low one.** `effect_group_for` matches bare substrings
-//! from a short vocabulary, and two of them are short enough to catch a great
-//! deal: `pay` (so `paymnt.send` classifies as `Spend` — the typo resolves) and
-//! `sign` (so `design.review` classifies as `Sign`). It reliably rejects only
-//! an entry carrying no consequence substring at all — `pubish_artifact`,
-//! `web_serch`. That is a real class: a mistyped **tool name** is the operator
-//! error this validation actually catches, and it is the common one, because
-//! tool names are what an operator has to type exactly.
-//!
-//! Do not read this check as a proof that a configured entry will fire. It
-//! proves only that the entry is not obvious nonsense.
-//!
-//! **That limit is the reason [`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE)
-//! ships empty.** A default the runtime cannot prove will ever fire must not be
-//! shipped as though it were protection: that is exactly the state issue #684
-//! describes, where every company running the default believed payments and
-//! publishing were gated and none of them were.
-
-use crate::policy::consequence::declared_tools;
-use crate::ports::types::EffectGroup;
+//! Consequently there is no sound load-time "does this entry resolve?" check.
+//! Treating the effect classifier as a registry would reject working custom
+//! fences, while accepting a dotted string merely because it contains words
+//! such as `pay` or `sign` would still let typos through. The shipped default is
+//! held to a stricter standard in tests: every future default entry must name a
+//! declared tool and its intended target explicitly. Operator-authored entries
+//! remain open, just like the effect namespace they match.
 
 /// Whether `target` is gated by the operator's `always_approve` list.
 ///
@@ -130,47 +101,11 @@ fn gates(entry: &str, target: &str) -> bool {
         && target[..entry.len()].eq_ignore_ascii_case(entry)
 }
 
-/// Whether `entry` can ever match something this build is able to produce.
-///
-/// Two producers of gate targets exist, and an entry naming neither is a typo
-/// or a name for a capability this build does not have:
-///
-/// 1. the declaration table — the entry names a declared tool, checked exactly;
-/// 2. the effect-kind classifier — the entry carries a consequence word, so a
-///    brain emitting it would produce a gateable [`EffectGroup`].
-///
-/// See the module docs for why (2) is a floor rather than a proof, and why
-/// that is not fixable here.
-pub fn resolves(entry: &str) -> bool {
-    let entry = entry.trim();
-    if entry.is_empty() {
-        return false;
-    }
-    // (1) A declared tool this entry would gate — the exact name, or any tool
-    // sitting under it as a dotted segment. The same rule `matches` applies,
-    // asked in reverse: "is there anything this entry could gate?"
-    if declared_tools().any(|tool| gates(entry, tool)) {
-        return true;
-    }
-    // (2) A consequence-bearing effect kind a brain may emit over the wire.
-    //     `effect_group_for` lowercases internally.
-    crate::brain::medulla::effects::effect_group_for(entry) != EffectGroup::Other
-}
-
-/// Every entry in `always_approve` that [`resolves`] rejects, in the operator's
-/// own spelling, for [`Manifest::validate`](crate::company::Manifest).
-pub fn unresolved(always_approve: &[String]) -> Vec<&str> {
-    always_approve
-        .iter()
-        .map(String::as_str)
-        .filter(|entry| !resolves(entry))
-        .collect()
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::company::DEFAULT_ALWAYS_APPROVE;
+    use crate::policy::consequence::declared_tools;
 
     fn list(entries: &[&str]) -> Vec<String> {
         entries.iter().map(|e| e.to_string()).collect()
@@ -219,63 +154,6 @@ mod test {
         assert!(!matches(&[], "publish_artifact"));
     }
 
-    #[test]
-    fn a_declared_tool_resolves() {
-        assert!(resolves("publish_artifact"));
-        assert!(resolves("web_search"));
-        assert!(resolves("shell"));
-    }
-
-    #[test]
-    fn a_consequence_bearing_effect_kind_resolves() {
-        // No tool of these names exists — and none needs to. A hosted brain
-        // names its own effects, and each of these classifies into a group
-        // `evaluate_supervised` parks.
-        assert!(resolves("payment.send"));
-        assert!(resolves("filing.submit"));
-        assert!(resolves("external.publish"));
-    }
-
-    /// The fail-closed case: an entry that names neither a tool nor a
-    /// consequence-bearing kind can never fire, and the operator must be told
-    /// rather than handed a list that silently gates nothing.
-    ///
-    /// These are all **mistyped tool names**, which is the operator error this
-    /// check actually catches — and the common one, because a tool name is the
-    /// thing an operator has to spell exactly.
-    #[test]
-    fn a_mistyped_tool_name_does_not_resolve() {
-        assert!(!resolves("pubish_artifact"));
-        assert!(!resolves("web_serch"));
-        assert!(!resolves("totally_made_up"));
-        assert!(!resolves(""));
-    }
-
-    /// The floor, pinned as a limit rather than left to be discovered.
-    ///
-    /// `effect_group_for` matches bare substrings, and `pay` and `sign` are
-    /// short enough to catch words that were never meant to be consequence
-    /// vocabulary. So a typo'd *effect kind* generally still resolves, and this
-    /// validation must not be described — in docs, in a review, or to an
-    /// operator — as proving that a configured entry will fire.
-    ///
-    /// Asserted rather than commented so that tightening `effect_group_for`
-    /// later fails here and makes somebody update the claim.
-    #[test]
-    fn the_effect_kind_half_of_the_check_is_a_low_floor() {
-        // `pay` is a substring of `paymnt`, so the typo classifies as `Spend`.
-        assert!(resolves("paymnt.send"));
-        // `sign` is a substring of `design`.
-        assert!(resolves("design.review"));
-    }
-
-    #[test]
-    fn unresolved_reports_the_operators_own_spelling() {
-        let entries = list(&["web_search", "pubish_artifact", "publish_artifact"]);
-        assert_eq!(unresolved(&entries), vec!["pubish_artifact"]);
-        assert!(unresolved(&list(&["web_search"])).is_empty());
-    }
-
     /// The drift guard issue #684 asks for, and the reason the default is
     /// empty.
     ///
@@ -287,12 +165,27 @@ mod test {
     /// pins the emptiness as a decision, so restoring an entry has to come
     /// through here and face the loop.
     #[test]
-    fn every_default_entry_resolves_and_the_default_is_empty() {
-        for entry in DEFAULT_ALWAYS_APPROVE {
+    fn every_default_entry_names_a_declared_target_and_the_default_is_empty() {
+        // A future non-empty default must add one explicit `(entry, target)`
+        // pair here. That makes the intended effect executable as a test rather
+        // than leaving another unvalidated string list behind.
+        const INTENDED_TARGETS: &[(&str, &str)] = &[];
+        assert_eq!(
+            DEFAULT_ALWAYS_APPROVE.len(),
+            INTENDED_TARGETS.len(),
+            "every shipped entry needs an explicit target in this test"
+        );
+        for ((entry, target), shipped) in INTENDED_TARGETS.iter().zip(DEFAULT_ALWAYS_APPROVE.iter())
+        {
+            assert_eq!(entry, shipped, "the target table must track the default");
             assert!(
-                resolves(entry),
-                "the shipped default gates `{entry}`, which names nothing this \
-                 build can produce — issue #684 all over again"
+                declared_tools().any(|tool| tool == *target),
+                "the intended target `{target}` is not a declared tool"
+            );
+            assert!(
+                matches(&list(&[*entry]), target),
+                "the shipped default `{entry}` does not gate its intended target \
+                 `{target}` — issue #684 all over again"
             );
         }
         assert!(

--- a/src/policy/always_approve.rs
+++ b/src/policy/always_approve.rs
@@ -1,0 +1,306 @@
+//! `[policy].always_approve` — the operator's override, and the one matcher
+//! both approval paths read (issue #684).
+//!
+//! ## Two matchers, one list, two different answers
+//!
+//! `always_approve` is the list that, per
+//! [`PolicyMode::Full`](crate::harness::policy::PolicyMode), *"wins over
+//! everything else, including Full autonomy"*. It is what an operator is
+//! pointed at when they ask how to make sure a company never sends money
+//! without asking.
+//!
+//! Until this module it was matched in two places, against two namespaces,
+//! under two different rules:
+//!
+//! * [`ManifestApprovalGate::evaluate`](crate::policy::gate::ManifestApprovalGate)
+//!   — the **native-effect** path, where a hosted or sidecar brain emits an
+//!   effect frame. Matched `entry == effect.kind()`: exact, no prefix.
+//! * [`ApprovalPolicy::check`](crate::harness::policy::ApprovalPolicy) — the
+//!   **harness tool-call** path, where an openhuman agent calls a tool.
+//!   Matched the **tool name**, exact *or* leading dotted segment.
+//!
+//! So one operator list meant two things depending on which brain was running,
+//! and `always_approve = ["payment"]` parked `payment.send` on one path and
+//! silently did nothing on the other. The shipped default —
+//! `payment.send` / `filing.submit` / `external.publish` — is dotted effect
+//! kinds, so it reached the first matcher and was **inert on the second**,
+//! which is the path every company using the openhuman toolbelt actually runs.
+//!
+//! ## They were never two namespaces
+//!
+//! The fix is not to pick a winner, because there is no genuine conflict to
+//! resolve. [`ApprovalPolicy::effect_for`](crate::harness::policy::ApprovalPolicy::effect_for)
+//! projects a flagged tool call onto an [`Effect`](crate::ports::types::Effect)
+//! by making **the tool name the effect kind, verbatim**. A tool name already
+//! *is* an effect kind — the single-segment, undotted case of one. The two
+//! matchers were reading the same namespace through two different rules, and
+//! the rules disagreeing is the whole defect.
+//!
+//! So there is one namespace and, now, one matcher: [`matches`]. Both call
+//! sites read it. Both syntaxes keep working, because they were always one
+//! syntax.
+//!
+//! ## What can and cannot be validated (and why the default is empty)
+//!
+//! [`resolves`] answers "can this entry ever match anything this build
+//! produces?", so [`Manifest::validate`](crate::company::Manifest) can reject a
+//! typo loudly instead of handing back a list that silently gates nothing.
+//!
+//! It is **exact on one half of the namespace and heuristic on the other**, and
+//! that asymmetry is a property of the system rather than a shortcut here:
+//!
+//! * Tool names are a **closed** set — [`declared_tools`] enumerates every one
+//!   the crate can wire, and a coverage test fails if a live tool is missing
+//!   from it. An entry naming a tool can be checked exactly.
+//! * Effect kinds are **open by specification**. `docs/spec/integrations/medulla.md`
+//!   types the wire field as `"string(1..64)"`, and `effect_from_frame` copies
+//!   `frame.kind` verbatim, so the brain names its own effects. There is no set
+//!   to check against, and there cannot be one without breaking every
+//!   legitimate hosted-brain configuration that gates a kind this repo has
+//!   never heard of.
+//!
+//! The best available check on that half is `effect_group_for`: a kind carrying
+//! no recognised consequence word classifies as
+//! [`EffectGroup::Other`](crate::ports::types::EffectGroup::Other), which
+//! `evaluate_supervised` waves through — so it cannot be the thing an operator
+//! meant to gate.
+//!
+//! **It is a floor, and a low one.** `effect_group_for` matches bare substrings
+//! from a short vocabulary, and two of them are short enough to catch a great
+//! deal: `pay` (so `paymnt.send` classifies as `Spend` — the typo resolves) and
+//! `sign` (so `design.review` classifies as `Sign`). It reliably rejects only
+//! an entry carrying no consequence substring at all — `pubish_artifact`,
+//! `web_serch`. That is a real class: a mistyped **tool name** is the operator
+//! error this validation actually catches, and it is the common one, because
+//! tool names are what an operator has to type exactly.
+//!
+//! Do not read this check as a proof that a configured entry will fire. It
+//! proves only that the entry is not obvious nonsense.
+//!
+//! **That limit is the reason [`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE)
+//! ships empty.** A default the runtime cannot prove will ever fire must not be
+//! shipped as though it were protection: that is exactly the state issue #684
+//! describes, where every company running the default believed payments and
+//! publishing were gated and none of them were.
+
+use crate::policy::consequence::declared_tools;
+use crate::ports::types::EffectGroup;
+
+/// Whether `target` is gated by the operator's `always_approve` list.
+///
+/// `target` is an effect kind — which, on the harness path, is the tool name
+/// (see the module docs for why those are the same thing).
+///
+/// Matches the exact entry or a **leading dotted segment**, so `payment` gates
+/// `payment.send` but not `payments_report`. The segment boundary is load
+/// bearing: a bare `starts_with` would let `pay` gate `payroll.export`, which
+/// is a different capability an operator did not name.
+///
+/// The comparison is **ASCII-case-insensitive**. Tool names reach the harness
+/// matcher from openhuman's own registry, and
+/// [`consequence_of`](crate::policy::consequence::consequence_of) already
+/// lowercases defensively before consulting the declaration table — so a name
+/// whose case differs from the operator's spelling would classify correctly and
+/// then slip the override. That is the same silent-miss this module exists to
+/// end, and the fail-safe direction is to match rather than to skip.
+pub fn matches(always_approve: &[String], target: &str) -> bool {
+    let target = target.trim();
+    always_approve
+        .iter()
+        .any(|entry| gates(entry.trim(), target))
+}
+
+/// Whether one `always_approve` entry gates `target`. Allocation-free: this
+/// runs on every gated tool call, and the old form built a `String` per entry
+/// per call to test a prefix.
+fn gates(entry: &str, target: &str) -> bool {
+    if entry.is_empty() {
+        return false;
+    }
+    if target.eq_ignore_ascii_case(entry) {
+        return true;
+    }
+    // Leading dotted segment: `payment` gates `payment.send`.
+    //
+    // The `.` check runs before the slice, which is what makes the slice safe:
+    // a byte equal to `.` is ASCII, and an ASCII byte in valid UTF-8 is always
+    // a char boundary, so `target[..entry.len()]` cannot split a code point.
+    target.len() > entry.len()
+        && target.as_bytes()[entry.len()] == b'.'
+        && target[..entry.len()].eq_ignore_ascii_case(entry)
+}
+
+/// Whether `entry` can ever match something this build is able to produce.
+///
+/// Two producers of gate targets exist, and an entry naming neither is a typo
+/// or a name for a capability this build does not have:
+///
+/// 1. the declaration table — the entry names a declared tool, checked exactly;
+/// 2. the effect-kind classifier — the entry carries a consequence word, so a
+///    brain emitting it would produce a gateable [`EffectGroup`].
+///
+/// See the module docs for why (2) is a floor rather than a proof, and why
+/// that is not fixable here.
+pub fn resolves(entry: &str) -> bool {
+    let entry = entry.trim();
+    if entry.is_empty() {
+        return false;
+    }
+    // (1) A declared tool this entry would gate — the exact name, or any tool
+    // sitting under it as a dotted segment. The same rule `matches` applies,
+    // asked in reverse: "is there anything this entry could gate?"
+    if declared_tools().any(|tool| gates(entry, tool)) {
+        return true;
+    }
+    // (2) A consequence-bearing effect kind a brain may emit over the wire.
+    //     `effect_group_for` lowercases internally.
+    crate::brain::medulla::effects::effect_group_for(entry) != EffectGroup::Other
+}
+
+/// Every entry in `always_approve` that [`resolves`] rejects, in the operator's
+/// own spelling, for [`Manifest::validate`](crate::company::Manifest).
+pub fn unresolved(always_approve: &[String]) -> Vec<&str> {
+    always_approve
+        .iter()
+        .map(String::as_str)
+        .filter(|entry| !resolves(entry))
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::company::DEFAULT_ALWAYS_APPROVE;
+
+    fn list(entries: &[&str]) -> Vec<String> {
+        entries.iter().map(|e| e.to_string()).collect()
+    }
+
+    /// The bug in issue #684, pinned from the harness side: a dotted effect
+    /// kind must gate a tool call of the same name.
+    ///
+    /// Before this module the harness matcher and the gate matcher were
+    /// separate functions, and this list reached only one of them.
+    #[test]
+    fn an_entry_gates_the_same_name_on_either_path() {
+        assert!(matches(&list(&["publish_artifact"]), "publish_artifact"));
+        assert!(matches(&list(&["payment.send"]), "payment.send"));
+    }
+
+    /// The divergence the shared matcher removes: leading-segment matching was
+    /// the harness rule and the gate was exact-only, so `["payment"]` gated a
+    /// tool call and silently missed the identically-named native effect.
+    #[test]
+    fn a_leading_segment_gates_everything_under_it() {
+        assert!(matches(&list(&["payment"]), "payment.send"));
+        assert!(matches(&list(&["payment"]), "payment.refund"));
+    }
+
+    /// The segment boundary, which is what stops the prefix rule from being a
+    /// bare `starts_with` that gates capabilities the operator never named.
+    #[test]
+    fn a_prefix_that_is_not_a_whole_segment_does_not_gate() {
+        assert!(!matches(&list(&["pay"]), "payroll.export"));
+        assert!(!matches(&list(&["payment"]), "payments_report"));
+    }
+
+    #[test]
+    fn case_and_surrounding_space_do_not_defeat_the_override() {
+        assert!(matches(&list(&["  Publish_Artifact "]), "publish_artifact"));
+        assert!(matches(&list(&["payment.send"]), "PAYMENT.SEND"));
+    }
+
+    /// An empty entry must not become a wildcard. `"".starts_with(..)` logic is
+    /// exactly how a list of typos turns into "gate everything", which would be
+    /// fail-safe but would also brick every company that had one.
+    #[test]
+    fn an_empty_entry_gates_nothing() {
+        assert!(!matches(&list(&["", "   "]), "publish_artifact"));
+        assert!(!matches(&[], "publish_artifact"));
+    }
+
+    #[test]
+    fn a_declared_tool_resolves() {
+        assert!(resolves("publish_artifact"));
+        assert!(resolves("web_search"));
+        assert!(resolves("shell"));
+    }
+
+    #[test]
+    fn a_consequence_bearing_effect_kind_resolves() {
+        // No tool of these names exists — and none needs to. A hosted brain
+        // names its own effects, and each of these classifies into a group
+        // `evaluate_supervised` parks.
+        assert!(resolves("payment.send"));
+        assert!(resolves("filing.submit"));
+        assert!(resolves("external.publish"));
+    }
+
+    /// The fail-closed case: an entry that names neither a tool nor a
+    /// consequence-bearing kind can never fire, and the operator must be told
+    /// rather than handed a list that silently gates nothing.
+    ///
+    /// These are all **mistyped tool names**, which is the operator error this
+    /// check actually catches — and the common one, because a tool name is the
+    /// thing an operator has to spell exactly.
+    #[test]
+    fn a_mistyped_tool_name_does_not_resolve() {
+        assert!(!resolves("pubish_artifact"));
+        assert!(!resolves("web_serch"));
+        assert!(!resolves("totally_made_up"));
+        assert!(!resolves(""));
+    }
+
+    /// The floor, pinned as a limit rather than left to be discovered.
+    ///
+    /// `effect_group_for` matches bare substrings, and `pay` and `sign` are
+    /// short enough to catch words that were never meant to be consequence
+    /// vocabulary. So a typo'd *effect kind* generally still resolves, and this
+    /// validation must not be described — in docs, in a review, or to an
+    /// operator — as proving that a configured entry will fire.
+    ///
+    /// Asserted rather than commented so that tightening `effect_group_for`
+    /// later fails here and makes somebody update the claim.
+    #[test]
+    fn the_effect_kind_half_of_the_check_is_a_low_floor() {
+        // `pay` is a substring of `paymnt`, so the typo classifies as `Spend`.
+        assert!(resolves("paymnt.send"));
+        // `sign` is a substring of `design`.
+        assert!(resolves("design.review"));
+    }
+
+    #[test]
+    fn unresolved_reports_the_operators_own_spelling() {
+        let entries = list(&["web_search", "pubish_artifact", "publish_artifact"]);
+        assert_eq!(unresolved(&entries), vec!["pubish_artifact"]);
+        assert!(unresolved(&list(&["web_search"])).is_empty());
+    }
+
+    /// The drift guard issue #684 asks for, and the reason the default is
+    /// empty.
+    ///
+    /// **The loop is vacuous today, deliberately and visibly**: the default
+    /// ships `[]` because nothing in this build emits the three kinds it used
+    /// to name, and the one real name behind them (`publish_artifact`) must not
+    /// be defaulted — issue #658 ruled that `full` publishes unattended. The
+    /// assertion below the loop is what makes this test non-vacuous now: it
+    /// pins the emptiness as a decision, so restoring an entry has to come
+    /// through here and face the loop.
+    #[test]
+    fn every_default_entry_resolves_and_the_default_is_empty() {
+        for entry in DEFAULT_ALWAYS_APPROVE {
+            assert!(
+                resolves(entry),
+                "the shipped default gates `{entry}`, which names nothing this \
+                 build can produce — issue #684 all over again"
+            );
+        }
+        assert!(
+            DEFAULT_ALWAYS_APPROVE.is_empty(),
+            "the default is empty on purpose (issue #684): a default that \
+             cannot be proven to fire must not ship as though it were \
+             protection. Adding an entry is a product decision — see #658 for \
+             why `publish_artifact` in particular is not it."
+        );
+    }
+}

--- a/src/policy/always_approve.rs
+++ b/src/policy/always_approve.rs
@@ -152,6 +152,14 @@ mod test {
     fn an_empty_entry_gates_nothing() {
         assert!(!matches(&list(&["", "   "]), "publish_artifact"));
         assert!(!matches(&[], "publish_artifact"));
+        // The empty *target* is the case that actually reaches the guard in
+        // `gates`. Against any other name an empty entry already falls out of
+        // both arms on its own, so dropping the guard changes nothing and the
+        // two assertions above keep passing — they pin the contract without
+        // exercising the mechanism. Here the guard is the only thing standing
+        // between a blank entry and `"" == ""`, which would make a
+        // whitespace-only line in an operator's list gate a blank effect kind.
+        assert!(!matches(&list(&["", "   "]), ""));
     }
 
     /// The drift guard issue #684 asks for, and the reason the default is

--- a/src/policy/gate.rs
+++ b/src/policy/gate.rs
@@ -395,12 +395,16 @@ impl ApprovalGate for ManifestApprovalGate {
         //    stub, so this list is currently always empty.
 
         // 2. `always_approve` effect kinds park regardless of mode or amount.
-        if self
-            .policy
-            .always_approve
-            .iter()
-            .any(|kind| kind == effect.kind())
-        {
+        //
+        //    The match is `always_approve::matches`, shared with the harness
+        //    tool policy. This arm used to compare exactly while the harness
+        //    also honoured a leading segment, so one operator list meant two
+        //    different things depending on which brain was running (issue
+        //    #684). Adopting the harness rule here widens this arm: an entry
+        //    like `payment` now parks `payment.send` natively, where before it
+        //    parked nothing. That direction is the fail-safe one — an operator
+        //    who named a family meant the family.
+        if crate::policy::always_approve::matches(&self.policy.always_approve, effect.kind()) {
             return Ok(PolicyDecision::RequireApproval);
         }
 
@@ -456,13 +460,21 @@ mod test {
     use super::*;
     use crate::ports::types::ActorKind;
 
+    /// The fence these tests run under, written out rather than taken from
+    /// [`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE).
+    ///
+    /// It used to be the default, which made every assertion below depend on a
+    /// constant these tests do not own — and when that constant turned out to
+    /// gate nothing on the *other* approval path, nothing here noticed, because
+    /// on this path it did match (issue #684). A test that borrows a shipped
+    /// default tests the default, not the mechanism; the default is empty now
+    /// and this list is the mechanism's own fixture.
+    const FENCE: &[&str] = &["payment.send"];
+
     fn policy(mode: &str, cap: Option<f64>) -> Policy {
         Policy {
             mode: mode.to_string(),
-            always_approve: crate::company::DEFAULT_ALWAYS_APPROVE
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
+            always_approve: FENCE.iter().map(|s| s.to_string()).collect(),
             auto_approve_under_usd: cap,
         }
     }
@@ -516,7 +528,7 @@ mod test {
     #[tokio::test]
     async fn always_approve_overrides_full() {
         let gate = ManifestApprovalGate::new(policy("full", None));
-        // `payment.send` is in the default always_approve list.
+        // `payment.send` is in FENCE, this module's always_approve fixture.
         assert_eq!(
             decide(&gate, &effect("payment.send", EffectGroup::Spend)).await,
             PolicyDecision::RequireApproval
@@ -830,7 +842,7 @@ mod test {
         let gate = ManifestApprovalGate::new(policy("supervised", Some(100.0)));
         let mut cheap = effect("payment.send", EffectGroup::Spend);
         cheap.amount_usd = Some(1.0);
-        // `payment.send` is in the default always_approve list, so it parks...
+        // `payment.send` is in FENCE, this module's always_approve fixture, so it parks...
         assert_eq!(decide(&gate, &cheap).await, PolicyDecision::RequireApproval);
         // ...but a dollar under a hundred-dollar cap is not irreversible.
         assert!(!gate.is_irreversible(&cheap));
@@ -977,7 +989,7 @@ mod test {
     async fn releasing_restores_normal_evaluation() {
         let gate = ManifestApprovalGate::new(policy("full", None));
         let spend = effect("payment.send", EffectGroup::Spend);
-        // `payment.send` is in the default always_approve list, so `full` parks it.
+        // `payment.send` is in FENCE, this module's always_approve fixture, so `full` parks it.
         let before = decide(&gate, &spend).await;
         assert_eq!(before, PolicyDecision::RequireApproval);
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -4,6 +4,12 @@
 //! [`ApprovalGate`](crate::ports::ApprovalGate) that evaluates emitted effects
 //! against a company's declared policy and holds the in-memory approval queue.
 //!
+//! The [`always_approve`] module holds the one matcher both approval paths read
+//! for `[policy].always_approve`, plus the resolver the manifest validator uses
+//! to reject an entry that could never fire (issue #684). It is always
+//! compiled, because the native-effect gate below reads it in the default build
+//! while the harness tool policy reads it only under the `openhuman` feature.
+//!
 //! The [`consequence`] module declares, once, what every tool can reach — the
 //! single source both approval questions read ("may this run unattended?" and
 //! "may an operator grant it standing?"). It is always compiled, because the
@@ -11,6 +17,7 @@
 //! console card) while the tool policy that parks calls compiles only under the
 //! `openhuman` feature.
 
+pub mod always_approve;
 pub mod consequence;
 pub mod gate;
 

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -5,10 +5,9 @@
 //! against a company's declared policy and holds the in-memory approval queue.
 //!
 //! The [`always_approve`] module holds the one matcher both approval paths read
-//! for `[policy].always_approve`, plus the resolver the manifest validator uses
-//! to reject an entry that could never fire (issue #684). It is always
-//! compiled, because the native-effect gate below reads it in the default build
-//! while the harness tool policy reads it only under the `openhuman` feature.
+//! for `[policy].always_approve` (issue #684). It is always compiled, because
+//! the native-effect gate below reads it in the default build while the harness
+//! tool policy reads it only under the `openhuman` feature.
 //!
 //! The [`consequence`] module declares, once, what every tool can reach — the
 //! single source both approval questions read ("may this run unattended?" and

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -432,11 +432,11 @@ mod tests {
     /// A company record whose `[policy]` is the only thing under test.
     ///
     /// `always_approve` is written explicitly on every call — including as an
-    /// empty list — because the manifest default is NOT empty
-    /// ([`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE) is
-    /// `payment.send` / `filing.submit` / `external.publish`). Letting it
-    /// default would make these tests read as if the tier decided something the
-    /// always-approve list had actually decided.
+    /// empty list. [`DEFAULT_ALWAYS_APPROVE`](crate::company::DEFAULT_ALWAYS_APPROVE)
+    /// is empty as of issue #684, so letting it default would no longer decide
+    /// anything behind these tests' backs; writing it out stays the rule
+    /// anyway, because a test that borrows a shipped default tests the default
+    /// rather than the mechanism, and this module's subject is the tier.
     fn company(mode: &str, always_approve: &[&str]) -> CompanyRecord {
         let always = always_approve
             .iter()


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#684.

`always_approve` is the operator's override — the list that wins over every
tier, `full` included. The shipped default was
`["payment.send", "filing.submit", "external.publish"]`, and it did not do what
it read as doing.

**The issue's premise is right about the harm and wrong about the mechanism, in
a way that changes the fix.** There are **two** consumers of `always_approve`,
not one, and they were matching different things under different rules:

| path | where | matched against | rule |
|---|---|---|---|
| native effect (hosted / sidecar brain emits an effect frame) | `ManifestApprovalGate::evaluate` | `Effect.kind` | exact only |
| harness tool call (an openhuman agent calls a tool) | `ApprovalPolicy::always_requires_approval` | tool name | exact **or leading dotted segment** |

So the default was **not** globally inert — `gate.rs`'s own test
`always_approve_overrides_full` proves `payment.send` parks a `payment.send`
effect today. What is true is narrower and still bad: it was inert on the
**harness** path, which is the path every company using the openhuman toolbelt
actually runs, and the path #658's ruling was about (`always_approve =
["publish_artifact"]` — a tool name).

Two further defects the issue did not name, both found on the way in:

- **The matchers disagreed.** `always_approve = ["payment"]` parked
  `payment.send` on the harness path and silently did nothing on the native one.
  One operator list, two answers, depending on which brain was running.
- **The spec contradicted itself.** `docs/spec/runtime/manifest.md:198` said
  "`always_approve` lists effect kinds"; line 257 told the operator to write
  `always_approve = ["web_search"]` — a tool name.

## 1. Which namespace is authoritative

**Neither, because there was never a conflict to resolve — there is one
namespace and it was being read twice.**

`ApprovalPolicy::effect_for` projects a flagged tool call onto an `Effect` by
making **the tool name the effect kind, verbatim**. A tool name already *is* an
effect kind: the single-segment, undotted case of one. `publish_artifact` and
`payment.send` are the same syntax at different segment counts.

So the fix is not to pick a winner and delete the loser. Both call sites now
read one matcher — `policy::always_approve::matches` — with one rule: exact, or
a **leading dotted segment** (`payment` gates `payment.send`, never
`payroll.export`; the segment boundary is what stops a bare `starts_with` from
gating a capability the operator did not name). Both syntaxes keep working
because they were always one syntax. No half-supported second syntax is left
behind.

The rejected alternative was an explicitly tagged syntax (`kind:payment.send` vs
a bare tool name). It validates better, but it turns every operator list of
dotted kinds into a load-time validation error, which bricks a running company
on upgrade. Not worth it for a distinction the type system already collapses.

## 2. Should the default be non-empty

**No. It ships `[]`.**

- **Two of the three named capabilities this product does not have.** The
  declaration table has no payment tool and no `Sign`-group tool at all, and
  outside test code nothing emits either kind. A default cannot gate a
  capability that does not exist.
- **The third must not be defaulted.** The real name behind `external.publish`
  is `publish_artifact`, and **#658 ruled that `full` publishes unattended** —
  an operator who wants otherwise writes `always_approve =
  ["publish_artifact"]`. Defaulting it would overturn that ruling silently, in
  a PR about a different bug.
- **It costs no protection that was ever real.** The default mode is
  `supervised`, and `evaluate_supervised` already parks every `Spend`, `Sign`
  and `Publish` effect on its own. The three entries added nothing to the
  default configuration.

## ⚠️ Behaviour change on next load — and it runs the *opposite* way to the obvious one

The expected risk here was widening: make an inert default match, and companies
start parking calls they never parked. **That is not what happens**, because the
default was only inert on one of the two paths. Shipping `[]` is a
**narrowing**, and it is the thing to review hardest:

- `readonly` / `supervised` / `auto` — **no change whatsoever.** The supervised
  taxonomy parks `Spend`/`Sign`/`Publish` on its own, and `auto` falls to
  `gate.rs`'s `_ => RequireApproval` arm.
- **`full` + a hosted or sidecar brain — a real loss.** A company whose brain
  emits an effect kind spelled *exactly* `payment.send`, `filing.submit` or
  `external.publish` will **stop parking it** on next load.

Argued rather than waved through: the protection removed was arbitrary even
where it fired — three exact spellings out of a namespace the Medulla wire spec
types as a free `string(1..64)`, so `payment.transfer` or `pay.send` were never
gated — and `full` means "unattended except what the operator listed", which an
operator who never wrote a list never did. Nothing in this repo emits those
kinds. **The honest limit: I cannot see what Medulla emits in production, so the
loss is speculative rather than zero.**

If a maintainer weighs that unknown differently, the alternative is
`["payment", "filing", "publish"]`, which with the new leading-segment matcher
gates strictly *more* natively than the old default (`payment.*`, not just
`payment.send`) and narrows nothing. Its cost is that it stays inert on the
harness path — reproducing the exact confusion #684 is about. I did not take it
for that reason, but it is a one-line change.

## 3. Why operator-authored entries are not registry-validated

The first implementation attempted to fail company loading when an
`always_approve` entry named neither a declared tool nor a
consequence-classified effect. Inspection after rebasing found that check was
unsound, so it is deliberately **not** part of this PR.

- **Tool names are closed.** `declared_tools()` enumerates every tool the crate
  can wire.
- **Effect kinds are open by specification.**
  `docs/spec/integrations/medulla.md` types the wire field as
  `"string(1..64)"`, and `effect_from_frame` copies `frame.kind` verbatim. A
  hosted brain can emit a legitimate custom kind this repository has never
  seen.

Most importantly, the native gate checks `always_approve` **before**
`EffectGroup`. An otherwise-unclassified custom kind can therefore be exactly
the one an operator meant to stop. Using `effect_group_for` as a registry would
turn that working fence into a load error; it also would not reliably catch
typos because the classifier uses broad substrings such as `pay` and `sign`.

> The breadth of those substrings is a live defect in its own right —
> `effect_group_for` (`src/brain/medulla/effects.rs:459`) classifies
> `design.review` as `Sign` and `paymnt.send` as `Spend`. It is **adjacent to
> but not part of** this PR, which only stops depending on the classifier for
> validation; it is being filed separately. Nothing here changes
> `effect_group_for`.

The shipped default is different from open operator input: this repository owns
it and can require executable proof. The drift test therefore requires every
future default entry to add an explicit intended target and prove that target is
a declared tool the shared matcher gates. The list is empty today, and the test
pins that as a deliberate decision.

## Tests that asserted the default's *contents* rather than its *effect*

These passed before this PR and would have passed after a fix that changed
nothing. This is the shape that let the defect ship, so all three are converted:

- `src/company/manifest.rs` `defaults_are_prosumer_safe` — asserted the
  three-string vector verbatim. Now asserts emptiness, with the comment naming
  `supervised` as the thing that actually makes the defaults safe.
- `src/company/manifest.rs` template test — asserted only
  `!always_approve.is_empty()`. A list's length says nothing about whether it
  fires; it now proves the template fence matches `publish_artifact` on the
  harness path the template uses.
- `src/policy/gate.rs` test helper — seeded its fence from
  `DEFAULT_ALWAYS_APPROVE`, so ~27 tests depended on a constant they do not own.
  Replaced with an explicit `FENCE` fixture. A test that borrows a shipped
  default tests the default, not the mechanism.

## Also fixed: the shipped template carried the same false fence explicitly

`companies/signals_opportunity_studio/company.toml:73` did not inherit the
default — it wrote all three entries out. Fixing only the constant would have
left the flagship template advertising a fence that gates nothing. It now reads
`always_approve = ["publish_artifact"]`: a real name, behaviour-neutral today
(`supervised` already parks every publish), and a shipped example of the correct
namespace.

## API Or Behavior Changes

- **`DEFAULT_ALWAYS_APPROVE` is now `&[]`** (was three dotted kinds). See the
  behaviour-change section above — it is a narrowing under `full` + a hosted
  brain, and a no-op under every other mode.
- **Operator-authored effect kinds remain open-ended.** There is no new
  registry-based manifest rejection; a hosted brain may emit a valid kind this
  repository does not know in advance.
- **The native-effect gate now honours leading-segment entries.** `["payment"]`
  parks `payment.send` natively, where before it parked nothing. This widens
  that arm, in the fail-safe direction, and makes it agree with the harness.
- **Matching is ASCII-case-insensitive and trims surrounding space** on both
  paths. Tool names reach the harness from openhuman's registry and
  `consequence_of` already lowercases defensively before consulting the
  declaration table, so a case difference would classify correctly and then slip
  the override — the same silent-miss class as this issue.
- New public module `crate::policy::always_approve` with the shared `matches`
  rule.

## Tests

All four lanes were run locally on the final head, after the rebase onto current
`main`:

- [x] `cargo fmt --all -- --check` — passed.
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — passed, zero lints. (`--no-deps` keeps pre-existing `vendor/tinyagents` lints, which CI does not see, out of the run.)
- [x] `cargo build --all-targets --features openhuman,tinycortex` — passed. Also `cargo check --locked --all-features --all-targets`, which is the lane that sees the `store::mongodb` / `store::sqlite` row-built `CompanyRecord` paths.
- [x] `cargo test --features openhuman,tinycortex` — **3089 passed, 0 failed, 3 ignored** (lib), plus 10 / 1 / 11 / 2 / 0 across the five other targets. No failures.

### Every added test was checked by reverting its fix

A test that cannot fail proves nothing, so each mechanism was reverted
individually and the suite re-run. Counts are quoted so a run that silently
selected nothing is distinguishable from a pass:

| reverted mechanism | result | test that caught it |
|---|---|---|
| segment boundary → bare `starts_with` | 16 ran, 1 failed | `a_prefix_that_is_not_a_whole_segment_does_not_gate` |
| matcher → exact-only | 16 ran, **5** failed | `a_leading_segment_gates_everything_under_it`, `both_approval_paths_agree_…`, +3 harness tests |
| case-insensitivity and trim dropped | 16 ran, 1 failed | `case_and_surrounding_space_do_not_defeat_the_override` |
| `gates` empty-entry guard dropped | 1 ran, 1 failed | `an_empty_entry_gates_nothing` |
| default restored to the three kinds | 16 ran, 1 failed | `every_default_entry_names_a_declared_target_and_the_default_is_empty` |
| default restored to the three kinds | 1 ran, 1 failed | `defaults_are_prosumer_safe` |
| native gate → exact-only compare | 16 ran, 1 failed | `both_approval_paths_agree_on_the_same_always_approve_list` |
| template's false fence restored | 1 ran, 1 failed | `signals_opportunity_studio_template_passes_lint` |

#### One of these tests was vacuous as first written, and this PR says so

`an_empty_entry_gates_nothing` **failed its revert-check**: it went on passing
with `gates`'s `entry.is_empty()` early return deleted — 16 ran, 0 failed. It
was not testing the guard at all.

The reason is the failure mode worth naming, because it is not obvious from
reading the test. Its assertions ran an empty entry against
`publish_artifact`, and for that target an empty entry already falls out of
both arms of `gates` unaided: `"".eq_ignore_ascii_case("publish_artifact")` is
false, and the segment arm reads `target.as_bytes()[0]`, which is `p`, not `.`.
The assertion was routed *through* the matcher and satisfied by the matcher's
own behaviour, so it pinned the stated contract while never reaching the
mechanism named in its own doc comment.

The empty **target** is the only input the guard actually decides — it is the
one case where the exact arm would otherwise return true, since `"" == ""`.
That case is now asserted, and the test fails when the guard is removed: **1
ran, 1 failed**. The guard is load bearing, and a whitespace-only line in an
operator's list cannot gate a blank effect kind.

Recorded rather than quietly repaired, because the test as first written is the
same shape as the defect this PR fixes: something that reads as protection,
passes, and checks nothing. A green assertion is not evidence until it has been
shown it can fail.

## Documentation

- `docs/spec/company-brain/approvals.md` — new section on what an entry names,
  why there is one namespace, why open effect kinds cannot be registry-validated,
  and why the default is empty.
- `docs/spec/runtime/manifest.md` — resolved the tool-name-vs-effect-kind
  contradiction between the `[policy]` prose and the `web_search` example, and
  updated the sample block.
- `src/policy/always_approve.rs` module docs carry the argument in full.
