### PR TITLE
feat(delegation): a desk member can hand work one level further (#176)

### DIFF
--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -33,6 +33,7 @@ description = "Write ads, pages, and campaign copy."
 # NEW optional per-agent keys:
 tier = "reasoning"                 # cognition tier hint (see glossary)
 tools = ["docs.*", "email.send"]   # tool grant globs
+delegates_to = ["research"]        # desks this agent may hand work to ("*" = all)
 budget_usd_daily = 5.0             # per-agent daily spend cap (UTC day)
 
 # ── new tables (all optional) ──────────────────────────────────────────
@@ -68,6 +69,8 @@ provider = "openhuman"             # openhuman (default) | builtin
 allow = ["web.*", "docs.*", "search"]  # company-wide grant; agents intersect
                                    # `search` must be named — `*` never grants it
 search_daily_calls = 200           # per-company daily web_search cap (0 = paused)
+max_delegation_depth = 2           # how deep one message's hand-off chain may run
+                                   # 1 = desks may not re-delegate at all; 1..=4
 
 [policy]                           # see company-brain/approvals.md
 mode = "supervised"                # readonly | supervised (default) | auto | full
@@ -106,6 +109,43 @@ prompt = "Weekly review and operator digest"
   use when delegating; it never selects a model (the backend maps tiers to
   SKUs). `tools` and `budget_usd_daily` intersect with the company-wide
   `[tools].allow` and `[budget]` — the most restrictive wins.
+
+  **`delegates_to`** (issue #176) is the one per-agent key that is *not* a
+  narrowing of a company-wide list: it is an **opt-in**. Empty — the default,
+  and every manifest written before it existed — means the agent carries no
+  delegation tool at all, which is how a dispatched desk agent has always
+  behaved. Naming one or more desks wires exactly two tools onto it,
+  `spawn_task` and a `delegate_to_desk` narrowed to those desks, so a desk lead
+  can pull a specialist in for one slice instead of handing the whole request
+  back to the orchestrator.
+
+  It takes **desk** ids or names (`[[group_chat]]` entries), never teammate
+  ids — desks are the address space `delegate_to_desk` already resolves
+  against — and `"*"` means every desk the company has. An entry that names no
+  declared desk fails validation, because at runtime it would fail silently:
+  the member would carry the tool and every call would be refused.
+
+  It never confers the orchestrator's *authority* — `assign_task`,
+  `review_task`, `add_agent`, `query_company`, `run_workflow`,
+  `create_workflow` stay orchestrator-only. A member gets what it needs to pass
+  a slice on and to leave the rest tracked, and nothing more.
+
+  Three runtime guards bound what it can do, all enforced at the tool boundary
+  in the member's own turn rather than by which tools were wired (belts are
+  cached per roster, so a tool cannot be withheld from one turn):
+
+  - **Depth** — `[tools].max_delegation_depth`, below.
+  - **Cycles** — a hand-off to a desk already on the current chain (A→B→A), or
+    to the desk the caller itself leads, is refused.
+  - **Allowlist** — a target outside `delegates_to` is refused, and the refusal
+    names the desks the member *can* reach so it can retry in the same turn.
+
+  Each refusal reaches both the model and the board: the run trail carries it
+  verbatim, and a refused hand-off is recorded on the dispatched card's note,
+  so the operator reads the fact rather than inferring it from an absence.
+
+  The per-turn fan-out cap (three delegations) applies **per level**, not per
+  message — each turn starts against an empty queue.
 
   **`budget_usd_daily`** (enforced since issue #304 — before that it was
   validated, stored and displayed, but nothing read it) caps one teammate's
@@ -268,6 +308,24 @@ prompt = "Weekly review and operator digest"
       does not get one.
     - **There is no `search` Cargo feature.** The tool rides the `openhuman`
       harness feature so CI's gated lane actually compiles and tests it.
+
+  **`max_delegation_depth`** (issue #176) bounds how deep one operator
+  message's hand-off chain may run, counted in hand-offs: the orchestrator
+  handing work to a desk lead is level 1, that lead handing a slice on is
+  level 2. Default `2`; valid `1..=4`, where `1` is the "recursion off" setting
+  and reproduces the pre-#176 behaviour exactly.
+
+  The depth in force is read from the **live company record** on every call, so
+  lowering it takes effect on the next turn without a rebuild. A hand-off past
+  the bound is refused in the model's own turn with the reason
+  `depth_capped` — while `spawn_task` still works at the bound, so a member that
+  has run out of chain leaves the remaining work tracked instead of doing it
+  silently.
+
+  The bound only ever matters to an agent some manifest opted in with
+  `delegates_to`; a company that names nobody is unaffected by any value here.
+  It is deliberately low: the fan-out cap applies per level, so each extra
+  level multiplies the turns one message can buy.
     The Usage view surfaces a `Web searches` KPI plus a search status row
     (active / paused at cap 0 / awaiting credential / not granted / not in this
     build).

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -12,8 +12,15 @@ use crate::error::{OpenCompanyError, Result};
 
 use super::types::{
     BRAIN_MODES, CONNECTION_PRIORITIES, CompanyManifest, GATEABLE_NAMESPACES, KNOWN_CHANNELS,
-    PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, TIERS, TOOL_PROVIDERS,
+    MAX_DELEGATION_DEPTH_BOUNDS, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, TIERS, TOOL_PROVIDERS,
 };
+
+/// The `delegates_to` entry that means "every desk this company has".
+///
+/// Shared with the runtime allowlist check
+/// ([`reject_out_of_allowlist_target`](crate::runtime::delegation_tools::reject_out_of_allowlist_target))
+/// so validation and enforcement cannot disagree about what `"*"` means.
+pub const DELEGATES_TO_WILDCARD: &str = "*";
 
 /// Preferred manifest filename.
 pub const MANIFEST_FILE: &str = "company.toml";
@@ -178,6 +185,44 @@ impl CompanyManifest {
             }
         }
 
+        // Delegation allowlists (issue #176): every `delegates_to` entry must
+        // name a desk this manifest actually declares.
+        //
+        // Checked here rather than in the roster loop above because it is the
+        // one agent field whose target lives in a *later* section — the desks
+        // are only fully known once `[[group_chat]]` has been walked. An entry
+        // that resolves to nothing would otherwise fail silently at runtime:
+        // the member would carry `delegate_to_desk`, every call would be
+        // refused as off-allowlist, and the manifest would look fine.
+        for agent in &self.agents {
+            let label = if agent.id.is_empty() {
+                "an agent".to_string()
+            } else {
+                format!("agent `{}`", agent.id)
+            };
+            for desk in &agent.delegates_to {
+                let key = desk.trim();
+                if key == DELEGATES_TO_WILDCARD {
+                    continue;
+                }
+                if key.is_empty() {
+                    problems.push(format!(
+                        "{label} has an empty entry in `delegates_to` — list desk ids, or `\"*\"` for every desk."
+                    ));
+                    continue;
+                }
+                let resolves = self
+                    .group_chats
+                    .iter()
+                    .any(|chat| chat.id == key || chat.name.eq_ignore_ascii_case(key));
+                if !resolves {
+                    problems.push(format!(
+                        "{label} may delegate to `{key}`, which is not a desk in this company — `delegates_to` takes `[[group_chat]]` ids (or `\"*\"` for every desk), not teammate ids."
+                    ));
+                }
+            }
+        }
+
         // Connections: a provider is required; a stated priority must be known.
         for (index, connection) in self.connections.iter().enumerate() {
             let label = if connection.provider.trim().is_empty() {
@@ -236,6 +281,21 @@ impl CompanyManifest {
                 "`[tools].provider`",
                 TOOL_PROVIDERS,
                 &self.tools.provider,
+            ));
+        }
+
+        // The delegation chain bound (issue #176). `0` would refuse the
+        // orchestrator's own hand-off — delegation off entirely, by a knob that
+        // reads like a depth — and anything past the ceiling is a runaway with
+        // a number in front of it, since the per-turn fan-out cap applies at
+        // every level.
+        if let Some(depth) = self.tools.max_delegation_depth
+            && !MAX_DELEGATION_DEPTH_BOUNDS.contains(&depth)
+        {
+            problems.push(format!(
+                "`[tools].max_delegation_depth` must be between {} and {} — you wrote `{depth}`. Use `1` to stop desks re-delegating at all.",
+                MAX_DELEGATION_DEPTH_BOUNDS.start(),
+                MAX_DELEGATION_DEPTH_BOUNDS.end(),
             ));
         }
 
@@ -585,6 +645,94 @@ mod tests {
                  validator rejects — unreachable from a company.toml: {problems:?}"
             );
         }
+    }
+
+    /// A `delegates_to` entry must name a real desk (issue #176).
+    ///
+    /// The failure this catches is silent at runtime rather than loud: a member
+    /// whose allowlist resolves to nothing still carries `delegate_to_desk`, and
+    /// every call it makes is refused as off-allowlist. The manifest is where
+    /// that is visible.
+    #[test]
+    fn rejects_a_delegates_to_entry_that_is_not_a_desk() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n\
+             [[agent]]\nid = \"lead\"\nrole = \"Lead\"\ndelegates_to = [\"writer\"]\n\
+             [[agent]]\nid = \"writer\"\nrole = \"Writer\"\n\
+             [[group_chat]]\nid = \"content\"\nname = \"Content desk\"\nmembers = [\"writer\"]\n",
+        );
+        let problems = manifest.validate();
+        assert_eq!(problems.len(), 1, "{problems:?}");
+        assert!(problems[0].contains("agent `lead`"), "{}", problems[0]);
+        assert!(problems[0].contains("`writer`"), "{}", problems[0]);
+        // The most common mistake is naming the teammate instead of the desk,
+        // so the message has to say which vocabulary the field takes.
+        assert!(problems[0].contains("teammate ids"), "{}", problems[0]);
+    }
+
+    /// Desk **ids**, desk **names**, and the `"*"` wildcard all resolve; an
+    /// empty entry is called out separately from an unknown one.
+    #[test]
+    fn accepts_desk_ids_names_and_the_wildcard_in_delegates_to() {
+        let ok = parse(
+            "[company]\nname = \"X\"\n\
+             [[agent]]\nid = \"lead\"\nrole = \"Lead\"\ndelegates_to = [\"content\", \"Legal desk\", \"*\"]\n\
+             [[group_chat]]\nid = \"content\"\nname = \"Content desk\"\n\
+             [[group_chat]]\nid = \"legal\"\nname = \"Legal desk\"\n",
+        );
+        assert!(ok.validate().is_empty(), "{:?}", ok.validate());
+
+        let blank = parse(
+            "[company]\nname = \"X\"\n\
+             [[agent]]\nid = \"lead\"\nrole = \"Lead\"\ndelegates_to = [\"  \"]\n\
+             [[group_chat]]\nid = \"content\"\nname = \"Content desk\"\n",
+        );
+        let problems = blank.validate();
+        assert_eq!(problems.len(), 1, "{problems:?}");
+        assert!(problems[0].contains("empty entry"), "{}", problems[0]);
+    }
+
+    /// The depth knob is bounded on both sides (issue #176): `0` would mean
+    /// "delegation off" wearing a depth's clothes, and past the ceiling the
+    /// per-level fan-out cap compounds into a runaway.
+    #[test]
+    fn rejects_a_delegation_depth_outside_its_bounds() {
+        for depth in ["0", "5"] {
+            let manifest = parse(&format!(
+                "[company]\nname = \"X\"\n[tools]\nmax_delegation_depth = {depth}\n"
+            ));
+            let problems = manifest.validate();
+            assert_eq!(problems.len(), 1, "depth {depth}: {problems:?}");
+            assert!(
+                problems[0].contains("`[tools].max_delegation_depth`"),
+                "{}",
+                problems[0]
+            );
+            assert!(problems[0].contains("between 1 and 4"), "{}", problems[0]);
+        }
+        for depth in ["1", "2", "3", "4"] {
+            let manifest = parse(&format!(
+                "[company]\nname = \"X\"\n[tools]\nmax_delegation_depth = {depth}\n"
+            ));
+            assert!(
+                manifest.validate().is_empty(),
+                "depth {depth} must be accepted: {:?}",
+                manifest.validate()
+            );
+        }
+        // Absent is always fine and means the default.
+        let bare = parse("[company]\nname = \"X\"\n");
+        assert_eq!(bare.tools.max_delegation_depth, None);
+        assert!(bare.validate().is_empty());
+    }
+
+    /// An existing manifest that names no `delegates_to` parses to the empty
+    /// allowlist, which is what keeps #176 a no-op for every company that did
+    /// not ask for it.
+    #[test]
+    fn delegates_to_defaults_to_empty() {
+        let manifest = parse("[company]\nname = \"X\"\n[[agent]]\nid = \"a\"\nrole = \"A\"\n");
+        assert!(manifest.agents[0].delegates_to.is_empty());
     }
 
     #[test]

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -80,15 +80,16 @@ pub use credentials::{Credential, CredentialSource, TinyhumansTokenSource, Token
 /// outside the crate the validator speaks through `CompanyManifest::validate`.
 #[cfg(test)]
 pub(crate) use manifest::is_snake_case;
-pub use manifest::{LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
+pub use manifest::{DELEGATES_TO_WILDCARD, LEGACY_MANIFEST_FILE, Located, MANIFEST_FILE, discover};
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
-    Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS,
-    GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
-    McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
-    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit,
-    grants_repo_explicit, grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
+    Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_DELEGATION_DEPTH, DEFAULT_MAX_IN_FLIGHT_RUNS,
+    DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS,
+    Inference, KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, McpServer, ORCHESTRATOR_TIER,
+    PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy, Schedule, Skill, TIERS,
+    TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit, grants_repo_explicit,
+    grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -307,6 +307,27 @@ pub struct Agent {
     /// Tool grant globs, intersected with `[tools].allow`.
     #[serde(default)]
     pub tools: Vec<String>,
+    /// Desks this agent may hand work on to (issue #176).
+    ///
+    /// Empty (the default) means **no delegation tools at all** — the behaviour
+    /// every manifest had before this field existed, and the reason adding it is
+    /// a no-op for an existing company. A non-empty list wires exactly
+    /// `spawn_task` + `delegate_to_desk` onto this agent (never the
+    /// orchestrator's roster/workflow/lifecycle authority) and narrows
+    /// `delegate_to_desk` to the desks named here. `"*"` is a wildcard for
+    /// "every desk the company has".
+    ///
+    /// Entries are **desk** ids or names, not teammate ids: desks are
+    /// OpenCompany's delegation address space, and `delegate_to_desk` already
+    /// resolves its target that way. Deliberately a field of its own rather than
+    /// more [`tools`](Self::tools) grant globs — that vocabulary feeds the
+    /// capability-namespace math, and a desk id is not a namespace.
+    ///
+    /// This is simultaneously the per-member enable switch and the capability
+    /// budget: what a member may reach is stated once, in the manifest, rather
+    /// than inferred from who happens to lead which desk.
+    #[serde(default)]
+    pub delegates_to: Vec<String>,
     /// Per-agent daily spend cap in USD.
     #[serde(default)]
     pub budget_usd_daily: Option<f64>,
@@ -607,6 +628,24 @@ pub struct Tools {
     /// whereas an agent handed an empty result invents citations.
     #[serde(default)]
     pub search_daily_calls: Option<u32>,
+    /// How many levels deep one operator message's delegation chain may run
+    /// (issue #176), counted in **hand-offs**: the orchestrator handing work to
+    /// a desk lead is level 1, that lead handing a slice to a second desk is
+    /// level 2.
+    ///
+    /// Absent (the default) uses [`DEFAULT_MAX_DELEGATION_DEPTH`]. `1` is the
+    /// "recursion off" setting — it reproduces the pre-#176 depth cap exactly,
+    /// where a dispatched desk agent could not re-delegate at all — and is the
+    /// config gate a company reaches for when a chain is costing more than it
+    /// returns. Valid values are `1..=4`; the ceiling is deliberately low
+    /// because each level multiplies the turns one message can buy.
+    ///
+    /// Enforced **dynamically**, at the tool boundary, rather than by which
+    /// tools were wired: belts are cached per roster and rebuilt rarely, so a
+    /// member's tools are static while its depth is a property of the chain it
+    /// is running inside.
+    #[serde(default)]
+    pub max_delegation_depth: Option<u8>,
 }
 
 /// Daily `web_search` call ceiling applied when `[tools].search_daily_calls` is
@@ -617,6 +656,29 @@ pub struct Tools {
 /// roughly $2/day/company while leaving a genuine multi-topic research session
 /// (a handful of searches per question) comfortably inside it.
 pub const DEFAULT_SEARCH_DAILY_CALLS: u32 = 200;
+
+/// Delegation chain depth applied when `[tools].max_delegation_depth` is absent
+/// (issue #176).
+///
+/// Two levels: the orchestrator hands work to a desk lead, and that lead may
+/// hand one slice on to a second desk. That is the shape the issue asks for —
+/// a lead that can bring in a specialist without going back through the CEO —
+/// and it stops there because a third level buys little and costs a full extra
+/// turn per branch on top of an already-multiplied fan-out.
+///
+/// The default is only reachable by a member the manifest opted in with
+/// [`Agent::delegates_to`](crate::company::Agent::delegates_to); a company that
+/// names nobody behaves exactly as it did before this existed, whatever this
+/// number says.
+pub const DEFAULT_MAX_DELEGATION_DEPTH: u8 = 2;
+
+/// The inclusive bounds `[tools].max_delegation_depth` is validated against.
+///
+/// `1` disables recursion (the pre-#176 behaviour). `4` is the ceiling: a chain
+/// deeper than that is indistinguishable from a runaway, and the per-turn
+/// fan-out cap applies *per level*, so depth 5 admits `3^5` hand-offs from one
+/// message.
+pub const MAX_DELEGATION_DEPTH_BOUNDS: std::ops::RangeInclusive<u8> = 1..=4;
 
 /// `[tools.composio]` — the per-tenant Composio toolkit allowlist (issue #110).
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -646,6 +708,7 @@ impl Default for Tools {
             web_allowed_domains: Vec::new(),
             composio: ComposioTools::default(),
             search_daily_calls: None,
+            max_delegation_depth: None,
         }
     }
 }

--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -537,18 +537,51 @@ mod tests {
         assert_eq!(names(&ws, &company).await, vec!["Notes"]);
     }
 
+    /// Reconstruct a tree the `fs` backend now refuses to build, seeded
+    /// straight into the workspace index instead of through `create`.
+    ///
+    /// Two folders named `Agents` under the same parent is the shape the sweep
+    /// must refuse to pick under — but on `fs` it can only *arrive*, never be
+    /// made: [`reject_path_collision`](crate::store::fs_ops) has refused a
+    /// colliding physical path since #711, so the second `create` errors before
+    /// the store ever holds the ambiguity. The tree still occurs for real on
+    /// the tenants the sweep exists for — an index written before the check, or
+    /// a sqlite/mongodb tenant whose key is the node id rather than the path —
+    /// so this seeds the index the same way
+    /// [`workspace_scaffold`](crate::company::workspace_scaffold) does for its
+    /// duplicate-root tests, and the sweep's refusal is exercised over that
+    /// shape rather than over one the backend has already rejected.
+    async fn seed_ambiguous_agents_root(dir: &std::path::Path, company: &CompanyId) {
+        let index: std::collections::HashMap<String, WorkspaceNode> = [
+            folder("dup-a", AGENTS_ROOT, None),
+            folder("dup-b", AGENTS_ROOT, None),
+        ]
+        .into_iter()
+        .map(|node| (node.id.clone(), node))
+        .collect();
+        let bundle = crate::store::Bundle::new(dir.to_path_buf(), company);
+        tokio::fs::create_dir_all(bundle.workspace_dir())
+            .await
+            .expect("workspace dir");
+        tokio::fs::write(
+            bundle.workspace_index_json(),
+            serde_json::to_vec(&index).expect("index json"),
+        )
+        .await
+        .expect("seed index");
+    }
+
     /// Fail closed, exactly as the scaffold does: two roots named `Agents` make
     /// "under `Agents/`" undecidable, so the sweep refuses instead of picking
     /// one and deleting beneath it.
     #[tokio::test]
     async fn an_ambiguous_root_is_refused_and_removes_nothing() {
-        let (_dir, ws) = store().await;
+        let (dir, ws) = store().await;
         let company = CompanyId::new("odd");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
-                .await
-                .unwrap();
-        }
+        seed_ambiguous_agents_root(dir.path(), &company).await;
+        // The third node goes through the store: its own path is unique, so the
+        // backend accepts it, and it is what makes "which `Agents/` is this
+        // under?" a question with real content beneath it.
         ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
             .await
             .unwrap();

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -1597,6 +1597,10 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
+            // Issue #176: this repo-tools fixture predates `delegates_to` and is
+            // only compiled under the gated feature combo, so neither this
+            // branch's CI nor #245's could see the other's half.
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -1125,6 +1125,7 @@ mod tests {
             description: description.map(str::to_string),
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         }
     }
@@ -1286,6 +1287,7 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
@@ -1324,6 +1326,7 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
@@ -1358,6 +1361,7 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
@@ -1390,6 +1394,7 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -43,15 +43,34 @@
 //!   only `Agents/<agent id>/`. Unlike the file tools these are scoped by the
 //!   store, not the filesystem: every call resolves through one company-scoped
 //!   `tree()` read, so no host path is ever built from agent input.
-//! * **Delegation is orchestrator-only.** `query_company` / `spawn_task` /
-//!   `delegate_to_desk` (and the other orchestrator roster/workflow tools) are
-//!   wired only when `is_orchestrator`; a **dispatched** desk/roster agent never
-//!   gets them. That is the depth cap = 1 / "no re-delegation in v1" invariant
-//!   (issue #178). The dispatched belt is thus a curated, metered derivative of
-//!   an OpenHuman agent — the exec subset above plus intrinsic memory / file /
-//!   MCP / skill tools, and nothing more. Both halves (the exact dispatched set,
-//!   and the orchestrator-vs-dispatched delegation contrast) are pinned by the
-//!   contract tests in this module's `tests` submodule.
+//! * **Delegation authority is orchestrator-only; delegation itself is
+//!   opt-in per member.** `query_company`, `run_workflow`, `create_workflow`,
+//!   `add_agent`, `assign_task` and `review_task` are wired only when
+//!   `is_orchestrator` — they are the company's *authority* (who owns a card,
+//!   what passes review, who is on the roster) and no desk agent gets them.
+//!
+//!   The two **hand-off** tools, `spawn_task` and `delegate_to_desk`, are also
+//!   wired onto a desk agent whose manifest entry names a
+//!   [`delegates_to`](crate::company::Agent::delegates_to) allowlist (issue
+//!   #176), narrowed to those desks. A member that names none — every agent of
+//!   every manifest written before this — carries no delegation tool at all,
+//!   which is #178's original depth cap = 1 invariant, now the default rather
+//!   than the only possibility.
+//!
+//!   Recursion is bounded **dynamically**, not by which tools were wired: belts
+//!   are cached per roster and rebuilt rarely, so the tool cannot be withheld
+//!   from the one turn that happens to be running too deep. `[tools]
+//!   .max_delegation_depth` is enforced at the tool boundary by
+//!   [`DelegationQueue::push_within_cap`](crate::harness::orchestrator::DelegationQueue::push_within_cap)
+//!   against the live scope chain, and a hand-off that would loop or leave the
+//!   member's allowlist is refused there too.
+//!
+//!   The dispatched belt is otherwise a curated, metered derivative of an
+//!   OpenHuman agent — the exec subset above plus intrinsic memory / file / MCP
+//!   / skill tools, and nothing more. All three halves (the exact dispatched
+//!   set with and without an allowlist, and the orchestrator-vs-member
+//!   authority contrast) are pinned by the contract tests in this module's
+//!   `tests` submodule.
 //! * **Workflows/skills** start empty. Parsing enabled `SKILL.md` bodies via
 //!   `openhuman::skills::ops_parse` depends on WS1's skill parsing; the seam is
 //!   the `.workflows(...)` setter.
@@ -660,6 +679,34 @@ pub fn build_agent(
             // the `read_run_output` companion reads back, so a clipped preview
             // is reachable within the turn. Orchestrator-only, like the tools.
             deps.run_outputs.clone(),
+        ));
+    }
+    // Recursive desk delegation (issue #176): a NON-orchestrator agent whose
+    // manifest entry names a `delegates_to` allowlist gets exactly the two
+    // hand-off tools — `spawn_task` and a `delegate_to_desk` narrowed to that
+    // allowlist — and nothing else from the orchestrator's set. It is what lets
+    // a desk lead pull in a specialist for one slice instead of handing the
+    // whole thing back to the CEO.
+    //
+    // `else if` rather than a second `if`: the orchestrator already has both
+    // tools from `orchestrator_tools` above, and wiring a second, narrowed
+    // `delegate_to_desk` beside its unrestricted one would put two tools with
+    // the same name on one belt.
+    //
+    // An empty allowlist wires nothing, which is the pre-#176 belt exactly — so
+    // this whole block is inert for every manifest that has not opted in.
+    else if !manifest_agent.delegates_to.is_empty() {
+        persona.push_str(&orchestrator::member_delegation_brief(
+            &manifest_agent.delegates_to,
+        ));
+        tools.extend(orchestrator::member_delegation_tools(
+            &deps.delegations,
+            company.clone(),
+            deps.store.clone(),
+            orchestrator::MemberScope {
+                member: manifest_agent.id.clone(),
+                delegates_to: manifest_agent.delegates_to.clone(),
+            },
         ));
     }
 
@@ -1279,6 +1326,17 @@ mod tests {
     /// Build one agent under `grants` and return its live tool names, sorted, so
     /// a snapshot compares byte-stably against a literal.
     fn built_tool_names(grants: &[&str], is_orchestrator: bool) -> Vec<String> {
+        built_tool_names_delegating(grants, is_orchestrator, &[])
+    }
+
+    /// [`built_tool_names`] with a `delegates_to` allowlist on the agent (issue
+    /// #176) — the only difference between a member that may re-delegate and one
+    /// that may not.
+    fn built_tool_names_delegating(
+        grants: &[&str],
+        is_orchestrator: bool,
+        delegates_to: &[&str],
+    ) -> Vec<String> {
         let dir = tempfile::tempdir().expect("tempdir");
         let deps = pin_deps(dir.path().to_path_buf());
         let manifest_agent = ManifestAgent {
@@ -1287,7 +1345,7 @@ mod tests {
             description: None,
             tier: None,
             tools: Vec::new(),
-            delegates_to: Vec::new(),
+            delegates_to: delegates_to.iter().map(|d| d.to_string()).collect(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
@@ -1847,10 +1905,16 @@ mod tests {
         assert_eq!(names, expected, "dispatched desk belt drifted: {names:?}");
     }
 
-    /// (b) The depth-cap = 1 invariant (issue #178): a dispatched desk agent
-    /// must NEVER receive the orchestrator's delegation tools, while the
-    /// orchestrator agent MUST. Building both from the same grant and contrasting
-    /// them is the registration check that a dispatched turn cannot re-delegate.
+    /// (b) The **default** depth cap (issues #178, #176): a dispatched desk
+    /// agent that named no `delegates_to` must NEVER receive a delegation tool,
+    /// while the orchestrator agent MUST. Building both from the same grant and
+    /// contrasting them is the registration check that an ordinary dispatched
+    /// turn cannot re-delegate.
+    ///
+    /// #176 made this the default rather than the only possibility — the
+    /// opt-in case is pinned by
+    /// [`a_member_with_delegates_to_gets_exactly_the_two_hand_off_tools`], and
+    /// the belt above is unchanged for every agent that does not opt in.
     #[test]
     fn dispatched_agent_has_no_delegation_tools_but_orchestrator_does() {
         let delegation = ["query_company", "spawn_task", "delegate_to_desk"];
@@ -1870,6 +1934,81 @@ mod tests {
                 "orchestrator agent MUST receive delegation tool `{tool}`: {orchestrator:?}"
             );
         }
+    }
+
+    /// (b2) Issue #176: a member the manifest opted in with `delegates_to` gets
+    /// **exactly two** tools more than it had — `spawn_task` and
+    /// `delegate_to_desk` — and not one tool of the orchestrator's authority.
+    ///
+    /// Expressed as a delta against the un-opted-in belt rather than as a second
+    /// flat literal, so the feature-aware snapshot above stays the single place
+    /// the dispatched belt is written down. What this pins is the thing #176
+    /// could get wrong: reaching for `orchestrator_tools` and handing a desk
+    /// lead `add_agent`, `assign_task` and `review_task` along with the hand-off
+    /// it actually needs.
+    #[test]
+    fn a_member_with_delegates_to_gets_exactly_the_two_hand_off_tools() {
+        let plain = built_tool_names(&["*"], false);
+        let delegating = built_tool_names_delegating(&["*"], false, &["research"]);
+
+        let added: Vec<&String> = delegating.iter().filter(|t| !plain.contains(t)).collect();
+        assert_eq!(
+            added,
+            vec!["delegate_to_desk", "spawn_task"],
+            "a delegating member's belt must differ from the plain one by exactly the two \
+             hand-off tools: {delegating:?}"
+        );
+        assert!(
+            plain.iter().all(|t| delegating.contains(t)),
+            "opting in must ADD tools, never remove any: {delegating:?}"
+        );
+        for authority in [
+            "query_company",
+            "assign_task",
+            "review_task",
+            "add_agent",
+            "run_workflow",
+            "create_workflow",
+            "read_run_output",
+        ] {
+            assert!(
+                !delegating.contains(&authority.to_string()),
+                "a desk member must NOT receive orchestrator authority `{authority}`: \
+                 {delegating:?}"
+            );
+        }
+    }
+
+    /// (b3) Issue #176: the wiring is inert for an agent that named no
+    /// allowlist, and the orchestrator's own belt is untouched by the feature.
+    ///
+    /// The empty-allowlist half is what makes #176 a no-op for every manifest
+    /// written before it; the orchestrator half is what proves the `else if`
+    /// really is exclusive, since a second narrowed `delegate_to_desk` beside
+    /// the orchestrator's unrestricted one would put two tools of the same name
+    /// on one belt.
+    #[test]
+    fn an_empty_allowlist_wires_nothing_and_the_orchestrator_belt_is_unchanged() {
+        assert_eq!(
+            built_tool_names_delegating(&["*"], false, &[]),
+            built_tool_names(&["*"], false),
+            "an empty `delegates_to` must produce the pre-#176 belt byte-for-byte"
+        );
+
+        let orchestrator = built_tool_names(&["*"], true);
+        assert_eq!(
+            built_tool_names_delegating(&["*"], true, &["research"]),
+            orchestrator,
+            "an orchestrator's belt must not change when it also names `delegates_to`"
+        );
+        assert_eq!(
+            orchestrator
+                .iter()
+                .filter(|t| *t == "delegate_to_desk")
+                .count(),
+            1,
+            "exactly one `delegate_to_desk` may be wired: {orchestrator:?}"
+        );
     }
 
     /// (c) No deferred family leaks into a dispatched belt: raw browser

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -607,6 +607,7 @@ mod tests {
             description: None,
             tier: None,
             tools: grants.iter().map(|g| g.to_string()).collect(),
+            delegates_to: vec![],
             budget_usd_daily: None,
         }
     }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2303,6 +2303,10 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         // A non-empty list is intersected with `[tools].allow` by that same
         // function below (narrow-only, never a widen).
         tools: overlay.tools.clone(),
+        // Issue #176: an overlay teammate declares no delegation allowlist in
+        // this slice, so it carries today's behaviour — no hand-off tools wired.
+        // Opting overlays in needs a console write surface; see the follow-up.
+        delegates_to: Vec::new(),
         budget_usd_daily: None,
     }
 }
@@ -5273,6 +5277,7 @@ budget_usd_daily = 0.0
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
@@ -5382,6 +5387,7 @@ budget_usd_daily = 0.0
             description: None,
             tier: None,
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         };
         let agent = build::build_agent(

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1550,10 +1550,8 @@ impl DelegateToDeskTool {
     /// Grounds `desk` against the live company record: the refusal for it, if
     /// any, plus the depth bound this company runs under.
     ///
-    /// **Fails open**: if the record cannot be read the delegation is queued
-    /// exactly as it was before this grounding existed, under the default depth.
-    /// A store hiccup must not take delegation offline; the drain-time
-    /// fall-through still records what happened.
+    /// **Fails open for the orchestrator, closed for a member** — see
+    /// [`ungrounded`](Self::ungrounded) for why the two halves differ.
     ///
     /// Order matters. Grounding (#272) runs first — "there is no such desk"
     /// outranks "you may not reach that desk", because a model told the latter
@@ -1563,15 +1561,15 @@ impl DelegateToDeskTool {
     async fn ground(&self, desk: &str) -> Grounding {
         let record = match self.store.load(&self.company).await {
             Ok(Some(record)) => record,
-            Ok(None) => return Grounding::open(),
+            Ok(None) => return self.ungrounded(desk, "this company's record is not there"),
             Err(err) => {
                 tracing::warn!(
                     company = %self.company,
                     error = %err,
-                    "[delegate_to_desk] could not read the company record to ground the desk target; \
-                     queuing the hand-off ungrounded"
+                    member = self.member.as_ref().map(|s| s.member.as_str()).unwrap_or("-"),
+                    "[delegate_to_desk] could not read the company record to ground the desk target"
                 );
-                return Grounding::open();
+                return self.ungrounded(desk, "this company's record could not be read");
             }
         };
         let max_depth = usize::from(
@@ -1594,6 +1592,34 @@ impl DelegateToDeskTool {
                 })
         });
         Grounding { refusal, max_depth }
+    }
+
+    /// What a hand-off grounds to when the record behind the grounding could
+    /// not be read at all — the two callers above.
+    ///
+    /// The **orchestrator** fails open, exactly as it has since #272: it has
+    /// nothing to authorise (its target set is every desk), so an unreadable
+    /// record costs it only the "there is no such desk" courtesy, and a store
+    /// hiccup must not take delegation offline.
+    ///
+    /// A **member** fails closed. Its allowlist and its cycle guard are checked
+    /// here and nowhere else — `run_delegation` executes what the queue holds
+    /// without re-deriving either — so queuing ungrounded would hand the member
+    /// the orchestrator's reach for the duration of the hiccup, one level below
+    /// where anyone is looking. Refusing costs a retry; queuing costs the bound.
+    fn ungrounded(&self, desk: &str, why: &str) -> Grounding {
+        let Some(scope) = self.member.as_ref() else {
+            return Grounding::open();
+        };
+        Grounding {
+            refusal: Some(format!(
+                "Could not hand `{desk}` off: {why}, so the desks {member} is allowed to reach \
+                 could not be checked. Nothing was queued — try again, or carry the work out \
+                 yourself.",
+                member = scope.member
+            )),
+            max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
+        }
     }
 }
 
@@ -4836,6 +4862,112 @@ members = ["ceo"]
             );
             queue.clear();
         }
+    }
+
+    /// A store that cannot answer, so the grounding read has nothing to check
+    /// the target against.
+    struct BrokenStore;
+
+    #[async_trait::async_trait]
+    impl CompanyStore for BrokenStore {
+        async fn load(&self, _id: &CompanyId) -> crate::Result<Option<CompanyRecord>> {
+            Err(crate::OpenCompanyError::Store("store is down".to_string()))
+        }
+        async fn save(&self, _record: &CompanyRecord) -> crate::Result<()> {
+            Ok(())
+        }
+        async fn list(&self) -> crate::Result<Vec<CompanySummary>> {
+            Ok(Vec::new())
+        }
+        async fn append_ledger(&self, _id: &CompanyId, _entry: LedgerEntry) -> crate::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// A member's hand-off fails **closed** when the record cannot be read, and
+    /// the orchestrator's still fails open.
+    ///
+    /// The asymmetry is the whole point. The allowlist and the cycle guard are
+    /// enforced at this tool boundary and nowhere else — `run_delegation`
+    /// executes whatever the queue holds without re-deriving either — so a
+    /// member queued ungrounded reaches every desk in the company for as long
+    /// as the store is unhappy. The orchestrator has no allowlist to lose, so
+    /// an unreadable record leaves it exactly where #272 left it.
+    #[tokio::test]
+    async fn a_members_hand_off_is_refused_when_the_record_cannot_be_read() {
+        let company = CompanyId::new("acme");
+        let scope = || MemberScope {
+            member: "writer".to_string(),
+            delegates_to: vec!["research".to_string()],
+        };
+
+        // Ok(None) — no record under that id.
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let missing = DelegateToDeskTool::for_member(
+            queue.clone(),
+            company.clone(),
+            Arc::new(MemStore::default()) as Arc<dyn CompanyStore>,
+            scope(),
+        );
+        let refused = missing
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(
+            refused.is_error,
+            "a member may not be queued against a record nobody could read: {}",
+            refused.output_for_llm(true)
+        );
+        let text = refused.output_for_llm(true);
+        assert!(text.contains("research"), "{text}");
+        assert!(
+            text.contains("writer"),
+            "the refusal must name whose allowlist went unchecked: {text}"
+        );
+        assert_eq!(queue.queued(), 0, "nothing may be staged ungrounded");
+        assert_eq!(
+            queue.drain_refusals(MAX_DELEGATIONS_PER_TURN),
+            vec!["research".to_string()],
+            "the drain must be able to record the attempt on the card"
+        );
+
+        // Err(..) — the store is there and unhappy. Same answer.
+        let broken = DelegateToDeskTool::for_member(
+            queue.clone(),
+            company.clone(),
+            Arc::new(BrokenStore) as Arc<dyn CompanyStore>,
+            scope(),
+        );
+        let refused = broken
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(
+            refused.is_error,
+            "a store error must refuse too: {}",
+            refused.output_for_llm(true)
+        );
+        assert_eq!(queue.queued(), 0);
+        queue.clear();
+        let _ = queue.drain_refusals(MAX_DELEGATIONS_PER_TURN);
+
+        // …and the orchestrator's copy over the same broken store still queues.
+        let orchestrator = DelegateToDeskTool::new(
+            queue.clone(),
+            company,
+            Arc::new(BrokenStore) as Arc<dyn CompanyStore>,
+        );
+        let queued = orchestrator
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(
+            !queued.is_error,
+            "a store hiccup must not take the orchestrator's delegation offline: {}",
+            queued.output_for_llm(true)
+        );
+        assert_eq!(queue.queued(), 1);
     }
 
     /// The depth bound comes off the **live company record**, not a build-time

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -96,6 +96,16 @@ pub use crate::company::ORCHESTRATOR_TIER;
 /// told five were opened, find two.
 pub const MAX_DELEGATIONS_PER_TURN: usize = 3;
 
+/// The depth argument passed by the delegations the chain bound does not apply
+/// to (issue #176).
+///
+/// [`DelegationQueue::push_within_cap`] gates on depth only for a
+/// [`Delegation::DelegateToDesk`] — the one delegation that runs another
+/// synchronous turn and can therefore multiply. A board write passes a bound it
+/// can never reach, rather than a plausible-looking real number that would
+/// quietly start mattering if the gate were widened.
+const NO_DEPTH_BOUND: usize = usize::MAX;
+
 /// How many recent events [`QueryCompanyTool`] surfaces.
 const RECENT_EVENTS: usize = 10;
 /// How many facts [`QueryCompanyTool`] surfaces.
@@ -365,6 +375,27 @@ pub struct DelegationQueue {
     /// wiped by the same [`clear`](Self::clear) that keeps a prior turn from
     /// leaking into this one.
     refused: Arc<Mutex<Vec<String>>>,
+    /// The **scope chain**: the resolved desk ids of the hand-offs currently
+    /// being executed, outermost first (issue #176).
+    ///
+    /// Depth **is** `scope.len()` — there is no counter beside it to fall out of
+    /// step. Empty while the orchestrator's own turn runs (depth 0); one entry
+    /// while a desk lead the orchestrator handed work to runs (depth 1); two
+    /// while that lead's own delegate runs (depth 2).
+    ///
+    /// It lives on the queue for the same reason [`refused`](Self::refused)
+    /// does, and for one more. Belts are cached per roster
+    /// ([`HarnessPool::ensure`](crate::harness::HarnessPool::ensure)) and rebuilt
+    /// rarely, so a member's tools are wired **statically** — the queue handle
+    /// they were constructed with is the only shared state they can reach at
+    /// call time. Putting depth anywhere else (the message context, the task
+    /// record, the runner) would put it somewhere the member's own tool cannot
+    /// see it.
+    ///
+    /// Deliberately **not** touched by [`clear`](Self::clear): clearing runs
+    /// between delegations *inside* a scope, and dropping the chain there would
+    /// reset the depth of a chain that is still running.
+    scope: Arc<Mutex<Vec<String>>>,
 }
 
 impl DelegationQueue {
@@ -432,10 +463,54 @@ impl DelegationQueue {
     /// The shared body of the two claim constructors.
     fn claim_as(&self, state: DrainClaim) -> DelegationClaim {
         self.clear();
+        // Issue #176: a claim opens a fresh chain. The chain outlives an
+        // ordinary `clear`, so it is reset on the two boundaries that really do
+        // end a chain — the claim's acquire and its `Drop` — and nowhere else.
+        // Both halves matter: a panic inside a nested turn unwinds past the
+        // `ScopeGuard`s, and without the exit reset a leftover chain would make
+        // the *next* operator message start at depth 2 and refuse its first
+        // hand-off. Same every-exit-path discipline the claim already applies to
+        // the queue itself.
+        self.reset_scope();
         *self.committed.lock().expect("delegation commitment") = state;
         DelegationClaim {
             queue: self.clone(),
         }
+    }
+
+    /// How deep the delegation chain currently running is: `0` inside the
+    /// orchestrator's own turn, `1` inside a desk lead it handed work to, and so
+    /// on (issue #176).
+    pub fn scope_depth(&self) -> usize {
+        self.scope.lock().expect("delegation scope").len()
+    }
+
+    /// The resolved desk ids currently on the chain, outermost first (issue
+    /// #176) — the set a hand-off target is checked against for a cycle.
+    pub fn scope_chain(&self) -> Vec<String> {
+        self.scope.lock().expect("delegation scope").clone()
+    }
+
+    /// Enters the scope of a hand-off to `desk_id`, for as long as the returned
+    /// [`ScopeGuard`] lives (issue #176).
+    ///
+    /// Pushes on the way in and pops on `Drop`, so every exit path from the
+    /// delegate's turn — an early return, a `?`, a panic — leaves the chain
+    /// exactly as deep as it found it. `desk_id` must be the **resolved** id
+    /// rather than whatever key the model typed, so the cycle check compares
+    /// identities rather than spellings.
+    #[must_use = "the scope pops on drop; dropping it immediately leaves the chain unchanged"]
+    pub fn enter_scope(&self, desk_id: String) -> ScopeGuard {
+        self.scope.lock().expect("delegation scope").push(desk_id);
+        ScopeGuard {
+            queue: self.clone(),
+        }
+    }
+
+    /// Empties the scope chain. Called only where a chain genuinely ends — the
+    /// claim's acquire and release.
+    fn reset_scope(&self) {
+        self.scope.lock().expect("delegation scope").clear();
     }
 
     /// Enqueues a delegation unless nothing will drain it, or `cap` are already
@@ -466,8 +541,22 @@ impl DelegationQueue {
     /// the cap instead would tell the model to try again next turn, and the next
     /// turn on that path drains no better than this one. The two refusals are
     /// therefore distinct [`Staged`] variants and never collapsed.
+    ///
+    /// # Why the depth gate is here too (issue #176)
+    ///
+    /// A desk member that may re-delegate is wired with `delegate_to_desk`
+    /// **statically** — belts are cached per roster, so the tool cannot be
+    /// withheld from the one turn that happens to be running too deep. The bound
+    /// therefore has to be dynamic, and this is the one place every hand-off
+    /// passes through. It applies only to
+    /// [`DelegateToDesk`](Delegation::DelegateToDesk): that is the delegation
+    /// that runs another synchronous turn, and so the only one that can
+    /// multiply. A [`SpawnTask`](Delegation::SpawnTask) opens a To-do card and
+    /// stops — refusing it at depth would push a member that has hit the bound
+    /// into working silently instead of leaving the work tracked, which is the
+    /// opposite of what the bound is for.
     #[must_use = "a refused delegation must be reported to the model, not dropped"]
-    pub fn push_within_cap(&self, delegation: Delegation, cap: usize) -> Staged {
+    pub fn push_within_cap(&self, delegation: Delegation, cap: usize, max_depth: usize) -> Staged {
         match self.claim_state() {
             DrainClaim::Unclaimed => return Staged::NoDrain(NoDrainReason::Unwired),
             // Issue #267: the operator asked a question. A hand-off is how one
@@ -476,6 +565,14 @@ impl DelegationQueue {
                 return Staged::NoDrain(NoDrainReason::Triage);
             }
             DrainClaim::Answering | DrainClaim::Full => {}
+        }
+        // Issue #176: checked after the claim (a context that drains nothing is
+        // still the only fact worth reporting) and before the queue lock, so the
+        // two locks are never held at once.
+        if matches!(delegation, Delegation::DelegateToDesk { .. })
+            && self.scope_depth() >= max_depth
+        {
+            return Staged::NoDrain(NoDrainReason::Depth);
         }
         let mut guard = self.inner.lock().expect("delegation queue");
         if guard.len() >= cap {
@@ -489,6 +586,33 @@ impl DelegationQueue {
     /// to, so the drain can report the attempt (issue #272).
     pub fn push_refusal(&self, desk: String) {
         self.refused.lock().expect("delegation queue").push(desk);
+    }
+
+    /// How many refused desk keys are recorded right now (issue #176).
+    ///
+    /// Sampled either side of a delegate's turn so a **nested** refusal can be
+    /// attributed to the member that made it, rather than swept up with the
+    /// refusals its delegator left behind. Exactly the shape
+    /// [`ApprovalRequestQueue::queued`](crate::harness::policy::ApprovalRequestQueue::queued)
+    /// is used in for parked approvals, and for the same reason: a difference
+    /// across a turn is the only honest way to say *this* turn did it.
+    pub fn refusals_queued(&self) -> usize {
+        self.refused.lock().expect("delegation queue").len()
+    }
+
+    /// Drains up to `cap` refused desk keys recorded **after** the first
+    /// `from` (issue #176), leaving the earlier ones for whoever owns them.
+    ///
+    /// [`drain_refusals`](Self::drain_refusals) also clears the tail; this one
+    /// deliberately does not, because the entries before `from` belong to an
+    /// outer turn that has not read them yet.
+    pub fn drain_refusals_after(&self, from: usize, cap: usize) -> Vec<String> {
+        let mut guard = self.refused.lock().expect("delegation queue");
+        if guard.len() <= from {
+            return Vec::new();
+        }
+        let take = (guard.len() - from).min(cap);
+        guard.drain(from..from + take).collect()
     }
 
     /// Drains up to `cap` refused desk keys (FIFO) and discards the rest, so a
@@ -592,6 +716,17 @@ pub enum NoDrainReason {
     /// operator's message triaged as a question, so board writes are held back
     /// for **this message only** (issue #267).
     Triage,
+    /// The delegation chain is already as deep as
+    /// `[tools].max_delegation_depth` allows (issue #176), so a further
+    /// **hand-off** is refused. Board writes are unaffected — a member at the
+    /// bound may still open a card.
+    ///
+    /// Unlike the two above this is not a property of the context at all: the
+    /// same member, on the same company, delegating from a shallower chain would
+    /// have been staged. So the refusal must not tell the model its context
+    /// cannot do board work (it can) nor that the message was a question (it was
+    /// not) — it must say the chain has run as deep as the company allows.
+    Depth,
 }
 
 impl NoDrainReason {
@@ -606,6 +741,7 @@ impl NoDrainReason {
         match self {
             Self::Unwired => "drain_unwired",
             Self::Triage => "triaged_as_question",
+            Self::Depth => "depth_capped",
         }
     }
 }
@@ -659,6 +795,31 @@ impl Drop for DelegationClaim {
     fn drop(&mut self) {
         *self.queue.committed.lock().expect("delegation commitment") = DrainClaim::Unclaimed;
         self.queue.clear();
+        // Issue #176: the chain ends with the claim. `ScopeGuard` pops its own
+        // entry on every ordinary exit, so this is the belt to that braces — a
+        // panic mid-nested-turn unwinds past the guards, and a chain left
+        // standing would make the next message start at depth 2.
+        self.queue.reset_scope();
+    }
+}
+
+/// One level of the delegation scope chain, held for the span in which a
+/// delegate's turn runs (issue #176).
+///
+/// Pushes its desk id when created and pops on `Drop`. Same reasoning as
+/// [`DelegationClaim`]: the pop has to happen on **every** exit path, including
+/// the ones nobody wrote by hand, or a chain that dies mid-turn leaves the queue
+/// permanently one level deeper than it is.
+///
+/// Deliberately not [`Clone`] — two guards for one level would pop twice and
+/// take a live outer level off the chain with them.
+pub struct ScopeGuard {
+    queue: DelegationQueue,
+}
+
+impl Drop for ScopeGuard {
+    fn drop(&mut self) {
+        self.queue.scope.lock().expect("delegation scope").pop();
     }
 }
 
@@ -1282,6 +1443,7 @@ impl Tool for SpawnTaskTool {
                 assignee,
             },
             MAX_DELEGATIONS_PER_TURN,
+            NO_DEPTH_BOUND,
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
@@ -1307,6 +1469,13 @@ impl Tool for SpawnTaskTool {
 /// [intrinsic tool](crate::harness::steps), so the refusal reaches both the
 /// model (as a failed tool result it can retry from in the same turn) and the
 /// operator's run trail verbatim.
+///
+/// Since issue #176 the same tool is also wired onto a **desk member** the
+/// manifest opted in with `delegates_to`. That copy carries a [`MemberScope`],
+/// which adds two more target checks on top of the grounding above — the
+/// member's allowlist and the cycle guard — and names who is delegating so a
+/// hand-off back to the caller's own desk can be caught. The orchestrator's copy
+/// carries `None` and is unrestricted, exactly as before.
 pub struct DelegateToDeskTool {
     queue: DelegationQueue,
     company: CompanyId,
@@ -1316,30 +1485,85 @@ pub struct DelegateToDeskTool {
     /// stale snapshot would refuse a desk that exists — a worse failure than the
     /// one this grounding fixes.
     store: Arc<dyn CompanyStore>,
+    /// Set when this copy of the tool belongs to a desk member rather than the
+    /// orchestrator (issue #176). `None` is the orchestrator: unrestricted
+    /// target set, no cycle guard, and depth 0 by construction.
+    member: Option<MemberScope>,
+}
+
+/// Who is delegating, when it is a desk member rather than the orchestrator
+/// (issue #176).
+///
+/// Both fields exist for the same reason and travel together: a member's
+/// hand-off has to be checked against something the orchestrator's does not
+/// have — the desks its manifest entry permits, and its own identity, so it
+/// cannot hand work back to the desk it leads.
+#[derive(Clone, Debug)]
+pub struct MemberScope {
+    /// The roster id of the member this tool is wired onto.
+    pub member: String,
+    /// The desks it may hand work to — its manifest
+    /// [`delegates_to`](crate::company::Agent::delegates_to), with `"*"` meaning
+    /// every desk.
+    pub delegates_to: Vec<String>,
+}
+
+/// What one read of the company record decided about a hand-off target: the
+/// refusal to return, if any, and the depth bound in force.
+struct Grounding {
+    /// The refusal to hand back to the model, or `None` when the target is good.
+    refusal: Option<String>,
+    /// `[tools].max_delegation_depth`, or its default. Read from the same record
+    /// load as the refusal so a single store round-trip decides both.
+    max_depth: usize,
 }
 
 impl DelegateToDeskTool {
-    /// Builds the tool over the shared delegation queue and the company store it
-    /// grounds the target against.
+    /// Builds the orchestrator's unrestricted copy of the tool over the shared
+    /// delegation queue and the company store it grounds the target against.
     pub fn new(queue: DelegationQueue, company: CompanyId, store: Arc<dyn CompanyStore>) -> Self {
         Self {
             queue,
             company,
             store,
+            member: None,
         }
     }
 
-    /// The refusal for `desk`, or `None` when it names a desk that can take
-    /// work.
+    /// Builds a **desk member's** copy (issue #176): the same tool, narrowed to
+    /// the desks `scope` permits and guarded against handing work back up its
+    /// own chain.
+    pub fn for_member(
+        queue: DelegationQueue,
+        company: CompanyId,
+        store: Arc<dyn CompanyStore>,
+        scope: MemberScope,
+    ) -> Self {
+        Self {
+            queue,
+            company,
+            store,
+            member: Some(scope),
+        }
+    }
+
+    /// Grounds `desk` against the live company record: the refusal for it, if
+    /// any, plus the depth bound this company runs under.
     ///
     /// **Fails open**: if the record cannot be read the delegation is queued
-    /// exactly as it was before this grounding existed. A store hiccup must not
-    /// take delegation offline; the drain-time fall-through still records what
-    /// happened.
-    async fn refusal(&self, desk: &str) -> Option<String> {
-        match self.store.load(&self.company).await {
-            Ok(Some(record)) => delegation_tools::reject_desk_target(&record, desk),
-            Ok(None) => None,
+    /// exactly as it was before this grounding existed, under the default depth.
+    /// A store hiccup must not take delegation offline; the drain-time
+    /// fall-through still records what happened.
+    ///
+    /// Order matters. Grounding (#272) runs first — "there is no such desk"
+    /// outranks "you may not reach that desk", because a model told the latter
+    /// about a desk it invented would go on inventing. Then the allowlist, which
+    /// is retryable in the same turn with a desk from the list the message
+    /// names, and only then the cycle guard, which is not.
+    async fn ground(&self, desk: &str) -> Grounding {
+        let record = match self.store.load(&self.company).await {
+            Ok(Some(record)) => record,
+            Ok(None) => return Grounding::open(),
             Err(err) => {
                 tracing::warn!(
                     company = %self.company,
@@ -1347,8 +1571,38 @@ impl DelegateToDeskTool {
                     "[delegate_to_desk] could not read the company record to ground the desk target; \
                      queuing the hand-off ungrounded"
                 );
-                None
+                return Grounding::open();
             }
+        };
+        let max_depth = usize::from(
+            record
+                .manifest
+                .tools
+                .max_delegation_depth
+                .unwrap_or(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
+        );
+        let refusal = delegation_tools::reject_desk_target(&record, desk).or_else(|| {
+            let scope = self.member.as_ref()?;
+            delegation_tools::reject_out_of_allowlist_target(&record, &scope.delegates_to, desk)
+                .or_else(|| {
+                    delegation_tools::reject_cycle_target(
+                        &record,
+                        &self.queue.scope_chain(),
+                        desk,
+                        &scope.member,
+                    )
+                })
+        });
+        Grounding { refusal, max_depth }
+    }
+}
+
+impl Grounding {
+    /// The fail-open grounding: nothing refused, default depth.
+    fn open() -> Self {
+        Self {
+            refusal: None,
+            max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
         }
     }
 }
@@ -1390,7 +1644,10 @@ impl Tool for DelegateToDeskTool {
         // Ground the target before queuing anything: an invented desk is
         // refused here, in the model's own turn, rather than surviving as a
         // queued hand-off that the drain silently cannot deliver (issue #272).
-        if let Some(refusal) = self.refusal(&desk).await {
+        // For a desk member (issue #176) this also refuses a target outside its
+        // allowlist and one that would close a loop.
+        let grounding = self.ground(&desk).await;
+        if let Some(refusal) = grounding.refusal {
             tracing::info!(
                 company = %self.company,
                 "[delegate_to_desk] refused an ungrounded delegation target"
@@ -1409,6 +1666,7 @@ impl Tool for DelegateToDeskTool {
                 instruction,
             },
             MAX_DELEGATIONS_PER_TURN,
+            grounding.max_depth,
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
@@ -1495,6 +1753,7 @@ impl Tool for AssignTaskTool {
                 note,
             },
             MAX_DELEGATIONS_PER_TURN,
+            NO_DEPTH_BOUND,
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
@@ -1582,6 +1841,7 @@ impl Tool for ReviewTaskTool {
                 note,
             },
             MAX_DELEGATIONS_PER_TURN,
+            NO_DEPTH_BOUND,
         ) {
             Staged::Queued => {}
             Staged::OverCap => return Ok(ToolResult::error(over_cap(&effect))),
@@ -1679,6 +1939,13 @@ fn no_drain(tool: &str, effect: &str, reason: NoDrainReason) -> String {
              card as moved. If the operator did mean it as work, say so plainly and ask them to \
              restate it as a direct request."
         ),
+        NoDrainReason::Depth => format!(
+            "Refused: this work has already been handed on as far as this company allows, so \
+             {effect}. You are the last link in the chain — do the part you can do yourself and \
+             say plainly what still needs another desk, or open a task card for it with \
+             `spawn_task`, which still works. Do not retry this call; it will fail the same way, \
+             and do NOT report the hand-off as done."
+        ),
     }
 }
 
@@ -1721,6 +1988,73 @@ pub fn delegation_tools(
         Box::new(AssignTaskTool::new(queue.clone())),
         Box::new(ReviewTaskTool::new(queue.clone())),
     ]
+}
+
+/// The **two** delegation tools a desk member gets when its manifest entry
+/// names a `delegates_to` allowlist (issue #176): `spawn_task` and a
+/// `delegate_to_desk` narrowed to that allowlist.
+///
+/// Deliberately a subset of [`delegation_tools`] rather than the same list.
+/// `assign_task`, `review_task`, `query_company`, `run_workflow`,
+/// `create_workflow` and `add_agent` are the orchestrator's *authority* over the
+/// company — who owns a card, whether work passes review, who is on the roster —
+/// and #176 is about a lead pulling in a specialist, not about every desk lead
+/// becoming a second CEO. A member gets exactly what it needs to pass a slice
+/// on and to leave the rest tracked.
+///
+/// Both names are already covered by
+/// [`is_delegation_tool`], so
+/// [`ApprovalPolicy`](crate::harness::policy::ApprovalPolicy) classifies them as
+/// internal here exactly as it does on the orchestrator — no policy change comes
+/// with this wiring.
+pub fn member_delegation_tools(
+    queue: &DelegationQueue,
+    company: CompanyId,
+    store: Arc<dyn CompanyStore>,
+    scope: MemberScope,
+) -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(SpawnTaskTool::new(queue.clone())),
+        Box::new(DelegateToDeskTool::for_member(
+            queue.clone(),
+            company,
+            store,
+            scope,
+        )),
+    ]
+}
+
+/// The persona brief appended for a desk member that may re-delegate (issue
+/// #176).
+///
+/// It exists because a refusal costs a whole turn. A model handed
+/// `delegate_to_desk` with no idea that its reach is narrowed, or that the chain
+/// it is running inside is nearly at its bound, spends turns discovering both
+/// one refusal at a time — and the depth refusal in particular is not
+/// retryable, so a model that has not been told will burn every remaining call
+/// on it. Naming the allowlist and the shape of the bound up front is cheaper
+/// than the refusals it avoids.
+///
+/// The bound is stated qualitatively rather than as a number. The number lives
+/// on the live company record and is read at call time; baking a snapshot of it
+/// into a persona that is cached with the belt would be a claim that goes stale
+/// the moment an operator edits the manifest — and a *confidently wrong* bound
+/// is worse guidance than an honest "there is one".
+pub fn member_delegation_brief(desks: &[String]) -> String {
+    let reach = match desks.iter().any(|d| d.trim() == "*") {
+        true => "any desk in the company".to_string(),
+        false => desks.join(", "),
+    };
+    format!(
+        "\n\n## Handing work on\n\nYou can pass a slice of your work to another desk with \
+`delegate_to_desk`, and open a tracked card for anything that should be followed up later with \
+`spawn_task`. The desks you may hand work to: {reach}.\n\nHand on only the part somebody else is \
+genuinely better placed to do, and do the rest yourself — every hand-off costs another turn. The \
+chain is bounded: if you are told the work has already been handed on as far as this company \
+allows, that is final, so do what you can and say plainly what is left rather than calling the \
+tool again. You cannot hand work back to a desk it already came from, or to a desk you lead \
+yourself.\n"
+    )
 }
 
 // ---------------------------------------------------------------------------
@@ -3637,6 +3971,7 @@ mod tests {
                         assignee: None,
                     },
                     MAX_DELEGATIONS_PER_TURN,
+                    NO_DEPTH_BOUND,
                 ),
                 Staged::Queued
             );
@@ -3649,6 +3984,7 @@ mod tests {
                     assignee: None,
                 },
                 MAX_DELEGATIONS_PER_TURN,
+                NO_DEPTH_BOUND,
             ),
             Staged::OverCap
         );
@@ -3673,6 +4009,7 @@ mod tests {
                     assignee: None,
                 },
                 MAX_DELEGATIONS_PER_TURN,
+                NO_DEPTH_BOUND,
             ),
             Staged::NoDrain(NoDrainReason::Unwired),
             "an EMPTY unclaimed queue is still a queue nothing drains"
@@ -3699,6 +4036,7 @@ mod tests {
                         note: None,
                     },
                     MAX_DELEGATIONS_PER_TURN,
+                    NO_DEPTH_BOUND,
                 ),
                 Staged::Queued
             );
@@ -3867,12 +4205,12 @@ mod tests {
             assignee: None,
         };
         assert_eq!(
-            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN),
+            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN, NO_DEPTH_BOUND),
             Staged::NoDrain(NoDrainReason::Unwired)
         );
         let claim = queue.claim_answering();
         assert_eq!(
-            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN),
+            queue.push_within_cap(spawn(), MAX_DELEGATIONS_PER_TURN, NO_DEPTH_BOUND),
             Staged::NoDrain(NoDrainReason::Triage)
         );
         // …and a hand-off is not refused at all under the same claim, because it
@@ -3884,6 +4222,7 @@ mod tests {
                     instruction: "what did you ship?".to_string(),
                 },
                 MAX_DELEGATIONS_PER_TURN,
+                NO_DEPTH_BOUND,
             ),
             Staged::Queued
         );
@@ -4210,6 +4549,343 @@ members = ["nobody"]
                 instruction: "draft a plan".to_string(),
             }]
         );
+    }
+
+    // --- Recursive desk delegation (issue #176) -----------------------------
+
+    /// A three-desk record where two desks have roster leads, so a member of one
+    /// can be given an allowlist that admits one desk and not another.
+    fn nested_desks_record(id: &CompanyId) -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+
+[[agent]]
+id = "writer"
+role = "Writer"
+delegates_to = ["research"]
+
+[[agent]]
+id = "analyst"
+role = "Analyst"
+
+[[group_chat]]
+id = "strategy"
+name = "Strategy desk"
+members = ["writer"]
+
+[[group_chat]]
+id = "research"
+name = "Research desk"
+members = ["analyst"]
+
+[[group_chat]]
+id = "legal"
+name = "Legal desk"
+members = ["ceo"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            manifest,
+            ..seeded_record(id)
+        }
+    }
+
+    /// The `writer`'s copy of `delegate_to_desk`: allowed `research` only.
+    fn member_desk_tool(record: CompanyRecord, queue: &DelegationQueue) -> DelegateToDeskTool {
+        let company = record.id.clone();
+        DelegateToDeskTool::for_member(
+            queue.clone(),
+            company,
+            Arc::new(MemStore::seeded(record)) as Arc<dyn CompanyStore>,
+            MemberScope {
+                member: "writer".to_string(),
+                delegates_to: vec!["research".to_string()],
+            },
+        )
+    }
+
+    /// Depth is the length of the scope chain, and it gates **hand-offs only**.
+    ///
+    /// At the bound a `delegate_to_desk` is refused with the new
+    /// [`NoDrainReason::Depth`], while a `spawn_task` still stages — refusing
+    /// that too would push a member that has hit the bound into working silently
+    /// rather than leaving the work tracked.
+    #[test]
+    fn push_within_cap_refuses_a_hand_off_past_the_depth_bound() {
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let hand_off = || Delegation::DelegateToDesk {
+            desk: "research".to_string(),
+            instruction: "dig into it".to_string(),
+        };
+        let card = || Delegation::SpawnTask {
+            title: "follow up".to_string(),
+            note: None,
+            assignee: None,
+        };
+
+        // Depth 0 (the orchestrator's own turn) under a bound of 1: allowed.
+        assert_eq!(queue.scope_depth(), 0);
+        assert_eq!(
+            queue.push_within_cap(hand_off(), MAX_DELEGATIONS_PER_TURN, 1),
+            Staged::Queued
+        );
+        queue.clear();
+
+        // One level in, under a bound of 1: refused as depth-capped.
+        let scope = queue.enter_scope("strategy".to_string());
+        assert_eq!(queue.scope_depth(), 1);
+        assert_eq!(
+            queue.push_within_cap(hand_off(), MAX_DELEGATIONS_PER_TURN, 1),
+            Staged::NoDrain(NoDrainReason::Depth)
+        );
+        // …while the board write at the same depth is untouched.
+        assert_eq!(
+            queue.push_within_cap(card(), MAX_DELEGATIONS_PER_TURN, 1),
+            Staged::Queued
+        );
+        queue.clear();
+        // …and the same hand-off under the default bound of 2 stages.
+        assert_eq!(
+            queue.push_within_cap(hand_off(), MAX_DELEGATIONS_PER_TURN, 2),
+            Staged::Queued
+        );
+        queue.clear();
+
+        // Two levels in, under a bound of 2: refused.
+        let deeper = queue.enter_scope("research".to_string());
+        assert_eq!(queue.scope_depth(), 2);
+        assert_eq!(
+            queue.push_within_cap(hand_off(), MAX_DELEGATIONS_PER_TURN, 2),
+            Staged::NoDrain(NoDrainReason::Depth)
+        );
+
+        // The guards pop on drop, outermost last.
+        drop(deeper);
+        assert_eq!(queue.scope_depth(), 1);
+        drop(scope);
+        assert_eq!(queue.scope_depth(), 0);
+    }
+
+    /// The refusal has to be countable and distinguishable from the two that
+    /// preceded it, and its text must not claim either of their causes — the
+    /// same message would tell a fully capable company that its context cannot
+    /// do board work.
+    #[test]
+    fn the_depth_refusal_is_its_own_reason_and_its_own_sentence() {
+        assert_eq!(NoDrainReason::Depth.as_str(), "depth_capped");
+        for other in [NoDrainReason::Unwired, NoDrainReason::Triage] {
+            assert_ne!(NoDrainReason::Depth.as_str(), other.as_str());
+        }
+        let text = no_drain(
+            DELEGATE_TO_DESK_TOOL,
+            "nothing was handed to the research desk",
+            NoDrainReason::Depth,
+        );
+        assert!(text.contains("as far as this company allows"), "{text}");
+        assert!(
+            text.contains("`spawn_task`"),
+            "the model must be told what still works: {text}"
+        );
+        assert!(
+            !text.contains("question"),
+            "a depth refusal must not borrow the triage cause: {text}"
+        );
+        assert!(
+            !text.contains("unavailable in this context"),
+            "a depth refusal must not borrow the unwired cause: {text}"
+        );
+    }
+
+    /// The chain ends with the claim, on **both** boundaries.
+    ///
+    /// The exit half is the load-bearing one: a `ScopeGuard` pops on every
+    /// ordinary exit, but a panic inside a nested turn unwinds past it, and a
+    /// chain left standing would make the next operator message start at depth 2
+    /// and refuse its first hand-off. An ordinary `clear()` must NOT reset it —
+    /// clearing happens between delegations inside a live chain.
+    #[test]
+    fn the_scope_chain_resets_with_the_claim_and_survives_a_clear() {
+        let queue = DelegationQueue::default();
+        {
+            let _claim = queue.claim();
+            std::mem::forget(queue.enter_scope("strategy".to_string()));
+            std::mem::forget(queue.enter_scope("research".to_string()));
+            assert_eq!(queue.scope_chain(), ["strategy", "research"]);
+            queue.clear();
+            assert_eq!(
+                queue.scope_chain(),
+                ["strategy", "research"],
+                "clear() runs between delegations inside a live chain and must not reset depth"
+            );
+        }
+        assert_eq!(
+            queue.scope_depth(),
+            0,
+            "the claim's Drop must reset a chain leaked past its guards"
+        );
+        // …and the acquire resets too, for a claim taken after a leak.
+        std::mem::forget(queue.enter_scope("strategy".to_string()));
+        let _claim = queue.claim();
+        assert_eq!(queue.scope_depth(), 0);
+    }
+
+    /// A member may not hand work back up its own chain (A→B→A), and the
+    /// refusal is recorded for the card as well as returned to the model.
+    #[tokio::test]
+    async fn a_member_may_not_hand_work_back_to_a_desk_on_the_chain() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        // The chain the orchestrator's hand-off to `strategy` opened, with the
+        // writer's own turn running inside it.
+        let _scope = queue.enter_scope("strategy".to_string());
+        // `writer` leads `strategy`, so it is BOTH on the chain and self-led;
+        // give it a wildcard allowlist so the allowlist check cannot be what
+        // refuses.
+        let tool = DelegateToDeskTool::for_member(
+            queue.clone(),
+            company.clone(),
+            Arc::new(MemStore::seeded(nested_desks_record(&company))) as Arc<dyn CompanyStore>,
+            MemberScope {
+                member: "writer".to_string(),
+                delegates_to: vec!["*".to_string()],
+            },
+        );
+        let result = tool
+            .execute(json!({ "desk": "strategy", "instruction": "start over" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "a cycle must be refused");
+        let text = result.output_for_llm(true);
+        assert!(text.contains("strategy"), "{text}");
+        assert_eq!(queue.queued(), 0, "nothing may be staged for a cycle");
+        assert_eq!(
+            queue.drain_refusals(MAX_DELEGATIONS_PER_TURN),
+            vec!["strategy".to_string()],
+            "the drain must be able to record the attempt on the card"
+        );
+
+        // A desk that is neither on the chain nor led by the caller goes
+        // through.
+        let ok = tool
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(!ok.is_error, "{}", ok.output_for_llm(true));
+    }
+
+    /// A member may only reach the desks its manifest entry names, and the
+    /// refusal lists them — the model has no other way to learn its allowlist.
+    #[tokio::test]
+    async fn a_member_may_only_reach_the_desks_its_manifest_allows() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let tool = member_desk_tool(nested_desks_record(&company), &queue);
+
+        let refused = tool
+            .execute(json!({ "desk": "legal", "instruction": "review it" }))
+            .await
+            .expect("execute");
+        assert!(refused.is_error, "an off-allowlist desk must be refused");
+        let text = refused.output_for_llm(true);
+        assert!(text.contains("legal"), "{text}");
+        assert!(
+            text.contains("research"),
+            "the permitted set must be named so the model can retry in-turn: {text}"
+        );
+        assert_eq!(queue.queued(), 0);
+
+        let allowed = tool
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(!allowed.is_error, "{}", allowed.output_for_llm(true));
+        assert_eq!(queue.queued(), 1);
+    }
+
+    /// The **orchestrator's** copy is unrestricted: no allowlist, no cycle
+    /// guard, and it reaches every desk exactly as it did before #176.
+    #[tokio::test]
+    async fn the_orchestrators_copy_is_unrestricted() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        // Even from inside a chain — which the orchestrator never is, but the
+        // contrast is the point.
+        let _scope = queue.enter_scope("legal".to_string());
+        let tool = desk_tool(nested_desks_record(&company), &queue);
+        for desk in ["strategy", "research", "legal"] {
+            let result = tool
+                .execute(json!({ "desk": desk, "instruction": "go" }))
+                .await
+                .expect("execute");
+            assert!(
+                !result.is_error,
+                "the orchestrator must reach {desk}: {}",
+                result.output_for_llm(true)
+            );
+            queue.clear();
+        }
+    }
+
+    /// The depth bound comes off the **live company record**, not a build-time
+    /// snapshot — an operator can edit `[tools].max_delegation_depth` without
+    /// the cached belt being rebuilt.
+    #[tokio::test]
+    async fn the_depth_bound_is_read_from_the_manifest_at_call_time() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let _claim = queue.claim();
+        let mut record = nested_desks_record(&company);
+        record.manifest.tools.max_delegation_depth = Some(1);
+        let tool = member_desk_tool(record, &queue);
+        // One level in, under the manifest's bound of 1.
+        let _scope = queue.enter_scope("strategy".to_string());
+        let result = tool
+            .execute(json!({ "desk": "research", "instruction": "dig into it" }))
+            .await
+            .expect("execute");
+        assert!(result.is_error, "depth 1 must stop a member re-delegating");
+        assert!(
+            result
+                .output_for_llm(true)
+                .contains("as far as this company allows"),
+            "{}",
+            result.output_for_llm(true)
+        );
+        assert_eq!(queue.queued(), 0);
+    }
+
+    /// The member's belt is exactly `spawn_task` + `delegate_to_desk` — never
+    /// the orchestrator's authority tools.
+    #[test]
+    fn a_members_delegation_belt_is_the_two_hand_off_tools() {
+        let company = CompanyId::new("acme");
+        let queue = DelegationQueue::default();
+        let store: Arc<dyn CompanyStore> =
+            Arc::new(MemStore::seeded(nested_desks_record(&company)));
+        let tools = member_delegation_tools(
+            &queue,
+            company,
+            store,
+            MemberScope {
+                member: "writer".to_string(),
+                delegates_to: vec!["research".to_string()],
+            },
+        );
+        let mut names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        names.sort();
+        assert_eq!(names, [DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL]);
     }
 
     /// Issue #272: the observed failure — the orchestrator handed work to

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -3367,6 +3367,7 @@ mod tests {
             description: None,
             tier: tier.map(str::to_string),
             tools: Vec::new(),
+            delegates_to: Vec::new(),
             budget_usd_daily: None,
         }
     }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1693,9 +1693,57 @@ mod tests {
         ));
         assert_eq!(
             harness
-                .check(&request("payroll.export", serde_json::json!({})))
+                .check(&request("file_write", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::Allow
+        );
+
+        // The fence near-miss, pinned where the answer is stable.
+        //
+        // `payroll.export` is what the shared matcher tests call the near-miss:
+        // sharing `payment`'s first four letters is not the same capability, so
+        // the operator list names it nowhere and must not gate it. All three
+        // statements are asserted because the two paths legitimately differ on
+        // the last of them:
+        //
+        // * the *matcher* — the part both paths actually share — does not gate
+        //   it;
+        // * the gate, effect-level and mode-driven, hands `full` the Allow this
+        //   fence implies;
+        // * the harness instead parks it, because #338's per-call judgement
+        //   fail-closes an undeclared non-read call — a layer the effect gate
+        //   does not have, and the reason the near-miss cannot live inside the
+        //   agreement loop above.
+        assert!(
+            !crate::policy::always_approve::matches(&always_approve_vec(fence), "payroll.export"),
+            "the operator list must not gate the leading-segment near-miss"
+        );
+        assert!(matches!(
+            harness
+                .check(&request("payroll.export", serde_json::json!({})))
+                .await,
+            ToolPolicyDecision::RequireApproval { .. }
+        ));
+        assert_eq!(
+            gate.evaluate(
+                &CompanyId::new("acme"),
+                &Effect {
+                    kind: "payroll.export".to_string(),
+                    ..Effect {
+                        group: EffectGroup::Other,
+                        amount_usd: None,
+                        established_thread: false,
+                        first_time_counterparty: false,
+                        payload: serde_json::Value::Null,
+                        agent: None,
+                        run_id: None,
+                        kind: String::new(),
+                    }
+                },
+            )
+            .await
+            .unwrap(),
+            PolicyDecision::Allow
         );
     }
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1714,8 +1714,9 @@ mod tests {
         //   fail-closes an undeclared non-read call — a layer the effect gate
         //   does not have, and the reason the near-miss cannot live inside the
         //   agreement loop above.
+        let fence_list: Vec<String> = fence.iter().map(|s| s.to_string()).collect();
         assert!(
-            !crate::policy::always_approve::matches(&always_approve_vec(fence), "payroll.export"),
+            !crate::policy::always_approve::matches(&fence_list, "payroll.export"),
             "the operator list must not gate the leading-segment near-miss"
         );
         assert!(matches!(
@@ -1724,25 +1725,20 @@ mod tests {
                 .await,
             ToolPolicyDecision::RequireApproval { .. }
         ));
+        let near_miss_effect = Effect {
+            kind: "payroll.export".to_string(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
         assert_eq!(
-            gate.evaluate(
-                &CompanyId::new("acme"),
-                &Effect {
-                    kind: "payroll.export".to_string(),
-                    ..Effect {
-                        group: EffectGroup::Other,
-                        amount_usd: None,
-                        established_thread: false,
-                        first_time_counterparty: false,
-                        payload: serde_json::Value::Null,
-                        agent: None,
-                        run_id: None,
-                        kind: String::new(),
-                    }
-                },
-            )
-            .await
-            .unwrap(),
+            gate.evaluate(&CompanyId::new("acme"), &near_miss_effect)
+                .await
+                .unwrap(),
             PolicyDecision::Allow
         );
     }

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1611,14 +1611,27 @@ mod tests {
         use crate::ports::approvals::ApprovalGate;
         use crate::ports::types::PolicyDecision;
 
-        // A leading segment, an exact dotted kind, a bare tool name, a
-        // near-miss that must NOT be gated, and a case variant.
+        // A leading segment, an exact dotted kind, a bare tool name, a case
+        // variant, and — last — a name the fence deliberately does NOT gate.
         //
         // Every name here is one the tier itself has no opinion about under
         // `full`, so the only thing that can make the two paths disagree is the
         // fence. A priced name like `web_search` would drag the harness's
         // metered-read and budget arms into a comparison that is not about
         // `always_approve`, so it is deliberately absent.
+        //
+        // The un-gated control is `file_write`, not the `payroll.export`
+        // near-miss the shared matcher's own tests use. The harness path has
+        // one layer the native gate does not — the per-call judgement arm
+        // (issue #338), which fail-closes an *undeclared* call that is not a
+        // pure read. `payroll.export` is undeclared, so the harness parks it
+        // for that reason alone; the gate is effect-level and mode-driven, so
+        // under `full` it allows it. That divergence is the documented shape of
+        // the two layers, not an `always_approve` disagreement, and an
+        // assertion demanding agreement on it is exactly the one that goes
+        // stale the next time #338's net widens. It is pinned separately below.
+        // `file_write` is declared, grantable and fence-ungated, so both paths
+        // agree on it with nothing to do.
         let fence = &["payment", "filing.submit", "publish_artifact"];
         let names = [
             "payment.send",
@@ -1626,7 +1639,7 @@ mod tests {
             "filing.submit",
             "publish_artifact",
             "PUBLISH_ARTIFACT",
-            "payroll.export",
+            "file_write",
         ];
 
         // `full` on both sides, so the tier decides nothing and any parking

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -110,6 +110,7 @@ mod tests {
                 description: None,
                 tier: None,
                 tools: vec![],
+                delegates_to: vec![],
                 budget_usd_daily: None,
             },
             Agent {
@@ -118,6 +119,7 @@ mod tests {
                 description: None,
                 tier: None,
                 tools: vec![],
+                delegates_to: vec![],
                 budget_usd_daily: None,
             },
         ];

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -210,6 +210,16 @@ pub(crate) struct Drained {
     /// Synchronous desk answers, in the order they came back. Empty when
     /// [`HandOffs::Drop`] was asked for.
     pub(crate) desk_replies: Vec<DeskReply>,
+    /// The desks whose hand-off an operator CANCELLED mid-flight (issue #176).
+    ///
+    /// Carried as a fact rather than inferred from a missing reply, for the
+    /// same reason [`DelegationOutcome::cancelled`] is: a hand-off yields no
+    /// reply for several reasons and only one of them is a cancellation. The
+    /// nested drain reads this so a delegate's own cancelled hand-off is folded
+    /// into the reply as a cancellation note instead of vanishing — the
+    /// alternative being an answer that quietly omits a branch the model said it
+    /// had started.
+    pub(crate) cancelled_desks: Vec<String>,
     /// The **first** board card this drain opened, matching
     /// [`OperatorTurn::spawned_task`]'s first-wins rule.
     pub(crate) spawned_task: Option<String>,
@@ -666,7 +676,15 @@ impl<'a> DelegationRunner<'a> {
                 );
                 continue;
             }
+            // Captured before the delegation is consumed, so a cancellation can
+            // be reported against the desk it was aimed at (issue #176).
+            let target = desk_of(&delegation).map(str::to_string);
             let out = self.run_delegation(delegation, chat_id, ctx).await?;
+            if out.cancelled
+                && let Some(desk) = target
+            {
+                drained.cancelled_desks.push(desk);
+            }
             if let Some(id) = out.spawned_task {
                 drained.spawned_task.get_or_insert(id);
             }
@@ -1180,8 +1198,14 @@ impl<'a> DelegationRunner<'a> {
     /// `delegate_to_desk` runs a single turn on the desk's lead member and
     /// **returns its reply for the orchestrator to relay** (a [`DeskReply`]). An
     /// unknown desk (no roster-backed lead) or a cancelled run yields nothing to
-    /// relay. No sub-agent re-delegation in v1: desk members carry no delegation
-    /// tools, so their turns queue nothing.
+    /// relay.
+    ///
+    /// Since issue #176 a desk member the manifest opted in with `delegates_to`
+    /// carries the hand-off tools itself, so its turn may queue too. That queue
+    /// is drained **here**, recursively, inside this hand-off's scope — and the
+    /// deeper answers are folded into this member's reply rather than relayed
+    /// separately. Depth is bounded at the tool boundary by the scope chain, not
+    /// by this function.
     ///
     /// `ctx` carries what
     /// [`handle_operator_message`](Self::handle_operator_message) already
@@ -1292,10 +1316,31 @@ impl<'a> DelegationRunner<'a> {
                     },
                 );
                 let control = guard.control().clone();
+                // Issue #176: enter this hand-off's scope BEFORE the member's
+                // turn runs, so a `delegate_to_desk` the member itself calls is
+                // validated at the depth it is actually running at — and against
+                // a chain that already contains this desk, which is what makes
+                // A→B→A a detectable cycle. The guard pops on every exit path
+                // below, including the `?`s and the cancellation return.
+                //
+                // The RESOLVED id, not the key the model typed: the chain is
+                // compared by identity, and "Content desk" and "content" are the
+                // same desk. An unresolvable key cannot reach here — `desk_lead`
+                // above returned `Some` — so the fallback is unreachable and
+                // merely avoids a panic if that ever stops holding.
+                let scoped_desk = self
+                    .record
+                    .resolve_desk_id(&desk)
+                    .unwrap_or_else(|| desk.clone());
+                let _scope = self.queue.enter_scope(scoped_desk);
                 // Issue #465, same sampling as the direct-answer path: a desk
                 // delegation whose first call parks has produced nothing to
                 // review either.
                 let approvals_before = self.approvals_queued();
+                // Issue #176, the same before/after shape: a hand-off the
+                // MEMBER's tool refused must be attributed to the member, not
+                // swept up with whatever its delegator left unread.
+                let refusals_before = self.queue.refusals_queued();
                 let outcome = self
                     .run_turn
                     .run_steered(
@@ -1317,6 +1362,13 @@ impl<'a> DelegationRunner<'a> {
                 // has to explain the empty result can name the cause instead of
                 // guessing at it (issue #213 review).
                 if matches!(control.take(), Some(SteerAction::Cancel)) {
+                    // Anything the cancelled member queued before it was stopped
+                    // is dropped with it (issue #176). The outer drain already
+                    // moved its own items into a local vector, so the queue holds
+                    // nothing but this member's pushes; leaving them would run
+                    // them under the NEXT sibling hand-off's scope, attributing
+                    // one member's work to another.
+                    self.queue.clear();
                     // The card this hand-off opened outlives the cancellation:
                     // settling it returns it to To-do with the cancellation on
                     // its note, so an operator sees the work was asked for and
@@ -1337,15 +1389,78 @@ impl<'a> DelegationRunner<'a> {
                         ..DelegationOutcome::default()
                     });
                 }
+                // A hand-off the member's own tool REFUSED never becomes a
+                // `Delegation`, so it is read separately — and read here, before
+                // the nested drain, because that drain runs turns of its own
+                // which can push refusals a further level down.
+                let refused = self
+                    .queue
+                    .drain_refusals_after(refusals_before, self.max_delegations);
+                // Issue #176: run whatever the MEMBER queued during its own turn,
+                // one level deeper, before the card is settled.
+                //
+                // This is the half without which the whole feature is a receipt
+                // for work that never happens (#453's failure, one level down):
+                // the member's tool told it the hand-off "will be answered this
+                // turn", and if nobody drains here the delegation is destroyed by
+                // the next `clear()` with the member none the wiser.
+                //
+                // `Box::pin` is mandatory, not stylistic — this is async
+                // recursion (`run_delegation` → `drain_and_execute` →
+                // `run_delegation`) and an unboxed cycle is an
+                // infinitely-sized future the compiler rejects. It also keeps the
+                // stack flat, which this repo has been bitten by before.
+                //
+                // Bounded by construction: each level pushes onto the scope chain
+                // and `push_within_cap` refuses past `max_delegation_depth`,
+                // which validation caps at 4.
+                //
+                // `ctx` is threaded through unchanged. `carded_by_handler` and
+                // `answering` are properties of the OPERATOR's message, and they
+                // stay true at every depth — a question the operator asked is
+                // still a question three desks down, and must still mint no card.
+                let nested = Box::pin(self.drain_and_execute(chat_id, ctx, HandOffs::Run)).await?;
+                // Fold the nested answers INTO this member's reply rather than
+                // giving each level its own relay turn. The top-level CEO-relay
+                // already synthesises every desk reply into one coherent answer
+                // for the operator, so a per-level relay would only multiply
+                // turns to reach the same text. Steps ride along the same way, so
+                // the operator's timeline shows the deeper member working.
+                let mut reply = outcome.reply;
+                let mut steps = outcome.steps;
+                for deeper in nested.desk_replies {
+                    reply.push_str(&format!(
+                        "\n\n{} (delegated by {member}) replied:\n{}",
+                        deeper.member, deeper.reply
+                    ));
+                    steps.extend(deeper.steps);
+                }
+                // A cancelled nested run folds in as a cancellation, NEVER as a
+                // reply: the member said it was handing that slice on, and an
+                // answer that silently omits the branch is the confident
+                // falsehood the delegation stack exists to prevent.
+                for desk in nested.cancelled_desks {
+                    reply.push_str(&format!(
+                        "\n\n(the {desk} desk was handed a slice of this by {member}, but that run \
+                         was cancelled before it replied)"
+                    ));
+                }
+                // A hand-off the member's OWN tool refused — an unknown desk, one
+                // outside its allowlist, or one that would loop — never becomes a
+                // `Delegation`, so without this the only record is the tool
+                // result the member is free to describe however it likes. Folding
+                // it into the reply puts it on the card note and in front of the
+                // operator, the same independence #272 gave the delegator's
+                // refusals.
+                for desk in refused {
+                    reply.push_str(&format!(
+                        "\n\n({member} tried to hand a slice of this to the {desk} desk, but that \
+                         hand-off was refused and did not happen)"
+                    ));
+                }
                 if let Some(card) = card.as_mut() {
-                    self.settle_work_card(
-                        card,
-                        &member,
-                        TaskRunEnd::Completed,
-                        parked,
-                        &outcome.reply,
-                    )
-                    .await?;
+                    self.settle_work_card(card, &member, TaskRunEnd::Completed, parked, &reply)
+                        .await?;
                 }
                 // Hand the teammate's answer back to RELAY through a second
                 // orchestrator turn (the CEO-relay hand-back). Their steps ride
@@ -1354,8 +1469,8 @@ impl<'a> DelegationRunner<'a> {
                     bubble: None,
                     desk_reply: Some(DeskReply {
                         member,
-                        reply: outcome.reply,
-                        steps: outcome.steps,
+                        reply,
+                        steps,
                     }),
                     cancelled: false,
                     // Issue #442: the hand-off's own card, reported the same way
@@ -1363,7 +1478,12 @@ impl<'a> DelegationRunner<'a> {
                     // says a card was opened whichever hand-off the orchestrator
                     // chose. This is the field the console's "Card opened" chip
                     // renders from.
-                    spawned_task: card.map(|c| c.id),
+                    //
+                    // First-wins across the nested drain too (issue #176): this
+                    // hand-off's own card predates anything the member opened one
+                    // level down, so it stays the reported one; a card the member
+                    // opened is reported only when this hand-off opened none.
+                    spawned_task: card.map(|c| c.id).or(nested.spawned_task),
                 })
             }
             // ── Issue #186 part b: orchestrator lifecycle authority ─────────
@@ -1928,6 +2048,12 @@ investor update for the quarter\n]"
         /// on a question turn is REFUSED in the model's own turn, and a fixture
         /// that pushed straight onto the queue could never observe the refusal.
         tool_pushes: Vec<Delegation>,
+        /// Desks this turn named that the tool REFUSED (issue #272 for the
+        /// delegator, #176 for a member), recorded the way
+        /// `DelegateToDeskTool` records them so the drain can report the
+        /// attempt. A refusal never becomes a `Delegation`, so this is the only
+        /// way a fixture can stand in for one.
+        refuses: Vec<String>,
     }
 
     impl Turn {
@@ -1964,6 +2090,17 @@ investor update for the quarter\n]"
             }
         }
 
+        /// A turn whose `delegate_to_desk` call was REFUSED at the tool
+        /// boundary (issue #176): nothing is queued, and the desk it named is
+        /// recorded for the drain to report.
+        fn refused(reply: &str, desks: &[&str]) -> Self {
+            Self {
+                reply: reply.to_string(),
+                refuses: desks.iter().map(|d| d.to_string()).collect(),
+                ..Self::default()
+            }
+        }
+
         /// A turn whose **first** tool call parked for approval, so it produced
         /// nothing: the reply is the agent saying it is blocked, not a result.
         /// This is the shape in the issue #465 report.
@@ -1989,6 +2126,12 @@ investor update for the quarter\n]"
         /// The board as it looked at the START of each turn, so a test can prove
         /// a card existed *while* an agent worked rather than only afterwards.
         board_at_turn: Mutex<Vec<Vec<(String, String)>>>,
+        /// The delegation-chain bound the scripted tool boundary enforces
+        /// (issue #176), standing in for `[tools].max_delegation_depth`. The
+        /// production `DelegateToDeskTool` reads it off the live record; a
+        /// scripted turn has no tool, so the depth a test runs under is set
+        /// here.
+        max_depth: usize,
         /// How the delegation queue was **claimed** while each turn ran (issues
         /// #453, #267). This is what a real tool reads to decide between
         /// staging and refusing, so recording it here is how a test proves the
@@ -2015,7 +2158,16 @@ investor update for the quarter\n]"
                 staged: Mutex::new(Vec::new()),
                 tasks: fx.tasks.clone(),
                 company: fx.record.id.clone(),
+                max_depth: usize::from(crate::company::DEFAULT_MAX_DELEGATION_DEPTH),
             }
+        }
+
+        /// Runs this script under a different `[tools].max_delegation_depth`
+        /// (issue #176) — `1` reproduces the pre-#176 "desks may not
+        /// re-delegate" behaviour.
+        fn with_max_depth(mut self, max_depth: usize) -> Self {
+            self.max_depth = max_depth;
+            self
         }
 
         /// What the tool boundary answered every [`Turn::tool_pushes`] call, in
@@ -2082,10 +2234,17 @@ investor update for the quarter\n]"
             // …and the ones that go through the boundary a real tool goes
             // through, recording what it answered (issue #267).
             for delegation in turn.tool_pushes {
-                let staged = self
-                    .queue
-                    .push_within_cap(delegation, orchestrator::MAX_DELEGATIONS_PER_TURN);
+                let staged = self.queue.push_within_cap(
+                    delegation,
+                    orchestrator::MAX_DELEGATIONS_PER_TURN,
+                    self.max_depth,
+                );
                 self.staged.lock().expect("staged").push(staged);
+            }
+            // …and the ones the tool refused outright, which never become a
+            // `Delegation` at all (issues #272, #176).
+            for desk in turn.refuses {
+                self.queue.push_refusal(desk);
             }
             for tool in turn.parks {
                 self.approvals
@@ -2192,6 +2351,67 @@ members = ["engineer"]
         }
     }
 
+    /// A roster with **two** delegatable desks, where the engineering lead may
+    /// hand a slice on to research (issue #176).
+    ///
+    /// `design` is deliberately outside `engineer`'s allowlist and led by a
+    /// third teammate, so a test can prove a third lead never runs.
+    fn nested_record() -> CompanyRecord {
+        let manifest = toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "chief"
+role = "Chief of Staff"
+tier = "orchestrator"
+
+[[agent]]
+id = "engineer"
+role = "Engineer"
+delegates_to = ["research_desk"]
+
+[[agent]]
+id = "researcher"
+role = "Researcher"
+delegates_to = ["design_desk"]
+
+[[agent]]
+id = "designer"
+role = "Designer"
+
+[[group_chat]]
+id = "eng_desk"
+name = "Engineering"
+members = ["engineer"]
+
+[[group_chat]]
+id = "research_desk"
+name = "Research"
+members = ["researcher"]
+
+[[group_chat]]
+id = "design_desk"
+name = "Design"
+members = ["designer"]
+"#,
+        )
+        .expect("valid manifest");
+        CompanyRecord {
+            manifest,
+            ..record()
+        }
+    }
+
+    /// The hand-off the engineering lead makes one level down (issue #176).
+    fn nested_handoff(instruction: &str) -> Delegation {
+        Delegation::DelegateToDesk {
+            desk: "research_desk".to_string(),
+            instruction: instruction.to_string(),
+        }
+    }
+
     /// The wired pieces one drain needs: the company record, a real task store
     /// over a temp dir, the shared queue, and the steer registry.
     struct Fixture {
@@ -2208,11 +2428,21 @@ members = ["engineer"]
 
     impl Fixture {
         fn new() -> Self {
+            Self::over(record())
+        }
+
+        /// A fixture over a three-desk roster whose leads may re-delegate
+        /// (issue #176).
+        fn nested() -> Self {
+            Self::over(nested_record())
+        }
+
+        fn over(record: CompanyRecord) -> Self {
             let dir = tempfile::tempdir().expect("tempdir");
             Self {
                 tasks: Arc::new(FsOps::new(dir.path())) as Arc<dyn TaskStore>,
                 _dir: dir,
-                record: record(),
+                record,
                 queue: DelegationQueue::default(),
                 steer: InflightRegistry::default(),
                 approvals: ApprovalRequestQueue::default(),
@@ -3261,6 +3491,350 @@ members = ["engineer"]
         assert!(
             fx.cards().await.is_empty(),
             "a dropped hand-off opens no card either"
+        );
+    }
+
+    // ── Issue #176: recursive desk-member delegation ────────────────────────
+
+    /// The whole point of the slice: a desk lead handed work by the
+    /// orchestrator hands a slice on to a second desk, that second lead's turn
+    /// really runs, and its answer arrives folded into the first lead's reply
+    /// rather than lost.
+    ///
+    /// Without the nested drain this is #453's failure one level down — the
+    /// member's tool told it the hand-off "will be answered this turn", the
+    /// delegation sat in the queue, and the next `clear()` destroyed it while
+    /// the member reported it as done.
+    ///
+    /// `Turn::tooling`, not `Turn::queueing`: the escape hatch bypasses
+    /// `push_within_cap` entirely and would assert nothing about the gate the
+    /// depth bound lives on.
+    #[tokio::test]
+    async fn a_desk_lead_can_hand_a_slice_on_and_the_answer_comes_back() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                // 0 — the orchestrator hands the work to engineering.
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                // 1 — the engineering lead does its part and hands a slice on.
+                Turn::tooling(
+                    "I built it; asking research about the rate limits",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                // 2 — the research lead answers.
+                Turn::reply("everyone lands around 100 rps"),
+                // 3 — the CEO relay.
+                Turn::reply("Built, and research says ~100 rps is the norm."),
+            ],
+        );
+
+        let out = fx
+            .runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            4,
+            "four turns: chief, engineer, researcher, relay: {calls:?}"
+        );
+        assert_eq!(calls[1].0, "engineer", "{calls:?}");
+        assert_eq!(
+            calls[2].0, "researcher",
+            "the nested hand-off must actually run the second lead's turn: {calls:?}"
+        );
+        assert_eq!(calls[3].0, "chief", "{calls:?}");
+        assert_eq!(
+            turns.staged(),
+            vec![orchestrator::Staged::Queued, orchestrator::Staged::Queued],
+            "both hand-offs passed the tool boundary"
+        );
+
+        // The nested answer reaches the relay folded into the engineer's reply,
+        // attributed to who said it and who asked them — one bubble, not two.
+        let relay_prompt = &calls[3].1;
+        assert!(
+            relay_prompt.contains("everyone lands around 100 rps"),
+            "the nested answer must reach the relay: {relay_prompt}"
+        );
+        assert!(
+            relay_prompt.contains("researcher (delegated by engineer) replied"),
+            "the fold must name both ends of the chain: {relay_prompt}"
+        );
+        assert_eq!(
+            out.reply, "Built, and research says ~100 rps is the norm.",
+            "the operator still gets ONE coherent answer from the relay"
+        );
+
+        // The card the hand-off opened is settled from the folded reply, so the
+        // board carries the nested answer too.
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(cards[0].assignee, "engineer", "{cards:?}");
+        assert!(
+            cards[0]
+                .note
+                .as_deref()
+                .unwrap_or_default()
+                .contains("everyone lands around 100 rps"),
+            "the nested answer must be on the card note: {:?}",
+            cards[0].note
+        );
+    }
+
+    /// The bound bites in the MEMBER'S OWN TURN, and the third lead never runs.
+    ///
+    /// Under `max_delegation_depth = 1` — the "recursion off" setting, and the
+    /// pre-#176 behaviour exactly — the engineering lead's hand-off is refused
+    /// at the tool boundary with the new reason, so no second desk turn happens
+    /// at all.
+    #[tokio::test]
+    async fn a_hand_off_past_the_depth_bound_is_refused_and_never_runs() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                Turn::tooling(
+                    "asking research",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                Turn::reply("Done, though I could not consult research."),
+            ],
+        )
+        .with_max_depth(1);
+
+        fx.runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::NoDrain(orchestrator::NoDrainReason::Depth),
+            ],
+            "the member's hand-off must be refused in its own turn, as depth-capped"
+        );
+        let calls = turns.calls();
+        assert_eq!(
+            calls.len(),
+            3,
+            "chief, engineer, relay — the researcher must never run: {calls:?}"
+        );
+        assert!(
+            calls.iter().all(|(agent, _)| agent != "researcher"),
+            "{calls:?}"
+        );
+    }
+
+    /// The per-turn fan-out cap applies at **every** level, and needs no new
+    /// code to do so: the outer drain moves its items into a local vector
+    /// before running any of them, so a member's turn starts against an empty
+    /// queue and gets the whole cap to itself — and its fourth push is refused.
+    ///
+    /// Pinned because "the cap is per turn" is an emergent property of how the
+    /// drain is written, not something stated anywhere. A refactor that drained
+    /// lazily would silently make the cap per *message* and this is what would
+    /// catch it.
+    #[tokio::test]
+    async fn the_fan_out_cap_applies_at_every_level() {
+        let fx = Fixture::nested();
+        let card = |n: u32| Delegation::SpawnTask {
+            title: format!("follow-up {n}"),
+            note: None,
+            assignee: None,
+        };
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                // The member gets the FULL cap of its own, and one more is
+                // refused.
+                Turn::tooling(
+                    "built it, opening follow-ups",
+                    vec![card(1), card(2), card(3), card(4)],
+                ),
+                Turn::reply("Shipped."),
+            ],
+        );
+
+        fx.runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turns.staged(),
+            vec![
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::Queued,
+                orchestrator::Staged::OverCap,
+            ],
+            "the member's own turn gets the full per-turn cap, and no more"
+        );
+        // Three follow-up cards from the member, plus the hand-off's own card.
+        let mut titles: Vec<String> = fx.cards().await.into_iter().map(|c| c.title).collect();
+        titles.sort();
+        assert_eq!(titles.len(), 4, "{titles:?}");
+        assert!(
+            titles.contains(&"follow-up 3".to_string())
+                && !titles.contains(&"follow-up 4".to_string()),
+            "{titles:?}"
+        );
+    }
+
+    /// A cancelled NESTED run folds in as a cancellation, never as a reply.
+    ///
+    /// The member said it was handing that slice on; an answer that silently
+    /// omits the branch is the confident falsehood the whole delegation stack
+    /// exists to prevent.
+    #[tokio::test]
+    async fn a_cancelled_nested_run_folds_in_as_a_cancellation() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                Turn::tooling("handing it to engineering", vec![handoff("ship the API")]),
+                Turn::tooling(
+                    "asking research",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                Turn::cancelled("(discarded)"),
+                Turn::reply("Built; the research question was stopped."),
+            ],
+        );
+
+        fx.runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let calls = turns.calls();
+        assert_eq!(calls.len(), 4, "{calls:?}");
+        let relay_prompt = &calls[3].1;
+        assert!(
+            relay_prompt.contains("was cancelled before it replied"),
+            "a cancelled branch must be named, not omitted: {relay_prompt}"
+        );
+        assert!(
+            !relay_prompt.contains("(discarded)"),
+            "a cancelled run's text must NEVER be folded in as a reply: {relay_prompt}"
+        );
+    }
+
+    /// A hand-off the MEMBER's own tool refused reaches the card and the
+    /// operator, attributed to the member that attempted it.
+    ///
+    /// A refusal never becomes a `Delegation`, so the only other record is the
+    /// tool result — which the member is free to describe however it likes, and
+    /// "I consulted design" is exactly the claim that must not stand unchecked.
+    /// The delegator's own unread refusals must NOT be swept into the member's
+    /// account of its turn, which is what the before/after sampling buys.
+    #[tokio::test]
+    async fn a_refusal_inside_a_members_turn_is_recorded_against_that_member() {
+        let fx = Fixture::nested();
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                // The orchestrator hands off AND has a refusal of its own,
+                // which belongs to its turn and must not be folded into the
+                // member's account of theirs.
+                Turn {
+                    reply: "handing it to engineering".to_string(),
+                    tool_pushes: vec![handoff("ship the API")],
+                    refuses: vec!["nowhere_desk".to_string()],
+                    ..Turn::default()
+                },
+                // The member reaches for a desk it may not have — refused.
+                Turn::refused("built it; design did not pick it up", &["design_desk"]),
+                Turn::reply("Shipped."),
+            ],
+        );
+
+        fx.runner(&turns)
+            .handle_operator_message("chief", "ship the API", Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        let note = cards[0].note.clone().unwrap_or_default();
+        assert!(
+            note.contains("design_desk") && note.contains("refused"),
+            "the member's refused hand-off must reach the card: {note}"
+        );
+        assert!(
+            !note.contains("nowhere_desk"),
+            "the delegator's own unread refusal must not be attributed to the member: {note}"
+        );
+    }
+
+    /// On the DISPATCHED-card path the card stays owned by the level-1 member
+    /// the orchestrator handed it to — nested delegation is visible in the note
+    /// and the steps, not by the card changing hands again.
+    #[tokio::test]
+    async fn a_dispatched_card_stays_with_the_level_one_member() {
+        let fx = Fixture::nested();
+        let mut card = TaskRecord {
+            id: "card-1".to_string(),
+            title: "Ship the API".to_string(),
+            note: None,
+            column: COLUMN_TODO.to_string(),
+            priority: "medium".to_string(),
+            assignee: "chief".to_string(),
+            updated_at_millis: now_millis(),
+            origin_chat_id: None,
+            parent_task_id: None,
+            output: None,
+            plan: None,
+            deliverable: crate::ports::tasks::TaskDeliverable::Once,
+            workflow_proposal: None,
+        };
+        fx.tasks.upsert(&fx.record.id, &card).await.expect("seed");
+
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![
+                // The engineering lead's turn, run by the dispatched card.
+                Turn::tooling(
+                    "asking research",
+                    vec![nested_handoff("what rate limits do competitors use?")],
+                ),
+                Turn::reply("everyone lands around 100 rps"),
+            ],
+        );
+        // The dispatched turn's own delegations are staged by the orchestrator
+        // before this, so the queue is claimed the way `run_task` claims it.
+        let _claim = fx.queue.claim();
+        fx.queue.push(handoff("ship the API"));
+
+        let handed = fx
+            .runner(&turns)
+            .for_task("card-1")
+            .handle_task_delegations(&mut card, "chief")
+            .await
+            .expect("delegations drained")
+            .expect("a hand-off happened");
+
+        assert_eq!(
+            handed.delegate, "engineer",
+            "the card belongs to the member the ORCHESTRATOR handed it to"
+        );
+        let reply = handed.reply.expect("the level-1 member answered");
+        assert!(
+            reply.contains("researcher (delegated by engineer) replied"),
+            "the nested answer rides on the level-1 member's reply: {reply}"
+        );
+        assert_eq!(
+            card.assignee, "engineer",
+            "nested delegation must not move the card a second time"
         );
     }
 }

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -19,7 +19,20 @@
 //!   [`delegation`](crate::runtime::delegation) module so the hosted path can
 //!   resolve a desk's lead without the `openhuman` feature);
 //! - the argument parsers ([`SpawnTaskArgs`], [`DelegateArgs`]) the host uses
-//!   to service a `spawn_task` / `delegate_to_desk` tool-call frame.
+//!   to service a `spawn_task` / `delegate_to_desk` tool-call frame;
+//! - the hand-off **target checks** — [`reject_desk_target`] (issue #272) and,
+//!   since the recursive-delegation slice, [`reject_cycle_target`] and
+//!   [`reject_out_of_allowlist_target`] (issue #176). Each returns the refusal
+//!   as an `Option<String>` rather than rejecting in place, so the harness tool
+//!   can turn it into a `ToolResult::error` and the hosted device-side handler
+//!   into a failed tool frame, from one definition.
+//!
+//! What is *not* here is the enforcement of delegation **depth**. That lives on
+//! the harness [`DelegationQueue`](crate::harness::orchestrator::DelegationQueue),
+//! because only the harness runs a desk member's turn at all: the hosted path
+//! services delegation tools solely for the orchestrator's own cycle and writes
+//! a durable card, so its chain is always empty. The definitions above are
+//! brain-agnostic; the recursion they guard is not.
 //!
 //! Compiled in every build (no feature gate): the hosted brain is in the
 //! default build, and the harness path re-exports from here.
@@ -223,6 +236,109 @@ on is \"{desk}\". Valid desk ids: {list}."
 Valid desk ids: {list}."
         ),
     }
+}
+
+/// Why a **desk member's** `delegate_to_desk` call would close a loop rather
+/// than make progress — or `None` when the target is a step forward (issue
+/// #176).
+///
+/// Two shapes, both of which the depth cap alone would let run to its bound
+/// while producing nothing:
+///
+/// * **Back up the chain** — the target desk is already executing somewhere
+///   above this turn (`chain` is the scope chain, outermost first). A→B→A is the
+///   loop the issue names; the desk that handed this work out cannot be the desk
+///   it is handed back to.
+/// * **Back to itself** — the target desk's lead *is* the member calling. Its
+///   own turn is the one running; handing work to itself would re-enter it a
+///   level deeper to do what it is already doing.
+///
+/// Identity here is the **resolved desk id**, deliberately, on both sides. That
+/// is what `delegate_to_desk` already validates and what the chain records, and
+/// an agent-keyed visited set would false-positive on the perfectly ordinary
+/// company where one strong teammate leads two desks — refusing a real hand-off
+/// to a second, different desk. The self-lead arm is the one place an *agent*
+/// identity is compared, and only against the immediate caller.
+///
+/// The depth cap, not this, is the real runaway bound; this is what keeps a
+/// bounded chain from spending its whole budget going in a circle, and what
+/// keeps the guard honest if the cap is ever raised.
+pub fn reject_cycle_target(
+    record: &CompanyRecord,
+    chain: &[String],
+    key: &str,
+    delegator: &str,
+) -> Option<String> {
+    // An unresolvable key is `reject_desk_target`'s refusal to give, not this
+    // one's: saying "that would loop" about a desk that does not exist would
+    // send the model looking for a cycle it cannot find.
+    let desk_id = record.resolve_desk_id(key)?;
+    if chain.iter().any(|scoped| scoped == &desk_id) {
+        let trail = chain.join(" → ");
+        return Some(format!(
+            "The \"{desk_id}\" desk is already working on this — it is where the work came from \
+({trail}). Handing it back would loop. Do the part you can do yourself, or hand it to a desk \
+that is not already on that list."
+        ));
+    }
+    if desk_lead(record, &desk_id).as_deref() == Some(delegator) {
+        return Some(format!(
+            "You lead the \"{desk_id}\" desk, so handing this to it would hand it back to \
+yourself. Do it in this turn instead, or hand it to a different desk."
+        ));
+    }
+    None
+}
+
+/// Why a **desk member's** `delegate_to_desk` target is outside what its
+/// manifest entry permits — or `None` when the member may reach it (issue #176).
+///
+/// `allowed` is the member's
+/// [`delegates_to`](crate::company::Agent::delegates_to) list, whose entries are
+/// desk ids or names; [`DELEGATES_TO_WILDCARD`] admits every desk. Both sides
+/// are resolved to desk ids before comparison, so an allowlist written with
+/// display names and a call made with an id agree.
+///
+/// The refusal **names the desks the member may reach**, because the model has
+/// no other way to learn its own allowlist: the tool schema is shared with the
+/// orchestrator's unrestricted copy, and a bare "not allowed" costs a turn per
+/// guess. Retryable in the same turn, unlike the depth and no-drain refusals.
+///
+/// Never reached with an empty `allowed`: an empty allowlist means the tool was
+/// not wired at all. It still fails closed if one ever arrives — nothing
+/// resolves, so everything is refused.
+///
+/// [`DELEGATES_TO_WILDCARD`]: crate::company::DELEGATES_TO_WILDCARD
+pub fn reject_out_of_allowlist_target(
+    record: &CompanyRecord,
+    allowed: &[String],
+    key: &str,
+) -> Option<String> {
+    if allowed
+        .iter()
+        .any(|entry| entry.trim() == crate::company::DELEGATES_TO_WILDCARD)
+    {
+        return None;
+    }
+    // As above: an unresolvable key belongs to `reject_desk_target`.
+    let desk_id = record.resolve_desk_id(key)?;
+    let permitted: Vec<String> = allowed
+        .iter()
+        .filter_map(|entry| record.resolve_desk_id(entry.trim()))
+        .collect();
+    if permitted.contains(&desk_id) {
+        return None;
+    }
+    Some(match desk_list(permitted) {
+        Some(list) => format!(
+            "You may not hand work to the \"{desk_id}\" desk. The desks you can hand work to are: \
+{list}. Call `delegate_to_desk` again with one of those, or do the work yourself."
+        ),
+        None => format!(
+            "You may not hand work to the \"{desk_id}\" desk, and there is no other desk you can \
+hand work to either. Do the work yourself, or say what you cannot do."
+        ),
+    })
 }
 
 /// The first desk `member` is on, so an invented teammate-as-desk target can be
@@ -451,6 +567,99 @@ members = ["counsel"]
         let list = desk_list(ids).expect("non-empty");
         assert!(list.ends_with("(+3 more)"), "{list}");
         assert_eq!(desk_list(Vec::new()), None);
+    }
+
+    // --- Recursive-delegation target checks (issue #176) -------------------
+
+    /// The A→B→A loop the issue names: a desk already on the chain cannot be
+    /// handed the work back.
+    #[test]
+    fn a_desk_already_on_the_chain_is_refused_as_a_cycle() {
+        let record = record();
+        let chain = vec!["engineering".to_string()];
+        let message =
+            reject_cycle_target(&record, &chain, "engineering", "writer").expect("rejected");
+        assert!(message.contains("engineering"), "{message}");
+        assert!(message.contains("loop"), "{message}");
+        // A desk that is NOT on the chain is a step forward.
+        assert_eq!(reject_cycle_target(&record, &chain, "content", "ceo"), None);
+        // The id-or-name key `resolve_desk_id` accepts is checked identically —
+        // a cycle written with the display name is still a cycle.
+        assert!(reject_cycle_target(&record, &chain, "Engineering desk", "writer").is_some());
+    }
+
+    /// Handing work to the desk you lead is handing it to yourself.
+    #[test]
+    fn a_desk_the_caller_leads_is_refused_as_self_delegation() {
+        let record = record();
+        // `writer` leads `content`.
+        let message = reject_cycle_target(&record, &[], "content", "writer").expect("rejected");
+        assert!(message.contains("yourself"), "{message}");
+        // Somebody who does NOT lead it may hand work to it.
+        assert_eq!(reject_cycle_target(&record, &[], "content", "ceo"), None);
+    }
+
+    /// An unresolvable key belongs to `reject_desk_target`, not to either of
+    /// the #176 checks — otherwise an invented desk would be reported as a
+    /// cycle or an allowlist miss and the model would go looking for the wrong
+    /// mistake.
+    #[test]
+    fn an_unknown_desk_is_left_to_the_grounding_check() {
+        let record = record();
+        assert_eq!(reject_cycle_target(&record, &[], "nowhere", "ceo"), None);
+        assert_eq!(
+            reject_out_of_allowlist_target(&record, &["content".into()], "nowhere"),
+            None
+        );
+        // …and it IS refused by the check that owns it.
+        assert!(reject_desk_target(&record, "nowhere").is_some());
+    }
+
+    /// The allowlist refusal must name what the member CAN reach: the model has
+    /// no other way to learn its own `delegates_to`.
+    #[test]
+    fn an_out_of_allowlist_desk_is_refused_with_the_permitted_set() {
+        let record = record();
+        let allowed = vec!["content".to_string()];
+        let message =
+            reject_out_of_allowlist_target(&record, &allowed, "engineering").expect("rejected");
+        assert!(message.contains("engineering"), "{message}");
+        assert!(message.contains("content"), "{message}");
+        // The permitted desk itself passes, by id and by display name.
+        assert_eq!(
+            reject_out_of_allowlist_target(&record, &allowed, "content"),
+            None
+        );
+        assert_eq!(
+            reject_out_of_allowlist_target(&record, &allowed, "Content desk"),
+            None
+        );
+        // …and an allowlist written with display names admits the id.
+        let by_name = vec!["Content desk".to_string()];
+        assert_eq!(
+            reject_out_of_allowlist_target(&record, &by_name, "content"),
+            None
+        );
+    }
+
+    /// `"*"` admits every desk; an empty allowlist admits none (fail-closed —
+    /// though the tool is never wired in that state).
+    #[test]
+    fn the_wildcard_admits_every_desk_and_an_empty_allowlist_admits_none() {
+        let record = record();
+        let wildcard = vec!["*".to_string()];
+        for desk in ["engineering", "content", "legal"] {
+            assert_eq!(
+                reject_out_of_allowlist_target(&record, &wildcard, desk),
+                None,
+                "`*` must admit {desk}"
+            );
+        }
+        let message = reject_out_of_allowlist_target(&record, &[], "content").expect("rejected");
+        assert!(
+            message.contains("no other desk"),
+            "an empty allowlist must say so rather than offer an empty list: {message}"
+        );
     }
 
     #[test]

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -561,7 +561,9 @@ mod test {
         // because `hardening_flags()` prepends its own `-c` arguments ahead of
         // it in the argv.
         let original_path = std::env::var("PATH").unwrap_or_default();
-        std::env::set_var("PATH", format!("{}:{original_path}", bin.display()));
+        // SAFETY: a single-threaded test lifetime; we restore the variable on
+        // every exit path below. Edition-2024 marks this unsafe.
+        unsafe { std::env::set_var("PATH", format!("{}:{original_path}", bin.display())) };
 
         // A 500ms deadline against a 60s sleep is a ~120x margin, not a race.
         let err = run_bounded(

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -512,42 +512,72 @@ mod test {
         std::fs::remove_dir_all(&base).ok();
     }
 
-    #[tokio::test(start_paused = true)]
+    #[tokio::test]
     async fn a_git_that_overruns_its_deadline_is_stopped_and_reported() {
-        // Virtual time, not a zero deadline racing a real process.
+        // Drive the deadline against a git that deterministically blocks, not a
+        // real `git version` under virtual time. `tokio::time::timeout` polls
+        // its inner future first and only consults the deadline once that future
+        // returns `Pending`; a fast `git version` finished and had its output
+        // buffered before the first `Pending`, so the old `start_paused` version
+        // returned `Ok` — exactly what failed on Linux CI. Auto-advancing the
+        // clock does not help while the runtime is still waiting on a real
+        // child's I/O, so the deadline never reached the timeout arm reliably.
         //
-        // `tokio::time::timeout` polls its inner future first and only consults
-        // the deadline when that future returns `Pending`. `git version` can
-        // finish and have its output buffered before the first `Pending`, so a
-        // `Duration::ZERO` deadline returns `Ok` — which is exactly what
-        // happened on Linux CI while passing locally. The old comment here
-        // claimed determinism the code did not have.
-        //
-        // Under `start_paused` the clock is virtual and auto-advances whenever
-        // the runtime has nothing ready, which is precisely the state it is in
-        // while waiting on a real child's I/O. The deadline therefore fires on
-        // the first idle rather than on a stopwatch, and no wall-clock second
-        // is actually spent.
-        //
-        // What this proves is the shape of the timeout arm — the error an
-        // operator sees, and that the child is dropped (and so reaped, by
-        // `kill_on_drop`) rather than leaked. It does not, and cannot cheaply,
-        // prove the kill against a remote that really hangs; that is what the
-        // deadline exists for.
+        // So this test puts a fake `git` on `PATH` whose only special case is to
+        // block, checks that the deadline arm fires, and relies on `kill_on_drop`
+        // to reap the child instead of leaking it. The fake delegates everything
+        // else to the real git, so its presence on `PATH` cannot perturb sibling
+        // tests running concurrently in the same binary.
         let base = std::env::temp_dir().join(format!("oc-gittimeout-{}", std::process::id()));
         std::fs::create_dir_all(&base).unwrap();
+
+        let real_git = std::process::Command::new("sh")
+            .arg("-c")
+            .arg("command -v git")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .expect("real git must be on PATH");
+        let bin = base.join("bin");
+        std::fs::create_dir_all(&bin).unwrap();
+        let fake_git = bin.join("git");
+        std::fs::write(
+            &fake_git,
+            format!(
+                "#!/bin/sh\ncase \" $* \" in\n  *\" __deadline__ \"*) sleep 60;;\nesac\nexec {real_git} \"$@\"\n"
+            ),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        // `run_bounded` rebuilds the child environment from this process's, so a
+        // test-local `PATH` prepend is enough to route `git` to the fake for the
+        // duration of the run. The marker still reaches the fake's `$*` scan
+        // because `hardening_flags()` prepends its own `-c` arguments ahead of
+        // it in the argv.
+        let original_path = std::env::var("PATH").unwrap_or_default();
+        std::env::set_var("PATH", format!("{}:{original_path}", bin.display()));
+
+        // A 500ms deadline against a 60s sleep is a ~120x margin, not a race.
         let err = run_bounded(
             &base,
-            &["version"],
+            &["__deadline__"],
             None,
             None,
-            std::time::Duration::from_secs(300),
+            std::time::Duration::from_millis(500),
         )
         .await
         .unwrap_err()
         .to_string();
         assert!(err.contains("did not finish"), "{err}");
         assert!(err.contains("was stopped"), "{err}");
+
+        std::env::set_var("PATH", original_path);
         std::fs::remove_dir_all(&base).ok();
     }
 

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -579,7 +579,7 @@ mod test {
         assert!(err.contains("did not finish"), "{err}");
         assert!(err.contains("was stopped"), "{err}");
 
-        std::env::set_var("PATH", original_path);
+        unsafe { std::env::set_var("PATH", original_path) };
         std::fs::remove_dir_all(&base).ok();
     }
 

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -545,7 +545,12 @@ mod test {
         std::fs::write(
             &fake_git,
             format!(
-                "#!/bin/sh\ncase \" $* \" in\n  *\" __deadline__ \"*) sleep 60;;\nesac\nexec {real_git} \"$@\"\n"
+                // `exec sleep`, not `sleep`: `kill_on_drop` stops the direct
+                // child and nothing below it, so a plain `sleep` outlives the
+                // shell that spawned it and keeps running for its full minute
+                // after the deadline arm has fired. Replacing the shell makes
+                // the blocking process the one Tokio holds.
+                "#!/bin/sh\ncase \" $* \" in\n  *\" __deadline__ \"*) exec sleep 60;;\nesac\nexec {real_git} \"$@\"\n"
             ),
         )
         .unwrap();

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -285,12 +285,21 @@ pub(crate) async fn run(
     token: Option<&str>,
     askpass: Option<&AskpassDir>,
 ) -> Result<GitOutput> {
-    run_bounded(cwd, args, token, askpass, GIT_TIMEOUT).await
+    run_bounded(Path::new("git"), cwd, args, token, askpass, GIT_TIMEOUT).await
 }
 
-/// [`run`], with the deadline supplied. Separate only so the timeout path is
-/// reachable from a test without one taking [`GIT_TIMEOUT`] to run.
+/// [`run`], with the program and the deadline supplied. Separate only so the
+/// timeout path is reachable from a test without one taking [`GIT_TIMEOUT`] to
+/// run, and against a program that blocks on purpose.
+///
+/// `program` is `git` for every caller but that test. It is a parameter rather
+/// than something the test arranges on `PATH`, because `PATH` is process-global:
+/// `std::env::set_var` races every other test in the binary reading the
+/// environment (which is why edition 2024 marks it `unsafe`), and a panic
+/// between the set and the restore would leave the fake in place for whatever
+/// ran next.
 async fn run_bounded(
+    program: &Path,
     cwd: &Path,
     args: &[&str],
     token: Option<&str>,
@@ -298,7 +307,7 @@ async fn run_bounded(
     limit: std::time::Duration,
 ) -> Result<GitOutput> {
     let plan = SpawnPlan::build(args, askpass);
-    let mut cmd = tokio::process::Command::new("git");
+    let mut cmd = tokio::process::Command::new(program);
     cmd.current_dir(cwd);
     cmd.args(&plan.args);
     // Start from nothing, then add back only what git needs. Building the
@@ -523,55 +532,30 @@ mod test {
         // clock does not help while the runtime is still waiting on a real
         // child's I/O, so the deadline never reached the timeout arm reliably.
         //
-        // So this test puts a fake `git` on `PATH` whose only special case is to
-        // block, checks that the deadline arm fires, and relies on `kill_on_drop`
-        // to reap the child instead of leaking it. The fake delegates everything
-        // else to the real git, so its presence on `PATH` cannot perturb sibling
-        // tests running concurrently in the same binary.
+        // So this test hands `run_bounded` a program whose whole job is to
+        // block, and checks that the deadline arm fires. The program is passed
+        // in rather than arranged on `PATH`: `PATH` is process-global, every
+        // sibling test in this binary reads the environment while this one runs,
+        // and a panic before the restore would leave the fake in place for
+        // whatever ran next.
         let base = std::env::temp_dir().join(format!("oc-gittimeout-{}", std::process::id()));
         std::fs::create_dir_all(&base).unwrap();
 
-        let real_git = std::process::Command::new("sh")
-            .arg("-c")
-            .arg("command -v git")
-            .output()
-            .ok()
-            .and_then(|o| String::from_utf8(o.stdout).ok())
-            .map(|s| s.trim().to_string())
-            .expect("real git must be on PATH");
-        let bin = base.join("bin");
-        std::fs::create_dir_all(&bin).unwrap();
-        let fake_git = bin.join("git");
-        std::fs::write(
-            &fake_git,
-            format!(
-                // `exec sleep`, not `sleep`: `kill_on_drop` stops the direct
-                // child and nothing below it, so a plain `sleep` outlives the
-                // shell that spawned it and keeps running for its full minute
-                // after the deadline arm has fired. Replacing the shell makes
-                // the blocking process the one Tokio holds.
-                "#!/bin/sh\ncase \" $* \" in\n  *\" __deadline__ \"*) exec sleep 60;;\nesac\nexec {real_git} \"$@\"\n"
-            ),
-        )
-        .unwrap();
+        // `exec sleep`, not `sleep`: `kill_on_drop` stops the direct child and
+        // nothing below it, so a shell-spawned `sleep` outlives the deadline arm
+        // and keeps running for its full minute. Replacing the shell makes the
+        // blocking process the one Tokio holds.
+        let fake_git = base.join("blocking-git");
+        std::fs::write(&fake_git, "#!/bin/sh\nexec sleep 60\n").unwrap();
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
             std::fs::set_permissions(&fake_git, std::fs::Permissions::from_mode(0o755)).unwrap();
         }
 
-        // `run_bounded` rebuilds the child environment from this process's, so a
-        // test-local `PATH` prepend is enough to route `git` to the fake for the
-        // duration of the run. The marker still reaches the fake's `$*` scan
-        // because `hardening_flags()` prepends its own `-c` arguments ahead of
-        // it in the argv.
-        let original_path = std::env::var("PATH").unwrap_or_default();
-        // SAFETY: a single-threaded test lifetime; we restore the variable on
-        // every exit path below. Edition-2024 marks this unsafe.
-        unsafe { std::env::set_var("PATH", format!("{}:{original_path}", bin.display())) };
-
         // A 500ms deadline against a 60s sleep is a ~120x margin, not a race.
         let err = run_bounded(
+            &fake_git,
             &base,
             &["__deadline__"],
             None,
@@ -584,7 +568,6 @@ mod test {
         assert!(err.contains("did not finish"), "{err}");
         assert!(err.contains("was stopped"), "{err}");
 
-        unsafe { std::env::set_var("PATH", original_path) };
         std::fs::remove_dir_all(&base).ok();
     }
 

--- a/src/runtime/repo_manager/git.rs
+++ b/src/runtime/repo_manager/git.rs
@@ -521,6 +521,12 @@ mod test {
         std::fs::remove_dir_all(&base).ok();
     }
 
+    // Unix-only by construction: it hands `run_bounded` a `/bin/sh` script to
+    // execute, which `Command::new` cannot spawn on Windows (no script
+    // interpreter), and marks it executable with a `chmod`. The whole test
+    // carries the gate the script's chmod already did, so a Windows lane does
+    // not build a test that can never pass there.
+    #[cfg(unix)]
     #[tokio::test]
     async fn a_git_that_overruns_its_deadline_is_stopped_and_reported() {
         // Drive the deadline against a git that deterministically blocks, not a


### PR DESCRIPTION
## Summary

Implements the **recursive desk-member delegation depth** half of #176. A desk lead handed work via `delegate_to_desk` could not hand a slice one level further: delegation tools were wired only onto the orchestrator, and the "depth cap = 1" invariant from #178 was pinned by test. A member with a declared `delegates_to` now gets exactly two hand-off tools, bounded by depth, a cycle guard, and a per-member allowlist.

Two constraints in the codebase forced the design, and they are worth stating because they rule out the obvious alternatives:

**Belts are cached per roster** (`HarnessPool::ensure` is fingerprinted and rebuilt rarely), so member tools must be wired *statically* while depth is enforced *dynamically* at the tool boundary. **The only shared state a member's tool can reach at call time is the `DelegationQueue` handle it was built with** — so the scope chain lives on the queue, not on `MessageContext` (the member's tool never sees one), not on the task record (async hops are already operator-gated), and not on the runner.

Depth **is** `chain.len()` — one source of truth, so there is no counter to drift out of sync with the chain it describes.

## API Or Behavior Changes

- **Manifest gains two keys.** `Agent.delegates_to` (desk ids, `"*"` wildcard, serde-default **empty**) and `Tools.max_delegation_depth` (default **2** = orchestrator → lead → member, validated `1..=4`). Empty `delegates_to` means no delegation tools, so **every existing manifest keeps today's behaviour exactly**. The field is both the enable switch and the capability budget. `max_delegation_depth = 1` is the "recursion off" config gate the issue asks for. Modelled on OpenHuman's `AgentDefinition.subagents` — "tools is what I execute, subagents is what I can delegate to" — but addressed by **desk**, since desks are OpenCompany's delegation address space. Deliberately *not* folded into the `tools` grant vocabulary, which feeds `CapabilityFilter` namespace math.
- **`NoDrainReason::Depth`** (`"depth_capped"`), refused at `push_within_cap`. The enum's match sites are wildcard-free, so a new variant is a compile-driven sweep rather than a silent fall-through — composing with #267's machinery instead of duplicating it.
- **`SpawnTask` is not depth-refused.** It opens a To-do card and runs no synchronous turn; refusing it would push members to work silently instead of tracking. Hand-offs are what the cap bounds.
- **Cycle guard is keyed on resolved desk ids**, not agents — A→B→A on desks is the loop the issue names, and an agent-keyed set would false-positive on one agent legitimately leading two desks.
- **The fan-out cap needed no new code**: the outer drain moves items into a local Vec before executing, so the queue is empty when each member's turn starts and the existing per-turn cap applies at every level. Pinned by test rather than assumed.
- **Cross-brain, precisely:** definitions (manifest field, refusal helpers, messages) are brain-agnostic and compile in every build; live enforcement is harness-only, because only the harness runs member turns. The hosted path services delegation tools solely for the orchestrator's own cycle as a durable async card, so depth there is always 0 and **`cycle.rs` needed no change**.
- **A member's hand-off fails closed when its target cannot be grounded** (review round 1). `DelegateToDeskTool::ground` is where the allowlist and the cycle guard are checked, and the drain (`run_delegation`) executes what the queue holds without re-deriving either — so a company record that could not be read widened a member to the orchestrator's unrestricted reach until the store recovered. Both the `Ok(None)` and the `Err` arm now refuse for a member: nothing is queued, and the attempt is still recorded via `push_refusal` so the card carries it. The orchestrator's copy still fails **open** — it has no allowlist to lose, and a store hiccup must not take delegation offline.

**Deviations from the plan, both deliberate:**

1. `orchestrator.rs` landed as **one commit** rather than a queue/tool split. The split produces a non-compiling intermediate: `DelegateToDeskTool`'s `push_within_cap` call needs the new third argument, whose value comes from the tool's own record read. A broken bisect point is worse than a larger commit.
2. Added **`refusals_queued` / `drain_refusals_after`** beyond the plan, so a nested refusal is attributed to the member that made it instead of being swept up with whatever its delegator left unread.

**Verified, not assumed:** nothing auto-promotes To-do → In-Progress. `COLUMN_PLANNING` is only written by an operator dragging a card, and the Planning→In-Progress promotion fires off that edge. That is what makes "async card chains need no depth-seeding" true — every async hop has an operator or orchestrator gate, so there is no unbounded automation path.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test --locked` — **2214 passed, 0 failed** (lib)
- [x] `cargo test --features openhuman,mcp,telegram` — **3329 passed, 0 failed** (lib), 11/0 `one_card_per_message`, 2/0 `product_identity`

Coverage splits by lane, and the split is worth knowing: `company::manifest` and `runtime::delegation_tools` tests are **default-build and run in CI**. Everything in `harness::orchestrator`, `harness::build` and `runtime::delegation` compiles **only** under `openhuman,mcp,telegram` — and **no CI lane builds that combo**, so those were run locally and are reported as such rather than implied.

**Teeth proven, with the observed failures:**

```
remove the depth gate:
  push_within_cap_refuses_a_hand_off_past_the_depth_bound
    left: Queued   right: NoDrain(Depth)
  a_hand_off_past_the_depth_bound_is_refused_and_never_runs
    unscripted turn: chief <- …        (the third lead runs and eats the relay's turn)

replace the nested drain with Drained::default():
  three tests fail, incl.
    four turns: chief, engineer, researcher, relay …   left: 3  right: 4
```

Round 1 added `a_members_hand_off_is_refused_when_the_record_cannot_be_read`, covering the missing-record arm, the store-error arm, and the orchestrator's fail-open contrast. Teeth: forcing the helper back to unconditional fail-open turns it red on the real tool output — `a member may not be queued against a record nobody could read: Delegated to the research desk. Its lead will answer this turn.`

Both reverts restored. Every nested/depth test uses `Turn::tooling`, never `Turn::queueing` — the latter bypasses `push_within_cap`, so a gate test written on it would assert nothing about the gate. Added `Turn::refused`, because a refusal never becomes a `Delegation` and no existing fixture could express one.

**The console half of manual verification did not happen — stating it plainly rather than implying a pass.** The backend is genuinely verified: live validator refusals, a booted host serving a company whose lead declares `delegates_to`, real magic-link sign-in, and `note` / `assignee` / `parentTaskId` round-tripping through the authenticated task API. Two blockers stopped the UI half:

1. No inference credential in this environment (`"cognition": "echo"`; messages answer `"You said: …"`), so **no delegating turn can be provoked by hand on any surface**.
2. The console cannot finish sign-in against a single-company local host — verify returns 200, then `GET /api/v1/companies` → 401 and `GET /api/v1/company` → 404, bouncing back to the login form, with and without the `tinyhumans` feature.

Both are pre-existing: this series touches **zero** files under `src/server/` or `frontend/`. The card note used to exercise the API shape was hand-written, **not** produced by a delegating turn, and is not presented as one. Happy to redo the console pass on a host with a credential if you would rather hold the merge for it.

## Documentation

`docs/spec/runtime/manifest.md` documents both keys, the depth default and bounds, and the refusal behaviour. The `build.rs` module doc — which stated the now-superseded "no re-delegation" invariant from #178 — is rewritten, along with the framing comments on the belt tests that pinned it.

## Also in this diff (not #176)

Commits pushed onto this branch outside the #176 series ride along in the diff, so they are reviewed here:

- `src/harness/policy.rs` — a test pinning the approval-fence leading-segment near-miss (`payroll.export` shares four letters with `payment` and must not be gated by it).
- `src/runtime/repo_manager/git.rs` — the git deadline test moved off `start_paused`, which returned `Ok` on Linux CI because `tokio::time::timeout` polls its inner future before consulting the deadline.

Review round 1 raised two problems in that git test, both fixed here:

1. The fake helper's `sleep 60` outlived the timeout arm. `kill_on_drop` stops the direct child and nothing below it, so the shell's `sleep` kept running for its full minute — measured with `pgrep`, alive a second after the test returned. The marker branch now `exec`s, making the blocking process the one Tokio holds.
2. The test mutated process-global `PATH`, under a SAFETY note claiming a single-threaded test lifetime. `cargo test` runs this binary's tests on parallel threads, which is the race edition 2024 marks `set_var` unsafe for, and a panic before the restore would have left the fake in place. `run_bounded` now takes the program to spawn and `run` passes `"git"`; with the program explicit the fake drops to a blocking stub that needs no `PATH`, no `git` filename, and no delegation to the real binary.

## Related

Part of #176.

**The other half of #176 is deliberately not here.** The synchronous hosted (Medulla) hand-back is blocked on infrastructure that does not exist: `src/brain/medulla/http.rs` is a stub whose Socket.IO methods are all TODO no-ops, so there is no live Medulla client to hand back through. The issue body's proposed fallback — "run it on the local harness pool, which is always attached" — does not work, because a hosted build links no harness pool at all. Nothing in this slice depends on it: the durable async hand-off already covers hosted delegation, and because the guards land brain-agnostically, the hosted relay inherits them whenever that client exists. Filing it separately keeps the Medulla-side dependency visible instead of parking half an epic behind it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable desk-to-desk delegation allowlists, including wildcard access.
  - Added recursive delegation with cycle prevention and configurable depth limits from 1–4.
  - Delegated tasks now preserve nested replies, cancellations, ownership, and refusal details.
  - Agents without delegation permissions remain restricted, while approved agents receive appropriate delegation tools.
- **Documentation**
  - Documented delegation rules, validation, fan-out behavior, depth limits, and refusal reporting.
- **Bug Fixes**
  - Improved timeout handling and reporting for long-running Git operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
