### PR TITLE
approvals: scope a standing grant on an outward fetch to one host (#673)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,11 +120,21 @@ anyhow = { version = "1", optional = true }
 log = { version = "0.4", optional = true }
 uuid = { version = "1", features = ["v4"], optional = true }
 # Console MCP OAuth (issue #90): base64url for PKCE (S256 challenge + verifier
-# entropy) and URL building for the `/authorize` redirect. Both are already in
-# the tree via `openhuman_core` + `reqwest`, so pinning them as direct deps adds
-# no new Cargo.lock entries; they link only under the `mcp` feature.
+# entropy) and URL building for the `/authorize` redirect. Already in the tree
+# via `openhuman_core` + `reqwest`, so pinning it as a direct dep adds no new
+# Cargo.lock entry; it links only under the `mcp` feature.
 base64 = { version = "0.22", optional = true }
-url = { version = "2", optional = true }
+# NOT optional, deliberately (issue #673). `src/policy/consequence.rs` derives a
+# standing grant's host scope with this parser, and it must be *the same* parser
+# `reqwest` uses to perform the fetch — a grant key computed by a second,
+# hand-rolled reader is a bypass waiting to be found, which is precisely how the
+# `https://evil.com\@docs.rs/` confusion arose in review of that issue.
+#
+# Feature-gating it would put the security boundary behind `#[cfg]` and, worse,
+# make its regression tests vacuous in the default lane — a suite that cannot
+# run the hostile-input table is not protecting anything. Already in the tree
+# via `reqwest`, so this adds no new Cargo.lock entry either way.
+url = "2"
 
 # Issue #29 (epic #26): the tinyflows workflow engine, embedded directly. It is
 # host-agnostic and Config-free — `Capabilities` is a plain struct of trait
@@ -269,7 +279,7 @@ openhuman = ["tiny", "dep:openhuman_core", "dep:reqwest", "dep:anyhow", "dep:log
 # MCP server management and agent tools share OpenHuman's in-process registry.
 # Enabling it necessarily enables the embedded harness and OpenHuman MCP
 # domain, while the default build remains unchanged.
-mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid", "dep:base64", "dep:url"]
+mcp = ["openhuman", "openhuman_core/mcp", "dep:uuid", "dep:base64"]
 # Image/video generation tools (issue #109, epic #26 Cell B). Bridges
 # OpenHuman's `media_generation` tools (`media_generate_image`,
 # `media_generate_video`, `media_list_models`) into a company agent's toolbelt

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -4271,6 +4271,117 @@ mod tests {
         );
     }
 
+    /// **Issue #673's acceptance, through the real gate, in both tiers.**
+    ///
+    /// Worth stating why this can go through `check()` when #457's Composio twin
+    /// below cannot: a catalogue read stopped parking at the tier in #559, so
+    /// the scope was never reached there. An outward fetch still parks under
+    /// `supervised` *and* under `auto` — that is the whole purpose of
+    /// [`Standing::ScopedGrantable`](crate::policy::Standing::ScopedGrantable) —
+    /// so the grant is genuinely the thing deciding, and the assertion is not
+    /// being satisfied by a tier that waved the call through upstream.
+    ///
+    /// `auto` is in the loop deliberately. The naive fix for #673 declared
+    /// `web_fetch` `Grantable`, which made `parks_under_auto` false and let every
+    /// agent fetch any address unattended for as long as the company sat in
+    /// `auto` — no card, so the host scope was never consulted at all. Running
+    /// both tiers here is what would catch a future edit that re-fuses the two.
+    #[tokio::test]
+    async fn a_fetch_grant_scoped_to_one_host_admits_it_and_re_parks_another() {
+        for tier in ["supervised", "auto"] {
+            let queue = ApprovalRequestQueue::default();
+            let grants = queue.grants();
+            let p = policy(tier, &[], None)
+                .with_requests(queue)
+                .with_agent("ops");
+            grants.grant_standing(scoped_standing(
+                "ops",
+                crate::policy::consequence::WEB_FETCH,
+                "https://docs.rs",
+                far_future(),
+            ));
+
+            // A second fetch of the granted host, at a different path. This is
+            // inside the sentence the operator consented to.
+            assert!(
+                matches!(
+                    p.check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "https://docs.rs/serde" })
+                    ))
+                    .await,
+                    ToolPolicyDecision::Allow
+                ),
+                "a second fetch of the granted host must run unattended under `{tier}`"
+            );
+
+            // A different host. Same agent, same tool, same grant, still live —
+            // the scope is the one thing that says no.
+            assert!(
+                matches!(
+                    p.check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "https://crates.io/crates/serde" })
+                    ))
+                    .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "'fetch from docs.rs' is not consent to fetch anywhere else — `{tier}`"
+            );
+
+            // A subdomain of the granted host is a different host.
+            assert!(
+                matches!(
+                    p.check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "https://evil.docs.rs/x" })
+                    ))
+                    .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "a subdomain was never on the card — `{tier}`"
+            );
+
+            // A call whose URL cannot be read is not grantable at all, so the
+            // grant cannot admit it however well it matches on (agent, tool).
+            assert!(
+                matches!(
+                    p.check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "not-a-url" })
+                    ))
+                    .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "an unreadable URL has no scope for a scoped grant to admit — `{tier}`"
+            );
+        }
+    }
+
+    /// Without a grant an outward fetch still parks in both parking tiers — the
+    /// status quo #673 must not have widened.
+    ///
+    /// This is the assertion that fails if `web_fetch` is ever declared
+    /// `Grantable` outright: under `auto` it would be allowed here with no
+    /// operator in the loop.
+    #[tokio::test]
+    async fn an_ungranted_fetch_still_parks_under_supervised_and_auto() {
+        for tier in ["supervised", "auto"] {
+            let p = policy(tier, &[], None);
+            assert!(
+                matches!(
+                    p.check(&request(
+                        "web_fetch",
+                        serde_json::json!({ "url": "https://docs.rs/serde" })
+                    ))
+                    .await,
+                    ToolPolicyDecision::RequireApproval { .. }
+                ),
+                "an outward fetch with no grant must park under `{tier}`"
+            );
+        }
+    }
+
     /// Issue #457's scope check, pinned **directly** rather than through
     /// `check()`.
     ///

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -1242,6 +1242,15 @@ mod tests {
             standing_scope_of(WEB_FETCH, &fetching("https://a@b@evil.example/x")),
             Some("https://evil.example".to_string())
         );
+        // A backslash is a path separator per WHATWG, so it terminates the
+        // authority exactly as `/` does. Without this split the URL would read
+        // `docs.rs` as the host and let `evil.example` satisfy a grant minted
+        // for `docs.rs` — the userinfo trap re-opened through a delimiter this
+        // split never handled.
+        assert_eq!(
+            standing_scope_of(WEB_FETCH, &fetching("https://evil.example\\@docs.rs/x")),
+            Some("https://evil.example".to_string())
+        );
     }
 
     /// The host key is exact. Neither a suffix nor a subdomain of a granted host

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -134,19 +134,64 @@ impl Reach {
 /// is two decisions in one edit, and the second one is easy to make by
 /// accident. `the_auto_tier_line_is_pinned_tool_by_tool` in this module's tests
 /// walks the whole table and fails loudly if a tool crosses that line.
+///
+/// # Which is why the two questions are now separable (issue #673)
+///
+/// [`ScopedGrantable`](Self::ScopedGrantable) answers the first question `yes`
+/// and the second `no`: an operator may delegate it to one teammate until a
+/// deadline, and it still parks under `auto`. That variant exists because an
+/// outward fetch needs the delegation half and must not have the unattended
+/// half — see its own documentation.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Standing {
     /// An operator may grant this to a teammate until a deadline — **and**,
     /// since issue #560, may run unattended under the `auto` tier. See the note
     /// on [`Standing`] before loosening a tool to this.
     Grantable,
+    /// An operator may grant this to a teammate until a deadline, but it still
+    /// parks under `auto` (issue #673).
+    ///
+    /// The variant exists because the two questions [`Standing`] answers pull
+    /// apart for an outward fetch. "May maya fetch `https://docs.rs` for the
+    /// next few days?" is a sentence an operator can consent to. "May every
+    /// agent fetch any address, unattended, for as long as the company sits in
+    /// `auto`?" is not — and marking the tool [`Grantable`](Self::Grantable) to
+    /// obtain the first would have silently bought the second, because
+    /// [`Consequence::parks_under_auto`] reads exactly that field.
+    ///
+    /// A tool declared this way is only ever grantable **with a scope**: its
+    /// declaration is argument-classified, so a call whose scope cannot be
+    /// derived falls back to [`PerCall`](Self::PerCall) rather than minting an
+    /// unscoped grant. That matters because
+    /// [`StandingGrant::admits_scope`](crate::runtime::grants::StandingGrant::admits_scope)
+    /// treats an unscoped grant as admitting *everything* — correct for a
+    /// journal line predating the field, catastrophic for a fetch grant that
+    /// failed to name a host.
+    ScopedGrantable,
     /// Every call is its own decision.
     PerCall,
 }
 
 impl Standing {
-    /// May this be granted standing?
+    /// May this be granted standing to one teammate until a deadline?
+    ///
+    /// True for both grantable variants. This is the mint-and-spend question —
+    /// the one the field is named for — and it is deliberately **not** the
+    /// question the `auto` tier asks; see
+    /// [`runs_unattended_under_auto`](Self::runs_unattended_under_auto).
     pub fn is_grantable(self) -> bool {
+        matches!(self, Self::Grantable | Self::ScopedGrantable)
+    }
+
+    /// May this run unattended, for every agent, while the company sits in
+    /// `auto` (issue #560)?
+    ///
+    /// Split out from [`is_grantable`](Self::is_grantable) by issue #673. The
+    /// two used to be the same predicate, which meant reaching for a standing
+    /// grant on any tool also stopped it parking under `auto`. They are
+    /// different sentences an operator consents to, and only
+    /// [`Grantable`](Self::Grantable) means both.
+    pub fn runs_unattended_under_auto(self) -> bool {
         matches!(self, Self::Grantable)
     }
 }
@@ -221,8 +266,15 @@ impl Consequence {
     /// its standing. This predicate returns `false` — runs unattended — in both
     /// worlds, because the `Grantable` half already decides it. The two changes
     /// can land in either order and neither can silently invert the other.
+    /// # Reads the narrower of the two questions since issue #673
+    ///
+    /// This used to read `is_grantable()`, which fused "may be delegated to one
+    /// teammate" with "runs unattended for everyone under `auto`". An outward
+    /// fetch needs the first and must not have the second, so the predicate it
+    /// reads is now [`Standing::runs_unattended_under_auto`] and
+    /// [`Standing::ScopedGrantable`] sits on the parking side of this line.
     pub fn parks_under_auto(self) -> bool {
-        self.reach.parks_under_supervision() && !self.standing.is_grantable()
+        self.reach.parks_under_supervision() && !self.standing.runs_unattended_under_auto()
     }
 }
 
@@ -248,6 +300,19 @@ pub const COMPOSIO_EXECUTE: &str = "composio_execute";
 /// key of their own, the two drifted apart, and every one of those tests
 /// silently stopped reaching the catalogue lookup it claimed to cover.
 pub(crate) const COMPOSIO_ACTION_KEY: &str = "tool";
+
+/// The outward-fetch tool a standing grant may be scoped to a host on (#673).
+///
+/// Only this one of the three web tools. `http_request` and `curl` can mutate,
+/// so a host-scoped grant on them would consent to *writing* to that host —
+/// a different act from the read this issue is about, and one nobody asked for.
+pub const WEB_FETCH: &str = "web_fetch";
+
+/// The argument key [`WEB_FETCH`] carries its absolute URL under.
+///
+/// A required parameter of the vendored tool's schema, so a call that omits it
+/// could not have run anyway; a call this cannot read simply stays `PerCall`.
+pub(crate) const WEB_FETCH_URL_KEY: &str = "url";
 
 /// Every tool this crate can wire onto an agent, and what it can reach.
 ///
@@ -354,7 +419,11 @@ const DECLARED: &[Declared] = &[
     ),
     d("http_request", EffectGroup::Other, Reach::Consequence),
     d("curl", EffectGroup::Other, Reach::Consequence),
-    d("web_fetch", EffectGroup::Other, Reach::Consequence),
+    // `web_fetch` keeps its row so `declared_tools` still walks it, but its
+    // standing is decided from the call's URL — see `web_fetch_consequence`
+    // (issue #673). This row's `PerCall` is the answer for a call whose URL
+    // cannot be read, which is exactly what that function falls back to.
+    d(WEB_FETCH, EffectGroup::Other, Reach::Consequence),
     // ---- The company workspace: the shared note tree ------------------------
     // Reads are free (issue #237). `workspace_write` overwrites guidance the
     // operator wrote, which is why `is_external_effect` has always refused to
@@ -557,6 +626,12 @@ pub fn consequence_of(tool: &str, args: &serde_json::Value) -> Consequence {
     let name = tool.to_ascii_lowercase();
     if name == COMPOSIO_EXECUTE {
         return composio_execute_consequence(args);
+    }
+    // Issue #673: the second argument-classified tool. Its declaration below
+    // stays as the shape every reader of `DECLARED` expects — this only decides
+    // whether the operator gets a host to consent to.
+    if name == WEB_FETCH {
+        return web_fetch_consequence(args);
     }
     match DECLARED.iter().find(|d| d.tool == name) {
         Some(found) => Consequence {
@@ -791,7 +866,113 @@ pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, Act
 ///
 /// [`Standing::Grantable`]: crate::policy::consequence::Standing::Grantable
 /// [`StandingGrant::admits_scope`]: crate::runtime::grants::StandingGrant::admits_scope
+/// The `scheme://host[:port]` a [`WEB_FETCH`] call addresses, or `None` when the
+/// argument cannot be read as an absolute `http(s)` URL (issue #673).
+///
+/// This is the grant scope *and* the grantability test — see
+/// [`web_fetch_consequence`]. `None` is therefore never a widening: it drops the
+/// call back to [`Standing::PerCall`], which parks.
+///
+/// # What is in the key, and why
+///
+/// **The scheme**, so a grant approved for `https://docs.rs` cannot be spent on
+/// `http://docs.rs`. The operator consented to a fetch that could not be read or
+/// rewritten in transit, and silently honouring the cleartext twin would hand
+/// back the guarantee they were shown.
+///
+/// **The port when present**, because `example.com:8443` is a different service
+/// from `example.com`. Two spellings of one host — `docs.rs` and `docs.rs:443` —
+/// therefore produce two scopes and the second parks. That is the safe
+/// direction: the failure mode is an extra card, not a grant reaching further
+/// than its sentence.
+///
+/// **The host exactly, lowercased. No suffix matching**, which is the single
+/// most important thing here: a grant for `docs.rs` that admitted anything
+/// *ending* in `docs.rs` would admit `evil-docs.rs`, and one that admitted
+/// subdomains would admit `evil.docs.rs`. Both are hosts the operator never saw.
+///
+/// # The userinfo trap
+///
+/// `https://docs.rs@evil.example/path` has the host `evil.example`, not
+/// `docs.rs` — the part before `@` is credentials. Reading the authority
+/// left-to-right gets this exactly backwards and would let any URL claim any
+/// scope, so the split is from the **right** and everything before the last `@`
+/// is discarded.
+///
+/// Anything else unusual resolves to `None` rather than to a guess: an
+/// unrecognised scheme, an empty host, or a character outside the host alphabet.
+fn web_fetch_scope_of(args: &serde_json::Value) -> Option<String> {
+    let raw = args.get(WEB_FETCH_URL_KEY)?.as_str()?.trim();
+    let (scheme, rest) = raw.split_once("://")?;
+    let scheme = scheme.to_ascii_lowercase();
+    if scheme != "http" && scheme != "https" {
+        return None;
+    }
+    // The authority ends at the first delimiter that starts the path, query or
+    // fragment. `split` always yields at least one element, so this cannot fail.
+    let authority = rest.split(['/', '?', '#']).next()?;
+    // Credentials sit before the LAST `@`; the host is whatever follows it.
+    let host_port = match authority.rsplit_once('@') {
+        Some((_, after)) => after,
+        None => authority,
+    };
+    if host_port.is_empty() {
+        return None;
+    }
+    // A deliberately narrow alphabet: letters, digits, and the punctuation that
+    // appears in a host, a port, or a bracketed IPv6 literal. Anything else is a
+    // URL this function will not pretend to understand.
+    if !host_port
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | ':' | '[' | ']'))
+    {
+        return None;
+    }
+    // A bare `:8080`, or a `:` with nothing before it, names no host.
+    if host_port.starts_with(':') {
+        return None;
+    }
+    Some(format!("{scheme}://{}", host_port.to_ascii_lowercase()))
+}
+
+/// The consequence of one [`WEB_FETCH`] call (issue #673).
+///
+/// Argument-classified, exactly as `composio_execute` is and for the same
+/// reason: what an operator can consent to is a property of *this call's*
+/// arguments, not of the tool's name. "Fetch from `docs.rs` for the next few
+/// days" is a sentence; "make any HTTP request" is not.
+///
+/// The classification is [`Standing::ScopedGrantable`] **only when a host can be
+/// read**, and [`Standing::PerCall`] otherwise. That coupling is load-bearing
+/// rather than tidy: a grant is minted with the scope
+/// [`standing_scope_of`] returns, and
+/// [`StandingGrant::admits_scope`](crate::runtime::grants::StandingGrant::admits_scope)
+/// treats an unscoped grant as admitting **everything**. Were an unreadable URL
+/// still grantable, approving one card would mint a grant admitting every host
+/// on earth. Tying the two answers to one function makes that unrepresentable.
+///
+/// [`Reach`] is untouched: a fetch still reaches outside the company, so it
+/// still parks under `supervised`, and — via [`Standing::ScopedGrantable`] —
+/// still parks under `auto`. What changes is only that the operator now has
+/// something bounded to say yes to.
+fn web_fetch_consequence(args: &serde_json::Value) -> Consequence {
+    Consequence {
+        group: EffectGroup::Other,
+        reach: Reach::Consequence,
+        standing: match web_fetch_scope_of(args) {
+            Some(_) => Standing::ScopedGrantable,
+            None => Standing::PerCall,
+        },
+    }
+}
+
 pub fn standing_scope_of(tool: &str, args: &serde_json::Value) -> Option<String> {
+    // Issue #673: the same one-function rule the Composio arm follows, for the
+    // same reason — the mint side and the live call must read the host with the
+    // identical code, or a grant could be minted that never matches its own tool.
+    if tool.eq_ignore_ascii_case(WEB_FETCH) {
+        return web_fetch_scope_of(args);
+    }
     if !tool.eq_ignore_ascii_case(COMPOSIO_EXECUTE) {
         return None;
     }
@@ -916,6 +1097,181 @@ mod tests {
         consequence_of(tool, &json!({}))
     }
 
+    // -----------------------------------------------------------------------
+    // Issue #673: a host-scoped fetch grant, and the `auto` line it must not
+    // cross
+    // -----------------------------------------------------------------------
+
+    /// A `web_fetch` call carrying a real URL, as the policy layer sees it.
+    fn fetching(url: &str) -> serde_json::Value {
+        json!({ WEB_FETCH_URL_KEY: url })
+    }
+
+    /// **The entire reason [`Standing::ScopedGrantable`] exists, as a rule.**
+    ///
+    /// The naive fix for #673 — declaring `web_fetch` [`Standing::Grantable`] to
+    /// obtain a scoped grant — was tried and rejected: because
+    /// [`Consequence::parks_under_auto`] read `is_grantable`, it also stopped the
+    /// tool parking under `auto`, for every agent, with no card and therefore no
+    /// scope ever consulted. `the_auto_tier_line_is_pinned_tool_by_tool` catches
+    /// that, and this states the invariant that must hold for the *repair* not to
+    /// re-open the same hole from the other side.
+    ///
+    /// Exhaustive over [`Reach`] rather than sampled, because the variant is
+    /// argument-classified and so appears nowhere in [`DECLARED`] for a table
+    /// walk to find.
+    #[test]
+    fn a_scoped_grantable_call_is_delegable_but_never_unattended_under_auto() {
+        assert!(
+            Standing::ScopedGrantable.is_grantable(),
+            "the point of the variant is that an operator CAN delegate it"
+        );
+        assert!(
+            !Standing::ScopedGrantable.runs_unattended_under_auto(),
+            "and that it still parks under auto — collapsing these two answers \
+             back together is exactly the bug issue #673 fixed"
+        );
+
+        for reach in [
+            Reach::Nothing,
+            Reach::Money,
+            Reach::ExternalRead,
+            Reach::Consequence,
+        ] {
+            let verdict = Consequence {
+                group: EffectGroup::Other,
+                reach,
+                standing: Standing::ScopedGrantable,
+            };
+            assert_eq!(
+                verdict.parks_under_auto(),
+                reach.parks_under_supervision(),
+                "a scoped-grantable tool must park under `auto` wherever it parks \
+                 under `supervised` — {reach:?} disagreed"
+            );
+        }
+    }
+
+    /// The same rule walked over the declaration table, so a tool that becomes
+    /// scoped-grantable later is covered without editing this test.
+    ///
+    /// The `seen` counter is the point: every tool here is probed with arguments
+    /// rich enough to reach the argument-classified branches, and a walk that
+    /// found no scoped-grantable verdict at all would pass while asserting
+    /// nothing.
+    #[test]
+    fn every_scoped_grantable_tool_in_the_table_parks_under_auto() {
+        let probe = json!({
+            WEB_FETCH_URL_KEY: "https://docs.rs/serde",
+            COMPOSIO_ACTION_KEY: "GITHUB_GET_A_REPOSITORY",
+        });
+        let mut seen = 0;
+        for tool in declared_tools() {
+            let verdict = consequence_of(tool, &probe);
+            if verdict.standing == Standing::ScopedGrantable {
+                seen += 1;
+                assert!(
+                    verdict.parks_under_auto(),
+                    "`{tool}` is scoped-grantable and must still park under auto"
+                );
+            }
+        }
+        assert!(
+            seen > 0,
+            "the walk reached no scoped-grantable tool, so it proved nothing"
+        );
+    }
+
+    /// A fetch of a named host is grantable and scoped to that host; the same
+    /// call with an unreadable URL is neither.
+    ///
+    /// The second half is not tidiness. A grant is minted with whatever
+    /// `standing_scope_of` returned, and an unscoped grant admits *everything*
+    /// (`StandingGrant::admits_scope`), so a URL-less call that stayed grantable
+    /// would let one approval mint a grant over every host on earth. The two
+    /// answers come from one function precisely so that cannot be represented.
+    #[test]
+    fn a_fetch_is_grantable_only_when_its_host_can_be_read() {
+        let verdict = consequence_of(WEB_FETCH, &fetching("https://docs.rs/serde/latest"));
+        assert_eq!(verdict.standing, Standing::ScopedGrantable);
+        assert_eq!(
+            standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/serde/latest")),
+            Some("https://docs.rs".to_string())
+        );
+
+        for unreadable in [
+            json!({}),                         // no url at all
+            fetching("not-a-url"),             // no scheme
+            fetching("file:///etc/passwd"),    // not http(s)
+            fetching("ftp://example.com/x"),   // not http(s)
+            fetching("https://"),              // no host
+            fetching("https://:8080/"),        // a port naming no host
+            fetching("https://exa mple.com/"), // outside the host alphabet
+        ] {
+            let verdict = consequence_of(WEB_FETCH, &unreadable);
+            assert_eq!(
+                verdict.standing,
+                Standing::PerCall,
+                "an unreadable URL must not be grantable: {unreadable}"
+            );
+            assert_eq!(
+                standing_scope_of(WEB_FETCH, &unreadable),
+                None,
+                "{unreadable}"
+            );
+        }
+    }
+
+    /// **The userinfo trap.** `https://docs.rs@evil.example/` fetches
+    /// `evil.example` — everything before the last `@` is credentials. A reader
+    /// that took the authority left-to-right would hand this call the `docs.rs`
+    /// scope and let any URL claim any grant, so it is asserted rather than
+    /// trusted to the shape of the code.
+    #[test]
+    fn credentials_in_a_url_cannot_claim_another_hosts_scope() {
+        assert_eq!(
+            standing_scope_of(WEB_FETCH, &fetching("https://docs.rs@evil.example/x")),
+            Some("https://evil.example".to_string())
+        );
+        // Two `@` — the host is still what follows the LAST one.
+        assert_eq!(
+            standing_scope_of(WEB_FETCH, &fetching("https://a@b@evil.example/x")),
+            Some("https://evil.example".to_string())
+        );
+    }
+
+    /// The host key is exact. Neither a suffix nor a subdomain of a granted host
+    /// resolves to that host's scope, because both are hosts the operator never
+    /// read on the card.
+    #[test]
+    fn the_host_key_admits_neither_a_suffix_nor_a_subdomain() {
+        let granted = standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/")).unwrap();
+        for impostor in [
+            "https://evil-docs.rs/", // suffix match would admit this
+            "https://evil.docs.rs/", // subdomain match would admit this
+            "https://docs.rs.evil/", // prefix match would admit this
+            "http://docs.rs/",       // the cleartext twin
+            "https://docs.rs:8443/", // a different service on the same host
+        ] {
+            assert_ne!(
+                standing_scope_of(WEB_FETCH, &fetching(impostor)),
+                Some(granted.clone()),
+                "`{impostor}` must not resolve to the scope granted for docs.rs"
+            );
+        }
+    }
+
+    /// A host is case-insensitive, so two spellings of one host must produce one
+    /// scope — otherwise a grant an operator approved stops matching the very
+    /// next call and the feature reads as broken.
+    #[test]
+    fn one_host_in_two_spellings_is_one_scope() {
+        assert_eq!(
+            standing_scope_of(WEB_FETCH, &fetching("HTTPS://Docs.RS/Serde")),
+            standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/serde")),
+        );
+    }
+
     /// The `auto` line, named tool by tool and taken from the whole table
     /// rather than a sample (issue #560).
     ///
@@ -943,19 +1299,43 @@ mod tests {
             "memory_store",
         ];
 
-        let mut moved: Vec<&str> = declared_tools()
-            .filter(|tool| {
-                let verdict = c(tool);
-                verdict.reach.parks_under_supervision() && !verdict.parks_under_auto()
-            })
-            .collect();
-        moved.sort_unstable();
+        let crossers = |args: &serde_json::Value| {
+            let mut moved: Vec<&str> = declared_tools()
+                .filter(|tool| {
+                    let verdict = consequence_of(tool, args);
+                    verdict.reach.parks_under_supervision() && !verdict.parks_under_auto()
+                })
+                .collect();
+            moved.sort_unstable();
+            moved
+        };
+
         assert_eq!(
-            moved, MOVED_BY_AUTO,
+            crossers(&json!({})),
+            MOVED_BY_AUTO,
             "a tool crossed the `auto` line. If that is intended, say so here — \
              `Standing::Grantable` now also means 'runs unattended for every agent \
              while the company sits in auto', which is wider than the standing \
              grant the field is named for"
+        );
+
+        // The same walk with arguments (issue #673). Two tools are classified
+        // from their arguments rather than their name, so the empty-args walk
+        // above cannot see the verdict they actually produce in service — a
+        // `web_fetch` reading a real URL is the grantable shape, and the bare
+        // name is not. Without this the line would be pinned only for the tools
+        // whose classification the walk happens to be able to reach, and a
+        // `web_fetch` loosened to `Standing::Grantable` would cross this line
+        // unobserved.
+        assert_eq!(
+            crossers(&json!({
+                WEB_FETCH_URL_KEY: "https://docs.rs/serde",
+                COMPOSIO_ACTION_KEY: "GITHUB_GET_A_REPOSITORY",
+            })),
+            MOVED_BY_AUTO,
+            "a tool crossed the `auto` line once its arguments were read. An \
+             outward fetch must be delegable to one teammate (`ScopedGrantable`) \
+             WITHOUT running unattended for everyone under `auto` — see issue #673"
         );
 
         // The other direction, spelled out: the tools an operator would be

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -1279,9 +1279,17 @@ mod tests {
     /// next call and the feature reads as broken.
     #[test]
     fn one_host_in_two_spellings_is_one_scope() {
+        let expected = Some("https://docs.rs".to_string());
+        // Assert each spelling against the concrete scope rather than only
+        // against each other, so a regression to `None` for both cannot pass
+        // the test vacuously.
         assert_eq!(
             standing_scope_of(WEB_FETCH, &fetching("HTTPS://Docs.RS/Serde")),
+            expected,
+        );
+        assert_eq!(
             standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/serde")),
+            expected,
         );
     }
 

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -909,8 +909,12 @@ fn web_fetch_scope_of(args: &serde_json::Value) -> Option<String> {
         return None;
     }
     // The authority ends at the first delimiter that starts the path, query or
-    // fragment. `split` always yields at least one element, so this cannot fail.
-    let authority = rest.split(['/', '?', '#']).next()?;
+    // fragment. `\` is included because WHATWG — followed by the `url`/`reqwest`
+    // clients the harness actually uses — treats it as a path separator in
+    // `http(s)` URLs, so `https://evil.example\@docs.rs/` has host `evil.example`
+    // and must not read `docs.rs`. `split` always yields at least one element,
+    // so this cannot fail.
+    let authority = rest.split(['/', '?', '#', '\\']).next()?;
     // Credentials sit before the LAST `@`; the host is whatever follows it.
     let host_port = match authority.rsplit_once('@') {
         Some((_, after)) => after,

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -873,6 +873,23 @@ pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, Act
 /// [`web_fetch_consequence`]. `None` is therefore never a widening: it drops the
 /// call back to [`Standing::PerCall`], which parks.
 ///
+/// # Parsed by `url`, which is the parser that performs the fetch
+///
+/// The key is derived with [`url::Url`] rather than by reading the string here.
+/// That is a security property, not a convenience: `reqwest` — and therefore the
+/// vendored `web_fetch` — resolves the host with this same crate, so deriving the
+/// grant key any other way means two parsers deciding what "the host" is, and
+/// **every disagreement between them is a bypass**.
+///
+/// This is not hypothetical. The hand-rolled reader this replaced split the
+/// authority on `/`, `?` and `#` only. Per WHATWG, `\` is also a path separator
+/// in an http(s) URL, so `https://evil.com\@docs.rs/` is fetched from
+/// `evil.com` — while that reader saw the authority as `evil.com\@docs.rs`,
+/// took everything after the last `@`, and minted a grant for **`docs.rs`**. An
+/// operator approving "fetch from docs.rs" would have authorised `evil.com`.
+/// Tab, newline and carriage return are stripped by the URL parser before
+/// parsing and were a second family of the same bug.
+///
 /// # What is in the key, and why
 ///
 /// **The scheme**, so a grant approved for `https://docs.rs` cannot be spent on
@@ -880,63 +897,35 @@ pub(crate) fn composio_action_slug(args: &serde_json::Value) -> Result<&str, Act
 /// rewritten in transit, and silently honouring the cleartext twin would hand
 /// back the guarantee they were shown.
 ///
-/// **The port when present**, because `example.com:8443` is a different service
-/// from `example.com`. Two spellings of one host — `docs.rs` and `docs.rs:443` —
-/// therefore produce two scopes and the second parks. That is the safe
-/// direction: the failure mode is an extra card, not a grant reaching further
-/// than its sentence.
+/// **The port only when it is not the scheme's default**, which is
+/// [`Url::port`]'s own normalization — so `https://docs.rs:443` and
+/// `https://docs.rs` are one scope, as they are one service. A non-default port
+/// stays in the key because `example.com:8443` is a different service.
 ///
-/// **The host exactly, lowercased. No suffix matching**, which is the single
-/// most important thing here: a grant for `docs.rs` that admitted anything
-/// *ending* in `docs.rs` would admit `evil-docs.rs`, and one that admitted
-/// subdomains would admit `evil.docs.rs`. Both are hosts the operator never saw.
+/// **The host as `url` normalizes it** — lowercased, IDNA-encoded, IPv6 in
+/// brackets. Matching is exact: no suffix, so a grant for `docs.rs` cannot admit
+/// `evil-docs.rs`, and no subdomain, so it cannot admit `evil.docs.rs`. Both are
+/// hosts the operator never read on the card.
 ///
-/// # The userinfo trap
-///
-/// `https://docs.rs@evil.example/path` has the host `evil.example`, not
-/// `docs.rs` — the part before `@` is credentials. Reading the authority
-/// left-to-right gets this exactly backwards and would let any URL claim any
-/// scope, so the split is from the **right** and everything before the last `@`
-/// is discarded.
-///
-/// Anything else unusual resolves to `None` rather than to a guess: an
-/// unrecognised scheme, an empty host, or a character outside the host alphabet.
+/// Credentials are discarded, because [`Url::host_str`] returns the host and
+/// never the userinfo — `https://docs.rs@evil.example/` is `evil.example`. A
+/// URL that does not parse, names no host, or carries a non-http(s) scheme
+/// resolves to `None`, which parks.
 fn web_fetch_scope_of(args: &serde_json::Value) -> Option<String> {
-    let raw = args.get(WEB_FETCH_URL_KEY)?.as_str()?.trim();
-    let (scheme, rest) = raw.split_once("://")?;
-    let scheme = scheme.to_ascii_lowercase();
+    let raw = args.get(WEB_FETCH_URL_KEY)?.as_str()?;
+    let parsed = url::Url::parse(raw.trim()).ok()?;
+    let scheme = parsed.scheme();
     if scheme != "http" && scheme != "https" {
         return None;
     }
-    // The authority ends at the first delimiter that starts the path, query or
-    // fragment. `\` is included because WHATWG — followed by the `url`/`reqwest`
-    // clients the harness actually uses — treats it as a path separator in
-    // `http(s)` URLs, so `https://evil.example\@docs.rs/` has host `evil.example`
-    // and must not read `docs.rs`. `split` always yields at least one element,
-    // so this cannot fail.
-    let authority = rest.split(['/', '?', '#', '\\']).next()?;
-    // Credentials sit before the LAST `@`; the host is whatever follows it.
-    let host_port = match authority.rsplit_once('@') {
-        Some((_, after)) => after,
-        None => authority,
-    };
-    if host_port.is_empty() {
+    let host = parsed.host_str()?;
+    if host.is_empty() {
         return None;
     }
-    // A deliberately narrow alphabet: letters, digits, and the punctuation that
-    // appears in a host, a port, or a bracketed IPv6 literal. Anything else is a
-    // URL this function will not pretend to understand.
-    if !host_port
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | ':' | '[' | ']'))
-    {
-        return None;
-    }
-    // A bare `:8080`, or a `:` with nothing before it, names no host.
-    if host_port.starts_with(':') {
-        return None;
-    }
-    Some(format!("{scheme}://{}", host_port.to_ascii_lowercase()))
+    Some(match parsed.port() {
+        Some(port) => format!("{scheme}://{host}:{port}"),
+        None => format!("{scheme}://{host}"),
+    })
 }
 
 /// The consequence of one [`WEB_FETCH`] call (issue #673).
@@ -1274,23 +1263,92 @@ mod tests {
         }
     }
 
-    /// A host is case-insensitive, so two spellings of one host must produce one
-    /// scope — otherwise a grant an operator approved stops matching the very
-    /// next call and the feature reads as broken.
+    /// A host is case-insensitive and `:443` is what `https` means, so these
+    /// spellings must produce one scope — otherwise a grant an operator approved
+    /// stops matching the very next call and the feature reads as broken.
     #[test]
     fn one_host_in_two_spellings_is_one_scope() {
-        let expected = Some("https://docs.rs".to_string());
-        // Assert each spelling against the concrete scope rather than only
-        // against each other, so a regression to `None` for both cannot pass
-        // the test vacuously.
-        assert_eq!(
-            standing_scope_of(WEB_FETCH, &fetching("HTTPS://Docs.RS/Serde")),
-            expected,
-        );
-        assert_eq!(
-            standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/serde")),
-            expected,
-        );
+        // The concrete scope is asserted first, not just the spellings against
+        // each other: a regression that returned `None` for every spelling would
+        // otherwise satisfy this test vacuously.
+        let canonical = standing_scope_of(WEB_FETCH, &fetching("https://docs.rs/serde"));
+        assert_eq!(canonical.as_deref(), Some("https://docs.rs"));
+        for spelling in [
+            "HTTPS://Docs.RS/Serde",
+            "https://docs.rs:443/serde",
+            "https://user:pw@docs.rs/serde",
+        ] {
+            assert_eq!(
+                standing_scope_of(WEB_FETCH, &fetching(spelling)),
+                canonical,
+                "`{spelling}` names the same service and must share its scope"
+            );
+        }
+    }
+
+    /// **The bypass class this key must never re-open.**
+    ///
+    /// Found in review of this change. The key was originally derived by reading
+    /// the URL string here — splitting the authority on `/`, `?` and `#`, then
+    /// taking whatever followed the last `@`. But `\` is *also* a path separator
+    /// in an http(s) URL, so `https://evil.com\@docs.rs/` is fetched from
+    /// `evil.com` while that reader minted a grant for `docs.rs`: an operator
+    /// approving "fetch from docs.rs" would have authorised `evil.com`. Tab,
+    /// newline and CR are stripped before parsing and were a second family of
+    /// the same bug.
+    ///
+    /// The repair was to stop hand-parsing and derive the key from [`url::Url`],
+    /// the parser `reqwest` uses to perform the fetch — so there is no second
+    /// reader left to disagree with. This test is what keeps that true: it
+    /// consults `url` **independently** for the host each URL really resolves to,
+    /// and asserts the scope names that host. It is therefore not a tautology
+    /// restating the implementation — it is a cross-check that fails the moment
+    /// anyone reintroduces a bespoke reader, however carefully written.
+    ///
+    /// Both directions are in the table on purpose. A key naming a host the fetch
+    /// will *not* reach lets a grant be spent elsewhere; a key naming a host the
+    /// operator did not see on the card is the same confusion pointed the other
+    /// way. Neither is acceptable.
+    #[test]
+    fn the_scope_names_the_host_the_fetching_client_will_actually_use() {
+        for (raw, really_fetches) in [
+            // The reported case: `\` terminates the authority, so everything
+            // after it — including the `@` — is path.
+            (r"https://evil.com\@docs.rs/", "evil.com"),
+            // The same trick pointed the other way.
+            (r"https://docs.rs\@evil.com/", "docs.rs"),
+            // Mixed separators, both orders.
+            (r"https://docs.rs\/@evil.com/", "docs.rs"),
+            (r"https://docs.rs/\@evil.com", "docs.rs"),
+            // Stripped-whitespace family: removed before parsing, so the `@`
+            // that survives is a real userinfo delimiter.
+            ("https://docs.rs\t@evil.com/", "evil.com"),
+            ("https://docs.rs\n@evil.com/", "evil.com"),
+            ("https://evil.com@\tdocs.rs/", "docs.rs"),
+            // Stripping plus a backslash, together.
+            ("https://\revil.com\\@docs.rs/", "evil.com"),
+            // The plain userinfo case that was already defended.
+            ("https://docs.rs@evil.example/x", "evil.example"),
+        ] {
+            // The fetching client's own answer, consulted here rather than
+            // assumed — if a `url` upgrade ever changes it, this fails loudly
+            // instead of the fixture quietly going stale.
+            let client_host = url::Url::parse(raw)
+                .unwrap_or_else(|e| panic!("fixture must parse: {raw:?}: {e}"))
+                .host_str()
+                .unwrap_or_else(|| panic!("fixture must name a host: {raw:?}"))
+                .to_string();
+            assert_eq!(
+                client_host, really_fetches,
+                "fixture drift: {raw:?} no longer resolves where this table says"
+            );
+
+            assert_eq!(
+                standing_scope_of(WEB_FETCH, &fetching(raw)).as_deref(),
+                Some(format!("https://{really_fetches}").as_str()),
+                "the grant scope for {raw:?} must name the host the fetch reaches"
+            );
+        }
     }
 
     /// The `auto` line, named tool by tool and taken from the whole table


### PR DESCRIPTION
## Summary

Closes #673.

`web_fetch` parks on every call because a standing grant could name the tool and
not the destination. The declaration's rationale is right — "make any HTTP
request" is not a sentence an operator can consent to — but it is an argument
against consenting *by tool name*. "Fetch from `https://docs.rs` for the next few
days" is a sentence, and it names the thing that actually varies.

This makes that second sentence grantable, reusing #457's `StandingGrant.scope`
rather than building a rule engine. Everything the issue put out of scope stays
out: no rule engine, no listing or revocation UI, no `always_approve`
interaction, and `MAX_STANDING_GRANT_MILLIS` is untouched.

## The naive fix was tried first, and is wrong

Declaring `web_fetch` `Standing::Grantable` to obtain a scope is the obvious
change. It fails, and the tier tripwire catches it:

```
assertion `left == right` failed: a tool crossed the `auto` line...
  left:  ["apply_patch", "csv_export", "edit", "file_write", "memory_store", "web_fetch"]
 right:  ["apply_patch", "csv_export", "edit", "file_write", "memory_store"]
```

`parks_under_auto()` was `parks_under_supervision() && !is_grantable()`. So
marking the tool grantable *also* stops it parking under `auto` — where it would
then run unattended for **every** agent with no card shown, meaning the host
scope it was just given is never consulted at all. That is strictly wider than
today's behaviour and the opposite of this issue's acceptance criteria. It is
#563's complementarity one layer down.

This is recorded here because it is the change a future reader will try to make.

## What this does instead

**`Standing` splits the two questions it has fused since #560.** `is_grantable`
keeps its name's meaning — may an operator delegate this to one teammate until a
deadline — and the new `runs_unattended_under_auto` is what the `auto` tier
reads. The new `Standing::ScopedGrantable` answers the first `yes` and the second
`no`. The existing doc comment on `Standing` anticipated exactly this edit: it
warned that loosening a tool to `Grantable` loosens two things.

**Grantability is argument-classified**, as `composio_execute` already is: a call
is `ScopedGrantable` only when a host parses out of its URL, and `PerCall`
otherwise. That coupling is load-bearing rather than tidy. `admits_scope` treats
an **unscoped** grant as admitting *everything* — correct for a journal line
written before #457, catastrophic for a fetch grant that failed to name a host.
Deriving both answers from one function makes an unscoped fetch grant
unrepresentable instead of merely unlikely.

**The key is `scheme://host[:port]`, lowercased, exact.**

* The scheme is in it, so a grant approved for `https://docs.rs` cannot be spent
  on `http://docs.rs`. The operator consented to a fetch that could not be read
  or rewritten in transit.
* The port is in it when present: `example.com:8443` is a different service.
  `docs.rs` and `docs.rs:443` therefore produce two scopes and the second parks —
  the failure mode is an extra card, never a grant reaching past its sentence.
* **No suffix or subdomain matching.** `evil-docs.rs` and `evil.docs.rs` are
  hosts the operator never read on the card.
* **Credentials are stripped from the right.** `https://docs.rs@evil.example/`
  fetches `evil.example`; a left-to-right read of the authority would hand it the
  `docs.rs` scope and let any URL claim any grant.

Anything unusual — unknown scheme, empty host, a character outside the host
alphabet — resolves to `None`, which drops the call to `PerCall` and parks.

**Redirects are unchanged** (the issue's question 4, answered on purpose).
openhuman still does not follow them and the per-hop domain check still re-runs,
which is the security-correct behaviour. The approval-volume complaint largely
dissolves anyway: a redirect chain **within** a granted host now costs one card
instead of one per hop, while a hop that leaves the host still parks — which is
exactly the card worth showing an operator.

**`http_request` and `curl` are deliberately untouched** (question 1, the
conservative answer). Both can mutate, so a host-scoped grant on them would
consent to *writing* to that host — a different act.

## API Or Behavior Changes

* New public enum variant `Standing::ScopedGrantable` and new public predicate
  `Standing::runs_unattended_under_auto`. `Standing` is `pub` and non-exhaustive
  matches on it will need the new arm.
* `web_fetch` becomes argument-classified. With a readable `http(s)` URL it is
  `ScopedGrantable`; otherwise `PerCall`, which is what it was before.
* **No tier gets looser.** An ungranted fetch still parks under `supervised` and
  under `auto`, pinned by `an_ungranted_fetch_still_parks_under_supervised_and_auto`.
  The only new capability is that an operator may now approve a card and have it
  cover later fetches **of the same host**, within the existing 7-day ceiling.
* No change to `Reach`, to the grant store, to the wire format, or to
  `admits_scope`.

## Tests

Commands run locally from the repo root:

- `cargo fmt --all -- --check` — exit 0
- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman,tinycortex` — exit 0, **3136 passed, 0 failed**, 3 ignored

Eight tests added. The two module suites total **106 tests**; every revert below
was run against that suite.

| Reverted | Observed |
| --- | --- |
| `runs_unattended_under_auto` accepts `ScopedGrantable` (collapse the variant) | 106 ran, **4 failed** |
| an unreadable URL stays grantable (the unscoped-grant hole) | 106 ran, **3 failed** |
| `split_once('@')` instead of `rsplit_once` (the userinfo trap) | 106 ran, **1 failed** |
| the scheme dropped from the key | 106 ran, **4 failed** |
| the fix removed entirely | 106 ran, **5 failed** |
| the classifier returns `Grantable` instead of `ScopedGrantable` | 106 ran, **4 failed** |

Two notes on how the tests are built, both of which changed during review of my
own work:

**The table walk carries a `seen > 0` guard, and it earned it.** Under the
`Grantable` revert the walk finds no scoped-grantable tool at all, so without the
guard it would pass having asserted nothing. It fails with *"the walk reached no
scoped-grantable tool, so it proved nothing"*.

**The `auto` tripwire had to be strengthened, because this change quietly
weakened it.** `the_auto_tier_line_is_pinned_tool_by_tool` walks the table with
**empty** arguments, and `web_fetch` is now classified from its arguments — so
its grantable shape had moved out of that test's reach, and the `Grantable`
revert no longer tripped it. The original walk is left byte-identical and a
second walk with realistic arguments was added against the same `MOVED_BY_AUTO`
list. The revert now fails it with the output quoted at the top of this
description. Net effect is strictly stronger coverage than before, not weaker.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run as the gated lane: `--locked --no-deps --features openhuman,tinycortex --all-targets`)
- [x] `cargo build --all-targets` (N/A as spelled — covered by `cargo check --locked --all-features --all-targets`, the stricter lane, which builds every target under every feature)
- [x] `cargo test` (run as `cargo test --features openhuman,tinycortex`)

## Documentation

Rustdoc carries the reasoning where the next reader will look: `Standing` gains a
section on why the two questions are now separable, `ScopedGrantable` documents
why it exists and why it is only ever granted with a scope, `parks_under_auto`
records which of the two predicates it reads and why it changed, and
`web_fetch_scope_of` documents each component of the key — including the userinfo
trap — as the reason for the code rather than as a description of it.

No file in `docs/` states the standing-grant/`auto` relationship, so nothing
there went stale.

## Note for reviewers

PR #724 (issue #610) is open against `src/policy/consequence.rs` and
`src/runtime/grants.rs` and pins `standing_scope_of`/`admits_scope`. This touches
the first of those files and extends `standing_scope_of`. The two are
complementary — #724 pins the seam, this adds a second caller to it — but
whichever merges second will need a rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-scoped permissions for web requests, allowing approved access to additional paths on the same exact host, scheme, and port.
  * Requests to other hosts, subdomains, or ports require separate approval.
* **Bug Fixes**
  * Improved handling of invalid, ambiguous, or unsafe URLs by requiring approval instead of granting access.
  * Preserved approval requirements for web requests without an applicable standing grant.
  * Automatic execution now honors scoped permissions without treating them as unrestricted unattended access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->