### PR TITLE
usage: meter MCP tool calls, so per-connection usage is a real number

### DIFF
--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -616,11 +616,21 @@ pub fn build_agent(
         // `OcMcpCallTool` replaces upstream's `McpCallTool`: same name/schema,
         // but it classifies + scrubs failures, rewrites the agent-facing text,
         // and records each failure on the shared queue the brain drains.
+        // The metering handle lets `mcp_call_tool` record an `OauthCall` usage
+        // sample per completed call, so a company routing its real work through
+        // MCP stops reading as zero in the Usage view's calls-by-provider chart
+        // and `connections` KPI (issue #698). A `None` meter leaves metering
+        // off, exactly as on the Composio path.
         tools.push(Box::new(OcMcpCallTool::new(
             registry,
             mcp_security,
             secrets,
             deps.mcp_failures.clone(),
+            crate::harness::mcp::McpMetering {
+                company: company.clone(),
+                agent: manifest_agent.id.clone(),
+                meter: deps.meter.clone(),
+            },
         )));
         // Stale-memory mitigation: direct the agent to answer capability
         // questions from a live `mcp_list_servers` call, never from memory.

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -307,17 +307,6 @@ impl Tool for OcMcpListServersTool {
     }
 }
 
-/// A hardening decorator around upstream's [`McpCallTool`](oh::tools::McpCallTool)
-/// that keeps the same tool name + schema but turns a raw transport failure into
-/// a **scrubbed, actionable** result and records it on a shared
-/// [`McpFailureQueue`] the brain drains after the turn.
-///
-/// Upstream's tool surfaces `mcp_call_tool failed: {err}` verbatim — which can
-/// carry a response body or (with query-parameter auth) the full request URL
-/// including the credential. This decorator classifies the error, scrubs it
-/// against the granted servers' known credentials, rewrites the agent-facing
-/// text into a "don't retry blindly, tell the operator" directive, and pushes an
-/// [`McpFailure`] so the operator sees a warning after the turn.
 /// What `mcp_call_tool` needs to record an `OauthCall` usage sample.
 ///
 /// Mirrors [`ComposioMetering`](crate::harness::composio::ComposioMetering):
@@ -347,6 +336,17 @@ impl McpMetering {
     }
 }
 
+/// A hardening decorator around upstream's [`McpCallTool`](oh::tools::McpCallTool)
+/// that keeps the same tool name + schema but turns a raw transport failure into
+/// a **scrubbed, actionable** result and records it on a shared
+/// [`McpFailureQueue`] the brain drains after the turn.
+///
+/// Upstream's tool surfaces `mcp_call_tool failed: {err}` verbatim — which can
+/// carry a response body or (with query-parameter auth) the full request URL
+/// including the credential. This decorator classifies the error, scrubs it
+/// against the granted servers' known credentials, rewrites the agent-facing
+/// text into a "don't retry blindly, tell the operator" directive, and pushes an
+/// [`McpFailure`] so the operator sees a warning after the turn.
 pub struct OcMcpCallTool {
     registry: Arc<McpServerRegistry>,
     security: Arc<SecurityPolicy>,
@@ -954,6 +954,151 @@ mod tests {
         assert!(
             !serialized.contains(CANARY),
             "the drained failure leaked the reflected credential: {serialized}"
+        );
+    }
+
+    /// A completed MCP call is counted, and a failed one is not (issue #698).
+    ///
+    /// The rule this exercises — `mcp:` namespacing — is unit-tested in
+    /// `crate::metering::oauth`. What only this test can reach is the wiring:
+    /// that the success branch calls the meter at all, that it passes *this*
+    /// company and agent rather than a default, and that the failure branch
+    /// stays silent. Deleting the `if let Some(meter)` block, moving it to the
+    /// `Err` arm, or threading the wrong field all pass every other test in the
+    /// tree.
+    ///
+    /// Both outcomes are driven through one fixture whose `tools/call` succeeds
+    /// or fails on the tool name, because "counts a success" is only half the
+    /// contract: `connections` is the count of providers seen, so a metered
+    /// failure would mint a connection row for a server that never answered.
+    #[tokio::test]
+    async fn a_completed_mcp_call_is_metered_and_a_failed_one_is_not() {
+        use axum::extract::State;
+        use axum::routing::post;
+        use axum::{Json, Router};
+        use std::sync::Mutex;
+
+        use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+
+        #[derive(Default)]
+        struct RecordingMeter {
+            samples: Mutex<Vec<(String, UsageSample)>>,
+        }
+
+        #[async_trait]
+        impl UsageMeter for RecordingMeter {
+            async fn record(&self, company: &CompanyId, sample: &UsageSample) -> crate::Result<()> {
+                self.samples
+                    .lock()
+                    .unwrap()
+                    .push((company.to_string(), sample.clone()));
+                Ok(())
+            }
+            async fn query(
+                &self,
+                _company: &CompanyId,
+                _since: u64,
+            ) -> crate::Result<Vec<UsageSample>> {
+                Ok(Vec::new())
+            }
+        }
+
+        async fn handler(
+            State(()): State<()>,
+            Json(body): Json<Value>,
+        ) -> axum::response::Response {
+            use axum::response::IntoResponse;
+            let id = body.get("id").cloned().unwrap_or(Value::Null);
+            let method = body.get("method").and_then(Value::as_str).unwrap_or("");
+            match method {
+                "initialize" => Json(json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "protocolVersion": "2025-11-25", "capabilities": {},
+                                "serverInfo": { "name": "fixture", "version": "0" } }
+                }))
+                .into_response(),
+                "tools/list" => Json(json!({
+                    "jsonrpc": "2.0", "id": id,
+                    "result": { "tools": [
+                        { "name": "echo", "description": "e", "inputSchema": { "type": "object" } },
+                        { "name": "boom", "description": "b", "inputSchema": { "type": "object" } }
+                    ] }
+                }))
+                .into_response(),
+                "tools/call" => {
+                    let called = body
+                        .get("params")
+                        .and_then(|p| p.get("name"))
+                        .and_then(Value::as_str)
+                        .unwrap_or("");
+                    if called == "boom" {
+                        return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "boom")
+                            .into_response();
+                    }
+                    Json(json!({
+                        "jsonrpc": "2.0", "id": id,
+                        "result": { "content": [{ "type": "text", "text": "ok" }] }
+                    }))
+                    .into_response()
+                }
+                _ => Json(json!({ "jsonrpc": "2.0" })).into_response(),
+            }
+        }
+
+        let app = Router::new().route("/mcp", post(handler)).with_state(());
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let endpoint = format!("http://{addr}/mcp");
+        let registry = registry_for_agent(&[decl("fixture", &endpoint)], &grants(&["mcp:*"]))
+            .expect("registry");
+
+        let meter = Arc::new(RecordingMeter::default());
+        let tool = OcMcpCallTool::new(
+            registry,
+            Arc::new(SecurityPolicy::default()),
+            Vec::new(),
+            McpFailureQueue::default(),
+            McpMetering {
+                company: CompanyId::new("acme"),
+                agent: "ceo".to_string(),
+                meter: Some(meter.clone()),
+            },
+        );
+
+        let ok = tool
+            .execute(json!({ "server": "fixture", "tool": "echo", "arguments": {} }))
+            .await
+            .expect("mcp_call_tool");
+        assert!(!ok.is_error, "the fixture's `echo` succeeds: {ok:?}");
+
+        {
+            let samples = meter.samples.lock().unwrap();
+            assert_eq!(samples.len(), 1, "one completed call, one sample");
+            let (company, sample) = &samples[0];
+            assert_eq!(company, "acme", "the sample is scoped to this company");
+            assert_eq!(sample.agent, "ceo", "attributed to the calling agent");
+            assert_eq!(sample.kind, SampleKind::OauthCall);
+            // Namespaced, so this row cannot merge with a Composio toolkit that
+            // happens to share the server's name.
+            assert_eq!(sample.provider, "mcp:fixture");
+            assert_eq!(sample.input_tokens, 0);
+            assert_eq!(sample.output_tokens, 0);
+            assert_eq!(sample.cost_usd, 0.0);
+        }
+
+        let failed = tool
+            .execute(json!({ "server": "fixture", "tool": "boom", "arguments": {} }))
+            .await
+            .expect("mcp_call_tool");
+        assert!(failed.is_error, "the fixture's `boom` fails: {failed:?}");
+        assert_eq!(
+            meter.samples.lock().unwrap().len(),
+            1,
+            "a call that never reached the server must not mint a connection row"
         );
     }
 

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -36,6 +36,8 @@ use crate::error::OpenCompanyError;
 use crate::harness::mcp_probe::{
     McpFailure, McpFailureQueue, classify_mcp_error, operator_message, scrub, strip_endpoint,
 };
+use crate::ports::types::CompanyId;
+use crate::ports::usage::UsageMeter;
 use crate::runtime::tools::{grant_matches, grants_cover_server};
 
 /// Builds a registry from a set of decls, keeping only the enabled ones.
@@ -316,6 +318,35 @@ impl Tool for OcMcpListServersTool {
 /// against the granted servers' known credentials, rewrites the agent-facing
 /// text into a "don't retry blindly, tell the operator" directive, and pushes an
 /// [`McpFailure`] so the operator sees a warning after the turn.
+/// What `mcp_call_tool` needs to record an `OauthCall` usage sample.
+///
+/// Mirrors [`ComposioMetering`](crate::harness::composio::ComposioMetering):
+/// the company and agent the sample is scoped to, and a meter that may be
+/// absent because the harness wires none in some embeddings — in which case the
+/// tool still works and simply is not metered.
+#[derive(Clone)]
+pub struct McpMetering {
+    /// The company the sample is scoped to.
+    pub company: CompanyId,
+    /// The agent whose turn made the call.
+    pub agent: String,
+    /// The usage meter. `None` leaves metering off entirely.
+    pub meter: Option<Arc<dyn UsageMeter>>,
+}
+
+impl McpMetering {
+    /// A handle that records nothing — for embeddings and tests that wire no
+    /// meter. Named rather than spelled out at each call site so "unmetered" is
+    /// a visible decision instead of a `None` a reader has to interpret.
+    pub fn off() -> Self {
+        Self {
+            company: CompanyId::new("unmetered"),
+            agent: String::new(),
+            meter: None,
+        }
+    }
+}
+
 pub struct OcMcpCallTool {
     registry: Arc<McpServerRegistry>,
     security: Arc<SecurityPolicy>,
@@ -324,23 +355,28 @@ pub struct OcMcpCallTool {
     secrets: Vec<String>,
     /// The shared failure queue the brain drains after the turn.
     failures: McpFailureQueue,
+    /// Where a completed call is counted (issue #698). See
+    /// [`McpMetering`].
+    metering: McpMetering,
 }
 
 impl OcMcpCallTool {
     /// Builds the decorator over the agent's registry, the (permissive) MCP
-    /// security policy, the granted servers' credential substrings, and the
-    /// shared failure queue.
+    /// security policy, the granted servers' credential substrings, the shared
+    /// failure queue, and the metering handle.
     pub fn new(
         registry: Arc<McpServerRegistry>,
         security: Arc<SecurityPolicy>,
         secrets: Vec<String>,
         failures: McpFailureQueue,
+        metering: McpMetering,
     ) -> Self {
         Self {
             registry,
             security,
             secrets,
             failures,
+            metering,
         }
     }
 
@@ -437,6 +473,23 @@ impl Tool for OcMcpCallTool {
 
         match self.registry.call_tool(&server, &tool, arguments).await {
             Ok(result) => {
+                // Metered on success only, mirroring `composio_execute`: a call
+                // that actually reached the server. `connections` in the read
+                // model is the count of providers seen, so counting a failed
+                // call would mint a connection row for a server that never
+                // answered (issue #698). One line by design — see the module
+                // docs on `crate::metering::oauth` for why the shape and the
+                // swallow live there rather than here.
+                if let Some(meter) = &self.metering.meter {
+                    crate::metering::record_oauth_call(
+                        meter.as_ref(),
+                        &self.metering.company,
+                        &self.metering.agent,
+                        &crate::metering::mcp_provider(&server),
+                        crate::ports::now_millis(),
+                    )
+                    .await;
+                }
                 let mut result = result.rendered;
                 if options.prefer_markdown && result.markdown_formatted.is_none() {
                     result.markdown_formatted = Some(result.output());
@@ -876,6 +929,7 @@ mod tests {
             Arc::new(SecurityPolicy::default()),
             secrets,
             queue.clone(),
+            McpMetering::off(),
         );
 
         let result = tool

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -67,7 +67,9 @@ pub use inference::{
     INFERENCE_SPEND_KIND, MEDULLA_PROVIDER, UNATTRIBUTED_AGENT, inference_ledger_entry,
     inference_sample, record_inference_usage,
 };
-pub use oauth::{UNKNOWN_PROVIDER, oauth_call_sample, record_oauth_call};
+pub use oauth::{
+    MCP_PROVIDER_PREFIX, UNKNOWN_PROVIDER, mcp_provider, oauth_call_sample, record_oauth_call,
+};
 pub use planning::{planning_sample, record_planning_usage};
 pub use search::{
     FALLBACK_SEARCH_COST_USD, MANAGED_SEARCH_PROVIDER, record_search_call, search_call_sample,

--- a/src/metering/oauth.rs
+++ b/src/metering/oauth.rs
@@ -45,6 +45,36 @@ pub fn normalize_provider(provider: &str) -> String {
     trimmed.to_ascii_lowercase()
 }
 
+/// The namespace prefix for a remote MCP server's provider slug.
+///
+/// Composio toolkit slugs and MCP server names are two different namespaces
+/// that `by_provider` would otherwise merge, because it groups on one flat
+/// string. A company with a Composio `gmail` toolkit and an MCP server its
+/// operator also called `gmail` would see one row carrying the sum of both —
+/// and, since the `connections` KPI is that map's *row count*, would be told it
+/// has one connection where it has two (issue #698).
+pub const MCP_PROVIDER_PREFIX: &str = "mcp:";
+
+/// The provider slug recorded for a call through a remote MCP server.
+///
+/// Namespaced rather than bare, so the row cannot collide with a Composio
+/// toolkit of the same name. The prefix is part of the grouping key, which
+/// means it is also what an operator reads in the calls-by-provider chart —
+/// deliberately, because "which of my two `gmail` connections was this?" is a
+/// question the chart could not otherwise answer.
+///
+/// An empty or whitespace-only server name yields a bare [`UNKNOWN_PROVIDER`]
+/// rather than a prefixed one. A sample that cannot name its server is not
+/// evidence about MCP specifically, and minting `mcp:unknown` would invent a
+/// connection row for a server that was never identified.
+pub fn mcp_provider(server: &str) -> String {
+    let normalized = normalize_provider(server);
+    if normalized == UNKNOWN_PROVIDER {
+        return normalized;
+    }
+    format!("{MCP_PROVIDER_PREFIX}{normalized}")
+}
+
 /// Builds the [`UsageSample`] for one connected-tool invocation.
 ///
 /// Carries no tokens and no cost: an OAuth call is counted, not billed by token
@@ -212,5 +242,56 @@ mod tests {
         assert_eq!(usage.by_provider[1].calls, 1);
         // OAuth calls carry no tokens, so they never distort the token series.
         assert_eq!(usage.totals.tokens, 0);
+    }
+
+    #[test]
+    fn an_mcp_server_is_namespaced_away_from_composio_toolkits() {
+        assert_eq!(mcp_provider("linear"), "mcp:linear");
+        // Same normalisation as every other provider: the prefix does not
+        // exempt a server name from the case folding that stops `Linear` and
+        // `linear` becoming two connections.
+        assert_eq!(mcp_provider("  LINEAR "), "mcp:linear");
+    }
+
+    #[test]
+    fn an_unnamed_server_does_not_mint_a_phantom_mcp_connection() {
+        // `mcp:unknown` would be a connection row for a server nobody can
+        // point at. Falling back to the bare slug keeps the call counted in
+        // `oauthCalls` without inventing an MCP connection in `byProvider`.
+        assert_eq!(mcp_provider(""), UNKNOWN_PROVIDER);
+        assert_eq!(mcp_provider("   "), UNKNOWN_PROVIDER);
+    }
+
+    /// The collision issue #698 asks to prevent, asserted through the
+    /// aggregation rather than on the string, because the string is not the
+    /// claim — "two connections, counted separately" is.
+    #[test]
+    fn a_composio_toolkit_and_an_mcp_server_of_one_name_stay_two_connections() {
+        use std::collections::HashMap;
+
+        use crate::metering::{UsageRange, bucket_usage};
+
+        let now = 1_700_000_000_000u64;
+        let samples = vec![
+            // The Composio toolkit: bare slug, as `composio_execute` emits it.
+            oauth_call_sample("ceo", "gmail", now),
+            // An MCP server the operator also named `gmail`.
+            oauth_call_sample("ceo", &mcp_provider("gmail"), now),
+        ];
+        let usage = bucket_usage(&samples, UsageRange::D7, now, &HashMap::new());
+
+        assert_eq!(usage.totals.oauth_calls, 2);
+        assert_eq!(
+            usage.totals.connections, 2,
+            "an MCP server and a Composio toolkit sharing a name are two \
+             connections; merging them under-reports the KPI"
+        );
+        let providers: Vec<&str> = usage
+            .by_provider
+            .iter()
+            .map(|p| p.provider.as_str())
+            .collect();
+        assert!(providers.contains(&"gmail"), "{providers:?}");
+        assert!(providers.contains(&"mcp:gmail"), "{providers:?}");
     }
 }


### PR DESCRIPTION
## Summary

Closes #698.

`composio_execute` was the only production site in the codebase emitting an
`OauthCall` sample. So for a company routing its real work through remote MCP
servers, `oauthCalls`, `byProvider` and the `connections` KPI all reported a
zero — and a zero there reads as *"nothing has happened on this connection"*
when it means *"nothing has been counted on this connection"*. Those are
different sentences and only one of them was true.

This emits one `OauthCall` per successful `mcp_call_tool` invocation, with the
server name as the provider. The existing aggregation, the `byProvider` chart
and the `connections` KPI then work with no downstream change.

## This wires an existing helper rather than building metering

Worth stating up front, because the call site is six lines and that will
otherwise read as thin. `record_oauth_call` has been in `src/metering/oauth.rs`
since #161, and **its module doc already anticipates this exact second caller**:

> ## Why it lives here (always compiled) and not at the call site
>
> The connected-tool execution sites are behind non-default features
> (`composio`, `mcp`), and CI builds only the default feature set — so code
> written *at* those sites is neither compiled nor tested by CI. Keeping the
> sample shape and the record-and-swallow behaviour here, beside the aggregation
> that reads it, means the contract is unit-tested on every CI run and the gated
> call site stays a single line.

So the shape of this change is the shape that module was written for: the new
rule (`mcp_provider`) goes in `metering/oauth.rs` where the default `cargo test`
covers it, and `src/harness/mcp.rs` gains one guarded call.

(One clarification on that quote, since it is the module's own text and it
over-reaches slightly: the *Composio* site genuinely is feature-gated in the way
described, but `src/harness/mcp.rs` is not — see the correction below. The
argument for putting the rule in `metering/` still stands on its own: that is
where the aggregation it must agree with lives.)

## Where the tests live, and a correction

An earlier revision of this description argued that a test in
`src/harness/mcp.rs` "would compile and never run", and used that to justify
shipping the call site with no behavioural test. **That was wrong, and the
review caught it.**

The reasoning generalised `metering/oauth.rs`'s module doc — "the connected-tool
execution sites are behind non-default features (`composio`, `mcp`)" — to this
file. It holds for `composio.rs`, whose live tool bodies sit inside
`#[cfg(feature = "composio")] mod live`. It does **not** hold for
`src/harness/mcp.rs`: that module is `pub mod mcp;`, gated only by `openhuman`
like the rest of `harness`, so its tests run in the ordinary
`Rust (openhuman, tinycortex)` lane. Twelve of them already do — including
`oc_call_tool_scrubs_reflected_credential`, the very test this PR touched.

So the call site is testable, and is now tested. The split is:

| what | where | run by |
|---|---|---|
| the `mcp:` namespacing rule + the collision behaviour | `src/metering/oauth.rs` | default `cargo test` — every lane |
| the wiring: success is metered, failure is not, with the right company/agent/provider | `src/harness/mcp.rs` | `Rust (openhuman, tinycortex)` |

The unit tests and the call-site test cover different things on purpose:
`mcp_provider("gmail") == "mcp:gmail"` says nothing about whether the success
branch ever calls the meter, passes *this* company and agent rather than a
default, or stays silent on the `Err` path. Those are only reachable through the
tool, and all three are now asserted.

## The one deliberate decision: MCP servers are namespaced

The issue asks for this to be settled rather than defaulted, and names a prefix
as the safer answer. Taking it: the provider slug is **`mcp:<server>`**.

`by_provider` groups on one flat string, so without a prefix a Composio `gmail`
toolkit and an MCP server an operator also called `gmail` collapse into a single
row carrying the sum of both. Because the `connections` KPI is that map's *row
count*, the company would be told it has one connection where it has two — a
new under-report, introduced by the change meant to fix one.

Two smaller calls inside that:

- **The prefix is part of the grouping key**, so it is also what an operator
  reads in the chart. Deliberate: *"which of my two `gmail` connections was
  this?"* is otherwise unanswerable from the chart.
- **An unnamed server falls back to the bare `unknown` slug**, not
  `mcp:unknown`. A sample that cannot name its server is not evidence about MCP
  specifically, and minting `mcp:unknown` would invent a connection row for a
  server nobody can point at. The call is still counted in `oauthCalls`.

Metered **on success only**, mirroring `composio_execute`: a failed call never
reached the server, and counting it would mint a connection row for a server
that did not answer.

## Scope: one of the two MCP surfaces, named rather than assumed

There are two, and this covers one:

| tool | type | in scope |
|---|---|---|
| `mcp_call_tool` | `OcMcpCallTool` (`src/harness/mcp.rs`) — manifest-configured, granted remote servers | **yes** |
| `mcp_registry_tool_call` | upstream `oh::mcp::registry::tools::McpRegistryToolCallTool` — OpenHuman's live *process* registry | no |

#698 and #404 are about **per-connection** usage, and `OcMcpCallTool` is the
surface scoped to configured connections. `mcp_registry_tool_call` reaches
locally installed MCP processes, which are not a connection in the
connection-detail sense, and it is an upstream type pushed directly — metering
it needs a decorator (there is precedent: `OcMcpListServersTool` already
replaces an upstream tool). Flagged rather than silently covering one of two.

**Part 2 of the issue** — the console saying "usage is not recorded for this
connection type" — is out of scope by the issue's own instruction: it is
console-only and belongs with the #404 work.

## API Or Behavior Changes

- **`mcp_call_tool` now records an `OauthCall` usage sample on success.** A
  company using MCP stops reading as zero in the Usage view. No behaviour change
  when no meter is wired.
- **New public API**: `metering::mcp_provider`, `metering::MCP_PROVIDER_PREFIX`,
  and `harness::mcp::McpMetering` (mirroring `ComposioMetering`).
- **`OcMcpCallTool::new` takes a fifth argument**, `McpMetering`.
  `McpMetering::off()` is the named "records nothing" handle, so unmetered is a
  visible decision rather than a `None` a reader has to interpret.
- Provider slugs from MCP are `mcp:`-prefixed, so they occupy their own
  `byProvider` rows and their own `connections` count.

## Tests

- [x] `cargo fmt --all -- --check` — passed.
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — passed, zero lints. **Also** run under `openhuman,mcp,telegram`, the combo that additionally covers the `#[cfg(feature = "mcp")]` wiring in `build.rs` — passed, zero lints in both.
- [x] `cargo build` / `cargo check --locked --all-features --all-targets` — passed.
- [x] `cargo test --features openhuman,tinycortex` — **3328 passed, 0 failed**. Also `cargo test --locked` (default) — **2207 passed, 0 failed** — and `cargo test --locked --features openhuman,mcp,telegram --lib harness::build::tests` — **22 passed**.

### Rebased onto green `main`; fully green with nothing inherited

An earlier revision of this PR sat on `main` @ `a9c75878`, which was itself red on
two tests unrelated to this change. Both are now fixed directly in `main`
(`d1d01ae5`), this branch has been rebased onto that, and **every lane is green
with zero failures** — so there is no "inherited red" caveat to apply to this
PR and none should be read into it.

The rebase was conflict-free: this change touches
`src/metering/{oauth,mod}.rs`, `src/harness/mcp.rs` and `src/harness/build.rs`,
none of which the fixes went near.

All three revert-checks below were **re-run after the rebase**, because a rebase
can hollow a test without the diff moving. Counts are from the post-rebase run.

### Every added test was checked by reverting its fix

| reverted mechanism | result | test that caught it |
|---|---|---|
| `mcp:` prefix dropped (return the bare slug) | 9 ran, **2** failed | `an_mcp_server_is_namespaced_away_from_composio_toolkits`, `a_composio_toolkit_and_an_mcp_server_of_one_name_stay_two_connections` |
| `UNKNOWN_PROVIDER` guard removed (prefix everything) | 9 ran, 1 failed | `an_unnamed_server_does_not_mint_a_phantom_mcp_connection` |
| normalisation skipped inside `mcp_provider` | 9 ran, 2 failed | `an_mcp_server_is_namespaced_away_from_composio_toolkits`, `an_unnamed_server_does_not_mint_a_phantom_mcp_connection` |
| **the whole `if let Some(meter)` block deleted** | 1 ran, 1 failed | `a_completed_mcp_call_is_metered_and_a_failed_one_is_not` |
| **the bare server name metered instead of the `mcp:`-prefixed one** | 1 ran, 1 failed | same |
| **metering moved onto the `Err` arm as well** | 1 ran, 1 failed | same |

The last three are exactly the three failure modes the review named as
currently undetectable — deleting the block, firing on `Err`, threading the
wrong value — so each was sabotaged individually and each is now caught.

Baseline of that filter on the unmodified, post-rebase tree: **9 passed, 0
failed** — so each red above is attributable to its own revert rather than to a
broken tree.

The collision test deliberately asserts through `bucket_usage` rather than on
the string: `mcp_provider("gmail") == "mcp:gmail"` is not the claim worth
pinning — *"two connections, counted separately"* is, and that only shows up
after aggregation.

## Documentation

Reasoning lives next to the code it constrains: `mcp_provider` carries the
namespace argument, `McpMetering` states why it mirrors `ComposioMetering`, and
the call site says why it is one line and why it fires on success only. No
`docs/spec/` change — this fills in an existing contract rather than altering
one.
