### PR TITLE
approvals: pin #457's per-toolkit grant scoping directly, and record why it has no live caller (#610)

### DIFF
--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -730,6 +730,35 @@ pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, Act
 /// the first place — `without_the_catalogue_every_composio_action_is_a_send`
 /// pins that — so there is no scoped grant there for `None` to widen.
 ///
+/// # No live caller, and retained on purpose (issue #610)
+///
+/// **Nothing in any current tier routes a Composio call to this.** Since #559 a
+/// catalogue read no longer parks under `supervised`, so the tier allows it well
+/// above the grant checks; under `readonly` the #243 emergency brake denies
+/// every external effect *above* them; under `full` everything is allowed. The
+/// scope is minted and stored, and no tier spends it.
+///
+/// That is dormancy, not death, and the distinction is written here because a
+/// mechanism with no caller and no note is indistinguishable from dead code —
+/// and this one is a reviewed security boundary. It is what any future durable
+/// allowlist would consult, and rebuilding it later would mean re-deriving the
+/// same decision: that consent attaches to a *provider*, that a slug the
+/// catalogue cannot place resolves to `None`, and that a scoped grant refuses
+/// `None` rather than guessing permissively. #563 proposed one such feature and
+/// was closed because its **card-promotion** shape cannot work under `auto`: a
+/// tool parks under `auto` exactly when it is not [`Standing::Grantable`], and
+/// the standing-grant control is offered only for `Grantable` tools, so no card
+/// under `auto` can ever offer "don't ask again" — exact complements on the
+/// parked set, a partition rather than a gap. A console- or manifest-managed
+/// allowlist consulted **before** the tier check has no such problem, and would
+/// use this.
+///
+/// Deleting it is therefore a decision to re-derive it later, and should be made
+/// as one. `the_minted_scope_is_the_scope_a_grant_admits` pins this function
+/// against [`StandingGrant::admits_scope`] directly, so the pairing keeps its
+/// coverage while no caller connects them.
+///
+/// [`Standing::Grantable`]: crate::policy::consequence::Standing::Grantable
 /// [`StandingGrant::admits_scope`]: crate::runtime::grants::StandingGrant::admits_scope
 pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String> {
     if !tool.eq_ignore_ascii_case(COMPOSIO_EXECUTE) {
@@ -1389,6 +1418,87 @@ mod tests {
             .standing,
             Standing::Grantable,
             "the curated lookup is case-insensitive on the slug too"
+        );
+    }
+
+    /// The two halves of #457's scoping, exercised **together and directly**
+    /// (issue #610).
+    ///
+    /// [`standing_scope_of`] mints the scope and
+    /// [`StandingGrant::admits_scope`] spends it, and since #559 no tier routes
+    /// a Composio read through both — see the retention note on
+    /// `standing_scope_of`. Each half is pinned on its own elsewhere, and each
+    /// of those tests spells the toolkit as its own `"github"` literal. Two
+    /// literals in two files are not an agreement: change what
+    /// `standing_scope_of` returns and both suites can be made green
+    /// separately while the pairing they describe is broken, with no live
+    /// caller left to notice.
+    ///
+    /// So nothing here is written down. Every scope comes out of
+    /// `standing_scope_of` and goes straight into a grant or into
+    /// `admits_scope`, which makes this a test of whether the two functions
+    /// still agree rather than of what either one says.
+    #[test]
+    #[cfg(feature = "openhuman")]
+    fn the_minted_scope_is_the_scope_a_grant_admits() {
+        use crate::runtime::grants::{GrantId, StandingGrant};
+
+        let scope_of = |slug: &str| standing_scope_of(COMPOSIO_EXECUTE, &json!({ "tool": slug }));
+
+        let minted = scope_of("GITHUB_LIST_BRANCHES");
+        assert!(
+            minted.is_some(),
+            "a catalogued action must resolve a toolkit, or this test proves nothing"
+        );
+        // Minted the way the cycle mints one: from the parked effect's payload.
+        let grant = StandingGrant {
+            id: GrantId::new("g610"),
+            agent: "ops".to_string(),
+            tool: COMPOSIO_EXECUTE.to_string(),
+            granted_by: crate::ports::types::Actor {
+                kind: crate::ports::types::ActorKind::User,
+                id: "user-1".to_string(),
+            },
+            approval_id: crate::ports::types::ApprovalId::new("a610"),
+            at_millis: 1_000,
+            expires_at_millis: u64::MAX,
+            origin_thread: None,
+            origin_parent: None,
+            scope: minted,
+        };
+
+        // A second read from the provider the operator named. Scoped by
+        // toolkit and not by slug, so a *different* GitHub action passes.
+        assert!(
+            grant.admits_scope(scope_of("GITHUB_LIST_PULL_REQUESTS").as_deref()),
+            "the operator consented to a provider, not to one action slug"
+        );
+        // Another provider's read: every other dimension matches and the scope
+        // is the one thing that says no.
+        assert!(
+            !grant.admits_scope(scope_of("GMAIL_FETCH_EMAILS").as_deref()),
+            "'read from GitHub' is not consent to read the company's mail"
+        );
+        // An action the catalogue cannot place resolves to `None`, and a scoped
+        // grant refuses `None` rather than guessing permissively.
+        assert_eq!(
+            scope_of("NOT_A_REAL_TOOLKIT_DO_SOMETHING"),
+            None,
+            "an unplaceable action must not resolve a toolkit"
+        );
+        assert!(
+            !grant.admits_scope(scope_of("NOT_A_REAL_TOOLKIT_DO_SOMETHING").as_deref()),
+            "unknown is a send here too"
+        );
+        // And the unscoped grant a pre-#457 journal line replays into still
+        // admits whatever its `(agent, tool)` pair already admitted.
+        let unscoped = StandingGrant {
+            scope: None,
+            ..grant
+        };
+        assert!(
+            unscoped.admits_scope(scope_of("GMAIL_FETCH_EMAILS").as_deref()),
+            "an unscoped grant must keep behaving as it did before scopes existed"
         );
     }
 

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -333,6 +333,15 @@ impl StandingGrant {
     ///   direction. It falls through and parks instead, which is the same answer
     ///   this codebase gives an unrecognised action everywhere else: unknown is
     ///   a send.
+    ///
+    /// # Dormant, deliberately (issue #610)
+    ///
+    /// No current tier routes a Composio call through this: since #559 a
+    /// catalogue read is allowed by the tier before the grant checks, and under
+    /// `readonly` the #243 brake denies above them. The scope this spends is
+    /// still minted, and the reasoning for keeping both halves is recorded once,
+    /// at [`standing_scope_of`](crate::policy::consequence::standing_scope_of) —
+    /// read it before concluding this is unused.
     pub fn admits_scope(&self, scope: Option<&str>) -> bool {
         match self.scope.as_deref() {
             None => true,


### PR DESCRIPTION
## Summary

**No behaviour change.** #457's per-toolkit grant scoping is correct and shipped, and
after #559 no live tier routes a Composio call to it. Working, reviewed security
machinery with no caller and no test is what a future reader deletes as dead code. This
retains it deliberately and says so where that reader will look.

### The test: the two halves, pinned against each other

`standing_scope_of` (`src/policy/consequence.rs`) mints a scope and
`StandingGrant::admits_scope` (`src/runtime/grants.rs`) spends it. Both are called
**directly** — not through a tier, which would pass vacuously since no tier reaches them.

Each half already has direct coverage, so this does not duplicate it. What was unpinned is
the **seam**: `a_composio_call_is_scoped_to_its_toolkit` spells the toolkit as its own
`"github"` literal, and `grants.rs`'s scope tests spell it as theirs. Two literals in two
files are not an agreement — change what `standing_scope_of` returns and both suites can
be brought to green independently while the pairing they describe is broken, and there is
no live caller left to notice.

So `the_minted_scope_is_the_scope_a_grant_admits` writes no scope string down. Every scope
comes out of `standing_scope_of` and goes straight into a `StandingGrant` or into
`admits_scope`, which makes it a test of whether the two still agree rather than of what
either one says. It covers the four cases that matter: a second action from the same
provider is admitted (toolkit grain, not slug grain), another provider's action is
refused, an action the catalogue cannot place resolves to `None` and is refused rather
than guessed at, and a pre-#457 unscoped grant still admits whatever its `(agent, tool)`
pair did.

**What this test deliberately does not catch, and what does.** Because both sides derive
from `standing_scope_of`, a change that moves both together — returning `GITHUB` instead
of `github` — leaves it green. That is inherent to testing an agreement. The hazard such a
rename actually poses is to *stored* grants, where a journal line written under the old
spelling would silently stop matching, and that is caught by the existing
`a_composio_call_is_scoped_to_its_toolkit`, which asserts the literal `Some("github")`.
The two tests are complementary and neither alone is sufficient; this is recorded here
because a reader who assumes the new test subsumes the old one could delete the wrong one.

### The comment: why it is uncalled, at the definition

`standing_scope_of` now carries a "no live caller, and retained on purpose" section
stating the justification directly rather than by reference to a ticket a reader would
have to go and interpret. It names the three tiers and why each misses the scope
(`supervised` allows a catalogue read at the tier since #559; `readonly` denies at the
#243 brake, which sits *above* the grant checks; `full` allows everything), what would be
re-derived if it were deleted, and why #563 closed — its card-promotion shape cannot work
under `auto`, because `parks_under_auto()` is `reach.parks_under_supervision() &&
!standing.is_grantable()` while the standing-grant control is offered only for `Grantable`
tools: exact complements on the parked set, a partition rather than a gap. A console- or
manifest-managed allowlist consulted **before** the tier check has no such problem and
would use this.

`admits_scope` gets a short pointer to that one explanation rather than a second copy.

Closes tinyhumansai/opencompany#610

## API Or Behavior Changes

None. Two doc comments and one test; no runtime code path is touched. `cargo build` output
differs only by the added test.

## Tests

- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman,tinycortex` — **3129 + 10 + 1 + 11 + 2 = 3153 passed, 0 failed**
- `cargo test` (default features) — **2083 passed, 0 failed**

Revert-and-check on `the_minted_scope_is_the_scope_a_grant_admits`, each run selecting
exactly one test:

| Reverted | Test outcome |
|---|---|
| `admits_scope` always returns `true` | 1 selected, **1 FAILED** ("'read from GitHub' is not consent to read the company's mail") |
| a scoped grant admits `None` | 1 selected, **1 FAILED** ("unknown is a send here too") |
| `standing_scope_of` scopes by action slug, not toolkit | 1 selected, **1 FAILED** ("the operator consented to a provider, not to one action slug") |
| `standing_scope_of` uppercases the toolkit | 1 selected, **PASSED — not caught** |

The last row is reported rather than omitted: it is the limitation described above, and it
is covered by `a_composio_call_is_scoped_to_its_toolkit`'s literal assertion instead.

The test is gated `#[cfg(feature = "openhuman")]`, matching the neighbouring scope tests —
without the catalogue every toolkit resolves to `None`, and that build cannot mint a
Composio standing grant at all. It is run by the `Rust (openhuman, tinycortex)` lane.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `--locked --no-deps --features openhuman,tinycortex --all-targets`; `--no-deps` keeps pre-existing `vendor/tinyagents` lints out, which CI does not see either
- [x] `cargo build --all-targets`
- [x] `cargo test` — plus the gated `--features openhuman,tinycortex` lane, which is the one that runs the new test
- [x] N/A — no i18n keys: this change adds no user-facing UI text, only Rust doc comments and a unit test

## Documentation

The documentation *is* the change: the retention rationale lives at `standing_scope_of` in
`src/policy/consequence.rs`, with a pointer from `StandingGrant::admits_scope` in
`src/runtime/grants.rs`. No `docs/` page describes this internal seam, and adding one would
put the explanation somewhere the reader deciding whether to delete the function would not
be looking.
