### PR TITLE
fix(tasks): restrict an irreversible effect's amount to admins

### DIFF
--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -305,6 +305,32 @@ There is **no payload**. The record is read back onto an operator's screen
 through `GET …/tasks/{task_id}`, which scrubs by construction, so recipients and
 message bodies are never retained in the first place.
 
+**The amount is admin-only** (issue #705). Unlike the payload, the amount *is*
+retained — the whole point of the record is to say what a retry would repeat,
+and "sent a payment" is a materially weaker warning than "sent a payment of
+$2,400". So it is restricted at read time rather than dropped at write time,
+through the *same* predicate that restricts an approval's amount for issue #618
+(`approval_visibility::may_read_approval_contents`). A Member gets the row —
+what a retry would re-do stays visible to whoever is doing the work — without
+the number.
+
+Two consequences worth stating, because both were a defect before:
+
+* **The decision travels, not the role.** `ScopedCompany` deliberately drops the
+  role at the edge, so it carries what the predicate *decided*. Nothing
+  downstream can answer the question differently, because nothing downstream
+  holds the input.
+* **Hidden is not absent.** `amountUsd` is omitted from a Member's response and
+  `amountHidden: true` is set in its place — but only where an amount was
+  actually withheld. Without that flag a withheld payment and a free tool call
+  are the same bytes, and a reader cannot tell "this cost nothing" from "you may
+  not see what this cost". The flag is skipped when false, so an admin's
+  response is byte-identical to before.
+
+The redaction is applied inside `assemble_detail`, which the JSON route and the
+export document (issue #352) both call, so the guarantee covers the exported
+record too rather than depending on two callers remembering.
+
 The task attribution comes from the cycle that ran the effect. Under
 `supervised` an irreversible effect never executes in the cycle that emitted it
 — it parks, and the operator's approval opens a fresh cycle carrying only

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -84,6 +84,48 @@ pub(crate) fn hide_contents(approval: &mut ApprovalSummary) {
     approval.contents_hidden = true;
 }
 
+/// The same rule applied to the **executed** effects on a task's detail read
+/// (issue #705).
+///
+/// #618 restricted the money on an approval — the effect a person has *not yet*
+/// signed off. The identical amount on the effect once it has run was projected
+/// by a different DTO on a different route, and that route was never covered:
+/// any Member could `GET` a card and read the dollar value of every irreversible
+/// effect on it.
+///
+/// It lives here, beside [`for_principal`], rather than in the task module,
+/// because the thing that must not fork is the *rule*. A second redactor in the
+/// tasks route could drift from this one, and two role checks disagreeing about
+/// what an operator may see is worse than the leak either was written to close.
+///
+/// Takes `may_read_contents` rather than the principal because
+/// [`ScopedCompany`](crate::server::ops::ScopedCompany) deliberately drops the
+/// role at the edge, carrying this decision forward instead — see the field's
+/// own note. The decision is still made by
+/// [`may_read_approval_contents`] and nowhere else.
+///
+/// Takes the whole list, like [`for_principal`], so a caller cannot apply it to
+/// some entries and forget others.
+pub(crate) fn effects_for_principal(
+    may_read_contents: bool,
+    mut effects: Vec<crate::server::ops::tasks::IrreversibleEffect>,
+) -> Vec<crate::server::ops::tasks::IrreversibleEffect> {
+    if may_read_contents {
+        return effects;
+    }
+    for effect in &mut effects {
+        // `amount_hidden` only where something was actually withheld: an effect
+        // that never carried money must not report itself as redacted, or
+        // "nothing to show" and "not shown to you" stop being distinguishable
+        // in the direction that matters.
+        if effect.amount_usd.is_some() {
+            effect.amount_usd = None;
+            effect.amount_hidden = true;
+        }
+    }
+    effects
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/server/ops/scope.rs
+++ b/src/server/ops/scope.rs
@@ -71,6 +71,21 @@ pub(crate) struct ScopedCompany {
     /// distinction [`CompanyEvent::OperatorMessage`](crate::ports::types::CompanyEvent::OperatorMessage)'s
     /// `by` already draws.
     pub(crate) actor: Option<Actor>,
+    /// Whether this principal may read the *money and arguments* an effect
+    /// carries — issue #618's rule, answered once here for routes that project
+    /// such a field (issue #705).
+    ///
+    /// **The decision, not the credential.** The comment below on `actor` is
+    /// the rule for this struct: the role does not travel. So this carries what
+    /// [`may_read_approval_contents`](crate::server::approval_visibility::may_read_approval_contents)
+    /// *decided*, resolved at the edge where the principal still exists, rather
+    /// than the role that decided it. Nothing downstream can re-derive the
+    /// answer differently, because nothing downstream has the input.
+    ///
+    /// Deliberately the same predicate the Approvals read uses rather than a
+    /// second one. Two role checks that can disagree about what an operator may
+    /// see is a worse outcome than the leak either was written to close.
+    pub(crate) may_read_contents: bool,
 }
 
 impl ScopedCompany {
@@ -123,6 +138,11 @@ impl FromRequestParts<AppState> for ScopedCompany {
         if let Some(resp) = refuse_until_password_changed(&auth) {
             return Err(resp);
         }
+        // Resolved here, while the principal still exists, because the role is
+        // about to be dropped on purpose (issue #705). This is the answer, not
+        // the input to it.
+        let may_read_contents =
+            crate::server::approval_visibility::may_read_approval_contents(&auth);
         // Keep the person, drop the credential: only a human principal names an
         // actor, and only the user id travels — never the email or the role.
         let actor = match auth {
@@ -132,7 +152,11 @@ impl FromRequestParts<AppState> for ScopedCompany {
             }),
             GqlAuth::Platform(_) => None,
         };
-        Ok(ScopedCompany { runtime, actor })
+        Ok(ScopedCompany {
+            runtime,
+            actor,
+            may_read_contents,
+        })
     }
 }
 
@@ -201,8 +225,14 @@ impl FromRequestParts<AppState> for AdminScopedCompany {
         // Addressing, company resolution and the temporary-password boundary
         // are already exactly right; this only adds the authority question on
         // top of them.
-        let ScopedCompany { runtime, actor } =
-            ScopedCompany::from_request_parts(parts, state).await?;
+        let ScopedCompany {
+            runtime,
+            actor,
+            // Not carried on: every principal that reaches this extractor may
+            // read contents by construction (an admin, or the platform bearer
+            // which this extractor admits and #618 refuses contents to anyway).
+            may_read_contents: _,
+        } = ScopedCompany::from_request_parts(parts, state).await?;
         match actor {
             // A human. `ScopedCompany` keeps the person but drops the role, so
             // the role has to be re-resolved — which is the whole reason this

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -770,8 +770,28 @@ pub(crate) struct IrreversibleEffect {
     at_millis: u64,
     /// The USD amount involved, if any — what makes "sent a payment" into
     /// "sent a payment of $2,400".
+    ///
+    /// **Role-restricted (issue #705).** This is money, and it is the same
+    /// class of field [`ApprovalSummary::amount_usd`](crate::runtime::types::ApprovalSummary)
+    /// is restricted to admins by issue #618. It is redacted through the *same*
+    /// predicate, at the edge, by
+    /// [`effects_for_principal`](crate::server::approval_visibility::effects_for_principal)
+    /// — never here, because the projection does not know who is asking.
     #[serde(skip_serializing_if = "Option::is_none")]
-    amount_usd: Option<f64>,
+    pub(crate) amount_usd: Option<f64>,
+    /// Whether an amount was withheld from this reader.
+    ///
+    /// The same reasoning as
+    /// [`ApprovalSummary::contents_hidden`](crate::runtime::types::ApprovalSummary):
+    /// `amount_usd: None` already means "this effect involved no money", so
+    /// blanking alone would make a withheld payment and a free tool call the
+    /// same bytes on the wire. A console has to be able to say *hidden by your
+    /// role* rather than render a payment that looks like it cost nothing.
+    ///
+    /// Skipped when `false`, so an admin's response — and every response
+    /// produced before this field existed — serializes byte-identically.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) amount_hidden: bool,
 }
 
 impl From<crate::runtime::journal::ExecutedEffect> for IrreversibleEffect {
@@ -780,6 +800,9 @@ impl From<crate::runtime::journal::ExecutedEffect> for IrreversibleEffect {
             kind: e.kind,
             at_millis: e.at_millis,
             amount_usd: e.amount_usd,
+            // Never redacted at construction — the journal does not know who is
+            // asking. `effects_for_principal` is the only thing that sets this.
+            amount_hidden: false,
         }
     }
 }
@@ -1283,12 +1306,21 @@ async fn assemble_detail_with_cursor(
     // What a retry would re-do (issue #351). A pure journal read — one indexed
     // lookup, no event scan — so a task that did nothing irreversible costs
     // nothing extra however long the company has been running.
-    let irreversible_effects = company
-        .runtime
-        .irreversible_effects(&task_id)
-        .into_iter()
-        .map(IrreversibleEffect::from)
-        .collect();
+    //
+    // Redacted at the edge (issue #705): the amount is money, and a Member gets
+    // the row without it. Applied here rather than in the handler because this
+    // function is deliberately shared with the export document — see
+    // [`assemble_detail`] — so the guarantee holds for both readers by
+    // construction instead of by two callers remembering.
+    let irreversible_effects = crate::server::approval_visibility::effects_for_principal(
+        company.may_read_contents,
+        company
+            .runtime
+            .irreversible_effects(&task_id)
+            .into_iter()
+            .map(IrreversibleEffect::from)
+            .collect(),
+    );
 
     // An indexed store read, not another journal pass (issue #242).
     let runs = runs_for_task(company, &task_id).await?;

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -7670,3 +7670,257 @@ async fn a_company_that_raised_its_blob_cap_can_use_it() {
     assert_eq!(node["size"], size as u64);
     assert!(tree_names(&state).await.contains(&"raised.bin".to_string()));
 }
+
+// ---------------------------------------------------------------------------
+// Issue #705 — an irreversible effect's amount is admin-only
+// ---------------------------------------------------------------------------
+
+/// Reads a task's detail as a specific principal.
+///
+/// The harness signs every other request in as an admin, which is exactly why
+/// this exists: a redaction verified only as an admin passes identically
+/// against no redaction at all.
+async fn detail_as(state: &AppState, id: &str, cookie: String) -> Value {
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/api/v1/company/tasks/{id}"))
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Issue #705: any Member could read the dollar value of every irreversible
+/// effect on a card.
+///
+/// #618 restricted the money on an approval — the effect nobody has signed off
+/// yet. The *executed* effect carries the same number through a different DTO
+/// on a different route, and that route had no role check at all.
+///
+/// **Asserted on the serialized JSON, not on the struct.** `amount_usd` carries
+/// `skip_serializing_if`, so the wire shape is the only thing that settles
+/// whether the field shipped; a struct-level assertion can pass while the bytes
+/// still carry the amount.
+#[tokio::test]
+async fn a_member_does_not_see_an_irreversible_effects_amount() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    crate::server::test_support::seed_fixed_member(&state, "acme").await;
+
+    let (status, task) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Pay the Q3 retainer"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{task}");
+    let id = task["id"].as_str().unwrap().to_string();
+
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    // Two effects: one carrying money, one not. The second is the control that
+    // keeps "withheld" and "there was never an amount" distinguishable.
+    runtime
+        .journal
+        .record_executed(
+            "exec-705-paid",
+            crate::runtime::journal::ExecutedEffect {
+                kind: "payment.send".to_string(),
+                amount_usd: Some(2400.0),
+                task_id: Some(id.clone()),
+                at_millis: 1_000,
+                irreversible: true,
+            },
+        )
+        .await
+        .unwrap();
+    runtime
+        .journal
+        .record_executed(
+            "exec-705-free",
+            crate::runtime::journal::ExecutedEffect {
+                kind: "email.send".to_string(),
+                amount_usd: None,
+                task_id: Some(id.clone()),
+                at_millis: 2_000,
+                irreversible: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    // The admin signs these off, so the admin sees what they cost.
+    let as_admin = detail_as(
+        &state,
+        &id,
+        crate::server::test_support::fixed_cookie("acme"),
+    )
+    .await;
+    let admin_effects = as_admin["irreversibleEffects"].as_array().unwrap();
+    assert_eq!(admin_effects.len(), 2, "{as_admin}");
+    let admin_paid = admin_effects
+        .iter()
+        .find(|e| e["kind"] == "payment.send")
+        .unwrap();
+    assert_eq!(admin_paid["amountUsd"].as_f64(), Some(2400.0), "{as_admin}");
+    assert!(
+        admin_paid.get("amountHidden").is_none(),
+        "an admin is not told anything was withheld: {as_admin}"
+    );
+
+    let as_member = detail_as(
+        &state,
+        &id,
+        crate::server::test_support::member_cookie("acme"),
+    )
+    .await;
+    let member_effects = as_member["irreversibleEffects"].as_array().unwrap();
+    assert_eq!(
+        member_effects.len(),
+        2,
+        "the rows survive — a member must still see what a retry would re-do: {as_member}"
+    );
+    let member_paid = member_effects
+        .iter()
+        .find(|e| e["kind"] == "payment.send")
+        .unwrap();
+
+    // The leak, closed. Absent from the wire, not null: `skip_serializing_if`.
+    assert!(
+        member_paid.get("amountUsd").is_none(),
+        "the amount must not reach a member: {as_member}"
+    );
+    // Hidden is not absent — the console has to be able to say why.
+    assert_eq!(
+        member_paid["amountHidden"], true,
+        "a withheld amount must be distinguishable from an effect that cost \
+         nothing: {as_member}"
+    );
+    // Everything that makes the retry warning legible survives.
+    assert_eq!(member_paid["kind"], "payment.send");
+    assert_eq!(member_paid["atMillis"].as_u64(), Some(1_000));
+
+    // The control: an effect that never carried money is not reported as
+    // redacted, or "nothing to show" and "not shown to you" collapse.
+    let member_free = member_effects
+        .iter()
+        .find(|e| e["kind"] == "email.send")
+        .unwrap();
+    assert!(member_free.get("amountUsd").is_none(), "{as_member}");
+    assert!(
+        member_free.get("amountHidden").is_none(),
+        "an effect with no amount was not redacted: {as_member}"
+    );
+}
+
+/// The export path is covered by construction, because it is handed the same
+/// value.
+///
+/// `assemble_detail` is deliberately shared between the JSON route and the
+/// export document (issue #352 calls that sharing "the export's redaction
+/// guarantee"). This drives that shared function directly with a
+/// member-scoped principal, so the guarantee is asserted at the seam both
+/// readers pass through rather than only at the JSON one.
+///
+/// **Why not assert on the exported HTML alone.** The export template does not
+/// currently render effect amounts at all, so an HTML-only assertion would pass
+/// whether or not the redaction exists — coverage that cannot fail. The HTML
+/// check below is kept as a secondary guard against a future template that does
+/// render them; the assertion that actually holds the line is the one on the
+/// shared projection.
+#[tokio::test]
+async fn the_export_document_is_built_from_the_redacted_detail() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    crate::server::test_support::seed_fixed_member(&state, "acme").await;
+
+    let (status, task) = send(
+        &state,
+        "POST",
+        "/api/v1/company/tasks",
+        Some(json!({"title": "Pay the Q3 retainer"})),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{task}");
+    let id = task["id"].as_str().unwrap().to_string();
+
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    runtime
+        .journal
+        .record_executed(
+            "exec-705-export",
+            crate::runtime::journal::ExecutedEffect {
+                kind: "payment.send".to_string(),
+                amount_usd: Some(2400.0),
+                task_id: Some(id.clone()),
+                at_millis: 1_000,
+                irreversible: true,
+            },
+        )
+        .await
+        .unwrap();
+
+    // The seam both readers share, driven as a member. `assemble_detail` is
+    // exactly what `export_task` calls.
+    let as_member = super::tasks::assemble_detail(
+        &super::ScopedCompany {
+            runtime: runtime.clone(),
+            actor: None,
+            may_read_contents: false,
+        },
+        &id,
+    )
+    .await
+    .expect("detail assembles");
+    // Serialized, not read off the struct: `skip_serializing_if` means the wire
+    // shape is what settles whether the amount shipped.
+    let wire = serde_json::to_value(&as_member.irreversible_effects).unwrap();
+    let paid = &wire.as_array().unwrap()[0];
+    assert!(
+        paid.get("amountUsd").is_none(),
+        "the shared projection the export renders must already be redacted: {wire}"
+    );
+    assert_eq!(paid["amountHidden"], true, "{wire}");
+
+    // …and the same principal reading it as an admin still gets the number, so
+    // the assertion above is redaction rather than the field being gone.
+    let as_admin = super::tasks::assemble_detail(
+        &super::ScopedCompany {
+            runtime: runtime.clone(),
+            actor: None,
+            may_read_contents: true,
+        },
+        &id,
+    )
+    .await
+    .expect("detail assembles");
+    let admin_wire = serde_json::to_value(&as_admin.irreversible_effects).unwrap();
+    assert_eq!(
+        admin_wire.as_array().unwrap()[0]["amountUsd"].as_f64(),
+        Some(2400.0),
+        "{admin_wire}"
+    );
+
+    // Secondary guard: the rendered document must not carry it either. This
+    // passes today regardless (the template renders no effects) and exists so a
+    // future template that does render them cannot reintroduce the leak.
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/api/v1/company/tasks/{id}/export"))
+        .header("cookie", crate::server::test_support::member_cookie("acme"))
+        .body(Body::empty())
+        .unwrap();
+    let response = router(state.clone()).oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let html = String::from_utf8(bytes.to_vec()).expect("the export is utf-8");
+    assert!(
+        !html.contains("2400"),
+        "the exported document must not carry an amount this reader may not read"
+    );
+}


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#705.

`GET …/tasks/{task_id}` projects every irreversible effect a card executed, including `amountUsd`. The handler takes a bare `ScopedCompany` — membership, not authority — so **any Member of the company could read the dollar value of every irreversible effect on any card**.

### This is #618/#685's defect in a different DTO, not a new policy question

The rule already exists and is already written down. `src/server/approval_visibility.rs` states it, and `for_principal` already implements it: an Admin reads an effect's money and arguments, a Member gets the row without them. Issue #618 applied that to `ApprovalSummary` — the effect nobody has signed off **yet**. The identical amount on the effect **once it has run** is projected by `IrreversibleEffect` on a different route, and that route simply never called the machinery.

So there is nothing to decide here about whether Members should see amounts — that was settled by #618, and this only extends the existing answer to the DTO it missed. Concretely, the fix **calls the same predicate** rather than adding a second redactor: two role checks that can disagree about what an operator may see is a worse outcome than the leak either was written to close.

The struct's own doc comment already showed the intent was scrub discipline — *"Deliberately no payload… a recipient or a message body cannot reach this response even by accident"*. The payload was scrubbed; the money was not.

### How it is wired

| piece | what it does |
|---|---|
| `ScopedCompany::may_read_contents` | the **decision**, resolved at the edge by `may_read_approval_contents` |
| `approval_visibility::effects_for_principal` | applies it to the effect list, beside `for_principal` |
| `assemble_detail_with_cursor` | the single call site both readers pass through |

**The decision travels, not the role.** `ScopedCompany` deliberately drops the role at the edge — *"Keep the person, drop the credential… never the email or the role."* Rather than working around that rule, the extractor now resolves the question while the principal still exists and carries the **answer** forward. Nothing downstream can re-derive it differently, because nothing downstream holds the input.

**`effects_for_principal` lives in `approval_visibility.rs`, beside `for_principal`** — not in the tasks module — because the thing that must not fork is the *rule*. It takes the whole list for the same reason `for_principal` does: so a caller cannot redact some entries and forget others.

**Hidden is not absent**, exactly as #618 reasoned. A withheld amount is omitted **and** `amountHidden: true` is set — but only where an amount actually existed. Without the flag a withheld payment and a free tool call are the same bytes on the wire, and a reader cannot tell "this cost nothing" from "you may not see what this cost". Skipped when `false`, so an admin's response — and every response produced before this field existed — serializes byte-identically.

### The export document is covered, and that is why one fix is enough

`assemble_detail` is deliberately shared between the JSON route and the export document (`task_export.rs:58`), and #352 documents that sharing as **"the export's redaction guarantee"**. The redaction is applied **inside** `assemble_detail`, so the exported HTML is covered by construction rather than by a second caller remembering. A reviewer checking only the API route would not see that this single change covers both.

**One accuracy note, having read the template:** the export does **not** leak the amount today — `task_export.rs` never renders `irreversible_effects` at all (the strings `effect`, `irreversible` and `retry` do not appear in that file; it renders task, durations, timeline and lineage). So the live leak was the JSON read only. The fix is still placed in `assemble_detail` for exactly the reason above: it is the shared seam, and a future template that renders effects inherits the guarantee instead of reopening the hole. The tests assert both halves.

## API Or Behavior Changes

- **`GET …/tasks/{task_id}` now redacts `irreversibleEffects[].amountUsd` for a non-admin.** The rows themselves survive — a Member must still see what a retry would re-do; that is #468's stalled-work signal and #351's retry warning, and neither is weakened.
- **New optional field `irreversibleEffects[].amountHidden`** (`true` only when an amount was withheld, skipped otherwise). Additive: an admin's response is byte-identical to before, and a client that reads no such field is unaffected.
- The **platform bearer** is fail-closed, inherited from `may_read_approval_contents` — #618's deliberate choice, not a new one.
- **No console change and no i18n.** #618's own `contentsHidden` is likewise not consumed by the frontend today; this matches that precedent rather than inventing operator wording and 14 locale entries the issue does not ask for. Zero frontend files changed.

## Tests

Two tests added, both driven with **two accounts** — the harness signs every request in as an admin, so a redaction verified only as an admin passes identically against no redaction at all.

**Both assert on the serialized JSON, never on the struct.** `amount_usd` carries `skip_serializing_if`, so the wire shape is the only thing that settles whether the field shipped; a struct-level assertion can pass while the bytes still carry the amount. The HTTP test reads the response body; the shared-seam test calls `serde_json::to_value` on the projection before asserting.

- `a_member_does_not_see_an_irreversible_effects_amount` — drives the real route as Admin and as Member. Admin: `amountUsd == 2400.0`, no `amountHidden`. Member: `amountUsd` **absent from the wire**, `amountHidden == true`, and `kind`/`atMillis` still present. Includes a **control effect that never carried money**, asserting it is *not* flagged as hidden — otherwise "nothing to show" and "not shown to you" collapse.
- `the_export_document_is_built_from_the_redacted_detail` — drives `assemble_detail` (what `export_task` calls) directly as a member **and** as an admin, asserting on the serialized effects both ways, plus a secondary check that the rendered HTML carries no amount.

```
cargo fmt --all -- --check                                                                     → 0
cargo check  --locked --all-features --all-targets                                             → 0
cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings   → 0
cargo build  --all-targets                                                                     → 0
cargo test   --features openhuman,tinycortex   → 0 — 3130 + 10 + 1 + 11 + 2 = 3154 passed, 0 failed, 3 ignored
```

**Revert-checked**, counts quoted so a run that executed nothing cannot pass for a pass:

| revert | result |
|---|---|
| `assemble_detail` stops calling `effects_for_principal` | **both** FAILED — 0 passed; 2 failed |
| `effects_for_principal` blanks nothing | **both** FAILED — 0 passed; 2 failed |
| `ScopedCompany` hardcodes `may_read_contents = true` | **1 of 2** FAILED — 1 passed; 1 failed |
| `amount_hidden` set `false` instead of `true` | **both** FAILED — 0 passed; 2 failed |

The 1-of-2 is **correct rather than a gap**, and is flagged rather than left to read as a clean sweep: the export test constructs `ScopedCompany` directly in order to drive the shared projection, so by design it does not exercise the extractor. The HTTP test, which does, failed.

**One test was rewritten because it was vacuous.** The first version of the export test asserted only that the exported HTML lacks `2400` — which passes with or without the fix, since the template renders no effects. That is coverage that cannot fail. It was replaced with the member-and-admin assertion on the shared projection described above, which fails on three of the four reverts; the HTML check survives only as an explicitly-labelled secondary guard.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; `--no-deps` keeps it off pre-existing `vendor/tinyagents` lints CI never sees
- [x] `cargo build --all-targets`
- [x] `cargo test` — run as `cargo test --features openhuman,tinycortex`

## Documentation

`docs/spec/runtime/events.md` — the executed-effect section stated that the task-detail read *"scrubs by construction"*. True of the payload, and it read as an all-clear that covered the amount too. The amount is retained **deliberately** (the record exists to say what a retry would repeat, and "sent a payment" is a materially weaker warning than "sent a payment of $2,400"), so it is restricted at read time rather than dropped at write time.

The revised section states: the restriction and that it reuses #618's predicate; that the decision travels rather than the role; that hidden is not absent and why the flag is set only where something was withheld; and that the redaction sits in `assemble_detail` so the export inherits it. File is 391 lines, within the 500-line guideline.
