### PR TITLE
feat(workspace): sweep provably empty agent folders (#700)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -46,7 +46,7 @@ why this is not a read/write split: [authority.md](authority.md).
 | `tasks` | `POST …/tasks`, `GET …/tasks`, `GET …/tasks/{id}` (the Task Detail read, #185), `PATCH`/`DELETE …/tasks/{id}`, `GET …/tasks/inflight`, `POST …/tasks/{id}/steer` (#111), `POST …/tasks/{id}/discussion` (#335), `DELETE …/tasks/{id}/discussion/{seq}` (#358) |
 | `task_export` | `GET …/tasks/{id}/export` (the task's record as a document, #352) |
 | `memory` | `POST …/memory`, `DELETE …/memory/{id}` (journals `MemoryFactDeleted`) |
-| `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `GET …/workspace/search?q=…` (#607), `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}` (the `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177). Node bodies carry `createdBy`/`updatedBy` (#326) |
+| `workspace` | `GET …/workspace`, `GET …/workspace/file/{id}`, `GET …/workspace/search?q=…` (#607), `POST …/workspace`, `PUT …/workspace/file/{id}`, `PATCH`/`DELETE …/workspace/{id}`, `POST …/workspace/sweep-empty-agent-folders?dry_run=` (#700, removes only folders with no children counted structurally) (the `GET`s are REST twins of the GraphQL reads — the console has no GraphQL client, #177). Node bodies carry `createdBy`/`updatedBy` (#326) |
 | `skills` | `POST …/skills`, `GET …/skills/registry`, `POST …/skills/{slug}/install\|uninstall`, `PUT …/skills/{slug}` |
 | `team` | `POST …/team`, `DELETE …/team/{id}`, `PUT …/team/{id}/inbox` (overlay; roster-only in v1) |
 | `mail` | `POST …/inboxes/{key}/read` |

--- a/docs/spec/runtime/api.md
+++ b/docs/spec/runtime/api.md
@@ -141,6 +141,7 @@ POST   …/workspace                          create a folder/file (or upload)
 PUT    …/workspace/file/{nodeId}             write file content
 PATCH  …/workspace/{nodeId}                  rename / move
 DELETE …/workspace/{nodeId}                  delete a node
+POST   …/workspace/sweep-empty-agent-folders?dry_run=  tidy `Agents/` strays (#700)
 POST   …/skills                             add a custom skill
 GET    …/skills/registry                     browse the shared skill library
 POST   …/skills/{slug}/install              install a registry/company skill
@@ -201,6 +202,22 @@ cleared search box into a full-tree fetch. `limit=0` is a `400` for the same
 reason — it is never read as "no limit". A **binary** node matches on its name
 only: a text read of a payload is empty by the port's definition, and its bytes
 are never scanned or excerpted.
+
+`POST …/workspace/sweep-empty-agent-folders` (#700) removes the empty
+`Agents/<id>/` folders a pre-#570 company still carries. Operator-triggered
+rather than automatic — the affected tenants are hosted, so a subcommand would
+be unreachable for the operators who need it, and a boot sweep would change a
+tree on an upgrade nobody asked for. `?dry_run=true` answers
+`{"wouldRemove":[{id,name}…]}` and touches nothing, so the console can name
+every folder on a confirm dialog; the real call answers `{"removed":[…]}`, and
+which field carries the list is what actually happened. A node qualifies only
+when it is a direct child of the `Agents` root **by id**, is a folder, and has
+**no children counted structurally** — over every node in the tree, before any
+path is rendered, because a folder whose only child carries a path separator
+reads as empty to anything path-shaped while the recursive delete would still
+take it (#671), and sqlite and mongodb both accept such a name. An ambiguous
+root is a `409`, not a guess. Each removal announces its own
+`WorkspaceChanged{removed}` (#327); a second run removes nothing.
 
 Both workspace `GET`s — and the `POST` / `PATCH` node bodies — carry
 `createdBy` and `updatedBy` (#326), each `{"kind":"seed"|"operator"|"agent",

--- a/frontend/src/api/workspace.ts
+++ b/frontend/src/api/workspace.ts
@@ -317,6 +317,50 @@ export function deleteNode(
   return client.del<void>(`${client.scopeFor(company)}/workspace/${encodeURIComponent(id)}`);
 }
 
+/** One folder the sweep removed, or would remove (issue #700). */
+export interface SweptFolder {
+  id: string;
+  name: string;
+}
+
+/**
+ * The sweep's answer. Exactly one list is present, and **which** one is what
+ * actually happened: a preview answers `wouldRemove`, a real run answers
+ * `removed`.
+ */
+interface SweepResult {
+  wouldRemove?: SweptFolder[];
+  removed?: SweptFolder[];
+}
+
+/**
+ * Remove the empty `Agents/<id>/` folders a pre-#570 company still carries
+ * (issue #700), or — with `dryRun` — find out which ones those are without
+ * touching anything.
+ *
+ * The two calls are the same request twice: the console previews, names every
+ * folder on a confirm dialog, and only then asks for the deletion. Nothing here
+ * decides emptiness; the host counts children structurally, over every node in
+ * the tree, because a folder whose only child has no renderable path reads as
+ * empty to anything that goes by paths while the store's recursive delete would
+ * still take it (issue #671).
+ *
+ * Reads the field that matches what was asked for, rather than whichever list
+ * turns up. If the host ever disagrees with this caller about `dryRun`, an
+ * absent field yields an empty list — so a preview cannot render as "17 folders
+ * deleted", and a real run cannot be mistaken for a preview.
+ */
+export async function sweepEmptyAgentFolders(
+  client: OpenCompanyClient,
+  company: string | null,
+  dryRun: boolean,
+): Promise<SweptFolder[]> {
+  const result = await client.post<SweepResult>(
+    `${client.scopeFor(company)}/workspace/sweep-empty-agent-folders?dry_run=${dryRun}`,
+  );
+  return (dryRun ? result.wouldRemove : result.removed) ?? [];
+}
+
 /**
  * Upload a file of any kind (issue #553).
  *

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -7,6 +7,7 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
+  FolderX,
   Link2,
   Loader2,
   MoreHorizontal,
@@ -34,11 +35,13 @@ import {
   originLabel,
   renameMoveNode,
   searchWorkspace,
+  sweepEmptyAgentFolders,
   uploadFile,
   writeFile,
   OPERATOR_ORIGIN,
   type SearchHit,
   type SearchResults as SearchResultsPage,
+  type SweptFolder,
   type WorkspaceFile,
   type WorkspaceOrigin,
 } from "@/api/workspace";
@@ -358,6 +361,11 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
   const [showExplorer, setShowExplorer] = useState(true);
   const [legacy, setLegacy] = useState<FsNode[]>([]);
   const [importing, setImporting] = useState(false);
+  // The empty-agent-folder tidy (issue #700), in its two stages: `preview` is
+  // what the host says *would* go, `done` is what actually went. Both name every
+  // folder — a count is not something an operator who disagrees can check.
+  const [sweep, setSweep] = useState<SweepState | null>(null);
+  const [sweeping, setSweeping] = useState(false);
   // The pending scratchpad partitioned by kind, once, for every surface that
   // describes or imports it: the banner's sentence, the import loops, and the
   // receipt. #500 partitioned inside `importLegacy` so the loops and the
@@ -965,6 +973,53 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
     }
   }
 
+  /**
+   * Ask the host which `Agents/<id>/` folders are empty, and show them
+   * (issue #700).
+   *
+   * A preview, always — the deletion is a second call the operator makes from
+   * the dialog. Nothing about emptiness is decided here: the host counts
+   * children structurally, over every node in the tree, and this only renders
+   * the answer.
+   */
+  async function previewSweep() {
+    setSweeping(true);
+    try {
+      const folders = await sweepEmptyAgentFolders(client, company, true);
+      if (folders.length === 0) {
+        toast.success("No empty agent folders to tidy.");
+        return;
+      }
+      setSweep({ stage: "preview", folders });
+    } catch (e) {
+      toast.error(message(e, "could not check for empty agent folders"));
+    } finally {
+      setSweeping(false);
+    }
+  }
+
+  /**
+   * Remove them, then report what actually went.
+   *
+   * The result list is the host's, not the preview echoed back: a folder that
+   * gained a deliverable between the two calls is left standing and is absent
+   * here, so the receipt describes the tree rather than the operator's intent.
+   */
+  async function confirmSweep() {
+    setSweeping(true);
+    try {
+      const removed = await sweepEmptyAgentFolders(client, company, false);
+      const gone = new Set(removed.map((f) => f.id));
+      setNodes((all) => all.filter((n) => !gone.has(n.id)));
+      setSweep({ stage: "done", folders: removed });
+    } catch (e) {
+      toast.error(message(e, "could not tidy the empty agent folders"));
+      setSweep(null);
+    } finally {
+      setSweeping(false);
+    }
+  }
+
   async function onWiki(target: string) {
     const existing = fileByTitle(nodes, target);
     if (existing) {
@@ -1027,6 +1082,19 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
           </IconBtn>
           <IconBtn label="Upload" onClick={() => uploadRef.current?.click()}>
             <Upload className="size-4" />
+          </IconBtn>
+          {/* Issue #700. A company provisioned before the tree went lazy carries
+              one empty folder per teammate, and nothing else will ever remove
+              them. Deliberately a button rather than something boot does: the
+              operator's click is the opt-in, and the dialog names every folder
+              before any of them goes. */}
+          <IconBtn
+            label="Tidy empty agent folders"
+            disabled={sweeping}
+            onClick={() => void previewSweep()}
+            data-testid="workspace-sweep"
+          >
+            <FolderX className="size-4" />
           </IconBtn>
           <input
             ref={uploadRef}
@@ -1298,6 +1366,12 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
           if (moving) void move(moving, destId);
           setMoving(null);
         }}
+      />
+      <SweepDialog
+        state={sweep}
+        busy={sweeping}
+        onClose={() => setSweep(null)}
+        onConfirm={() => void confirmSweep()}
       />
     </div>
   );
@@ -1769,6 +1843,81 @@ function MoveDialog({
             <DestRow key={f.id} label={f.name} disabled={moving?.parentId === f.id} onClick={() => onMove(f.id)} />
           ))}
         </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * The empty-agent-folder tidy, in its two stages (issue #700).
+ *
+ * `preview` asks; `done` reports. Both list the folders by name, which is the
+ * point of the dialog rather than a nicety: an operator who disagrees with the
+ * sweep can only say so if they can see what it means to take, and can only
+ * check it afterwards if they are told what it took. "17 empty folders" is a
+ * number nobody can verify.
+ */
+interface SweepState {
+  stage: "preview" | "done";
+  folders: SweptFolder[];
+}
+
+function SweepDialog({
+  state,
+  busy,
+  onClose,
+  onConfirm,
+}: {
+  state: SweepState | null;
+  busy: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  const done = state?.stage === "done";
+  const count = state?.folders.length ?? 0;
+
+  return (
+    <Dialog open={Boolean(state)} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{done ? "Tidied" : "Tidy empty agent folders"}</DialogTitle>
+          <DialogDescription>
+            {done
+              ? count === 0
+                ? "Nothing was removed — every folder had gained something by the time the tidy ran."
+                : `Removed ${count} empty folder${count === 1 ? "" : "s"} from Agents/.`
+              : `${count} folder${count === 1 ? "" : "s"} under Agents/ hold nothing at all. Removing them cannot take anything with them — a folder holding any file, note or subfolder is left alone.`}
+          </DialogDescription>
+        </DialogHeader>
+        <ul
+          className="max-h-64 space-y-1 overflow-y-auto"
+          data-testid="workspace-sweep-folders"
+        >
+          {state?.folders.map((folder) => (
+            <li
+              key={folder.id}
+              className="flex items-center gap-2 rounded-lg px-2.5 py-1.5 text-sm"
+            >
+              <Folder className="size-4 shrink-0 text-tone-2" />
+              <span className="truncate">{folder.name}</span>
+            </li>
+          ))}
+        </ul>
+        <DialogFooter>
+          {done ? (
+            <Button onClick={onClose}>Done</Button>
+          ) : (
+            <>
+              <Button variant="ghost" onClick={onClose}>
+                Cancel
+              </Button>
+              <Button variant="destructive" disabled={busy} onClick={onConfirm}>
+                {busy && <Loader2 className="mr-1 size-4 animate-spin" />}
+                Remove {count}
+              </Button>
+            </>
+          )}
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -66,6 +66,11 @@ pub mod workspace_search;
 // default build, and it touches nothing but the `WorkspaceStore` port.
 pub mod workspace_scaffold;
 pub mod workspace_seed;
+// Issue #700: the operator-triggered removal of the empty `Agents/<id>/` folders
+// a pre-#570 company still carries. Always compiled and openhuman-free, like the
+// scaffold whose fail-closed root lookup it shares: its only caller is the
+// console's REST route, and it touches nothing but the `WorkspaceStore` port.
+pub mod workspace_sweep;
 
 use std::path::Path;
 

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -265,7 +265,14 @@ async fn ensure_member_folder(
 }
 
 /// What a lookup for one named node under one parent found.
-enum Found {
+///
+/// `pub(crate)` alongside [`find`], for the one other module that has to resolve
+/// a system root: [`workspace_sweep`](crate::company::workspace_sweep). A sweep
+/// that removes folders *under* `Agents/` has to agree with the scaffold about
+/// which node that root is, and about when there isn't one — a second lookup
+/// with its own idea of "the `Agents` folder" could adopt a node this module
+/// refuses to touch, and then delete beneath it.
+pub(crate) enum Found {
     /// Exactly one folder carries the name — adopt it, by id.
     Folder(String),
     /// Nothing carries the name; it is free to create.
@@ -277,7 +284,10 @@ enum Found {
 
 /// Look for a node named `name` whose parent is `parent` (`None` = the
 /// workspace root).
-fn find(nodes: &[WorkspaceNode], parent: Option<&str>, name: &str) -> Found {
+///
+/// `pub(crate)` so the fail-closed adoption rule above has exactly one
+/// implementation. See [`Found`].
+pub(crate) fn find(nodes: &[WorkspaceNode], parent: Option<&str>, name: &str) -> Found {
     let matches: Vec<&WorkspaceNode> = nodes
         .iter()
         .filter(|node| node.parent_id.as_deref() == parent && node.name == name)

--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -1,0 +1,752 @@
+//! Issue #700: remove the empty `Agents/<id>/` folders a pre-#570 company is
+//! still carrying, and nothing else.
+//!
+//! Every company provisioned before issue #570 minted one folder per roster
+//! member at boot, whether or not that member ever produced anything. #570
+//! stopped doing it and deliberately chose no backfill — the right call at the
+//! time, and the reason there is no migration to lean on here. What changed
+//! since is what those folders now *mean*:
+//!
+//! * #570 made a member folder mean "this teammate produced something", so on a
+//!   pre-#570 tenant the two populations are indistinguishable by eye.
+//! * #552 publishes deliverables into `Agents/<agent>/<task-id>/`, so an empty
+//!   folder now reads as "this agent has produced nothing" — a claim, and on
+//!   these tenants an unfounded one.
+//! * #607 made the tree searchable with a bounded result set, so a name-matching
+//!   empty folder competes for slots against notes that actually hold something.
+//!
+//! # The whole risk is the emptiness predicate
+//!
+//! The failure mode is deleting somebody's work, and the port's
+//! [`delete`](WorkspaceStore::delete) is **recursive** — so a folder handed to it
+//! takes its subtree with it whether or not the caller knew the subtree was
+//! there. Issue #671 found exactly this bug one layer over, in the agent delete
+//! tool: the tool layer's `PathIndex` omits every node it cannot address by path
+//! (a name carrying a separator, a dangling or cyclic ancestor chain), so a
+//! folder holding only such children looks empty by every path-shaped measure
+//! while `delete` would still take them.
+//!
+//! [`empty_agent_folder_candidates`] therefore counts **structurally**, over
+//! every node `tree()` returned, before and without any path rendering — the
+//! same `parent id → child count` map #671 replaced the prefix scan with. It is
+//! also exact per node id rather than per rendered path: two folders may share a
+//! path, they never share an id.
+//!
+//! The shape is not hypothetical on the tenants this targets. The `fs` backend
+//! rejects separator-carrying names at creation (`reject_unsafe_name`); the
+//! sqlite and mongodb backends do not, and hosted tenants run those.
+//!
+//! # Why there is no authorship filter
+//!
+//! Stamping would be the obvious narrower predicate — sweep only what the #551
+//! boot burst created — and it cannot work here. A node written before issue
+//! #326 has no origin field at all and deserializes to
+//! [`Operator`](crate::ports::workspace::WorkspaceOrigin::Operator), which is
+//! precisely the population this exists for. Structural emptiness is the only
+//! predicate that is safe on the affected tenants, and naming every folder
+//! before it goes (see `dry_run`) is what keeps that honest.
+//!
+//! # Operator-triggered, not automatic
+//!
+//! Nothing here runs at boot. A tenant finding its tree changed by an upgrade it
+//! did not ask for is the outcome #570 and #645 both avoided by leaving existing
+//! nodes alone; the console's action is the opt-in that replaces it. The
+//! functions below are a stateless function of the current tree, so running the
+//! sweep twice removes nothing the second time — a property the tests assert
+//! rather than assume.
+
+use std::collections::{HashMap, HashSet};
+
+use serde::Serialize;
+
+use crate::Result;
+use crate::company::workspace_scaffold::{AGENTS_ROOT, Found, find};
+use crate::error::OpenCompanyError;
+use crate::ports::types::CompanyId;
+use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
+
+/// One folder the sweep removed, or would remove.
+///
+/// The name is the point. "Removed 17 empty folders" is a number an operator
+/// cannot check; an operator who disagrees with the sweep needs to know *what*
+/// went, which is why this carries the name on the preview as well as on the
+/// result. The id comes along because a console that wants to drop the row it is
+/// showing needs to match it.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+pub struct SweptFolder {
+    /// The node id.
+    pub id: String,
+    /// The folder's name, as the tree holds it.
+    pub name: String,
+}
+
+impl From<&WorkspaceNode> for SweptFolder {
+    fn from(node: &WorkspaceNode) -> Self {
+        Self {
+            id: node.id.clone(),
+            name: node.name.clone(),
+        }
+    }
+}
+
+/// Which folders directly under `Agents/` hold nothing at all.
+///
+/// Pure: it decides from one tree snapshot and touches no store, which is what
+/// lets the shapes that matter — an unaddressable child, a dangling chain — be
+/// pinned on hand-built input that no backend would let a test create.
+///
+/// Three conditions, all necessary:
+///
+/// 1. **A direct child of the `Agents` root, by node id.** Never by rendered
+///    path: the root is resolved with the scaffold's own
+///    [`find`](crate::company::workspace_scaffold::find), so the sweep and the
+///    scaffold cannot disagree about which node that root is.
+/// 2. **A folder.** A *file* sitting directly under `Agents/` is somebody's
+///    note, not a stray container.
+/// 3. **No children, counted structurally.** See the module docs: the count runs
+///    over every node the store returned, so a child with no renderable path
+///    still protects its parent.
+///
+/// # Errors
+///
+/// An ambiguous root — several nodes named `Agents`, or a *file* carrying the
+/// name — is refused rather than guessed at. "Under `Agents/`" has no single
+/// answer there, and picking one would delete beneath a root the scaffold itself
+/// refuses to touch. No root at all is not an error: there is simply nothing to
+/// sweep.
+pub(crate) fn empty_agent_folder_candidates(
+    nodes: &[WorkspaceNode],
+) -> Result<Vec<&WorkspaceNode>> {
+    let root_id = match find(nodes, None, AGENTS_ROOT) {
+        Found::Folder(id) => id,
+        Found::Free => return Ok(Vec::new()),
+        Found::Collision(why) => {
+            return Err(OpenCompanyError::Conflict(format!(
+                "{why}, so which folders are `{AGENTS_ROOT}/` members is undecidable; nothing \
+                 was removed"
+            )));
+        }
+    };
+
+    // Counted before anything is filtered, and over parent ids rather than
+    // rendered paths — the issue #671 measure. A child whose name carries a
+    // separator has no path, is absent from every path-shaped index, and would
+    // still be taken by the port's recursive delete; here it is a child like
+    // any other.
+    let mut child_count: HashMap<&str, usize> = HashMap::new();
+    for node in nodes {
+        if let Some(parent) = node.parent_id.as_deref() {
+            *child_count.entry(parent).or_insert(0) += 1;
+        }
+    }
+
+    Ok(nodes
+        .iter()
+        .filter(|node| {
+            node.parent_id.as_deref() == Some(root_id.as_str())
+                && node.kind == NodeKind::Folder
+                && child_count
+                    .get(node.id.as_str())
+                    .copied()
+                    .unwrap_or_default()
+                    == 0
+        })
+        .collect())
+}
+
+/// Remove every provably empty `Agents/<id>/` folder in `company`, naming what
+/// went.
+///
+/// `dry_run` returns the candidates without touching anything, so the console
+/// can name every folder on a confirm dialog before the operator agrees to lose
+/// them. A real run answers with what it actually removed, which is not
+/// necessarily the same list — see below.
+///
+/// # Two snapshots, on purpose
+///
+/// A real run re-reads the tree and intersects the two candidate sets by id
+/// before deleting anything. Issue #552's publish path can mint a deliverable
+/// into a folder at any moment, and a candidate list computed once is a claim
+/// about a tree that has since moved on. Two reads do not make this atomic —
+/// the port offers no transaction across `tree` and `delete`, and pretending
+/// otherwise would be worse than saying so — but they narrow the window to the
+/// gap between the second read and each delete, instead of leaving it open for
+/// the whole preview-then-confirm round trip.
+///
+/// A folder that raced away entirely (`delete` answering `false`) is logged and
+/// left out of the result. It is not an error: the outcome the caller asked for
+/// — that folder gone — is the outcome they got.
+pub async fn sweep_empty_agent_folders(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    dry_run: bool,
+) -> Result<Vec<SweptFolder>> {
+    let nodes = store.tree(company).await?;
+    let candidates: Vec<SweptFolder> = empty_agent_folder_candidates(&nodes)?
+        .into_iter()
+        .map(SweptFolder::from)
+        .collect();
+
+    if dry_run {
+        return Ok(candidates);
+    }
+
+    let fresh = store.tree(company).await?;
+    let still_empty: HashSet<&str> = empty_agent_folder_candidates(&fresh)?
+        .into_iter()
+        .map(|node| node.id.as_str())
+        .collect();
+
+    let mut removed = Vec::new();
+    for folder in candidates {
+        if !still_empty.contains(folder.id.as_str()) {
+            tracing::info!(
+                company = %company,
+                node = %folder.id,
+                name = %folder.name,
+                "[workspace] `{AGENTS_ROOT}/{}` gained a child between the preview and the \
+                 sweep; leaving it alone",
+                folder.name
+            );
+            continue;
+        }
+        if store.delete(company, &folder.id).await? {
+            removed.push(folder);
+        } else {
+            tracing::info!(
+                company = %company,
+                node = %folder.id,
+                name = %folder.name,
+                "[workspace] `{AGENTS_ROOT}/{}` was already gone",
+                folder.name
+            );
+        }
+    }
+
+    tracing::info!(
+        company = %company,
+        count = removed.len(),
+        folders = %removed
+            .iter()
+            .map(|folder| folder.name.as_str())
+            .collect::<Vec<_>>()
+            .join(", "),
+        "[workspace] swept empty `{AGENTS_ROOT}/` member folders"
+    );
+
+    Ok(removed)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::company::workspace_scaffold::{
+        DESKS_ROOT, create_folder, ensure_agent_folder, ensure_workspace_scaffold,
+    };
+    use crate::ports::workspace::WorkspaceOrigin;
+    use crate::store::FsOps;
+
+    async fn store() -> (tempfile::TempDir, Arc<dyn WorkspaceStore>) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ops: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+        (dir, ops)
+    }
+
+    /// The sorted names in the tree, so an assertion says what survived rather
+    /// than counting.
+    async fn names(ws: &Arc<dyn WorkspaceStore>, company: &CompanyId) -> Vec<String> {
+        let mut out: Vec<String> = ws
+            .tree(company)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|node| node.name)
+            .collect();
+        out.sort();
+        out
+    }
+
+    fn swept_names(folders: &[SweptFolder]) -> Vec<&str> {
+        let mut out: Vec<&str> = folders.iter().map(|f| f.name.as_str()).collect();
+        out.sort();
+        out
+    }
+
+    async fn root_id(ws: &Arc<dyn WorkspaceStore>, company: &CompanyId) -> String {
+        ws.tree(company)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|node| node.name == AGENTS_ROOT)
+            .expect("the scaffold laid down the root")
+            .id
+    }
+
+    fn folder(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+        WorkspaceNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind: NodeKind::Folder,
+            parent_id: parent.map(str::to_string),
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Seed,
+            updated_by: WorkspaceOrigin::Seed,
+            mime: None,
+            size: None,
+            sha256: None,
+        }
+    }
+
+    fn file(id: &str, name: &str, parent: Option<&str>) -> WorkspaceNode {
+        WorkspaceNode {
+            kind: NodeKind::File,
+            ..folder(id, name, parent)
+        }
+    }
+
+    // -- over a real store --------------------------------------------------
+
+    /// The whole point, in one tree: the folder that was minted for a teammate
+    /// who never produced anything goes, and the one holding a deliverable
+    /// stays.
+    #[tokio::test]
+    async fn it_removes_empty_member_folders_and_keeps_occupied_ones() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+        for id in ["ceo", "cmo", "cto"] {
+            ensure_agent_folder(ws.as_ref(), &company, id)
+                .await
+                .unwrap();
+        }
+        // The CMO actually published something.
+        let cmo = ws
+            .tree(&company)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|node| node.name == "cmo")
+            .unwrap()
+            .id;
+        create_folder(
+            ws.as_ref(),
+            &company,
+            "task-1",
+            Some(cmo),
+            WorkspaceOrigin::Seed,
+        )
+        .await
+        .unwrap();
+
+        let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert_eq!(swept_names(&removed), vec!["ceo", "cto"]);
+        assert_eq!(
+            names(&ws, &company).await,
+            vec!["Agents", "cmo", "task-1"],
+            "a folder holding anything at all must survive"
+        );
+    }
+
+    /// A *file* directly under `Agents/` is somebody's note, not a stray
+    /// container — and a file has no children by construction, so a predicate
+    /// that forgot to check the kind would take it.
+    #[tokio::test]
+    async fn a_file_directly_under_the_root_is_never_a_candidate() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+        let root = root_id(&ws, &company).await;
+        ws.create(
+            &company,
+            &file("readme", "README.md", Some(&root)),
+            Some("# who is who"),
+        )
+        .await
+        .unwrap();
+        ensure_agent_folder(ws.as_ref(), &company, "ceo")
+            .await
+            .unwrap();
+
+        let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert_eq!(swept_names(&removed), vec!["ceo"]);
+        assert_eq!(names(&ws, &company).await, vec!["Agents", "README.md"]);
+    }
+
+    /// Acceptance criterion: running it twice is a no-op the second time. The
+    /// sweep is a function of the current tree and holds no state, so this is
+    /// the property that makes an operator's double click harmless.
+    #[tokio::test]
+    async fn running_it_twice_removes_nothing_the_second_time() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+        ensure_agent_folder(ws.as_ref(), &company, "ceo")
+            .await
+            .unwrap();
+
+        let first = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+        let after_first = names(&ws, &company).await;
+        let second = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert_eq!(swept_names(&first), vec!["ceo"]);
+        assert!(second.is_empty(), "the second run removed {second:?}");
+        assert_eq!(
+            names(&ws, &company).await,
+            after_first,
+            "the second run must not change the tree either"
+        );
+    }
+
+    /// A dry run is the confirm dialog's evidence: it names every folder and
+    /// leaves the tree exactly as it found it.
+    #[tokio::test]
+    async fn a_dry_run_names_the_candidates_and_removes_nothing() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+        for id in ["ceo", "cmo"] {
+            ensure_agent_folder(ws.as_ref(), &company, id)
+                .await
+                .unwrap();
+        }
+        let before = names(&ws, &company).await;
+
+        let preview = sweep_empty_agent_folders(ws.as_ref(), &company, true)
+            .await
+            .unwrap();
+
+        assert_eq!(swept_names(&preview), vec!["ceo", "cmo"]);
+        assert_eq!(names(&ws, &company).await, before);
+        assert!(
+            preview.iter().all(|folder| !folder.id.is_empty()),
+            "the console needs an id to drop the row it is showing"
+        );
+    }
+
+    /// Acceptance criterion: nothing outside `Agents/` is touched — not an empty
+    /// folder at the workspace root, not one under `Desks/` (issue #645 left
+    /// those alone on the same reasoning), and not a nested empty folder that
+    /// happens to sit *below* a member folder.
+    #[tokio::test]
+    async fn nothing_outside_the_agents_root_is_touched() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("acme");
+        ensure_workspace_scaffold(ws.as_ref(), &company)
+            .await
+            .unwrap();
+        create_folder(
+            ws.as_ref(),
+            &company,
+            "Archive",
+            None,
+            WorkspaceOrigin::Operator,
+        )
+        .await
+        .unwrap();
+        let desks = create_folder(
+            ws.as_ref(),
+            &company,
+            DESKS_ROOT,
+            None,
+            WorkspaceOrigin::Seed,
+        )
+        .await
+        .unwrap();
+        create_folder(
+            ws.as_ref(),
+            &company,
+            "creative_studio",
+            Some(desks),
+            WorkspaceOrigin::Seed,
+        )
+        .await
+        .unwrap();
+        let ceo = ensure_agent_folder(ws.as_ref(), &company, "ceo")
+            .await
+            .unwrap();
+        create_folder(
+            ws.as_ref(),
+            &company,
+            "drafts",
+            Some(ceo),
+            WorkspaceOrigin::Seed,
+        )
+        .await
+        .unwrap();
+
+        let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert!(removed.is_empty(), "the sweep removed {removed:?}");
+        assert_eq!(
+            names(&ws, &company).await,
+            vec![
+                "Agents",
+                "Archive",
+                "Desks",
+                "ceo",
+                "creative_studio",
+                "drafts"
+            ],
+        );
+    }
+
+    /// No `Agents/` root at all — a company that never booted the scaffold — is
+    /// nothing to sweep rather than an error. The console offers the action
+    /// unconditionally, so this is a real request shape, not a defensive branch.
+    #[tokio::test]
+    async fn a_company_with_no_agents_root_is_a_no_op() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("fresh");
+        create_folder(
+            ws.as_ref(),
+            &company,
+            "Notes",
+            None,
+            WorkspaceOrigin::Operator,
+        )
+        .await
+        .unwrap();
+
+        let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert!(removed.is_empty());
+        assert_eq!(names(&ws, &company).await, vec!["Notes"]);
+    }
+
+    /// Fail closed, exactly as the scaffold does: two roots named `Agents` make
+    /// "under `Agents/`" undecidable, so the sweep refuses instead of picking
+    /// one and deleting beneath it.
+    #[tokio::test]
+    async fn an_ambiguous_root_is_refused_and_removes_nothing() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("odd");
+        for id in ["dup-a", "dup-b"] {
+            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
+                .await
+                .unwrap();
+        }
+        ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
+            .await
+            .unwrap();
+
+        let err = sweep_empty_agent_folders(ws.as_ref(), &company, false)
+            .await
+            .expect_err("an ambiguous root must not be swept beneath");
+
+        assert!(err.to_string().contains(AGENTS_ROOT), "{err}");
+        assert_eq!(names(&ws, &company).await, vec!["Agents", "Agents", "ceo"]);
+    }
+
+    /// A *file* named `Agents` is the other unresolvable shape, and the refusal
+    /// has to reach the dry run too — a preview that answered "nothing to do"
+    /// would tell the operator the tree is fine when it is not.
+    #[tokio::test]
+    async fn a_root_file_named_agents_is_refused_on_the_dry_run_too() {
+        let (_dir, ws) = store().await;
+        let company = CompanyId::new("odd");
+        ws.create(
+            &company,
+            &file("note", AGENTS_ROOT, None),
+            Some("# not a folder"),
+        )
+        .await
+        .unwrap();
+
+        sweep_empty_agent_folders(ws.as_ref(), &company, true)
+            .await
+            .expect_err("a file carrying the root's name must be refused, not swept past");
+    }
+
+    /// The sweep is company-scoped: another tenant's identical tree is not
+    /// touched.
+    #[tokio::test]
+    async fn sweeping_one_company_leaves_another_alone() {
+        let (_dir, ws) = store().await;
+        let acme = CompanyId::new("acme");
+        let other = CompanyId::new("other");
+        for company in [&acme, &other] {
+            ensure_workspace_scaffold(ws.as_ref(), company)
+                .await
+                .unwrap();
+            ensure_agent_folder(ws.as_ref(), company, "ceo")
+                .await
+                .unwrap();
+        }
+
+        sweep_empty_agent_folders(ws.as_ref(), &acme, false)
+            .await
+            .unwrap();
+
+        assert_eq!(names(&ws, &acme).await, vec!["Agents"]);
+        assert_eq!(names(&ws, &other).await, vec!["Agents", "ceo"]);
+    }
+
+    // -- the predicate, on shapes no backend here would create ---------------
+
+    /// The issue #671 regression, stated as a dual assertion so it cannot be
+    /// satisfied by accident: a folder whose only child carries a path separator
+    /// in its name reads as **empty** by every path-shaped measure, while the
+    /// port's recursive `delete` would still take the child. The structural
+    /// count is what closes the gap, and this pins both halves.
+    ///
+    /// Hand-built rather than driven through a store on purpose: the `fs`
+    /// backend rejects such a name at creation (`reject_unsafe_name`), so the
+    /// shape is unreachable through `FsOps` — and sqlite and mongodb, the
+    /// backends hosted tenants actually run, accept it. See the sqlite and
+    /// mongodb test modules for the same shape through a real backend.
+    #[test]
+    fn a_folder_holding_only_an_unaddressable_child_is_not_a_candidate() {
+        let nodes = vec![
+            folder("root", AGENTS_ROOT, None),
+            folder("ghost", "ceo", Some("root")),
+            // No renderable path: the name carries a separator, so every
+            // path-shaped index drops it.
+            file("hidden", "quarterly/report.md", Some("ghost")),
+        ];
+
+        // What a path-shaped emptiness check would have measured: the rendered
+        // paths beneath `Agents/ceo`. It sees nothing — that is the bug.
+        let by_id: HashMap<&str, &WorkspaceNode> =
+            nodes.iter().map(|n| (n.id.as_str(), n)).collect();
+        let beneath = nodes
+            .iter()
+            .filter(|node| {
+                crate::company::workspace_paths::render_path(node, &by_id)
+                    .is_some_and(|path| path.starts_with("Agents/ceo/"))
+            })
+            .count();
+        assert_eq!(
+            beneath, 0,
+            "precondition: the path-shaped measure cannot see this child — that is the bug"
+        );
+
+        let candidates = empty_agent_folder_candidates(&nodes).unwrap();
+        assert!(
+            candidates.is_empty(),
+            "the structural measure must see a child the path rules exclude, but the sweep \
+             offered {:?}",
+            swept_names(
+                &candidates
+                    .iter()
+                    .copied()
+                    .map(SweptFolder::from)
+                    .collect::<Vec<_>>()
+            )
+        );
+    }
+
+    /// The dangling-chain half of the #671 shapes, and the thing it is easy to
+    /// get backwards.
+    ///
+    /// A node whose parent id names nothing has no renderable path at all, so a
+    /// naive renderer falls back to its bare name and files it at the workspace
+    /// root. That must not make it a member folder (it is not a child of the
+    /// root **by id**), and it must not protect an unrelated empty folder — its
+    /// child count belongs to the parent it names, which is not in the tree.
+    ///
+    /// Note what this shows about the exposure here: a child of a *candidate*
+    /// always has an intact chain through that candidate to the root, so a
+    /// dangling ancestor cannot hide one. The separator-named case above is the
+    /// whole of the #671 gap for this predicate — which is why the count is
+    /// still structural, and why this test states the boundary rather than
+    /// leaving it to be rediscovered.
+    #[test]
+    fn a_dangling_node_is_neither_a_candidate_nor_a_protection() {
+        let nodes = vec![
+            folder("root", AGENTS_ROOT, None),
+            folder("ghost", "ceo", Some("root")),
+            // Parent names a node that is not in the tree.
+            file("orphan", "stray.md", Some("vanished")),
+        ];
+
+        let candidates = empty_agent_folder_candidates(&nodes).unwrap();
+
+        assert_eq!(
+            candidates.iter().map(|n| n.id.as_str()).collect::<Vec<_>>(),
+            vec!["ghost"],
+            "a stray elsewhere in the tree neither joins the sweep nor calls it off"
+        );
+    }
+
+    /// A folder holding only *folders* is still occupied — the count is over
+    /// children, not over files.
+    #[test]
+    fn a_folder_holding_only_a_subfolder_is_not_a_candidate() {
+        let nodes = vec![
+            folder("root", AGENTS_ROOT, None),
+            folder("ghost", "ceo", Some("root")),
+            folder("sub", "drafts", Some("ghost")),
+            folder("empty", "cto", Some("root")),
+        ];
+
+        let candidates = empty_agent_folder_candidates(&nodes).unwrap();
+
+        assert_eq!(
+            candidates.iter().map(|n| n.id.as_str()).collect::<Vec<_>>(),
+            vec!["empty"]
+        );
+    }
+
+    /// Only *direct* children of the root are members. A folder two levels down
+    /// is somebody's own structure, and emptying it is not this sweep's business
+    /// even when it is empty.
+    #[test]
+    fn a_grandchild_of_the_root_is_never_a_candidate() {
+        let nodes = vec![
+            folder("root", AGENTS_ROOT, None),
+            folder("ceo", "ceo", Some("root")),
+            folder("deep", "archive", Some("ceo")),
+        ];
+
+        let candidates = empty_agent_folder_candidates(&nodes).unwrap();
+
+        assert!(
+            candidates.is_empty(),
+            "`ceo` holds `archive`, and `archive` is not a member folder"
+        );
+    }
+
+    /// The root is resolved by id, so a folder named `Agents` *nested* somewhere
+    /// else does not lend its children to the sweep.
+    #[test]
+    fn a_nested_folder_named_agents_is_not_the_root() {
+        let nodes = vec![
+            folder("root", AGENTS_ROOT, None),
+            folder("archive", "Archive", None),
+            folder("decoy", AGENTS_ROOT, Some("archive")),
+            folder("under-decoy", "ceo", Some("decoy")),
+        ];
+
+        let candidates = empty_agent_folder_candidates(&nodes).unwrap();
+
+        assert!(
+            candidates.is_empty(),
+            "only children of the real root are members, but the sweep offered {:?}",
+            candidates.iter().map(|n| n.id.as_str()).collect::<Vec<_>>()
+        );
+    }
+}

--- a/src/server/ops/workspace.rs
+++ b/src/server/ops/workspace.rs
@@ -13,6 +13,7 @@
 //! GET    …/workspace/search?q=…       which notes mention a phrase
 //! POST   …/workspace                  create a folder/file (JSON body)
 //! POST   …/workspace/upload           upload a file of any kind (multipart)
+//! POST   …/workspace/sweep-empty-agent-folders?dry_run=  tidy `Agents/` strays
 //! PUT    …/workspace/file/{nodeId}    overwrite file content
 //! PATCH  …/workspace/{nodeId}         rename / move
 //! DELETE …/workspace/{nodeId}         delete a node (folders recursive)
@@ -66,6 +67,9 @@ use crate::company::workspace_links::file_with_backlinks;
 use crate::company::workspace_search::{
     DEFAULT_SEARCH_LIMIT, MAX_SEARCH_RESULTS, search_workspace,
 };
+use crate::company::workspace_sweep::{
+    SweptFolder, sweep_empty_agent_folders as sweep_workspace_agent_folders,
+};
 use crate::error::OpenCompanyError;
 use crate::ports::artifacts::ArtifactAuthor;
 use crate::ports::generate_id;
@@ -87,6 +91,12 @@ pub fn router() -> Router<AppState> {
         // what `/workspace/upload` already is — axum's router prefers a literal
         // segment over a parameter, so `search` is never captured as a node id.
         .merge(scoped("/workspace/search", get(search)))
+        // Another static sibling of `/workspace/{node_id}`, for the same reason
+        // `search` is one (issue #700).
+        .merge(scoped(
+            "/workspace/sweep-empty-agent-folders",
+            post(sweep_empty_agent_folders),
+        ))
         .merge(scoped("/workspace/blob/{node_id}", get(read_blob)))
         .merge(
             scoped("/workspace/upload", post(upload))
@@ -243,6 +253,34 @@ struct SearchQuery {
     /// silent "everything".
     #[serde(default)]
     limit: Option<usize>,
+}
+
+/// Whether the sweep is a preview or the real thing (issue #700).
+#[derive(Debug, Deserialize)]
+struct SweepQuery {
+    /// `true` names what *would* go and removes nothing. Absent means a real
+    /// run: this is a `POST`, and a caller that asked for one without saying
+    /// "preview" asked for the deletion.
+    #[serde(default)]
+    dry_run: bool,
+}
+
+/// What the sweep did, or would do.
+///
+/// Exactly one of the two lists is present, and which one says what actually
+/// happened — a preview answers `wouldRemove`, a real run answers `removed`.
+/// That is deliberate rather than tidy: a console reading the field it asked for
+/// cannot mistake a preview for a deletion (or the reverse) if the host and the
+/// request ever disagree about `dry_run`.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SweepResult {
+    /// The candidates, on a dry run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    would_remove: Option<Vec<SweptFolder>>,
+    /// What was actually deleted, on a real run.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    removed: Option<Vec<SweptFolder>>,
 }
 
 /// The create-node body.
@@ -928,6 +966,52 @@ async fn delete_node(
             "workspace node {node_id}"
         ))))
     }
+}
+
+/// `POST …/workspace/sweep-empty-agent-folders` — remove the empty
+/// `Agents/<id>/` folders a pre-#570 company still carries (issue #700).
+///
+/// Operator-triggered rather than automatic, and this route is the surface that
+/// makes that possible. The affected population is hosted tenants whose operator
+/// has a console and no shell, so a subcommand would be unreachable for exactly
+/// the people who need it; a boot sweep would change a tenant's tree on an
+/// upgrade nobody asked for, which is the outcome #570 and #645 both declined.
+/// The click is the opt-in.
+///
+/// `?dry_run=true` names the candidates and touches nothing, so the console can
+/// list every folder on a confirm dialog before the operator agrees. The real
+/// call answers with what actually went, and logs it — "removed 17 folders" is
+/// not something an operator who disagrees can check.
+///
+/// The deletes run through `runtime.workspace()`, the same announcer-wrapped
+/// handle [`delete_node`] uses, so each removal emits its own
+/// `WorkspaceChanged{change:"removed"}` (issue #327) and any console watching
+/// the feed sees the tree change rather than discovering it on the next refetch.
+///
+/// Same authorization as the per-node delete: addressing the company is the
+/// guard, because this removes only nodes that provably hold nothing.
+async fn sweep_empty_agent_folders(
+    company: ScopedCompany,
+    Query(query): Query<SweepQuery>,
+) -> Result<Json<SweepResult>, ApiError> {
+    let folders = sweep_workspace_agent_folders(
+        company.runtime.workspace().as_ref(),
+        company.id(),
+        query.dry_run,
+    )
+    .await?;
+
+    Ok(Json(if query.dry_run {
+        SweepResult {
+            would_remove: Some(folders),
+            removed: None,
+        }
+    } else {
+        SweepResult {
+            would_remove: None,
+            removed: Some(folders),
+        }
+    }))
 }
 
 #[cfg(test)]

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1598,6 +1598,235 @@ async fn workspace_search_returns_hits_with_paths_and_excerpts() {
     assert_eq!(results["total"], json!(1));
 }
 
+/// `POST …/workspace/sweep-empty-agent-folders` (issue #700): the operator's
+/// one-time tidy of the empty `Agents/<id>/` folders a pre-#570 company still
+/// carries.
+///
+/// The whole route in one test, because the halves only mean something together:
+/// the dry run has to name every folder *and* leave the tree alone, or the
+/// confirm dialog it feeds is either uninformative or a lie; the real run has to
+/// remove exactly those folders, leave the occupied one, and announce each
+/// removal so a console watching the feed sees the tree change rather than
+/// discovering it on the next refetch.
+#[tokio::test]
+async fn workspace_sweep_previews_then_removes_only_the_empty_agent_folders() {
+    use crate::ports::types::CompanyEvent;
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+    // Boot already scaffolded `Agents/`; find it rather than making a rival.
+    let (_, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    let agents_id = tree
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["name"] == "Agents")
+        .expect("boot scaffolds the Agents root")["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Two strays from the #551 era, one folder that actually holds a
+    // deliverable, and a note filed directly under the root by an operator.
+    let mut empty = Vec::new();
+    for id in ["ceo", "cto"] {
+        let (_, folder) = send(
+            &state,
+            "POST",
+            "/api/v1/company/workspace",
+            Some(json!({"name": id, "kind": "folder", "parentId": agents_id})),
+        )
+        .await;
+        empty.push(folder["id"].as_str().unwrap().to_string());
+    }
+    let (_, cmo) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({"name": "cmo", "kind": "folder", "parentId": agents_id})),
+    )
+    .await;
+    send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({
+            "name": "launch-brief.md",
+            "kind": "file",
+            "parentId": cmo["id"].as_str().unwrap(),
+            "content": "# Launch",
+        })),
+    )
+    .await;
+    send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace",
+        Some(json!({
+            "name": "README.md",
+            "kind": "file",
+            "parentId": agents_id,
+            "content": "# who is who",
+        })),
+    )
+    .await;
+
+    let before = {
+        let (_, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+        provisioned_names(&tree)
+    };
+    let events_before = journal_len(&runtime).await;
+
+    // -- the preview ------------------------------------------------------
+    let (status, preview) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace/sweep-empty-agent-folders?dry_run=true",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        swept_names(&preview["wouldRemove"]),
+        vec!["ceo", "cto"],
+        "the confirm dialog needs every folder named, not a count: {preview}"
+    );
+    assert!(
+        preview.get("removed").is_none(),
+        "a preview must not claim it removed anything: {preview}"
+    );
+    let (_, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(
+        provisioned_names(&tree),
+        before,
+        "a dry run must leave the tree exactly as it found it"
+    );
+    assert_eq!(
+        journal_len(&runtime).await,
+        events_before,
+        "a dry run must not announce anything either"
+    );
+
+    // -- the real thing ---------------------------------------------------
+    let (status, done) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace/sweep-empty-agent-folders",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        swept_names(&done["removed"]),
+        vec!["ceo", "cto"],
+        "an operator who disagrees needs to know what went: {done}"
+    );
+    assert!(
+        done.get("wouldRemove").is_none(),
+        "a real run must not answer in the preview's field: {done}"
+    );
+
+    let (_, tree) = send(&state, "GET", "/api/v1/company/workspace", None).await;
+    assert_eq!(
+        provisioned_names(&tree),
+        vec![
+            "Agents".to_string(),
+            "README.md".to_string(),
+            "cmo".to_string(),
+            "launch-brief.md".to_string(),
+        ],
+        "the folder holding a deliverable, the operator's note and the root all stay"
+    );
+
+    // One `WorkspaceChanged{removed}` per folder — the announcer is reached
+    // because the handler deletes through `runtime.workspace()`, the same
+    // wrapped handle the per-node delete uses (issue #327).
+    let journal = runtime
+        .events()
+        .read_from(
+            runtime.id(),
+            crate::ports::types::EventSeq::new(0),
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+    //
+    // Sorted on both sides rather than compared in creation order: the sweep
+    // walks whatever order `tree()` returns, and the port promises none.
+    let mut announced: Vec<&str> = journal
+        .iter()
+        .filter_map(|stored| match &stored.event {
+            CompanyEvent::WorkspaceChanged { node_id, change } if change == "removed" => {
+                Some(node_id.as_str())
+            }
+            _ => None,
+        })
+        .collect();
+    announced.sort_unstable();
+    let mut expected: Vec<&str> = empty.iter().map(String::as_str).collect();
+    expected.sort_unstable();
+    assert_eq!(
+        announced, expected,
+        "each removal announces itself, exactly once, and nothing else was announced removed"
+    );
+
+    // -- and again, which must be a no-op ---------------------------------
+    let (status, again) = send(
+        &state,
+        "POST",
+        "/api/v1/company/workspace/sweep-empty-agent-folders",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        again["removed"],
+        json!([]),
+        "running it twice must remove nothing the second time: {again}"
+    );
+
+    // The route resolves under the platform scope form too, and is never
+    // captured as a node id by the `…/workspace/{node_id}` route.
+    let (status, scoped) = send(
+        &state,
+        "POST",
+        "/api/v1/companies/acme/workspace/sweep-empty-agent-folders?dry_run=true",
+        None,
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(scoped["wouldRemove"], json!([]));
+}
+
+/// The sorted folder names in a sweep response list.
+fn swept_names(list: &serde_json::Value) -> Vec<String> {
+    let mut names: Vec<String> = list
+        .as_array()
+        .unwrap_or_else(|| panic!("the sweep answers with a list, got {list}"))
+        .iter()
+        .map(|folder| folder["name"].as_str().unwrap_or_default().to_string())
+        .collect();
+    names.sort();
+    names
+}
+
+/// How many events the company has journalled so far.
+async fn journal_len(runtime: &std::sync::Arc<crate::company::runtime::CompanyRuntime>) -> usize {
+    runtime
+        .events()
+        .read_from(
+            runtime.id(),
+            crate::ports::types::EventSeq::new(0),
+            usize::MAX,
+        )
+        .await
+        .unwrap()
+        .len()
+}
+
 #[tokio::test]
 async fn skills_install_persists_the_registry_document_not_the_client_metadata() {
     let home_dir = home();

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3334,6 +3334,74 @@ mod test {
         drop_db(&s).await;
     }
 
+    /// The sqlite pin's mirror, on the other backend hosted tenants run
+    /// (issue #700).
+    ///
+    /// Both are needed: the guard exists because a backend accepts a node name
+    /// carrying a path separator, and "accepts it" is a fact about each backend
+    /// rather than about the port. A folder holding only such a child has no
+    /// renderable path to it, reads as empty by every path-shaped measure, and
+    /// would still lose it to the port's recursive `delete` (issue #671) — so
+    /// the sweep must leave that folder standing here too.
+    #[tokio::test]
+    async fn workspace_sweep_keeps_a_folder_whose_only_child_has_no_renderable_path() {
+        use crate::company::workspace_sweep::sweep_empty_agent_folders;
+        use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+        let Some(s) = store().await else { return };
+        let company = CompanyId::new("acme");
+        let node = |id: &str, name: &str, kind, parent: Option<&str>| WorkspaceNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            parent_id: parent.map(str::to_string),
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Seed,
+            updated_by: WorkspaceOrigin::Seed,
+            mime: None,
+            size: None,
+            sha256: None,
+        };
+
+        for (id, name, kind, parent, body) in [
+            ("root", "Agents", NodeKind::Folder, None, None),
+            ("ghost", "ceo", NodeKind::Folder, Some("root"), None),
+            ("empty", "cto", NodeKind::Folder, Some("root"), None),
+            (
+                "hidden",
+                "q/r.md",
+                NodeKind::File,
+                Some("ghost"),
+                Some("# quarterly"),
+            ),
+        ] {
+            WorkspaceStore::create(s.as_ref(), &company, &node(id, name, kind, parent), body)
+                .await
+                .expect("mongodb accepts these names — that is why the guard exists");
+        }
+
+        let removed = sweep_empty_agent_folders(s.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            removed.iter().map(|f| f.id.as_str()).collect::<Vec<_>>(),
+            vec!["empty"],
+            "only the genuinely empty folder may go"
+        );
+        let ids: Vec<String> = WorkspaceStore::tree(s.as_ref(), &company)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id)
+            .collect();
+        assert!(
+            ids.contains(&"ghost".to_string()) && ids.contains(&"hidden".to_string()),
+            "the folder and its unaddressable child must both survive, got {ids:?}"
+        );
+        drop_db(&s).await;
+    }
+
     #[tokio::test]
     async fn durable_ownership_round_trip() {
         let Some(s) = store().await else { return };

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2962,6 +2962,98 @@ mod test {
         conformance::assert_workspace_binary_store(store()).await;
     }
 
+    /// Issue #700's emptiness predicate, against the backend that can actually
+    /// hold the shape it has to survive.
+    ///
+    /// The sweep refuses a folder holding an unaddressable child — a name
+    /// carrying a path separator, which every path-shaped index drops and the
+    /// port's recursive `delete` would still take (issue #671). Its own module
+    /// tests pin that on a hand-built node list, because `FsOps` rejects such a
+    /// name at creation (`reject_unsafe_name`) and cannot produce one.
+    ///
+    /// This backend does not reject it, and hosted tenants run this backend — so
+    /// the shape is reachable data rather than a thought experiment, and that is
+    /// what this asserts: sqlite stores `q/r.md` under `Agents/ghost/`, and the
+    /// sweep leaves `ghost` alone. It lives here because
+    /// `cargo test --features sqlite --lib store::sqlite` is the only lane that
+    /// runs it.
+    #[tokio::test]
+    async fn workspace_sweep_keeps_a_folder_whose_only_child_has_no_renderable_path() {
+        use crate::company::workspace_sweep::sweep_empty_agent_folders;
+        use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+
+        let store = store();
+        let company = CompanyId::new("acme");
+        let node = |id: &str, name: &str, kind, parent: Option<&str>| WorkspaceNode {
+            id: id.to_string(),
+            name: name.to_string(),
+            kind,
+            parent_id: parent.map(str::to_string),
+            updated_at_millis: 1,
+            created_by: WorkspaceOrigin::Seed,
+            updated_by: WorkspaceOrigin::Seed,
+            mime: None,
+            size: None,
+            sha256: None,
+        };
+
+        WorkspaceStore::create(
+            store.as_ref(),
+            &company,
+            &node("root", "Agents", NodeKind::Folder, None),
+            None,
+        )
+        .await
+        .unwrap();
+        WorkspaceStore::create(
+            store.as_ref(),
+            &company,
+            &node("ghost", "ceo", NodeKind::Folder, Some("root")),
+            None,
+        )
+        .await
+        .unwrap();
+        WorkspaceStore::create(
+            store.as_ref(),
+            &company,
+            &node("empty", "cto", NodeKind::Folder, Some("root")),
+            None,
+        )
+        .await
+        .unwrap();
+        // The name `fs` would have refused. If this create ever starts failing,
+        // the premise of the whole guard has changed and this test should say so
+        // rather than the guard quietly becoming untested.
+        WorkspaceStore::create(
+            store.as_ref(),
+            &company,
+            &node("hidden", "q/r.md", NodeKind::File, Some("ghost")),
+            Some("# quarterly"),
+        )
+        .await
+        .expect("sqlite accepts a separator-carrying name — that is why the guard exists");
+
+        let removed = sweep_empty_agent_folders(store.as_ref(), &company, false)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            removed.iter().map(|f| f.id.as_str()).collect::<Vec<_>>(),
+            vec!["empty"],
+            "only the genuinely empty folder may go"
+        );
+        let ids: Vec<String> = WorkspaceStore::tree(store.as_ref(), &company)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|n| n.id)
+            .collect();
+        assert!(
+            ids.contains(&"ghost".to_string()) && ids.contains(&"hidden".to_string()),
+            "the folder and its unaddressable child must both survive, got {ids:?}"
+        );
+    }
+
     #[tokio::test]
     async fn one_store_serves_every_port_through_arc() {
         // A single Arc<SqliteStore> satisfies all five port trait objects — the


### PR DESCRIPTION
## Summary

A one-time, operator-triggered sweep that removes provably empty agent folders under `Agents/` — and nothing else.

Closes #700.

## Problem

Companies provisioned before #570 permanently carry one empty folder per roster member. On the `smoke1` staging tenant there are 17 of them, minted in a single boot burst ~34 ms apart, three weeks after the tenant's seeded content. #570 stopped creating them and deliberately chose no backfill; that decision was right, and this is the cleanup it left for later.

It matters more now than it did then. #570 made a folder mean *"this member produced something"*; #552 publishes deliverables into `Agents/<agent>/<task-id>/`, so an empty folder reads as a claim about that agent; and #607 made the tree searchable with a bounded result set, so empty folders compete for slots against files that actually contain something.

## Solution

`POST {scope}/workspace/sweep-empty-agent-folders?dry_run=`, surfaced as a "Tidy empty agent folders" action in the Workspace tab. The dry run names every folder it would remove, the operator confirms, and the receipt names each one that went.

**The emptiness predicate is the whole risk surface, so it is structural.** Children are counted by `parent_id` over every node the store returns, before any path is rendered. This is deliberate: `PathIndex` omits nodes with a dangling ancestor chain or a separator in the name, so a path-shaped check reports a folder as empty while the port's recursive `delete` still takes its children — exactly the bug #671 fixed in the agent delete tool. `fs` rejects unsafe names at creation, but sqlite and mongodb do not, so the shape is real data on precisely the hosted backends the affected tenants run. Both backends carry a reachability pin for it.

Notable non-goal: **no authorship filter.** Pre-#326 nodes deserialize `created_by` as `Operator`, so origin stamps cannot identify #551-era folders on the very tenants this targets. Structural emptiness is the only safe predicate, which is why the dry-run naming — not a heuristic — is what keeps it honest.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `cargo test --locked` — 2087 passed, 0 failed, 1 ignored
- [x] `cargo test --locked --features sqlite --lib store::sqlite` — 31 passed
- [x] `cargo test --locked --features mongodb --lib store::mongodb` — 27 passed, run against a real throwaway mongod with `OPENCOMPANY_TEST_MONGODB_REQUIRED=1`; without a URI this lane skips silently and still exits 0, so a skip was not accepted as a pass
- [x] `npx tsc --noEmit`, `npm run build`, `scripts/ci/assert-design-tokens.sh`
- [x] Verified end-to-end on a running instance, backend and UI
- [ ] N/A: no frontend test script exists in this repo, so no component tests are claimed

17 new tests: 14 predicate/module, 1 route, 1 sqlite pin, 1 mongodb pin.

## Impact

Idempotent by construction — the sweep is a stateless function of the current tree, pinned by a run-twice test at both the module and HTTP levels. Each delete emits one `WorkspaceChanged{removed}` through the announcer, so an open console reflects the change live; a 17-folder sweep emits 17 events, which matches the tolerated boot-seed burst precedent.

One race is narrowed rather than closed, and stated plainly: #552's publish drain can mint `Agents/<agent>/<task-id>/` between the snapshot and the delete, and the port delete is recursive. The sweep re-snapshots and re-derives candidates immediately before deleting, leaving the same per-delete instant every console delete already has. Closing it fully would need a conditional delete-only-if-empty primitive across all three backends — disproportionate here, and worth its own issue if the window ever bites.

Verified on a real instance: preview named three empties, the real call removed exactly those, a second call returned nothing, and the folder holding a file survived both.

## Related

- #570 — stopped eager provisioning and chose no backfill; this is that cleanup
- #551 — the era that provisioned them
- #552 — publishes into `Agents/<agent>/<task-id>/`, which gives an empty folder its meaning
- #607 — search; empty folders compete in a bounded result set
- #671 — the path-vs-structure emptiness bug this predicate is built to avoid
- #686 — eight of the seventeen on `smoke1` are also ULID-named
- #645 — the same leave-existing-nodes-alone decision, for `Desks/`

Note for merge order: this adds 17 lines to `docs/spec/runtime/api.md`, which #702 splits into focused files. Whichever lands second rebases — the sweep route belongs in `api-write-plane.md` once that split is in.
