### PR TITLE
feat(journal): flush host-critical records to stable storage (#392)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +150,12 @@ checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
@@ -1112,6 +1127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,6 +1273,33 @@ checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
 dependencies = [
  "chrono",
  "phf 0.12.1",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -1773,6 +1821,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
+dependencies = [
+ "alloca",
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "itertools 0.13.0",
+ "num-traits",
+ "oorandom",
+ "page_size",
+ "regex",
+ "serde",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
+dependencies = [
+ "cast",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -6210,6 +6291,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6255,6 +6342,7 @@ dependencies = [
  "bs58",
  "bytes",
  "clap",
+ "criterion",
  "ed25519-dalek",
  "fs2",
  "futures",
@@ -6502,6 +6590,16 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "palette"
@@ -9975,6 +10073,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec 0.11.6",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -427,3 +427,18 @@ tempfile = "3"
 # real child process. Dev-only: under resolver v2 this feature is not unified
 # into normal builds, so the shipped binary is unchanged.
 tokio = { version = "1", features = ["test-util"] }
+
+# Issue #392: measures what a per-append flush costs, so the per-record-kind
+# durability policy rests on a number rather than an intuition. Default features
+# off — the plotting and rayon extras would be dead weight in every test lane's
+# dependency graph, and this bench reports numbers rather than charts.
+criterion = { version = "0.8", default-features = false, features = [
+  "cargo_bench_support",
+] }
+
+# Opt-in only (`cargo bench --bench journal_append`). Not wired into CI: it is a
+# measurement of the host's storage, and a shared runner's numbers would mean
+# nothing to gate on.
+[[bench]]
+name = "journal_append"
+harness = false

--- a/benches/journal_append.rs
+++ b/benches/journal_append.rs
@@ -35,9 +35,9 @@
 //!
 //! | mode | ~200B p50 | ~200B p99 | ~700B p50 | ~700B p99 |
 //! |---|---|---|---|---|
-//! | `plain` | 16.1µs | 34.9µs | 19.9µs | 72.0µs |
-//! | `sync_data` | 3.98ms | 7.31ms | 3.99ms | 6.03ms |
-//! | `sync_data_and_dir` | 4.01ms | 8.94ms | 7.90ms | 11.30ms |
+//! | `plain` | 20.2µs | 103.2µs | 17.1µs | 31.5µs |
+//! | `sync_data` | 3.90ms | 6.83ms | 3.89ms | 4.80ms |
+//! | `sync_data_and_dir` | 6.91ms | 10.94ms | 3.95ms | 8.35ms |
 //!
 //! Two things fall out, and both are the policy's argument:
 //!
@@ -45,12 +45,16 @@
 //!   on `CycleStarted`, which is written on the front edge of every cycle, and
 //!   entirely invisible in front of an `EffectExecuted`'s 100ms-2s network call.
 //!   Blanket-flushing would have been the expensive answer to a rare problem.
-//! * The cost is **flat in record size** (~4ms at both 200B and 700B): it is the
-//!   flush, not the payload. So "how many appends flush" is the only lever, which
-//!   is exactly the lever a per-record-kind policy pulls.
+//! * The cost is **flat in record size** (~3.9ms at both 200B and 700B): it is
+//!   the flush, not the payload. So "how many appends flush" is the only lever,
+//!   which is exactly the lever a per-record-kind policy pulls.
 //!
-//! The directory flush is charged on every iteration here; in production only a
-//! journal's first-ever append pays it.
+//! Read the `sync_data_and_dir` row as "one flush or two, same order of
+//! magnitude", never as a size effect: *which* of the two sizes comes out slower
+//! swaps between runs — the 700B row on the run before this one, the 200B row on
+//! this one — so the second flush lands somewhere between free and a doubling
+//! depending on what the volume is doing underneath. It is charged on every
+//! iteration here; in production only a journal's first-ever append pays it.
 //!
 //! The three modes are reimplemented here rather than called: `append_line` and
 //! `append_line_durable` are `pub(crate)`, and a bench is an external crate.
@@ -63,7 +67,7 @@ use std::io::Write;
 use std::path::Path;
 use std::time::{Duration, Instant};
 
-use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use criterion::{BatchSize, BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
 
 /// How an append is written.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -87,6 +91,27 @@ impl Mode {
             Mode::SyncDataAndDir => "sync_data_and_dir",
         }
     }
+}
+
+/// Returns `path` to a fixed starting state: an existing, empty file.
+///
+/// Every loop below means to measure the cost of **one** append, which is only
+/// what it measures if every sample starts from the same file. Left alone, the
+/// file grows by a record per iteration — hundreds in the percentile loop,
+/// thousands under Criterion — so what the numbers track is the file's size as
+/// much as the append. Truncating rather than deleting is the other half: a
+/// create would fold the `open`'s file creation, and on the durable modes the
+/// parent-directory flush that production pays exactly once per journal, into
+/// whichever sample happened to run first.
+///
+/// Called outside the timed region in both loops.
+fn reset(path: &Path) {
+    OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(true)
+        .open(path)
+        .expect("reset");
 }
 
 /// One append, exactly as `store::fs::append_line_inner` performs it.
@@ -201,6 +226,7 @@ fn print_latency_percentiles() {
 
             let mut samples = Vec::with_capacity(SAMPLES);
             for _ in 0..SAMPLES {
+                reset(&path);
                 let start = Instant::now();
                 append(&path, &line, mode);
                 samples.push(start.elapsed());
@@ -252,7 +278,18 @@ fn journal_append(c: &mut Criterion) {
             group.bench_with_input(
                 BenchmarkId::new(mode.name(), size_label),
                 &line,
-                |b, line| b.iter(|| append(&path, line, mode)),
+                |b, line| {
+                    // `iter_batched` so the reset runs per iteration and stays
+                    // outside the measurement; `PerIteration` is the batch size
+                    // Criterion documents for a benchmark holding a file, and is
+                    // what keeps the file one record long rather than letting a
+                    // whole batch accumulate before the next setup.
+                    b.iter_batched(
+                        || reset(&path),
+                        |()| append(&path, line, mode),
+                        BatchSize::PerIteration,
+                    )
+                },
             );
         }
     }

--- a/benches/journal_append.rs
+++ b/benches/journal_append.rs
@@ -1,0 +1,264 @@
+//! What a durable journal append costs (issue #392).
+//!
+//! The per-record-kind durability policy in `RuntimeJournal::append` rests on a
+//! claim about price: a flush is affordable on `EffectExecuted` because that
+//! record is written at operator-decision scale in front of a network call, and
+//! unaffordable on `CycleStarted` because that one is written on the front edge
+//! of every cycle. This bench is the measurement behind the claim.
+//!
+//! Three write modes, at two realistic record sizes:
+//!
+//! * `plain` — one `write_all` under `O_APPEND`, what `store::fs::append_line`
+//!   does. Process-crash durable.
+//! * `sync_data` — the same write plus `File::sync_data`, what
+//!   `store::fs::append_line_durable` does for an append to an existing file.
+//! * `sync_data_and_dir` — plus opening the parent directory and `sync_all`ing
+//!   it. In production that is paid **only by the append that creates the
+//!   file**; here every iteration pays it, so the number is the upper bound for
+//!   that step rather than its amortised cost.
+//!
+//! # Reading these numbers honestly
+//!
+//! * **macOS overstates the cost.** Rust's `sync_data` maps to a full-flush
+//!   -flavoured `fcntl` on macOS, which is stronger (and slower, ~10-20ms on
+//!   APFS) than the Linux `fdatasync` a container would issue. A local macOS
+//!   figure is an upper-bound flavour, not the hosted truth.
+//! * **A local SSD does not predict EFS.** The deployed path writes to a network
+//!   volume whose client page cache is the thing `sync_data` forces through;
+//!   its absolute latency is a different measurement on different hardware.
+//!
+//! So what these numbers evidence is the **order of magnitude** of a flush and
+//! **what fraction of appends pay it** — which is the part the policy turns on —
+//! not the hosted absolute cost.
+//!
+//! # Measured baseline (macOS 15 / APFS / local SSD, `cargo bench`)
+//!
+//! | mode | ~200B p50 | ~200B p99 | ~700B p50 | ~700B p99 |
+//! |---|---|---|---|---|
+//! | `plain` | 16.1µs | 34.9µs | 19.9µs | 72.0µs |
+//! | `sync_data` | 3.98ms | 7.31ms | 3.99ms | 6.03ms |
+//! | `sync_data_and_dir` | 4.01ms | 8.94ms | 7.90ms | 11.30ms |
+//!
+//! Two things fall out, and both are the policy's argument:
+//!
+//! * A flush costs roughly **200× a plain append** here — far too much to spend
+//!   on `CycleStarted`, which is written on the front edge of every cycle, and
+//!   entirely invisible in front of an `EffectExecuted`'s 100ms-2s network call.
+//!   Blanket-flushing would have been the expensive answer to a rare problem.
+//! * The cost is **flat in record size** (~4ms at both 200B and 700B): it is the
+//!   flush, not the payload. So "how many appends flush" is the only lever, which
+//!   is exactly the lever a per-record-kind policy pulls.
+//!
+//! The directory flush is charged on every iteration here; in production only a
+//! journal's first-ever append pays it.
+//!
+//! The three modes are reimplemented here rather than called: `append_line` and
+//! `append_line_durable` are `pub(crate)`, and a bench is an external crate.
+//! They mirror `store::fs::append_line_inner` exactly, minus the
+//! `spawn_blocking` hop, which is deliberate — the point is to price the
+//! syscalls, not tokio's scheduler.
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+
+/// How an append is written.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Mode {
+    /// `store::fs::append_line`: one `O_APPEND` write, no flush.
+    Plain,
+    /// `store::fs::append_line_durable` appending to a file that exists.
+    SyncData,
+    /// `store::fs::append_line_durable` on the append that creates the file —
+    /// charged on every iteration, so an upper bound for the directory flush.
+    SyncDataAndDir,
+}
+
+impl Mode {
+    const ALL: [Mode; 3] = [Mode::Plain, Mode::SyncData, Mode::SyncDataAndDir];
+
+    fn name(self) -> &'static str {
+        match self {
+            Mode::Plain => "plain",
+            Mode::SyncData => "sync_data",
+            Mode::SyncDataAndDir => "sync_data_and_dir",
+        }
+    }
+}
+
+/// One append, exactly as `store::fs::append_line_inner` performs it.
+fn append(path: &Path, record: &str, mode: Mode) {
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)
+        .expect("open");
+    file.write_all(record.as_bytes()).expect("write");
+    if mode != Mode::Plain {
+        file.sync_data().expect("sync_data");
+    }
+    if mode == Mode::SyncDataAndDir {
+        let dir = File::open(path.parent().expect("parent")).expect("open parent");
+        dir.sync_all().expect("sync parent");
+    }
+}
+
+/// An `EffectExecuted` line at its realistic size (~200 bytes): the key plus the
+/// executed-effect description, which is what the at-most-once commit carries.
+fn effect_executed_line() -> String {
+    let line = serde_json::json!({
+        "record": "EffectExecuted",
+        "key": "effect:task-01H9Z2QK3M4N5P6R7S8T9V0W1X:filing.submit:3",
+        "effect": {
+            "kind": "filing.submit",
+            "amount_usd": 249.5,
+            "task_id": "task-01H9Z2QK3M4N5P6R7S8T9V0W1X",
+            "at_millis": 1_767_225_600_000u64,
+            "irreversible": true
+        }
+    })
+    .to_string();
+    pad_to(line, 200)
+}
+
+/// An `ApprovalParked` line at its realistic size (~700 bytes): the whole parked
+/// effect plus its four correlation keys. The largest record the journal writes
+/// in normal operation, and a process-durable one — included to show the flush
+/// cost is dominated by the syscall, not the payload.
+fn approval_parked_line() -> String {
+    let line = serde_json::json!({
+        "record": "ApprovalParked",
+        "id": "appr-01H9Z2QK3M4N5P6R7S8T9V0W1X",
+        "effect": {
+            "kind": "composio_execute",
+            "group": "Spend",
+            "amount_usd": 1249.0,
+            "established_thread": false,
+            "first_time_counterparty": true,
+            "payload": {
+                "tool": "gmail_send_email",
+                "arguments": {
+                    "recipient": "counterparty@example.invalid",
+                    "subject": "Q3 filing package",
+                    "body": "Attaching the signed filing package for counter-signature."
+                }
+            },
+            "agent": "finance",
+            "run_id": "run-01H9Z2QK3M4N5P6R7S8T9V0W1X"
+        },
+        "at_millis": 1_767_225_600_000u64,
+        "task": { "kind": "Task", "id": "task-01H9Z2QK3M4N5P6R7S8T9V0W1X" },
+        "thread": "desk-finance",
+        "parent": 4821,
+        "cycle": "cycle-01H9Z2QK3M4N5P6R7S8T9V0W1X"
+    })
+    .to_string();
+    pad_to(line, 700)
+}
+
+/// Pads a line to `target` bytes with a filler field, so the two sizes are the
+/// sizes they claim to be regardless of how the JSON above happens to serialize.
+fn pad_to(line: String, target: usize) -> String {
+    let mut line = line;
+    if line.len() + 12 < target {
+        let filler = "x".repeat(target - line.len() - 12);
+        line.truncate(line.len() - 1);
+        line.push_str(&format!(",\"_pad\":\"{filler}\"}}"));
+    }
+    line.push('\n');
+    line
+}
+
+/// A directly measured latency profile, printed before the criterion run.
+///
+/// Criterion reports a mean and a median; it does not report a p99, and the tail
+/// is the interesting part of a flush. So the percentiles are sampled here by
+/// hand: `SAMPLES` timed appends per (mode, size), sorted, reported at p50/p99
+/// alongside the appends-per-second implied by the p50.
+fn print_latency_percentiles() {
+    const SAMPLES: usize = 400;
+
+    println!("\n# issue #392 — append latency by durability mode");
+    println!("# (macOS sync_data is a full-flush flavour; local SSD, not EFS — see module docs)");
+    println!(
+        "\n{:<20} {:>6} {:>12} {:>12} {:>14}",
+        "mode", "bytes", "p50", "p99", "appends/sec@p50"
+    );
+
+    for (size_label, line) in [
+        ("~200B", effect_executed_line()),
+        ("~700B", approval_parked_line()),
+    ] {
+        for mode in Mode::ALL {
+            let dir = tempfile::Builder::new()
+                .prefix("opencompany-bench-")
+                .tempdir()
+                .expect("tempdir");
+            let path = dir.path().join("journal.jsonl");
+
+            let mut samples = Vec::with_capacity(SAMPLES);
+            for _ in 0..SAMPLES {
+                let start = Instant::now();
+                append(&path, &line, mode);
+                samples.push(start.elapsed());
+            }
+            samples.sort_unstable();
+
+            let p50 = samples[SAMPLES / 2];
+            let p99 = samples[(SAMPLES * 99) / 100];
+            let per_sec = 1.0 / p50.as_secs_f64();
+            println!(
+                "{:<20} {:>6} {:>12} {:>12} {:>14.0}",
+                format!("{} {}", mode.name(), size_label),
+                line.len(),
+                fmt(p50),
+                fmt(p99),
+                per_sec
+            );
+        }
+    }
+    println!();
+}
+
+fn fmt(d: Duration) -> String {
+    let micros = d.as_secs_f64() * 1e6;
+    if micros >= 1000.0 {
+        format!("{:.3}ms", micros / 1000.0)
+    } else {
+        format!("{micros:.1}us")
+    }
+}
+
+fn journal_append(c: &mut Criterion) {
+    print_latency_percentiles();
+
+    let mut group = c.benchmark_group("journal_append");
+    group.throughput(Throughput::Elements(1));
+
+    for (size_label, line) in [
+        ("effect_executed_200b", effect_executed_line()),
+        ("approval_parked_700b", approval_parked_line()),
+    ] {
+        for mode in Mode::ALL {
+            let dir = tempfile::Builder::new()
+                .prefix("opencompany-bench-")
+                .tempdir()
+                .expect("tempdir");
+            let path = dir.path().join("journal.jsonl");
+
+            group.bench_with_input(
+                BenchmarkId::new(mode.name(), size_label),
+                &line,
+                |b, line| b.iter(|| append(&path, line, mode)),
+            );
+        }
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, journal_append);
+criterion_main!(benches);

--- a/docs/spec/runtime/lifecycle.md
+++ b/docs/spec/runtime/lifecycle.md
@@ -85,6 +85,39 @@ re-runs them. Effects are executed at-most-once by the kernel — an effect is
 journaled *before* execution and marked after, so replay never re-fires a
 completed effect.
 
+### Which crash a journal record survives (issue #392)
+
+The runtime journal's durability is chosen **per record kind**, not once for the
+file. Each `JournalRecord` declares it, and `RuntimeJournal::append` — the single
+choke point every record goes through — honours the declaration:
+
+| Records | Survives | Why |
+|---|---|---|
+| `EffectExecuted`, `StandingGrantRevoked` | **Host crash / power loss.** Flushed to stable storage (`sync_data`, plus the parent directory on the file's first write) before the append returns. | These are the only kinds whose loss makes the runtime **repeat an external action**. `EffectExecuted` is written immediately before the side effect, so losing it re-fires that effect on the next boot; losing a revocation silently re-arms a standing grant an operator took back, letting it keep admitting calls until its own deadline. |
+| The other eleven | **Process crash.** In the kernel page cache when the append returns; a host crash can lose them. | Losing any of them makes the runtime **re-ask**, never re-fire: an approval is parked again, an operator is prompted again, a cycle bracket reads as interrupted. That is the safe direction, and it is a decision rather than an omission. |
+
+The split is affordable because the frequency runs the helpful way. The two
+flushed kinds are written at operator-decision scale — `EffectExecuted` sits in
+front of a network call costing 100ms–2s, so a flush ahead of it is invisible —
+while the highest-volume records (`CycleStarted`/`CycleFinished`, a pair per
+cycle) are pure observability. A blanket flush would tax the hottest cosmetic
+record to protect the rarest dangerous one.
+
+A failed flush **fails the append**, which aborts the effect before it runs: no
+record means no effect, so the failure cannot produce the duplicate it guards
+against. The flush is never retried, because a failed `fsync` may already have
+dropped the dirty pages and a retry would report success over lost data.
+
+**This guarantee is bounded by the volume underneath.** The journal is built on
+the filesystem path unconditionally, outside the storage ports, so a hosted
+tenant whose `/data` is ephemeral scratch — the documented arrangement under
+`OPENCOMPANY_STORAGE=mongodb`, see
+[storage.md](storage.md) — loses its journal to a container replacement and
+gains nothing from these flushes. Where the data directory is a real volume (the
+reference ECS deployment mounts EFS at `/data`, whose NFS client page cache is
+exactly what `sync_data` forces through) the flush buys real durability. Moving
+the journal behind the ports is tracked separately as issue #726.
+
 ## The fs bundle (default store)
 
 ```text

--- a/docs/spec/runtime/lifecycle.md
+++ b/docs/spec/runtime/lifecycle.md
@@ -93,10 +93,19 @@ choke point every record goes through — honours the declaration:
 
 | Records | Survives | Why |
 |---|---|---|
-| `EffectExecuted`, `StandingGrantRevoked` | **Host crash / power loss.** Flushed to stable storage (`sync_data`, plus the parent directory on the file's first write) before the append returns. | These are the only kinds whose loss makes the runtime **repeat an external action**. `EffectExecuted` is written immediately before the side effect, so losing it re-fires that effect on the next boot; losing a revocation silently re-arms a standing grant an operator took back, letting it keep admitting calls until its own deadline. |
-| The other eleven | **Process crash.** In the kernel page cache when the append returns; a host crash can lose them. | Losing any of them makes the runtime **re-ask**, never re-fire: an approval is parked again, an operator is prompted again, a cycle bracket reads as interrupted. That is the safe direction, and it is a decision rather than an omission. |
+| `EffectExecuted`, `GrantConsumed`, `StandingGrantRevoked` | **Host crash / power loss.** Flushed to stable storage (`sync_data`, plus every directory the append creates) before the append returns. | These are the only kinds whose loss makes the runtime **repeat an external action**. `EffectExecuted` is written immediately before the side effect, so losing it re-fires that effect on the next boot; losing a `GrantConsumed` keeps the `ApprovalGranted` that minted the grant and drops its redemption, returning a spent single-use grant to the live set where it admits the identical call again with no new approval card; losing a revocation silently re-arms a standing grant an operator took back, letting it keep admitting calls until its own deadline. |
+| The other ten | **Process crash.** In the kernel page cache when the append returns; a host crash can lose them. | Losing any of them makes the runtime **re-ask**, never re-fire: an approval is parked again, an operator is prompted again, a cycle bracket reads as interrupted. That is the safe direction, and it is a decision rather than an omission. |
 
-The split is affordable because the frequency runs the helpful way. The two
+`GrantConsumed`'s flush narrows its window rather than closing it, and is not
+claimed to do more. Redemption happens inside a synchronous `ToolPolicy::check`
+that holds no journal handle, so the id is buffered on the grant set and written
+when the cycle it belongs to ends; a crash inside *that* gap loses the record
+before any append is reached. The flush removes the half the journal controls —
+a record that was written but only page-cached. Closing the other half means
+recording the redemption where it happens, which is a change to the tool-policy
+seam rather than to durability.
+
+The split is affordable because the frequency runs the helpful way. The three
 flushed kinds are written at operator-decision scale — `EffectExecuted` sits in
 front of a network call costing 100ms–2s, so a flush ahead of it is invisible —
 while the highest-volume records (`CycleStarted`/`CycleFinished`, a pair per

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -379,9 +379,18 @@ struct GrantState {
     /// buffered instead and the cycle runner drains it after the cycle it
     /// belongs to. A crash between consuming and draining loses the
     /// `GrantConsumed` record, which on replay re-arms a grant whose tool
-    /// already ran — the same at-most-once trade the effect journal makes, and
-    /// in the safe direction: the operator is asked again rather than the tool
-    /// firing again unasked.
+    /// already ran: the `ApprovalGranted` that minted it survives, the
+    /// redemption does not, and [`GrantSet::consume`] will admit the identical
+    /// call a second time with **no** new approval card — until the grant's own
+    /// [`GRANT_TTL_MILLIS`] retires it.
+    ///
+    /// This is a duplication window, not the safe direction, and it is stated
+    /// that way because it used to be recorded here as the opposite. What issue
+    /// #392 could close from the journal's side it did: `GrantConsumed` is
+    /// host-durable, so a record that reached the append is on stable storage
+    /// before the append returns. This buffer is the half that remains — closing
+    /// it means recording the redemption where it happens, which needs a journal
+    /// handle at the `ToolPolicy::check` seam.
     consumed: Vec<ApprovalId>,
     /// Standing grants (issue #374), keyed by their own id.
     ///

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -28,7 +28,7 @@ use crate::error::OpenCompanyError;
 use crate::ports::types::{Actor, ApprovalId, Effect, EventSeq};
 use crate::runtime::grants::{GrantId, GrantedCall, StandingGrant};
 pub use crate::runtime::types::TaskLink;
-use crate::store::fs::{PathLocks, append_line, append_line_durable};
+use crate::store::fs::{PathLocks, append_line, append_line_durable, create_dir_all_durable};
 
 /// Journal append locks, keyed by path, shared by every [`RuntimeJournal`] in
 /// the process (issue #386).
@@ -1748,9 +1748,16 @@ impl RuntimeJournal {
         let durability = record.durability();
         let _guard = self.write_lock.lock().await;
         if let Some(parent) = self.path.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| self.io_err_at(parent, e))?;
+            match durability {
+                // The directories are part of what makes the flushed record
+                // findable. A journal's first append into a fresh data directory
+                // creates the whole chain, and a record flushed under ancestors
+                // that were never written down is lost with them.
+                Durability::Host => create_dir_all_durable(parent).await?,
+                Durability::Process => tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| self.io_err_at(parent, e))?,
+            }
         }
         match durability {
             Durability::Host => append_line_durable(&self.path, &line).await,
@@ -3535,6 +3542,39 @@ mod test {
         let reloaded = RuntimeJournal::new(&path);
         reloaded.load().await.unwrap();
         assert!(reloaded.is_executed("k-1"), "the flushed commit replays");
+    }
+
+    /// **Issue #392**: a host-durable record creates its journal's parent chain
+    /// durably too.
+    ///
+    /// The wiring half of `create_dir_all_durable`. A journal's *first* append
+    /// is the one that creates the directories, and it is also the one most
+    /// likely to be an `EffectExecuted` commit. Reaching for the plain
+    /// `create_dir_all` there would flush the record under ancestors that were
+    /// not flushed, and a host crash takes the subtree — and the record with it.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn a_host_record_flushes_the_directories_its_journal_creates() {
+        use crate::store::fs::append_probe;
+
+        let dir = tmp_dir();
+        let companies = dir.path().join("companies");
+        let home = companies.join("acme");
+        let journal = RuntimeJournal::new(&home.join("journal.jsonl"));
+
+        journal.record_executed("k-1", executed(1)).await.unwrap();
+
+        for (created, holder) in [("companies", dir.path()), ("acme", &companies)] {
+            assert!(
+                append_probe::dir_synced(holder),
+                "the directory holding the entry naming `{created}` must be flushed \
+                 before a host-durable record is reported durable"
+            );
+        }
+        assert!(
+            append_probe::dir_synced(&home),
+            "the journal file's own directory entry must be flushed"
+        );
     }
 
     /// **Issue #392**: a commit whose append fails must release its key, so the

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -1144,19 +1144,52 @@ impl RuntimeJournal {
     /// A no-op (returns `Ok`) if the key is already committed — which is also
     /// what keeps the executed-effect list free of duplicates: the second
     /// commit under a key never reaches the append.
+    ///
+    /// **A failed append releases the key again.** The in-memory set is a mirror
+    /// of what the file holds, and holding a key the append refused makes it lie
+    /// in the one direction that is silent: `execute_effect_once` aborts before
+    /// `perform_effect` on the error, so nothing external fired — but a later
+    /// attempt under the same key would then find the key present, take the
+    /// `Ok(())` early return, and skip the effect *reporting success*. The
+    /// effect would never run and no caller would ever hear that. Releasing the
+    /// key makes the retry a real retry.
+    ///
+    /// This does not weaken at-most-once, because the two are on opposite sides
+    /// of the side effect. The guarantee is about a crash *after* a commit that
+    /// succeeded; this is a commit that failed, before which nothing ran. The
+    /// worst case is the uncertain one — the write reached the file and only the
+    /// flush failed — and it still cannot duplicate: the retry appends a second
+    /// line for the key (replay dedupes, `executed` is a set) and runs the
+    /// effect exactly once, and a crash before the retry replays the first line
+    /// and skips the effect entirely. Every path is one execution or none.
+    ///
+    /// Contrast [`record_grant_consumed`](Self::record_grant_consumed), which
+    /// deliberately does *not* roll back: its tool has already run by the time
+    /// the record is written, so keeping the grant spent in memory is the safe
+    /// direction and restoring it would re-arm a grant that was redeemed.
     pub async fn record_executed(&self, key: &str, effect: ExecutedEffect) -> Result<()> {
         {
             let mut state = self.state.lock().expect("journal state poisoned");
             if !state.executed.insert(key.to_string()) {
                 return Ok(());
             }
-            state.index_executed(effect.clone());
         }
-        self.append(&JournalRecord::EffectExecuted {
-            key: key.to_string(),
-            effect: Some(effect),
-        })
-        .await
+        let appended = self
+            .append(&JournalRecord::EffectExecuted {
+                key: key.to_string(),
+                effect: Some(effect.clone()),
+            })
+            .await;
+        let mut state = self.state.lock().expect("journal state poisoned");
+        match appended {
+            // Indexed only once the commit is on the file, so the retry warnings
+            // built from it describe effects the journal actually committed.
+            Ok(()) => state.index_executed(effect),
+            Err(_) => {
+                state.executed.remove(key);
+            }
+        }
+        appended
     }
 
     /// Records a newly parked approval and which board task it belongs to
@@ -3481,5 +3514,44 @@ mod test {
         let reloaded = RuntimeJournal::new(&path);
         reloaded.load().await.unwrap();
         assert!(reloaded.is_executed("k-1"), "the flushed commit replays");
+    }
+
+    /// **Issue #392**: a commit whose append fails must release its key, so the
+    /// next attempt under that key is a real retry.
+    ///
+    /// Holding the key would make the failure silent in the worst way. The
+    /// append error aborts `execute_effect_once` before `perform_effect`, so
+    /// nothing external ran; a later attempt would then find the key present,
+    /// take the already-committed early return, and report `Ok` for an effect
+    /// that never happened and never will.
+    ///
+    /// The fault is injected by putting a **directory** where the journal file
+    /// belongs: `append`'s `create_dir_all` on the parent still succeeds, and
+    /// the append's own `open` then fails with `EISDIR`. A real failure of the
+    /// real `append_line_durable`, with no production seam added to stage it.
+    #[tokio::test]
+    async fn a_failed_commit_releases_the_key_for_a_retry() {
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        tokio::fs::create_dir_all(&path).await.unwrap();
+        let journal = RuntimeJournal::new(&path);
+
+        let first = journal.record_executed("k-1", executed(1)).await;
+        assert!(
+            first.is_err(),
+            "the append cannot land on a path occupied by a directory"
+        );
+        assert!(
+            !journal.is_executed("k-1"),
+            "a key whose commit never reached the file must not be held: \
+             the effect did not run, so the key must not claim it did"
+        );
+
+        let retry = journal.record_executed("k-1", executed(1)).await;
+        assert!(
+            retry.is_err(),
+            "the retry must re-attempt the commit and surface the failure again, \
+             never take the already-committed early return and report success"
+        );
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -3566,13 +3566,13 @@ mod test {
 
         for (created, holder) in [("companies", dir.path()), ("acme", &companies)] {
             assert!(
-                append_probe::dir_synced(holder),
+                append_probe::dir_syncs(holder) > 0,
                 "the directory holding the entry naming `{created}` must be flushed \
                  before a host-durable record is reported durable"
             );
         }
         assert!(
-            append_probe::dir_synced(&home),
+            append_probe::dir_syncs(&home) > 0,
             "the journal file's own directory entry must be flushed"
         );
     }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -3560,7 +3560,7 @@ mod test {
         let dir = tmp_dir();
         let companies = dir.path().join("companies");
         let home = companies.join("acme");
-        let journal = RuntimeJournal::new(&home.join("journal.jsonl"));
+        let journal = RuntimeJournal::new(home.join("journal.jsonl"));
 
         journal.record_executed("k-1", executed(1)).await.unwrap();
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -28,7 +28,7 @@ use crate::error::OpenCompanyError;
 use crate::ports::types::{Actor, ApprovalId, Effect, EventSeq};
 use crate::runtime::grants::{GrantId, GrantedCall, StandingGrant};
 pub use crate::runtime::types::TaskLink;
-use crate::store::fs::{PathLocks, append_line};
+use crate::store::fs::{PathLocks, append_line, append_line_durable};
 
 /// Journal append locks, keyed by path, shared by every [`RuntimeJournal`] in
 /// the process (issue #386).
@@ -290,6 +290,91 @@ enum JournalRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
+}
+
+/// The failure a journal record is written to outlast (issue #392).
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum Durability {
+    /// In the kernel's page cache when [`RuntimeJournal::append`] returns. A
+    /// killed process cannot lose the record; a host crash or power loss can.
+    Process,
+    /// On stable storage when [`RuntimeJournal::append`] returns, at the cost of
+    /// one flush per append.
+    Host,
+}
+
+impl JournalRecord {
+    /// Which failure this record must survive.
+    ///
+    /// Host durability is bought for exactly the records whose loss would make
+    /// the runtime **repeat an external action**, and for nothing else. The
+    /// frequency asymmetry is the whole argument, and it runs the helpful way:
+    /// the dangerous records are rare and the frequent records are harmless.
+    /// [`EffectExecuted`](Self::EffectExecuted) is written at human-approval
+    /// scale, immediately in front of a network call that costs 100ms-2s, so a
+    /// flush ahead of it is invisible; [`CycleStarted`](Self::CycleStarted) is
+    /// written on the front edge of *every* cycle, before the per-company serial
+    /// lock, and losing it costs an observability bracket. A blanket flush would
+    /// tax the hottest cosmetic record in the journal to protect the rarest
+    /// dangerous one.
+    ///
+    /// The match is **wildcard-free on purpose, and must stay that way**: a new
+    /// record kind is a compile error until its author has decided which failure
+    /// it must survive. That decision — not the two flushes — is what #392
+    /// delivers. Same reasoning as [`TaskLink`] being an enum rather than a bare
+    /// `Option`: the type refuses to let a decision be skipped by default.
+    fn durability(&self) -> Durability {
+        match self {
+            // Written *before* the side effect runs (`execute_effect_once`), so
+            // losing it makes the next boot re-fire the effect mechanically —
+            // the single duplication this journal exists to prevent.
+            Self::EffectExecuted { .. } => Durability::Host,
+            // Losing it silently un-revokes: the grant replays live on the next
+            // boot and keeps admitting calls until its own deadline, undoing an
+            // operator's withdrawal of authority. An operator action, so rare
+            // enough that the flush costs nothing measurable.
+            Self::StandingGrantRevoked { .. } => Durability::Host,
+
+            // Written *after* the tool already ran, batched at cycle end as an
+            // explicitly best-effort write whose failure is only logged
+            // (`CompanyCycle::run`). The design already accepts a turn-length
+            // loss window, so flushing inside a wider accepted window is
+            // theatre. A lost record re-arms a spent grant, which re-asks the
+            // operator.
+            Self::GrantConsumed { .. } => Durability::Process,
+            // Losing a park loses the *question*: the approval vanishes and the
+            // agent parks it again on its next attempt. Nothing external fired.
+            Self::ApprovalParked { .. } => Durability::Process,
+            // Bookkeeping after the decision. A ghost approval that is approved
+            // a second time cannot duplicate the effect, because the effect's
+            // own commit is host-durable and `is_executed` skips it.
+            Self::ApprovalResolved { .. } => Durability::Process,
+            // Recomputed: the parked record carries the deadline, so replay
+            // re-expires it.
+            Self::ApprovalExpired { .. } => Durability::Process,
+            // Audit-only. The queue removal rides on the paired
+            // `ApprovalResolved`, and the original effect stays recoverable from
+            // the earlier `ApprovalParked`.
+            Self::ApprovalAmended { .. } => Durability::Process,
+            // Written *before* the grant goes live, so losing it forgets a YES:
+            // the agent is blocked again and the operator is re-asked. The safe
+            // direction — the cost of the loss is an extra question, never an
+            // extra call.
+            Self::ApprovalGranted { .. } => Durability::Process,
+            // The same direction as `ApprovalGranted`, one scope wider.
+            Self::StandingGrantMinted { .. } => Durability::Process,
+            // Deadline arithmetic rather than state: `replayed_standing_grants`
+            // takes `now_millis` and re-expires anything past its deadline on
+            // the next boot regardless of whether the record survived.
+            Self::GrantExpired { .. } => Durability::Process,
+            Self::StandingGrantExpired { .. } => Durability::Process,
+            // Observability brackets, and the highest-volume records here.
+            // Losing either half reads as an interrupted cycle — which, after a
+            // host crash, it was.
+            Self::CycleStarted { .. } => Durability::Process,
+            Self::CycleFinished { .. } => Durability::Process,
+        }
+    }
 }
 
 /// A parked approval awaiting resolution.
@@ -1561,17 +1646,40 @@ impl RuntimeJournal {
     }
 
     /// Appends one record, whole, and does not return until the write syscall
-    /// has completed.
+    /// has completed — and, for the record kinds that need it, until the bytes
+    /// are on stable storage.
     ///
-    /// **The guarantee is process-crash durability, not host-crash durability.**
-    /// There is no `sync_data`/`sync_all` here, so the bytes are in the kernel's
-    /// page cache rather than on stable storage when this returns: killing the
-    /// process cannot lose them, but a host crash or power loss between the
-    /// append and the flush still can. The at-most-once contract therefore holds
-    /// against a process dying — the case this codebase actually handles, and
-    /// the one the boot reaper and the interrupted-run sweep are built around —
-    /// and not against losing the machine. Whether an `fsync` per append is
-    /// worth its cost on this path is a separate decision (see #392).
+    /// **Durability is per record kind, by decision (issue #392).** Every record
+    /// declares which failure it must outlast through
+    /// [`JournalRecord::durability`], and this is the single choke point that
+    /// honours it, exactly as it is the single choke point for
+    /// [`JOURNAL_WRITE_LOCKS`]:
+    ///
+    /// * The two [`Durability::Host`] kinds — `EffectExecuted` and
+    ///   `StandingGrantRevoked` — go through
+    ///   [`append_line_durable`](crate::store::fs::append_line_durable) and are
+    ///   flushed to stable storage before this returns. So the at-most-once
+    ///   contract holds against **losing the machine** for precisely the records
+    ///   whose loss would repeat an external action, and a failed flush fails
+    ///   the append — which aborts `execute_effect_once` before `perform_effect`
+    ///   and so cannot produce the duplicate it is guarding against.
+    /// * The other eleven are page-cache durable: killing the process cannot
+    ///   lose them, a host crash can. That is the decision, not a gap left open.
+    ///   Losing any of them makes the runtime **re-ask** — an approval is parked
+    ///   again, an operator is prompted again, a cycle bracket reads as
+    ///   interrupted — and never re-fire. Flushing them would tax the journal's
+    ///   highest-volume records to protect against a re-asked question.
+    ///
+    /// **This is bounded by the volume underneath.** The journal is constructed
+    /// unconditionally on the filesystem path, outside the storage ports, so a
+    /// hosted tenant whose `/data` is ephemeral scratch (the documented
+    /// arrangement under `OPENCOMPANY_STORAGE=mongodb` — see
+    /// `docs/spec/runtime/storage.md`) does not keep its journal across a
+    /// container replacement, let alone a host crash, and gains nothing from
+    /// this flush. Where the data directory is a real volume — the reference ECS
+    /// deployment mounts EFS at `/data`, whose NFS client page cache is exactly
+    /// what `sync_data` forces through — it buys real durability. Moving the
+    /// journal behind the ports is issue #726 and is not attempted here.
     ///
     /// Delegates to [`append_line`](crate::store::fs::append_line), which emits
     /// the record **and** its newline in a single blocking `write_all` under
@@ -1595,13 +1703,17 @@ impl RuntimeJournal {
     /// and the feedback store's copy of it; the journal was the last twin.
     async fn append(&self, record: &JournalRecord) -> Result<()> {
         let line = serde_json::to_string(record)?;
+        let durability = record.durability();
         let _guard = self.write_lock.lock().await;
         if let Some(parent) = self.path.parent() {
             tokio::fs::create_dir_all(parent)
                 .await
                 .map_err(|e| self.io_err_at(parent, e))?;
         }
-        append_line(&self.path, &line).await
+        match durability {
+            Durability::Host => append_line_durable(&self.path, &line).await,
+            Durability::Process => append_line(&self.path, &line).await,
+        }
     }
 
     fn io_err(&self, source: std::io::Error) -> OpenCompanyError {
@@ -3190,5 +3302,184 @@ mod test {
                 serde_json::to_string(&record).unwrap()
             );
         }
+    }
+
+    /// One value of every [`JournalRecord`] variant (issue #392).
+    ///
+    /// Hand-built, so it carries its own completeness check below — the tag
+    /// count. The *classification* needs no such guard: `durability`'s match is
+    /// wildcard-free, so a new variant cannot compile until somebody decides
+    /// which failure it must survive.
+    fn every_record_kind() -> Vec<JournalRecord> {
+        vec![
+            JournalRecord::EffectExecuted {
+                key: "k".into(),
+                effect: Some(executed(1)),
+            },
+            JournalRecord::ApprovalParked {
+                id: ApprovalId::new("a"),
+                effect: effect(),
+                at_millis: 1,
+                task: Some(TaskLink::Unlinked),
+                thread: None,
+                parent: None,
+                cycle: None,
+            },
+            JournalRecord::ApprovalResolved {
+                id: ApprovalId::new("a"),
+            },
+            JournalRecord::ApprovalExpired {
+                id: ApprovalId::new("a"),
+                at_millis: 2,
+            },
+            JournalRecord::ApprovalAmended {
+                id: ApprovalId::new("a"),
+                amended_effect: effect(),
+                at_millis: 3,
+            },
+            JournalRecord::ApprovalGranted {
+                grant: grant("a", 4),
+            },
+            JournalRecord::GrantConsumed {
+                id: ApprovalId::new("a"),
+                effect: None,
+            },
+            JournalRecord::GrantExpired {
+                id: ApprovalId::new("a"),
+                at_millis: 5,
+            },
+            JournalRecord::StandingGrantMinted {
+                grant: standing("s", "composio_execute", 9),
+            },
+            JournalRecord::StandingGrantRevoked {
+                id: GrantId::new("s"),
+                by: revoker(),
+                at_millis: 6,
+            },
+            JournalRecord::StandingGrantExpired {
+                id: GrantId::new("s"),
+                at_millis: 7,
+            },
+            JournalRecord::CycleStarted {
+                cycle_id: "c".into(),
+                at_millis: 8,
+                trigger: "test".into(),
+            },
+            JournalRecord::CycleFinished {
+                cycle_id: "c".into(),
+                at_millis: 9,
+                error: None,
+            },
+        ]
+    }
+
+    /// The operator who takes a standing grant back.
+    fn revoker() -> Actor {
+        Actor {
+            kind: crate::ports::types::ActorKind::User,
+            id: "user-42".into(),
+        }
+    }
+
+    /// A record's `record` tag — the same name the serialized line carries, so a
+    /// failure names the variant rather than an index.
+    fn record_tag(record: &JournalRecord) -> String {
+        serde_json::to_value(record).unwrap()["record"]
+            .as_str()
+            .expect("every record is tagged")
+            .to_string()
+    }
+
+    /// **Issue #392**: the host-durable set is a policy, and this pins it.
+    ///
+    /// The wildcard-free match in [`JournalRecord::durability`] already makes
+    /// *completeness* a compile error — a new variant will not build until it is
+    /// classified. What no compiler can catch is an existing kind being moved
+    /// across the line: flipping `EffectExecuted` to `Process` compiles, passes
+    /// every other test in this file, and silently gives up the one guarantee
+    /// the journal exists for. This is the test that notices.
+    #[test]
+    fn host_durable_kinds_are_exactly_effect_executed_and_standing_grant_revoked() {
+        let all = every_record_kind();
+        let tags: HashSet<String> = all.iter().map(record_tag).collect();
+        assert_eq!(
+            tags.len(),
+            13,
+            "every JournalRecord variant must appear once in every_record_kind"
+        );
+
+        let mut host: Vec<String> = all
+            .iter()
+            .filter(|record| record.durability() == Durability::Host)
+            .map(record_tag)
+            .collect();
+        host.sort();
+        assert_eq!(
+            host,
+            vec![
+                "EffectExecuted".to_string(),
+                "StandingGrantRevoked".to_string()
+            ],
+            "the host-durable set is these two kinds and nothing else; \
+             widening it taxes the hot path, narrowing it lets an effect duplicate"
+        );
+    }
+
+    /// **Issue #392**: a host-durable record's append really does take the
+    /// flushing path, and a process-durable one really does not.
+    ///
+    /// What this proves and what it does not. It proves the **policy** (which
+    /// kinds route where) and the **plumbing** (the flush was requested and its
+    /// syscall returned `Ok` — the append would have failed otherwise), plus
+    /// that the record is readable back afterwards. It does **not** prove the
+    /// bytes reached stable storage, and no portable unit test can: a synced and
+    /// an unsynced line are byte-identical on disk, and `SIGKILL` does not drop
+    /// the page cache, so no process-level test can simulate host loss. Proving
+    /// that needs a crash-consistency harness — dm-log-writes, or a VM whose
+    /// unsynced page cache is dropped — which this repo does not have. The OS
+    /// contract carries the rest.
+    #[tokio::test]
+    async fn host_records_route_through_the_durable_append() {
+        use crate::store::fs::append_probe;
+
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+        let journal = RuntimeJournal::new(&path);
+
+        journal.record_cycle_started("c-1", "test").await.unwrap();
+        assert_eq!(
+            append_probe::counts(&path),
+            (1, 0),
+            "CycleStarted is process-durable and must not flush"
+        );
+
+        journal.record_executed("k-1", executed(1)).await.unwrap();
+        assert_eq!(
+            append_probe::counts(&path),
+            (1, 1),
+            "EffectExecuted must flush before its side effect runs"
+        );
+
+        journal
+            .record_standing_revoked(&GrantId::new("s-1"), revoker(), 6)
+            .await
+            .unwrap();
+        assert_eq!(
+            append_probe::counts(&path),
+            (1, 2),
+            "StandingGrantRevoked must flush"
+        );
+
+        journal.record_cycle_finished("c-1", None).await.unwrap();
+        assert_eq!(
+            append_probe::counts(&path),
+            (2, 2),
+            "CycleFinished is process-durable and must not flush"
+        );
+
+        // The durable path must leave a journal that still replays.
+        let reloaded = RuntimeJournal::new(&path);
+        reloaded.load().await.unwrap();
+        assert!(reloaded.is_executed("k-1"), "the flushed commit replays");
     }
 }

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -334,14 +334,23 @@ impl JournalRecord {
             // operator's withdrawal of authority. An operator action, so rare
             // enough that the flush costs nothing measurable.
             Self::StandingGrantRevoked { .. } => Durability::Host,
-
-            // Written *after* the tool already ran, batched at cycle end as an
-            // explicitly best-effort write whose failure is only logged
-            // (`CompanyCycle::run`). The design already accepts a turn-length
-            // loss window, so flushing inside a wider accepted window is
-            // theatre. A lost record re-arms a spent grant, which re-asks the
-            // operator.
-            Self::GrantConsumed { .. } => Durability::Process,
+            // Losing it re-arms a grant whose tool already ran. Replay keeps the
+            // `ApprovalGranted` that minted it and drops the redemption, so the
+            // grant returns to the live set and `GrantSet::consume` will admit
+            // the identical call again — no card, no operator, until the grant's
+            // own TTL. That is a repeated external action under an authority the
+            // operator spent once, which is the criterion above.
+            //
+            // The flush does not close the window on its own, and is not claimed
+            // to: redemption happens inside a sync `ToolPolicy::check` with no
+            // journal handle, so the id is buffered and written at cycle end
+            // (`CompanyCycle::run`), and a crash inside *that* gap loses the
+            // record before any append is reached. Flushing removes the part
+            // this file controls — the record that was written but only
+            // page-cached. Narrowing a duplication window is worth one flush on
+            // a record written at operator-decision scale; the batching is the
+            // remaining half and is not this issue's to close.
+            Self::GrantConsumed { .. } => Durability::Host,
             // Losing a park loses the *question*: the approval vanishes and the
             // agent parks it again on its next attempt. Nothing external fired.
             Self::ApprovalParked { .. } => Durability::Process,
@@ -1688,15 +1697,15 @@ impl RuntimeJournal {
     /// honours it, exactly as it is the single choke point for
     /// [`JOURNAL_WRITE_LOCKS`]:
     ///
-    /// * The two [`Durability::Host`] kinds — `EffectExecuted` and
-    ///   `StandingGrantRevoked` — go through
+    /// * The three [`Durability::Host`] kinds — `EffectExecuted`,
+    ///   `GrantConsumed` and `StandingGrantRevoked` — go through
     ///   [`append_line_durable`](crate::store::fs::append_line_durable) and are
     ///   flushed to stable storage before this returns. So the at-most-once
     ///   contract holds against **losing the machine** for precisely the records
     ///   whose loss would repeat an external action, and a failed flush fails
     ///   the append — which aborts `execute_effect_once` before `perform_effect`
     ///   and so cannot produce the duplicate it is guarding against.
-    /// * The other eleven are page-cache durable: killing the process cannot
+    /// * The other ten are page-cache durable: killing the process cannot
     ///   lose them, a host crash can. That is the decision, not a gap left open.
     ///   Losing any of them makes the runtime **re-ask** — an approval is parked
     ///   again, an operator is prompted again, a cycle bracket reads as
@@ -3432,7 +3441,7 @@ mod test {
     /// every other test in this file, and silently gives up the one guarantee
     /// the journal exists for. This is the test that notices.
     #[test]
-    fn host_durable_kinds_are_exactly_effect_executed_and_standing_grant_revoked() {
+    fn host_durable_kinds_are_exactly_the_three_that_could_repeat_an_action() {
         let all = every_record_kind();
         let tags: HashSet<String> = all.iter().map(record_tag).collect();
         assert_eq!(
@@ -3451,10 +3460,12 @@ mod test {
             host,
             vec![
                 "EffectExecuted".to_string(),
+                "GrantConsumed".to_string(),
                 "StandingGrantRevoked".to_string()
             ],
-            "the host-durable set is these two kinds and nothing else; \
-             widening it taxes the hot path, narrowing it lets an effect duplicate"
+            "the host-durable set is these three kinds and nothing else; \
+             widening it taxes the hot path, narrowing it lets an effect duplicate \
+             or a spent grant re-arm"
         );
     }
 
@@ -3503,10 +3514,20 @@ mod test {
             "StandingGrantRevoked must flush"
         );
 
+        journal
+            .record_grant_consumed(&ApprovalId::new("appr-1"), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            append_probe::counts(&path),
+            (1, 3),
+            "GrantConsumed must flush: losing it re-arms a grant whose tool ran"
+        );
+
         journal.record_cycle_finished("c-1", None).await.unwrap();
         assert_eq!(
             append_probe::counts(&path),
-            (2, 2),
+            (2, 3),
             "CycleFinished is process-durable and must not flush"
         );
 

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -134,12 +134,14 @@ pub(crate) async fn append_line(path: &Path, line: &str) -> Result<()> {
 ///
 /// The write itself is unchanged — one `write_all` under `O_APPEND`, so the
 /// atomicity argument in [`append_line`] carries over untouched — and is
-/// followed by `File::sync_data`. When the file did **not** exist before the
-/// open, the parent directory is opened and `sync_all`ed as well: on a create it
-/// is the directory entry that names the new file, and that entry is a separate
-/// write which a host crash can lose on its own, leaving a flushed file nothing
-/// can find. One `try_exists` pays for that, and it is confined to this function
-/// so the plain path never stats.
+/// followed by `File::sync_data`. When this append is the one that **creates**
+/// the file, the parent directory is opened and `sync_all`ed as well: on a
+/// create it is the directory entry that names the new file, and that entry is a
+/// separate write which a host crash can lose on its own, leaving a flushed file
+/// nothing can find. Whether it created the file is decided by the open itself
+/// rather than by a prior stat ([`open_for_append`]), so a concurrent deleter
+/// cannot make the append skip that flush. Creating the file's *parent chain*
+/// durably is [`create_dir_all_durable`], and is the caller's to ask for.
 ///
 /// **A failed flush fails the append.** For the caller this exists for — the
 /// journal's `EffectExecuted` commit, written immediately before the side effect
@@ -165,15 +167,8 @@ async fn append_line_inner(path: &Path, line: &str, sync: bool) -> Result<()> {
     tokio::task::spawn_blocking(move || {
         use std::io::Write;
         // Whether this append is the one that creates the file, which is the
-        // only append whose directory entry needs flushing. Asked before the
-        // open, and only on the durable path. An error answers "assume new",
-        // which costs one needless directory flush and never skips a needed one.
-        let creating = sync && !owned_path.try_exists().unwrap_or(false);
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&owned_path)
-            .map_err(|e| io_err(&owned_path, e))?;
+        // only append whose directory entry needs flushing.
+        let (mut file, creating) = open_for_append(&owned_path, sync)?;
         file.write_all(record.as_bytes())
             .map_err(|e| io_err(&owned_path, e))?;
         if sync {
@@ -188,6 +183,63 @@ async fn append_line_inner(path: &Path, line: &str, sync: bool) -> Result<()> {
     })
     .await
     .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+}
+
+/// Opens `path` for appending, reporting whether **this open** created it.
+///
+/// The plain path does not need the answer and takes the single-syscall route.
+/// The durable path does need it — it decides whether the directory entry naming
+/// the file is flushed — and needs it to be *true*, which is why it is not asked
+/// with a `try_exists` before the open. That would be a time-of-check window: a
+/// concurrent deleter landing between the stat and the open answers "already
+/// there" for a file this open then re-creates, and the append skips the
+/// directory flush it exists to guarantee, leaving a synced record under a name
+/// that was never written down. An in-process [`path_lock`] does not help,
+/// because the deleter that matters is another process on the same data
+/// directory.
+///
+/// So the answer comes from the open itself, where it cannot be stale:
+/// `create_new` succeeding **is** the creation, and an append-open succeeding is
+/// proof the file was already there. Neither is cheaper than the stat it
+/// replaces — one open when the file exists, two when it does not, against the
+/// stat-plus-open it cost before.
+///
+/// The two opens can lose to each other repeatedly (created, then deleted, then
+/// absent again), so the retry is bounded and gives up in the safe direction:
+/// assume created, pay one needless directory flush, never skip a needed one.
+fn open_for_append(path: &Path, sync: bool) -> Result<(std::fs::File, bool)> {
+    /// Enough to absorb a racing deleter; past this the path is being churned by
+    /// something whose behaviour no answer here would survive anyway.
+    const ATTEMPTS: usize = 3;
+
+    let create_or_open = || {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|e| io_err(path, e))
+    };
+    if !sync {
+        // `creating` is meaningless on the plain path — nothing flushes.
+        return Ok((create_or_open()?, false));
+    }
+    for _ in 0..ATTEMPTS {
+        match std::fs::OpenOptions::new().append(true).open(path) {
+            Ok(file) => return Ok((file, false)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(io_err(path, e)),
+        }
+        match std::fs::OpenOptions::new()
+            .create_new(true)
+            .append(true)
+            .open(path)
+        {
+            Ok(file) => return Ok((file, true)),
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+            Err(e) => return Err(io_err(path, e)),
+        }
+    }
+    Ok((create_or_open()?, true))
 }
 
 /// Flushes the directory entry naming `path`, so a newly created file is still
@@ -289,7 +341,7 @@ pub(crate) async fn create_dir_all_durable(dir: &Path) -> Result<()> {
 /// full statement of what a unit test can and cannot establish here.
 #[cfg(test)]
 pub(crate) mod append_probe {
-    use std::collections::{HashMap, HashSet};
+    use std::collections::HashMap;
     use std::path::{Path, PathBuf};
     use std::sync::{LazyLock, Mutex};
 
@@ -323,28 +375,33 @@ pub(crate) mod append_probe {
             .unwrap_or((0, 0))
     }
 
-    /// Every directory [`super::sync_parent_dir`] has flushed.
+    /// How many times [`super::sync_parent_dir`] has flushed each directory.
     ///
     /// The same argument as the append tally: a flushed directory and an
     /// unflushed one are identical on disk, so the honest check is to count the
-    /// request where it is made. Never cleared — tests own unique temp paths and
-    /// ask about their own.
-    static DIR_SYNCS: LazyLock<Mutex<HashSet<PathBuf>>> =
-        LazyLock::new(|| Mutex::new(HashSet::new()));
+    /// request where it is made. A count rather than a set, because *how often*
+    /// is the question for the directory flush — it is meant to be paid by the
+    /// append that creates a file and by no other. Never cleared: tests own
+    /// unique temp paths and ask about their own.
+    static DIR_SYNCS: LazyLock<Mutex<HashMap<PathBuf, usize>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
 
     pub(crate) fn record_dir_sync(path: &Path) {
-        DIR_SYNCS
+        *DIR_SYNCS
             .lock()
             .expect("append-probe poisoned")
-            .insert(key(path));
+            .entry(key(path))
+            .or_insert(0) += 1;
     }
 
-    /// Whether `path`'s directory entry block was flushed.
-    pub(crate) fn dir_synced(path: &Path) -> bool {
+    /// How many times `path`'s directory entry block was flushed.
+    pub(crate) fn dir_syncs(path: &Path) -> usize {
         DIR_SYNCS
             .lock()
             .expect("append-probe poisoned")
-            .contains(&key(path))
+            .get(&key(path))
+            .copied()
+            .unwrap_or(0)
     }
 }
 
@@ -1402,7 +1459,7 @@ mod test {
             (&journal_dir, "holds the entry naming the journal file"),
         ] {
             assert!(
-                append_probe::dir_synced(dir),
+                append_probe::dir_syncs(dir) > 0,
                 "{} — unflushed, a host crash can lose the subtree under it",
                 why
             );
@@ -1410,6 +1467,51 @@ mod test {
 
         let rows: Vec<serde_json::Value> = read_jsonl(&path).await.expect("no corrupt lines");
         assert_eq!(rows.len(), 1, "the record itself still landed");
+    }
+
+    /// **Issue #392**: the directory flush is paid by the append that *creates*
+    /// the file, and by no other — decided by the open rather than by a stat
+    /// taken before it.
+    ///
+    /// The race the decision-by-open closes (a deleter landing between a
+    /// `try_exists` and the open, so a re-created file skips the flush that
+    /// makes it findable) cannot be reproduced deterministically in a unit test;
+    /// it needs a second process interleaved between two syscalls. What is
+    /// pinned here is the contract that race would break, across all three
+    /// answers: create flushes, append-to-existing does not, and a re-create
+    /// after a delete flushes again.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_directory_flush_is_paid_only_by_the_append_that_creates() {
+        let root_dir = tmp_root();
+        let dir = root_dir.path().join("journal");
+        tokio::fs::create_dir_all(&dir).await.unwrap();
+        let path = dir.join("journal.jsonl");
+        // The `create_dir_all` above is not durable, so the tally starts here.
+        let before = append_probe::dir_syncs(&dir);
+
+        append_line_durable(&path, "{\"i\":0}").await.unwrap();
+        assert_eq!(
+            append_probe::dir_syncs(&dir) - before,
+            1,
+            "the creating append flushes the entry naming the new file"
+        );
+
+        append_line_durable(&path, "{\"i\":1}").await.unwrap();
+        assert_eq!(
+            append_probe::dir_syncs(&dir) - before,
+            1,
+            "an append to a file that is already there writes no new entry, \
+             so it must not pay for a directory flush"
+        );
+
+        tokio::fs::remove_file(&path).await.unwrap();
+        append_line_durable(&path, "{\"i\":2}").await.unwrap();
+        assert_eq!(
+            append_probe::dir_syncs(&dir) - before,
+            2,
+            "re-creating the file writes a new entry, which must be flushed"
+        );
     }
 
     /// A durable append into a directory that does not exist must surface the

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -210,12 +210,73 @@ fn sync_parent_dir(path: &Path) -> Result<()> {
     };
     std::fs::File::open(parent)
         .and_then(|dir| dir.sync_all())
-        .map_err(|e| io_err(parent, e))
+        .map_err(|e| io_err(parent, e))?;
+    #[cfg(test)]
+    append_probe::record_dir_sync(parent);
+    Ok(())
 }
 
 #[cfg(not(unix))]
 fn sync_parent_dir(_path: &Path) -> Result<()> {
     Ok(())
+}
+
+/// Creates `dir` and every missing ancestor, and does not return until each
+/// directory entry it created is on **stable storage** (issue #392).
+///
+/// A create is durable only once the block that holds its *name* is, and that
+/// block belongs to the parent. [`sync_parent_dir`] covers the entry naming the
+/// file, which is the whole story for a journal whose directory already existed.
+/// It is not the whole story for the first append into a fresh company data
+/// directory: that append creates a *chain*, and flushing only its innermost
+/// link leaves the outer ones as unflushed writes a host crash can lose
+/// independently. Losing one takes the entire subtree with it — synced record
+/// included — which is precisely the loss the flush was bought to prevent, with
+/// the flush's cost already paid.
+///
+/// Each created directory is made durable by syncing **its** parent, walking
+/// outermost-first so every `mkdir` lands in a directory that exists. The
+/// innermost created directory is deliberately not synced here; it is the
+/// parent of the file the caller is about to create, and [`sync_parent_dir`]
+/// flushes it as part of that create.
+///
+/// POSIX-only on the same terms as [`sync_parent_dir`] — a non-unix build
+/// creates the chain and skips the flushes.
+pub(crate) async fn create_dir_all_durable(dir: &Path) -> Result<()> {
+    // Mirrors `std::fs::create_dir_all`, which treats the empty path as a no-op
+    // rather than an error.
+    if dir.as_os_str().is_empty() {
+        return Ok(());
+    }
+    let owned = dir.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        // Innermost-first while walking up, so the creation loop below reverses
+        // it. A readable ancestor that already exists ends the walk; anything
+        // else is treated as missing and left for `create_dir` to report against
+        // the path that actually failed.
+        let mut missing: Vec<&Path> = Vec::new();
+        let mut cursor = Some(owned.as_path());
+        while let Some(path) = cursor {
+            if matches!(path.try_exists(), Ok(true)) {
+                break;
+            }
+            missing.push(path);
+            cursor = path.parent().filter(|p| !p.as_os_str().is_empty());
+        }
+        for path in missing.iter().rev() {
+            match std::fs::create_dir(path) {
+                Ok(()) => {}
+                // Lost the race to another creator. The entry exists either way,
+                // and the winner owns flushing it.
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(io_err(path, e)),
+            }
+            sync_parent_dir(path)?;
+        }
+        Ok::<_, OpenCompanyError>(())
+    })
+    .await
+    .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
 }
 
 /// A test-only tally of how each append to a path was performed (issue #392).
@@ -228,7 +289,7 @@ fn sync_parent_dir(_path: &Path) -> Result<()> {
 /// full statement of what a unit test can and cannot establish here.
 #[cfg(test)]
 pub(crate) mod append_probe {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::path::{Path, PathBuf};
     use std::sync::{LazyLock, Mutex};
 
@@ -260,6 +321,30 @@ pub(crate) mod append_probe {
             .get(&key(path))
             .copied()
             .unwrap_or((0, 0))
+    }
+
+    /// Every directory [`super::sync_parent_dir`] has flushed.
+    ///
+    /// The same argument as the append tally: a flushed directory and an
+    /// unflushed one are identical on disk, so the honest check is to count the
+    /// request where it is made. Never cleared — tests own unique temp paths and
+    /// ask about their own.
+    static DIR_SYNCS: LazyLock<Mutex<HashSet<PathBuf>>> =
+        LazyLock::new(|| Mutex::new(HashSet::new()));
+
+    pub(crate) fn record_dir_sync(path: &Path) {
+        DIR_SYNCS
+            .lock()
+            .expect("append-probe poisoned")
+            .insert(key(path));
+    }
+
+    /// Whether `path`'s directory entry block was flushed.
+    pub(crate) fn dir_synced(path: &Path) -> bool {
+        DIR_SYNCS
+            .lock()
+            .expect("append-probe poisoned")
+            .contains(&key(path))
     }
 }
 
@@ -1274,6 +1359,57 @@ mod test {
             vec![0, 1, 2],
             "durable appends append, never truncate"
         );
+    }
+
+    /// **Issue #392**: creating the journal's parent chain durably flushes
+    /// **every** directory it creates, not only the innermost one.
+    ///
+    /// A create records the new name in its parent's block, so a chain of fresh
+    /// directories is a chain of independent writes and a host crash can lose
+    /// any of them on its own. Flushing only the file's own parent would leave a
+    /// synced record under ancestors that were never written down — unreachable
+    /// after exactly the crash the flush is bought for, with the flush's cost
+    /// already paid.
+    ///
+    /// Starts with the complete nested parent path absent, and asserts the flush
+    /// was requested for each link. As everywhere else in this module, what a
+    /// unit test can prove is that the request was made and its syscall returned
+    /// `Ok`; the platter is the OS contract's half.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn the_durable_path_flushes_every_directory_it_creates() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        let companies = root.join("companies");
+        let acme = companies.join("acme");
+        let journal_dir = acme.join("journal");
+        let path = journal_dir.join("journal.jsonl");
+
+        assert!(
+            !companies.try_exists().unwrap(),
+            "the whole chain below the temp root must be absent to start"
+        );
+
+        create_dir_all_durable(&journal_dir).await.unwrap();
+        append_line_durable(&path, "{\"i\":0}").await.unwrap();
+
+        // Each created directory's entry lives in its parent, so the parent is
+        // what has to be flushed. `journal_dir` is flushed by the file create.
+        for (dir, why) in [
+            (&root, "holds the entry naming `companies`"),
+            (&companies, "holds the entry naming `acme`"),
+            (&acme, "holds the entry naming `journal`"),
+            (&journal_dir, "holds the entry naming the journal file"),
+        ] {
+            assert!(
+                append_probe::dir_synced(dir),
+                "{} — unflushed, a host crash can lose the subtree under it",
+                why
+            );
+        }
+
+        let rows: Vec<serde_json::Value> = read_jsonl(&path).await.expect("no corrupt lines");
+        assert_eq!(rows.len(), 1, "the record itself still landed");
     }
 
     /// A durable append into a directory that does not exist must surface the

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -116,13 +116,59 @@ pub(crate) fn path_lock(path: &Path) -> Arc<TokioMutex<()>> {
 /// Tokio's async `File` buffers internally and can return before the kernel
 /// write completes, which makes concurrent-appends tests unreliable; this
 /// version always waits for the write syscall to finish before returning.
+///
+/// **Process-crash durable, not host-crash durable**: the bytes are in the
+/// kernel's page cache when this returns, so killing the process cannot lose
+/// them but losing the machine can. A caller that must have a record on stable
+/// storage before it proceeds uses [`append_line_durable`] instead. Which
+/// records those are is decided per record kind by the runtime journal (issue
+/// #392) — not here, and deliberately not for every append: this function is
+/// the hot path for the event log and the ledger, whose own durability is a
+/// separate decision that #392 does not make.
 pub(crate) async fn append_line(path: &Path, line: &str) -> Result<()> {
+    append_line_inner(path, line, false).await
+}
+
+/// Appends one line exactly as [`append_line`] does, and does not return until
+/// the bytes are on **stable storage** (issue #392).
+///
+/// The write itself is unchanged — one `write_all` under `O_APPEND`, so the
+/// atomicity argument in [`append_line`] carries over untouched — and is
+/// followed by `File::sync_data`. When the file did **not** exist before the
+/// open, the parent directory is opened and `sync_all`ed as well: on a create it
+/// is the directory entry that names the new file, and that entry is a separate
+/// write which a host crash can lose on its own, leaving a flushed file nothing
+/// can find. One `try_exists` pays for that, and it is confined to this function
+/// so the plain path never stats.
+///
+/// **A failed flush fails the append.** For the caller this exists for — the
+/// journal's `EffectExecuted` commit, written immediately before the side effect
+/// runs — that is the safe direction: no record means `execute_effect_once`
+/// aborts before `perform_effect`, so nothing external fires and nothing can
+/// duplicate. It is also the only correct handling of an `fsync` error on Linux,
+/// where a failed flush may already have dropped the dirty pages and a *retry*
+/// would cheerfully report success over lost data.
+pub(crate) async fn append_line_durable(path: &Path, line: &str) -> Result<()> {
+    append_line_inner(path, line, true).await
+}
+
+/// The one append implementation, with the flush as a parameter.
+///
+/// Shared rather than duplicated so the two entry points can never drift on the
+/// part that matters to both of them: the single whole-record `write_all` under
+/// `O_APPEND`.
+async fn append_line_inner(path: &Path, line: &str, sync: bool) -> Result<()> {
     let owned_path = path.to_path_buf();
     let mut record = String::with_capacity(line.len() + 1);
     record.push_str(line);
     record.push('\n');
     tokio::task::spawn_blocking(move || {
         use std::io::Write;
+        // Whether this append is the one that creates the file, which is the
+        // only append whose directory entry needs flushing. Asked before the
+        // open, and only on the durable path. An error answers "assume new",
+        // which costs one needless directory flush and never skips a needed one.
+        let creating = sync && !owned_path.try_exists().unwrap_or(false);
         let mut file = std::fs::OpenOptions::new()
             .create(true)
             .append(true)
@@ -130,10 +176,91 @@ pub(crate) async fn append_line(path: &Path, line: &str) -> Result<()> {
             .map_err(|e| io_err(&owned_path, e))?;
         file.write_all(record.as_bytes())
             .map_err(|e| io_err(&owned_path, e))?;
+        if sync {
+            file.sync_data().map_err(|e| io_err(&owned_path, e))?;
+            if creating {
+                sync_parent_dir(&owned_path)?;
+            }
+        }
+        #[cfg(test)]
+        append_probe::record(&owned_path, sync);
         Ok::<_, OpenCompanyError>(())
     })
     .await
     .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+}
+
+/// Flushes the directory entry naming `path`, so a newly created file is still
+/// *findable* after a host crash.
+///
+/// `sync_data` on the file covers the file's own data and the metadata needed to
+/// read it back. It does not cover the parent directory's block, which is where
+/// a create records the new name — flush only the file and a crash can leave the
+/// data durable under a name that was never written down.
+///
+/// POSIX-only by construction: Windows has no directory handle to flush (the
+/// nearest equivalent flushes a whole volume), and `File::open` on a directory
+/// fails there outright, so a non-unix build must not turn that into a failed
+/// append. The deployed target is Linux containers and the development target is
+/// macOS; both are covered.
+#[cfg(unix)]
+fn sync_parent_dir(path: &Path) -> Result<()> {
+    let Some(parent) = path.parent().filter(|p| !p.as_os_str().is_empty()) else {
+        return Ok(());
+    };
+    std::fs::File::open(parent)
+        .and_then(|dir| dir.sync_all())
+        .map_err(|e| io_err(parent, e))
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+/// A test-only tally of how each append to a path was performed (issue #392).
+///
+/// The seam a per-kind durability policy needs proved is "this record asked for
+/// the flush", and no inspection of the file can answer it: a synced line and an
+/// unsynced line are byte-identical on disk. Counting the request where it is
+/// made is the honest check. What it proves is the plumbing, not the platter —
+/// see the journal's `host_records_route_through_the_durable_append` for the
+/// full statement of what a unit test can and cannot establish here.
+#[cfg(test)]
+pub(crate) mod append_probe {
+    use std::collections::HashMap;
+    use std::path::{Path, PathBuf};
+    use std::sync::{LazyLock, Mutex};
+
+    /// `(plain, durable)` append counts, keyed like [`super::path_lock`] on the
+    /// absolutised path so a test and the code under test always meet.
+    static COUNTS: LazyLock<Mutex<HashMap<PathBuf, (usize, usize)>>> =
+        LazyLock::new(|| Mutex::new(HashMap::new()));
+
+    fn key(path: &Path) -> PathBuf {
+        std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    pub(crate) fn record(path: &Path, synced: bool) {
+        let mut counts = COUNTS.lock().expect("append-probe poisoned");
+        let entry = counts.entry(key(path)).or_insert((0, 0));
+        if synced {
+            entry.1 += 1;
+        } else {
+            entry.0 += 1;
+        }
+    }
+
+    /// The `(plain, durable)` appends observed for `path`. Tests use their own
+    /// temp paths, so no two of them share a tally.
+    pub(crate) fn counts(path: &Path) -> (usize, usize) {
+        COUNTS
+            .lock()
+            .expect("append-probe poisoned")
+            .get(&key(path))
+            .copied()
+            .unwrap_or((0, 0))
+    }
 }
 
 /// Reads a file to a string, returning an empty string if it does not exist.
@@ -1100,6 +1227,67 @@ mod test {
         let mut seen: Vec<u64> = rows.iter().map(|r| r["i"].as_u64().unwrap()).collect();
         seen.sort_unstable();
         assert_eq!(seen, (0..N).collect::<Vec<_>>(), "all records intact");
+    }
+
+    /// **Issue #392**: the durable append must behave exactly like the plain one
+    /// from the file's point of view — same bytes, same one-record-per-line
+    /// framing, appending rather than truncating — and must report the flush it
+    /// performed.
+    ///
+    /// It cannot assert the bytes are on the platter; nothing in a unit test
+    /// can, because a synced and an unsynced line are identical on disk. It
+    /// asserts the two things that *are* observable: the flush was requested and
+    /// its syscall returned `Ok` (the append would have failed otherwise), and
+    /// the content is intact.
+    #[tokio::test]
+    async fn durable_append_writes_the_same_bytes_and_reports_the_flush() {
+        let root_dir = tmp_root();
+        // A nested directory so the create path — and with it the parent
+        // directory flush — is exercised on a directory this test owns.
+        let root = root_dir.path().join("nested");
+        tokio::fs::create_dir_all(&root).await.unwrap();
+        let path = root.join("durable.jsonl");
+
+        // The first append creates the file; the second finds it already there.
+        for i in 0..2u64 {
+            let line = serde_json::to_string(&serde_json::json!({ "i": i })).unwrap();
+            append_line_durable(&path, &line).await.unwrap();
+        }
+        // A plain append to the same file must still take the unsynced path.
+        append_line(
+            &path,
+            &serde_json::to_string(&serde_json::json!({ "i": 2 })).unwrap(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            append_probe::counts(&path),
+            (1, 2),
+            "two durable appends and one plain one, each on its own path"
+        );
+
+        let rows: Vec<serde_json::Value> = read_jsonl(&path).await.expect("no corrupt lines");
+        let seen: Vec<u64> = rows.iter().map(|r| r["i"].as_u64().unwrap()).collect();
+        assert_eq!(
+            seen,
+            vec![0, 1, 2],
+            "durable appends append, never truncate"
+        );
+    }
+
+    /// A durable append into a directory that does not exist must surface the
+    /// error rather than half-succeed. This is the direction the journal's
+    /// at-most-once guarantee depends on: a failed commit stops the effect.
+    #[tokio::test]
+    async fn durable_append_reports_an_unwritable_path() {
+        let root_dir = tmp_root();
+        let path = root_dir.path().join("absent-dir").join("durable.jsonl");
+        let err = append_line_durable(&path, "{}").await.unwrap_err();
+        assert!(
+            matches!(err, OpenCompanyError::StoreIo { .. }),
+            "an unwritable durable append must report a store IO error, got {err:?}"
+        );
     }
 
     // The fs backend runs the identical port-conformance suite the sqlite


### PR DESCRIPTION
## Summary

Closes #392.

#392 asked a question rather than reporting a bug: should a journal append survive losing the **host**, not just the process? #386 made the write syscall complete before returning, so a process crash cannot lose a record reported durable — but without `sync_data` the bytes sit in the kernel page cache, and a power loss between the append and writeback still can.

**The answer is per-kind, and the argument is a frequency asymmetry: the hot records are harmless and the risky records are rare.**

Enumerating all 13 `JournalRecord` variants, exactly **two** can cause a duplicated external action if lost:

| Kind | Written before/after the effect | Risk if lost | Sync? |
|---|---|---|---|
| `EffectExecuted` | **Before** (`cycle.rs:1155` → `:1167`) | **HIGH** — replay re-fires the effect mechanically on next boot | **YES** |
| `StandingGrantRevoked` | n/a (authorization change) | An operator's revocation is undone; the grant replays live until its deadline | **YES** (rare, so free) |
| `GrantConsumed` | After — batched at cycle end, best-effort, failure only `warn!`ed (`cycle.rs:371-397`) | Pre-accepted: the design already tolerates a turn-length loss window, so flushing its tail is incoherent | No |
| `ApprovalParked` | Before parking takes effect | Approval vanishes, gets re-asked | No |
| `ApprovalResolved` | After decision | None once `EffectExecuted` is durable — a ghost approval re-approved is deduped by `is_executed` (`cycle.rs:1141`) | No |
| `ApprovalGranted` / `StandingGrantMinted` | **Before** the grant goes live | Loss forgets the YES → agent re-parks → operator re-asked (safe direction) | No |
| `ApprovalExpired` / `ApprovalAmended` | n/a | Recomputed / audit-only | No |
| `GrantExpired` / `StandingGrantExpired` | n/a | Deadline math re-expires on replay | No |
| `CycleStarted` / `CycleFinished` | n/a — **highest volume** | A bracket reads as interrupted | No |

`CycleStarted` is written on the front edge of *every* cycle, before the per-company serial lock, and its loss is cosmetic. `EffectExecuted` is written at human-approval scale, immediately in front of a network call costing 100ms–2s. Blanket fsync would tax the hottest path to protect records whose loss self-heals; per-kind pays only where duplication is possible, and there the cost is invisible.

The policy is a **wildcard-free match naming all 13 variants**, each arm carrying its reason. A new record kind is a compile error until its author decides which failure it must survive. Verified directly rather than assumed — adding a probe variant produced `error[E0004]: non-exhaustive patterns` at `durability()`, and notably it fired at the *existing* replay match too, so the codebase already leans on this discipline.

## API Or Behavior Changes

- `JournalRecord::durability()` (private) and a private `Durability { Process, Host }`. No public surface.
- `append` routes on it and remains the single choke point.
- New `store::fs::append_line_durable`, sharing `append_line_inner(path, line, sync)` with `append_line`. **`append_line` is byte-identical in behaviour** — events/ledger durability is a separate decision and out of scope.
- A `sync_data` error now **fails the append**. That is deliberate and it is the safe direction: it aborts `execute_effect_once` *before* `perform_effect`, so no record ⇒ no effect ⇒ no duplicate. It is also fsyncgate-safe, since a failed fsync is never retried.
- The parent-directory flush (first append only, so the dirent survives) is `#[cfg(unix)]`. Windows has no directory handle to flush and `File::open` on a directory fails there — a non-unix build must not turn that into a failed append.
- No journal format change. Old journals replay identically; existing tests are untouched.

**The doc now states a decision rather than a limitation.** The old comment ended "Whether an `fsync` per append is worth its cost on this path is a separate decision (see #392)." That question is now answered in place.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 2076 + 10 + 1 passed, 0 failed
- [x] `cargo test --features openhuman,mcp,telegram` — 3110 + 10 + 1 + 11 + 2 passed, 0 failed

Only the gated-combo row ran locally-only — **no CI lane builds `openhuman,mcp,telegram`**. Everything else is CI-covered: `src/runtime/mod.rs` has `pub mod journal;` un-gated, and nothing landed in `tests/`, so no #475 lane wiring was needed.

Both new tests were proven to fail against the pre-change behaviour:

```
flipped EffectExecuted to Process ->
  assertion `left == right` failed: the host-durable set is these two kinds and nothing
  else; widening it taxes the hot path, narrowing it lets an effect duplicate
    left: ["StandingGrantRevoked"]
   right: ["EffectExecuted", "StandingGrantRevoked"]

broke the routing (Durability::Host => append_line(...)) ->
  assertion `left == right` failed: EffectExecuted must flush before its side effect runs
    left: (2, 0)
   right: (1, 1)
```

**What these tests do not prove, stated plainly:** that bytes reached the platter. No portable test can — `SIGKILL` does not drop the page cache, so no process-level test simulates host loss; that needs `dm-log-writes` or a VM harness this repo does not have. The tests prove the **policy** (which kinds) and the **plumbing** (sync requested, syscall returned `Ok`); the OS contract carries the rest. Both tests say so in their doc comments rather than implying more.

## The measurement #392 asked for

`benches/journal_append.rs` (criterion, `harness = false`, not wired to CI). macOS 15 / APFS / local SSD:

| mode | ~200B p50 | ~200B p99 | ~700B p50 | ~700B p99 | appends/s @p50 |
|---|---|---|---|---|---|
| plain | 16.1µs | 34.9µs | 19.9µs | 72.0µs | ~62,000 |
| `sync_data` | 3.98ms | 7.31ms | 3.99ms | 6.03ms | ~251 |
| `sync_data` + dir | 4.01ms | 8.94ms | 7.90ms | 11.30ms | ~249 |

Two findings, and together they *are* the policy's argument:

1. A flush costs **~200× a plain append**.
2. It is **flat in record size** — 200B and 700B cost the same. It is the syscall, not the payload.

So the only lever is *how many appends flush*, which is exactly what a per-kind policy pulls. It also makes the decision robust to the storage constant: whether a flush is 1ms or 20ms, the answer stays "flush the two rare kinds."

**Caveats, because these numbers invite over-reading:** macOS `sync_data` maps to a full-flush-flavoured fcntl and **overstates** the Linux cost; and a local SSD does not predict EFS or any network-backed volume. These numbers evidence the *order of magnitude* and *what fraction of appends pay* — not the hosted absolute cost.

## Documentation

`docs/spec/runtime/lifecycle.md` gains "Which crash a journal record survives (#392)" with the per-kind table and the volume bound below.

**This fix is bounded by the volume it writes to, and that bound is now stated.** The reference ECS deploy mounts **EFS** at `/data` (`deploy/aws-ecs-task-definition.json:54-63`), where the NFS client's page cache is exactly what `sync_data` forces through — that is where this buys real durability. But `RuntimeJournal` is constructed **unconditionally on the fs path** (`src/runtime/builder.rs:1123-1125`), outside the fourteen storage ports, and for a hosted tenant on `OPENCOMPANY_STORAGE=mongodb`, `/data` is documented as **ephemeral scratch** — so their journal does not survive a container replacement, let alone a host crash, and this fix buys them nothing. That is a larger gap, filed as **#726**, deliberately not folded in here. This PR's per-kind declaration travels with the record kind and survives any backing-store move, so it is not wasted work either way.

## Related

Closes #392. Surfaced and linked: #726. Follows #386.

**Three things for the reviewer to weigh, none hidden:**

1. **Three commits, not the five the plan sketched.** Splitting the fs helper or the enum from its only caller produces a commit that fails `cargo clippy -- -D warnings` on `dead_code` — verified empirically (`warning: function 'append_line_durable' is never used`). Provider, policy and routing therefore land as one validated slice, per CLAUDE.md's "commit each coherent, validated slice on its own".
2. **New build cost.** Criterion is a dev-dependency, so every `cargo test` lane now compiles ~15 extra crates (~90s cold). `default-features = false` keeps plotters and rayon out of the graph. If that is unwelcome, the bench can move behind a feature or out of the workspace — say which.
3. **`StandingGrantRevoked` in the `Host` set is a judgment call.** It cannot duplicate an external action the way `EffectExecuted` can; it undoes an operator's revocation. Included because it is rare enough to be free. Trimming to `EffectExecuted`-only is a one-arm edit.

Also noted, not hidden: durable appends serialize concurrent appenders on the flush, since the per-path lock is held across `append_line`. Acceptable at the `Host` set's rate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger journal durability for critical records, ensuring data is flushed to stable storage before append operations complete.
  * Added performance benchmarks comparing standard writes with increasingly durable write modes.

* **Documentation**
  * Documented journal durability guarantees, failure behavior, and filesystem-related limitations.

* **Bug Fixes**
  * Improved handling of durable writes, including parent-directory flushing and error propagation.
  * Strengthened validation for ambiguous workspace indexes without deleting existing data.

* **Tests**
  * Added coverage for durability policies, write routing, data preservation, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->