### PR TITLE
approvals: give a newly provisioned company the `auto` tier (#605)

### DIFF
--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -36,3 +36,13 @@ description = "Assemble documentation for audits."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["month_end_close"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -63,3 +63,13 @@ description = "Turn strategy into an execution roadmap."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["engagement_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -36,3 +36,13 @@ description = "Process refunds within policy."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["ticket_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -53,3 +53,13 @@ description = "User testing and design validation."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["design_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -41,3 +41,13 @@ description = "Nurture and follow up on pipeline."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["sales_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_game_business/company.toml
+++ b/companies/agentic_game_business/company.toml
@@ -46,3 +46,13 @@ description = "Resolve player issues and refunds."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["liveops_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_game_studio/company.toml
+++ b/companies/agentic_game_studio/company.toml
@@ -46,3 +46,13 @@ description = "Market and promote the launch."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["game_build_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_influencer_business/company.toml
+++ b/companies/agentic_influencer_business/company.toml
@@ -51,3 +51,13 @@ description = "Source and negotiate sponsorships."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["content_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -53,3 +53,13 @@ description = "Check regulatory compliance."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["matter_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -112,3 +112,13 @@ reason = "Measure campaign performance."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["campaign_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -68,3 +68,13 @@ description = "Distribute across social channels."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["newsroom_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -31,3 +31,13 @@ description = "Design and plan clinical trials."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["discovery_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -36,3 +36,13 @@ description = "Manage tenants and property operations."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["acquisition_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_recruiting_company/company.toml
+++ b/companies/agentic_recruiting_company/company.toml
@@ -41,3 +41,13 @@ description = "Draft and generate offers."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["hiring_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -101,3 +101,13 @@ members = ["devrel", "docs_writer", "customer_support"]
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["feature_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -41,3 +41,13 @@ description = "Support portfolio companies post-investment."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["diligence_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -56,3 +56,13 @@ description = "Source and staff each venture with agents or humans."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["venture_launch_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -51,3 +51,13 @@ description = "Support alumni after the program."
 # directory (one file per id), not inline here.
 [workflows]
 enabled = ["cohort_pipeline"]
+
+# Approval tier for this company (issue #605). Declared explicitly rather than
+# left to the serde default, so the tier a shipped company runs on is readable
+# from its own manifest instead of inferred from an absent block.
+#
+# `auto` runs the agent's own sandbox writes and outward reads unattended and
+# still parks everything that leaves the company or spends money. `always_approve`
+# is omitted, so it keeps its default.
+[policy]
+mode = "auto"

--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -335,6 +335,41 @@ with actor and timestamps, but each admitted call writes no journal record.
 Defensible because a standing grant only ever admits tools declared grantable
 and never a priced call; a per-use record is additive later.
 
+### Which tier a new company gets
+
+Issue #605. A **new** company is given `auto`; an **existing** one is never
+re-tiered. Two knobs, and that distinction is the decision:
+
+- `default_policy_mode()` — what a manifest with no stated `mode` *parses* to.
+  Stays **`supervised`**.
+- `PROVISIONED_POLICY_MODE` — what provisioning *writes into* a new company's
+  manifest when its author stated none. **`auto`**.
+
+Every shipped preset declares `mode` outright, so both paths that read one
+(`serve --company <dir>`, the desktop app) arrive carrying a tier.
+`POST /api/v1/companies` is the only creation path with no template behind it,
+and is where the write happens.
+
+**Why not simply move the parse default.** That value answers for every manifest
+ever parsed, including the re-parse of a company that has run for months, so
+moving it re-tiers existing companies rather than creating them differently.
+Two things then go wrong:
+
+1. Every company with no `[policy]` block silently widens on its next load.
+   Nobody edited anything and nothing is written down.
+2. Less obvious and worse: the persisted record stores the *defaulted* value, so
+   a silent `company.toml` that parsed to `supervised` last boot parses to `auto`
+   this boot — and `carry_policy_override`, which is `previous_seed ==
+   next_seed` over the whole block, reads that as version control speaking and
+   **discards the operator's console `[policy]` override**, including one that
+   had *tightened* the tier.
+
+Writing the tier at provisioning avoids both, and makes it legible: a
+provisioned tenant has no `company.toml`, so the record is the only place its
+tier appears. `a_provisioned_company_with_no_stated_tier_is_recorded_on_auto`
+and `a_provisioned_company_keeps_whatever_tier_it_states` pin both halves, the
+second walking `POLICY_MODES` so a fifth tier cannot escape the guarantee.
+
 ### Precedence at the tool gate
 
 A tool call is decided in this order:

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -70,7 +70,8 @@ allow = ["web.*", "docs.*", "search"]  # company-wide grant; agents intersect
 search_daily_calls = 200           # per-company daily web_search cap (0 = paused)
 
 [policy]                           # see company-brain/approvals.md
-mode = "supervised"                # readonly | supervised (default) | auto | full
+mode = "supervised"                # readonly | supervised | auto | full
+                                   # parse default supervised; new companies get auto
 always_approve = ["payment.send", "filing.submit", "external.publish"]
 auto_approve_under_usd = 1.0
 
@@ -197,8 +198,13 @@ prompt = "Weekly review and operator digest"
   outward reads run unattended, anything that leaves the company or spends on
   submit still parks). `always_approve` lists effect kinds that park for
   approval regardless of amount and wins over every tier including `full`;
-  `auto_approve_under_usd` lets small spends through. Defaults are
-  conservative: `supervised`, with all money/publish/filing effects gated.
+  `auto_approve_under_usd` lets small spends through. The parse default is
+  `supervised`, with all money/publish/filing effects gated — but a **new**
+  company is given `auto`, written into its manifest explicitly rather than
+  left to that default. See
+  [approvals.md](../company-brain/approvals.md#which-tier-a-new-company-gets)
+  for why those are two separate knobs, and why moving the parse default is the
+  one thing issue #605 declined to do.
 - **`[place]`** drives the [going-public flow](../company-as-agent/README.md).
   `skills` feed Agent Card generation; prices are decimal strings (USDC).
 - **`[budget].monthly_usd`** is a hard ceiling enforced by the kernel across

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -81,9 +81,10 @@ pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
     Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS,
     GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
-    McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, Place, Plan, Policy,
-    Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit,
-    grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
+    McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROVISIONED_POLICY_MODE,
+    Place, Plan, Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit,
+    grants_media_explicit, grants_search_explicit, grants_workspace_write_explicit,
+    orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -88,8 +88,8 @@ pub use types::{
     GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS,
     McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROVISIONED_POLICY_MODE,
     Place, Plan, Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit,
-    grants_media_explicit, grants_repo_explicit, grants_search_explicit, grants_workspace_write_explicit,
-    orchestrator_id,
+    grants_media_explicit, grants_repo_explicit, grants_search_explicit,
+    grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -54,6 +54,21 @@ pub const TOOL_PROVIDERS: &[&str] = &["openhuman", "builtin"];
 /// variant` in `harness::policy`.
 pub const POLICY_MODES: &[&str] = &["readonly", "supervised", "auto", "full"];
 
+/// The tier a **newly provisioned** company is given when its manifest does not
+/// name one (issue #605).
+///
+/// Deliberately *not* the same knob as [`default_policy_mode`]. That one answers
+/// for every manifest ever parsed, including the re-parse of a company that has
+/// been running for months, so moving it changes companies rather than creating
+/// them. This one is applied once, at provisioning, and written into the stored
+/// manifest as an ordinary explicit `mode` — after which nothing distinguishes
+/// the company from one whose author typed the line themselves.
+///
+/// See `docs/spec/company-brain/approvals.md` for why `auto` is the defensible
+/// default for a new company and why that argument does not extend to
+/// retroactively re-tiering existing ones.
+pub const PROVISIONED_POLICY_MODE: &str = "auto";
+
 /// Channels the runtime knows how to enable under `[channels.*]`.
 pub const KNOWN_CHANNELS: &[&str] = &["operator", "email", "slack", "sms", "web", "telegram"];
 
@@ -609,10 +624,26 @@ fn default_tool_provider() -> String {
 pub struct Policy {
     /// `readonly` | `supervised` (default) | `auto` | `full`.
     ///
-    /// The default stays `supervised` deliberately: issue #560 argues `auto`
-    /// should become it, but flipping it changes behaviour for every existing
-    /// company with no `[policy]` block on its next load, so that is its own
-    /// decision rather than a rider on adding the tier.
+    /// **The default stays `supervised`, and issue #605 is the decision to keep
+    /// it there rather than an unfinished flip.** #560 argued `auto` should
+    /// become the shipped default, and #605 agrees on the destination — new
+    /// companies do get `auto`. What it declines is delivering that by moving
+    /// *this* value, because this value answers for every manifest ever parsed,
+    /// not only for new ones. See [`PROVISIONED_POLICY_MODE`].
+    ///
+    /// Two things go wrong if it moves. The obvious one is that every company
+    /// with no `[policy]` block silently widens on its next load. The other is
+    /// not obvious and is worse: the persisted record stores this *defaulted*
+    /// value, so a silent `company.toml` that parsed to `supervised` last boot
+    /// parses to `auto` this boot, and `carry_policy_override` in
+    /// [`crate::runtime::builder`] — which is `previous_seed == next_seed` over
+    /// the whole block — reads that as version control having spoken and
+    /// **discards the operator's console `[policy]` override**, including one
+    /// that had tightened the tier. Nobody edited anything.
+    ///
+    /// So the tier a new company gets is written into its manifest at
+    /// provisioning, explicitly, where an operator can read it. Existing
+    /// companies are not re-tiered by a constant changing under them.
     #[serde(default = "default_policy_mode")]
     pub mode: String,
     /// Effect kinds that always park for approval regardless of amount.

--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -540,25 +540,25 @@ mod tests {
     /// Fail closed, exactly as the scaffold does: two roots named `Agents` make
     /// "under `Agents/`" undecidable, so the sweep refuses instead of picking
     /// one and deleting beneath it.
-    #[tokio::test]
-    async fn an_ambiguous_root_is_refused_and_removes_nothing() {
-        let (_dir, ws) = store().await;
-        let company = CompanyId::new("odd");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
-                .await
-                .unwrap();
-        }
-        ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
-            .await
-            .unwrap();
+    ///
+    /// Hand-built rather than driven through `FsOps` on purpose: the backend now
+    /// rejects a second `Agents` root at creation (`reject_path_collision`, see
+    /// issue #665), so the ambiguous shape is no longer reachable through it —
+    /// the same reason the #671 shape below is fed straight to the predicate.
+    #[test]
+    fn an_ambiguous_root_is_refused_and_removes_nothing() {
+        let nodes = vec![
+            folder("dup-a", AGENTS_ROOT, None),
+            folder("dup-b", AGENTS_ROOT, None),
+            // A real member beneath the (ambiguous) root: there is content a
+            // naive pick would have deleted, and the refusal exists to protect
+            // exactly that.
+            file("stray", "stray.md", Some("dup-a")),
+        ];
 
-        let err = sweep_empty_agent_folders(ws.as_ref(), &company, false)
-            .await
+        let err = empty_agent_folder_candidates(&nodes)
             .expect_err("an ambiguous root must not be swept beneath");
-
         assert!(err.to_string().contains(AGENTS_ROOT), "{err}");
-        assert_eq!(names(&ws, &company).await, vec!["Agents", "Agents", "ceo"]);
     }
 
     /// A *file* named `Agents` is the other unresolvable shape, and the refusal

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1686,7 +1686,7 @@ mod tests {
         ));
         assert_eq!(
             harness
-                .check(&request("payroll.export", serde_json::json!({})))
+                .check(&request("workspace_read", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::Allow
         );

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1611,14 +1611,20 @@ mod tests {
         use crate::ports::approvals::ApprovalGate;
         use crate::ports::types::PolicyDecision;
 
-        // A leading segment, an exact dotted kind, a bare tool name, a
-        // near-miss that must NOT be gated, and a case variant.
+        // A leading segment, an exact dotted kind, a bare tool name, an
+        // unrelated declared tool that must NOT be gated, and a case variant.
         //
-        // Every name here is one the tier itself has no opinion about under
-        // `full`, so the only thing that can make the two paths disagree is the
-        // fence. A priced name like `web_search` would drag the harness's
+        // Every name here is one both paths leave to the fence: the tier has no
+        // opinion about it under `full`, **and** it is a declared, non-priced
+        // tool, so the per-call judgement (issue #338) is silent on it too — the
+        // thing that used to make a not-gated name diverge after `full` decided
+        // to allow was that undeclared tools stop under the judgement. The
+        // near-miss the segment boundary exists to exclude (`payment` vs
+        // `payroll.export`) stopped fitting here once the judge began stopping
+        // undeclared tools; that boundary is pinned in `always_approve::test`
+        // instead. A priced name like `web_search` would drag the harness's
         // metered-read and budget arms into a comparison that is not about
-        // `always_approve`, so it is deliberately absent.
+        // `always_approve`, so it is deliberately absent here.
         let fence = &["payment", "filing.submit", "publish_artifact"];
         let names = [
             "payment.send",
@@ -1626,7 +1632,7 @@ mod tests {
             "filing.submit",
             "publish_artifact",
             "PUBLISH_ARTIFACT",
-            "payroll.export",
+            "workspace_read",
         ];
 
         // `full` on both sides, so the tier decides nothing and any parking

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -85,6 +85,30 @@ struct ProvisionBody {
     id: Option<String>,
 }
 
+/// Did the submitted manifest **text** name an approval tier?
+///
+/// Read from the raw TOML rather than from the parsed [`CompanyManifest`], and
+/// that is the whole point of the function. `Policy::mode` is a plain `String`
+/// behind a serde default, so a parsed manifest *always* carries a mode and can
+/// never be asked what its author actually wrote. Only the text distinguishes
+/// "the author chose `supervised`" from "the author said nothing".
+///
+/// Anything that does not parse as a table with `policy.mode` set counts as not
+/// declared. Unparseable text cannot reach here — the caller has already
+/// rejected it — so the `unwrap_or(false)` is for the shape, not for a case
+/// this can actually meet.
+fn declares_policy_mode(manifest_toml: &str) -> bool {
+    toml::from_str::<toml::Value>(manifest_toml)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("policy")
+                .and_then(|policy| policy.get("mode"))
+                .cloned()
+        })
+        .is_some()
+}
+
 /// `POST /api/v1/companies` — provision a company from a manifest body.
 async fn provision(
     PlatformScope(claims): PlatformScope,
@@ -113,7 +137,7 @@ async fn provision(
         (body, None)
     };
 
-    let manifest: CompanyManifest = match toml::from_str(&manifest_toml) {
+    let mut manifest: CompanyManifest = match toml::from_str(&manifest_toml) {
         Ok(manifest) => manifest,
         Err(err) => {
             return envelope(
@@ -123,6 +147,22 @@ async fn provision(
             );
         }
     };
+    // Issue #605: a company provisioned without a stated tier gets `auto`,
+    // recorded explicitly rather than inherited from a serde default.
+    //
+    // This is the one creation path with no template behind it. The other two
+    // both arrive carrying a tier already: `serve --company <dir>` and the
+    // desktop app read a `companies/*/company.toml`, and every shipped preset
+    // now declares `mode`.
+    //
+    // Written onto the manifest *before* the build, so the tier lands in the
+    // stored manifest the same way an authored one would. A provisioned tenant
+    // has no `company.toml` anywhere, so that record is the only place an
+    // operator can read their tier — leaving it implicit would make it
+    // unreadable rather than merely unstated.
+    if !declares_policy_mode(&manifest_toml) {
+        manifest.policy.mode = crate::company::PROVISIONED_POLICY_MODE.to_string();
+    }
     let problems = manifest.validate();
     if !problems.is_empty() {
         // Render the prosumer problem list; never leak serde traces.

--- a/src/server/provision/test.rs
+++ b/src/server/provision/test.rs
@@ -1145,3 +1145,119 @@ async fn webhook_emitted_on_approval_requested() {
     assert!(!approval.1.is_empty());
     assert!(approval.1.starts_with("kh1="));
 }
+
+// ---------------------------------------------------------------------------
+// Issue #605 — the tier a provisioned company is recorded on
+// ---------------------------------------------------------------------------
+
+/// The tier `id` was persisted with, read back off the stored record rather
+/// than off the response.
+///
+/// The record is what matters here: it is the manifest a rebuild re-reads and
+/// the only place a platform-provisioned tenant's tier is written down at all,
+/// since it has no `company.toml` anywhere on disk.
+async fn recorded_mode(state: &AppState, id: &str) -> String {
+    let id = CompanyId::new(id);
+    let runtime = state.registry().get(&id).expect("company is registered");
+    runtime
+        .store()
+        .load(&id)
+        .await
+        .expect("store readable")
+        .expect("record exists")
+        .manifest
+        .policy
+        .mode
+}
+
+/// Issue #605: a company provisioned from a manifest that names no tier is
+/// recorded on `auto`, explicitly.
+///
+/// This is the one creation path with no template behind it — `serve` and the
+/// desktop app both read a `companies/*/company.toml`, and every shipped preset
+/// declares `mode`. So this is where the "new companies get `auto`" half of
+/// #605 is actually delivered.
+///
+/// Asserting `auto` is also what pins the change as *doing something*: the serde
+/// default is still `supervised`, deliberately (see `Policy::mode`), so a
+/// regression that dropped the provisioning write would record `supervised`
+/// here and fail rather than quietly reverting the feature.
+#[tokio::test]
+async fn a_provisioned_company_with_no_stated_tier_is_recorded_on_auto() {
+    let home_dir = home();
+    let state = platform_state(home_dir.path(), None);
+    let app = router(state.clone());
+
+    let response = app
+        .oneshot(provision_req(
+            Some(PLATFORM_SECRET),
+            "[company]\nname = \"Acme\"\n",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    assert_eq!(
+        recorded_mode(&state, "acme").await,
+        crate::company::PROVISIONED_POLICY_MODE,
+        "a manifest that states no tier must be recorded on the provisioning \
+         default, explicitly — not left to the serde default"
+    );
+    assert_ne!(
+        crate::company::PROVISIONED_POLICY_MODE,
+        crate::company::Policy::default().mode,
+        "if these ever coincide this test proves nothing — it would pass with \
+         the provisioning write deleted"
+    );
+}
+
+/// ...and a manifest that *does* state a tier keeps it, whichever tier it is.
+///
+/// **Preserve, never widen**, which is the property the whole of #605 turns on.
+/// Walked over `POLICY_MODES` rather than spot-checked, so a fifth tier cannot
+/// silently escape the guarantee the way `auto` escaped the prose tier lists in
+/// #660: the day someone adds one, this covers it without being edited.
+///
+/// `supervised` is the sharp case and the reason this is a walk and not a single
+/// `readonly` assertion — it is the value the serde default *also* produces, so
+/// a broken "did the author declare a mode?" check is invisible on every other
+/// tier and caught only here.
+#[tokio::test]
+async fn a_provisioned_company_keeps_whatever_tier_it_states() {
+    let home_dir = home();
+    let state = platform_state(home_dir.path(), None);
+    let app = router(state.clone());
+
+    let mut checked = 0;
+    for mode in crate::company::POLICY_MODES {
+        let name = format!("Acme {mode}");
+        let manifest = format!("[company]\nname = \"{name}\"\n[policy]\nmode = \"{mode}\"\n");
+        let response = app
+            .clone()
+            .oneshot(provision_req(Some(PLATFORM_SECRET), &manifest))
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::CREATED,
+            "provisioning `{mode}` failed"
+        );
+
+        let id = json_body(response).await["id"]
+            .as_str()
+            .unwrap()
+            .to_string();
+        assert_eq!(
+            recorded_mode(&state, &id).await,
+            *mode,
+            "`{mode}` was stated in the manifest and must survive provisioning \
+             untouched"
+        );
+        checked += 1;
+    }
+    assert_eq!(
+        checked,
+        crate::company::POLICY_MODES.len(),
+        "the walk skipped a tier"
+    );
+}


### PR DESCRIPTION
## Summary

Issue #605 asked whether `auto` becomes the default policy mode. The answer here is **yes for a new company, never retroactively for an existing one** — which is the issue's own recommended option 2.

`auto` is delivered by **writing the tier into a new company's manifest at provisioning**. `default_policy_mode()` stays `"supervised"`, deliberately.

Two knobs, and the distinction is the whole decision:

- **`default_policy_mode()`** — what a manifest with no stated `mode` *parses* to. Stays **`supervised`**.
- **`PROVISIONED_POLICY_MODE`** — what provisioning *writes into* a new company's manifest when its author stated no tier. **`auto`**.

## Why `default_policy_mode()` is not flipped

A reader who knows this issue's title will expect the one-line flip, so the argument is written down rather than left as an omission — in the `Policy::mode` doc comment, in `approvals.md`, and below.

That value answers for **every manifest ever parsed**, including the re-parse of a company that has been running for months. Moving it re-tiers existing companies rather than creating them differently. Two things go wrong:

1. **The obvious one.** Every company with no `[policy]` block silently widens on its next load. Nobody edited anything and nothing is written down.

2. **The one that is not obvious, and is worse.** The persisted record stores the *defaulted* value, not what the file said. So a silent `company.toml` that parsed to `supervised` last boot parses to `auto` this boot — and `carry_policy_override` (`runtime/builder.rs:232`) is literally `(previous_seed == next_seed).then(...)` over the whole `[policy]` block, with `Policy` deriving `PartialEq`. It reads that as version control having spoken, and **discards the operator's console `[policy]` override — including one that had *tightened* the tier to `readonly`.**

A migration that rewrites *stored* manifests cannot prevent (2): the right-hand side of that comparison is a fresh parse of the operator's own file, which must not be rewritten.

Writing the tier at provisioning avoids both, and makes the tier legible: a platform-provisioned tenant has no `company.toml` anywhere, so the stored manifest is the only place its tier is written at all.

**This was never a one-line change.** Revert 5 below shows a pre-existing test, `company::manifest::tests::defaults_are_prosumer_safe` (`manifest.rs:454`), already pins the parse default at `supervised`.

## API Or Behavior Changes

**New:** `crate::company::PROVISIONED_POLICY_MODE`.

**Behaviour:** a company provisioned through `POST /api/v1/companies` whose manifest states no `[policy].mode` is now recorded on `auto` instead of `supervised`. One whose manifest **does** state a tier is untouched, whichever tier it is.

**Unchanged:** every existing company, on every backend. Nothing re-tiers anything already stored, and `default_policy_mode()` is the same value it was.

### Creation paths — exactly one needed the change

1. `serve --company <dir>` (`bin/opencompany.rs:273`) — reads a `companies/*/company.toml`; every shipped preset now declares `mode`.
2. The desktop app (`desktop.rs:138`) — `include_str!` of the same presets.
3. **`POST /api/v1/companies`** (`server/provision.rs`) — the only creation path with no template behind it. This is where the write happens.

There is no `createCompany` GraphQL mutation (every `create_company_*` symbol is a *workflow* creator). `runtime/rebuild.rs` rebuilds from the persisted record, so a provisioned tier survives restarts.

### Why the check reads the raw TOML

`declares_policy_mode` parses the submitted **text**, not the resulting `CompanyManifest`. `Policy::mode` is a plain `String` behind a serde default, so a parsed manifest *always* carries a mode and can never be asked what its author actually wrote. Only the text distinguishes "the author chose `supervised`" from "the author said nothing".

## Tests

- `a_provisioned_company_with_no_stated_tier_is_recorded_on_auto` — the new-company half. It also asserts `PROVISIONED_POLICY_MODE != Policy::default().mode`, so it cannot pass vacuously if the two ever coincide.
- `a_provisioned_company_keeps_whatever_tier_it_states` — **preserve, never widen**. Walks `POLICY_MODES` rather than spot-checking, so a fifth tier cannot escape the guarantee without failing a test. `supervised` is the sharp case and the reason it is a walk: it is the value the parse default *also* produces, so a broken declared-mode check is invisible on every other tier and caught only there.

Both read the **stored record**, not the HTTP response — the record is the manifest a rebuild re-reads, and the only place a provisioned tenant's tier is written down.

### Verified locally

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; exit 0, no lints.
- [x] `cargo build --all-targets` — N/A as written; ran the stronger `cargo check --locked --all-features --all-targets`, exit 0, because `mongodb.rs` / `sqlite.rs` build `CompanyRecord` from a row and neither the default nor the gated lane sees it.
- [x] `cargo test` — ran as `cargo test --features openhuman,tinycortex`; exit 0. **3130 passed, 0 failed, 3 ignored** in the lib target, plus 5 integration targets green.

### Revert-and-check

Each row applies one revert, proves the file actually changed (a pattern matching nothing is a silent no-op that would score green), runs the full gated lib suite, and restores.

| # | Revert | Tests failed |
|---|---|---|
| 1 | remove the provisioning write | 1 — `..._recorded_on_auto` |
| 2 | never detect a declared tier | 1 — `..._keeps_whatever_tier_it_states` |
| 3 | always claim a tier was declared | 1 — `..._recorded_on_auto` |
| 4 | set `PROVISIONED_POLICY_MODE` to the parse default | 1 — `..._recorded_on_auto` |
| 5 | flip the parse default to `auto` | **2** — plus `defaults_are_prosumer_safe` |

Row 4 is the vacuity guard doing its job. Row 5 is the change this PR declined to make, and it fails a test that was already in the tree.

## Documentation

- `docs/spec/company-brain/approvals.md` — a new **"Which tier a new company gets"** section: the two knobs, why the parse default does not move, and the `carry_policy_override` mechanism spelled out.
- `docs/spec/runtime/manifest.md` — the `[policy]` entry now distinguishes the parse default from what a new company gets, and links to the section above.
- Both remain within the repo's 500-line cap (`approvals.md` is at exactly 500).

## Notes for review

The `carry_policy_override` behaviour described above is **latent, not currently firing**: with the parse default unchanged, a silent manifest parses to `supervised` on both sides of the comparison and the override is correctly preserved. It is a tripwire armed by any future change to a `[policy]` serde default — `default_policy_mode` or `default_always_approve`. Recorded as a comment on #605 rather than silently fixed here, since it is out of this PR's scope.

Closes #605


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New companies now default to automatic approval mode when no policy tier is specified.
  * Explicitly configured approval tiers remain unchanged.
  * Automatic policies allow unattended sandbox writes and outward reads while retaining approval requirements for external actions and spending.

* **Documentation**
  * Updated policy and manifest documentation to clarify provisioning defaults and parsing behavior.

* **Tests**
  * Added coverage verifying default policy assignment and preservation of explicitly selected tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->