### PR TITLE
test(workspace): unbreak main — seed the sweep's ambiguous root instead of creating it (#711 × #719)

### DIFF
--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -254,6 +254,37 @@ mod tests {
         (dir, ops)
     }
 
+    /// Seeds root folders that share a name by writing the workspace index
+    /// directly.
+    ///
+    /// The filesystem store refuses to *create* two siblings under one name,
+    /// because on that backend they resolve to one path (issue #666). The tree
+    /// below is the one this test needs to find rather than to build: an index
+    /// written before that refusal existed, or one an id-keyed backend can
+    /// still represent legally. Going through `create` would only re-assert the
+    /// store's refusal and never reach the sweep.
+    async fn seed_duplicate_roots(
+        dir: &std::path::Path,
+        company: &CompanyId,
+        name: &str,
+        ids: &[&str],
+    ) {
+        let index: std::collections::HashMap<String, WorkspaceNode> = ids
+            .iter()
+            .map(|id| ((*id).to_string(), folder(id, name, None)))
+            .collect();
+        let bundle = crate::store::Bundle::new(dir.to_path_buf(), company);
+        tokio::fs::create_dir_all(bundle.workspace_dir())
+            .await
+            .expect("workspace dir");
+        tokio::fs::write(
+            bundle.workspace_index_json(),
+            serde_json::to_vec(&index).expect("index json"),
+        )
+        .await
+        .expect("seed index");
+    }
+
     /// The sorted names in the tree, so an assertion says what survived rather
     /// than counting.
     async fn names(ws: &Arc<dyn WorkspaceStore>, company: &CompanyId) -> Vec<String> {
@@ -542,13 +573,9 @@ mod tests {
     /// one and deleting beneath it.
     #[tokio::test]
     async fn an_ambiguous_root_is_refused_and_removes_nothing() {
-        let (_dir, ws) = store().await;
+        let (dir, ws) = store().await;
         let company = CompanyId::new("odd");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
-                .await
-                .unwrap();
-        }
+        seed_duplicate_roots(dir.path(), &company, AGENTS_ROOT, &["dup-a", "dup-b"]).await;
         ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
             .await
             .unwrap();


### PR DESCRIPTION
## Summary

**`main` is red on the default `Rust` lane. This is one of the two reasons.**

```
company::workspace_sweep::tests::an_ambiguous_root_is_refused_and_removes_nothing
called `Result::unwrap()` on an `Err` value:
    Conflict("workspace already contains `Agents` in that folder")
```

A latent conflict between two already-merged PRs, each green against a `main` that lacked
the other:

- **#711 (#666)** made the filesystem store refuse a write whose resolved path another node
  already holds — two siblings under one name are one path on that backend.
- **#719 (#700)** added `src/company/workspace_sweep.rs`, whose ambiguity test builds its
  fixture by calling that same store's `create` twice with `Agents`.

So the fixture now asks the store for exactly the state the store exists to refuse, and
fails in setup — before reaching the sweep at all.

**The sweep's behaviour is not in question and is not changed here.** An ambiguous root is
still refused, still names `Agents`, still removes nothing. What changes is how the test
*obtains* an ambiguous tree: it writes the workspace index directly instead of requesting an
illegal create.

That is also the more honest fixture. The sweep's job is to fail closed on an ambiguous tree
it **finds** — one written before #666's refusal existed, or one an id-keyed backend can
still represent legally — not on one it was able to create a moment earlier. #711 made the
same change to the two `workspace_scaffold` fixtures for the same reason; this uses the same
helper shape, so the two modules seed the case identically.

Verified on pristine `upstream/main` @ `a9c75878` (none of this branch's commits) before
writing anything, so the failure is attributed rather than assumed.

## API Or Behavior Changes

None. One test fixture. No production code is touched — the diff is confined to
`#[cfg(test)]`.

## Tests

- `cargo test --locked` — **2202 + 10 + 1 passed, 0 failed** (this is the lane `main` is red
  on; it is green with this change)
- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo fmt --all -- --check` — exit 0

**Revert-and-check**, because a reseeded fixture is exactly the kind of change that can
quietly stop testing anything. With the sweep's ambiguity refusal replaced by "return no
candidates" (and the refusal's absence confirmed by `grep` before running):

| reverted | test | result |
|---|---|---|
| `Found::Collision(_) => return Ok(Vec::new())` | `an_ambiguous_root_is_refused_and_removes_nothing` | 1 selected, **1 FAILED** |

The test still discriminates: it fails when the sweep stops refusing, which is what it is for.

### The other reason `main` is red

`harness::policy::tests::both_approval_paths_agree_on_the_same_always_approve_list` also
fails on pristine `main` — a separate latent conflict between #660 (#338) and #715 (#684),
being fixed in its own PR. It is untouched here and is not weakened or skipped. `main` needs
both fixes.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — run as `--locked --no-deps --features openhuman,tinycortex --all-targets`; `--no-deps` keeps pre-existing `vendor/tinyagents` lints out, which CI does not see either
- [x] `cargo build --all-targets` — covered by `check --locked --all-features --all-targets` plus the full `cargo test --locked` build above
- [x] `cargo test`
- [x] N/A — no i18n keys: the diff is one Rust test fixture, with no user-facing text

## Documentation

None needed: no behaviour, API or architecture changes. The reason the fixture is seeded
rather than created is recorded on the helper itself, where the next person tempted to
"simplify" it back into a `create` loop will read it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for ambiguous workspace states involving duplicate roots.
  * Confirmed ambiguous workspaces are refused without deleting existing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->