### PR TITLE
fix(console): name the eleven gated tools on the approval card (#701)

### DIFF
--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -332,6 +332,20 @@ export function payloadLines(a: ApprovalSummary): PayloadLine[] {
 const PAYLOAD_KEY_ORDER: Readonly<Record<string, string[]>> = {
   shell: ["command", "cwd", "timeout"],
   glob: ["pattern", "path"],
+  // The #701 labels lean on this block harder than the two above do. "Download a
+  // file from the internet" is only half a question until the operator can see
+  // *which* address, and both network payloads carry headers and a body that
+  // will happily push the url off the first line. Same for the git operation,
+  // which is the entire difference between reading a log and committing.
+  //
+  // Key names are the tools' own, not guesses: `curl` takes `url`/`dest_path`
+  // and no method (it streams a download to disk), `http_request` takes
+  // `url`/`method`, and `git_operations` takes `operation` — an enum, not a
+  // command line. Nothing is hidden here; this promotes, and every unlisted
+  // argument still follows.
+  curl: ["url", "dest_path"],
+  http_request: ["url", "method"],
+  git_operations: ["operation"],
 };
 
 function renderValue(value: unknown): string {

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -166,6 +166,72 @@ const TOOL_LABELS: Readonly<Record<string, string>> = {
   memory_recall: "Look something up in its memory",
   web_fetch: "Fetch a web page",
   query_company: "Look up something about the company",
+  // Issue #701 — the rest of the gated surface, found the way #671 was: by
+  // cross-checking every `Reach::Consequence` declaration in
+  // `src/policy/consequence.rs` against the keys of both tables here, rather
+  // than by anyone noticing a card. `every_consequence_tool_has_a_console_label`
+  // in that file is now what keeps the two in step.
+  //
+  // All of these park under their own raw tool name. That was the issue's open
+  // question and it is pinned as a test (`parked_kind_is_the_tool_name` in
+  // `src/harness/policy.rs`) rather than left to prose, because two of them
+  // invite the opposite guess: `publish_artifact` does NOT park as
+  // `external.publish` (a native workflow-gate class the tool never builds), and
+  // `run_workflow` does NOT park as `workflow.approve` (that is a workflow
+  // resuming mid-run, #395 — a different event from an agent asking to start
+  // one). A label filed under a kind nothing parks with is a label nobody sees.
+  //
+  // They belong here rather than in EFFECT_LABELS for the reason stated above:
+  // none is self-describing without the payload block underneath it — `curl`
+  // without its address says nothing — and EFFECT_LABELS' `satisfies` mirror
+  // would additionally demand a past-tense twin for a retry dialog these kinds
+  // never reach as native effects.
+  curl: "Download a file from the internet",
+  http_request: "Make a request to a web address",
+  // Three network tools, three sentences, and the differences are read off what
+  // the tools actually take rather than off their names. `curl` is not the
+  // arbitrary-method one its name suggests — it accepts a `url` and streams the
+  // body to a file in the workspace — while `http_request` carries any of GET,
+  // POST, PUT, DELETE, PATCH, HEAD, OPTIONS with headers and a body, and
+  // `web_fetch` above returns a page inline. Two labels an operator cannot tell
+  // apart are the #374 defect in a different costume.
+  git_operations: "Run a git command in its workspace",
+  read_workspace_state: "Check its workspace's git status",
+  // Both name git, which reads like a runtime internal and is not one here: it
+  // is what these tools literally run, the console already says so to an
+  // operator (`denial_reason` in `consequence.rs` explains a readonly refusal in
+  // exactly those words), and the alternative — "check its version control" over
+  // a payload block reading `git log` — is the vaguer of the two, not the
+  // plainer. `read_workspace_state` is gated *because* it shells out to git in a
+  // directory the agent can write git's own config into (#459); the operator is
+  // told what it does, and the reason it is gated stays the classifier's
+  // business.
+  mcp_call_tool: "Use a tool on a connected server",
+  // Distinct wording from `mcp_registry_tool_call`'s "Use a connected tool"
+  // below on purpose — the two are separate gates and an operator seeing both in
+  // the Standing permissions list has to be able to tell which is which.
+  publish_artifact: "Publish a file it produced",
+  // Not "…publicly", though the declaration's own comment calls publishing
+  // "externally visible": the tool's description is the narrower and more
+  // careful claim — an agent's sandbox is private, and publishing is the only
+  // thing that hands a finished file over. A card that says "publicly" over a
+  // hand-off to the operator is the misleading-label failure this issue refused
+  // to risk, so the label states what is true under either reading.
+  run_workflow: "Run one of its saved workflows",
+  // The four tools an operator may grant standing on (#444). They are not in the
+  // catch-all `Other` group by accident — they are the low-consequence writes
+  // the standing-grant feature exists to apply to, which means they are the
+  // entries most likely to sit next to each other in the #374 Standing
+  // permissions list, where no payload block exists to tell them apart. Four
+  // rows all reading "Use one of its tools" is precisely the state that list was
+  // added to end.
+  file_write: "Write a file in its workspace",
+  edit: "Edit a file in its workspace",
+  // `apply_patch` is a batch of exact-string edits applied atomically across one
+  // or more files — "a patch" in the diff sense is what it is *not*, and the
+  // count is the whole difference between it and `edit` above.
+  apply_patch: "Edit several files in its workspace at once",
+  csv_export: "Save data as a spreadsheet file in its workspace",
   // `mcp_registry_tool_call` is deliberately absent: EFFECT_LABELS already
   // names it and is consulted first, so an entry here would be unreachable.
 };

--- a/frontend/test/unit/language.test.ts
+++ b/frontend/test/unit/language.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import { approvalAction, payloadLines, toolAction } from "@/lib/language";
+import type { ApprovalSummary } from "@/api/types";
+
+/**
+ * The gated tools an operator is asked to sign off on say what they are (#701).
+ *
+ * The Rust guard (`every_consequence_tool_has_a_console_label` in
+ * `src/policy/consequence.rs`) asserts that each of these tools has a *key* in
+ * one of the label tables — that is the half which cannot be checked from here,
+ * because the declaration table it reads is Rust. This is the other half: that
+ * the key is reachable through the resolution the console actually performs.
+ *
+ * Both are needed. A key in `TOOL_LABELS` satisfies the guard while remaining
+ * invisible if `approvalAction`'s rung order ever changed, and the whole defect
+ * class (#372, #551 → #671, #701) is labels that exist somewhere and reach
+ * nobody.
+ */
+
+function approval(over: Partial<ApprovalSummary> & Pick<ApprovalSummary, "kind">): ApprovalSummary {
+  return { id: "a1", amount_usd: null, at_millis: 1_000, agent: "ceo", ...over };
+}
+
+/** What each per-call tool gate asks for, keyed by the kind it parks under. */
+const PER_CALL: Record<string, string> = {
+  curl: "Download a file from the internet",
+  http_request: "Make a request to a web address",
+  git_operations: "Run a git command in its workspace",
+  read_workspace_state: "Check its workspace's git status",
+  mcp_call_tool: "Use a tool on a connected server",
+  publish_artifact: "Publish a file it produced",
+  run_workflow: "Run one of its saved workflows",
+};
+
+/** The four an operator may grant standing on, so the #374 list renders them. */
+const GRANTABLE: Record<string, string> = {
+  file_write: "Write a file in its workspace",
+  edit: "Edit a file in its workspace",
+  apply_patch: "Edit several files in its workspace at once",
+  csv_export: "Save data as a spreadsheet file in its workspace",
+};
+
+describe("an approval card for a gated tool", () => {
+  for (const [kind, sentence] of Object.entries(PER_CALL)) {
+    it(`says what \`${kind}\` is asking for`, () => {
+      expect(approvalAction(approval({ kind }))).toBe(sentence);
+    });
+  }
+
+  it("never leaves one of them on the generic fallback", () => {
+    for (const kind of [...Object.keys(PER_CALL), ...Object.keys(GRANTABLE)]) {
+      expect(approvalAction(approval({ kind }))).not.toBe("Use one of its tools");
+    }
+  });
+
+  it("still resolves a business effect through the effect glossary first", () => {
+    // Rung 1 is unchanged by #701 — nothing was added to EFFECT_LABELS, and a
+    // tool label that shadowed one of its entries would be a silent rewording of
+    // a card that has read the same way since #372.
+    expect(approvalAction(approval({ kind: "payment.send" }))).toBe("Send a payment");
+    expect(approvalAction(approval({ kind: "mcp_registry_tool_call" }))).toBe(
+      "Use a connected tool",
+    );
+  });
+});
+
+describe("the standing permissions list", () => {
+  for (const [kind, sentence] of Object.entries({ ...PER_CALL, ...GRANTABLE })) {
+    it(`names \`${kind}\` without an approval to read it from`, () => {
+      expect(toolAction(kind)).toBe(sentence);
+    });
+  }
+
+  it("tells the four grantable tools apart", () => {
+    // The point of labelling them: this list has no payload block, so two rows
+    // reading the same sentence are two permissions an operator cannot choose
+    // between.
+    const rendered = Object.keys(GRANTABLE).map(toolAction);
+    expect(new Set(rendered).size).toBe(rendered.length);
+  });
+});
+
+describe("the payload block underneath the label", () => {
+  // The labels for these three are the shortest of the eleven precisely because
+  // the address is right below them. If the ordering regresses, the card still
+  // renders — it just buries the one argument being consented to under a header
+  // map, which is the failure no type catches.
+  it("leads a request with its address, not with its headers", () => {
+    const lines = payloadLines(
+      approval({
+        kind: "http_request",
+        payload: { headers: { Authorization: "…" }, body: "{}", url: "https://x.test", method: "POST" },
+      }),
+    );
+    expect(lines.map((l) => l.label)).toStrictEqual(["url", "method", "headers", "body"]);
+  });
+
+  it("leads a download with its address", () => {
+    const lines = payloadLines(
+      approval({ kind: "curl", payload: { dest_path: "out.bin", url: "https://x.test/f" } }),
+    );
+    expect(lines.map((l) => l.label)).toStrictEqual(["url", "dest_path"]);
+  });
+
+  it("leads a git call with the operation it is about to run", () => {
+    const lines = payloadLines(
+      approval({ kind: "git_operations", payload: { message: "wip", operation: "commit" } }),
+    );
+    expect(lines[0]).toStrictEqual({ label: "operation", value: "commit" });
+  });
+});
+
+describe("a kind nobody has named", () => {
+  it("says a teammate wants a tool rather than inventing one", () => {
+    expect(approvalAction(approval({ kind: "some_tool_nobody_declared" }))).toBe(
+      "Use one of its tools",
+    );
+  });
+
+  it("says less again when there is no teammate to name", () => {
+    expect(approvalAction(approval({ kind: "some.native.effect", agent: null }))).toBe(
+      "Do something that needs your sign-off",
+    );
+  });
+
+  it("falls back the same way from the permissions list", () => {
+    expect(toolAction("some_tool_nobody_declared")).toBe("Use one of its tools");
+  });
+});

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1712,6 +1712,53 @@ mod tests {
         );
     }
 
+    /// What string a per-call **tool** gate actually puts in front of an
+    /// operator (issue #701).
+    ///
+    /// The issue could not answer this from the frontend, and declined to
+    /// invent labels without it — rightly: a card whose job is informed consent
+    /// is worse off with a label naming the wrong action than with a vague one.
+    /// The answer is that a tool gate parks under the tool's own raw name.
+    /// [`ApprovalPolicy::require_approval`] is the only construction site for a
+    /// `RequireApproval` decision, it builds its request through
+    /// [`ApprovalPolicy::effect_for`], and that sets `kind` to `tool_name`
+    /// verbatim; `CompanyRuntime::pending_approvals` — the only projection
+    /// point for an `ApprovalSummary` — copies it through unchanged.
+    ///
+    /// Two of the seven invite the opposite guess, so both are pinned here
+    /// rather than argued in prose:
+    ///
+    /// * `publish_artifact` does **not** park as `external.publish`. That kind
+    ///   exists only as a native workflow-gate class and a `DEFAULT_ALWAYS_APPROVE`
+    ///   entry; `harness::publish` builds no effect and touches no gate.
+    /// * `run_workflow` does **not** park as `workflow.approve`. That kind is a
+    ///   workflow *resuming* mid-run (issue #395, `WORKFLOW_APPROVE_KIND`),
+    ///   which is a different event from an agent asking to start one.
+    ///
+    /// So all seven need entries in the console's tool-label table, and this
+    /// test is what stops that answer decaying back into a guess.
+    #[test]
+    fn parked_kind_is_the_tool_name() {
+        let p = policy("supervised", &[], None);
+        for tool in [
+            "curl",
+            "git_operations",
+            "http_request",
+            "mcp_call_tool",
+            "publish_artifact",
+            "read_workspace_state",
+            "run_workflow",
+        ] {
+            assert_eq!(
+                p.effect_for(tool, &serde_json::json!({})).kind,
+                tool,
+                "`{tool}` parks under a kind the console's tool-label table does \
+                 not key on; the label added for it in `language.ts` is now \
+                 unreachable"
+            );
+        }
+    }
+
     /// Per-tenant Composio (issue #110): the read tools are read-only (allowed
     /// even under supervised/readonly), while `composio_authorize` /
     /// `composio_execute` are external — parked under supervised, denied under

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -1515,4 +1515,129 @@ mod tests {
             );
         }
     }
+
+    /// Where the console keeps the words an operator reads instead of a tool
+    /// name. Named once so both the parser and every failure message point at
+    /// the same file.
+    const LANGUAGE_TS: &str = "frontend/src/lib/language.ts";
+
+    /// The keys of one object literal in [`LANGUAGE_TS`].
+    ///
+    /// A line parser rather than the two alternatives, and the reasons are the
+    /// same ones that make this a `cargo test` at all:
+    ///
+    /// * a **checked-in generated manifest** of the declared set would give the
+    ///   contract two failure sites and a window between the declaration commit
+    ///   and the regenerate commit where nothing is wrong;
+    /// * a **CI grep** would have no local signal for the Rust contributor who
+    ///   adds the next `Reach::Consequence` line — and that is who introduced
+    ///   all three instances of this defect (#372, #551 → #671, now #701).
+    ///
+    /// It is deliberately literal about the shape it accepts: an object literal
+    /// opened by `const <NAME>` on a line ending in `{` and closed by a `};`
+    /// line. Anything else panics rather than returning a short list, because a
+    /// parser that silently reads nothing turns this test into a green light
+    /// for the exact regression it exists to catch — see the vacuity guards in
+    /// [`every_consequence_tool_has_a_console_label`].
+    fn label_keys(source: &str, decl: &str) -> Vec<String> {
+        let mut lines = source.lines();
+        let opened = lines.any(|line| {
+            let line = line.trim_start();
+            line.starts_with(&format!("const {decl}")) && line.ends_with('{')
+        });
+        assert!(
+            opened,
+            "no `const {decl} … {{` line in {LANGUAGE_TS}. If the table was \
+             renamed or reshaped, update this parser — do not delete the test"
+        );
+
+        let mut keys = Vec::new();
+        for line in lines {
+            let line = line.trim();
+            if line == "};" {
+                return keys;
+            }
+            if line.is_empty() || line.starts_with("//") || line.starts_with('*') {
+                continue;
+            }
+            let Some((key, _)) = line.split_once(':') else {
+                continue;
+            };
+            keys.push(key.trim().trim_matches('"').to_string());
+        }
+        panic!("`const {decl}` in {LANGUAGE_TS} is never closed by a `}};` line");
+    }
+
+    /// Every tool that reaches an operator resolves to a sentence, not to
+    /// "Use one of its tools" (issue #701).
+    ///
+    /// The console's `approvalAction` resolves `EFFECT_LABELS` → `TOOL_LABELS`
+    /// → a generic fallback, so a gated tool in neither table asks an operator
+    /// to consent to "use one of its tools" — the #372 defect. It has now
+    /// recurred three times, and every time the commit that caused it was a
+    /// Rust one adding a `Reach::Consequence` declaration with no reason to
+    /// open the frontend at all. So the coupling belongs here, next to
+    /// [`DECLARED`], where that contributor's `cargo test` reports it.
+    ///
+    /// Scoped to the whole [`Reach::Consequence`] class rather than to the
+    /// per-call subset. The grantable ones (`file_write`, `edit`,
+    /// `apply_patch`, `csv_export`) park exactly the same way, and they are
+    /// *also* the ones issue #374's Standing-permissions list renders through
+    /// `toolAction` with no payload block to disambiguate them. A test scoped
+    /// to `Standing::PerCall` would ship blind to four instances of the class
+    /// it exists to kill.
+    #[test]
+    fn every_consequence_tool_has_a_console_label() {
+        let source = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/frontend/src/lib/language.ts"
+        ));
+        let effects = label_keys(source, "EFFECT_LABELS");
+        let tools = label_keys(source, "TOOL_LABELS");
+
+        // Vacuity guards. A parse that quietly returned nothing would report
+        // every gated tool as unlabelled — noisy, and therefore self-correcting.
+        // A parse that quietly returned *the wrong block* would report none of
+        // them, which is the failure that matters: the test would pass forever
+        // while the console regressed. These anchors are entries with no reason
+        // to move, so a reformat of `language.ts` breaks here loudly instead.
+        for anchor in ["payment.send", "workflow.approve"] {
+            assert!(
+                effects.iter().any(|k| k == anchor),
+                "parsed EFFECT_LABELS from {LANGUAGE_TS} without `{anchor}` — \
+                 the parser is reading the wrong block, not the table shrinking"
+            );
+        }
+        for anchor in ["shell", "workspace_create"] {
+            assert!(
+                tools.iter().any(|k| k == anchor),
+                "parsed TOOL_LABELS from {LANGUAGE_TS} without `{anchor}` — \
+                 the parser is reading the wrong block, not the table shrinking"
+            );
+        }
+        assert!(
+            effects.len() >= 15 && tools.len() >= 10,
+            "parsed only {} EFFECT_LABELS and {} TOOL_LABELS keys from \
+             {LANGUAGE_TS}; both tables are larger than that, so the parser is \
+             stopping early",
+            effects.len(),
+            tools.len()
+        );
+
+        let mut unlabelled: Vec<&str> = declared_tools()
+            .filter(|tool| c(tool).reach.parks_under_supervision())
+            .filter(|tool| !effects.iter().any(|k| k == tool) && !tools.iter().any(|k| k == tool))
+            .collect();
+        unlabelled.sort_unstable();
+        assert!(
+            unlabelled.is_empty(),
+            "{unlabelled:?} park for an operator but have no entry in either \
+             label map in {LANGUAGE_TS}, so their approval card reads \"Use one \
+             of its tools\". Add each to TOOL_LABELS — a gated tool's label \
+             only ever appears above the payload block, which is what \
+             EFFECT_LABELS entries do not assume and why its \
+             EFFECT_DONE_LABELS mirror would demand a past-tense twin these \
+             kinds never reach"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Eleven gated tools now name themselves on the approval card, and a test makes the omission un-reintroducible.

Closes #701.

## Problem

Tools declared `Reach::Consequence` park on every call and reach an operator on an approval card. Eleven of them had no entry in either console label map, so `approvalAction` fell through to its generic rung and asked the operator to approve **"Use one of its tools"** — a card whose entire job is informed consent, showing nothing to consent to.

This is the third instance of the same class: #372 was the original, #671 fixed `workspace_create` (generic since #551, found only while grepping to *confirm* that no frontend change was needed), and these eleven are the rest.

The issue stated an open question rather than guessing at it — whether these park under their tool name or under an effect kind — and it is now answered in one direction for all of them. `require_approval` is the single construction site for a `RequireApproval` decision; it builds the effect through `effect_for`, which sets `kind: tool_name` verbatim, and `pending_approvals` copies it through unchanged. `external.publish` exists only as a workflow-gate class with no `Effect` construction site, so `publish_artifact` really is uncovered. That invariant is now pinned by `parked_kind_is_the_tool_name` rather than recorded as prose.

Eleven, not the seven the issue lists: writing the guard honestly — any `Reach::Consequence` tool, not just per-call ones — surfaces `file_write`, `edit`, `apply_patch` and `csv_export`, three of which are wired in real belts today. Scoping the test to `PerCall` would have shipped a guard already blind to four instances of the class it exists to kill.

## Solution

Labels in `TOOL_LABELS` — none in `EFFECT_LABELS`, whose `satisfies` mirror would force a past-tense twin into a dialog these kinds never reach.

The guard is a Rust test colocated with the `DECLARED` table: it iterates the declarations, filters to the ones that park, reads `frontend/src/lib/language.ts`, and asserts each has a key in one of the two maps. It was chosen over a generated manifest (two failure sites plus a regenerate drift window) and over a CI grep script (fragile against multi-line `d(...)` entries, and no local `cargo test` signal for the Rust contributor adding the next declaration — which is where all three historical instances came from). Anchored vacuity guards mean a reformat fails loudly instead of passing on an empty set.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --all-targets -- -D warnings`, and again under `--features openhuman`
- [x] `cargo check --locked --all-features --all-targets`
- [x] `cargo test --locked` — 2073 passed, 0 failed, 1 ignored
- [x] `cargo test --locked --features openhuman --lib harness::policy::tests` — 75 passed, including the new parked-kind pin
- [x] `npm test` — 468 tests across 40 files (was 441/39)
- [x] `npx tsc --noEmit`, `npm run build`, `scripts/ci/assert-design-tokens.sh`

The guard was committed **before** the labels and observed to fail, naming exactly the eleven; it passes after. A test written after its fix proves nothing about whether it would have caught the bug.

Note: `--features openhuman` is required for the parked-kind test to be selected at all — `src/harness/` compiles only under it, so the default `cargo test` run would silently not have included it.

## Impact

Operator-facing copy only, plus tests. No change to `approvalAction`/`toolAction` logic, the `DECLARED` table, `EFFECT_LABELS`, or the pinned mode lists. Nothing asserted on the old generic string anywhere in the tree, so nothing breaks as the eleven start resolving.

Four labels differ from what the issue and plan proposed, because the tools do not do what their names suggest:

- **`curl` does not take a method.** Its schema is `{url, dest_path, headers}` and it streams a download to disk under a byte ceiling; `http_request` is the one carrying GET/POST/PUT/DELETE/etc. Shipped `"Download a file from the internet"`. The proposed payload order `url, method` would have promoted a key that never arrives; it is `url, dest_path`.
- **`git_operations` takes an `operation` enum**, not a command line, so the proposed `["command"]` ordering was also a no-op key.
- **`apply_patch` is not a patch** — it is a batch of exact-string edits applied atomically across files. The count, not the format, distinguishes it from `edit`.
- **`publish_artifact` is not documented as public.** Shipped `"Publish a file it produced"`, which is true under either reading — see below.

## Related

- #372 — the original raw-identifier-on-the-card bug
- #671 — fixed `workspace_create` and surfaced this class
- #459 — reclassified `read_workspace_state`, adding it to the set
- #551 — where `workspace_create`'s gap began
- #374 — the Standing-permissions list, which renders the four grantable tools with no payload block to disambiguate
- #245 PR-B adds `repo_checkout`/`repo_pr` with their own labels; regions are disjoint in `consequence.rs` and adjacent in `TOOL_LABELS`, so whoever lands second rebases keeping both. The guard works in either order.

**One thing worth a maintainer's call:** the declaration comment for `publish_artifact` says it is "externally visible and not reversible by the company alone", while the tool's own description says the sandbox is private and publishing is what hands a file to *the operator*. Those disagree about whether publishing leaves the building. The shipped label is true either way and the conflict is written down at the entry, but the underlying question should be settled by someone who knows the intent.
