### PR TITLE
fix(scheduler): scheduler catch-up minors — re-arm boot, defer-not-forfeit, identity doc (#661 L6)

### DIFF
--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -187,6 +187,17 @@ pub struct CompanyScheduler {
     /// Per-schedule last-fired epoch minute, so a schedule fires at most once per
     /// minute no matter how often [`tick`](Self::tick) is called.
     last_fired: HashMap<usize, u64>,
+    /// Whether the one restart catch-up (issue #241) has **completed** — a pass
+    /// that got past the `ensure_running` guard AND touched the claim store
+    /// without error (issue #661 F1). Starts `false` and, crucially, is NOT set
+    /// by a pass that early-returned because the company was paused/archived: a
+    /// company paused across boot would otherwise silently forfeit its make-up
+    /// forever. [`spawn`](Self::spawn) calls [`catch_up`](Self::catch_up) once
+    /// before the loop and again on every tick while this stays `false`, so the
+    /// missed fire lands on the first minute the company is actually running.
+    /// Re-running a partial pass is idempotent: a fired schedule advanced its
+    /// durable anchor and a durable claim already made is not re-made.
+    caught_up: bool,
 }
 
 impl CompanyScheduler {
@@ -218,6 +229,7 @@ impl CompanyScheduler {
             schedules: parsed,
             clock,
             last_fired: HashMap::new(),
+            caught_up: false,
         })
     }
 
@@ -328,24 +340,51 @@ impl CompanyScheduler {
     /// (no anchor) makes up nothing. A claim-store read failure fails closed
     /// (skip), for the same reason [`tick`](Self::tick) does.
     ///
-    /// Run once, from [`spawn`](Self::spawn), before the steady-state loop.
+    /// Run from [`spawn`](Self::spawn) before the steady-state loop, and again on
+    /// every tick until it latches (issue #661 F1) — a no-op once it has, and one
+    /// `ensure_running` probe per minute while it has not.
+    ///
+    /// # Re-arming until one successful pass (issue #661 F1)
+    ///
+    /// The pre-loop-only call this replaced early-returned `Ok(0)` whenever
+    /// `ensure_running` rejected — so a company **paused across boot** and resumed
+    /// later never made up its missed fire, because the one attempt it ever got
+    /// happened while it was paused. This now latches only after a pass that got
+    /// *past* the `ensure_running` guard AND touched the store without error;
+    /// [`spawn`](Self::spawn) re-drives it every minute until then, so the make-up
+    /// lands on the first running minute. A pause never latches; a *transient*
+    /// store error on the anchor read or the claim clears `complete`, so that pass
+    /// does not latch either and a later tick retries — the same "defer, never
+    /// forfeit" doctrine the workflow scheduler's first-sight catch-up follows.
+    /// Re-running a partial pass is safe: a fired schedule advanced its durable
+    /// anchor, and a durable claim already made is not re-made.
     ///
     /// [`latest_fire`]: crate::ports::ScheduleFireStore::latest_fire
-    pub async fn catch_up(&self) -> Result<usize> {
+    pub async fn catch_up(&mut self) -> Result<usize> {
+        // Already made up — nothing more this process needs to do.
+        if self.caught_up {
+            return Ok(0);
+        }
         if self.schedules.is_empty() {
             return Ok(0);
         }
         let runtime = self.runtime();
         if runtime.ensure_running().await.is_err() {
+            // Paused/archived: do NOT latch, so a later resume still catches up.
             return Ok(0);
         }
         let now_minute = self.clock.now_millis() / MINUTE_MS;
         let store = runtime.schedule_fires().clone();
         let mut fired = 0;
+        // Whether this pass reached a verdict for every schedule without a
+        // transient store error. A single failed read/claim leaves it `false`, so
+        // the latch stays clear and a later tick retries rather than forfeiting.
+        let mut complete = true;
         for schedule in &self.schedules {
             let anchor = match store.latest_fire(runtime.id(), &schedule.id).await {
                 Ok(anchor) => anchor,
                 Err(err) => {
+                    complete = false;
                     tracing::warn!(
                         company = %runtime.id(),
                         schedule = %schedule.id,
@@ -378,13 +417,20 @@ impl CompanyScheduler {
                 }
                 // A simultaneously-booting replica claimed the catch-up first.
                 Ok(false) => {}
-                Err(err) => tracing::warn!(
-                    company = %runtime.id(),
-                    schedule = %schedule.id,
-                    %err,
-                    "scheduler: could not claim catch-up fire; skipping (fail closed)"
-                ),
+                Err(err) => {
+                    complete = false;
+                    tracing::warn!(
+                        company = %runtime.id(),
+                        schedule = %schedule.id,
+                        %err,
+                        "scheduler: could not claim catch-up fire; skipping (fail closed)"
+                    );
+                }
             }
+        }
+        // Latch only a clean pass; a partial one stays re-armed for a later tick.
+        if complete {
+            self.caught_up = true;
         }
         Ok(fired)
     }
@@ -449,6 +495,14 @@ impl CompanyScheduler {
                 tokio::select! {
                     _ = &mut notified => break,
                     _ = tokio::time::sleep(Duration::from_millis(sleep_ms)) => {
+                        // Issue #661 F1: re-attempt the boot catch-up until it
+                        // latches. A no-op once made up; while the company is
+                        // paused this is one cheap `ensure_running` probe a minute,
+                        // so a company resumed after boot still makes up its missed
+                        // fire on its first running minute rather than never.
+                        if let Err(err) = self.catch_up().await {
+                            tracing::warn!(company = %self.runtime.id(), %err, "scheduled catch-up failed");
+                        }
                         if let Err(err) = self.tick().await {
                             tracing::warn!(company = %self.runtime.id(), %err, "scheduled cycle failed");
                         }
@@ -1111,7 +1165,7 @@ mod test {
                 .unwrap()
         );
         let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
-        let scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
 
         assert_eq!(
             scheduler.catch_up().await.unwrap(),
@@ -1147,7 +1201,7 @@ mod test {
                 .unwrap(),
         );
         let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
-        let scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
         assert_eq!(scheduler.catch_up().await.unwrap(), 0);
         assert_eq!(fired_count(&rt).await, 0);
     }
@@ -1174,12 +1228,225 @@ mod test {
             .await
             .unwrap();
         let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
-        let a = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
-        let b = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        let mut a = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
+        let mut b = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
 
         let fa = a.catch_up().await.unwrap();
         let fb = b.catch_up().await.unwrap();
         assert_eq!(fa + fb, 1, "only one booting replica fires the catch-up");
+        assert_eq!(fired_count(&rt).await, 1);
+    }
+
+    // --- issue #661 (F1): re-arm the boot catch-up until one successful pass ----
+
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+    use std::sync::atomic::AtomicUsize;
+
+    /// Moves the company's durable lifecycle, so a test can pause the company
+    /// across a boot catch-up and later resume it.
+    async fn set_lifecycle(rt: &CompanyRuntime, lifecycle: &str) {
+        let store = rt.store().clone();
+        let mut record = store
+            .load(rt.id())
+            .await
+            .expect("loads")
+            .expect("the builder materialized a record");
+        record.lifecycle = lifecycle.to_string();
+        store.save(&record).await.expect("saves");
+    }
+
+    /// An in-memory claim store whose first N `latest_fire` reads error, then
+    /// works — the flaky-once double for "a transient store error does NOT latch
+    /// the boot catch-up, so a later pass retries" (issue #661 F1). `seed` presets
+    /// an anchor without consuming the fail budget.
+    struct FlakyOnceFires {
+        claims: Mutex<HashMap<(String, String), HashSet<u64>>>,
+        fail_latest: AtomicUsize,
+    }
+
+    impl FlakyOnceFires {
+        fn new(fail_latest: usize) -> Self {
+            Self {
+                claims: Mutex::new(HashMap::new()),
+                fail_latest: AtomicUsize::new(fail_latest),
+            }
+        }
+        fn seed(&self, c: &CompanyId, s: &str, m: u64) {
+            self.claims
+                .lock()
+                .unwrap()
+                .entry((c.as_ref().to_string(), s.to_string()))
+                .or_default()
+                .insert(m);
+        }
+    }
+
+    #[async_trait]
+    impl ScheduleFireStore for FlakyOnceFires {
+        async fn claim_fire(&self, c: &CompanyId, s: &str, m: u64) -> Result<bool> {
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .entry((c.as_ref().to_string(), s.to_string()))
+                .or_default()
+                .insert(m))
+        }
+        async fn latest_fire(&self, c: &CompanyId, s: &str) -> Result<Option<u64>> {
+            if self.fail_latest.load(Ordering::SeqCst) > 0 {
+                self.fail_latest.fetch_sub(1, Ordering::SeqCst);
+                return Err(OpenCompanyError::Store("flaky once claim store".into()));
+            }
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .get(&(c.as_ref().to_string(), s.to_string()))
+                .and_then(|set| set.iter().max().copied()))
+        }
+        async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> Result<usize> {
+            Ok(0)
+        }
+    }
+
+    /// A company paused across boot gets its catch-up on RESUME, not never. The
+    /// pre-loop-only catch-up used to early-return on `ensure_running` and latch
+    /// nothing — but with no re-arm the missed fire was gone. Now the pause does
+    /// not latch, so the first running pass makes it up.
+    #[tokio::test]
+    async fn catch_up_skipped_while_paused_runs_on_resume() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        // Anchor two Mondays back so the most recent Monday (2026-07-13) is missed.
+        let sid = manifest_schedule_id("0 9 * * MON", "weekly standup");
+        rt.schedule_fires()
+            .claim_fire(rt.id(), &sid, millis_at(2026, 7, 6, 9, 0) / MINUTE_MS)
+            .await
+            .unwrap();
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        // Paused across boot: the guard rejects and nothing is made up — but the
+        // latch stays clear.
+        set_lifecycle(&rt, "paused").await;
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            0,
+            "a paused company makes up nothing"
+        );
+        assert_eq!(fired_count(&rt).await, 0);
+
+        // Resumed: the very next catch-up pass makes up the missed fire.
+        set_lifecycle(&rt, "running").await;
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            1,
+            "the resumed company gets its deferred catch-up"
+        );
+        assert_eq!(fired_count(&rt).await, 1);
+    }
+
+    /// One clean pass latches: a second pass is a no-op even when a genuinely new
+    /// occurrence has since been missed. Proven by contrast with a fresh
+    /// (non-latched) scheduler over the same store, which DOES make up the new one.
+    #[tokio::test]
+    async fn catch_up_latches_after_one_successful_pass() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .build()
+                .await
+                .unwrap(),
+        );
+        let sid = manifest_schedule_id("0 9 * * MON", "weekly standup");
+        rt.schedule_fires()
+            .claim_fire(rt.id(), &sid, millis_at(2026, 7, 6, 9, 0) / MINUTE_MS)
+            .await
+            .unwrap();
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock.clone()).unwrap();
+
+        // First pass fires the most recent missed Monday and LATCHES.
+        assert_eq!(scheduler.catch_up().await.unwrap(), 1);
+        assert_eq!(fired_count(&rt).await, 1);
+
+        // Advance a week: 2026-07-27 09:00 is now a genuinely new missed fire.
+        clock.set(millis_at(2026, 7, 27, 9, 5));
+        // The latched scheduler ignores it — that is the whole point of the latch.
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            0,
+            "a latched scheduler runs no second pass"
+        );
+        assert_eq!(
+            fired_count(&rt).await,
+            1,
+            "no new fire from the latched one"
+        );
+
+        // A fresh scheduler (latch clear) over the SAME store proves the new miss
+        // was real and would have been caught but for the latch.
+        let mut fresh = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+        assert_eq!(
+            fresh.catch_up().await.unwrap(),
+            1,
+            "a non-latched scheduler still makes up the newly missed fire"
+        );
+        assert_eq!(fired_count(&rt).await, 2);
+    }
+
+    /// A pass that hit a transient store error does NOT latch, so a later pass
+    /// retries and fires — 0 then 1 across a flaky-once store.
+    #[tokio::test]
+    async fn a_failed_pass_does_not_latch() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let manifest = scheduled_manifest();
+        let schedules = manifest.schedules.clone();
+        let flaky = Arc::new(FlakyOnceFires::new(1));
+        let rt = Arc::new(
+            RuntimeBuilder::new(home, manifest)
+                .with_brain(Arc::new(ScheduleBrain))
+                .with_schedule_fires(flaky.clone())
+                .build()
+                .await
+                .unwrap(),
+        );
+        let sid = manifest_schedule_id("0 9 * * MON", "weekly standup");
+        // Seed the anchor directly (bypassing the fail budget) so the miss is real.
+        flaky.seed(rt.id(), &sid, millis_at(2026, 7, 6, 9, 0) / MINUTE_MS);
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 20, 9, 5)));
+        let mut scheduler = CompanyScheduler::new(rt.clone(), &schedules, clock).unwrap();
+
+        // First pass: the anchor read errors, so the pass does not complete and
+        // must NOT latch.
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            0,
+            "a store error fires nothing and does not latch"
+        );
+        assert_eq!(fired_count(&rt).await, 0);
+
+        // Second pass: the store now works, so the deferred catch-up fires.
+        assert_eq!(
+            scheduler.catch_up().await.unwrap(),
+            1,
+            "the retry makes up the missed fire"
+        );
         assert_eq!(fired_count(&rt).await, 1);
     }
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -654,7 +654,10 @@ impl WorkflowScheduler {
         // still-present workflow leaves one stale entry, harmless: it is only a
         // "have I run catch-up for this" bit and a re-created workflow of the same
         // id is a first sight again only after this sweep — acceptable, since a
-        // re-created workflow's anchor is whatever it last durably fired.)
+        // re-created workflow's anchor is whatever it last durably fired. That the
+        // anchor survives a delete+recreate is the durable-identity reuse issue
+        // #708 documents on `workflow_schedule_id` — bounded by the catch-up
+        // window, fixed by purging the fire ledger at delete time, not re-keying.)
         self.caught_up
             .retain(|(company, _)| registry.get(company).is_some());
 
@@ -788,6 +791,43 @@ fn lock_in_flight(
 /// not depend on any positional index. The `workflow-` prefix (a hyphen, never a
 /// colon) keeps it readable in a log line; the fs backend hashes it before it
 /// can address the filesystem, so a console-chosen `<workflow_id>` is safe.
+///
+/// # Identity reuse across delete+recreate (issue #708)
+///
+/// Because this key is the workflow id alone, deleting a workflow and recreating
+/// one with the **same id** makes the new workflow **inherit the old one's fire
+/// ledger** — its durable `claim_fire` / [`latest_fire`] rows survive the delete
+/// (`delete_workflow` in `src/server/ops/workflows.rs` tears down the graph,
+/// revisions, and events, but not the schedule's claim rows). Two effects, each
+/// bounded by [`CATCHUP_WINDOW_MINUTES`]:
+///
+/// * **one suppressed minute** — if the recreated schedule matches a minute the
+///   old id already claimed, `claim_fire` returns `false` and that single
+///   occurrence is skipped; and
+/// * **one inherited make-up** — the first-sight catch-up reads the stale anchor,
+///   so it may fire (or decline) a make-up on the *deleted* workflow's history.
+///   The `caught_up` sweep note in [`tick`](WorkflowScheduler::tick) already
+///   spells this out: a re-created workflow's anchor is whatever it last durably
+///   fired, so it is a first sight against a non-empty ledger.
+///
+/// The key is **deliberately not re-keyed** to erase that history, for three
+/// reasons — the re-key was considered for #661 and rejected:
+///
+/// 1. **Per-deploy catch-up loss** — a new key orphans every deployed tenant's
+///    existing anchors, so the first boot after the change treats every armed
+///    schedule as a fresh install and forfeits its legitimate restart catch-up.
+/// 2. **Rolling-deploy double-fire (a #241 regression)** — during a rolling
+///    deploy, mixed-version replicas would key the same minute under two ids and
+///    both could win a claim: the exact cross-replica double-fire the #241
+///    durable claim exists to prevent.
+/// 3. It is the natural, restart-stable `(company, workflow)` identity that
+///    survives a restart without depending on a positional index.
+///
+/// The real fix purges the fire-ledger rows at delete time instead (a new
+/// [`ScheduleFireStore`](crate::ports::ScheduleFireStore) delete method, called
+/// from `delete_company_workflow`), leaving the key as-is. Tracked in issue #708.
+///
+/// [`latest_fire`]: crate::ports::ScheduleFireStore::latest_fire
 fn workflow_schedule_id(workflow_id: &str) -> String {
     format!("workflow-{workflow_id}")
 }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -159,12 +159,27 @@ pub struct WorkflowScheduler {
     /// is once a minute forever, so the warning is latched here and re-armed
     /// only when the situation changes — see [`note_unwired`](Self::note_unwired).
     warned_unwired: HashSet<CompanyId>,
-    /// Workflows this scheduler has already run its one restart catch-up check
-    /// for (issue #241). Keyed per `(company, workflow)` and checked the FIRST
-    /// time each is seen — not once globally — so a tenant provisioned after boot
-    /// and a workflow created at runtime each get their catch-up when they first
+    /// Workflows whose one restart catch-up attempt has **completed** (issue
+    /// #241). Keyed per `(company, workflow)` and inserted the FIRST time each is
+    /// seen — not once globally — so a tenant provisioned after boot and a
+    /// workflow created at runtime each get their catch-up when they first
     /// appear, rather than being missed by a boot-only pass. Swept when a company
     /// leaves the registry, like [`warned_unwired`](Self::warned_unwired).
+    ///
+    /// The invariant is **latched ⇔ the catch-up attempt COMPLETED**, not merely
+    /// "was reached once". An attempt completes when it fires the make-up
+    /// (`Ok(true)`), finds a peer already claimed the minute (`Ok(false)`), or
+    /// finds nothing to make up (`missed_instant == None`) — all terminal. But an
+    /// attempt that could not run to a verdict on a *transient* condition —
+    /// admission rejected at the #401 cap, the durable anchor read failing, the
+    /// catch-up claim failing, or a still-in-flight prior run holding the overlap
+    /// slot — DROPS the key again (issue #661 F2), so a later tick re-attempts the
+    /// make-up while the missed minute is still inside the catch-up window rather
+    /// than the transient forfeiting that workflow's catch-up for the life of the
+    /// process. The re-attempt is bounded: at most one [`latest_fire`] read per
+    /// key per minute-tick, and it stops the moment an attempt completes.
+    ///
+    /// [`latest_fire`]: crate::ports::ScheduleFireStore::latest_fire
     caught_up: HashSet<WorkflowKey>,
     /// How many unwired-company warnings have been emitted, so a test can assert
     /// the latch actually suppresses the repeat.
@@ -468,15 +483,39 @@ impl WorkflowScheduler {
                                         Err(err) => {
                                             drop(guard);
                                             drop(claim);
+                                            // Issue #661 (F2): a transient claim
+                                            // failure defers, it does not forfeit.
+                                            // Drop the first-sight latch (the #676
+                                            // at-cap style, above) so a later tick
+                                            // re-attempts the make-up while `missed`
+                                            // is still inside the catch-up window.
+                                            self.caught_up.remove(&key);
                                             tracing::warn!(%company, workflow = %file.id, %err, "workflow scheduler: could not claim catch-up fire; skipping (fail closed)");
                                         }
                                     }
+                                } else {
+                                    // Issue #661 (F2): the overlap slot is held by
+                                    // a prior run still in flight, so the make-up
+                                    // could not even be attempted this tick. Drop
+                                    // the first-sight latch so a later tick — once
+                                    // that run finishes and frees the slot —
+                                    // re-attempts it while `missed` is still inside
+                                    // the catch-up window, rather than the overlap
+                                    // forfeiting catch-up for this key entirely.
+                                    self.caught_up.remove(&key);
                                 }
                             }
                         }
                         // Fail closed: without a trustworthy anchor we cannot tell
                         // a missed fire from an already-made one.
                         Err(err) => {
+                            // Issue #661 (F2): the anchor read failed transiently,
+                            // so this attempt reached no verdict. Drop the
+                            // first-sight latch so a later tick re-reads the anchor
+                            // and re-attempts catch-up — without this, one flaky
+                            // read permanently forfeits this workflow's make-up for
+                            // the life of the process.
+                            self.caught_up.remove(&key);
                             tracing::warn!(%company, workflow = %file.id, %err, "workflow scheduler: could not read catch-up anchor; skipping catch-up (fail closed)");
                         }
                     }
@@ -3418,5 +3457,276 @@ to = "done"
         );
         wait_for(|| started.lock().unwrap().len() == 1).await;
         assert_eq!(started.lock().unwrap()[0].input["catchUp"], true);
+    }
+
+    // --- issue #661 (F2): a transient failure DEFERS the first-sight catch-up,
+    // it does not forfeit it ----------------------------------------------------
+
+    use crate::error::OpenCompanyError;
+    use crate::ports::ScheduleFireStore;
+
+    /// An in-memory [`ScheduleFireStore`] that can be told to fail its first N
+    /// `latest_fire` reads and/or its first N `claim_fire` writes, then behaves
+    /// normally. The double for issue #661 F2: a transient store error on the
+    /// first-sight catch-up must drop the `caught_up` latch so a later tick
+    /// re-attempts the make-up, rather than one flaky call forfeiting it for the
+    /// life of the process. `seed` presets an anchor WITHOUT consuming a fail
+    /// budget, so a test can arrange a genuine missed fire and still arm the
+    /// failure it wants to observe.
+    struct FlakyFires {
+        claims: Mutex<HashMap<(String, String), HashSet<u64>>>,
+        fail_latest: AtomicUsize,
+        fail_claim: AtomicUsize,
+    }
+
+    impl FlakyFires {
+        fn new() -> Self {
+            Self {
+                claims: Mutex::new(HashMap::new()),
+                fail_latest: AtomicUsize::new(0),
+                fail_claim: AtomicUsize::new(0),
+            }
+        }
+        /// Arm the next `n` `latest_fire` reads to fail (armed AFTER any seeding).
+        fn arm_latest_failures(&self, n: usize) {
+            self.fail_latest.store(n, Ordering::SeqCst);
+        }
+        /// Arm the next `n` `claim_fire` writes to fail.
+        fn arm_claim_failures(&self, n: usize) {
+            self.fail_claim.store(n, Ordering::SeqCst);
+        }
+        /// Preset an anchor directly, bypassing the fail budgets.
+        fn seed(&self, company: &str, schedule: &str, minute: u64) {
+            self.claims
+                .lock()
+                .unwrap()
+                .entry((company.to_string(), schedule.to_string()))
+                .or_default()
+                .insert(minute);
+        }
+    }
+
+    #[async_trait]
+    impl ScheduleFireStore for FlakyFires {
+        async fn claim_fire(&self, c: &CompanyId, s: &str, m: u64) -> crate::Result<bool> {
+            if self.fail_claim.load(Ordering::SeqCst) > 0 {
+                self.fail_claim.fetch_sub(1, Ordering::SeqCst);
+                return Err(OpenCompanyError::Store("flaky claim store".into()));
+            }
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .entry((c.as_ref().to_string(), s.to_string()))
+                .or_default()
+                .insert(m))
+        }
+        async fn latest_fire(&self, c: &CompanyId, s: &str) -> crate::Result<Option<u64>> {
+            if self.fail_latest.load(Ordering::SeqCst) > 0 {
+                self.fail_latest.fetch_sub(1, Ordering::SeqCst);
+                return Err(OpenCompanyError::Store("flaky claim store".into()));
+            }
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .get(&(c.as_ref().to_string(), s.to_string()))
+                .and_then(|set| set.iter().max().copied()))
+        }
+        async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> crate::Result<usize> {
+            Ok(0)
+        }
+    }
+
+    /// [`company_with_overlays`] with a caller-supplied [`ScheduleFireStore`], so a
+    /// test can drive the scheduler against a flaky claim store (issue #661 F2).
+    async fn company_with_overlays_and_fires(
+        home: &std::path::Path,
+        id: &str,
+        overlays: Vec<OverlayWorkflow>,
+        runner: Option<Arc<dyn WorkflowRunner>>,
+        lifecycle: &str,
+        fires: Arc<dyn ScheduleFireStore>,
+    ) -> CompanyRegistry {
+        let company = CompanyId::new(id);
+        let mut runtime = RuntimeBuilder::new(home.to_path_buf(), manifest())
+            .with_id(company.clone())
+            .with_schedule_fires(fires)
+            .build()
+            .await
+            .expect("builds");
+        if let Some(runner) = runner {
+            runtime.set_workflow_runner(runner);
+        }
+        let store = runtime.store().clone();
+        let mut record: CompanyRecord = store
+            .load(&company)
+            .await
+            .expect("loads")
+            .expect("the builder materialized a record");
+        record.overlay_workflows = overlays;
+        record.lifecycle = lifecycle.to_string();
+        store.save(&record).await.expect("saves");
+
+        let registry = CompanyRegistry::new();
+        registry.insert(company, Arc::new(runtime));
+        registry
+    }
+
+    /// A transient anchor-read failure on first sight DEFERS the catch-up: the
+    /// latch is dropped so the NEXT tick re-reads the anchor and makes up the
+    /// missed fire, instead of one flaky `latest_fire` forfeiting it forever.
+    #[tokio::test]
+    async fn a_transient_anchor_read_error_defers_first_sight_catch_up() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let fires = Arc::new(FlakyFires::new());
+        let registry = company_with_overlays_and_fires(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+            fires.clone(),
+        )
+        .await;
+        // Anchor two Mondays back; the most recent missed Monday is 2026-07-13.
+        fires.seed("acme", "workflow-digest", minute_at(2026, 7, 6, 9, 0));
+        // The FIRST anchor read fails; the second (next tick) succeeds.
+        fires.arm_latest_failures(1);
+
+        // "Now" is a Tuesday, so the current minute never matches — isolating the
+        // catch-up as the only possible fire.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        // First tick: the anchor read errors, so catch-up is deferred and the
+        // latch dropped — nothing fires, nothing is claimed.
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "a flaky anchor read defers the catch-up on first sight"
+        );
+        assert!(started.lock().unwrap().is_empty());
+
+        // Second tick: the anchor read now succeeds, so the deferred make-up lands
+        // at the ORIGINAL missed minute, proving the latch did not forfeit it.
+        assert_eq!(
+            scheduler.tick().await,
+            1,
+            "the next tick re-attempts and fires the deferred catch-up"
+        );
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        let run = started.lock().unwrap()[0].clone();
+        assert_eq!(run.input["catchUp"], true);
+        assert_eq!(
+            run.input["firedAtMs"],
+            minute_at(2026, 7, 13, 9, 0) * MINUTE_MS,
+            "the make-up carries the original missed minute"
+        );
+    }
+
+    /// A transient claim failure on the first-sight catch-up DEFERS it and — the
+    /// part that would otherwise be a silent leak — releases the admission guard,
+    /// so the in-flight slot is not permanently occupied by a run that never
+    /// started. A later tick re-attempts and fires it.
+    #[tokio::test]
+    async fn a_transient_claim_error_on_catch_up_defers_not_forfeits() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let fires = Arc::new(FlakyFires::new());
+        let registry = company_with_overlays_and_fires(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+            fires.clone(),
+        )
+        .await;
+        // Anchor two Mondays back; the most recent missed Monday is 2026-07-13.
+        fires.seed("acme", "workflow-digest", minute_at(2026, 7, 6, 9, 0));
+        // The FIRST claim (the catch-up claim) fails; the next succeeds.
+        fires.arm_claim_failures(1);
+
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        // "Now" is a Tuesday: the current minute never matches, isolating catch-up.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        // First tick: the catch-up claim errors after admission, so the guard is
+        // released on the fail-closed arm — no run starts, no guard leaks.
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "a flaky catch-up claim defers, firing nothing"
+        );
+        assert!(started.lock().unwrap().is_empty());
+        assert_eq!(
+            runtime.run_supervisor().len(),
+            0,
+            "the admission guard was released — no in-flight slot leaked"
+        );
+
+        // Second tick: the claim now succeeds, so the deferred make-up fires.
+        assert_eq!(
+            scheduler.tick().await,
+            1,
+            "the next tick re-attempts and fires the deferred catch-up"
+        );
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+        assert_eq!(started.lock().unwrap()[0].input["catchUp"], true);
+    }
+
+    /// The overlap arm: when a prior run still holds the in-flight slot on first
+    /// sight, the catch-up cannot even be attempted — so the latch is dropped
+    /// (not left set), letting a later tick re-attempt once the slot frees. Driven
+    /// directly on the private latch, since the overlap-on-first-sight race is not
+    /// cheap to stage through the public tick alone.
+    #[tokio::test]
+    async fn an_overlap_on_first_sight_drops_the_catch_up_latch() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("0 9 * * MON"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        // A genuine missed fire is available (anchor two Mondays back).
+        runtime
+            .schedule_fires()
+            .claim_fire(&company, "workflow-digest", minute_at(2026, 7, 6, 9, 0))
+            .await
+            .unwrap();
+
+        // "Now" is a Tuesday, so nothing matches the current minute — the only
+        // path that could touch the latch this tick is the first-sight catch-up.
+        let clock = Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+        let mut scheduler = WorkflowScheduler::new(registry.clone(), clock);
+
+        // Occupy the overlap slot for this key BEFORE the tick, standing in for a
+        // prior scheduled run still executing when first sight happens.
+        let key = (company.clone(), "digest".to_string());
+        let _held = scheduler.claim(&key).expect("take the overlap slot");
+
+        assert_eq!(
+            scheduler.tick().await,
+            0,
+            "the overlap suppresses the catch-up attempt this tick"
+        );
+        assert!(started.lock().unwrap().is_empty());
+        assert!(
+            !scheduler.caught_up.contains(&key),
+            "the latch was dropped, so a later tick will re-attempt the catch-up"
+        );
     }
 }


### PR DESCRIPTION
**Part of #661 — L6 (scheduler minors).** Not `Closes` — #661 is a multi-PR tracker.

Three independent minor defects in the two cron schedulers, each additive on top of the admit→claim→run rework in #676 (no reordering of admit→claim→run, no change to guard-drop behavior).

## Summary

**F2 — workflow scheduler: drop the first-sight catch-up latch on a transient defer.** `WorkflowScheduler::tick` latches its per-`(company, workflow)` restart catch-up on the FIRST sighting (`caught_up.insert(key)`), before the make-up attempt runs. #676 already drops that latch on the two at-cap defer arms, but three arms still left it **set** after an incomplete attempt — permanently forfeiting that workflow's downtime make-up for the life of the process on a transient condition. Now the latch is also dropped (the same #676 at-cap style) on: the `latest_fire` anchor-read error arm, the catch-up `claim_fire` error arm, and the overlap `claim == None` arm (a prior run still holding the slot). The latch STAYS on the terminal outcomes — nothing missed (`missed_instant == None`), fired (`Ok(true)`), and peer-claimed (`Ok(false)`). Invariant is now **latched ⇔ a catch-up attempt COMPLETED**; a later tick re-attempts a deferred one while the missed minute is still inside the catch-up window (bounded: one `latest_fire` read per key per minute-tick).

**F1 — manifest scheduler: re-arm the boot catch-up until one clean pass.** `CompanyScheduler::catch_up` ran exactly once, before the steady-state loop, and early-returned `Ok(0)` whenever `ensure_running` rejected. A company **paused across boot** and resumed later therefore never made up its missed fire — its one and only attempt happened while it was paused. Added a `caught_up` latch set only after a pass that got past `ensure_running` **and** touched the store without error, and drive `catch_up()` from the tick loop until it latches. A pause never latches (one cheap `ensure_running` probe a minute while paused); a transient store error clears the pass so a later tick retries. Re-running a partial pass is idempotent — a fired schedule advanced its durable anchor and a durable claim already made is not re-made.

**F3 — schedule identity across delete+recreate: DOCUMENT, do not re-key.** `workflow_schedule_id` is keyed on the workflow id alone, so delete+recreate of a same-id workflow inherits the old schedule's fire ledger (one suppressed minute or one inherited make-up, each bounded by `CATCHUP_WINDOW_MINUTES`). The key is deliberately **not** re-keyed, for three reasons carried into the doc so this does not read as a dodge:
1. **Per-deploy catch-up loss** — a new key orphans every deployed tenant's anchors, so the first boot after the change treats every armed schedule as a fresh install and forfeits its legitimate restart catch-up.
2. **Rolling-deploy double-fire (a #241 regression)** — mixed-version replicas would key one minute under two ids and both could win a claim.
3. The key is the natural, restart-stable `(company, workflow)` identity.

The real fix (purge the fire ledger in `delete_workflow` via a new `ScheduleFireStore` method) is tracked in **#708**.

## API Or Behavior Changes

No public API changes. Behavior:
- A workflow-schedule restart catch-up that hits a transient condition (store error / at-cap / overlap) is now **retried on a later tick** instead of being forfeited for the process lifetime.
- A manifest-schedule company **paused across boot** now gets its restart catch-up on its first running minute after resume, instead of never.
- No change to steady-state firing, the durable claim, the in-flight cap, or the admit→claim→run ordering from #676.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings` (and `--features openhuman,tinycortex`)
- [x] `cargo check --locked --all-targets` (and `--all-features`)
- [x] `cargo test` (default: 2078 passed) and `cargo test --locked --features openhuman,tinycortex --tests` (3134+ passed)

New tests (mirroring #676's deterministic single-tick style):
- `workflow_scheduler`: `a_transient_anchor_read_error_defers_first_sight_catch_up`, `a_transient_claim_error_on_catch_up_defers_not_forfeits` (asserts the admission guard is released — `supervisor.len() == 0`, no leak), `an_overlap_on_first_sight_drops_the_catch_up_latch` (drives the latch disposition directly).
- `scheduler`: `catch_up_skipped_while_paused_runs_on_resume`, `catch_up_latches_after_one_successful_pass`, `a_failed_pass_does_not_latch`.
- All #676 regressions stay green untouched (`a_catch_up_at_the_in_flight_cap_is_deferred_not_burned`, the at-cap leave-unclaimed test, `first_sight_catch_up_fires_one_missed_run`, `a_late_provisioned_company_gets_its_catch_up_on_first_sight`, `a_disabled_workflow_gets_no_catch_up`, `racing_catch_up_fires_once`, `catch_up_fires_one_missed_instant_then_none_left`).

## Documentation

- Rustdoc on `WorkflowScheduler::caught_up`, `CompanyScheduler::caught_up` / `catch_up`, and `workflow_schedule_id` (the delete+recreate identity-reuse section) updated in-line with the behavior.
- F3 real fix tracked as #708.