### PR TITLE
test: restore main — isolate always_approve parity + pin ambiguous-root refusal

### DIFF
--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -540,25 +540,26 @@ mod tests {
     /// Fail closed, exactly as the scaffold does: two roots named `Agents` make
     /// "under `Agents/`" undecidable, so the sweep refuses instead of picking
     /// one and deleting beneath it.
-    #[tokio::test]
-    async fn an_ambiguous_root_is_refused_and_removes_nothing() {
-        let (_dir, ws) = store().await;
-        let company = CompanyId::new("odd");
-        for id in ["dup-a", "dup-b"] {
-            ws.create(&company, &folder(id, AGENTS_ROOT, None), None)
-                .await
-                .unwrap();
-        }
-        ws.create(&company, &folder("stray", "ceo", Some("dup-a")), None)
-            .await
-            .unwrap();
+    ///
+    /// Built as a hand-rolled node slice and fed straight to
+    /// [`empty_agent_folder_candidates`], which exists for exactly this: two
+    /// sibling folders both named `Agents` resolve to one on-disk path, so
+    /// [`FsOps`](crate::store::fs_ops::FsOps) refuses the second create
+    /// (issue #666) and no backend can be driven into this shape. The refusal
+    /// is still the sweep's own to make — the store's rejection is a second
+    /// fence, not this one — so it is pinned here on input no `create` allows.
+    #[test]
+    fn an_ambiguous_root_is_refused_and_removes_nothing() {
+        let nodes = vec![
+            folder("dup-a", AGENTS_ROOT, None),
+            folder("dup-b", AGENTS_ROOT, None),
+            folder("stray", "ceo", Some("dup-a")),
+        ];
 
-        let err = sweep_empty_agent_folders(ws.as_ref(), &company, false)
-            .await
+        let err = empty_agent_folder_candidates(&nodes)
             .expect_err("an ambiguous root must not be swept beneath");
 
         assert!(err.to_string().contains(AGENTS_ROOT), "{err}");
-        assert_eq!(names(&ws, &company).await, vec!["Agents", "Agents", "ceo"]);
     }
 
     /// A *file* named `Agents` is the other unresolvable shape, and the refusal

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1631,7 +1631,14 @@ mod tests {
 
         // `full` on both sides, so the tier decides nothing and any parking
         // observed is the override's doing.
-        let harness = policy("full", fence, None);
+        //
+        // On the authored-workflow path so per-call judgement (#338) stays
+        // silent: `ManifestApprovalGate` has no `judge` step, so comparing it
+        // against the agent path — where an undeclared tool like
+        // `payroll.export` stops on judge alone — would measure that Agent-only
+        // rule, not the `always_approve` parity this test is about. Silencing
+        // judge here isolates the one list both paths are supposed to share.
+        let harness = policy("full", fence, None).for_authored_workflow_nodes();
         let gate = ManifestApprovalGate::new(Policy {
             mode: "full".to_string(),
             always_approve: fence.iter().map(|s| s.to_string()).collect(),


### PR DESCRIPTION
## Summary

`main` is red on two library tests. Both are **union collisions** — each PR was green on its own branch, and the pair that broke the test never ran together in CI. Neither failure is a runtime regression; both are tests whose setup/assumption a sibling PR invalidated. The fixes are **test-only, behavior-preserving**.

**1. `harness::policy::tests::both_approval_paths_agree_on_the_same_always_approve_list`**
Per-call judgement (#338, #660) runs on the agent path but not on `ManifestApprovalGate`. The test compared the two paths end-to-end, so an undeclared tool (`payroll.export`) that stops on **judge alone** looked like an `always_approve` disagreement. It isn't — judge is Agent-path-only by design (`for_authored_workflow_nodes` silences it; the gate has no judge step at all). Fix: run the test harness on the authored-workflow path so judge stays silent, leaving `always_approve` as the only difference the assertion measures. `always_approve::matches` is untouched, so the #684 invariant it guards is fully preserved.

**2. `company::workspace_sweep::tests::an_ambiguous_root_is_refused_and_removes_nothing`**
`FsOps` now refuses a second node at a colliding physical path (#666, #711), so no store can be driven into two sibling `Agents` roots — the second `create` returns `Conflict` and the test's `.unwrap()` panics in setup. The sweep's own ambiguity refusal is still correct and still wanted (defense-in-depth behind the store's fence). Fix: pin it on a hand-built node slice fed straight to `empty_agent_folder_candidates` — the seam the module docs explicitly reserve for "shapes no backend would let a test create."

### Open design questions for the owner (@M3gA-Mind)
These two are yours (#660 / #684 / #700 / #711). The fixes above restore green without pre-empting either call:
- **Should `ManifestApprovalGate` also run `judge`?** Today only the agent path does. If workflow/manifest effects should get the same #338 stop, that's a runtime change (stricter gate), not a test tweak — say the word and I'll follow up.
- **Is the sweep's ambiguity guard still worth keeping** now that `FsOps` prevents the state upstream? Kept as defense-in-depth here; drop it if you'd rather the store be the single fence.

## API Or Behavior Changes

None. Both changes are within `#[cfg(test)]`; no runtime code paths change.

## Tests

- `cargo test --features openhuman,tinycortex --lib both_approval_paths_agree_on_the_same_always_approve_list` — pass (was failing)
- `cargo test --features openhuman,tinycortex --lib an_ambiguous_root_is_refused_and_removes_nothing` — pass (was failing)
- `cargo fmt --all -- --check` — clean
- `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean

## Documentation

None needed — the "why" lives in each test's doc comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for detecting conflicting agent workspace roots.
  * Updated approval-path comparisons to use consistent authored-workflow policy behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->