### PR TITLE
workspace: make a first publish claim its path

### DIFF
--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -254,7 +254,85 @@ pub async fn materialize(
                 sha256,
             })
         }
-        None => create_payload(workspace, company, Some(parent), filename, target).await,
+        // Nothing at this path — *as of the read above*. Issue #697: that read
+        // is not a claim, so two first publishes of one deliverable both land
+        // here and, before this, both created. Two nodes, one name.
+        //
+        // The state does not decay. `resolve_file` answers a duplicated name
+        // with `Conflict`, so a race that lasted microseconds refuses every
+        // future publish to that deliverable, for every agent, until somebody
+        // edits the tree by hand.
+        None => create_first(workspace, company, &parent, filename, target).await,
+    }
+}
+
+/// Publishes a deliverable to a path that nothing occupies yet, and loses
+/// rather than duplicates if that stops being true (issue #697).
+///
+/// # Why this is not just `create_payload`
+///
+/// It was, and that is the defect. `resolve_file` returning `None` is a
+/// statement about the instant it read the tree; a plain create acts on it
+/// later, and two publishers that both read "free" both created. The window is
+/// small and the damage is permanent, which is the worst combination — nothing
+/// cleans up after it and every later publish is refused.
+///
+/// # The shape is `replace_payload`'s, deliberately
+///
+/// Stage under a name no publish can produce and [`resolve_file`] will never
+/// match, then ask the store to install it conditionally. The only difference
+/// is what the caller expects to find: a republish names the node it supersedes,
+/// a first publish asserts the name is still free. One primitive answers both
+/// (see [`WorkspaceStore::swap_files`]), which is what keeps the loser-cleanup
+/// rule — consume the staged node, payload included — in one place rather than
+/// two that drift.
+///
+/// Staging costs the same quota it costs a republish: the payload is charged
+/// while it is staged, so a company at its ceiling can be refused here. That is
+/// the trade #662 already argued, and a refusal leaves nothing behind.
+async fn create_first(
+    workspace: &dyn WorkspaceStore,
+    company: &CompanyId,
+    parent: &str,
+    filename: &str,
+    target: PublishTarget<'_>,
+) -> Result<Mirrored> {
+    let staged_name = format!("{filename}.publishing-{}", crate::ports::generate_id());
+    let staged = create_payload(
+        workspace,
+        company,
+        Some(parent.to_string()),
+        &staged_name,
+        target,
+    )
+    .await?;
+
+    match workspace
+        .swap_files(company, None, &staged.node_id, filename)
+        .await
+    {
+        Ok(Some(node)) => Ok(Mirrored {
+            node_id: node.id,
+            sha256: node.sha256,
+        }),
+        Ok(None) => Err(OpenCompanyError::Conflict(format!(
+            "the deliverable at `{filename}` was created by another publish while this one was \
+             being prepared; nothing was overwritten — publish again to revise it"
+        ))),
+        Err(err) => {
+            // The same reasoning as the republish path: an indeterminate store
+            // error may or may not have committed, so the staging id is logged
+            // for recovery rather than deleted.
+            tracing::error!(
+                company = %company,
+                staged = %staged.node_id,
+                name = %staged_name,
+                error = %err,
+                "[publish] the store could not decide the staged first publish; its id is logged \
+                 for recovery rather than deleted after an indeterminate write"
+            );
+            Err(err)
+        }
     }
 }
 
@@ -361,7 +439,11 @@ async fn replace_payload(
     .await?;
 
     match workspace
-        .swap_files(company, superseded, &staged.node_id, filename)
+        // `Some`, emphatically: this is a republish, and it must lose if the
+        // node it expected to supersede is no longer the one at the path.
+        // `None` here would mean "install only if the name is free", which for
+        // a path that is by definition occupied would refuse every republish.
+        .swap_files(company, Some(superseded), &staged.node_id, filename)
         .await
     {
         Ok(Some(node)) => Ok(Mirrored {
@@ -751,7 +833,7 @@ mod test {
         async fn swap_files(
             &self,
             company: &CompanyId,
-            expected_id: &str,
+            expected_id: Option<&str>,
             replacement_id: &str,
             name: &str,
         ) -> Result<Option<WorkspaceNode>> {
@@ -1083,7 +1165,7 @@ mod test {
         async fn swap_files(
             &self,
             company: &CompanyId,
-            expected_id: &str,
+            expected_id: Option<&str>,
             replacement_id: &str,
             name: &str,
         ) -> Result<Option<WorkspaceNode>> {
@@ -1163,6 +1245,91 @@ mod test {
         assert!(
             !nodes.iter().any(|n| n.name.contains(".publishing-")),
             "the losing compare-and-swap must consume its staged node: {nodes:?}"
+        );
+    }
+
+    /// Issue #697, the sibling race: two **first** publishes of a path that
+    /// does not exist yet.
+    ///
+    /// Both resolve the path to `None` — correctly, at the instant they look —
+    /// and before the fix both then created, leaving two nodes under one name.
+    /// That state does not decay: `resolve_file` answers a duplicated name with
+    /// `Conflict`, so a race lasting microseconds refuses every later publish to
+    /// that deliverable, for every agent, permanently.
+    ///
+    /// Reuses `PausedSwap` unchanged, which is the point of routing creates
+    /// through the same primitive: both publishers are held at the store's
+    /// compare-and-swap boundary and released together, so the interleaving is
+    /// forced rather than hoped for. A test that merely ran two publishes
+    /// concurrently would pass on a machine that happened to serialize them.
+    #[tokio::test]
+    async fn two_first_publishes_of_one_path_have_one_winner_and_no_duplicate() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        // A different deliverable is published first, purely to mint the agent
+        // and task folders the racers will share. Without it each publisher
+        // walks `ensure_agent_folder` / `resolve_folder` itself and mints its
+        // OWN parent, so the two `report.md` nodes land under different folders
+        // and never contend for one path — the test would pass while asserting
+        // nothing about the race it names. (That folder walk is racy in its own
+        // right; it is a separate defect from this one and is not what this
+        // test pins.)
+        materialize(ws, &co, target("seed.md", "# Seed"))
+            .await
+            .expect("seeding the shared folders");
+
+        // The path under test must still not exist: this is the create arm.
+        let before = ws.tree(&co).await.unwrap();
+        assert!(
+            !before.iter().any(|n| n.name == "report.md"),
+            "the race is about a path that does not exist yet: {before:?}"
+        );
+
+        let racing = PausedSwap(ops.clone(), Arc::new(tokio::sync::Barrier::new(2)));
+        let left = materialize(&racing, &co, target("report.md", "# From the left"));
+        let right = materialize(&racing, &co, target("report.md", "# From the right"));
+        let (left, right) = tokio::join!(left, right);
+        let outcomes = [left, right];
+
+        assert_eq!(
+            outcomes.iter().filter(|result| result.is_ok()).count(),
+            1,
+            "exactly one first publish may create the path: {outcomes:?}"
+        );
+        let loser = outcomes
+            .iter()
+            .find_map(|result| result.as_ref().err())
+            .expect("one publisher loses");
+        assert!(
+            loser.to_string().contains("another publish"),
+            "the refusal must say what happened: {loser}"
+        );
+
+        let nodes = ws.tree(&co).await.unwrap();
+        let named: Vec<&WorkspaceNode> = nodes.iter().filter(|n| n.name == "report.md").collect();
+        assert_eq!(
+            named.len(),
+            1,
+            "one name, one node — a duplicate here is permanent: {named:?}"
+        );
+        assert!(
+            !nodes.iter().any(|n| n.name.contains(".publishing-")),
+            "the loser must consume its staged node: {nodes:?}"
+        );
+
+        // The path stays publishable. This is the assertion that speaks to why
+        // the issue ranks the defect as it does: a duplicate would make every
+        // future publish refuse, so proving the winner can still be revised is
+        // proving the damage did not happen.
+        materialize(ws, &co, target("report.md", "# A later revision"))
+            .await
+            .expect("the surviving path must still accept a publish");
+        let after = ws.tree(&co).await.unwrap();
+        assert_eq!(
+            after.iter().filter(|n| n.name == "report.md").count(),
+            1,
+            "and revising it must not fork the path either: {after:?}"
         );
     }
 

--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -617,7 +617,7 @@ impl WorkspaceStore for FixedTree {
     async fn swap_files(
         &self,
         _company: &CompanyId,
-        _expected_id: &str,
+        _expected_id: Option<&str>,
         _replacement_id: &str,
         _name: &str,
     ) -> crate::Result<Option<WorkspaceNode>> {

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2987,7 +2987,7 @@ mod tests {
         async fn swap_files(
             &self,
             _company: &CompanyId,
-            _expected_id: &str,
+            _expected_id: Option<&str>,
             _replacement_id: &str,
             _name: &str,
         ) -> crate::Result<Option<WorkspaceNode>> {

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -409,26 +409,43 @@ pub trait WorkspaceStore: Send + Sync {
         name: Option<&str>,
         parent: Option<Option<&str>>,
     ) -> Result<WorkspaceNode>;
-    /// Atomically promotes a staged file over the file it supersedes.
+    /// Atomically installs a staged file at `name`, conditional on what is
+    /// there now. A compare-and-swap on the *occupant of the path*.
     ///
-    /// Both ids must name files under the same parent. `replacement_id` is
-    /// renamed to `name` as part of the swap; `expected_id` is removed. The
-    /// operation is conditional on `expected_id` still naming the node being
-    /// replaced, so concurrent publishers cannot both win the same path.
+    /// `replacement_id` is renamed to `name` as part of the operation, under
+    /// its own existing parent. `expected_id` says what the caller believes
+    /// occupies that name, and is the whole guard:
     ///
-    /// Returns the promoted node on success. If the expected node has already
-    /// gone, returns `None` **and consumes the staged replacement**, including
-    /// any binary payload. That cleanup is part of the port contract: a caller
-    /// losing the compare-and-swap must not leak its private staging node.
+    /// * **`Some(id)`** — expect `id` to be the file at `name`. It is removed
+    ///   and the staged file takes its place. This is a republish (issue #662).
+    /// * **`None`** — assert the name is **unoccupied**, and install only while
+    ///   that holds. This is a first publish (issue #697).
+    ///
+    /// `None` does **not** mean "any occupant will do", and it is not a way to
+    /// skip the check: passing `None` for a path that *is* occupied must fail
+    /// the compare-and-swap rather than overwrite the node that is there. The
+    /// two spellings are one type apart and mean opposite things, so a caller
+    /// that means "replace whatever is at this path" must read the current id
+    /// and pass `Some(it)`. The conformance suite pins the occupied-`None` case
+    /// directly, because nothing else stops that mistake from compiling.
+    ///
+    /// Returns the promoted node on success. When the compare-and-swap loses —
+    /// the expected node has already gone, or the name the caller expected to
+    /// be free has been taken — returns `None` **and consumes the staged
+    /// replacement**, including any binary payload. That cleanup is part of the
+    /// port contract: a caller losing the race must not leak its private
+    /// staging node, which would charge the tenant's quota for bytes nothing
+    /// can reach.
     ///
     /// Backends must make the logical tree transition without an observable
-    /// delete-then-rename gap. This is deliberately a store primitive rather
-    /// than two existing calls: a process-local lock cannot protect MongoDB
-    /// when two server instances publish concurrently.
+    /// delete-then-rename gap, and must decide concurrent callers so that
+    /// exactly one wins. This is deliberately a store primitive rather than two
+    /// existing calls: a process-local lock cannot protect MongoDB when two
+    /// server instances publish concurrently.
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<WorkspaceNode>>;

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -245,7 +245,7 @@ impl WorkspaceStore for WorkspaceAnnouncer {
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<WorkspaceNode>> {
@@ -255,7 +255,13 @@ impl WorkspaceStore for WorkspaceAnnouncer {
             .await?;
         match &promoted {
             Some(node) => {
-                self.announce(company, expected_id, CHANGE_REMOVED).await;
+                // Only a republish retires a node. A first publish (issue #697)
+                // supersedes nothing, so announcing a removal would name an id
+                // that never existed and close a watcher's handle on a file it
+                // never had open.
+                if let Some(superseded) = expected_id {
+                    self.announce(company, superseded, CHANGE_REMOVED).await;
+                }
                 self.announce(company, &node.id, CHANGE_UPDATED).await;
             }
             None => {

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -345,6 +345,12 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
     /// change can add. Workspace quota counts binary payloads only, and a
     /// shape-changing swap has exactly one binary side, so forwarding the swap
     /// cannot transiently double-count two blobs.
+    ///
+    /// A first publish (issue #697, `expected_id` of `None`) is charged the
+    /// same way and needs no separate accounting: its staged create paid, and
+    /// there is no superseded side at all. A publisher that *loses* that race
+    /// has its stage consumed by the store, so the charge is released rather
+    /// than stranded on bytes nothing can reach.
     async fn swap_files(
         &self,
         company: &CompanyId,

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -348,7 +348,7 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<WorkspaceNode>> {

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2673,7 +2673,7 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
     .await
     .unwrap();
     let promoted = ws
-        .swap_files(&alpha, "swap-old", "swap-new", "report.md")
+        .swap_files(&alpha, Some("swap-old"), "swap-new", "report.md")
         .await
         .unwrap()
         .expect("the expected node is still current");
@@ -2699,13 +2699,103 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
     .await
     .unwrap();
     assert!(
-        ws.swap_files(&alpha, "already-gone", "swap-loser", "report.md")
+        ws.swap_files(&alpha, Some("already-gone"), "swap-loser", "report.md")
             .await
             .unwrap()
             .is_none()
     );
     assert!(ws.read(&alpha, "swap-loser").await.unwrap().is_none());
     assert!(ws.read_bytes(&alpha, "swap-loser").await.unwrap().is_none());
+
+    // -- Conditional first publish (issue #697) ---------------------------
+    //
+    // `None` installs only while the name is unoccupied. `report.md` is
+    // occupied at this point — the swap above promoted `swap-new` onto it — so
+    // this must LOSE rather than overwrite it.
+    //
+    // This case is the whole reason the parameter is an `Option` rather than
+    // two methods: `Some(id)` and `None` are one type apart and mean opposite
+    // things, and a caller that passes `None` meaning "replace whatever is
+    // there" compiles. Nothing but this assertion stops that mistake from
+    // silently reintroducing the duplicate-path race it was meant to fix.
+    ws.create_binary(
+        &alpha,
+        &node(
+            "create-onto-occupied",
+            "report.md.publishing-occupied",
+            Some("application/pdf"),
+            None,
+        ),
+        b"must-not-land",
+    )
+    .await
+    .unwrap();
+    assert!(
+        ws.swap_files(&alpha, None, "create-onto-occupied", "report.md")
+            .await
+            .unwrap()
+            .is_none(),
+        "`None` asserts the name is free; it must not overwrite an occupant"
+    );
+    let survivor = ws.read(&alpha, "swap-new").await.unwrap();
+    assert!(
+        survivor.is_some(),
+        "the node that held the path must still hold it"
+    );
+    let (_, stream) = ws.read_bytes(&alpha, "swap-new").await.unwrap().unwrap();
+    assert_eq!(
+        drain(stream).await,
+        b"new-payload".to_vec(),
+        "and its payload must be untouched"
+    );
+    // The loser consumes its own stage on this arm too, payload included.
+    assert!(
+        ws.read(&alpha, "create-onto-occupied")
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        ws.read_bytes(&alpha, "create-onto-occupied")
+            .await
+            .unwrap()
+            .is_none()
+    );
+
+    // And the arm that succeeds: a name nothing holds is installed, keeping
+    // the staged node's id and taking the final name.
+    ws.create_binary(
+        &alpha,
+        &node(
+            "create-fresh",
+            "fresh.md.publishing-test",
+            Some("application/pdf"),
+            None,
+        ),
+        b"fresh-payload",
+    )
+    .await
+    .unwrap();
+    let created = ws
+        .swap_files(&alpha, None, "create-fresh", "fresh.md")
+        .await
+        .unwrap()
+        .expect("the name was free");
+    assert_eq!(created.id, "create-fresh");
+    assert_eq!(created.name, "fresh.md");
+    let (_, stream) = ws
+        .read_bytes(&alpha, "create-fresh")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(drain(stream).await, b"fresh-payload".to_vec());
+    // Exactly one node answers to the new name.
+    let tree = ws.tree(&alpha).await.unwrap();
+    assert_eq!(
+        tree.iter().filter(|n| n.name == "fresh.md").count(),
+        1,
+        "a first publish must leave exactly one node at the path: {tree:?}"
+    );
 
     // -- A binary node must carry a mime ----------------------------------
     assert!(

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1300,7 +1300,7 @@ impl WorkspaceStore for FsOps {
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<WorkspaceNode>> {
@@ -1320,12 +1320,27 @@ impl WorkspaceStore for FsOps {
             ));
         }
 
-        let expected = index.get(expected_id).cloned();
-        let still_current = expected.as_ref().is_some_and(|node| {
-            node.kind == NodeKind::File
-                && node.name == name
-                && node.parent_id == replacement.parent_id
-        });
+        // The two readings of `expected_id`, decided under the same index lock
+        // that the install below runs under — so a concurrent publisher cannot
+        // slip between the question and the answer.
+        let expected = expected_id.and_then(|id| index.get(id).cloned());
+        let still_current = match expected_id {
+            Some(_) => expected.as_ref().is_some_and(|node| {
+                node.kind == NodeKind::File
+                    && node.name == name
+                    && node.parent_id == replacement.parent_id
+            }),
+            // Issue #697: `None` asserts the name is unoccupied. Any node
+            // already holding it — of either kind, however it got there — loses
+            // this caller the compare-and-swap. The staged node is excluded
+            // because it is the thing being installed and still carries its
+            // staging name.
+            None => !index.values().any(|node| {
+                node.id != replacement.id
+                    && node.name == name
+                    && node.parent_id == replacement.parent_id
+            }),
+        };
         if !still_current {
             // The compare-and-swap lost. The staging node is private to this
             // operation, so consume it while the same index lock is held.
@@ -1340,22 +1355,36 @@ impl WorkspaceStore for FsOps {
             return Ok(None);
         }
 
-        let expected = expected.expect("still_current requires an expected node");
-        let old_physical = self.physical_path(company, &index, expected_id)?;
         let staged_physical = self.physical_path(company, &index, replacement_id)?;
         let mut promoted = replacement;
         promoted.name = name.to_string();
         promoted.updated_at_millis = now_millis();
 
+        // Where the staged payload lands differs by mode. Replacing, it is the
+        // superseded node's own path — that rename IS the swap boundary, which
+        // is why the destination is computed before the index changes.
+        // Creating, there is no such path yet, so the promoted node is named in
+        // the index first and its final path derived from that.
+        let destination = match expected.as_ref() {
+            Some(node) => self.physical_path(company, &index, &node.id)?,
+            None => {
+                index.insert(promoted.id.clone(), promoted.clone());
+                self.physical_path(company, &index, &promoted.id)?
+            }
+        };
+
         // `rename` is the filesystem compare-and-swap boundary: on the
         // supported Unix server platforms it replaces the destination in one
         // operation, so a payload reader sees either the old bytes or the new
         // bytes and never an absent final path. If it fails, the index is still
-        // untouched and the old deliverable remains authoritative.
-        tokio::fs::rename(&staged_physical, &old_physical)
+        // untouched on disk — nothing above here has been saved — and the old
+        // deliverable, where there was one, remains authoritative.
+        tokio::fs::rename(&staged_physical, &destination)
             .await
-            .map_err(|e| io_err(&old_physical, e))?;
-        index.remove(&expected.id);
+            .map_err(|e| io_err(&destination, e))?;
+        if let Some(node) = expected {
+            index.remove(&node.id);
+        }
         index.insert(promoted.id.clone(), promoted.clone());
         self.save_index(company, &index).await?;
         Ok(Some(promoted))

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -110,6 +110,50 @@ fn get_i64(doc: &Document, key: &str) -> Result<i64> {
         .map_err(|e| mongo_err(format!("missing field {key}: {e}")))
 }
 
+/// A unique index restricted to the documents that carry `present` at all
+/// (issue #697).
+///
+/// MongoDB is the one backend with no transaction to decide a first publish
+/// under, so the uniqueness of a file's path has to be the database's own
+/// invariant rather than a read followed by a write.
+///
+/// PARTIAL, and that is what makes it safe to add to a live tenant. A plain
+/// unique index is built over every existing document, so a company that
+/// already lost this race — carrying the duplicate pair issue #697 is about —
+/// would fail index creation, and that failure happens during
+/// [`MongoStore::ensure_indexes`], which means the store's startup goes down
+/// for that tenant. Restricted to documents that *have* the field, the index
+/// covers everything this code writes from now on and ignores history it cannot
+/// repair. Legacy duplicates keep being caught one level up, where
+/// `resolve_file` already answers them with `Conflict`.
+///
+/// # `present` is a runtime value, not a literal
+///
+/// `doc! {present: ...}` uses the **value** of `present`, not the string
+/// `"present"`. The `doc!`/`bson!` key arms end at
+/// `$object.insert::<_, Bson>(($($key)+), $value)` — the accumulated key tokens
+/// are passed to `insert` as an *expression*, and `insert<KT: Into<String>>`
+/// takes this `&str` by value. There is no `stringify!` anywhere on that path;
+/// the macro only treats a key as a literal when one is written literally.
+///
+/// This is worth saying out loud because the failure it would cause is
+/// invisible: a partial filter keyed on a field no document has would match
+/// nothing, the index would be built over an empty set, and it would reject no
+/// insert — silently removing the guarantee this function exists to provide,
+/// while every test that does not actually race still passed.
+/// `the_partial_filter_is_keyed_on_the_field_not_the_parameter_name` pins it.
+fn unique_partial(keys: Document, present: &str) -> IndexModel {
+    IndexModel::builder()
+        .keys(keys)
+        .options(
+            IndexOptions::builder()
+                .unique(true)
+                .partial_filter_expression(doc! {present: {"$exists": true}})
+                .build(),
+        )
+        .build()
+}
+
 /// The uniqueness key for a **file's** path inside one company (issue #697).
 ///
 /// Stored beside the node document so the partial unique index in
@@ -188,30 +232,7 @@ impl MongoStore {
         // Not every index can be unique: a user holds many sessions, and an
         // address may have several login codes over time.
         let nonunique = |keys: Document| IndexModel::builder().keys(keys).build();
-        // Unique only over the documents that carry the key at all (issue
-        // #697). MongoDB is the one backend with no transaction to decide a
-        // first publish under, so the uniqueness of a file's path has to be the
-        // database's own invariant rather than a read followed by a write.
-        //
-        // PARTIAL, and that is what makes it safe to add to a live tenant. A
-        // plain unique index is built over every existing document, so a
-        // company that already lost this race — the duplicate pair this issue
-        // is about — would fail index creation and take the store's startup
-        // down with it. Restricted to documents that *have* `file_path_key`,
-        // the index covers everything this code writes from now on and ignores
-        // history it cannot repair. Legacy duplicates keep being caught one
-        // level up, where `resolve_file` already answers them with `Conflict`.
-        let unique_partial = |keys: Document, present: &str| {
-            IndexModel::builder()
-                .keys(keys)
-                .options(
-                    IndexOptions::builder()
-                        .unique(true)
-                        .partial_filter_expression(doc! {present: {"$exists": true}})
-                        .build(),
-                )
-                .build()
-        };
+        // See `unique_partial`.
         let plans: [(&str, IndexModel); 31] = [
             ("companies", unique(doc! {"company_id": 1})),
             ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
@@ -2943,6 +2964,58 @@ mod test {
     fn required() -> bool {
         std::env::var("OPENCOMPANY_TEST_MONGODB_REQUIRED")
             .is_ok_and(|value| !value.is_empty() && value != "0")
+    }
+
+    /// Issue #697. The partial filter must be keyed on the **field name passed
+    /// in**, never on the literal `"present"` — the parameter's own name.
+    ///
+    /// Raised in review of #733 as a HIGH finding: that `doc!` stringifies
+    /// identifier keys, so `doc! {present: ...}` would build
+    /// `{"present": {"$exists": true}}`, a filter no document matches. The
+    /// index would then be built over an empty set and reject no insert,
+    /// silently removing the one-file-per-path guarantee on this backend.
+    ///
+    /// It does not: the `bson!` key arms end at
+    /// `insert::<_, Bson>(($($key)+), $value)`, passing the key tokens as an
+    /// expression rather than through `stringify!`. But that is an argument
+    /// about a macro's expansion, and the cost of being wrong is a guard that
+    /// looks present and enforces nothing — so this asserts the built artifact
+    /// instead of the reasoning.
+    ///
+    /// Needs no server: it inspects the `IndexModel` this code constructs, so
+    /// it runs on the `mongodb` feature alone and cannot pass vacuously the way
+    /// the URI-gated tests can.
+    #[test]
+    fn the_partial_filter_is_keyed_on_the_field_not_the_parameter_name() {
+        let model = unique_partial(doc! {"company_id": 1, "file_path_key": 1}, "file_path_key");
+        let filter = model
+            .options
+            .as_ref()
+            .and_then(|options| options.partial_filter_expression.as_ref())
+            .expect("the index is partial");
+
+        assert!(
+            filter.contains_key("file_path_key"),
+            "the filter must name the field it guards: {filter:?}"
+        );
+        assert!(
+            !filter.contains_key("present"),
+            "a filter keyed on the parameter's own name would match no document, so the \
+             index would be built over an empty set and reject nothing: {filter:?}"
+        );
+        assert_eq!(
+            filter.get_document("file_path_key").expect("the condition"),
+            &doc! {"$exists": true},
+            "and the condition is existence of that field: {filter:?}"
+        );
+        assert!(
+            model
+                .options
+                .as_ref()
+                .and_then(|options| options.unique)
+                .unwrap_or(false),
+            "a partial filter without uniqueness would guard nothing at all"
+        );
     }
 
     /// The URI with any `user:password@` replaced by `***@`, for the panic

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -110,6 +110,33 @@ fn get_i64(doc: &Document, key: &str) -> Result<i64> {
         .map_err(|e| mongo_err(format!("missing field {key}: {e}")))
 }
 
+/// The uniqueness key for a **file's** path inside one company (issue #697).
+///
+/// Stored beside the node document so the partial unique index in
+/// [`MongoStore::ensure_indexes`] can enforce "one file per path" as a database
+/// invariant. That is what lets a first publish be a real compare-and-swap on
+/// this backend: fs and SQLite decide the race under a lock and a transaction
+/// respectively, and MongoDB has neither across two documents, so the insert
+/// either violates the index or it does not.
+///
+/// Files only. Folders deliberately carry no key, so the index never indexes
+/// them and a folder may still share a name with a file exactly as before —
+/// this is a race fix, not a new tree rule.
+///
+/// NUL is the separator because [`reject_unsafe_name`](crate::store::fs_ops)
+/// keeps it out of every node name, so no name can forge a different pair's
+/// key. The root is the empty string; a node parented at the root and one
+/// parented under a folder therefore never collide.
+fn file_path_key(parent_id: Option<&str>, name: &str) -> String {
+    format!("{}\u{0}{}", parent_id.unwrap_or(""), name)
+}
+
+/// The key a node should carry, or `None` when it is not a file.
+fn node_path_key(node: &crate::ports::workspace::WorkspaceNode) -> Option<String> {
+    (node.kind == crate::ports::workspace::NodeKind::File)
+        .then(|| file_path_key(node.parent_id.as_deref(), &node.name))
+}
+
 /// A single MongoDB database implementing all five storage ports.
 #[derive(Clone)]
 pub struct MongoStore {
@@ -161,7 +188,31 @@ impl MongoStore {
         // Not every index can be unique: a user holds many sessions, and an
         // address may have several login codes over time.
         let nonunique = |keys: Document| IndexModel::builder().keys(keys).build();
-        let plans: [(&str, IndexModel); 30] = [
+        // Unique only over the documents that carry the key at all (issue
+        // #697). MongoDB is the one backend with no transaction to decide a
+        // first publish under, so the uniqueness of a file's path has to be the
+        // database's own invariant rather than a read followed by a write.
+        //
+        // PARTIAL, and that is what makes it safe to add to a live tenant. A
+        // plain unique index is built over every existing document, so a
+        // company that already lost this race — the duplicate pair this issue
+        // is about — would fail index creation and take the store's startup
+        // down with it. Restricted to documents that *have* `file_path_key`,
+        // the index covers everything this code writes from now on and ignores
+        // history it cannot repair. Legacy duplicates keep being caught one
+        // level up, where `resolve_file` already answers them with `Conflict`.
+        let unique_partial = |keys: Document, present: &str| {
+            IndexModel::builder()
+                .keys(keys)
+                .options(
+                    IndexOptions::builder()
+                        .unique(true)
+                        .partial_filter_expression(doc! {present: {"$exists": true}})
+                        .build(),
+                )
+                .build()
+        };
+        let plans: [(&str, IndexModel); 31] = [
             ("companies", unique(doc! {"company_id": 1})),
             ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
             ("events", unique(doc! {"company_id": 1, "seq": 1})),
@@ -178,6 +229,12 @@ impl MongoStore {
             (
                 "workspace_nodes",
                 unique(doc! {"company_id": 1, "node_id": 1}),
+            ),
+            // One file per path. This is the compare-and-swap a first publish
+            // wins or loses (issue #697); see `file_path_key`.
+            (
+                "workspace_nodes",
+                unique_partial(doc! {"company_id": 1, "file_path_key": 1}, "file_path_key"),
             ),
             ("users", unique(doc! {"company_id": 1, "user_id": 1})),
             // Enforces one account per address per company, and backs the login
@@ -2365,14 +2422,19 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                 }
             }
         }
+        let mut document = doc! {
+            "company_id": company.as_ref(),
+            "node_id": &node.id,
+            "node_json": serde_json::to_string(node)?,
+            "content": content.unwrap_or(""),
+            "updated_ms": node.updated_at_millis as i64,
+        };
+        // Issue #697: claims this file's path against the partial unique index.
+        if let Some(key) = node_path_key(node) {
+            document.insert("file_path_key", key);
+        }
         self.collection("workspace_nodes")
-            .insert_one(doc! {
-                "company_id": company.as_ref(),
-                "node_id": &node.id,
-                "node_json": serde_json::to_string(node)?,
-                "content": content.unwrap_or(""),
-                "updated_ms": node.updated_at_millis as i64,
-            })
+            .insert_one(document)
             .await
             .map_err(mongo_err)?;
         Ok(())
@@ -2426,14 +2488,19 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             }
         }
         self.put_blob(company, &node.id, &node.name, bytes).await?;
+        let mut document = doc! {
+            "company_id": company.as_ref(),
+            "node_id": &node.id,
+            "node_json": serde_json::to_string(&node)?,
+            "content": "",
+            "updated_ms": node.updated_at_millis as i64,
+        };
+        // Issue #697, as above.
+        if let Some(key) = node_path_key(&node) {
+            document.insert("file_path_key", key);
+        }
         self.collection("workspace_nodes")
-            .insert_one(doc! {
-                "company_id": company.as_ref(),
-                "node_id": &node.id,
-                "node_json": serde_json::to_string(&node)?,
-                "content": "",
-                "updated_ms": node.updated_at_millis as i64,
-            })
+            .insert_one(document)
             .await
             .map_err(mongo_err)?;
         // The stamped node, so the digest a caller records can only have come
@@ -2585,14 +2652,25 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             node.parent_id = parent.map(str::to_string);
         }
         node.updated_at_millis = now_millis();
+        // A rename or a reparent moves the file to a different path, so its
+        // claim has to move with it (issue #697) or the index would keep
+        // guarding the path it left and ignore the one it took.
+        let mut set = doc! {
+            "node_json": serde_json::to_string(&node)?,
+            "updated_ms": node.updated_at_millis as i64,
+        };
+        let mut update = match node_path_key(&node) {
+            Some(key) => {
+                set.insert("file_path_key", key);
+                doc! {"$set": set}
+            }
+            None => doc! {"$set": set},
+        };
+        if node_path_key(&node).is_none() {
+            update.insert("$unset", doc! {"file_path_key": ""});
+        }
         self.collection("workspace_nodes")
-            .update_one(
-                doc! {"company_id": company.as_ref(), "node_id": id},
-                doc! {"$set": {
-                    "node_json": serde_json::to_string(&node)?,
-                    "updated_ms": node.updated_at_millis as i64,
-                }},
-            )
+            .update_one(doc! {"company_id": company.as_ref(), "node_id": id}, update)
             .await
             .map_err(mongo_err)?;
         Ok(node)
@@ -2601,7 +2679,7 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<crate::ports::workspace::WorkspaceNode>> {
@@ -2629,13 +2707,16 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             ));
         }
 
-        let expected_doc = nodes
-            .find_one(doc! {
-                "company_id": company.as_ref(),
-                "node_id": expected_id,
-            })
-            .await
-            .map_err(mongo_err)?;
+        let expected_doc = match expected_id {
+            Some(id) => nodes
+                .find_one(doc! {
+                    "company_id": company.as_ref(),
+                    "node_id": id,
+                })
+                .await
+                .map_err(mongo_err)?,
+            None => None,
+        };
         let expected = expected_doc
             .as_ref()
             .map(
@@ -2645,11 +2726,15 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                 },
             )
             .transpose()?;
-        let still_current = expected.as_ref().is_some_and(|node| {
-            node.kind == NodeKind::File
-                && node.name == name
-                && node.parent_id == replacement.parent_id
-        });
+        // Only the replace arm can be decided by reading. The create arm is
+        // decided below, by the unique index, because a read here would be a
+        // check with a window after it.
+        let still_current = expected_id.is_none()
+            || expected.as_ref().is_some_and(|node| {
+                node.kind == NodeKind::File
+                    && node.name == name
+                    && node.parent_id == replacement.parent_id
+            });
 
         // Detach the private staging document before changing the expected
         // document's id: `(company_id, node_id)` is unique. The GridFS payload
@@ -2675,6 +2760,46 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             return Ok(None);
         }
 
+        let mut promoted = replacement.clone();
+        promoted.name = name.to_string();
+        promoted.updated_at_millis = now_millis();
+
+        // Issue #697, the first-publish arm. The staged document has just been
+        // detached, so re-inserting it under the final name is the whole
+        // operation — and the partial unique index on `file_path_key` is what
+        // decides it. Two publishers reaching here concurrently both attempt
+        // the insert; exactly one satisfies the index and the other is refused
+        // by the server, which is the only place this backend can hold that
+        // line without a transaction.
+        if expected_id.is_none() {
+            let staged_content = staged_doc
+                .get("content")
+                .cloned()
+                .unwrap_or_else(|| mongodb::bson::Bson::String(String::new()));
+            let mut document = doc! {
+                "company_id": company.as_ref(),
+                "node_id": replacement_id,
+                "node_json": serde_json::to_string(&promoted)?,
+                "content": staged_content,
+                "updated_ms": promoted.updated_at_millis as i64,
+            };
+            document.insert(
+                "file_path_key",
+                file_path_key(promoted.parent_id.as_deref(), &promoted.name),
+            );
+            return match nodes.insert_one(document).await {
+                Ok(_) => Ok(Some(promoted)),
+                Err(err) if is_duplicate_key(&err) => {
+                    // Lost the race: somebody else holds this path. The staged
+                    // node is already detached, so only its payload remains to
+                    // reclaim — the same cleanup the replace arm owes.
+                    self.drop_blobs(company, replacement_id, None).await?;
+                    Ok(None)
+                }
+                Err(err) => Err(mongo_err(err)),
+            };
+        }
+
         let expected_doc = expected_doc.expect("still_current requires an expected document");
         let expected_json = get_str(&expected_doc, "node_json")?.to_string();
         let expected_content = expected_doc
@@ -2685,9 +2810,6 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             .get("content")
             .cloned()
             .unwrap_or_else(|| mongodb::bson::Bson::String(String::new()));
-        let mut promoted = replacement;
-        promoted.name = name.to_string();
-        promoted.updated_at_millis = now_millis();
 
         // One document update is the compare-and-swap. Including the complete
         // old JSON and content makes an in-place writer count as a competing
@@ -2705,6 +2827,13 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                     "node_json": serde_json::to_string(&promoted)?,
                     "content": staged_content,
                     "updated_ms": promoted.updated_at_millis as i64,
+                    // The promoted node now holds the path, so it takes the
+                    // claim with it (issue #697). The superseded document is
+                    // this same document, so there is no stale key left behind.
+                    "file_path_key": file_path_key(
+                        promoted.parent_id.as_deref(),
+                        &promoted.name,
+                    ),
                 }},
             )
             .await
@@ -2718,10 +2847,11 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         // bytes are now unreachable; a cleanup failure must not turn a
         // successful atomic swap into a reported publish failure, because the
         // boot orphan sweep can safely finish this work later.
-        if let Err(err) = self.drop_blobs(company, expected_id, None).await {
+        let superseded = expected_id.expect("the replace arm has an expected id");
+        if let Err(err) = self.drop_blobs(company, superseded, None).await {
             tracing::warn!(
                 company = %company,
-                node_id = %expected_id,
+                node_id = %superseded,
                 error = %err,
                 "workspace file swap succeeded but old GridFS payload cleanup was deferred"
             );

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2813,8 +2813,19 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
                 Err(err) if is_duplicate_key(&err) => {
                     // Lost the race: somebody else holds this path. The staged
                     // node is already detached, so only its payload remains to
-                    // reclaim — the same cleanup the replace arm owes.
-                    self.drop_blobs(company, replacement_id, None).await?;
+                    // reclaim — the same cleanup the replace arm owes. A
+                    // cleanup failure must not turn the clean loss into a
+                    // reported publish failure: the compare-and-swap already
+                    // lost, and the boot orphan sweep finishes this later.
+                    if let Err(err) = self.drop_blobs(company, replacement_id, None).await {
+                        tracing::warn!(
+                            company = %company,
+                            node_id = %replacement_id,
+                            error = %err,
+                            "workspace first publish lost the race but staged GridFS payload \
+                             cleanup was deferred"
+                        );
+                    }
                     Ok(None)
                 }
                 Err(err) => Err(mongo_err(err)),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2584,7 +2584,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
     async fn swap_files(
         &self,
         company: &CompanyId,
-        expected_id: &str,
+        expected_id: Option<&str>,
         replacement_id: &str,
         name: &str,
     ) -> Result<Option<crate::ports::workspace::WorkspaceNode>> {
@@ -2610,11 +2610,23 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ));
         }
 
-        let still_current = nodes.get(expected_id).is_some_and(|node| {
-            node.kind == NodeKind::File
-                && node.name == name
-                && node.parent_id == replacement.parent_id
-        });
+        // Both readings of `expected_id`, decided inside the immediate
+        // transaction opened above so two writers cannot both see the name free.
+        let still_current = match expected_id {
+            Some(id) => nodes.get(id).is_some_and(|node| {
+                node.kind == NodeKind::File
+                    && node.name == name
+                    && node.parent_id == replacement.parent_id
+            }),
+            // Issue #697: `None` asserts the name is unoccupied. Any node
+            // already at it loses this caller the compare-and-swap; the staged
+            // node itself is excluded, since it is what is being installed.
+            None => !nodes.values().any(|node| {
+                node.id != replacement.id
+                    && node.name == name
+                    && node.parent_id == replacement.parent_id
+            }),
+        };
         if !still_current {
             tx.execute(
                 "DELETE FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
@@ -2628,11 +2640,15 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         let mut promoted = replacement;
         promoted.name = name.to_string();
         promoted.updated_at_millis = now_millis();
-        tx.execute(
-            "DELETE FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
-            params![company.as_ref(), expected_id],
-        )
-        .map_err(sql_err)?;
+        // Nothing to retire on a first publish: the name was free, which is
+        // exactly what the guard above established.
+        if let Some(id) = expected_id {
+            tx.execute(
+                "DELETE FROM workspace_nodes WHERE company_id = ?1 AND id = ?2",
+                params![company.as_ref(), id],
+            )
+            .map_err(sql_err)?;
+        }
         tx.execute(
             "UPDATE workspace_nodes SET node_json = ?1, updated_ms = ?2 \
              WHERE company_id = ?3 AND id = ?4",


### PR DESCRIPTION
## Summary

Two concurrent first publishes of a path that does not exist yet both resolved `None` and
both created it. Two nodes, one name.

```rust
None => create_payload(workspace, company, Some(parent), filename, target).await,
```

`resolve_file` returning `None` is a statement about the instant it read the tree. A plain
create acts on it later, so both publishers create.

**The damage is permanent, which is why this ranked above the other open defects.**
`resolve_file` answers a duplicated name with `Conflict`, so a race that lasted
microseconds refuses *every future publish to that deliverable, for every agent*, until
somebody edits the tree by hand. A transient race leaves a permanently broken path.

Reachable because workflow runs are `tokio::spawn`ed rather than serialized behind the
cycle lock, and `materialize` is reached from the publish drain rather than a
`company_write_lock`ed write plane — the same reasoning #683 accepted for the replace arm.

Closes tinyhumansai/opencompany#697

## The shape: #683's primitive, widened rather than duplicated

#683 already built the adjacent operation — `swap_files`, a conditional promotion that
fails when `expected_id` is no longer the node at that name, consumes the loser's staged
node, and has no observable gap. This PR makes that one primitive answer both questions by
turning its expectation into an `Option`:

```rust
async fn swap_files(
    &self,
    company: &CompanyId,
    expected_id: Option<&str>,   // Some(id) = expect that node; None = expect the name FREE
    replacement_id: &str,
    name: &str,
) -> Result<Option<WorkspaceNode>>;
```

`create_first` then mirrors `replace_payload` exactly: stage under
`{filename}.publishing-{uuid}` — a name no publish can produce and `resolve_file` will
never match, so the path resolves to exactly one node at every instant — then install
conditionally.

A sibling `create_if_absent` was the alternative. Widening won because **the
loser-cleanup contract is identical**: consume the staged node, payload included, so a
loser cannot leak bytes that charge the tenant's quota and nothing can reach. That rule is
the subtle part, and two copies of it are where it drifts the first time someone fixes a
leak in one and not the other. Widening also means the existing `PausedSwap` barrier
harness pins the create race with no new machinery.

## One contract, three enforcement layers

The backends enforce the same guarantee where each can actually hold the line:

| Backend | Where the race is decided |
| --- | --- |
| fs | Under the index lock the install already runs under |
| SQLite | Inside the existing `TransactionBehavior::Immediate` transaction |
| MongoDB | As an insert the database itself refuses |

### Why MongoDB is not a read-then-write — please do not "simplify" this

MongoDB has no expected document to `update_one` against on a create, and no transaction
across two documents on a standalone `mongod`. Checking "is the name free?" and then
inserting leaves exactly the window this issue is about, just narrower. So the create is
expressed as an insert that violates a unique index when it loses: a `file_path_key` field
on file documents, plus a unique index on `(company_id, file_path_key)`. Two publishers
both attempt the insert; exactly one satisfies the index and the server refuses the other.

**The index MUST be partial, and this is the part that is not recoverable from the diff.**
A plain unique index is built over every existing document. Any tenant that has *already*
lost this race is carrying the duplicate pair this PR exists to prevent — so building a
plain unique index over their data would fail, and that failure happens during
`ensure_indexes`, which means **store startup goes down for that tenant**. Restricting the
index to documents that carry `file_path_key`
(`partialFilterExpression: {file_path_key: {$exists: true}}`) guards everything this code
writes from now on and ignores history it cannot repair. Legacy duplicates keep being
caught one level up, where `resolve_file` already answers them with `Conflict` — so
nothing regresses; the pre-existing bad state simply keeps its pre-existing handling.

The key is **files only**. Folders carry no key and are never indexed, so a folder may
still share a name with a file exactly as before: this is a race fix, not a new tree rule.
The separator is NUL, which `reject_unsafe_name` keeps out of every node name, so no name
can forge another pair's key.

## API Or Behavior Changes

- **`WorkspaceStore::swap_files`** takes `expected_id: Option<&str>`. `Some(id)` is the
  existing republish; `None` asserts the name is unoccupied and installs only while that
  holds. `None` does **not** mean "any occupant will do" — against an occupied path it
  must lose rather than overwrite.
- **MongoDB** workspace file documents gain `file_path_key`, plus one partial unique index.
  No migration and no backfill: absent on legacy documents by design, per above.
- **A losing first publish** now returns `Conflict` ("...was created by another publish
  while this one was being prepared") instead of silently creating a duplicate.
- `workspace_events` no longer announces `CHANGE_REMOVED` on a first publish — there is no
  superseded node, and the old code would have named an id that never existed.

### The hazard this introduces, and how it is guarded

`expected_id: &str` → `Option<&str>` makes "replace this specific node" and "expect the
name to be free" a **silent, type-checking difference**. Passing `None` where `Some(id)`
was meant turns a guarded replace into install-if-absent — and it compiles. Guarded three
ways:

1. The port doc states both meanings imperatively, including that a caller meaning
   "replace whatever is at this path" must read the current id and pass `Some(it)`.
2. **A conformance case pins the `None` semantics directly**: `None` against an
   **occupied** name must fail rather than overwrite, the occupant and its payload must be
   untouched, and the loser must still consume its stage.
3. The pre-existing `replace_payload` call site carries a comment saying why it is `Some`
   and what `None` would break there.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — exit 0. Run in **both** forms: CI's
      default-feature form verbatim, and
      `--locked --no-deps --features openhuman,tinycortex --all-targets`.
- [x] `cargo build --all-targets` — exit 0. Also run:
      `cargo check --locked --all-features --all-targets` (exit 0). `--all-features`
      matters because `mongodb.rs` and `sqlite.rs` build `CompanyRecord` from a row rather
      than a struct literal, which the default and gated lanes cannot see.
- [x] `cargo test` — exit 0. Default lane **2073 passed**; gated
      (`--features openhuman,tinycortex`) **3129 passed, 0 failed, 3 ignored**;
      `--features sqlite --lib store::sqlite` **30 passed**;
      `--features mongodb --lib store::mongodb` **26 passed**.

**The MongoDB lane was genuinely exercised.** With
`OPENCOMPANY_TEST_MONGODB_URI` pointed at a local `mongod` it takes **15.34s**; without it
the same suite reports the same "26 passed" in **0.00s**, because `store()` returns `None`
and every test returns early having asserted nothing. Every mongodb figure quoted here is
from the 15s run.

**Count:** `upstream/main` 3131 → this branch 3132. A name-diff of the two `--list`
outputs shows **1 added, 0 removed**; the conformance work is added assertions inside an
existing test rather than new test functions.

**Every new assertion was verified to fail with its mechanism reverted** — four mutations,
each leaving the rest of the suite passing, so none was a silent no-op:

| Mutation | What failed |
| --- | --- |
| `create_first` → the old `create_payload` | the barrier test (19 passed, 1 failed) |
| fs `None` predicate → always-free | the barrier test **and** fs conformance (34 passed, 1 failed) |
| SQLite `None` predicate → always-free | SQLite conformance (29 passed, 1 failed) |
| MongoDB path claim removed | MongoDB conformance (25 passed, 1 failed, **16.15s** — real server) |

The occupied-`None` conformance case is what fails in all three backend rows, with
`` `None` asserts the name is free; it must not overwrite an occupant ``.

### A note on the barrier test

`two_first_publishes_of_one_path_have_one_winner_and_no_duplicate` reuses `PausedSwap`
unchanged, so both publishers are held at the store's compare-and-swap boundary and
released together — the interleaving is forced, not hoped for.

It seeds an unrelated deliverable first, and that is not incidental. Without it the test
**passes while asserting nothing**: `ensure_agent_folder` / `resolve_folder` run before
file resolution, so each racer mints its *own* parent folder and the two `report.md` nodes
never contend for one path. This is how the test first failed, with both publishes
succeeding.

**That folder walk has the same race**, and it is a separate defect from this one — not
fixed here, and worth filing.

## Documentation

The contract lives where a reader meets it: `WorkspaceStore::swap_files` documents both
readings of `expected_id` and the loser-cleanup rule; `file_path_key` documents why the
MongoDB index is partial and why it is files-only; `create_first` documents why a plain
create is not enough and why it takes `replace_payload`'s shape; the quota decorator
records that a first publish needs no separate accounting and that a loser's charge is
released with its consumed stage.

No `docs/` change: this closes a race inside an existing operation and adds no new
architecture or usage. No console or user-facing text changes.
