### PR TITLE
feat(chat): a settled dispatch marks the channel it came from (#377)

### DIFF
--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -51,10 +51,12 @@ orchestrator's `create_workflow` tool; journaled best-effort after persist),
 `TaskSteered` (an operator paused, cancelled, or redirected an in-flight task
 or delegation), `DeskTaskCompleted` (a dispatched board task finished its run —
 the terminal anchor a per-task timeline ends on; "completed" means the run
-stopped, not that it succeeded, `column` carries where the card landed, and
+stopped, not that it succeeded, `column` carries where the card landed,
 `artifact_ids` names the deliverables the run published — empty, and omitted
 from the wire, for the many tasks that produce no file; see
-[artifacts.md](artifacts.md)),
+[artifacts.md](artifacts.md) — and `origin_chat_id` records the conversation the
+card was raised from, absent when none did, see
+[the settle marker below](#the-settle-a-channel-can-see-issue-377)),
 `TaskDiscussionPosted` (a human posted to a card's discussion thread, issue
 #335 — the Discussion tab's whole store, folded back out by
 `GET …/tasks/{task_id}` beside that card's timeline), `WorkflowUpdated` /
@@ -283,6 +285,60 @@ in the desk lead's private line instead of the channel the operator asked in. It
 now uses `grant.origin_thread`, falling back to the agent when there is none,
 which is the previous behaviour kept for exactly the cases it was already right
 for.
+
+### The settle a channel can see (issue #377)
+
+A card dispatched from a channel can park in `paused`, or bounce back to `todo`
+on a failure or a cancellation. The channel showed none of that. All it got was
+the orchestrator's relay prose (#151), which reads like an answer — so a reader,
+live or arriving fresh after a reload, reasonably concluded the work had
+finished. Two correct halves producing one wrong impression.
+
+The fix is a **card-linked system marker**, not another bubble: `finished → In
+review`, carrying the column and a link to the card, and deliberately **not** the
+run's prose. The prose is already in that channel; repeating it would put one
+run's words into one conversation twice. What was missing was never the words —
+it was the structural fact that the card settled, and where.
+
+**The origin is captured, never derived.** `DeskTaskCompleted` gains
+`origin_chat_id`, stamped at the single emission point
+(`HarnessBrain::journal_task_outcome`) off `TaskRecord.origin_chat_id`, which
+every conversational creation path has recorded since #151. It cannot be
+recovered from the fields that were already there: `desk` is the *responder*, an
+agent id like `engineer`, and a channel is a desk id like `engineering`.
+Re-deriving it at completion time would also put a second "which conversation is
+this?" rule beside `chat_history`'s, which is precisely the drift #435 exists to
+have removed.
+
+**`None` means no conversation raised this card** — a board-native card, a
+scheduler's — and is emphatically *not* folded into the General desk, even
+though every other missing chat id in `chat_history` is. Folding it would post
+markers about board-only work into the operator's main line: a new bug, not the
+one being fixed. The frame omits `chatId` rather than sending null, so
+"board-created" is a presence check on the console, the same shape
+`approval_parked` uses for a page-only approval.
+
+**`chat_history::owns` admits the terminal**, which is what makes the marker
+survive a reload; without it the live line would appear and then vanish. Because
+`MessageView` is shared with the GraphQL `Message` projection, `Chat.history`
+starts returning system marker rows on existing fields — additive on both wire
+surfaces, and named here rather than discovered in review.
+
+**The stream frame drops `output`.** Nothing read it, and removing it at the
+projection is what stops a later reader from reintroducing the duplicate. An
+out-of-tree consumer of `/events` loses that field.
+
+Dedupe is on **identity**, never content: the live line is born under the host's
+own sequence (`h<seq>`, #483/#498's mechanism), which is exactly the id
+`chat/history` mints for the same event, so hydration recognises its own twin.
+The marker sentence exists twice — `dispatch_marker_text` on the host,
+`dispatchMarkerText` in the console, because the live frame is thin and carries
+the raw column id — and tests on both sides pin the identical literals. Drift can
+only reword a marker across a reload; it can never double one.
+
+Pre-#377 journal lines carry no origin, so existing channels grow no
+retroactive markers. That is correct rather than a migration gap: the fact was
+not recorded, and inventing one would be worse than its absence.
 
 ### What a retry would repeat (issue #351)
 

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -50,6 +50,7 @@ import { toast } from "sonner";
 
 import {
   type ChatMessage,
+  dispatchMarkerPlacement,
   fromHistory,
   hostMessageId,
   liveReplyIdentity,
@@ -725,6 +726,60 @@ export function AppShell({
     [chatChannelByThread],
   );
 
+  /**
+   * Post the card-linked system marker for a settled dispatch into the channel
+   * the card was raised in (issue #377).
+   *
+   * The gap it closes: a card dispatched from a channel could park in `paused`
+   * or bounce back to `todo`, and the only thing the channel showed was the
+   * agent's relay prose — so a reader, live or arriving fresh, reasonably
+   * concluded the work had finished. The marker is the structural fact the
+   * prose could not carry: the run *stopped*, and here is where the card
+   * landed, with a link to it.
+   *
+   * Every rule about *where* the line goes — a frame with no `chatId` going
+   * nowhere, a thread matching no channel going nowhere rather than to whatever
+   * channel is open (#368's bug), and the `h<seq>` identity that lets the next
+   * reload recognise its own twin (#483/#498) — lives in
+   * `dispatchMarkerPlacement`, so each stays assertable. This callback is only
+   * the write.
+   *
+   * Written into **both** stores for the same reason `injectAgentReply` is: the
+   * parked Conversation reads `threads`, the Chat workspace reads
+   * `transcripts`, and a line written to one alone is invisible on the other
+   * until a reload.
+   */
+  const injectDispatchMarker = useCallback(
+    (event: CompanyStreamEvent) => {
+      if (event.type !== "desk_task_completed") return;
+      const placement = dispatchMarkerPlacement(event, chatChannelByThread);
+      if (!placement) return;
+      const { threadId, channelId, message } = placement;
+
+      setThreads((ts) =>
+        ts.map((t) => {
+          if (t.id !== threadId) return t;
+          // The same id guard hydration runs. A marker cannot arrive twice off
+          // one stream, but a reconnecting `EventSource` can replay a frame,
+          // and the id is what makes that harmless.
+          if (t.messages.some((m) => m.id === message.id)) return t;
+          return { ...t, messages: [...t.messages, message] };
+        }),
+      );
+
+      if (!channelId) return;
+      setTranscripts((t) => {
+        const existing = t[channelId] ?? [];
+        if (existing.some((m) => m.id === message.id)) return t;
+        return { ...t, [channelId]: [...existing, message] };
+      });
+    },
+    // Same reasoning as `injectAgentReply`: `useEvents` holds its callbacks in
+    // refs, so this identity churning as the map lands cannot re-open the
+    // stream.
+    [chatChannelByThread],
+  );
+
   // Mark/unmark a thread's in-flight POST. `onSendStart` also resets its live
   // timeline so a fresh turn starts clean; `onSendEnd` clears it because the
   // final reply now carries the authoritative folded steps.
@@ -872,6 +927,10 @@ export function AppShell({
     pendingApprovals: pending,
     onAgentReply: injectAgentReply,
     onTaskEvent: useCallback(() => setTaskEventTick((n) => n + 1), []),
+    // Issue #377. Beside the board tick above, not instead of it: a settle both
+    // moves a card between columns and needs saying in the conversation the
+    // card came from.
+    onDispatchTerminal: injectDispatchMarker,
     // Issue #327. The payload is carried, not folded into a counter — see
     // `workspaceEvent` above. The view still re-reads the tree from the host
     // rather than patching it from the frame: the frame carries no node name

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -73,19 +73,34 @@ export type CompanyStreamEvent =
        *  newer host is not a type error. */
       change: string;
     }
-  // A dispatched card's run finished (issue #185). The host has projected this
-  // since #185; the console named no type for it, so it fell through to
-  // `default:` and was dropped — the same "the view does not subscribe" half of
-  // #464, one event over. A settle moves the card between columns, so the board
-  // wants it.
+  // A dispatched card's run finished (issue #185/#377). The host has projected
+  // this since #185; the console named no type for it until #464, so it fell
+  // through to `default:` and was dropped — the same "the view does not
+  // subscribe" half of #464, one event over. A settle moves the card between
+  // columns, so the board wants it.
+  //
+  // Issue #377 made it a *chat* frame as well as a board one, and reshaped it
+  // in both directions:
+  //
+  // - `chatId` in: the conversation the card was raised from, captured on the
+  //   card at raise time. Absent when nothing raised it from a chat — a
+  //   board-created card, a scheduler's. Such a settle belongs to no channel
+  //   and gets no marker, exactly as a `chatId`-less `approval_parked` stays on
+  //   the Approvals page.
+  // - `output` out: the run's prose already reaches the same channel as the
+  //   orchestrator's relay bubble, so the host stopped projecting it rather
+  //   than leave a second copy on the wire for a future reader to render.
+  //   Nothing in this console read it.
   | {
       type: "desk_task_completed";
       seq: number;
       atMillis: number;
       taskId: string;
+      /** The *responder* that ran it — an agent id, never a channel id. */
       desk: string;
-      output: string;
       column: string;
+      /** The channel the card was raised in; absent for a board-created card. */
+      chatId?: string;
     }
   | {
       type: "mcp_call_failed";
@@ -303,6 +318,23 @@ interface Options {
    */
   onTaskEvent?: (event: CompanyStreamEvent) => void;
   /**
+   * Called for each `desk_task_completed` frame (issue #377) so the shell can
+   * post a card-linked system marker into the channel the card was raised in.
+   *
+   * Beside {@link Options.onTaskEvent}, not instead of it: one frame, two
+   * genuinely different reactions. The board still wants its refetch tick — a
+   * settle moves a card between columns — and the channel wants a line saying
+   * the card settled and where. Folding them would force one subscriber to be
+   * both a counter and a payload.
+   *
+   * Takes the **payload**, for the same reason {@link Options.onWorkspaceEvent}
+   * does: the reaction depends on *which* conversation and *which* column, and
+   * a counter can say neither. The frame-loss trap that made the workflow
+   * canvas fold an event window does not apply — a dropped frame costs one
+   * marker that the next hydration restores from history, never wrong state.
+   */
+  onDispatchTerminal?: (event: CompanyStreamEvent) => void;
+  /**
    * Called for each `workspace_changed` frame (issue #327) so the Workspace
    * view can re-read the tree — and the open note — live.
    *
@@ -390,6 +422,7 @@ export function useEvents(
     pendingApprovals,
     onAgentReply,
     onTaskEvent,
+    onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
     onWorkflowRunEvent,
@@ -406,6 +439,10 @@ export function useEvents(
   useEffect(() => {
     onTaskEventRef.current = onTaskEvent;
   }, [onTaskEvent]);
+  const onDispatchTerminalRef = useRef(onDispatchTerminal);
+  useEffect(() => {
+    onDispatchTerminalRef.current = onDispatchTerminal;
+  }, [onDispatchTerminal]);
   const onWorkspaceEventRef = useRef(onWorkspaceEvent);
   useEffect(() => {
     onWorkspaceEventRef.current = onWorkspaceEvent;
@@ -466,6 +503,7 @@ export function useEvents(
           handleEvent(event, {
             onAgentReply: onAgentReplyRef.current,
             onTaskEvent: onTaskEventRef.current,
+            onDispatchTerminal: onDispatchTerminalRef.current,
             onWorkspaceEvent: onWorkspaceEventRef.current,
             onTurnEvent: onTurnEventRef.current,
             onWorkflowRunEvent: onWorkflowRunEventRef.current,
@@ -507,6 +545,7 @@ export function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers)
   const {
     onAgentReply,
     onTaskEvent,
+    onDispatchTerminal,
     onWorkspaceEvent,
     onTurnEvent,
     onWorkflowRunEvent,
@@ -549,8 +588,22 @@ export function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers)
     // toasts that do matter. The card appearing on the board IS the
     // notification.
     case "task_card_changed":
+      onTaskEvent?.(event);
+      break;
+    // Issue #377: the settle is two facts at once, so it reaches two
+    // subscribers. The board gets its tick, exactly as it has since #464 — a
+    // settle moves a card between columns. The channel the card was raised in
+    // gets a marker saying it settled and where, which is the fact that was
+    // missing: a reader watching only the relay prose could not tell a card
+    // that parked in `paused` from one that finished.
+    //
+    // Still **no toast**, and for the reason written above the board arm: this
+    // fires on every settle, and the marker appearing in the channel IS the
+    // notification. A toast on top would be the second notification for one
+    // action that #379 argues against.
     case "desk_task_completed":
       onTaskEvent?.(event);
+      onDispatchTerminal?.(event);
       break;
     // Issue #327, and **no toast** for the same reason the board frames above
     // raise none — more strongly, if anything. A workspace write is not an

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -110,6 +110,47 @@ export function liveReplyIdentity(event: { seq: number }): { messageId: string }
 }
 
 /**
+ * How the console labels each board column in a marker. Must stay in step with
+ * the host's `dispatch_marker_text` (`src/server/chat_history.rs`) and with
+ * `TASK_COLUMNS` (`./tasks-sample.ts`), which is where the same labels render
+ * on the board itself.
+ */
+const COLUMN_LABELS: Record<string, string> = {
+  todo: "To-do",
+  planning: "Planning",
+  in_progress: "In progress",
+  paused: "Paused",
+  in_review: "In review",
+  done: "Done",
+};
+
+/**
+ * The channel line a settled dispatch leaves behind (issue #377) —
+ * `finished → In review`.
+ *
+ * The console needs its own copy because the live SSE frame is **thin**: it
+ * carries the raw column id, not prose, exactly as `task_card_changed` and
+ * `approval_parked` do. The host holds the same sentence for the rehydrated
+ * half (`dispatch_marker_text`), and unit tests on both sides pin the identical
+ * literals — the same contract `BOARD_COLUMNS`/`TASK_COLUMNS` already live
+ * with.
+ *
+ * Drift between the two can only *reword* a marker across a reload; it can
+ * never double one, because the dedupe is on identity (`h<seq>`) and not on
+ * content. That was #483's lesson and it is what makes two spellings a
+ * tolerable cost rather than a returning bug.
+ *
+ * "finished" means the run **stopped**, not that it succeeded — a cancelled or
+ * failed dispatch says `finished → To-do`, a parked one `finished → Paused`.
+ * The misleading case this exists for is precisely the run that stopped without
+ * finishing the work. An unrecognised column id passes through verbatim rather
+ * than rendering blank.
+ */
+export function dispatchMarkerText(column: string): string {
+  return `finished → ${COLUMN_LABELS[column] ?? column}`;
+}
+
+/**
  * Build a stamped message. `at` is injected so callers stay pure/testable.
  *
  * `messageId` is the host's own id for the line, when the caller already has
@@ -141,6 +182,67 @@ export function makeMessage(
   };
 }
 
+/** The fields {@link dispatchMarkerPlacement} reads off a `desk_task_completed` frame. */
+export interface DispatchTerminalFrame {
+  taskId: string;
+  column: string;
+  /** The channel the card was raised in; absent for a board-created card. */
+  chatId?: string;
+  /** The host's `StoredEvent` sequence — the marker's durable identity. */
+  seq: number;
+  atMillis: number;
+}
+
+/** Where a settled dispatch's marker goes, and the line to put there. */
+export interface DispatchMarkerPlacement {
+  /** The chat thread the card was raised in. */
+  threadId: string;
+  /** The channel rendering that thread, or `null` when this company has none. */
+  channelId: string | null;
+  message: ChatMessage;
+}
+
+/**
+ * Decide where a settled dispatch's marker belongs (issue #377), or that it
+ * belongs nowhere.
+ *
+ * A named function rather than three lines inside the shell's injector, for the
+ * reason {@link liveReplyIdentity} is one: every rule below is a decision that
+ * silently stops being made if it is inlined, and each of them has a specific
+ * bug on the other side of it.
+ *
+ * - **No `chatId` → `null`.** Nothing raised that card from a conversation (it
+ *   was opened on the board, or by a scheduler), so no channel is the right
+ *   one. The host already declines to file such a card into any desk's history;
+ *   this is the live half of the same rule, and the two must agree or a marker
+ *   would appear live and vanish on reload.
+ * - **`channelId: null` when the thread matches no channel** — never a fall
+ *   back to whatever channel the operator has open. The shell's `noteInChannel`
+ *   does fall back, deliberately, because an approval decision has to be seen;
+ *   a marker does not, and falling back would file one conversation's settle
+ *   into another. That is issue #368's bug, and this is the shape that makes
+ *   re-introducing it impossible rather than merely discouraged.
+ * - **The line is born under the host's id** (`h<seq>`), which is exactly what
+ *   `chat/history` mints for the same event — so {@link fromHistory}'s twin
+ *   dedupes against it on the next reload. Identity, not content: #483 was a
+ *   content check hydration could never satisfy.
+ */
+export function dispatchMarkerPlacement(
+  event: DispatchTerminalFrame,
+  chatChannelByThread: Record<string, string>,
+): DispatchMarkerPlacement | null {
+  if (!event.chatId) return null;
+  return {
+    threadId: event.chatId,
+    channelId: chatChannelByThread[event.chatId] ?? null,
+    message: makeMessage("system", dispatchMarkerText(event.column), {
+      taskId: event.taskId,
+      messageId: String(event.seq),
+      at: event.atMillis,
+    }),
+  };
+}
+
 /**
  * Maps a desk's persisted transcript (`GET .../chat/history`, issue #65) to
  * the console's chat lines, preserving `mine`/author/text and ordering — the
@@ -150,7 +252,13 @@ export function makeMessage(
  */
 export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
   return entries.map((entry) => {
-    const from: ChatMessage["from"] = entry.mine ? "you" : "company";
+    // A host-authored system line (issue #377's dispatch marker) is neither
+    // yours nor the company's voice: it renders as a centred pill, not a
+    // bubble. Read off the author the host projected — `mine` is false for it,
+    // so without this check a rehydrated marker came back as a company message
+    // and a settle read like something an agent had said.
+    const from: ChatMessage["from"] =
+      entry.author === "system" ? "system" : entry.mine ? "you" : "company";
     return {
       id: hostMessageId(entry.id),
       from,
@@ -172,7 +280,13 @@ export function fromHistory(entries: ChatHistoryMessageDto[]): ChatMessage[] {
       // Rehydrate the "card opened" chip (issue #246) for the same reason as
       // the timeline above: a chip that lives only on the live POST response
       // vanishes on the first thread switch.
-      taskId: from === "company" ? entry.taskId : undefined,
+      //
+      // System rows carry it too (issue #377): a dispatch marker's whole
+      // usefulness is the link to the card that settled, and dropping the id
+      // here would leave a rehydrated marker as a sentence with nowhere to go.
+      // Only your own lines never have one — you did not open a card by
+      // speaking.
+      taskId: from === "you" ? undefined : entry.taskId,
     };
   });
 }

--- a/frontend/src/lib/chat.ts
+++ b/frontend/src/lib/chat.ts
@@ -1,5 +1,16 @@
 import type { ChatHistoryMessageDto, TurnStep } from "@/api/types";
 
+/**
+ * The company's main line, by thread id.
+ *
+ * Mirrors the host's `MAIN_THREAD_ID` (`src/server/chat_history.rs`), whose
+ * `is_general_chat` folds this id, `"General"` and the **empty string** into a
+ * single conversation. Named rather than spelled inline because
+ * {@link dispatchMarkerPlacement} has to resolve an empty origin to *this*
+ * thread rather than to nothing — see the rules on that function.
+ */
+export const MAIN_THREAD_ID = "main";
+
 /** One person's reaction on one line. Mirrors `ChatReactionDto` on the host. */
 export interface Reaction {
   emoji: string;
@@ -216,6 +227,17 @@ export interface DispatchMarkerPlacement {
  *   one. The host already declines to file such a card into any desk's history;
  *   this is the live half of the same rule, and the two must agree or a marker
  *   would appear live and vanish on reload.
+ * - **An empty `chatId` is the General thread, not an absent one.** The host
+ *   folds `""` into General (`is_general_chat` treats an empty id, `"main"` and
+ *   `"General"` as one conversation), and the chat route takes `chat` straight
+ *   off the request body without normalising it — so a client posting
+ *   `chat: ""` stores `origin_chat_id: Some("")` and the projection emits
+ *   `chatId: ""`. Treating that as absent would drop the live marker while
+ *   `chat/history` still served the rehydrated twin: the marker would appear
+ *   only after a reload, which is the live-vs-history split the whole
+ *   identity-dedupe exists to prevent. Absent means `undefined`, and only
+ *   `undefined`. (The REST create path already normalises a blank field away
+ *   for the same reason — issue #246.)
  * - **`channelId: null` when the thread matches no channel** — never a fall
  *   back to whatever channel the operator has open. The shell's `noteInChannel`
  *   does fall back, deliberately, because an approval decision has to be seen;
@@ -231,10 +253,12 @@ export function dispatchMarkerPlacement(
   event: DispatchTerminalFrame,
   chatChannelByThread: Record<string, string>,
 ): DispatchMarkerPlacement | null {
-  if (!event.chatId) return null;
+  if (event.chatId === undefined) return null;
+  // `""` is the General thread spelled empty, not a missing origin — see above.
+  const threadId = event.chatId === "" ? MAIN_THREAD_ID : event.chatId;
   return {
-    threadId: event.chatId,
-    channelId: chatChannelByThread[event.chatId] ?? null,
+    threadId,
+    channelId: chatChannelByThread[threadId] ?? null,
     message: makeMessage("system", dispatchMarkerText(event.column), {
       taskId: event.taskId,
       messageId: String(event.seq),

--- a/frontend/src/lib/threads.ts
+++ b/frontend/src/lib/threads.ts
@@ -3,7 +3,7 @@
 // and gives the company side a consistent identity (a "desk" you're talking to).
 
 import type { DeskDto, TeamMemberDto } from "../api/types";
-import type { ChatMessage } from "./chat";
+import { MAIN_THREAD_ID, type ChatMessage } from "./chat";
 import { toneFor } from "./team";
 
 export interface ThreadContact {
@@ -27,7 +27,7 @@ const DESK_TONES = ["sky", "violet", "amber", "emerald", "rose", "cyan"];
 /** The company's main line — the orchestrator you talk to for anything. */
 function mainThread(): Thread {
   return {
-    id: "main",
+    id: MAIN_THREAD_ID,
     contact: { name: "Your company", kind: "company" },
     blurb: "The main line — ask for anything",
     messages: [],

--- a/frontend/src/views/chat/MessageRow.tsx
+++ b/frontend/src/views/chat/MessageRow.tsx
@@ -59,15 +59,7 @@ export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) 
   const chips = reactionChips(message.reactions);
   const actionsUnavailable = actionsUnavailableFor(message);
 
-  if (sender.kind === "system") {
-    return (
-      <div className="flex justify-center px-4 py-1">
-        <p className="rounded-full bg-muted px-3 py-1 text-center text-xs text-muted-foreground">
-          {message.text}
-        </p>
-      </div>
-    );
-  }
+  if (sender.kind === "system") return <SystemPill message={message} />;
 
   return (
     <article
@@ -125,6 +117,39 @@ export function MessageRow({ entry, threadOpen, onOpenThread, onReact }: Props) 
         disabledReason={actionsUnavailable}
       />
     </article>
+  );
+}
+
+/**
+ * A centred system line — an approval decision, or a dispatch marker (issue
+ * #377).
+ *
+ * The pill becomes a **link to the card** when the line names one. That is what
+ * makes a marker useful rather than merely informative: `finished → Paused`
+ * tells a reader the run stopped, and the next thing they want is the card
+ * itself. Without the link they would have to find it on the board by title.
+ *
+ * A system line with no card — every approval line — renders exactly as it
+ * always has, as plain text. There is no icon and no chip here on purpose: this
+ * is one short sentence, and dressing it up would give a status line more visual
+ * weight than the messages around it.
+ */
+function SystemPill({ message }: { message: ChatMessage }) {
+  const className =
+    "rounded-full bg-muted px-3 py-1 text-center text-xs text-muted-foreground";
+  return (
+    <div className="flex justify-center px-4 py-1">
+      {message.taskId ? (
+        <a
+          href={`#/tasks/${encodeURIComponent(message.taskId)}`}
+          className={cn(className, "transition-opacity hover:opacity-80 hover:underline")}
+        >
+          {message.text}
+        </a>
+      ) : (
+        <p className={className}>{message.text}</p>
+      )}
+    </div>
   );
 }
 

--- a/frontend/test/e2e/chat-dispatch-marker.spec.ts
+++ b/frontend/test/e2e/chat-dispatch-marker.spec.ts
@@ -250,8 +250,24 @@ test("a card raised on the board leaves no channel marker", async ({ page, reque
     (await request.patch(`${SCOPE}/tasks/${id}`, { data: { column: "in_progress" } })).ok(),
   ).toBeTruthy();
 
-  // Give the run the same window the test above allows before believing this.
-  await page.waitForTimeout(20_000);
+  // Wait for the dispatch to actually *settle*, not merely for time to pass.
+  //
+  // A fixed sleep here would make this test pass for the wrong reason: if the
+  // run were still `in_progress` when the clock ran out, no terminal has fired,
+  // so no marker could exist yet and the absence below would be vacuous — green
+  // whether or not an originless completion wrongly marks a channel. Polling
+  // the card's own column means the assertion only runs once the event that
+  // could have produced a marker has been emitted.
+  await expect
+    .poll(
+      async () => {
+        const res = await request.get(`${SCOPE}/tasks/${id}`);
+        if (!res.ok()) return "in_progress";
+        return ((await res.json()).column as string) ?? "in_progress";
+      },
+      { timeout: 60_000, intervals: [1_000] },
+    )
+    .not.toBe("in_progress");
   // The load-bearing assertion: nothing anywhere links *this* card. It is
   // addressed by href rather than by count, so it cannot be satisfied or
   // broken by any other test's marker.

--- a/frontend/test/e2e/chat-dispatch-marker.spec.ts
+++ b/frontend/test/e2e/chat-dispatch-marker.spec.ts
@@ -262,8 +262,15 @@ test("a card raised on the board leaves no channel marker", async ({ page, reque
     .poll(
       async () => {
         const res = await request.get(`${SCOPE}/tasks/${id}`);
+        // A transient read keeps the poll waiting rather than concluding.
         if (!res.ok()) return "in_progress";
-        return ((await res.json()).column as string) ?? "in_progress";
+        // `GET /tasks/{id}` answers with a TaskDetail — the card is under
+        // `task`, as every other board spec reads it. Deliberately not
+        // defaulted: a missing column means the shape moved, and swallowing
+        // that would turn a contract change back into a silent timeout.
+        const column = (await res.json()).task?.column as string | undefined;
+        if (column === undefined) throw new Error("task detail carried no column");
+        return column;
       },
       { timeout: 60_000, intervals: [1_000] },
     )

--- a/frontend/test/e2e/chat-dispatch-marker.spec.ts
+++ b/frontend/test/e2e/chat-dispatch-marker.spec.ts
@@ -1,0 +1,226 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
+/**
+ * End-to-end proof for issue #377 — a completed dispatch says so in the channel
+ * the card came from.
+ *
+ * The defect this closes is a reader being **misled**, which is why it needs a
+ * browser. A card dispatched from a channel can park in `paused` or bounce back
+ * to `todo`, and all the channel showed was the agent's relay prose — so
+ * someone watching the conversation, or arriving fresh after a reload,
+ * reasonably concluded the work had finished. No unit test can observe that,
+ * because the wrong impression is made of two correct halves: real prose, and a
+ * missing structural line.
+ *
+ * Two tests, deliberately in two lanes:
+ *
+ * 1. **The addressing**, against a default host with a written stream. What
+ *    went wrong historically in this file's neighbourhood was never the event —
+ *    it was which channel it reached (#368 filed a decision into whatever
+ *    channel was open; #367 filed live replies into a store the visible surface
+ *    did not read). A default-feature host has no harness and cannot settle a
+ *    dispatch, so the frames are written here, exactly as
+ *    `chat-live-events.spec.ts` writes its `tool_call` rows for the same
+ *    reason. This runs on every push.
+ * 2. **The whole round trip**, behind the live-brain lane: a card raised from a
+ *    channel, really dispatched, really settled by the harness, and — the half
+ *    that only a reload can prove — still exactly one marker afterwards. The
+ *    live line and its rehydrated twin are two different writers putting the
+ *    same message into one transcript, which is precisely the shape that
+ *    produced issue #483's duplicate.
+ */
+
+/** The single-company alias the host answers on, for out-of-band writes. */
+const SCOPE = "/api/v1/company";
+
+/** The harness manifest's two desks. A desk's channel id is its thread id. */
+const ENGINEERING = "engineering";
+const CONTENT = "content";
+
+test.beforeEach(async ({ page }) => {
+  // The first-run tour opens a modal over the console and swallows every click
+  // beneath it. Answer "already skipped" for whatever company id the host
+  // resolves to rather than hard-coding the harness's.
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+/** Opens one channel by id and waits for its composer, i.e. for the view. */
+async function openChannel(page: Page, channelId: string) {
+  await page.goto(`/#/chat/${channelId}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Every dispatch marker rendered in the open transcript.
+ *
+ * Matched as a **link**, which does two jobs at once: it is the card link the
+ * marker exists to offer, and it excludes the rail's one-line channel preview —
+ * a button carrying the same text — which would otherwise make every count
+ * assertion here read one too many, intermittently, depending on which
+ * rendered first (the trap `chat-live-events.spec.ts` documents).
+ */
+function markers(page: Page) {
+  return page.getByRole("link", { name: /^finished → / });
+}
+
+test("a settled dispatch marks the channel its card was raised in — and only that one", async ({
+  page,
+}) => {
+  const raised = `t-raised-${Date.now()}`;
+
+  // The exact shape `project_event` puts on the wire for a settled dispatch:
+  // structural fields plus the conversation the card was raised from, and
+  // deliberately no `output` (issue #377 stopped projecting the run's prose —
+  // the relay bubble already carries it into this same channel).
+  const frames = [
+    {
+      type: "desk_task_completed",
+      seq: 90_001,
+      atMillis: Date.now(),
+      taskId: raised,
+      // The responder is an agent id, never a channel id. A console that
+      // routed on this instead of on `chatId` would file the marker nowhere —
+      // which is the reason the origin is carried at all.
+      desk: "engineer",
+      column: "paused",
+      chatId: ENGINEERING,
+    },
+    // A card nobody raised from a conversation: opened on the board, or by a
+    // scheduler. It belongs to no channel, and the console must write it to
+    // none rather than guessing at one.
+    {
+      type: "desk_task_completed",
+      seq: 90_002,
+      atMillis: Date.now(),
+      taskId: `t-boardonly-${Date.now()}`,
+      desk: "engineer",
+      column: "in_review",
+    },
+  ];
+  await page.route("**/events", (route) =>
+    route.fulfill({
+      status: 200,
+      headers: { "content-type": "text/event-stream", "cache-control": "no-cache" },
+      body: frames.map((f) => `data: ${JSON.stringify(f)}\n\n`).join(""),
+    }),
+  );
+
+  await openChannel(page, ENGINEERING);
+
+  // The parked landing is the motivating case: the prose reads like an answer,
+  // and without this line nothing says the card stopped short of finishing.
+  await expect(markers(page)).toHaveCount(1, { timeout: 30_000 });
+  await expect(markers(page)).toHaveText("finished → Paused");
+  expect(await markers(page).getAttribute("href")).toBe(`#/tasks/${raised}`);
+
+  // The origin-less frame wrote nothing here — and nothing anywhere else
+  // either. A fallback to "whatever channel is open" is issue #368's bug, and
+  // it would be worse than a missing marker: it would tell a reader a card
+  // settled in a conversation that never raised it.
+  await openChannel(page, CONTENT);
+  await expect(markers(page)).toHaveCount(0);
+});
+
+/**
+ * Raises a card from a channel the way the console does — the same
+ * `originChatId` the chat "Add to board" action sends — then dispatches it by
+ * moving it into the one column that fires a run.
+ *
+ * Driven over the API rather than through the board's drag gesture: what is
+ * under test here is the settle reaching the channel, and `board-drag.spec.ts`
+ * already owns the gesture. A drag here would couple this proof to that one.
+ */
+async function raiseAndDispatch(request: APIRequestContext, title: string, chatId: string) {
+  const created = await request.post(`${SCOPE}/tasks`, {
+    data: { title, originChatId: chatId },
+  });
+  expect(
+    created.ok(),
+    `raising the card failed: ${created.status()} ${await created.text()}`,
+  ).toBeTruthy();
+  const id = (await created.json()).id as string;
+
+  const dispatched = await request.patch(`${SCOPE}/tasks/${id}`, {
+    data: { column: "in_progress" },
+  });
+  expect(
+    dispatched.ok(),
+    `dispatching failed: ${dispatched.status()} ${await dispatched.text()}`,
+  ).toBeTruthy();
+  return id;
+}
+
+test("the marker lands live and survives a reload exactly once", async ({ page, request }) => {
+  // Needs a host that can actually run the card. Without the harness a
+  // dispatch settles nothing and there is no terminal to observe.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+  // A real dispatch is a model round trip plus a settle, then a reload and a
+  // second rehydration. The suite's 60s default would expire inside the first
+  // wait below and report a *timeout* rather than a missing marker — which is
+  // the least useful failure this spec could produce.
+  test.setTimeout(240_000);
+
+  await openChannel(page, ENGINEERING);
+
+  const title = `dispatch-marker ${Date.now()}`;
+  const id = await raiseAndDispatch(request, title, ENGINEERING);
+
+  // Addressed by the card's own href rather than by the marker text, so a
+  // marker left in this channel by an earlier run cannot be mistaken for this
+  // one — the harness company's data root outlives a single test.
+  const marker = page.locator(`a[href="#/tasks/${id}"]`);
+
+  // Live: the settle reaches the open channel with no reload. *Which* column it
+  // lands in depends on how the scripted run ends, and that is not what this
+  // asserts — the point is that something structural says it settled, and says
+  // where.
+  await expect(marker).toHaveCount(1, { timeout: 90_000 });
+  await expect(marker).toHaveText(/^finished → /);
+  const text = await marker.textContent();
+
+  // The reload is the half no unit test reaches. The live line came from the
+  // SSE injection; this one comes from `chat/history`. Two writers, one
+  // message — the shape that produced #483's duplicate — so the *count* is the
+  // assertion that matters, not the presence.
+  await page.reload();
+  await openChannel(page, ENGINEERING);
+  await expect(marker).toHaveCount(1, { timeout: 30_000 });
+  expect(await marker.textContent()).toBe(text);
+
+  // …and it settles at one rather than merely passing through it.
+  await page.waitForTimeout(3_000);
+  await expect(marker).toHaveCount(1);
+});
+
+test("a card raised on the board leaves no channel marker", async ({ page, request }) => {
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+  // Proving an absence means waiting out the run that could have produced it,
+  // so this needs headroom over the default too.
+  test.setTimeout(120_000);
+
+  await openChannel(page, ENGINEERING);
+  const before = await markers(page).count();
+
+  // No `originChatId`: the board's own "+" opens a card exactly like this. No
+  // conversation raised it, so no conversation is told it settled.
+  const created = await request.post(`${SCOPE}/tasks`, {
+    data: { title: `board-only ${Date.now()}` },
+  });
+  expect(created.ok()).toBeTruthy();
+  const id = (await created.json()).id as string;
+  expect(
+    (await request.patch(`${SCOPE}/tasks/${id}`, { data: { column: "in_progress" } })).ok(),
+  ).toBeTruthy();
+
+  // Give the run the same window the test above allows before believing this.
+  await page.waitForTimeout(20_000);
+  await expect(markers(page)).toHaveCount(before);
+  await expect(page.locator(`[href="#/tasks/${id}"]`)).toHaveCount(0);
+});

--- a/frontend/test/e2e/chat-dispatch-marker.spec.ts
+++ b/frontend/test/e2e/chat-dispatch-marker.spec.ts
@@ -70,6 +70,33 @@ function markers(page: Page) {
   return page.getByRole("link", { name: /^finished → / });
 }
 
+/**
+ * The marker count, once the channel's rehydration has stopped adding to it.
+ *
+ * A channel opens empty and fills from `chat/history` a moment later, so a
+ * count taken on arrival is a count of nothing — and a "no new marker appeared"
+ * assertion against it would be measuring the hydration instead. Waits for two
+ * equal readings rather than a fixed sleep, the same shape
+ * `chat-live-events.spec.ts` uses for its bubble counts and for the same
+ * reason: this suite shares one host and one data root across tests, so an
+ * earlier test's marker is legitimately in this channel's history.
+ */
+async function settledMarkerCount(page: Page): Promise<number> {
+  let last = -1;
+  await expect
+    .poll(
+      async () => {
+        const current = await markers(page).count();
+        const settled = current === last;
+        last = current;
+        return settled;
+      },
+      { intervals: [400, 400, 400, 400, 400, 400, 400, 400], timeout: 20_000 },
+    )
+    .toBe(true);
+  return last;
+}
+
 test("a settled dispatch marks the channel its card was raised in — and only that one", async ({
   page,
 }) => {
@@ -206,7 +233,11 @@ test("a card raised on the board leaves no channel marker", async ({ page, reque
   test.setTimeout(120_000);
 
   await openChannel(page, ENGINEERING);
-  const before = await markers(page).count();
+  // Settle the baseline before touching anything. This suite shares one host
+  // and one data root, so a marker an earlier test legitimately left in this
+  // channel's history is still arriving while the page loads — counting before
+  // that stops would measure the hydration, not this card.
+  const before = await settledMarkerCount(page);
 
   // No `originChatId`: the board's own "+" opens a card exactly like this. No
   // conversation raised it, so no conversation is told it settled.
@@ -221,6 +252,10 @@ test("a card raised on the board leaves no channel marker", async ({ page, reque
 
   // Give the run the same window the test above allows before believing this.
   await page.waitForTimeout(20_000);
-  await expect(markers(page)).toHaveCount(before);
+  // The load-bearing assertion: nothing anywhere links *this* card. It is
+  // addressed by href rather than by count, so it cannot be satisfied or
+  // broken by any other test's marker.
   await expect(page.locator(`[href="#/tasks/${id}"]`)).toHaveCount(0);
+  // …and the channel grew nothing at all.
+  await expect(markers(page)).toHaveCount(before);
 });

--- a/frontend/test/unit/chat-dispatch-marker.test.ts
+++ b/frontend/test/unit/chat-dispatch-marker.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 
 import type { ChatHistoryMessageDto } from "@/api/types";
 import {
+  MAIN_THREAD_ID,
   dispatchMarkerPlacement,
   dispatchMarkerText,
   fromHistory,
@@ -107,7 +108,24 @@ describe("where a settled dispatch's marker goes", () => {
    */
   it("nowhere, for a card no conversation raised", () => {
     expect(dispatchMarkerPlacement(terminal({ chatId: undefined }), CHANNELS)).toBeNull();
-    expect(dispatchMarkerPlacement(terminal({ chatId: "" }), CHANNELS)).toBeNull();
+  });
+
+  /**
+   * **An empty origin is the General thread, not a missing one.**
+   *
+   * The host's `is_general_chat` folds `""`, `"main"` and `"General"` into one
+   * conversation, and the chat route takes `chat` straight off the request body
+   * without normalising it — so `chat: ""` stores `origin_chat_id: Some("")`
+   * and the projection emits `chatId: ""`. Reading that as absent dropped the
+   * live marker while `chat/history` still served the rehydrated twin: the
+   * marker appeared only after a reload, which is exactly the live-vs-history
+   * split the identity-dedupe exists to close.
+   */
+  it("into the main thread when the origin is the empty string", () => {
+    const placement = dispatchMarkerPlacement(terminal({ chatId: "" }), CHANNELS);
+
+    expect(placement).not.toBeNull();
+    expect(placement?.threadId).toBe(MAIN_THREAD_ID);
   });
 
   /**

--- a/frontend/test/unit/chat-dispatch-marker.test.ts
+++ b/frontend/test/unit/chat-dispatch-marker.test.ts
@@ -1,0 +1,270 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { ChatHistoryMessageDto } from "@/api/types";
+import {
+  dispatchMarkerPlacement,
+  dispatchMarkerText,
+  fromHistory,
+  type ChatMessage,
+} from "@/lib/chat";
+import { handleEvent, type CompanyStreamEvent } from "@/hooks/use-events";
+
+/**
+ * Issue #377 — what a completed dispatch shows in the channel it came from.
+ *
+ * A card raised from a channel can settle in `paused` or bounce back to `todo`,
+ * and before this the channel showed only the agent's relay prose. A reader —
+ * live, or arriving fresh after a reload — reasonably concluded the work had
+ * finished. The marker is the structural fact the prose could not carry: the
+ * run *stopped*, and here is where the card landed.
+ *
+ * Two properties are worth more than the rest and are pinned hardest here:
+ *
+ * 1. **Exactly one marker, live and after a reload.** The dedupe is on
+ *    identity (`h<seq>`), never on content — that was issue #483's lesson, and
+ *    a content check here would be the same bug wearing a new hat.
+ * 2. **A marker never lands in a channel it did not come from.** A frame with
+ *    no origin, or one naming a thread this company has no channel for, writes
+ *    nothing at all. Falling back to "wherever the operator is looking" is
+ *    issue #368's bug, and it would be *worse* here than a missing marker: it
+ *    would tell someone a card settled in a conversation that never raised it.
+ */
+
+const AT = 1_700_000_000_000;
+
+function terminal(over: Partial<CompanyStreamEvent & { type: "desk_task_completed" }> = {}) {
+  return {
+    type: "desk_task_completed" as const,
+    seq: 4211,
+    atMillis: AT,
+    taskId: "t-1",
+    desk: "engineer",
+    column: "in_review",
+    chatId: "engineering",
+    ...over,
+  };
+}
+
+function historyEntry(over: Partial<ChatHistoryMessageDto> = {}): ChatHistoryMessageDto {
+  return {
+    id: "4211",
+    channel: "system",
+    author: "system",
+    text: "finished → In review",
+    atMillis: AT,
+    mine: false,
+    taskId: "t-1",
+    ...over,
+  };
+}
+
+/** The host's addressing map: chat thread id → the channel that renders it. */
+const CHANNELS = { engineering: "engineering", strategy: "strategy" };
+
+describe("the marker's wording", () => {
+  /**
+   * Pinned to the **identical literals** the host's `dispatch_marker_text`
+   * asserts (`src/server/chat_history.rs`). The sentence exists twice because
+   * the live SSE frame is thin — it carries the raw column id, not prose — and
+   * these two tests are the coupling that keeps the spellings together.
+   *
+   * Drift can only *reword* a marker across a reload, never double one, because
+   * the dedupe below is on identity. That is what makes two copies a tolerable
+   * cost rather than a returning bug.
+   */
+  it("names where the card landed, per column", () => {
+    expect(dispatchMarkerText("in_review")).toBe("finished → In review");
+    expect(dispatchMarkerText("paused")).toBe("finished → Paused");
+    expect(dispatchMarkerText("todo")).toBe("finished → To-do");
+    expect(dispatchMarkerText("done")).toBe("finished → Done");
+    expect(dispatchMarkerText("planning")).toBe("finished → Planning");
+    expect(dispatchMarkerText("in_progress")).toBe("finished → In progress");
+  });
+
+  /** A newer host's column reads a little raw rather than rendering blank. */
+  it("passes an unknown column through verbatim", () => {
+    expect(dispatchMarkerText("shipped_to_orbit")).toBe("finished → shipped_to_orbit");
+  });
+});
+
+describe("where a settled dispatch's marker goes", () => {
+  it("into the channel the card was raised in, carrying the card", () => {
+    const placement = dispatchMarkerPlacement(terminal(), CHANNELS);
+
+    expect(placement).not.toBeNull();
+    expect(placement!.threadId).toBe("engineering");
+    expect(placement!.channelId).toBe("engineering");
+    expect(placement!.message.from).toBe("system");
+    expect(placement!.message.text).toBe("finished → In review");
+    expect(placement!.message.taskId).toBe("t-1");
+    expect(placement!.message.at).toBe(AT);
+  });
+
+  /**
+   * A board-created card names no conversation. The host declines to file it
+   * into any desk's history, so a console that injected one anyway would show a
+   * marker live that vanished on reload — worse than showing none.
+   */
+  it("nowhere, for a card no conversation raised", () => {
+    expect(dispatchMarkerPlacement(terminal({ chatId: undefined }), CHANNELS)).toBeNull();
+    expect(dispatchMarkerPlacement(terminal({ chatId: "" }), CHANNELS)).toBeNull();
+  });
+
+  /**
+   * **Issue #368's bug, refused.** An unmatched thread yields no channel — not
+   * the first desk, not the channel the operator last had open. Filing one
+   * conversation's settle into another is the failure this shape exists to make
+   * impossible.
+   */
+  it("into no channel at all when the thread matches none — never a fallback", () => {
+    const placement = dispatchMarkerPlacement(terminal({ chatId: "a-desk-that-left" }), CHANNELS);
+
+    expect(placement).not.toBeNull();
+    expect(placement!.channelId).toBeNull();
+    // The thread store still keys directly on the origin, so a parked
+    // Conversation on that very thread would still get the line; what must not
+    // happen is a *different* channel receiving it.
+    expect(placement!.threadId).toBe("a-desk-that-left");
+  });
+
+  /** An empty addressing map is the pre-hydration state, not a licence to guess. */
+  it("into no channel before the addressing map has landed", () => {
+    expect(dispatchMarkerPlacement(terminal(), {})!.channelId).toBeNull();
+  });
+});
+
+describe("a live marker and its rehydrated twin", () => {
+  /**
+   * The property that keeps the count at one. The stream frame's `seq` and the
+   * history entry's `id` are the same host identifier, so the live line and the
+   * rehydrated one resolve to the same console id and `hydrateChannel`'s filter
+   * recognises the line it already has.
+   */
+  it("resolve to one console id", () => {
+    const live = dispatchMarkerPlacement(terminal(), CHANNELS)!.message;
+    const [rehydrated] = fromHistory([historyEntry()]);
+
+    expect(live.id).toBe(rehydrated.id);
+  });
+
+  it("leave exactly one line in the channel after a reload", () => {
+    // Live: the frame arrives and the shell appends the marker.
+    const channel: ChatMessage[] = [dispatchMarkerPlacement(terminal(), CHANNELS)!.message];
+
+    // Reload: `hydrateChannel` prepends everything it does not already know,
+    // by id — the filter written verbatim in shape.
+    const hydrated = fromHistory([historyEntry()]);
+    const known = new Set(channel.map((m) => m.id));
+    const fresh = hydrated.filter((m) => !known.has(m.id));
+
+    expect(fresh).toHaveLength(0);
+    expect([...fresh, ...channel]).toHaveLength(1);
+  });
+
+  /**
+   * The dedupe must not over-reach either: two cards settling into the same
+   * column produce the same *sentence*, and collapsing them would silently
+   * swallow a real settle. Identity is what tells them apart; content could
+   * not.
+   */
+  it("still separate two different settles that read identically", () => {
+    const first = dispatchMarkerPlacement(terminal({ seq: 1, taskId: "t-1" }), CHANNELS)!.message;
+    const second = dispatchMarkerPlacement(terminal({ seq: 2, taskId: "t-2" }), CHANNELS)!.message;
+
+    expect(first.text).toBe(second.text);
+    expect(first.id).not.toBe(second.id);
+  });
+});
+
+describe("a rehydrated marker", () => {
+  /**
+   * The host authors the marker as `system`, and `mine` is false on it — so
+   * without reading the author a reload rendered it as a **company bubble**,
+   * i.e. a settle that looked like something an agent had said. This is the
+   * half of the feature that only shows up after a refresh.
+   */
+  it("comes back as a system line, not a company bubble", () => {
+    const [marker] = fromHistory([historyEntry()]);
+
+    expect(marker.from).toBe("system");
+    expect(marker.text).toBe("finished → In review");
+  });
+
+  /** …still carrying its card, which is the whole reason the pill links out. */
+  it("keeps the card it names", () => {
+    expect(fromHistory([historyEntry()])[0].taskId).toBe("t-1");
+  });
+
+  /** An ordinary reply is untouched by the system branch. */
+  it("does not change how a company reply is read", () => {
+    const [reply] = fromHistory([
+      historyEntry({ author: "engineering", channel: "engineering", text: "on it", taskId: undefined }),
+    ]);
+
+    expect(reply.from).toBe("company");
+    expect(reply.channel).toBe("engineering");
+  });
+
+  /** …nor how your own message is, which must never grow a card chip. */
+  it("does not change how your own message is read", () => {
+    const [mine] = fromHistory([
+      historyEntry({ author: "ada", mine: true, text: "ship it", taskId: "t-1" }),
+    ]);
+
+    expect(mine.from).toBe("you");
+    expect(mine.taskId).toBeUndefined();
+  });
+});
+
+describe("the terminal frame's routing", () => {
+  /**
+   * One frame, two genuinely different reactions — and this file has been
+   * bitten before by an event reaching only one subscriber (#464, #371, #384).
+   * The board still needs its refetch tick because a settle moves a card
+   * between columns; the channel needs the marker.
+   */
+  it("reaches the board and the channel", () => {
+    const onTaskEvent = vi.fn();
+    const onDispatchTerminal = vi.fn();
+
+    handleEvent(terminal(), { onTaskEvent, onDispatchTerminal });
+
+    expect(onTaskEvent).toHaveBeenCalledTimes(1);
+    expect(onDispatchTerminal).toHaveBeenCalledTimes(1);
+    expect(onDispatchTerminal.mock.calls[0][0]).toMatchObject({
+      taskId: "t-1",
+      column: "in_review",
+      chatId: "engineering",
+    });
+  });
+
+  /**
+   * A board-created card still ticks the board — its column moved — and simply
+   * carries no origin for the channel half to act on.
+   */
+  it("still ticks the board for a card no conversation raised", () => {
+    const onTaskEvent = vi.fn();
+    const onDispatchTerminal = vi.fn();
+
+    handleEvent(terminal({ chatId: undefined }), { onTaskEvent, onDispatchTerminal });
+
+    expect(onTaskEvent).toHaveBeenCalledTimes(1);
+    expect(dispatchMarkerPlacement(onDispatchTerminal.mock.calls[0][0], CHANNELS)).toBeNull();
+  });
+
+  /**
+   * A card *changing* is not a card *settling*. Only the terminal posts a
+   * marker; if this ever routed both, every column drag would leave a
+   * "finished" line in a channel.
+   */
+  it("does not post a marker for an ordinary card write", () => {
+    const onDispatchTerminal = vi.fn();
+
+    handleEvent(
+      { type: "task_card_changed", seq: 9, atMillis: AT, taskId: "t-1", change: "updated", column: "todo" },
+      { onDispatchTerminal },
+    );
+
+    expect(onDispatchTerminal).not.toHaveBeenCalled();
+  });
+});

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -1318,6 +1318,20 @@ impl HarnessBrain {
                     output: result_text,
                     column: card.column.clone(),
                     artifact_ids,
+                    // Issue #377: the conversation this card was raised from,
+                    // **captured** off the card rather than derived at
+                    // completion. `responder` above is an agent id and a
+                    // channel is a desk id, so the origin cannot be recovered
+                    // from any other field on this event — and re-deriving it
+                    // would put a second rule beside `chat_history`'s, which is
+                    // the drift issue #435 exists to have removed.
+                    //
+                    // This is the one emission point every dispatch ending
+                    // passes through (`run_task`, `refuse_dispatch`), which is
+                    // why capturing it here cannot miss a path. A board-created
+                    // card carries `None` and gets no channel marker: no
+                    // conversation raised it.
+                    origin_chat_id: card.origin_chat_id.clone(),
                 },
             )
             .await

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4336,6 +4336,7 @@ members = ["nobody"]
                 output: "shipped".to_string(),
                 column: "done".to_string(),
                 artifact_ids: Vec::new(),
+                origin_chat_id: None,
             },
             at_millis: 30,
         });

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -804,6 +804,31 @@ pub enum CompanyEvent {
         /// no-deliverable case adds nothing to the log.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         artifact_ids: Vec<String>,
+        /// The conversation the card was raised from (issue #377), when one
+        /// was — [`TaskRecord::origin_chat_id`](crate::ports::tasks::TaskRecord::origin_chat_id),
+        /// stamped here at the moment the run settles.
+        ///
+        /// **Captured, never derived.** [`desk`](Self::DeskTaskCompleted::desk)
+        /// is the *responder* — an agent id like `engineer` — and a channel is
+        /// a desk id like `engineering`, so no reader can recover the origin
+        /// from the fields that were already here. Deriving it at completion
+        /// time would also re-open issue #435's failure mode: two places
+        /// deciding "which conversation is this?" by different rules. The card
+        /// has recorded its origin since #151, on every conversational path
+        /// that opens one, so the terminal simply carries what the card already
+        /// knows.
+        ///
+        /// `None` is a **positive fact**, not a lost id: nobody raised this
+        /// card from a conversation (it was created on the board, by a
+        /// scheduler, or before #151). Such a card belongs to no channel and
+        /// `chat_history::owns` deliberately keeps it out of every one of them
+        /// — it is emphatically *not* folded into the General desk.
+        ///
+        /// Additive: `#[serde(default)]` so every journal line written before
+        /// this field existed still replays, and skipped when absent so a
+        /// board-created card adds nothing to the log.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        origin_chat_id: Option<String>,
     },
     /// A human posted to a task's discussion thread (issue #335).
     ///
@@ -3531,6 +3556,7 @@ mod test {
             output: "shipped".to_string(),
             column: "in_review".to_string(),
             artifact_ids: Vec::new(),
+            origin_chat_id: None,
         };
         let json = serde_json::to_string(&done).unwrap();
         assert!(json.contains(r#""kind":"DeskTaskCompleted""#));
@@ -3538,8 +3564,61 @@ mod test {
             !json.contains("artifact_ids"),
             "a task that published nothing must add nothing to the log: {json}"
         );
+        assert!(
+            !json.contains("origin_chat_id"),
+            "a board-created card names no conversation, so it must add nothing \
+             to the log either: {json}"
+        );
         let back: CompanyEvent = serde_json::from_str(&json).unwrap();
         assert_eq!(back, done);
+    }
+
+    /// Issue #377: the terminal carries the conversation the card was raised
+    /// from, and a line written before the field existed still replays as
+    /// origin-less — which is the truth about it (nobody raised it from a chat
+    /// that this log records), not a default standing in for a lost id.
+    ///
+    /// The legacy blob is asserted verbatim for the same reason #244's is: it
+    /// is exactly what is already on disk in every company's event log. If this
+    /// fails, the change needs a migration rather than a `#[serde(default)]`.
+    #[test]
+    fn desk_task_completed_carries_its_origin_chat_and_still_reads_the_old_shape() {
+        let done = CompanyEvent::DeskTaskCompleted {
+            task_id: "t-1".to_string(),
+            desk: "engineer".to_string(),
+            output: "shipped".to_string(),
+            column: "in_review".to_string(),
+            artifact_ids: Vec::new(),
+            origin_chat_id: Some("engineering".to_string()),
+        };
+        let json = serde_json::to_string(&done).unwrap();
+        assert!(json.contains(r#""origin_chat_id":"engineering""#), "{json}");
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(&json).unwrap(),
+            done,
+            "the origin must survive the round trip"
+        );
+
+        // The responder and the channel are different words on purpose — this
+        // is why the origin has to be carried rather than derived from `desk`.
+        assert!(
+            !json.contains(r#""desk":"engineering""#),
+            "the responder is not the channel: {json}"
+        );
+
+        let legacy = r#"{"kind":"DeskTaskCompleted","task_id":"t-1","desk":"ceo","output":"shipped","column":"in_review"}"#;
+        assert_eq!(
+            serde_json::from_str::<CompanyEvent>(legacy).unwrap(),
+            CompanyEvent::DeskTaskCompleted {
+                task_id: "t-1".to_string(),
+                desk: "ceo".to_string(),
+                output: "shipped".to_string(),
+                column: "in_review".to_string(),
+                artifact_ids: Vec::new(),
+                origin_chat_id: None,
+            },
+            "a pre-#377 journal line must replay with no origin, not fail"
+        );
     }
 
     /// Issue #244: the terminal anchor names what the run published, and a line
@@ -3556,6 +3635,7 @@ mod test {
             output: "Drafted the launch spec.".to_string(),
             column: "in_review".to_string(),
             artifact_ids: vec!["art-1".to_string(), "art-2".to_string()],
+            origin_chat_id: None,
         };
         let json = serde_json::to_string(&done).unwrap();
         assert!(
@@ -3577,6 +3657,7 @@ mod test {
                 output: "shipped".to_string(),
                 column: "in_review".to_string(),
                 artifact_ids: Vec::new(),
+                origin_chat_id: None,
             },
             "a pre-#244 journal line must replay with no artifacts, not fail"
         );

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -4810,6 +4810,7 @@ mod test {
                         column: "done".into(),
                         artifact_ids: Vec::new(),
                         output: String::new(),
+                        origin_chat_id: None,
                     },
                 ],
                 approval_task,
@@ -5059,6 +5060,7 @@ mod test {
                 column: "done".into(),
                 artifact_ids: Vec::new(),
                 output: String::new(),
+                origin_chat_id: None,
             },
             CompanyEvent::AgentReply {
                 parent: None,

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -12,6 +12,9 @@ use std::collections::HashMap;
 
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
+use crate::ports::tasks::{
+    COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_PLANNING, COLUMN_TODO,
+};
 use crate::ports::types::{Actor, ActorKind, CompanyEvent, EventSeq, StoredEvent, TurnStep};
 use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
 
@@ -86,13 +89,78 @@ pub fn same_conversation(a: Option<&str>, b: Option<&str>) -> bool {
 /// `resolvable_parent`, which now folds through the same rule: a continuation
 /// could be parented to a root the main line refuses to render, and the console
 /// drops a reply whose parent it cannot find rather than showing it flat.
+///
+/// **A third kind of event routes here since issue #377**: the dispatch
+/// terminal. A card raised from a channel settles somewhere — `in_review`,
+/// `paused`, `todo` — and until #377 nothing structural said so in the channel
+/// it came from, so a reader saw the agent's relay prose and reasonably
+/// concluded the work had finished when it had in fact parked. The terminal
+/// routes by the origin the card recorded at raise time, matched on exactly the
+/// terms the other two are.
+///
+/// **`None` is not the General desk.** Everywhere else in this module a missing
+/// chat id means *the id was never addressed* and folds into General; on a
+/// terminal it means *no conversation raised this card* — it was created on the
+/// board, by a scheduler, or before the origin was recorded. Folding that into
+/// General would post a marker about board-only work into the operator's main
+/// line, which is a different bug from the one #377 fixes, so this arm answers
+/// `false` for every desk including General. It is the single most bug-prone
+/// line in this function and has its own test.
 pub fn owns(desk_id: &str, desk_name: &str, event: &CompanyEvent) -> bool {
     let stored = match event {
         CompanyEvent::AgentReply { chat_id, .. } => Some(chat_id.as_str()),
         CompanyEvent::OperatorMessage { chat, .. } => chat.as_deref(),
+        // Issue #377. `None` short-circuits to `false` here rather than
+        // falling through to the shared tail: `same_conversation` reads a
+        // `None` as "unaddressed, therefore General", and this event's `None`
+        // means the opposite — no conversation raised this card, so it belongs
+        // to no conversation's history.
+        CompanyEvent::DeskTaskCompleted { origin_chat_id, .. } => match origin_chat_id.as_deref() {
+            Some(origin) => Some(origin),
+            None => return false,
+        },
         _ => return false,
     };
     same_conversation(stored, Some(desk_id)) || same_conversation(stored, Some(desk_name))
+}
+
+/// The channel line a settled dispatch leaves behind (issue #377) —
+/// `finished → In review`.
+///
+/// Deliberately **structural and short**: where the card landed, and nothing
+/// else. The run's prose already reaches the same channel as the orchestrator's
+/// relay bubble (#151), so repeating it here would put one run's words into one
+/// conversation twice. What was missing was never the words — it was the fact
+/// that the card *settled*, and *where*, which a reader watching only the prose
+/// could not tell apart from "still working".
+///
+/// "finished" means *the run stopped*, not *it succeeded* — the same reading
+/// [`CompanyEvent::DeskTaskCompleted`] itself takes. A cancelled or failed
+/// dispatch lands in To-do and says so; a paused one says Paused. That is the
+/// whole point: the misleading case this exists for is precisely the run that
+/// stopped without finishing the work.
+///
+/// An unrecognised column id passes through **verbatim**, the same posture
+/// `harness::lifecycle::relay_text` takes — a newer host naming a column this
+/// build has not heard of should read a little raw, never render blank.
+///
+/// Pinned by tests on both sides of the wire: the console has its own
+/// `dispatchMarkerText` (`frontend/src/lib/chat.ts`), because the live SSE
+/// frame carries the raw column id rather than prose. Two spellings of one
+/// sentence can only *reword* a marker across a reload — never double it, since
+/// the dedupe is on identity — but the tests couple them anyway, on the same
+/// terms `BOARD_COLUMNS` and the console's `TASK_COLUMNS` are coupled.
+pub fn dispatch_marker_text(column: &str) -> String {
+    let landing = match column {
+        COLUMN_TODO => "To-do",
+        COLUMN_PLANNING => "Planning",
+        COLUMN_IN_PROGRESS => "In progress",
+        COLUMN_PAUSED => "Paused",
+        COLUMN_IN_REVIEW => "In review",
+        COLUMN_DONE => "Done",
+        other => other,
+    };
+    format!("finished → {landing}")
 }
 
 /// Who is reading a desk history. `mine` is relative to this.
@@ -312,6 +380,40 @@ impl MessageView {
                     reactions: Vec::new(),
                 }
             }
+            // The dispatch terminal (issue #377), as the channel marker a
+            // reader needs to see the card settle.
+            //
+            // A **dedicated arm**, not a lean on the defensive fallback below:
+            // that one renders `format!("{other:?}")`, so without this the
+            // marker would reach a person as a line of Rust `Debug` output —
+            // and it would do so only on reload, which is the half of this
+            // feature nobody watches while developing it.
+            //
+            // Authored as `system` on both keys, which is what makes the
+            // console render it as a centred pill rather than a company bubble
+            // (`MessageRow`), and `mine: false` because nobody said it.
+            // `task_id` carries the card so the pill can link to it — the same
+            // field, and therefore the same renderer, an `AgentReply`'s "card
+            // opened" chip uses. No new `MessageView` field: this type is
+            // shared with the GraphQL `Message` projection, and the reuse is
+            // what keeps #377 additive on both wire surfaces at once.
+            //
+            // No `steps` and no `parent_id`: a marker is not a turn and is
+            // never threaded, so `ThreadPanel` needs nothing from it.
+            CompanyEvent::DeskTaskCompleted {
+                task_id, column, ..
+            } => MessageView {
+                id,
+                channel: "system".to_string(),
+                author: "system".to_string(),
+                text: dispatch_marker_text(&column),
+                at_millis,
+                mine: false,
+                steps: Vec::new(),
+                task_id: Some(task_id),
+                parent_id: None,
+                reactions: Vec::new(),
+            },
             // `owns` never admits other variants into a history.
             other => MessageView {
                 id,
@@ -702,5 +804,157 @@ mod test {
         };
         assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
         assert!(!owns("strategy", "Strategy desk", &event));
+    }
+
+    /* ---- issue #377: the dispatch terminal as a channel marker ---- */
+
+    /// A settled dispatch, as the harness journals it. `desk` is deliberately
+    /// an agent id (`engineer`) and never a channel id (`engineering`) — that
+    /// difference is the whole reason the origin has to be carried.
+    fn desk_task_completed(origin: Option<&str>, column: &str) -> CompanyEvent {
+        CompanyEvent::DeskTaskCompleted {
+            task_id: "t-1".to_string(),
+            desk: "engineer".to_string(),
+            output: "the run's prose".to_string(),
+            column: column.to_string(),
+            artifact_ids: Vec::new(),
+            origin_chat_id: origin.map(str::to_string),
+        }
+    }
+
+    /// The terminal routes by the origin the card recorded, on exactly the same
+    /// terms a reply does: the desk's id or its name, and nothing else.
+    #[test]
+    fn a_terminal_belongs_to_the_channel_its_card_was_raised_in() {
+        let event = desk_task_completed(Some("engineering"), COLUMN_IN_REVIEW);
+        assert!(owns("engineering", "Engineering desk", &event));
+        // …and by the desk's *name*, for a card whose origin was journaled
+        // under it — the same either-spelling rule a reply routes by.
+        let by_name = desk_task_completed(Some("Engineering desk"), COLUMN_IN_REVIEW);
+        assert!(owns("engineering", "Engineering desk", &by_name));
+        // …and nowhere else. A settle in one channel must not surface in
+        // another, which is what would make the marker worse than no marker.
+        assert!(!owns("strategy", "Strategy desk", &event));
+        assert!(!owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
+        // The responder is not the channel — matching on it would file every
+        // settle under a desk whose id happens to equal an agent's.
+        assert!(!owns("engineer", "engineer", &event));
+    }
+
+    /// **The most bug-prone line in `owns`.** A card no conversation raised
+    /// belongs to no conversation's history — General emphatically included.
+    ///
+    /// Everywhere else in this module a missing chat id means "unaddressed,
+    /// therefore General". On a terminal it means the opposite: the card was
+    /// created on the board, by a scheduler, or before the origin was recorded.
+    /// Folding it would post markers about board-only work into the operator's
+    /// main line, which is a *new* bug rather than the one #377 fixes.
+    #[test]
+    fn a_terminal_with_no_origin_belongs_to_nobody_not_to_general() {
+        let event = desk_task_completed(None, COLUMN_IN_REVIEW);
+        assert!(
+            !owns(GENERAL_DESK, GENERAL_DESK, &event),
+            "an origin-less terminal must not fold into the General desk",
+        );
+        assert!(
+            !owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event),
+            "nor into the console's main line, which is General's other spelling",
+        );
+        assert!(!owns("", "", &event));
+        assert!(!owns("engineering", "Engineering desk", &event));
+    }
+
+    /// A terminal whose origin *is* one of General's four spellings still folds
+    /// like every other event does — the exception above is about `None`, not
+    /// about loosening [`same_conversation`].
+    #[test]
+    fn a_terminal_raised_on_the_main_line_folds_like_any_other_event() {
+        for origin in [GENERAL_DESK, MAIN_THREAD_ID, ""] {
+            let event = desk_task_completed(Some(origin), COLUMN_PAUSED);
+            assert!(
+                owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event),
+                "a terminal stored as `{origin}` belongs to the main line",
+            );
+            assert!(
+                owns(GENERAL_DESK, GENERAL_DESK, &event),
+                "…and to the General desk's own id/name",
+            );
+            assert!(
+                !owns("strategy", "Strategy desk", &event),
+                "…and to no named desk",
+            );
+        }
+    }
+
+    /// The marker's wording, pinned per column. The console holds the same
+    /// literals (`dispatchMarkerText`, `frontend/src/lib/chat.ts`) because the
+    /// live frame carries the raw column id; these two tests are what couple
+    /// them.
+    #[test]
+    fn the_marker_names_where_the_card_landed() {
+        assert_eq!(
+            dispatch_marker_text(COLUMN_IN_REVIEW),
+            "finished → In review"
+        );
+        assert_eq!(dispatch_marker_text(COLUMN_PAUSED), "finished → Paused");
+        assert_eq!(dispatch_marker_text(COLUMN_TODO), "finished → To-do");
+        assert_eq!(dispatch_marker_text(COLUMN_DONE), "finished → Done");
+        assert_eq!(dispatch_marker_text(COLUMN_PLANNING), "finished → Planning");
+        assert_eq!(
+            dispatch_marker_text(COLUMN_IN_PROGRESS),
+            "finished → In progress"
+        );
+    }
+
+    /// A column this build has not heard of reads a little raw rather than
+    /// rendering blank — the same fallback `relay_text` takes, and the reason a
+    /// newer host cannot produce an empty pill here.
+    #[test]
+    fn an_unknown_column_passes_through_verbatim() {
+        assert_eq!(
+            dispatch_marker_text("shipped_to_orbit"),
+            "finished → shipped_to_orbit"
+        );
+    }
+
+    /// The terminal projects as a system line carrying its card — not as the
+    /// `Debug` dump the defensive fallback would have rendered into a person's
+    /// transcript.
+    #[test]
+    fn project_renders_a_terminal_as_a_card_linked_system_marker() {
+        let view = MessageView::project(
+            at(
+                21,
+                desk_task_completed(Some("engineering"), COLUMN_IN_REVIEW),
+            ),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert_eq!(view.author, "system");
+        assert_eq!(view.channel, "system");
+        assert_eq!(view.text, "finished → In review");
+        assert_eq!(
+            view.task_id.as_deref(),
+            Some("t-1"),
+            "the pill links the card"
+        );
+        assert!(!view.mine);
+        assert!(view.steps.is_empty(), "a marker is not a turn");
+        assert!(view.parent_id.is_none(), "a marker is never threaded");
+        assert_eq!(view.id, "21", "the host id the console dedupes a reload on");
+    }
+
+    /// The run's prose stays out of the marker. It already reaches this same
+    /// channel as the orchestrator's relay bubble (#151); repeating it here
+    /// would put one run's words into one conversation twice.
+    #[test]
+    fn the_marker_does_not_repeat_the_runs_prose() {
+        let view = MessageView::project(
+            at(22, desk_task_completed(Some("engineering"), COLUMN_PAUSED)),
+            &Viewer::Operator,
+            &labels(),
+        );
+        assert!(!view.text.contains("the run's prose"), "{}", view.text);
+        assert_eq!(view.text, "finished → Paused");
     }
 }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -750,21 +750,38 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             }
             o
         }
-        // The dispatch terminal (#185). `output` is the agent's own reply text
-        // — the same string already written into the card's note — never raw
-        // tool output, so it is safe to project.
+        // The dispatch terminal (#185), narrowed and widened by #377.
+        //
+        // **Widened** with `chatId`: the conversation the card was raised from,
+        // which is what lets a console file the settle into the channel the
+        // work came from instead of guessing at one. Omitted rather than null
+        // when the card names none — mirroring `approval_parked` below, so "no
+        // conversation raised this" is a presence check on the console rather
+        // than a null check, and a board-created card is board-only on the wire
+        // too.
+        //
+        // **Narrowed** by dropping `output`. The run's prose already reaches
+        // the operator as the orchestrator's relay bubble (#151); what the
+        // channel was missing is the structural fact that the card *settled*
+        // and *where*, which is `column`. Carrying the prose here as well would
+        // put one run's words into the same channel twice, so it is dropped at
+        // the projection — the one place that can guarantee no later reader
+        // reintroduces the duplicate. Nothing in the console read it. `desk`
+        // stays for wire compatibility.
         CompanyEvent::DeskTaskCompleted {
             task_id,
             desk,
-            output,
             column,
+            origin_chat_id,
             ..
         } => {
             let mut o = envelope("desk_task_completed");
             o["taskId"] = json!(task_id);
             o["desk"] = json!(desk);
-            o["output"] = json!(output);
             o["column"] = json!(column);
+            if let Some(chat_id) = origin_chat_id {
+                o["chatId"] = json!(chat_id);
+            }
             o
         }
         // Issue #379: a request just parked, so a console watching the
@@ -4702,24 +4719,72 @@ mod test {
         assert!(uncorrelated.get("taskId").is_none());
     }
 
-    /// #185: the dispatch terminal projects all four fields. `column` is the one
-    /// that matters most — it is how a console tells a clean finish from a
-    /// cancelled or failed run without parsing `output`.
+    /// #185/#377: the dispatch terminal projects the structural fields, plus
+    /// the conversation the card was raised from. `column` is the one that
+    /// matters most — it is how a console tells a clean finish from a cancelled
+    /// or failed run — and `chatId` is what says which channel it belongs in.
     #[test]
     fn projects_desk_task_completed_with_every_field() {
         let v = super::project_event(&stored(CompanyEvent::DeskTaskCompleted {
             task_id: "t-1".into(),
-            desk: "ceo".into(),
+            desk: "engineer".into(),
+            output: "shipped".into(),
+            column: "in_review".into(),
+            artifact_ids: Vec::new(),
+            origin_chat_id: Some("engineering".into()),
+        }))
+        .expect("desk_task_completed is an attention signal");
+        assert_eq!(v["type"], serde_json::json!("desk_task_completed"));
+        assert_eq!(v["taskId"], serde_json::json!("t-1"));
+        assert_eq!(v["desk"], serde_json::json!("engineer"));
+        assert_eq!(v["column"], serde_json::json!("in_review"));
+        assert_eq!(v["chatId"], serde_json::json!("engineering"));
+        // The envelope's own keys still ride along — the console mints the
+        // marker's identity from `seq` (issue #483's mechanism), so losing it
+        // here would silently disable the reload dedupe.
+        assert!(v.get("seq").is_some(), "{v}");
+        assert!(v.get("atMillis").is_some(), "{v}");
+    }
+
+    /// Issue #377: the run's prose is **not** on this frame.
+    ///
+    /// The relay bubble (#151) already carries the agent's words into the same
+    /// channel this marker lands in. Projecting `output` here as well would put
+    /// one run's text into one conversation twice, and dropping it at the
+    /// projection is what stops any later reader from reintroducing that.
+    #[test]
+    fn desk_task_completed_does_not_project_the_runs_prose() {
+        let v = super::project_event(&stored(CompanyEvent::DeskTaskCompleted {
+            task_id: "t-1".into(),
+            desk: "engineer".into(),
+            output: "the whole reply, verbatim".into(),
+            column: "in_review".into(),
+            artifact_ids: Vec::new(),
+            origin_chat_id: Some("engineering".into()),
+        }))
+        .expect("desk_task_completed is an attention signal");
+        assert!(v.get("output").is_none(), "{v}");
+        assert!(
+            !v.to_string().contains("the whole reply"),
+            "the prose must not reach the wire under any key: {v}"
+        );
+    }
+
+    /// Issue #377: a card nobody raised from a conversation omits `chatId`
+    /// rather than sending null — so "board-created" is a presence check on the
+    /// console, the same shape `approval_parked` uses for a page-only approval.
+    #[test]
+    fn desk_task_completed_omits_the_chat_id_for_a_board_created_card() {
+        let v = super::project_event(&stored(CompanyEvent::DeskTaskCompleted {
+            task_id: "t-1".into(),
+            desk: "engineer".into(),
             output: "shipped".into(),
             column: "in_review".into(),
             artifact_ids: Vec::new(),
             origin_chat_id: None,
         }))
         .expect("desk_task_completed is an attention signal");
-        assert_eq!(v["type"], serde_json::json!("desk_task_completed"));
-        assert_eq!(v["taskId"], serde_json::json!("t-1"));
-        assert_eq!(v["desk"], serde_json::json!("ceo"));
-        assert_eq!(v["output"], serde_json::json!("shipped"));
+        assert!(v.get("chatId").is_none(), "{v}");
         assert_eq!(v["column"], serde_json::json!("in_review"));
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -4713,6 +4713,7 @@ mod test {
             output: "shipped".into(),
             column: "in_review".into(),
             artifact_ids: Vec::new(),
+            origin_chat_id: None,
         }))
         .expect("desk_task_completed is an attention signal");
         assert_eq!(v["type"], serde_json::json!("desk_task_completed"));

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3922,6 +3922,7 @@ async fn task_detail_assembles_timeline_and_lineage() {
             output: "shipped".into(),
             column: "in_review".into(),
             artifact_ids: Vec::new(),
+            origin_chat_id: None,
         },
     ] {
         runtime.events().append(&company, event).await.unwrap();
@@ -4878,6 +4879,7 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
             output: "shipped".into(),
             column: "in_review".into(),
             artifact_ids: Vec::new(),
+            origin_chat_id: None,
         },
         // After the window closed — must not leak either.
         approval("after"),
@@ -5280,6 +5282,7 @@ async fn a_task_that_never_waited_reports_no_waiting_fields() {
                 output: "shipped".into(),
                 column: "in_review".into(),
                 artifact_ids: Vec::new(),
+                origin_chat_id: None,
             },
         )
         .await


### PR DESCRIPTION
## Summary

Closes #377.

A dispatched card that settles into `paused` or `in_review` left its channel showing only the run's prose. A reader — live, or arriving fresh after a reload — reasonably concluded the work had finished. This posts a **card-linked system marker** (`finished → In review`) into the channel the card was raised in.

Built to the decision recorded on the issue, not around it: a **marker, not a bubble**; it carries the **column and a link to the card**, never the run's `output`; dedupe is **identity-based on the host `seq`**, never content-based (content-dedupe was #483, fixed in #498 and reused here rather than rebuilt).

**One correction to the issue body.** It says the frontend "falls to `default:` and is dropped". That is stale — `desk_task_completed` has been typed in the stream union since #464; it was routed to the board-refetch counter and simply never offered to chat. The gap was routing, not typing.

**Origin capture turned out to be the cheap case.** The plan budgeted for threading conversation identity through the dispatch path. It was already there: `TaskRecord.origin_chat_id` has existed since #151, and `journal_task_outcome` — the single emission point every dispatch ending passes through — already reads that exact field twenty lines further down for the #151 relay post-back. So @M3gA-Mind's #435 requirement (capture at dispatch time, never derive from the responder) is met by a one-line read. This matters because `desk` on the event is the *responder* (`engineer`), not a channel (`engineering`) — deriving would have been wrong, not just fragile. A board-created card carries `None` and deliberately gets no marker: no conversation raised it.

## API Or Behavior Changes

- **`DeskTaskCompleted` gains `origin_chat_id: Option<String>`**, serde-additive (`skip_serializing_if`). The pre-existing byte-identity replay test passes **untouched**, which is the proof old journals still replay.
- **`/events` frames lose `output`.** Dropped at the projection so no later reader can reintroduce the duplicate the decision exists to prevent. Verified no console consumer reads it — subscribers take a counter. **Out-of-tree stream consumers would lose it**; flagging explicitly rather than burying it.
- **`Chat.history` (GraphQL) now returns system marker rows** on existing fields, via the shared `MessageView`. Deliberate — reuse is what keeps this additive across both wire surfaces — but it widens a public response shape, so it is named here rather than discovered in review.
- `chat_history::owns` admits origin-matched terminals. **`None` returns `false` and is never General-folded** — the fold exists for a *lost* chat id; `None` is the positive fact that no conversation raised the card. This is the most bug-prone line in the change and is tested directly.
- `MessageView::project` gets a **dedicated** arm rather than relying on the defensive `other =>` fallback, which would have rendered Rust `Debug` output into a user-visible message. The teeth-proof below caught exactly that.
- Markers bump unread badges. Left deliberately — a settle is news — but raising it for review rather than pre-engineering it away.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — **2082 passed**
- [x] `cargo test --features openhuman,mcp,telegram` — **3116 passed**. No CI lane builds this combo, so this was run locally and is stated as such.
- [x] `npm run typecheck` / `typecheck:unit` / `typecheck:e2e`
- [x] `npx vitest run` — **457 passed**
- [x] `npm run build`
- [x] `npm run e2e` — **103 passed, 10 skipped**
- [x] Live-brain lane, built `--features openhuman,tinycortex,mcp` — **3 passed**: real dispatch, real settle, marker live in its channel, **still exactly one after reload**, and a board-created card producing none.

**Every new gate was proven red before it went green.** Reverting the two Rust arms puts **4 of 9** new tests into failure. The sharpest one printed the literal `Debug` dump as the message text — confirming the "dedicated arm, or a user sees Rust `Debug` output" hazard was real rather than theoretical. Unit: `expected 'company' to be 'system'`. Playwright: `Expected 1, Received 0`.

**One honest gap:** `a_terminal_with_no_origin_belongs_to_nobody_not_to_general` passes both before and after, because pre-change `owns` refused all terminals. Its teeth come from the sibling positive control asserted in the same file, not from itself.

**No hand-driven click-through was performed.** The paused-landing shape — the maintainer's motivating case — needs an approval-parking dispatch that could not be provoked by hand in this environment. Evidence for it rests on the live-brain spec plus a unit test pinning `finished → Paused`. Stating that rather than implying a manual pass that did not happen.

## Documentation

`docs/spec/runtime/events.md` gains a #377 section naming each deliberate choice: why the marker carries no `output`, why dedupe is identity-based, why `None` origin is not General-folded, and why the wording lives in two places (Rust and TS) with tests coupling the literals — drift can *reword* the line on reload but can never double it, since dedupe is id-based.

## Related

**Scope-ratification gap, raised explicitly.** The chat-history widening (`5ed4720b`) is @M3gA-Mind's fourth piece, and it was never replied to on the issue. It is included here because the mandated identity-dedupe presumes a rehydrated twin — without history, there is nothing to dedupe and the instruction is inert — and because the reader this issue exists to protect is most often the one arriving fresh. **If the intent was live-only, `5ed4720b` is the single commit to drop**; the rest stands without it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added “In review” system markers when task cards reach a terminal column.
  - Markers appear in the originating conversation and associated channel when available.
  - Markers link directly to the related task card.
  - Live updates and reloaded history prevent duplicate markers.

- **Bug Fixes**
  - Tasks without a conversational origin no longer create channel markers.
  - Existing history is not retroactively modified.
  - Completion events no longer expose task output prose.

- **Documentation**
  - Documented task origin tracking and terminal marker behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->