### PR TITLE
fix(policy): let an overlay teammate be scoped, and bound what add_agent may mint

### DIFF
--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -229,8 +229,16 @@ exactly one root and no member folders.
 Team writes are an **operator overlay** persisted through the store, merged
 into the manifest roster at read time — the version-controlled `company.toml`
 is never rewritten. Overlay teammates are addressable: since issue #71 the
-harness builds a real agent for each one, with the company-wide tool grant, no
-cognition tier, and never the orchestrator.
+harness builds a real agent for each one, with no cognition tier and never the
+orchestrator.
+
+Since issue #619 an overlay teammate carries its own `tools` list — the
+overlay's answer to a manifest `[[agent]].tools` line, and the thing that was
+missing when the only readable answer for every teammate was "everything the
+company allows". It obeys the same rule a manifest line does: **empty means the
+company's standard grant** (#264), so a teammate written before the field
+existed reads back exactly as it did. What changed is that a non-empty value is
+now writable at all.
 
 `POST …/team` and the orchestrator's `add_agent` tool both **derive the roster
 id from the display name** (issue #686): "Dana Designer" becomes
@@ -270,7 +278,7 @@ lists, because only the third is the answer:
 
 | field | meaning |
 |---|---|
-| `requested` | the agent's own `[[agent]].tools` globs. **Empty means the company's standard grant**, not "no tools" |
+| `requested` | the agent's own globs — a manifest `[[agent]].tools` line, or an overlay teammate's `tools` list (#619). **Empty means the company's standard grant**, not "no tools" |
 | `companyAllow` | the `[tools].allow` ceiling the request is intersected with |
 | `effective` | what the agent actually holds |
 
@@ -280,18 +288,42 @@ when it builds the agent, so the readout cannot drift from what is enforced.
 "orchestrator"` agent, else the first declared) rather than read off `tier`, so
 a company that tags nobody still names its orchestrator.
 
-`PATCH …/team/{agentId}` edits an **overlay** teammate's `name`, `role` and
-`description`. It is a patch: an omitted key is left alone, and `"description":
-null` clears it — the two must stay apart or every partial save would erase an
-agent's instructions. A blank `name`/`role` is `400`, an unknown teammate `404`,
+`PATCH …/team/{agentId}` edits an **overlay** teammate's `name`, `role`,
+`description` and `tools`. It is a patch: an omitted key is left alone, and
+`"description": null` clears it — the two must stay apart or every partial save
+would erase an agent's instructions. `tools` needs no such distinction: an
+omitted key leaves the scope alone and `"tools": []` is the deliberate way back
+to the company's standard grant, so `null` never has to mean a third thing. A
+blank glob inside the list is a `400` — `""` matches nothing an operator meant,
+and storing it would read as a scope that grants nothing while looking like a
+scope that was set. Globs are stored verbatim, exactly like a manifest line: the
+`[tools].allow` ceiling is applied at read time, so a glob the company does not
+cover surfaces as asked-for-but-not-granted rather than vanishing on save.
+
+A blank `name`/`role` is `400`, an unknown teammate `404`,
 and a **manifest** teammate is `409`: its fields live in the version-controlled
 `company.toml`, and the console does not rewrite the blueprint. The one thing
 that *is* changeable on such a teammate is its daily budget, and that works
 because #343 modelled it as an override rather than as a rewrite. Every detail
 response carries an `editable` list naming the fields this route will accept, so
 a client renders read-only from the host's answer instead of re-deriving the
-rule. `tier` and `tools` are read-only for both kinds: there is no override
-layer for either, and adding one is a policy decision rather than a form field.
+rule. `tier` stays read-only for both kinds: there is no override layer for it,
+and adding one is a policy decision rather than a form field. `tools` was
+read-only for the same reason until #619 made that policy decision for the
+overlay half — a manifest teammate's `tools` line still lives in the blueprint
+and is still `409`.
+
+The orchestrator's `add_agent` tool writes the same field, under one added rule:
+**a minted teammate is never wider than the agent that minted it** (#619).
+Omitting `tools` copies the minter's own line — so an unscoped minter still
+mints an unscoped teammate, which keeps tracking `[tools].allow` instead of
+freezing a copy of it. Passing `tools` narrows the request against what the
+minter actually holds, and a request that narrows to nothing is a clean tool
+error rather than a stored empty list, because an empty list means *inherit
+everything* — silently storing one would turn a deliberate narrowing into the
+widest grant in the company. Every mint is logged with the minter, the teammate
+and the resolved scope: `add_agent` is `Reach::Nothing` and never asks, so the
+log is the only place the grant is observable at all.
 
 The two **budget** routes (issue #343) are how a teammate's `budget_usd_daily`
 becomes changeable without a redeploy. Both are **admin-only** — a member gets

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -4597,6 +4597,7 @@ members = ["engineer"]
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         tasks
             .upsert(&CompanyId::new("acme"), &card("t1", "nova"))
@@ -4925,6 +4926,7 @@ members = ["eng1", "eng2"]
                 name: "Cto".to_string(),
                 role: "CTO".to_string(),
                 description: None,
+                tools: Vec::new(),
             }],
             overlay_desk_members: vec![crate::ports::types::OverlayDeskMember {
                 desk_id: "eng".to_string(),

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -610,6 +610,13 @@ pub fn build_agent(
             // the `read_run_output` companion reads back, so a clipped preview
             // is reachable within the turn. Orchestrator-only, like the tools.
             deps.run_outputs.clone(),
+            // Issue #619: who is minting, and how wide they are. `add_agent`
+            // bounds the teammate it mints by this agent's own scope, and names
+            // this agent in the mint log — a teammate can no longer be minted
+            // wider than its minter, or minted invisibly.
+            manifest_agent.id.clone(),
+            manifest_agent.tools.clone(),
+            grants.to_vec(),
         ));
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1867,6 +1867,12 @@ fn overlay_fingerprint(agents: &[OverlayAgent]) -> u64 {
         agent.name.hash(&mut hasher);
         agent.role.hash(&mut hasher);
         agent.description.hash(&mut hasher);
+        // Issue #619: the teammate's own tool line is roster-shaping, not
+        // display data — it decides what `build_agent` wires onto the agent. A
+        // scope narrowed through the console would otherwise not take effect
+        // until the next restart, which is the silent-no-op trap this repo has
+        // already hit twice (`policy_fingerprint` in #562, and this axis).
+        agent.tools.hash(&mut hasher);
     }
     hasher.finish()
 }
@@ -2129,10 +2135,11 @@ pub(crate) fn build_roster(
 }
 
 /// Converts an operator-added [`OverlayAgent`] into the manifest agent shape
-/// [`build::build_agent`] consumes: an empty `tools` list (so
-/// [`agent_effective_grants`] falls back to the full company `[tools].allow`
-/// — the "standard tool grant"), no cognition tier (→ the default `chat-v1`
-/// model), and no manifest budget cap — an overlay teammate has no manifest row
+/// [`build::build_agent`] consumes: the teammate's own `tools` line verbatim
+/// (issue #619 — empty, as it is for every teammate minted before that field
+/// existed, so [`agent_effective_grants`] falls back to the full company
+/// `[tools].allow`, the "standard tool grant"), no cognition tier (→ the default
+/// `chat-v1` model), and no manifest budget cap — an overlay teammate has no manifest row
 /// at all, so its cap (if any) comes from the record's budget overrides via
 /// [`CompanyRecord::effective_budget`], resolved by the caller. The overlay's
 /// `name` is a display
@@ -2146,7 +2153,7 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         role: overlay.role.clone(),
         description: overlay.description.clone(),
         tier: None,
-        tools: Vec::new(),
+        tools: overlay.tools.clone(),
         budget_usd_daily: None,
     }
 }
@@ -2574,6 +2581,84 @@ description = "Builds the product."
         );
     }
 
+    /// Issue #619: an overlay teammate's own tool line reaches the manifest
+    /// shape `build_agent` consumes, verbatim.
+    ///
+    /// This is the harness half of the lockstep pair the issue names — the
+    /// console's `requested_grants` is the other. If this dropped the scope
+    /// back to an empty list, the console would render a narrowing the harness
+    /// never applied.
+    #[test]
+    fn an_overlay_teammates_tool_line_reaches_the_manifest_shape() {
+        let scoped = OverlayAgent {
+            id: "growth".into(),
+            name: "Jamie".into(),
+            role: "Growth Lead".into(),
+            description: None,
+            tools: vec!["workspace".into()],
+        };
+        assert_eq!(
+            overlay_agent_to_manifest(&scoped).tools,
+            vec!["workspace".to_string()],
+            "the scope must survive the conversion, or nothing downstream \
+             enforces it"
+        );
+
+        // And the unscoped teammate — every one written before #619 — still
+        // converts to an empty list, which `agent_effective_grants` reads as the
+        // company's standard grant (#264, unchanged).
+        let unscoped = OverlayAgent {
+            tools: Vec::new(),
+            ..scoped
+        };
+        assert!(overlay_agent_to_manifest(&unscoped).tools.is_empty());
+    }
+
+    /// Issue #619, the fingerprint axis: narrowing a teammate's scope must make
+    /// `overlay_fingerprint` disagree with itself, or `HarnessPool::ensure`'s
+    /// staleness fast-path skips the rebuild and the narrowing does not take
+    /// effect until the process restarts.
+    ///
+    /// This repo has shipped that exact silent no-op twice (`policy_fingerprint`
+    /// in #562, and this axis). `overlay_fingerprint` hashes `overlay_agents`
+    /// only, so a field added to `OverlayAgent` is covered *only* if it is
+    /// hashed here.
+    #[test]
+    fn narrowing_a_teammates_scope_changes_the_overlay_fingerprint() {
+        let unscoped = OverlayAgent {
+            id: "growth".into(),
+            name: "Jamie".into(),
+            role: "Growth Lead".into(),
+            description: None,
+            tools: Vec::new(),
+        };
+        let scoped = OverlayAgent {
+            tools: vec!["workspace".into()],
+            ..unscoped.clone()
+        };
+        let widened = OverlayAgent {
+            tools: vec!["workspace".into(), "composio".into()],
+            ..unscoped.clone()
+        };
+
+        let fp = |a: &OverlayAgent| overlay_fingerprint(std::slice::from_ref(a));
+        assert_ne!(
+            fp(&unscoped),
+            fp(&scoped),
+            "scoping a teammate must be visible to the freshness gate"
+        );
+        assert_ne!(
+            fp(&scoped),
+            fp(&widened),
+            "and so must widening one that was already scoped"
+        );
+        assert_eq!(
+            fp(&unscoped),
+            fp(&unscoped.clone()),
+            "while an unchanged teammate must not churn the roster"
+        );
+    }
+
     /// Issue #71 — an operator/orchestrator-added overlay teammate is promoted
     /// into a real, addressable roster agent (not just a console row).
     #[tokio::test]
@@ -2585,6 +2670,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: Some("Owns acquisition experiments.".into()),
+            tools: Vec::new(),
         });
 
         let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
@@ -2608,6 +2694,7 @@ description = "Builds the product."
             name: "Impostor".into(),
             role: "Shadow CEO".into(),
             description: None,
+            tools: Vec::new(),
         });
 
         let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
@@ -2637,7 +2724,7 @@ description = "Builds the product."
     async fn a_tool_added_teammate_colliding_with_a_manifest_id_still_joins_the_roster() {
         use openhuman_core::openhuman::tools::Tool;
 
-        use crate::harness::orchestrator::AddAgentTool;
+        use crate::harness::orchestrator::unscoped_add_agent;
 
         /// A `CompanyStore` that actually holds the record, unlike
         /// `RecordingStore` — `add_agent` has to load what it saves.
@@ -2667,7 +2754,7 @@ description = "Builds the product."
         let fx = fixture();
         let company = CompanyId::new("acme");
         let store = Arc::new(SeededStore(StdMutex::new(record())));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         let result = tool
             .execute(serde_json::json!({ "name": "Engineer", "role": "Platform" }))
@@ -2731,6 +2818,7 @@ description = "Builds the product."
             name: "Dana".into(),
             role: "Designer".into(),
             description: None,
+            tools: Vec::new(),
         });
         pool.ensure(&rec, &fx.deps).await.expect("second ensure");
 
@@ -3765,6 +3853,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: None,
+            tools: Vec::new(),
         });
         live_store.save(&updated).await.unwrap();
 
@@ -4595,6 +4684,7 @@ description = "Builds the product."
             name: "Jamie".into(),
             role: "Growth Lead".into(),
             description: None,
+            tools: Vec::new(),
         });
         let live_store = Arc::new(LiveStore::default());
         live_store.save(&rec).await.unwrap();

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -124,6 +124,7 @@ pub const QUERY_COMPANY_TOOL: &str = "query_company";
 // The `spawn_task` / `delegate_to_desk` names are the brain-agnostic canonical
 // constants (issue #176) — re-exported here so the harness path and the hosted
 // path share one definition and cannot drift.
+use crate::runtime::builder::agent_effective_grants;
 use crate::runtime::delegation_tools;
 pub use crate::runtime::delegation_tools::{DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL};
 /// The `run_workflow` tool name (issue #67).
@@ -1738,7 +1739,35 @@ pub fn delegation_tools(
 ///
 /// No lifecycle states, budgets, or workspace/memory namespaces here — those
 /// stay future work per the design doc; this tool only ever appends a roster
-/// entry with the standard company-wide tool grant.
+/// entry.
+///
+/// # The minted teammate's tool scope (issue #619)
+///
+/// `add_agent` is [`Reach::Nothing`](crate::policy::consequence) and sits in
+/// `INTRINSIC_TOOLS`, so it is always present and never asks. Before #619 the
+/// teammate it minted had no tools field at all and therefore held the
+/// company's **whole** `[tools].allow` — a model could mint a teammate holding
+/// the widest grant in the company with no approval anywhere in the path.
+///
+/// The rule now: **a minted teammate is never wider than the agent that minted
+/// it.**
+///
+/// * With no `tools` argument, the teammate copies the minter's own `tools`
+///   line verbatim. Copying the *line* rather than the resolved grant matters:
+///   an unscoped minter (empty line) mints an unscoped teammate that keeps
+///   tracking `[tools].allow`, instead of freezing today's allow-list into the
+///   record as an explicit scope that a later company-wide narrowing would not
+///   reach.
+/// * With a `tools` argument, the request is narrowed against the minter's own
+///   **effective** grant, so the teammate cannot be handed something the minter
+///   does not itself hold. A request that survives that narrowing empty is a
+///   clean error rather than a stored empty list — an empty list means "inherit
+///   everything", so silently storing one would turn a deliberate narrowing
+///   into the widest possible grant. That inversion is the whole defect #619
+///   was filed about, and it must not be reachable through the fix for it.
+///
+/// Every mint is logged with the minter, the teammate, and the resolved grant.
+/// A narrowing nobody can observe is the same defect wearing a different hat.
 ///
 /// Writes are serialised per-company through a shared static mutex map, so the
 /// orchestrator's `add_agent` and the console `POST .../team` route can never
@@ -1752,14 +1781,55 @@ pub fn delegation_tools(
 pub struct AddAgentTool {
     company: CompanyId,
     store: Arc<dyn CompanyStore>,
+    /// The id of the agent this tool is wired onto — the minter, named in the
+    /// mint log so an operator can see who added a teammate and with what.
+    minter: String,
+    /// The minter's own `tools` line, verbatim. Empty means the minter itself
+    /// inherits the company grant; the teammate then does too.
+    minter_tools: Vec<String>,
+    /// The minter's **effective** grant — its line already narrowed by the
+    /// company `allow`. The ceiling an explicit `tools` argument is clamped to.
+    minter_grants: Vec<String>,
 }
 
 impl AddAgentTool {
     /// Builds the tool over the company id and its store handle
-    /// ([`HarnessDeps::store`](crate::harness::HarnessDeps::store)).
-    pub fn new(company: CompanyId, store: Arc<dyn CompanyStore>) -> Self {
-        Self { company, store }
+    /// ([`HarnessDeps::store`](crate::harness::HarnessDeps::store)), plus the
+    /// minting agent's identity and tool scope (issue #619) — see the type docs
+    /// for why a minted teammate is bounded by its minter.
+    pub fn new(
+        company: CompanyId,
+        store: Arc<dyn CompanyStore>,
+        minter: String,
+        minter_tools: Vec<String>,
+        minter_grants: Vec<String>,
+    ) -> Self {
+        Self {
+            company,
+            store,
+            minter,
+            minter_tools,
+            minter_grants,
+        }
     }
+}
+
+/// An `add_agent` tool wired onto an **unscoped** minter: an agent whose own
+/// `tools` line is empty and which therefore holds the whole company grant.
+///
+/// This is the pre-#619 shape of every minter, so a test written before the
+/// scoping seam existed still describes the same company through it. A test
+/// that cares about narrowing constructs the tool directly with a scoped
+/// minter instead.
+#[cfg(test)]
+pub(crate) fn unscoped_add_agent(company: CompanyId, store: Arc<dyn CompanyStore>) -> AddAgentTool {
+    AddAgentTool::new(
+        company,
+        store,
+        "ceo".to_string(),
+        Vec::new(),
+        vec!["fs:*".to_string(), "web:*".to_string()],
+    )
 }
 
 #[async_trait]
@@ -1769,7 +1839,7 @@ impl Tool for AddAgentTool {
     }
 
     fn description(&self) -> &str {
-        "Add a new teammate to the company. Provide a `name`, a `role` (job title), and an optional `description` of their mandate. The teammate becomes a real, addressable member of the roster starting next turn."
+        "Add a new teammate to the company. Provide a `name`, a `role` (job title), an optional `description` of their mandate, and an optional `tools` scope. The teammate becomes a real, addressable member of the roster starting next turn."
     }
 
     fn parameters_schema(&self) -> Value {
@@ -1778,7 +1848,12 @@ impl Tool for AddAgentTool {
             "properties": {
                 "name": { "type": "string", "description": "The new teammate's display name." },
                 "role": { "type": "string", "description": "The new teammate's job title." },
-                "description": { "type": "string", "description": "An optional description of the teammate's mandate." }
+                "description": { "type": "string", "description": "An optional description of the teammate's mandate." },
+                "tools": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional tool globs to scope the teammate to, e.g. [\"fs:read\"] for a read-only teammate. Omit to give them the same tools you hold. You cannot grant more than you hold yourself."
+                }
             },
             "required": ["name", "role"],
             "additionalProperties": false
@@ -1810,6 +1885,47 @@ impl Tool for AddAgentTool {
             .map(str::trim)
             .filter(|d| !d.is_empty())
             .map(str::to_string);
+
+        // Issue #619: resolve the teammate's scope before touching the store, so
+        // a refused scope is not a half-written roster.
+        let requested_tools: Option<Vec<String>> =
+            args.get("tools").and_then(Value::as_array).map(|globs| {
+                globs
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(str::trim)
+                    .filter(|g| !g.is_empty())
+                    .map(str::to_string)
+                    .collect()
+            });
+        let tools = match requested_tools {
+            // No scope asked for: the teammate copies the minter's own line, so
+            // an unscoped minter keeps minting teammates that track the company
+            // allow-list rather than freezing today's copy of it.
+            None => self.minter_tools.clone(),
+            // An explicitly empty list is the same request as none at all —
+            // "give them what you have" — not "grant everything".
+            Some(globs) if globs.is_empty() => self.minter_tools.clone(),
+            Some(globs) => {
+                // Narrow against what the minter actually holds. An empty
+                // result means nothing asked for was within reach, and storing
+                // that would read back as "inherit the whole company grant" —
+                // the exact inversion #619 exists to remove.
+                let narrowed = agent_effective_grants(&self.minter_grants, &globs);
+                if narrowed.is_empty() {
+                    return Ok(ToolResult::error(format!(
+                        "None of the requested tools ({}) are within your own tool grant ({}), so \"{name}\" was not added. Ask for a subset of what you hold, or omit `tools` to give them the same grant you have.",
+                        globs.join(", "),
+                        if self.minter_grants.is_empty() {
+                            "nothing".to_string()
+                        } else {
+                            self.minter_grants.join(", ")
+                        },
+                    )));
+                }
+                narrowed
+            }
+        };
 
         // Serialize per-company writes so the orchestrator's add_agent and the
         // console `POST .../team` route can never clobber each other's
@@ -1853,17 +1969,45 @@ impl Tool for AddAgentTool {
             name: name.clone(),
             role: role.clone(),
             description,
+            tools: tools.clone(),
         };
         record.overlay_agents.push(agent);
         self.store.save(&record).await?;
+
+        // Issue #619: the mint is observable, naming the minter, the teammate,
+        // and the grant it was given. A narrowing that happens silently is the
+        // defect this fixes, repeated one layer down — and an *inherited* grant
+        // is the line an operator most needs to see, because that is the
+        // teammate holding everything the company holds.
+        tracing::info!(
+            company = %self.company,
+            minter = %self.minter,
+            teammate = %id,
+            teammate_name = %name,
+            scope = %if tools.is_empty() {
+                "inherited: the company's standard grant".to_string()
+            } else {
+                tools.join(", ")
+            },
+            "[add_agent] minted an overlay teammate"
+        );
 
         // The id is in the result because the orchestrator has to be able to
         // address the teammate it just created — delegating to it, or putting it
         // on a desk, takes the id, not the display name. The console gets the
         // same answer from `TeamMemberDto.id`; before this the agent-facing half
         // had no way to learn it at all.
+        // The scope is in the result for the same reason it is in the log: the
+        // agent that minted the teammate should be able to see what it handed
+        // over, and "the same tools you hold" is a materially different answer
+        // from a named list.
+        let scope = if tools.is_empty() {
+            "They hold the company's standard tool grant, the same as you.".to_string()
+        } else {
+            format!("Their tools are scoped to: {}.", tools.join(", "))
+        };
         Ok(ToolResult::success(format!(
-            "Added {name} (id `{id}`) as {role} to the team. They'll be reachable as a teammate starting next turn."
+            "Added {name} (id `{id}`) as {role} to the team. {scope} They'll be reachable as a teammate starting next turn."
         )))
     }
 }
@@ -1901,6 +2045,9 @@ pub fn orchestrator_tools(
     store: Arc<dyn CompanyStore>,
     workflow_refs: WorkflowRefQueue,
     run_outputs: RunOutputCache,
+    minter: String,
+    minter_tools: Vec<String>,
+    minter_grants: Vec<String>,
 ) -> Vec<Box<dyn Tool>> {
     let mut tools: Vec<Box<dyn Tool>> = vec![Box::new(QueryCompanyTool::new(
         company.clone(),
@@ -1937,7 +2084,13 @@ pub fn orchestrator_tools(
         events,
         workflow_refs,
     )));
-    tools.push(Box::new(AddAgentTool::new(company, store)));
+    tools.push(Box::new(AddAgentTool::new(
+        company,
+        store,
+        minter,
+        minter_tools,
+        minter_grants,
+    )));
     tools
 }
 
@@ -4722,6 +4875,7 @@ name = "Morning"
             name: "Fact Fetcher".to_string(),
             role: "Researcher".to_string(),
             description: None,
+            tools: Vec::new(),
         });
         let store: Arc<dyn CompanyStore> = Arc::new(MemStore::seeded(record));
 
@@ -4834,7 +4988,7 @@ name = "Morning"
     async fn add_agent_tool_persists_an_overlay_teammate() {
         let company = CompanyId::new("acme");
         let store = Arc::new(MemStore::seeded(seeded_record(&company)));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         let result = tool
             .execute(json!({
@@ -4862,6 +5016,127 @@ name = "Morning"
         assert!(!added.id.is_empty(), "a stable id must be minted");
     }
 
+    /// A minter scoped to part of the company grant, for the #619 tests below.
+    /// `minter_tools` is the line it declares; `minter_grants` is that line
+    /// already narrowed by the company `allow` — which is what `build_agent`
+    /// hands the tool.
+    fn scoped_add_agent(company: CompanyId, store: Arc<dyn CompanyStore>) -> AddAgentTool {
+        AddAgentTool::new(
+            company,
+            store,
+            "ceo".to_string(),
+            vec!["workspace".to_string()],
+            vec!["workspace".to_string()],
+        )
+    }
+
+    /// Issue #619: a teammate minted by a **scoped** agent inherits that agent's
+    /// line, not the company's whole grant.
+    ///
+    /// Before this, `add_agent` — which is `Reach::Nothing` and never asks —
+    /// could mint a teammate holding everything the company held, from an agent
+    /// that held far less.
+    #[tokio::test]
+    async fn a_minted_teammate_copies_the_minters_scope() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = scoped_add_agent(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({ "name": "Jamie", "role": "Growth Lead" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "got {:?}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        assert_eq!(
+            record.overlay_agents[0].tools,
+            vec!["workspace".to_string()],
+            "the minted teammate must be bounded by the agent that minted it"
+        );
+    }
+
+    /// An **unscoped** minter still mints an unscoped teammate — the pre-#619
+    /// behaviour, kept deliberately. Copying the minter's *line* rather than its
+    /// resolved grant is what keeps the teammate tracking `[tools].allow`
+    /// instead of freezing today's copy of it into the record.
+    #[tokio::test]
+    async fn an_unscoped_minter_mints_an_unscoped_teammate() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = unscoped_add_agent(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({ "name": "Jamie", "role": "Growth Lead" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "got {:?}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        assert!(
+            record.overlay_agents[0].tools.is_empty(),
+            "an empty line means the company's standard grant (#264), and a \
+             minter holding that grant hands on exactly it"
+        );
+    }
+
+    /// An explicit `tools` request is narrowed against what the minter holds, so
+    /// the tool cannot be used to hand out a grant its caller does not have.
+    #[tokio::test]
+    async fn an_explicit_scope_is_narrowed_to_what_the_minter_holds() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = scoped_add_agent(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({
+                "name": "Jamie",
+                "role": "Growth Lead",
+                "tools": ["workspace", "composio"]
+            }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error, "got {:?}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        assert_eq!(
+            record.overlay_agents[0].tools,
+            vec!["workspace".to_string()],
+            "`composio` is outside the minter's own grant and must be dropped"
+        );
+    }
+
+    /// A request that narrows to **nothing** is a refusal, not a stored empty
+    /// list.
+    ///
+    /// This is the sharp edge of the fix: an empty `tools` list means "inherit
+    /// the company's standard grant". Storing the empty result of a narrowing
+    /// would therefore turn the single most deliberate narrowing an agent can
+    /// ask for into the widest grant in the company — the exact inversion #619
+    /// exists to remove.
+    #[tokio::test]
+    async fn a_scope_entirely_outside_the_minters_grant_is_refused() {
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemStore::seeded(seeded_record(&company)));
+        let tool = scoped_add_agent(company.clone(), store.clone());
+
+        let result = tool
+            .execute(json!({
+                "name": "Jamie",
+                "role": "Growth Lead",
+                "tools": ["composio"]
+            }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "got {:?}", result.text());
+
+        let record = store.load(&company).await.unwrap().expect("persisted");
+        assert!(
+            record.overlay_agents.is_empty(),
+            "and no teammate was written at all, scoped or otherwise"
+        );
+    }
+
     /// Issue #686 — the tool mints the same readable, name-derived id the
     /// console route does, and hands it back in the result so the orchestrator
     /// can delegate to the teammate it just created.
@@ -4869,7 +5144,7 @@ name = "Morning"
     async fn add_agent_tool_mints_a_readable_id_and_reports_it() {
         let company = CompanyId::new("acme");
         let store = Arc::new(MemStore::seeded(seeded_record(&company)));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         let result = tool
             .execute(json!({ "name": "Dana Designer", "role": "Designer" }))
@@ -4894,7 +5169,7 @@ name = "Morning"
     async fn add_agent_tool_still_refuses_a_duplicate_display_name() {
         let company = CompanyId::new("acme");
         let store = Arc::new(MemStore::seeded(seeded_record(&company)));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         for _ in 0..1 {
             let first = tool
@@ -4936,7 +5211,7 @@ name = "Morning"
         )
         .expect("valid manifest");
         let store = Arc::new(MemStore::seeded(record));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         let result = tool
             .execute(json!({ "name": "Backend Engineer", "role": "Platform" }))
@@ -4952,7 +5227,7 @@ name = "Morning"
     async fn add_agent_tool_requires_name_and_role() {
         let company = CompanyId::new("acme");
         let store = Arc::new(MemStore::seeded(seeded_record(&company)));
-        let tool = AddAgentTool::new(company.clone(), store.clone());
+        let tool = unscoped_add_agent(company.clone(), store.clone());
 
         assert!(
             tool.execute(json!({ "role": "Growth Lead" }))
@@ -4975,7 +5250,7 @@ name = "Morning"
     async fn add_agent_tool_reports_company_not_found() {
         let company = CompanyId::new("ghost");
         let store: Arc<dyn CompanyStore> = Arc::new(MemStore::default());
-        let tool = AddAgentTool::new(company, store);
+        let tool = unscoped_add_agent(company, store);
 
         let err = tool
             .execute(json!({ "name": "Jamie", "role": "Growth Lead" }))
@@ -5098,6 +5373,9 @@ name = "Morning"
             Arc::new(MemStore::default()),
             WorkflowRefQueue::default(),
             RunOutputCache::default(),
+            "ceo".to_string(),
+            Vec::new(),
+            vec!["fs:*".to_string()],
         );
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         // Six before #186; `assign_task` + `review_task` made eight; #418's

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -421,6 +421,7 @@ async fn an_overlay_teammate_added_at_runtime_writes_on_its_first_turn() {
         name: "Analyst".to_string(),
         role: "Analyst".to_string(),
         description: Some("Reads the numbers.".to_string()),
+        tools: Vec::new(),
     };
 
     let (script, workspace) = run_write_turn(dir.path(), OVERLAY_AGENT, vec![overlay]).await;

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -126,6 +126,7 @@ mod tests {
             name: "Creative studio (renamed)".into(),
             role: "Creative".into(),
             description: None,
+            tools: Vec::new(),
         }];
         let map = roster_display_names(&agents, &overlay);
         assert_eq!(map.get("strategy").unwrap(), "Strategy desk");

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2176,6 +2176,27 @@ pub struct OverlayAgent {
     /// An optional description of the teammate's mandate.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// The tool globs this teammate asks for — the overlay's answer to a
+    /// manifest `[[agent]].tools` line (issue #619).
+    ///
+    /// **Empty means "the company's standard grant"**, not "no tools": it falls
+    /// through
+    /// [`agent_effective_grants`](crate::runtime::builder::agent_effective_grants)
+    /// to the whole `[tools].allow`, exactly as an empty manifest `tools` line
+    /// does. That inheritance rule is #264 working as designed and is not what
+    /// this field disputes — before it existed there was simply nowhere to
+    /// write a *non-empty* value for an overlay teammate, so every one of them
+    /// held the widest grant the company had, permanently.
+    ///
+    /// Serde-additive: defaulted on read and skipped when empty on write, so a
+    /// record written before this field existed round-trips byte-identically.
+    ///
+    /// Read by [`overlay_agent_to_manifest`](crate::harness) on the harness side
+    /// and by `requested_grants` on the console side. Those two must stay in
+    /// lockstep — if they drift, the console shows a grant the harness does not
+    /// honour, which is the exact failure #264 exists to prevent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<String>,
 }
 
 /// An operator-added desk membership that the version-controlled manifest does
@@ -4199,6 +4220,41 @@ mod test {
         assert!(blob.desk_order.is_empty());
     }
 
+    /// Issue #619's serde-additivity condition: the `tools` field must not
+    /// change a single byte of an existing company record.
+    ///
+    /// Both halves matter and they are different claims. A record written
+    /// before the field existed has to still parse (or every company on disk
+    /// breaks on upgrade), and a teammate with no scope has to still serialize
+    /// *without* the key (or the first save after upgrade rewrites every
+    /// overlay row in the store for no behaviour change at all).
+    #[test]
+    fn an_overlay_teammates_tool_line_is_serde_additive() {
+        let legacy = r#"{"id":"a","name":"A","role":"r"}"#;
+        let parsed: OverlayAgent = serde_json::from_str(legacy).expect("pre-#619 row parses");
+        assert!(
+            parsed.tools.is_empty(),
+            "and reads as unscoped, which is the company's standard grant"
+        );
+        assert_eq!(
+            serde_json::to_string(&parsed).expect("serializes"),
+            legacy,
+            "an unscoped teammate round-trips byte-identically"
+        );
+
+        let scoped = OverlayAgent {
+            tools: vec!["workspace".into()],
+            ..parsed
+        };
+        let json = serde_json::to_string(&scoped).expect("serializes");
+        assert!(json.contains(r#""tools":["workspace"]"#), "got {json}");
+        assert_eq!(
+            serde_json::from_str::<OverlayAgent>(&json).expect("parses"),
+            scoped,
+            "and a scope survives the round trip"
+        );
+    }
+
     /// `is_roster_agent` accepts both manifest agents and overlay teammates, and
     /// rejects an unknown id — the validation the desk-add route relies on.
     #[test]
@@ -4210,6 +4266,7 @@ mod test {
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert!(record.is_roster_agent("ceo"));
         assert!(record.is_roster_agent("nova"));
@@ -4231,6 +4288,7 @@ mod test {
             name: name.into(),
             role: "Worker".into(),
             description: None,
+            tools: Vec::new(),
         });
     }
 
@@ -4668,6 +4726,7 @@ mod test {
             name: "Shane".to_string(),
             role: "Growth".to_string(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(record.effective_budget("shane"), None);
 

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -280,6 +280,7 @@ members = []
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "nova"),
@@ -313,6 +314,7 @@ members = []
             name: "Nova".into(),
             role: "Growth".into(),
             description: None,
+            tools: Vec::new(),
         });
         record.overlay_desk_members.push(OverlayDeskMember {
             desk_id: "empty".into(),
@@ -416,6 +418,7 @@ members = ["ceo"]
             name: "Shane".into(),
             role: "Support".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "Shane"),
@@ -440,6 +443,7 @@ members = ["ceo"]
             name: "engineer".into(),
             role: "Support".into(),
             description: None,
+            tools: Vec::new(),
         });
         assert_eq!(
             resolve(&record, "engineer"),
@@ -460,6 +464,7 @@ members = ["ceo"]
                 name: "Shane".into(),
                 role: "Support".into(),
                 description: None,
+                tools: Vec::new(),
             });
         }
         let resolution = resolve(&record, "Shane");

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -246,6 +246,7 @@ async fn team_reports_the_effective_cap_and_its_attribution() {
         name: "Jamie".to_string(),
         role: "Growth".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     let admin = Actor {
         kind: ActorKind::User,
@@ -329,12 +330,14 @@ async fn team_keeps_zero_explicit_null_and_manifest_only_caps_distinct() {
         name: "Zeroed".to_string(),
         role: "Growth".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     record.overlay_agents.push(OverlayAgent {
         id: "uncapped".to_string(),
         name: "Uncapped".to_string(),
         role: "Ops".to_string(),
         description: None,
+        tools: Vec::new(),
     });
     let admin = Actor {
         kind: ActorKind::User,

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -261,11 +261,12 @@ fn dto_from_decl(
 /// Every roster agent's *effective* tool grants (issue #568), as
 /// `(agent_id, grants)`. The roster is exactly what the harness builds in
 /// `build_roster`: the manifest agents (each with its own `tools` narrowed by
-/// the company `allow`), plus the promoted overlay teammates. An overlay
-/// teammate has no manifest `tools` row, so it inherits the full company `allow`
-/// — the standard grant `overlay_agent_to_manifest` gives it — and an overlay id
-/// already claimed by a manifest agent is skipped, both mirroring the harness so
-/// console reachability equals what an agent is actually granted.
+/// the company `allow`), plus the promoted overlay teammates — each with **its
+/// own** `tools` line narrowed the same way (issue #619), which for the
+/// overwhelmingly common empty line is still the full company `allow`, the
+/// standard grant `overlay_agent_to_manifest` gives it. An overlay id already
+/// claimed by a manifest agent is skipped, both mirroring the harness so console
+/// reachability equals what an agent is actually granted.
 fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)> {
     let allow = &record.manifest.tools.allow;
     let mut grants: Vec<(String, Vec<String>)> = record
@@ -289,9 +290,14 @@ fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)> {
         if manifest_ids.contains(overlay.id.as_str()) {
             continue;
         }
-        // No manifest tools row → the company's standard grant (empty `tools`
-        // ⇒ inherit `allow`), matching `overlay_agent_to_manifest`.
-        grants.push((overlay.id.clone(), agent_effective_grants(allow, &[])));
+        // The overlay teammate's own tools line (issue #619), read through the
+        // same function and with the same empty-means-inherit rule as a
+        // manifest row above — matching `overlay_agent_to_manifest`. A scoped
+        // teammate must not read back here as holding every granted server.
+        grants.push((
+            overlay.id.clone(),
+            agent_effective_grants(allow, &overlay.tools),
+        ));
     }
     grants
 }
@@ -859,4 +865,101 @@ async fn discover_tools(
 ) -> Response {
     let _ = (company, name);
     crate::server::ops::not_wired("mcp tool discovery")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::company::CompanyManifest;
+    use crate::ports::types::{CompanyId, OverlayAgent};
+
+    /// A company allowing two tool families, with one manifest agent that lists
+    /// none (so it inherits both).
+    fn record(overlay_agents: Vec<OverlayAgent>) -> CompanyRecord {
+        let manifest: CompanyManifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[tools]
+allow = ["mcp:notion", "mcp:linear"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+"#,
+        )
+        .expect("manifest parses");
+        CompanyRecord {
+            id: CompanyId::new("acme"),
+            manifest,
+            ledger: Vec::new(),
+            lifecycle: "running".to_string(),
+            overlay_agents,
+            overlay_desk_members: Vec::new(),
+            overlay_desk_order: Vec::new(),
+            overlay_desks: Vec::new(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        }
+    }
+
+    fn teammate(id: &str, tools: Vec<&str>) -> OverlayAgent {
+        OverlayAgent {
+            id: id.to_string(),
+            name: id.to_string(),
+            role: "Growth".to_string(),
+            description: None,
+            tools: tools.into_iter().map(str::to_string).collect(),
+        }
+    }
+
+    /// Issue #619: a scoped overlay teammate reads back here with its own
+    /// grant, not the company's.
+    ///
+    /// This is what `reachable_by` on every MCP server row is computed from, so
+    /// an overlay teammate whose scope this ignored would be listed as reaching
+    /// servers the harness does not grant it — the console asserting a
+    /// connection that is not there.
+    #[test]
+    fn a_scoped_overlay_teammate_does_not_read_back_as_reaching_everything() {
+        let scoped = record(vec![teammate("jamie", vec!["mcp:notion"])]);
+        let grants = roster_grants(&scoped);
+        let jamie = grants
+            .iter()
+            .find(|(id, _)| id == "jamie")
+            .expect("the overlay teammate is on the roster");
+        assert_eq!(
+            jamie.1,
+            vec!["mcp:notion".to_string()],
+            "a scoped teammate reaches only what it was scoped to"
+        );
+
+        // The manifest agent lists nothing and still inherits everything, so
+        // the narrowing above is the teammate's own and not a company change.
+        let ceo = grants
+            .iter()
+            .find(|(id, _)| id == "ceo")
+            .expect("on roster");
+        assert_eq!(
+            ceo.1,
+            vec!["mcp:notion".to_string(), "mcp:linear".to_string()]
+        );
+    }
+
+    /// The empty-means-inherit rule (#264) is untouched: a teammate written
+    /// before #619 — and every teammate the console still creates — reads back
+    /// holding the company's whole grant.
+    #[test]
+    fn an_unscoped_overlay_teammate_still_inherits_the_company_grant() {
+        let grants = roster_grants(&record(vec![teammate("jamie", Vec::new())]));
+        let jamie = grants.iter().find(|(id, _)| id == "jamie").expect("roster");
+        assert_eq!(
+            jamie.1,
+            vec!["mcp:notion".to_string(), "mcp:linear".to_string()]
+        );
+    }
 }

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -425,6 +425,10 @@ async fn add_member(
         name: body.name,
         role: body.role,
         description: body.description,
+        // Unscoped on creation — the company's standard grant, exactly as
+        // before #619. Scoping is a `PATCH …/team/{id}` away, which is also the
+        // only route that can narrow a teammate that already exists.
+        tools: Vec::new(),
     };
     record.overlay_agents.push(agent.clone());
     let attribution = author.map(|admin| BudgetOverride {

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -31,10 +31,11 @@
 //!
 //! An **overlay** teammate — one an operator defined through "Define an agent",
 //! or the orchestrator created with `add_agent` — lives on the
-//! [`CompanyRecord`], which this process writes. Its name, role and description
-//! are editable here, and that is the whole of #264's "the roster is write-once
-//! per member" complaint: before this, iterating on an agent's instructions
-//! meant deleting it and starting over.
+//! [`CompanyRecord`], which this process writes. Its name, role, description
+//! and (since issue #619) its tool scope are editable here, and that is the
+//! whole of #264's "the roster is write-once per member" complaint: before
+//! this, iterating on an agent's instructions meant deleting it and starting
+//! over.
 //!
 //! A **manifest** teammate is declared in the version-controlled `company.toml`
 //! and is not editable from a browser. This is the same line
@@ -49,10 +50,18 @@
 //! [`BudgetOverride`](crate::ports::types::BudgetOverride) layered on top rather
 //! than as a rewrite. It keeps its own route and is untouched here.
 //!
-//! `tier` and `tools` are read-only for **both** kinds. There is no override
-//! layer for either, and inventing one is a policy decision (an operator
-//! raising an agent's own tool grants from a browser is a privilege question,
-//! not a form field), not something to smuggle into a detail view.
+//! `tier` is read-only for **both** kinds. There is no override layer for it,
+//! and inventing one is a policy decision, not something to smuggle into a
+//! detail view.
+//!
+//! `tools` was read-only for the same reason until issue #619 made that policy
+//! decision for the overlay half — deliberately, and only for the half this
+//! process owns. The privilege question is real and the answer is that a
+//! manifest teammate's tool line still lives in git and is still a `409`; what
+//! changed is that an *overlay* teammate had no tool line at all, so it held
+//! the company's widest grant permanently with no way to say otherwise. The
+//! company `[tools].allow` ceiling is unchanged by this route, so the edit can
+//! only ever narrow a teammate within a grant the company already made.
 //!
 //! The server states the rule rather than leaving the console to re-derive it:
 //! every detail response carries an [`editable`](AgentDetailDto::editable) list,
@@ -100,7 +109,7 @@ pub(super) enum AgentSource {
 
 /// The fields a `PATCH` accepts for an overlay teammate. Sent to the console so
 /// it renders the same rule the host enforces.
-const OVERLAY_EDITABLE: [&str; 3] = ["name", "role", "description"];
+const OVERLAY_EDITABLE: [&str; 4] = ["name", "role", "description", "tools"];
 
 /// One agent, in full — everything #264 lists as unreachable.
 #[derive(Debug, Serialize)]
@@ -177,12 +186,19 @@ pub(super) struct AgentDeskDto {
 
 /// The tool globs an agent *asks* for, resolved identically for every reader.
 ///
-/// A manifest teammate's `[[agent]].tools` line; an **empty** list for an
-/// overlay teammate, which mirrors `harness::overlay_agent_to_manifest` — and
-/// which means "the company's standard grant", not "no tools".
+/// A manifest teammate's `[[agent]].tools` line, or an overlay teammate's
+/// [`OverlayAgent::tools`](crate::ports::types::OverlayAgent::tools) — which
+/// mirrors `harness::overlay_agent_to_manifest`, deliberately and in lockstep
+/// (issue #619). Either one being **empty** means "the company's standard
+/// grant", not "no tools".
+///
+/// Before #619 the overlay half was hard-coded empty here, because an overlay
+/// teammate had no tools field to read. Now that it has one, reading it is what
+/// keeps this route from showing an operator a grant the harness does not
+/// honour — the verification gap #264 exists to close.
 ///
 /// Its callers have already established that `agent_id` is on the roster, so a
-/// miss here can only be the overlay half.
+/// miss on both halves can only be a caller that skipped that check.
 pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<String> {
     record
         .manifest
@@ -190,6 +206,13 @@ pub(super) fn requested_grants(record: &CompanyRecord, agent_id: &str) -> Vec<St
         .iter()
         .find(|agent| agent.id == agent_id)
         .map(|agent| agent.tools.clone())
+        .or_else(|| {
+            record
+                .overlay_agents
+                .iter()
+                .find(|agent| agent.id == agent_id)
+                .map(|agent| agent.tools.clone())
+        })
         .unwrap_or_default()
 }
 
@@ -279,6 +302,13 @@ pub(super) struct EditAgent {
     role: Option<String>,
     #[serde(default, deserialize_with = "double_option")]
     description: Option<Option<String>>,
+    /// The teammate's tool scope (issue #619). Absent leaves it alone; an
+    /// **empty array** is the deliberate way back to the company's standard
+    /// grant, which is why this is a plain `Option` and not a double option —
+    /// `[]` already spells "clear it" without needing `null` to mean something
+    /// different from omission.
+    #[serde(default)]
+    tools: Option<Vec<String>>,
 }
 
 /// `GET {scope}/team/{agent_id}` — one agent, read.
@@ -338,6 +368,11 @@ async fn edit_agent(
 
     let name = trimmed_field(body.name.as_deref(), "name").map_err(|e| e.into_response())?;
     let role = trimmed_field(body.role.as_deref(), "role").map_err(|e| e.into_response())?;
+    let tools = body
+        .tools
+        .map(|globs| trimmed_globs(&globs))
+        .transpose()
+        .map_err(|e| e.into_response())?;
 
     {
         let agent = record
@@ -358,6 +393,15 @@ async fn edit_agent(
             agent.description = description
                 .map(|text| text.trim().to_string())
                 .filter(|text| !text.is_empty());
+        }
+        // Issue #619: the one place an operator can narrow an overlay teammate.
+        // Stored verbatim, exactly like a manifest `[[agent]].tools` line — the
+        // company `allow` ceiling is applied at *read* time by
+        // `agent_effective_grants`, so a glob the company does not cover is
+        // surfaced as asked-for-but-not-granted rather than silently dropped
+        // here.
+        if let Some(tools) = tools {
+            agent.tools = tools;
         }
     }
 
@@ -396,6 +440,34 @@ fn trimmed_field(value: Option<&str>, field: &str) -> Result<Option<String>, Api
         ))));
     }
     Ok(Some(trimmed.to_string()))
+}
+
+/// Trims a submitted tool-scope list, refusing a blank entry and dropping
+/// duplicates (issue #619).
+///
+/// A blank glob is a `400` rather than a stored empty string for a sharper
+/// reason than tidiness: `""` matches nothing an operator meant, so it would
+/// read as a scope that grants nothing while looking like a scope that was set.
+/// Duplicates are dropped rather than refused — a repeated glob is harmless and
+/// the resolved grant list is de-duplicated downstream anyway.
+///
+/// Same `ApiError`-not-`Response` return shape as [`trimmed_field`], for the
+/// reason given there.
+fn trimmed_globs(globs: &[String]) -> Result<Vec<String>, ApiError> {
+    let mut seen = std::collections::HashSet::new();
+    let mut out = Vec::with_capacity(globs.len());
+    for glob in globs {
+        let trimmed = glob.trim();
+        if trimmed.is_empty() {
+            return Err(ApiError(OpenCompanyError::InvalidRequest(
+                "a tool grant can't be empty. Send an empty list to give this teammate the company's standard grant.".to_string(),
+            )));
+        }
+        if seen.insert(trimmed.to_string()) {
+            out.push(trimmed.to_string());
+        }
+    }
+    Ok(out)
 }
 
 /// Builds one agent's detail from the loaded record, or 404s when the id names
@@ -1055,9 +1127,110 @@ members = ["writer", "ceo"]
         let (_, agent) = get_agent(&state, &jamie).await;
         assert_eq!(
             strings(&agent["editable"]),
-            vec!["name", "role", "description"],
+            vec!["name", "role", "description", "tools"],
             "{agent}"
         );
+    }
+
+    /// Issue #619: an overlay teammate can be narrowed, and the narrowing is
+    /// what the host enforces — not a label beside an unchanged grant.
+    ///
+    /// The three levels are asserted separately on purpose. `requested` proves
+    /// the scope was stored at all; `effective` proves it reached the function
+    /// the harness builds the agent with; and the company `allow` staying put
+    /// proves the narrowing is per-teammate rather than a company-wide edit.
+    #[tokio::test]
+    async fn an_overlay_teammate_can_be_scoped_and_the_scope_is_enforced() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        let jamie = add_overlay(&state, "Jamie", "Growth").await;
+
+        // Before: the widest grant the company has, which is the defect.
+        let (_, before) = get_agent(&state, &jamie).await;
+        assert!(
+            strings(&before["tools"]["requested"]).is_empty(),
+            "unscoped to begin with: {before}"
+        );
+        assert_eq!(
+            strings(&before["tools"]["effective"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "which resolves to everything the company allows: {before}"
+        );
+
+        let (status, scoped) = patch_agent(&state, &jamie, json!({"tools": ["workspace"]})).await;
+        assert_eq!(status, StatusCode::OK, "{scoped}");
+        assert_eq!(
+            strings(&scoped["tools"]["requested"]),
+            vec!["workspace"],
+            "{scoped}"
+        );
+        assert_eq!(
+            strings(&scoped["tools"]["effective"]),
+            vec!["workspace"],
+            "and it is narrower than the company grant, which is the whole \
+             point: {scoped}"
+        );
+        assert_eq!(
+            strings(&scoped["tools"]["companyAllow"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "the company ceiling is untouched — this scoped one teammate, not \
+             the company: {scoped}"
+        );
+
+        // Read back through a fresh request, so this is the stored record and
+        // not the handler's own answer.
+        let (_, reread) = get_agent(&state, &jamie).await;
+        assert_eq!(
+            strings(&reread["tools"]["requested"]),
+            vec!["workspace"],
+            "{reread}"
+        );
+
+        // An empty list is the deliberate way back to the standard grant, and
+        // it must read as "inherits everything" rather than "holds nothing".
+        let (status, cleared) = patch_agent(&state, &jamie, json!({"tools": []})).await;
+        assert_eq!(status, StatusCode::OK, "{cleared}");
+        assert!(
+            strings(&cleared["tools"]["requested"]).is_empty(),
+            "{cleared}"
+        );
+        assert_eq!(
+            strings(&cleared["tools"]["effective"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "{cleared}"
+        );
+    }
+
+    /// A blank glob is refused rather than stored: `""` matches nothing an
+    /// operator meant, so it would read as a scope that grants nothing while
+    /// looking like a scope that was set.
+    #[tokio::test]
+    async fn a_blank_tool_glob_is_refused() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        let jamie = add_overlay(&state, "Jamie", "Growth").await;
+
+        let (status, refusal) =
+            patch_agent(&state, &jamie, json!({"tools": ["workspace", "  "]})).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{refusal}");
+
+        let (_, unchanged) = get_agent(&state, &jamie).await;
+        assert!(
+            strings(&unchanged["tools"]["requested"]).is_empty(),
+            "and nothing was written: {unchanged}"
+        );
+    }
+
+    /// A manifest teammate's tool line lives in the version-controlled
+    /// blueprint, and #619 did not move it: the overlay half became writable,
+    /// the manifest half stayed a `409`.
+    #[tokio::test]
+    async fn a_manifest_teammates_tools_are_still_not_editable_here() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        let (status, refusal) = patch_agent(&state, "ceo", json!({"tools": ["workspace"]})).await;
+        assert_eq!(status, StatusCode::CONFLICT, "{refusal}");
     }
 
     /// A blank name would render a card with no way back to it, so it is a

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -2792,6 +2792,7 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
         name: "Helper".to_string(),
         role: "Assistant".to_string(),
         description: None,
+        tools: Vec::new(),
     };
     let state = state_with_manifest_and_overlays(&home, manifest, vec![overlay]).await;
 

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1329,6 +1329,7 @@ mod test {
             name: "Dana Designer".into(),
             role: "Design".into(),
             description: Some("Owns the brand".into()),
+            tools: Vec::new(),
         }];
         // That teammate added to the `eng` desk through the membership overlay.
         let desk_members = vec![OverlayDeskMember {


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#619.

`OverlayAgent` carried only `id`, `name`, `role`, `description`. With no tools field, an operator- or orchestrator-added teammate could not be scoped at all: empty `tools` falls through `agent_effective_grants` to the full company `[tools].allow`, so **every overlay teammate held everything the company held, permanently**, with no way to express "this one is read-only".

This adds the field and threads it through every reader, bounds what `add_agent` may mint, and makes the mint observable.

The empty-means-inherit rule itself (#264) is **not** touched. It is correct and stays. This is only about being able to write a *non-empty* value.

### The field

`OverlayAgent.tools: Vec<String>`, serde-additive — `#[serde(default, skip_serializing_if = "Vec::is_empty")]`. A record written before this field existed still parses, and an unscoped teammate still serialises **without** the key, so the first save after upgrade does not rewrite every overlay row in the store for no behaviour change. Both halves are pinned by `an_overlay_teammates_tool_line_is_serde_additive`.

### Three readers, threaded in lockstep

The issue calls for the harness and the console projections to move together — if they drift, the console shows a grant the harness does not honour, which is the exact failure #264 exists to prevent. There are **three** readers, not two:

| reader | what it decides |
|---|---|
| `harness::overlay_agent_to_manifest` | what `build_agent` actually wires onto the agent |
| `server::ops::team_agent::requested_grants` | the console's agent-detail read |
| `server::ops::mcp::roster_grants` | **every MCP server row's `reachableBy`** |

The third is the one easiest to miss on review. It computes who can reach each MCP server, and it hard-coded the overlay half to `&[]`. Left alone, a teammate scoped away from `mcp:*` would still be listed as reaching every enabled server — the console asserting a connection that is not there, which is the same inversion the issue is about wearing a different hat.

### The fingerprint axis

**`overlay_fingerprint` is the fingerprint covering this field**, and it did not cover it until this PR. It hashes `overlay_agents` only — which is the *correct* axis here precisely because `tools` lives on `OverlayAgent`, so no new axis was needed; `agent.tools.hash(&mut hasher)` joins the existing id/name/role/description hashes.

Without that line, narrowing a teammate from the console is a **silent no-op until the process restarts**: `HarnessPool::ensure`'s staleness fast-path would not notice, and the roster would not rebuild. This repo has shipped exactly that bug twice already (`policy_fingerprint` in #562, and this area). `narrowing_a_teammates_scope_changes_the_overlay_fingerprint` fails when the hash line is removed.

No other overlay field is written by this change, so no second axis is implicated. `fresh_company`'s pre-rebuild fold-in is untouched — it clones `overlay_agents` wholesale, so the new field rides along unchanged.

### `add_agent`: bounded, and no longer silent

`add_agent` is `Reach::Nothing` and sits in `INTRINSIC_TOOLS`, so it is always present and never asks. A model could mint a teammate holding the company's full grant with no approval anywhere in the path. The rule now: **a minted teammate is never wider than the agent that minted it.**

- **No `tools` argument** → the teammate copies the minter's own `tools` **line**, verbatim. Copying the line rather than the resolved grant is deliberate: an unscoped minter mints an unscoped teammate that keeps tracking `[tools].allow`, instead of freezing today's allow-list into the record as an explicit scope a later company-wide narrowing would not reach.
- **With a `tools` argument** → narrowed against the minter's own *effective* grant, so the tool cannot hand out what its caller does not hold.
- **A request that narrows to empty is a tool error, not a stored empty list.** This is the sharp edge and it is worth stating plainly, because it is the kind of thing a later refactor undoes without noticing: an empty `tools` list means *inherit the company's standard grant*. Storing the empty result of a narrowing would turn the single most deliberate narrowing an agent can ask for — "scope this teammate to something I don't have" — into the **widest grant in the company**.

**Observability is required and included.** Every mint logs the minter, the teammate, and the resolved scope at `info`, naming inheritance explicitly when the grant is inherited. A narrowing that happens silently is the defect being fixed, repeated one layer down.

### Console

`PATCH …/team/{agentId}` accepts `tools` for an overlay teammate. An omitted key leaves the scope alone; `[]` is the deliberate way back to the company's standard grant (so `null` never has to mean a third thing); a blank glob inside the list is a `400`, because `""` matches nothing an operator meant and would read as a scope that grants nothing while looking like a scope that was set. Globs are stored verbatim exactly like a manifest line — the `[tools].allow` ceiling is applied at read time, so a glob the company does not cover surfaces as asked-for-but-not-granted rather than vanishing on save.

The console can only ever *narrow* a teammate within a grant the company already made; this route does not touch `[tools].allow`.

**No new UI strings, so no i18n changes.** The console already distinguishes inherited-from-explicit through `summarizeGrants().standardGrant`, and that rendering now tells the truth for overlay teammates because `requested_grants` reads their line. This is the issue's item 4, satisfied by existing rendering. Zero frontend files changed.

## API Or Behavior Changes

- **`OverlayAgent` gains `tools`** (optional, additive). Existing records round-trip byte-identically; an unscoped teammate behaves exactly as before.
- **`PATCH {scope}/team/{agentId}` accepts `tools`** for an overlay teammate, and `editable` now lists `"tools"`. A **manifest** teammate's `tools` is still a `409` — its line lives in the version-controlled `company.toml`. **The scope of this change is the overlay half only.**
- **`add_agent` gains an optional `tools` parameter** and now bounds every mint by its minter (see above). Its success text names the resulting scope.
- **MCP `reachableBy`** now reflects a scoped overlay teammate's real grant instead of always reporting the company's.
- `POST {scope}/team` is unchanged — a console-created teammate is still unscoped on creation, and scoping is a `PATCH` away.

## Tests

Twelve tests added or changed; the full suite is green.

```
cargo fmt --all -- --check                                                      → 0
cargo check  --locked --all-features --all-targets                              → 0
cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings  → 0
cargo build  --all-targets                                                      → 0
cargo test   --features openhuman,tinycortex   → 0 — 3140 + 10 + 1 + 11 + 2 = 3164 passed, 0 failed, 3 ignored
```

`--all-features` is not redundant here: `mongodb.rs` / `sqlite.rs` build `CompanyRecord` from a row rather than a struct literal, so a field addition is invisible to the default and gated lanes and caught only by that one.

**Every new test was revert-checked** — its own fix removed, the named test re-run, and confirmed to fail. Counts quoted so a run that silently executed nothing cannot pass for a pass:

| revert | test | result |
|---|---|---|
| drop `skip_serializing_if` | `an_overlay_teammates_tool_line_is_serde_additive` | FAILED — 0 passed; 1 failed |
| `overlay_agent_to_manifest` → `Vec::new()` | `an_overlay_teammates_tool_line_reaches_the_manifest_shape` | FAILED — 0 passed; 1 failed |
| drop `tools` from `overlay_fingerprint` | `narrowing_a_teammates_scope_changes_the_overlay_fingerprint` | FAILED — 0 passed; 1 failed |
| drop the overlay lookup in `requested_grants` | `an_overlay_teammate_can_be_scoped_and_the_scope_is_enforced` | FAILED — 0 passed; 1 failed |
| `trimmed_globs` never refuses | `a_blank_tool_glob_is_refused` | FAILED — 0 passed; 1 failed |
| `OVERLAY_EDITABLE` back to three fields | `the_host_states_which_fields_are_editable` | FAILED — 0 passed; 1 failed |
| `mcp::roster_grants` → `&[]` | `a_scoped_overlay_teammate_does_not_read_back_as_reaching_everything` | FAILED — 0 passed; 1 failed |
| `add_agent` stores `Vec::new()` | `a_minted_teammate_copies_the_minters_scope`, `an_explicit_scope_is_narrowed_to_what_the_minter_holds` | both FAILED — 0 passed; **2 failed** |
| drop the empty-narrowing refusal | `a_scope_entirely_outside_the_minters_grant_is_refused` | FAILED — 0 passed; 1 failed |

The working tree was restored and re-verified after the reverts, and the five lanes above were run **after** restoration.

Three further tests are **regression guards on unchanged behaviour** and pass before and after by design — they are not claimed as revert-proven: `an_unscoped_minter_mints_an_unscoped_teammate`, `an_unscoped_overlay_teammate_still_inherits_the_company_grant` (both pin #264's empty-means-inherit), and `a_manifest_teammates_tools_are_still_not_editable_here` (pins the `409`).

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; `--no-deps` keeps it off pre-existing `vendor/tinyagents` lints CI never sees
- [x] `cargo build --all-targets`
- [x] `cargo test` — run as `cargo test --features openhuman,tinycortex`

## Documentation

`docs/spec/runtime/api.md` updated. It previously stated outright that **"`tier` and `tools` are read-only for both kinds"**, which this PR makes false for `tools` on the overlay half — so the correction is required, not cosmetic. The revised text is explicit that **only the overlay half changed**: a manifest teammate's tool line still lives in git and is still a `409`. The same claim in the `server/ops/team_agent.rs` module docs is corrected identically.

Also documented: the overlay `tools` field and its empty-means-inherit rule, the `PATCH` contract for it, and the `add_agent` minting rule including why a narrowing-to-empty is refused rather than stored.

`docs/spec/runtime/api.md` was already 587 lines — over the repo's 500-line guideline — before this change, and this adds ~32. Splitting it is out of scope here; flagging rather than growing it silently.

## Not in this PR

- **#610** (retaining #457's per-toolkit grant scoping, pinned by a direct unit test on `standing_scope_of` / `admits_scope`) is adjacent and assigned elsewhere. **Neither function is touched here** — #619 did not require them.
- The empty-means-inherit rule (#264) is unchanged, deliberately.
