### PR TITLE
fix: unbreak main on both Rust lanes (#684 x #338, and #711 x #719 from #742)

### DIFF
--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -254,6 +254,37 @@ mod tests {
         (dir, ops)
     }
 
+    /// Seeds root folders that share a name by writing the workspace index
+    /// directly.
+    ///
+    /// The filesystem store refuses to *create* two siblings under one name,
+    /// because on that backend they resolve to one path (issue #666). The tree
+    /// below is the one this test needs to find rather than to build: an index
+    /// written before that refusal existed, or one an id-keyed backend can
+    /// still represent legally. Going through `create` would only re-assert the
+    /// store's refusal and never reach the sweep.
+    async fn seed_duplicate_roots(
+        dir: &std::path::Path,
+        company: &CompanyId,
+        name: &str,
+        ids: &[&str],
+    ) {
+        let index: std::collections::HashMap<String, WorkspaceNode> = ids
+            .iter()
+            .map(|id| ((*id).to_string(), folder(id, name, None)))
+            .collect();
+        let bundle = crate::store::Bundle::new(dir.to_path_buf(), company);
+        tokio::fs::create_dir_all(bundle.workspace_dir())
+            .await
+            .expect("workspace dir");
+        tokio::fs::write(
+            bundle.workspace_index_json(),
+            serde_json::to_vec(&index).expect("index json"),
+        )
+        .await
+        .expect("seed index");
+    }
+
     /// The sorted names in the tree, so an assertion says what survived rather
     /// than counting.
     async fn names(ws: &Arc<dyn WorkspaceStore>, company: &CompanyId) -> Vec<String> {
@@ -542,13 +573,9 @@ mod tests {
     /// one and deleting beneath it.
     #[tokio::test]
     async fn an_ambiguous_root_is_refused_and_removes_nothing() {
-        let (_dir, ws) = store().await;
+        let (dir, ws) = store().await;
         let company = CompanyId::new("odd");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
-                .await
-                .unwrap();
-        }
+        seed_duplicate_roots(dir.path(), &company, AGENTS_ROOT, &["dup-a", "dup-b"]).await;
         ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
             .await
             .unwrap();

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1611,14 +1611,32 @@ mod tests {
         use crate::ports::approvals::ApprovalGate;
         use crate::ports::types::PolicyDecision;
 
-        // A leading segment, an exact dotted kind, a bare tool name, a
-        // near-miss that must NOT be gated, and a case variant.
+        // A leading segment, an exact dotted kind, a bare tool name, a name the
+        // fence does NOT cover, and a case variant.
         //
         // Every name here is one the tier itself has no opinion about under
         // `full`, so the only thing that can make the two paths disagree is the
         // fence. A priced name like `web_search` would drag the harness's
         // metered-read and budget arms into a comparison that is not about
         // `always_approve`, so it is deliberately absent.
+        //
+        // **The un-fenced name must be a DECLARED tool.** This is the trap, and
+        // it is not obvious. The fenced names never reach past `always_approve`,
+        // so their declaration status cannot matter; the un-fenced one is the
+        // only entry that falls through to everything below — including the
+        // per-call judgement arm (issue #338), which stops an *undeclared* tool
+        // as `StopReason::Undeclared` before the two paths can be compared. The
+        // effect gate has no such arm, so an undeclared name here makes the two
+        // paths disagree about fail-closed rather than about the fence, and this
+        // test fails for a reason it is not about.
+        //
+        // That is exactly how it broke: this test and the judgement arm landed
+        // from different branches, each green against a `main` without the
+        // other, and `payroll.export` — undeclared — turned red on the merge.
+        // Its over-matching job was never lost by the swap: `pay` failing to
+        // gate `payroll.export` is asserted directly on the matcher, in
+        // `crate::policy::always_approve`'s own tests, which is where a matcher
+        // question belongs.
         let fence = &["payment", "filing.submit", "publish_artifact"];
         let names = [
             "payment.send",
@@ -1626,7 +1644,9 @@ mod tests {
             "filing.submit",
             "publish_artifact",
             "PUBLISH_ARTIFACT",
-            "payroll.export",
+            // Declared, unpriced, and matched by nothing in the fence, so both
+            // paths must allow it.
+            "memory_recall",
         ];
 
         // `full` on both sides, so the tier decides nothing and any parking
@@ -1680,7 +1700,7 @@ mod tests {
         ));
         assert_eq!(
             harness
-                .check(&request("payroll.export", serde_json::json!({})))
+                .check(&request("memory_recall", serde_json::json!({})))
                 .await,
             ToolPolicyDecision::Allow
         );


### PR DESCRIPTION
## Summary

**`main` is red on BOTH Rust lanes, from two independent collisions. This PR carries both fixes, because neither can go green alone.**

| Lane | Failing test | Fix |
|---|---|---|
| `Rust` (default) | `company::workspace_sweep::tests::an_ambiguous_root_is_refused_and_removes_nothing` | #711 × #719 — **authored by OC-W3**, originally #742 |
| `Rust (openhuman, tinycortex)` | `harness::policy::tests::both_approval_paths_agree_on_the_same_always_approve_list` | #684 × #338 — below |

**They deadlock.** #742's fix alone still fails the gated lane on `both_approval_paths…`; this PR's own fix alone still fails **both** lanes on `an_ambiguous_root…` — it is not gated-only. So one PR has to carry both, and **#742 is closed in favour of this one**.

**Credit:** the `workspace_sweep` fixture fix and its diagnosis are **OC-W3's** work, cherry-picked here unchanged with their commit message intact. Only a paragraph of fold rationale was appended.

## Both breaks are the same hazard

Two PRs, each green against a `main` that lacked the other. **A green PR lane proves a branch built against its own base; it never proves the merged tree works.** Nothing could have caught either pre-merge, and no PR involved should have been held.

It also bites locally. This PR was first branched off `c630e8be`, which predates #711's merge (`deeb358d`) — so `an_ambiguous_root…` passed locally while failing in CI, because CI tests the PR **merged into current `main`**. Rebasing onto current `main` reproduced CI faithfully, which is what let the fix be verified honestly rather than assumed.

## The gated-lane break (#684 × #338)

Nothing is wrong with either change that caused it:

- **#684** (PR #715) added the test, unifying the `always_approve` matcher across the effect gate and the harness tool path.
- **#338** (PR #660) added the per-call judgement arm below the tier.

The test's premise is stated in its own comment:

> *"Every name here is one the tier itself has no opinion about under `full`, so the only thing that can make the two paths disagree is the fence."*

The judgement arm invalidated exactly that. `payroll.export` is an **undeclared** tool, so it is now stopped as `StopReason::Undeclared` — #338's fail-closed rule — on the harness path, while the effect gate has no such arm and allows it. The two paths disagree about **fail-closed**, not about `always_approve`. The test was failing for a reason it is not about.

**Only the un-fenced name is exposed.** Every other name matches `always_approve` and returns before anything below it can speak — which is why their declaration status has never mattered, and why this stayed invisible until a name that falls through met an arm that judges it.

`memory_recall` is **declared** (so the judgement arm is silent), **unpriced** (so the metered-read and budget arms stay out of a comparison that is not about them), and **matched by nothing in the fence** (so both paths must allow it — the case the test needs in order to compare an allow as well as a park). Neither #684's unification nor #338's fail-closed rule is weakened.

### The over-matching coverage is not lost

`payroll.export` was there as a name the fence must not over-match. That assertion already exists where it belongs — on the matcher itself, in `crate::policy::always_approve`'s own tests:

```rust
assert!(!matches(&list(&["pay"]), "payroll.export"));
```

A matcher question is tested on the matcher. This test is about the two paths *agreeing*.

### The comment is the real fix

The swap is two lines; what stops it regressing is the note added at the test. It names the trap: **the un-fenced name must be a declared tool**, because an undeclared one is stopped by #338's fail-closed arm before the fence is ever consulted. Without that, the next person to reach for a realistic-looking dotted kind reintroduces this exact failure.

## API Or Behavior Changes

None. Test inputs, test fixtures and comments only — no production code in either commit.

## Tests

### Verified locally — both lanes, both tests

Rebased onto current `main` (`a9c75878`) so the local tree reproduces what CI actually tests.

| Lane | Result | `an_ambiguous_root…` | `both_approval_paths…` |
|---|---|---|---|
| `Rust` (default) | **2202 passed, 0 failed**, 1 ignored | **ok** | not present (gated-only) |
| `Rust (openhuman, tinycortex)` | **3322 passed, 0 failed**, 3 ignored | **ok** | **ok** |

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; exit 0.
- [x] `cargo build --all-targets` — N/A as written; ran the stronger `cargo check --locked --all-features --all-targets`, exit 0.
- [x] `cargo test` — exit 0 on **both** lanes; counts above.

### Revert-and-check

Restoring `payroll.export` (both the name in the list and the non-vacuity assertion below it) reproduces the gated failure exactly:

| Tree | Gated lane |
|---|---|
| this branch | **0 failed** |
| gated fix reverted | **1 failed** — `both_approval_paths_agree_on_the_same_always_approve_list`, the same panic as `main` |

The revert was `cmp`-verified to have actually changed the file, so the run is not a silent no-op.

### On `a_git_that_overruns_its_deadline_is_stopped_and_reported`

It failed once on this PR's earlier `Rust` run. **Run 10× locally: 10 passed, 0 failed.** Treated as a flake and left untouched — not weakened, not skipped.

It does carry a real residual race, and its own comment records it flaking this way before (*"exactly what happened on Linux CI while passing locally"*) and being hardened with `tokio`'s `start_paused`. Virtual time only auto-advances when the runtime goes **idle**; if the child's output is buffered and ready before the first `Pending`, the timeout arm never fires and the test fails expecting a timeout. A loaded runner changes that ordering. Worth hardening on its own — not inside an unblock-main PR.

## Documentation

None needed — no behaviour or public API changed. Both arguments live at their tests, where the next person to touch them will read them.

Refs #684, #338, #711, #719. Supersedes #742.
