### PR TITLE
fix(workflows): honest workflow errors — schema failures + workspace mkdir (#661)

### DIFF
--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -112,6 +112,14 @@ type EffectSlots = (
 /// policy and search backend are not built at all for a dry run — nothing needs
 /// them. Because every effect is stubbed, a future node kind cannot reach a real
 /// effect through a dry bundle: the engine only calls what is on the bundle.
+///
+/// # Errors
+///
+/// Live mode (issue #661) creates the per-run workspace directory the
+/// `tool_call` / `http_request` slots are rooted at; if that mkdir fails this
+/// returns [`OpenCompanyError::Harness`](crate::error::OpenCompanyError::Harness)
+/// rather than proceeding with effects pointed at a directory that does not
+/// exist. A dry run builds no workspace and is infallible.
 pub async fn build_capabilities(
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
@@ -120,7 +128,7 @@ pub async fn build_capabilities(
     run_id: &str,
     run_request: Option<String>,
     dry_run: bool,
-) -> Capabilities {
+) -> crate::error::Result<Capabilities> {
     let company = record.id.clone();
     // Issue #562: the tier actually in force — the operator's console override
     // when one is set, the manifest's otherwise. Reading `manifest.policy` here
@@ -171,14 +179,20 @@ pub async fn build_capabilities(
         )
     } else {
         let workflow_ws = workflow_workspace(&deps.workspace_root, &company, workflow_id, run_id);
-        if let Err(err) = tokio::fs::create_dir_all(&workflow_ws).await {
-            tracing::warn!(
-                company = %company,
-                workspace = %workflow_ws.display(),
-                %err,
-                "workflow: could not create the per-run workspace"
-            );
-        }
+        // L2 (issue #661): a workspace the `tool_call` / `http_request` slots
+        // cannot create is not something to warn past and keep going — the run
+        // would proceed with those effects rooted at a directory that does not
+        // exist, failing later and further from the cause. Abort here so the
+        // caller sees the real reason. The failure precedes the WorkflowRunStarted
+        // journal append, so a failed mkdir leaves no orphaned started row.
+        tokio::fs::create_dir_all(&workflow_ws)
+            .await
+            .map_err(|err| {
+                crate::error::OpenCompanyError::Harness(format!(
+                    "workflow run could not create its workspace directory {}: {err}",
+                    workflow_ws.display()
+                ))
+            })?;
 
         // ONE exec-security policy shared by the tool_call toolbelt and the
         // http_request client, sandboxed to the workflow workspace with the
@@ -242,7 +256,7 @@ pub async fn build_capabilities(
         (Arc::new(tools), Arc::new(http), state, Some(agent))
     };
 
-    Capabilities {
+    Ok(Capabilities {
         llm: Arc::new(UnwiredLlm),
         tools,
         http,
@@ -260,7 +274,7 @@ pub async fn build_capabilities(
         // no company manifest can currently produce one (`NodeKind` has no
         // `memory` variant on our side).
         memory: None,
-    }
+    })
 }
 
 /// Builds a traversal-safe workspace path unique to one workflow execution.
@@ -813,7 +827,8 @@ mod tests {
             None,
             false,
         )
-        .await;
+        .await
+        .expect("build_capabilities");
 
         assert!(
             caps.memory.is_none(),
@@ -852,7 +867,8 @@ mod tests {
             None,
             true, // dry
         )
-        .await;
+        .await
+        .expect("build_capabilities");
 
         // http: the stub echoes without sending, carrying the marker.
         let http_out = caps
@@ -886,5 +902,87 @@ mod tests {
             None,
             "dry state must be the inert NoopState, never durable"
         );
+    }
+
+    // ── Issue #661 (L2): a workspace mkdir failure aborts the live build ──
+
+    /// T5 — live mode with an impossible `workspace_root` (a path rooted under a
+    /// regular file) fails the build with a `Harness` error naming the path and
+    /// the underlying I/O cause, instead of warning past it and handing back a
+    /// bundle whose effects are rooted at a directory that does not exist.
+    #[tokio::test]
+    async fn build_capabilities_live_errors_when_workspace_cannot_be_created() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        // A regular file where a directory would need to be: `create_dir_all`
+        // under it fails with ENOTDIR.
+        let not_a_dir = dir.path().join("not-a-dir");
+        std::fs::write(&not_a_dir, b"x").expect("write file");
+
+        let (mut deps, _journal) = crate::workflows::gated_tool_turn_test::deps(
+            "http://127.0.0.1:1/unused".to_string(),
+            dir.path(),
+        );
+        deps.workspace_root = not_a_dir.clone();
+        let record = crate::workflows::gated_tool_turn_test::record();
+
+        // `Capabilities` is not `Debug`, so match rather than `expect_err`.
+        let err = match build_capabilities(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &record,
+            "wf",
+            "run:1",
+            None,
+            false, // live: the workspace mkdir runs
+        )
+        .await
+        {
+            Ok(_) => panic!("an uncreatable workspace must fail the build"),
+            Err(err) => err,
+        };
+
+        let crate::error::OpenCompanyError::Harness(msg) = &err else {
+            panic!("expected a Harness error, got {err:?}");
+        };
+        assert!(
+            msg.contains("could not create its workspace directory"),
+            "message should name the failure: {msg}"
+        );
+        assert!(
+            msg.contains("not-a-dir"),
+            "message should name the offending path: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("not a directory"),
+            "message should carry the underlying I/O cause: {msg}"
+        );
+    }
+
+    /// T6 — the same impossible root is harmless for a dry run: it builds no
+    /// workspace, so the bundle assembles fine.
+    #[tokio::test]
+    async fn build_capabilities_dry_ignores_an_impossible_workspace_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let not_a_dir = dir.path().join("not-a-dir");
+        std::fs::write(&not_a_dir, b"x").expect("write file");
+
+        let (mut deps, _journal) = crate::workflows::gated_tool_turn_test::deps(
+            "http://127.0.0.1:1/unused".to_string(),
+            dir.path(),
+        );
+        deps.workspace_root = not_a_dir;
+        let record = crate::workflows::gated_tool_turn_test::record();
+
+        build_capabilities(
+            Arc::new(HarnessPool::new()),
+            deps,
+            &record,
+            "wf",
+            "run:1",
+            None,
+            true, // dry: no workspace mkdir at all
+        )
+        .await
+        .expect("a dry build never touches the workspace");
     }
 }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -36,7 +36,10 @@
 //! Still **not wired**: the bare-completion `LlmProvider` fallback and `code`
 //! nodes. They are explicit stubs that return a clear capability error rather
 //! than a silent no-op, so a workflow that reaches one fails loudly; a workflow
-//! that never reaches one is unaffected.
+//! that never reaches one is unaffected. The `llm` stub takes care to report the
+//! *right* failure: the engine's output_parser auto-fix (default on) calls `llm`
+//! to repair a schema mismatch, so that stub surfaces the schema errors rather
+//! than masking them behind "bare LLM completion is not wired" (issue #661).
 //!
 //! Also not wired, and for a different reason: **memory**, which tinyflows 0.6
 //! added with the #499 pin bump. The other two are unbuilt; this one is
@@ -640,20 +643,76 @@ pub(super) fn run_request_text(input: &Value) -> Option<String> {
     (!trimmed.is_empty()).then_some(trimmed.to_string())
 }
 
-/// The bare-completion fallback. An `agent` node with no `agent_ref` would land
-/// here; [`translate`](crate::workflows::translate) always sets `agent_ref` for a
-/// roster agent, so reaching this means an agent node with no teammate assigned.
+/// The message a bare-LLM call that is NOT the engine's schema auto-fix gets: an
+/// `agent` node reached `llm` with no `agent_ref`.
+/// [`translate`](crate::workflows::translate) always sets `agent_ref` for a roster
+/// agent, so reaching that path means an agent node with no teammate assigned.
+const BARE_LLM_UNWIRED_MESSAGE: &str = "workflow agent node has no roster agent; bare LLM \
+     completion is not wired for company workflows";
+
+/// The bare-completion fallback (`llm` capability), left unwired for company
+/// workflows.
+///
+/// Two distinct callers reach this, and issue #661 (M4) is that they used to get
+/// the same message:
+///
+/// * The engine's **output_parser auto-fix** (default on) calls `llm` to *repair*
+///   a value that failed schema validation — handing us
+///   `{ "task": "coerce_to_schema", "schema", "value", "errors": [ … ] }`. Because
+///   this path errors here, the generic "bare LLM completion is not wired"
+///   message used to **mask** the real failure (the schema errors) the operator
+///   needed to see. Now that shape surfaces the schema failures and merely *notes*
+///   that the repair path is unavailable.
+/// * An **`agent` node with no `agent_ref`** lands here with the node config as
+///   the request. That genuinely is "no roster agent", and keeps the original
+///   message byte-identical.
 struct UnwiredLlm;
 
 #[async_trait]
 impl LlmProvider for UnwiredLlm {
-    async fn complete(&self, _request: Value, _conn: Option<&str>) -> TfResult<Value> {
+    async fn complete(&self, request: Value, _conn: Option<&str>) -> TfResult<Value> {
+        // The engine's output-parser auto-fix asked us to coerce a value to a
+        // schema and handed us the schema failures. Surface THOSE — the real
+        // cause — rather than a message about the (unavailable) repair path,
+        // which is what masked them before #661. Same `output_parser: value
+        // failed schema validation:` lead the engine's non-auto-fix arm uses, so
+        // the on_error-routed error reads identically whichever arm produced it.
+        if let Some(errors) = auto_fix_schema_errors(&request) {
+            return Err(EngineError::Capability(format!(
+                "output_parser: value failed schema validation: {errors} (LLM auto-fix is not \
+                 available: bare LLM completion is not wired for company workflows)"
+            )));
+        }
+        // Any other request — an agent node with no `agent_ref`, whose request is
+        // the node config — keeps the original message unchanged.
         Err(EngineError::Capability(
-            "workflow agent node has no roster agent; bare LLM completion is not wired for \
-             company workflows"
-                .to_string(),
+            BARE_LLM_UNWIRED_MESSAGE.to_string(),
         ))
     }
+}
+
+/// Extracts the joined schema-validation failures from the engine's output-parser
+/// auto-fix request, if this is one.
+///
+/// The engine's `schema::parse_and_validate` asks `llm` to coerce a value to a
+/// schema with `{ "task": "coerce_to_schema", "schema", "value", "errors": [ … ] }`,
+/// where `errors` is the non-empty list of human-readable schema failures. Returns
+/// those failures joined by `; ` for exactly that shape, and `None` for anything
+/// else — including a `coerce_to_schema` request with a missing / empty / non-string
+/// `errors` — so the caller falls back to the generic bare-LLM message. Matching on
+/// the request shape (not the node kind) also covers the `agent` node's own
+/// output-parser sub-port, which routes through the same engine helper.
+fn auto_fix_schema_errors(request: &Value) -> Option<String> {
+    if request.get("task").and_then(Value::as_str) != Some("coerce_to_schema") {
+        return None;
+    }
+    let errors: Vec<&str> = request
+        .get("errors")?
+        .as_array()?
+        .iter()
+        .filter_map(Value::as_str)
+        .collect();
+    (!errors.is_empty()).then(|| errors.join("; "))
 }
 
 /// `code` nodes are not part of the OpenCompany model and never emitted by
@@ -902,6 +961,89 @@ mod tests {
             None,
             "dry state must be the inert NoopState, never durable"
         );
+    }
+
+    // ── Issue #661 (M4): the unwired `llm` stub reports the RIGHT failure ──
+
+    /// T1 — the engine's output_parser auto-fix request (it calls `llm` to repair
+    /// a schema mismatch) surfaces the SCHEMA errors, not the generic bare-LLM
+    /// lead that used to mask them.
+    #[tokio::test]
+    async fn unwired_llm_surfaces_schema_errors_on_auto_fix_request() {
+        let request = json!({
+            "task": "coerce_to_schema",
+            "schema": { "type": "object", "required": ["name", "age"] },
+            "value": { "other": 1 },
+            "errors": [
+                "$: missing required property `name`",
+                "$: missing required property `age`",
+            ],
+        });
+        let EngineError::Capability(msg) = UnwiredLlm
+            .complete(request, None)
+            .await
+            .expect_err("an unwired llm must error")
+        else {
+            panic!("expected a capability error");
+        };
+        // The real cause is present…
+        assert!(
+            msg.contains("failed schema validation"),
+            "should carry the schema-validation lead: {msg}"
+        );
+        assert!(
+            msg.contains("missing required property `name`")
+                && msg.contains("missing required property `age`"),
+            "should carry the specific schema failures: {msg}"
+        );
+        // …and it does NOT lead with the generic bare-LLM message that hid them.
+        assert!(
+            !msg.starts_with("workflow agent node has no roster agent"),
+            "the schema failure must not be masked by the generic lead: {msg}"
+        );
+    }
+
+    /// T2 — any other request (here an agent node with no `agent_ref`, whose
+    /// request is the node config) keeps the generic message byte-identical.
+    #[tokio::test]
+    async fn unwired_llm_keeps_generic_message_for_non_auto_fix_request() {
+        let EngineError::Capability(msg) = UnwiredLlm
+            .complete(json!({ "prompt": "hi" }), None)
+            .await
+            .expect_err("an unwired llm must error")
+        else {
+            panic!("expected a capability error");
+        };
+        assert_eq!(
+            msg, BARE_LLM_UNWIRED_MESSAGE,
+            "a non-auto-fix request must get the byte-identical generic message"
+        );
+    }
+
+    /// T4 — a `coerce_to_schema` request whose `errors` is empty or missing (or
+    /// not an array of strings) falls back to the generic message rather than
+    /// emitting an empty schema-error string or panicking.
+    #[tokio::test]
+    async fn unwired_llm_falls_back_when_auto_fix_carries_no_errors() {
+        for request in [
+            json!({ "task": "coerce_to_schema" }),
+            json!({ "task": "coerce_to_schema", "errors": [] }),
+            json!({ "task": "coerce_to_schema", "errors": "oops" }),
+            json!({ "task": "coerce_to_schema", "errors": [1, 2] }),
+        ] {
+            let EngineError::Capability(msg) = UnwiredLlm
+                .complete(request.clone(), None)
+                .await
+                .expect_err("an unwired llm must error")
+            else {
+                panic!("expected a capability error for {request}");
+            };
+            assert_eq!(
+                msg, BARE_LLM_UNWIRED_MESSAGE,
+                "a coerce_to_schema request with no usable errors must fall back \
+                 to the generic message: {request}"
+            );
+        }
     }
 
     // ── Issue #661 (L2): a workspace mkdir failure aborts the live build ──

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -260,6 +260,10 @@ async fn run_workflow_inner(
     // durable effect around the engine — the started/finished/node journal
     // writes, the delivery dispatch, and gate parking. Read once here.
     let dry_run = ctx.dry_run;
+    // Issue #661 (L2): a failed per-run-workspace mkdir aborts the run here,
+    // BEFORE the WorkflowRunStarted journal append below — so a workspace the
+    // effects cannot be rooted at leaves no orphaned started row, and the caller
+    // sees the real cause instead of a later, further-removed effect failure.
     let capabilities = super::caps::build_capabilities(
         pool,
         deps,
@@ -269,7 +273,7 @@ async fn run_workflow_inner(
         run_request,
         dry_run,
     )
-    .await;
+    .await?;
 
     // The opening bracket, appended BEFORE the engine call so a run killed
     // mid-flight leaves a start with no finish — which is precisely the shape

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -2018,6 +2018,65 @@ to = "done"
         );
     }
 
+    /// T-output_parser AUTO-FIX (issue #661, M4) — the vendored-engine drift
+    /// catcher. With `auto_fix` DEFAULTED (true) and no roster LLM wired, a
+    /// schema failure sends the engine to the `llm` capability to *repair* the
+    /// value. The unwired `llm` must surface the SCHEMA failure, so the
+    /// `on_error = continue` error item names the missing property — NOT the
+    /// generic "no roster agent" message that used to mask it.
+    ///
+    /// This exercises the real request the engine builds
+    /// (`task = "coerce_to_schema"` with the schema `errors`), so a future
+    /// tinyflows pin that reshapes that request fails here rather than silently
+    /// reverting to the masked message.
+    #[tokio::test]
+    async fn t_output_parser_auto_fix_surfaces_schema_failure_not_no_roster_agent() {
+        // Note: NO `auto_fix = false` — the default (true) is exactly the path
+        // that reaches the `llm` auto-fix capability.
+        let src = r#"
+id = "op_af_wf"
+name = "Parser Auto-fix WF"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "parse"
+kind = "output_parser"
+name = "Parse"
+on_error = "continue"
+[node.config.schema]
+type = "object"
+required = ["name"]
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "parse"
+[[edge]]
+from = "parse"
+to = "done"
+"#;
+        let dir = tempfile::tempdir().unwrap();
+        let run = run_src(dir.path(), src, serde_json::json!({ "other": 1 }))
+            .await
+            .expect("run completes despite the schema failure");
+
+        let message = run.output["nodes"]["parse"]["items"][0]["json"]["error"]["message"]
+            .as_str()
+            .unwrap_or_else(|| panic!("expected a routed error item: {}", run.output));
+        assert!(
+            message.contains("schema validation") && message.contains("name"),
+            "the auto-fix path must surface the schema failure: {message}"
+        );
+        assert!(
+            !message.contains("no roster agent"),
+            "the schema failure must not be masked by the bare-LLM message: {message}"
+        );
+    }
+
     /// T-sub_workflow — a `sub_workflow` node runs a child saved on disk (depth
     /// 1), resolved by id through the wired source directory.
     #[tokio::test]


### PR DESCRIPTION
## Summary

**Part of #661 — M4 + L2.** Two honest-error fixes on the company-workflow capability bundle, so a failing run reports the real cause instead of a masking or misleading one. Both are real-defect error-surfacing fixes: nothing is demoted or suppressed — nodes still fail and route per their `on_error` policy.

**M4 — schema failures masked by the unwired `llm` stub.** The vendored tinyflows engine's `output_parser` (and the `agent` node's output-parser sub-port) runs a one-shot LLM *auto-fix* by default: when a value fails schema validation it calls the `llm` capability to repair it. OpenCompany wires `llm` to `UnwiredLlm`, which errored with a generic `"bare LLM completion is not wired for company workflows"`. That error propagated in place of the actual schema errors, so an operator saw a message about an unwired LLM rather than *which field was wrong*. `UnwiredLlm::complete` now detects the engine's auto-fix request (`task == "coerce_to_schema"` carrying the schema `errors`) and surfaces those failures — using the same `output_parser: value failed schema validation:` lead the engine's own non-auto-fix arm uses — while noting the repair path is unavailable. Every other request (e.g. an `agent` node with no `agent_ref`) keeps the original generic message byte-identical. The vendored engine is not modified, and `auto_fix` is not stamped off at translate time (that would miss runtime-authored graphs and the agent sub-port).

**L2 — per-run workspace mkdir failure warned-and-continued.** In live mode `build_capabilities` creates the per-run workflow workspace the `tool_call` / `http_request` slots are rooted at. A failed `create_dir_all` only logged a warning and carried on, so the run proceeded with those effects pointed at a directory that does not exist and failed later, further from the cause. `build_capabilities` now returns `crate::error::Result<Capabilities>` and maps the mkdir error to `OpenCompanyError::Harness` (the variant capability failures already map to); the single production caller in `run_workflow_inner` aborts with `?`. Because the mkdir precedes the `WorkflowRunStarted` journal append, a failed mkdir aborts cleanly with no orphaned started row. The dry branch builds no workspace and stays infallible.

## API Or Behavior Changes

- `workflows::caps::build_capabilities` now returns `crate::error::Result<Capabilities>` instead of `Capabilities` (internal API; the one production caller and two tests are updated).
- A workflow whose per-run workspace cannot be created now fails the run with a clear `Harness` error instead of continuing into a later, misleading failure.
- An `output_parser` schema failure with `auto_fix` enabled (the default) now reports the schema errors instead of "bare LLM completion is not wired". Routing is unchanged — the node still errors and follows its `on_error` policy.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo clippy --locked --no-deps --all-targets --features openhuman,tinycortex -- -D warnings`
- [x] `cargo check --locked --all-targets`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `cargo test --locked`
- [x] `cargo test --locked --features openhuman,tinycortex --tests`

New tests: unit coverage that the unwired `llm` stub surfaces schema errors on the auto-fix request (with the specific failures), keeps the generic message byte-identical for a non-auto-fix request, and falls back safely when a `coerce_to_schema` request carries no usable `errors`; `build_capabilities` live-mode failing with an uncreatable workspace (naming the path + I/O cause) and the dry build ignoring the same impossible root; and an end-to-end drift catcher driving a real `output_parser` node through the engine with `auto_fix` defaulted, asserting the routed error item carries the schema failure and not the bare-LLM message — so a future tinyflows pin that reshapes the auto-fix request fails here.

## Documentation

Module and item docs in `src/workflows/caps/mod.rs` updated: the "still not wired" header note now explains the `llm` stub reports the schema failure, `build_capabilities` gained an `# Errors` section, and `UnwiredLlm` documents the two callers it disambiguates. No external docs affected.

Related: #661.
