### PR TITLE
fix(desktop): require https for a credentialed host, permit anonymous http

### DIFF
--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -63,6 +63,10 @@ second is what someone types into "Add a host". Parsing is not enough either —
 `URL` accepts `tauri://localhost` and `file:///x`, and neither is a company
 host — so the check is `http:` or `https:`.
 
+Whether that host may then be *trusted with a secret* is a separate question,
+answered separately — see "Where a credential may travel" below. Collapsing the
+two would either forbid anonymous HTTP or permit credentialed HTTP.
+
 Two consequences follow, and both are load-bearing
 ([#613](https://github.com/tinyhumansai/opencompany/issues/613)):
 
@@ -121,6 +125,48 @@ is attached. `RequestBuilder::header` appends and axum reads the *first* value,
 so a header from the webview would otherwise be the one the host honoured.
 Keeping the token out of the webview is worth little if the webview still
 decides what a request authenticates as.
+
+### Where a credential may travel
+
+Addressability is not the only question a base url has to answer. A host can be
+perfectly reachable over a wire anyone on the path can read, and the desktop's
+credential is a device session — a person's standing authority on a company,
+attached to every request and to the whole life of the event stream, and
+replayable by whoever copies it down
+([#731](https://github.com/tinyhumansai/opencompany/issues/731)).
+
+So a second rule sits beside the first: **a credential travels over HTTPS, or to
+a host on this machine, and nowhere else.** `may_carry_a_credential` in
+`src-tauri/src/proxy/mod.rs` is the one that enforces it, with
+`mayCarryACredential` in `frontend/src/api/transport/index.ts` as the console's
+copy — the same arrangement as `isAddressableBaseUrl`, and for the same reason:
+a check in the console alone is bypassed by anything reaching the proxy
+directly, and a check in Rust alone arrives as an opaque IPC rejection that
+`client.ts` flattens into "cannot reach the company host".
+
+Loopback is exempt because `http://127.0.0.1:<port>` is how the embedded host is
+reached, on a port that changes every launch and so can never carry a
+certificate; `localhost` and its subdomains come with it, per RFC 6761. The
+private ranges are deliberately **not** exempt — an office LAN is precisely
+where someone else is on the path.
+
+The rule turns on the credential rather than on the scheme, which is what keeps
+a home-lab or staging host without a certificate usable: an anonymous connection
+to one still registers and still reads, because nothing is exposed that a
+passer-by could not have asked the host for themselves. Three surfaces apply it:
+
+- `ProxyRegistry::upsert` refuses to register a credentialed connection to such
+  a host, by name — `this host is not encrypted`, not `not an absolute host url`,
+  because an operator told the second goes to debug a network that is working.
+- `claim` in `commands.rs` refuses the pairing exchange before opening a socket.
+  This is the one place a session token is *created* rather than replayed — the
+  code goes out in the request and the token comes back in the response — and it
+  never touches the registry, so `upsert`'s refusal does not cover it. Its client
+  also refuses redirects: a 307 from an HTTPS base to an HTTP one would re-send
+  the claim, body and all, over the wire the check just refused.
+- `probe` in `registry.ts` marks such a connection `down` with the reason,
+  before contacting it, so the row says what is wrong instead of blaming the
+  network.
 
 The webview also runs under a CSP (`src-tauri/tauri.conf.json`) whose
 `connect-src` allows the IPC origin only. All host traffic goes through Rust and
@@ -193,7 +239,9 @@ a paired session by connection id. Pairing runs entirely in Rust —
 answers with the company, device id and expiry — so the token exists for one
 HTTP response that the webview is not on the path of. That is the difference
 between a design where the webview *should not* hold the credential and one
-where it *cannot*.
+where it *cannot*. The claim itself is a plain `claim()` rather than command
+logic, so the rules on it can be tested without starting a GUI — see "Where a
+credential may travel" for the one it enforces.
 
 The console's `Credential { kind: "device", ref }` is therefore a record that
 this machine is paired, not something the core is told. `ref` is the host's

--- a/frontend/src/api/transport/index.ts
+++ b/frontend/src/api/transport/index.ts
@@ -71,6 +71,71 @@ export function isAddressableBaseUrl(baseUrl: string): boolean {
 }
 
 /**
+ * Whether a secret may be sent to `baseUrl`.
+ *
+ * **HTTPS, or a host that is this machine.** A device session is a person's
+ * standing authority on a company, and plain HTTP puts it in front of every
+ * device on the path — a LAN, a café, an office switch. Reading an unencrypted
+ * host anonymously is not this; the exposure is entirely in the credential, so
+ * that is what this gates and nothing else (issue #731).
+ *
+ * Loopback is exempt because `http://127.0.0.1:<port>` is how the embedded host
+ * is reached and a certificate for an ephemeral port cannot exist. `localhost`
+ * comes with it — RFC 6761 reserves the name, and it is what a developer types.
+ *
+ * ## This is a second copy of a rule that lives in Rust
+ *
+ * Deliberately, and the duplication is the point rather than a smell:
+ * `may_carry_a_credential` in `src-tauri/src/proxy/mod.rs` is the one that
+ * enforces it, because a check up here is bypassed by anything reaching the
+ * proxy directly. This copy exists so the console can say *why* before it asks
+ * — the core's refusal arrives as an opaque IPC rejection that
+ * `client.ts` flattens into "cannot reach the company host", which is the
+ * indistinguishable failure #613 was about.
+ *
+ * Kept beside {@link isAddressableBaseUrl} because they are the transport's two
+ * questions about one url and they answer different things: that one asks
+ * whether the host can be reached, this one whether it can be trusted with a
+ * secret. Neither implies the other, and collapsing them would either forbid
+ * anonymous HTTP or permit credentialed HTTP.
+ */
+export function mayCarryACredential(baseUrl: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol === "https:") return true;
+  // `URL.hostname` brackets nothing and lowercases the host, but an IPv6
+  // literal keeps the brackets it was written with.
+  const host = url.hostname.replace(/^\[|\]$/g, "");
+  return isLoopbackHost(host);
+}
+
+/**
+ * Whether a host names the machine the console is running on.
+ *
+ * Matched as text because the platform offers no IP type. That is safe here
+ * only because `URL` has already normalised what it was given: `127.1` and
+ * `0177.0.0.1` both arrive as `127.0.0.1`, so the shorthand spellings cannot
+ * walk past a literal comparison.
+ *
+ * `127.0.0.0/8` in full rather than `127.0.0.1` alone — the whole block is
+ * loopback, and a second local host on `127.0.0.2` is an ordinary thing to do.
+ */
+function isLoopbackHost(host: string): boolean {
+  if (host === "localhost" || host.endsWith(".localhost")) return true;
+  // The v6 loopback, and the v4-mapped form — which `URL` rewrites to hex, so
+  // `::ffff:127.0.0.1` is not the string that reaches here.
+  if (host === "::1" || host === "::ffff:7f00:1") return true;
+  const v4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!v4) return false;
+  const octets = v4.slice(1).map(Number);
+  return octets.every((o) => o <= 255) && octets[0] === 127;
+}
+
+/**
  * The transport for this environment.
  *
  * Selected here so no caller has to learn the difference. A `connectionId` is

--- a/frontend/src/components/device-pairing.tsx
+++ b/frontend/src/components/device-pairing.tsx
@@ -19,7 +19,7 @@
 import { useState } from "react";
 import { KeyRound, Loader2 } from "lucide-react";
 
-import { isDesktopRuntime } from "@/api/transport";
+import { isDesktopRuntime, mayCarryACredential } from "@/api/transport";
 import { forgetDevice, pairDevice } from "@/api/transport/desktop";
 import { Button } from "@/components/ui/button";
 import {
@@ -45,6 +45,11 @@ export function DevicePairing() {
   if (!isDesktopRuntime() || !connection) return null;
 
   const paired = connection.credential.kind === "device";
+  // A host this machine must not hand a session to. The core refuses the claim
+  // too — that is the check that counts, since it also covers anything invoking
+  // `oc_pair_device` directly — but a form that cannot succeed should say so
+  // before someone fetches a code from another screen to type into it.
+  const encrypted = mayCarryACredential(connection.baseUrl);
 
   const submit = async () => {
     const trimmed = code.trim();
@@ -80,7 +85,9 @@ export function DevicePairing() {
         <CardDescription>
           {paired
             ? "This machine is paired with this host and signs in as you."
-            : "Pair this machine so it acts as you rather than anonymously. Ask this host's web console for a pairing code under Settings → devices."}
+            : encrypted
+              ? "Pair this machine so it acts as you rather than anonymously. Ask this host's web console for a pairing code under Settings → devices."
+              : "This host is reached over an unencrypted connection, so pairing is unavailable — a session sent to it could be read by anyone on the network path."}
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -120,7 +127,17 @@ export function DevicePairing() {
             {error}
           </p>
         ) : null}
-        {!paired ? (
+        {!paired && !encrypted ? (
+          // No form at all, rather than a disabled one. A greyed-out field
+          // invites a person to hunt for what would enable it, and the answer
+          // is not on this screen — it is the host's address, which they
+          // change by re-adding it over https.
+          <p role="alert" data-testid="pairing-insecure-host" className="text-xs text-destructive">
+            {connection.baseUrl} is not encrypted. Pair over https, or from a host running on
+            this machine.
+          </p>
+        ) : null}
+        {!paired && encrypted ? (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
               <Input

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -17,7 +17,12 @@ import { useSyncExternalStore } from "react";
 
 import { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
-import { defaultTransport, isAddressableBaseUrl, isDesktopRuntime } from "@/api/transport";
+import {
+  defaultTransport,
+  isAddressableBaseUrl,
+  isDesktopRuntime,
+  mayCarryACredential,
+} from "@/api/transport";
 import type { Transport } from "@/api/transport";
 import { forgetConnection, registerConnection } from "@/api/transport/desktop";
 import {
@@ -510,6 +515,16 @@ export function resetConnections(): void {
 export async function probe(id: ConnectionId): Promise<void> {
   const client = clientFor(id);
   if (!client || probing.has(id)) return;
+  const insecure = insecurelyCredentialed(getConnection(id));
+  if (insecure) {
+    // Refused here rather than left to fail at the core, because this is the
+    // one function that owns a row's status — and the core's refusal arrives
+    // as an IPC rejection that `client.ts` has already flattened into "cannot
+    // reach the company host". Saying it here is what makes the row name the
+    // reason instead of blaming a network that is working (issue #731).
+    patch(id, { status: "down", error: insecure });
+    return;
+  }
   probing.add(id);
   patch(id, { status: "connecting", error: undefined });
   try {
@@ -560,6 +575,39 @@ async function readIdentity(client: OpenCompanyClient): Promise<InstanceIdentity
   } catch {
     return null;
   }
+}
+
+/**
+ * Why this connection must not be contacted, or `null` when it may be.
+ *
+ * A credential over plain HTTP to a host that is not this machine, which the
+ * core refuses at registration (`may_carry_a_credential`). Answering the same
+ * question here is what turns that refusal into something a person can act on;
+ * see the note on `mayCarryACredential`.
+ *
+ * Desktop only. A browser's credential is a cookie the browser decides about,
+ * with `Secure` and the origin's own rules doing this job — narrowing the web
+ * build here would refuse the plain-HTTP deployments `opencompany serve` is
+ * built for, on the transport where the console is not the thing holding the
+ * secret.
+ *
+ * Read off the profile's credential *kind*, which is a claim about this machine
+ * rather than the secret itself: a `device` entry means the keychain holds a
+ * session the core will attach, and `platform` with a token means one arrived
+ * in the url. `cookie` and a token-less `platform` carry nothing, so a host
+ * added by hand and read anonymously stays permitted — the whole point of
+ * gating on the credential rather than on the scheme.
+ */
+function insecurelyCredentialed(connection: Connection | undefined): string | null {
+  if (!connection || !isDesktopRuntime()) return null;
+  const carries =
+    connection.credential.kind === "device" ||
+    (connection.credential.kind === "platform" && Boolean(connection.credential.token));
+  if (!carries || mayCarryACredential(connection.baseUrl)) return null;
+  // Names the credential generically: this covers a paired device session and a
+  // platform bearer from `?token=`, and the person reading it needs the reason
+  // rather than which of the two it was.
+  return `${connection.baseUrl} is not encrypted, so this connection's credential cannot be sent to it. Use https, or a host on this machine.`;
 }
 
 function statusFromError(err: unknown): Partial<Connection> {

--- a/frontend/test/e2e/desktop-connections.spec.ts
+++ b/frontend/test/e2e/desktop-connections.spec.ts
@@ -45,6 +45,8 @@ interface RegisteredConnection {
 declare global {
   interface Window {
     __ocRegistered?: RegisteredConnection[];
+    /** Base urls `oc_request` was asked to send to, in order. */
+    __ocRequested?: string[];
   }
 }
 
@@ -67,8 +69,10 @@ async function asDesktop(page: Page, config: BridgeConfig) {
     }
 
     const registered: RegisteredConnection[] = [];
+    const requested: string[] = [];
     const hosts = new Map<string, string>();
     window.__ocRegistered = registered;
+    window.__ocRequested = requested;
 
     /** `ProxyRegistry::upsert`'s rule, restated: absolute http(s) or nothing. */
     const isAddressable = (baseUrl: string): boolean => {
@@ -123,6 +127,10 @@ async function asDesktop(page: Page, config: BridgeConfig) {
             // needed here — an unaddressable base never reached this map.
             const base = hosts.get(id);
             if (base === undefined) throw new Error(`no such connection: ${id}`);
+            // Recorded so a test can assert that a host was never *contacted*,
+            // which is a different claim from never being registered — and the
+            // one that matters when what must not travel is a credential.
+            requested.push(base);
             const req = args.request as {
               method: string;
               path: string;
@@ -305,6 +313,96 @@ test("a desktop waits for its own host rather than borrowing a remembered one", 
     timeout: 30_000,
   });
   await expect(page.getByTestId("connection-error")).toHaveCount(0);
+});
+
+/**
+ * A remote host on plain HTTP, on the network a laptop is actually on.
+ *
+ * Not loopback, and deliberately unlike `DEAD_REMOTE` above: that one is
+ * `127.0.0.1:9`, which this rule *permits* — being unreachable and being
+ * unencrypted are different failures, and the point of the test below is that
+ * the console now tells them apart.
+ */
+const INSECURE_REMOTE = "http://192.168.1.20:8080";
+
+test("a paired host on plain http is refused, and says why", async ({ page, baseURL }) => {
+  // Issue #731. A device session is a person's standing authority on a company,
+  // and `apply_credential` attaches it to every request and to the whole life of
+  // the event stream — so a connection remembered against an unencrypted remote
+  // address puts it in front of everyone on that network, repeatedly and
+  // replayably. The core refuses to register it; this is what the operator sees.
+  await asDesktop(page, { embedded: new URL(baseURL ?? "http://127.0.0.1:8123").origin });
+  await page.addInitScript((remote: string) => {
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        {
+          id: "conn-paired-cleartext",
+          baseUrl: remote,
+          label: "Paired over http",
+          defaultCompany: null,
+          // What a desktop paired before this rule existed wrote down. The ref
+          // is a device id, not the secret — the session it names is in the OS
+          // keychain, and it is what the core would attach.
+          credential: { kind: "device", ref: "dev-1" },
+        },
+      ]),
+    );
+  }, INSECURE_REMOTE);
+  await page.goto("/#/tasks");
+
+  // The embedded host still opens, and the console is usable. Refusing one row
+  // must not cost the others — that is the property the whole multi-connection
+  // slice exists for.
+  await expect(page.getByRole("button", { name: "Add task" })).toHaveCount(1, {
+    timeout: 30_000,
+  });
+
+  const refused = page.getByTestId("connection-row-conn-paired-cleartext");
+  await expect(refused).toHaveAttribute("data-status", "down");
+  // THE assertion. Before this, the row read "cannot reach the company host at
+  // http://192.168.1.20:8080" — indistinguishable from a host that is simply
+  // switched off, and it sends the operator to look at a network that works.
+  await expect(refused).toHaveAttribute("title", /not encrypted/);
+
+  // And nothing was sent there. The status is not a label applied after a round
+  // trip; the round trip is what must not happen.
+  const requested = await page.evaluate(() => window.__ocRequested ?? []);
+  expect(requested).not.toContain(INSECURE_REMOTE);
+});
+
+test("an unencrypted host with no credential still connects", async ({ page, baseURL }) => {
+  // The other half of the rule, and the reason it gates on the credential
+  // rather than on the scheme: a home-lab or staging box without a certificate
+  // stays usable. Nothing is exposed by reading it that a passer-by could not
+  // have asked the host for themselves.
+  //
+  // Registered against the suite's own host so it genuinely answers; what is
+  // under test is that an anonymous connection is not caught by #731's rule,
+  // not that an arbitrary LAN address is reachable from CI.
+  const host = new URL(baseURL ?? "http://127.0.0.1:8123").origin;
+  await asDesktop(page, { embedded: null });
+  await page.addInitScript((remote: string) => {
+    window.localStorage.setItem(
+      "oc.connections.v1",
+      JSON.stringify([
+        {
+          id: "conn-anonymous-http",
+          baseUrl: remote,
+          label: "Anonymous over http",
+          defaultCompany: null,
+          credential: { kind: "cookie" },
+        },
+      ]),
+    );
+  }, host);
+  await page.goto("/#/tasks");
+
+  await expect(page.getByTestId("connection-row-conn-anonymous-http")).toHaveAttribute(
+    "data-status",
+    "live",
+    { timeout: 30_000 },
+  );
 });
 
 test("a desktop whose host did not start says so, and can still add one", async ({ page }) => {

--- a/frontend/test/unit/connection-registry.test.ts
+++ b/frontend/test/unit/connection-registry.test.ts
@@ -7,10 +7,12 @@ import {
   adoptEmbeddedHost,
   getConnection,
   listConnections,
+  probe,
   removeConnection,
   resetConnections,
   restoreConnections,
 } from "@/connections/registry";
+import type { Transport } from "@/api/transport";
 import { findProfile, readProfiles } from "@/connections/profileStore";
 import { scopedKey } from "@/connections/types";
 
@@ -481,5 +483,114 @@ describe("a same-origin profile", () => {
 
     expect(restoreConnections()).toEqual([id]);
     expect(getConnection(id)?.label).toBe("This host");
+  });
+});
+
+/**
+ * A credential is not sent to a host anyone on the path can read.
+ *
+ * Issue #731. The core is what enforces this — `may_carry_a_credential` in
+ * `src-tauri/src/proxy/mod.rs`, which a console-side check cannot be a
+ * substitute for, since anything invoking `oc_connect` directly bypasses this
+ * module entirely. What is under test here is the *other* half: that the
+ * console asks the question before it contacts anything, so the row names the
+ * reason instead of reporting a network fault. The core's refusal arrives as an
+ * IPC rejection that `client.ts` has already flattened into "cannot reach the
+ * company host at …", which is indistinguishable from a host being switched off.
+ */
+describe("a credentialed host on plain http", () => {
+  /** Records whether anything was sent, and answers nothing useful if it was. */
+  class SilentTransport implements Transport {
+    calls = 0;
+    async request(): Promise<never> {
+      this.calls += 1;
+      throw new Error("the host answered nothing");
+    }
+    subscribe(): () => void {
+      throw new Error("no streaming");
+    }
+  }
+
+  const desktop = (present: boolean) => {
+    if (present) (window as unknown as { __TAURI__: unknown }).__TAURI__ = {};
+    else delete (window as unknown as { __TAURI__?: unknown }).__TAURI__;
+  };
+
+  afterEach(() => desktop(false));
+
+  it("is refused before a request is made, by name", async () => {
+    desktop(true);
+    const transport = new SilentTransport();
+    const id = addConnection({
+      baseUrl: "http://192.168.1.20:8080",
+      credential: { kind: "device", ref: "dev-1" },
+      transport,
+    });
+
+    await probe(id);
+
+    const connection = getConnection(id);
+    expect(connection?.status).toBe("down");
+    // The words matter as much as the status: "could not be reached" about a
+    // host that is answering fine sends an operator to debug their network.
+    expect(connection?.error).toContain("not encrypted");
+    // Refused *before* contact, not labelled after it. A credential that
+    // travelled once has already been read.
+    expect(transport.calls).toBe(0);
+  });
+
+  it("does not refuse the same host when nothing is attached", async () => {
+    // The narrow rule, and its whole point: an unencrypted home-lab or staging
+    // box stays readable. Nothing is exposed that a passer-by could not have
+    // asked the host for themselves.
+    desktop(true);
+    const transport = new SilentTransport();
+    const id = addConnection({ baseUrl: "http://192.168.1.20:8080", transport });
+
+    await probe(id);
+
+    // Down because the stub answers nothing, which is the point: it was asked.
+    expect(transport.calls).toBeGreaterThan(0);
+    expect(getConnection(id)?.error).not.toContain("not encrypted");
+  });
+
+  it("permits loopback and https, which is where a credential belongs", async () => {
+    desktop(true);
+    for (const baseUrl of [
+      // The embedded host, on a port that changes every launch and so can
+      // never carry a certificate.
+      "http://127.0.0.1:65364",
+      "http://localhost:8080",
+      "https://acme.example.com",
+    ]) {
+      const transport = new SilentTransport();
+      const id = addConnection({
+        baseUrl,
+        credential: { kind: "device", ref: "dev-1" },
+        transport,
+      });
+      await probe(id);
+      expect(transport.calls, `${baseUrl} must be contacted`).toBeGreaterThan(0);
+      expect(getConnection(id)?.error).not.toContain("not encrypted");
+    }
+  });
+
+  it("leaves the web build alone, where the credential is the browser's", async () => {
+    // A cookie is the browser's to send, with `Secure` and the origin's own
+    // rules doing this job. Narrowing here would refuse the plain-http
+    // deployments `opencompany serve` exists for, on the transport where the
+    // console is not the thing holding the secret.
+    desktop(false);
+    const transport = new SilentTransport();
+    const id = addConnection({
+      baseUrl: "http://192.168.1.20:8080",
+      credential: { kind: "platform", token: "a-bearer" },
+      transport,
+    });
+
+    await probe(id);
+
+    expect(transport.calls).toBeGreaterThan(0);
+    expect(getConnection(id)?.error).not.toContain("not encrypted");
   });
 });

--- a/frontend/test/unit/transport-seam.test.ts
+++ b/frontend/test/unit/transport-seam.test.ts
@@ -13,6 +13,7 @@ import {
   defaultTransport,
   isAddressableBaseUrl,
   isDesktopRuntime,
+  mayCarryACredential,
 } from "@/api/transport";
 import { ApiError } from "@/api/types";
 
@@ -299,5 +300,73 @@ describe("picking a transport", () => {
     // host is neither.
     expect(isAddressableBaseUrl("tauri://localhost")).toBe(false);
     expect(isAddressableBaseUrl("file:///Users/someone/console")).toBe(false);
+  });
+
+  /**
+   * Which hosts may be sent a secret, as opposed to merely reached.
+   *
+   * The console's copy of `may_carry_a_credential` in
+   * `src-tauri/src/proxy/mod.rs`; the Rust one enforces, this one explains. The
+   * two must agree, or the console offers a connection the core will refuse —
+   * which is the shape of the confusion #613 was about, and #731 asked not to
+   * repeat.
+   */
+  it("lets a secret travel over https, or to this machine, and nowhere else", () => {
+    expect(mayCarryACredential("https://acme.example.com")).toBe(true);
+    // Loopback: how the embedded host is reached, on a port that changes every
+    // launch and so can never have a certificate.
+    expect(mayCarryACredential("http://127.0.0.1:65364")).toBe(true);
+    expect(mayCarryACredential("http://127.0.0.2:8080")).toBe(true);
+    expect(mayCarryACredential("http://[::1]:8080")).toBe(true);
+    expect(mayCarryACredential("http://localhost:8080")).toBe(true);
+    expect(mayCarryACredential("http://sub.localhost:8080")).toBe(true);
+
+    // The hosts this exists for. A LAN is precisely where someone else is on
+    // the path, so the private ranges are the target rather than an exception.
+    expect(mayCarryACredential("http://192.168.1.20:8080")).toBe(false);
+    expect(mayCarryACredential("http://10.0.0.4:8080")).toBe(false);
+    expect(mayCarryACredential("http://acme.example.com")).toBe(false);
+    // A name is not an address: either of these is a host someone else's DNS
+    // answers for, and neither is this machine.
+    expect(mayCarryACredential("http://localhost.acme.example.com")).toBe(false);
+    expect(mayCarryACredential("http://127.0.0.1.acme.example.com")).toBe(false);
+    // Not a url, and so not a host to trust with anything.
+    expect(mayCarryACredential("")).toBe(false);
+    expect(mayCarryACredential("acme.example.com")).toBe(false);
+  });
+
+  /**
+   * A shorthand spelling of loopback is still loopback, and nothing else is.
+   *
+   * `URL` normalises `127.1` and `0177.0.0.1` to `127.0.0.1` before this sees
+   * them — asserted because that is the parser's property rather than this
+   * module's, and losing it would silently widen the rule to whatever the
+   * shorthand happens to parse as.
+   */
+  it("reads a host as an address rather than as a string", () => {
+    expect(mayCarryACredential("http://127.1:8080")).toBe(true);
+    expect(mayCarryACredential("http://0177.0.0.1:8080")).toBe(true);
+    expect(mayCarryACredential("http://[::ffff:127.0.0.1]:8080")).toBe(true);
+    // Digits and dots are not an address. `URL` keeps this one as a name, and
+    // a name that is not `localhost` resolves wherever DNS says.
+    expect(mayCarryACredential("http://127.0.0.1.example.com")).toBe(false);
+  });
+
+  /**
+   * The rule does not depend on the runtime, unlike its sibling above.
+   *
+   * `isAddressableBaseUrl` widens in a browser because a browser genuinely can
+   * address its own origin. Nothing equivalent is true here: an unencrypted
+   * wire is unencrypted on either transport. The web build simply does not
+   * consult this — its credential is a cookie, and `Secure` is the browser's
+   * own version of this decision (see `insecurelyCredentialed`).
+   */
+  it("answers the same in a browser as in the desktop", () => {
+    (globalThis as { window?: unknown }).window = {};
+    expect(mayCarryACredential("http://192.168.1.20:8080")).toBe(false);
+    (globalThis as { window?: unknown }).window = {
+      __TAURI__: { invoke: () => Promise.resolve(), Channel: class {} },
+    };
+    expect(mayCarryACredential("http://192.168.1.20:8080")).toBe(false);
   });
 });

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -13,7 +13,9 @@
 use tauri::State;
 use tauri::ipc::Channel;
 
-use crate::proxy::{Connection, Credential, ProxyRequest, ProxyResponse, SharedProxy};
+use crate::proxy::{
+    Connection, Credential, ProxyRequest, ProxyResponse, SharedProxy, may_carry_a_credential,
+};
 
 /// What the console needs to construct a connection record.
 #[derive(Debug, serde::Serialize)]
@@ -141,29 +143,38 @@ struct ClaimedDevice {
     expires_at_millis: u64,
 }
 
-/// Redeems a pairing code, keeping the session token out of the webview.
+/// Redeems a pairing code against a host, and returns what it answered.
 ///
-/// The whole flow lives in Rust for one reason: the token exists for exactly
-/// one HTTP response, and the console must not be on the path it takes. So this
-/// command performs the claim, writes the result to the keychain, re-registers
-/// the connection with the resolved credential, and returns only what a person
-/// needs to see — which company, which device, how long it lasts.
+/// Split out of [`oc_pair_device`] so it can be tested at all: a command takes
+/// `State<'_, SharedProxy>`, which needs a Tauri application to construct, and
+/// the module note above says why that matters — logic reachable only by
+/// starting a GUI is logic nothing checks. Everything here is the part with a
+/// rule in it, and the command below is the keychain write and the
+/// re-registration around it.
 ///
-/// Deliberately does its own request rather than going through
-/// `ProxyRegistry::request`: this runs *before* the connection has a credential
-/// worth attaching, and routing it through the proxy would mean a code path
-/// where the claim response body — the one place a raw token appears — passes
-/// through the same machinery that serialises bodies back to the webview.
-#[tauri::command]
-pub async fn oc_pair_device(
-    proxy: State<'_, SharedProxy>,
-    connection_id: String,
-    base_url: String,
-    code: String,
-    label: Option<String>,
-) -> Result<PairedDevice, String> {
+/// **The one exchange in which a session token is created rather than
+/// replayed.** The pairing code goes out in the request and the token comes
+/// back in the response body, so this is where an unencrypted wire costs the
+/// most — and it is not covered by `ProxyRegistry::upsert`, because it never
+/// goes through the registry (#731).
+async fn claim(base_url: &str, code: &str, label: Option<&str>) -> Result<ClaimedDevice, String> {
+    if !may_carry_a_credential(base_url) {
+        // The console shows this verbatim (`device-pairing.tsx`), so it is
+        // written for the person reading it rather than for a log.
+        return Err(format!(
+            "{base_url} is not encrypted, so pairing would send this device's session in the clear. Use https, or a host on this machine."
+        ));
+    }
     let base = base_url.trim_end_matches('/');
-    let response = reqwest::Client::new()
+    let response = reqwest::Client::builder()
+        // As `ProxyRegistry`'s client does, and here for a sharper reason: the
+        // default policy follows up to ten redirects, and a 307 from an https
+        // base to an http one re-sends this request — pairing code and all —
+        // over the wire the check above just refused. A check on the first url
+        // is worth nothing if the client will walk to a second.
+        .redirect(reqwest::redirect::Policy::none())
+        .build()
+        .map_err(|error| error.to_string())?
         .post(format!("{base}/api/v1/devices/claim"))
         .json(&serde_json::json!({ "code": code, "label": label }))
         .send()
@@ -183,7 +194,37 @@ pub async fn oc_pair_device(
         return Err(message);
     }
 
-    let claimed: ClaimedDevice = response.json().await.map_err(|error| error.to_string())?;
+    response.json().await.map_err(|error| error.to_string())
+}
+
+/// Redeems a pairing code, keeping the session token out of the webview.
+///
+/// The whole flow lives in Rust for one reason: the token exists for exactly
+/// one HTTP response, and the console must not be on the path it takes. So this
+/// command performs the claim, writes the result to the keychain, re-registers
+/// the connection with the resolved credential, and returns only what a person
+/// needs to see — which company, which device, how long it lasts.
+///
+/// Deliberately does its own request rather than going through
+/// `ProxyRegistry::request`: this runs *before* the connection has a credential
+/// worth attaching, and routing it through the proxy would mean a code path
+/// where the claim response body — the one place a raw token appears — passes
+/// through the same machinery that serialises bodies back to the webview.
+///
+/// Which is also why the transport rule has to be repeated here. Doing its own
+/// request means doing its own checking: the registry never sees this url, so
+/// `upsert`'s refusal does not cover the one exchange where the token is not
+/// merely replayed but *handed over* — the code goes out in the request and the
+/// session comes back in the response, both in the clear on a plain-HTTP host.
+#[tauri::command]
+pub async fn oc_pair_device(
+    proxy: State<'_, SharedProxy>,
+    connection_id: String,
+    base_url: String,
+    code: String,
+    label: Option<String>,
+) -> Result<PairedDevice, String> {
+    let claimed = claim(&base_url, &code, label.as_deref()).await?;
     // `<company>.<token>` is the header carrier's form, and the only form
     // anything downstream needs.
     crate::keychain::remember_device(
@@ -268,6 +309,9 @@ pub fn oc_embedded(state: State<'_, crate::AppHandleState>) -> Option<EmbeddedIn
 
 #[cfg(test)]
 mod test {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
     use super::*;
 
     /// The guarantee the console cannot make about itself.
@@ -292,5 +336,103 @@ mod test {
             "pairing must answer with these three fields and nothing else"
         );
         assert!(!wire.to_string().to_lowercase().contains("token"));
+    }
+
+    /// A one-shot host that answers every request with `head`, then closes.
+    ///
+    /// Returns its base url and a handle that says whether anything ever
+    /// connected — which is the assertion for a refusal that must happen
+    /// *before* the wire, not on the answer that comes back over it.
+    async fn host(head: &'static str) -> (String, Arc<AtomicBool>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let reached = Arc::new(AtomicBool::new(false));
+        let flag = reached.clone();
+        tokio::spawn(async move {
+            while let Ok((mut socket, _)) = listener.accept().await {
+                flag.store(true, Ordering::SeqCst);
+                use tokio::io::AsyncWriteExt as _;
+                let _ = socket.write_all(head.as_bytes()).await;
+                let _ = socket.shutdown().await;
+            }
+        });
+        (format!("http://{address}"), reached)
+    }
+
+    /// The claim is refused before a socket is opened, not after an answer.
+    ///
+    /// A token that travelled once has been read; there is no recovering from
+    /// it by rejecting the response. So this asserts on the connection, not on
+    /// the `Err` — the message alone would pass on a version that sent the
+    /// pairing code first and complained afterwards (#731).
+    #[tokio::test]
+    async fn pairing_over_an_unencrypted_remote_host_sends_nothing() {
+        // A real listener, addressed by a name that is not loopback. The
+        // resolver never runs, because the refusal comes first — which is the
+        // point.
+        let (_, reached) = host("HTTP/1.1 200 OK\r\ncontent-length: 0\r\n\r\n").await;
+        for base in [
+            "http://192.168.1.20:8080",
+            "http://acme.example.com",
+            "http://10.0.0.4:8080",
+        ] {
+            // `let else` rather than `expect_err`, which would need
+            // `ClaimedDevice: Debug` — and a `token` field behind a `{:?}` is
+            // the thing the type is shaped to prevent.
+            let Err(error) = claim(base, "code-123", None).await else {
+                panic!("{base} must not be paired with");
+            };
+            assert!(
+                error.contains("not encrypted"),
+                "{base} must be refused for the reason it is refused: {error}"
+            );
+        }
+        assert!(
+            !reached.load(Ordering::SeqCst),
+            "nothing may be sent to a host the rule refuses"
+        );
+    }
+
+    /// Loopback still pairs — the embedded host is reached no other way.
+    #[tokio::test]
+    async fn pairing_with_a_host_on_this_machine_still_works() {
+        let body = r#"{"token":"t","company":"acme","deviceId":"dev-1","expiresAtMillis":1}"#;
+        let head: &'static str = Box::leak(
+            format!(
+                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{body}",
+                body.len()
+            )
+            .into_boxed_str(),
+        );
+        let (base, reached) = host(head).await;
+
+        let claimed = claim(&base, "code-123", Some("a laptop"))
+            .await
+            .expect("a loopback host pairs");
+
+        assert!(reached.load(Ordering::SeqCst));
+        assert_eq!(claimed.company, "acme");
+        assert_eq!(claimed.device_id, "dev-1");
+    }
+
+    /// A redirect is not followed, so an https base cannot be walked to http.
+    ///
+    /// `reqwest`'s default policy follows up to ten, and a 307 re-sends the
+    /// body — so a host answering `307 → http://…` would put the pairing code
+    /// on exactly the wire the check above refuses, having passed it. Checking
+    /// the first url is worth nothing if the client will walk to a second.
+    #[tokio::test]
+    async fn a_redirect_away_from_the_checked_host_is_not_followed() {
+        let (base, _) = host(
+            "HTTP/1.1 307 Temporary Redirect\r\nlocation: http://192.168.1.20:8080/api/v1/devices/claim\r\ncontent-length: 0\r\n\r\n",
+        )
+        .await;
+
+        let Err(error) = claim(&base, "code-123", None).await else {
+            panic!("a redirect is an answer, not a detour to follow");
+        };
+        // The host's status, passed through — which is what "not followed"
+        // looks like from here.
+        assert!(error.contains("307"), "{error}");
     }
 }

--- a/src-tauri/src/proxy/mod.rs
+++ b/src-tauri/src/proxy/mod.rs
@@ -58,6 +58,18 @@ pub enum Credential {
     Platform(String),
 }
 
+impl Credential {
+    /// Whether a request for this connection carries a secret.
+    ///
+    /// The transport rule below turns on this and nothing else: reading a host
+    /// over plain HTTP exposes what a passer-by could have asked for
+    /// themselves, and attaching a credential to the same request exposes the
+    /// one thing they could not.
+    fn is_present(&self) -> bool {
+        !matches!(self, Credential::None)
+    }
+}
+
 /// One host this client is connected to.
 #[derive(Clone, Debug)]
 pub struct Connection {
@@ -103,6 +115,16 @@ pub enum ProxyError {
     UnknownConnection(ConnectionId),
     #[error("not an absolute host url: {0:?}")]
     UnusableBaseUrl(String),
+    /// A credentialed connection to a plain-HTTP host that is not this machine.
+    ///
+    /// Separate from [`Self::UnusableBaseUrl`] because the two are opposite
+    /// problems wearing one message. That one means the url addresses nothing;
+    /// this one means it addresses a host perfectly well, over a wire anyone on
+    /// the path can read. An operator told "could not be reached" about the
+    /// second goes looking at their network, which is working (#613's
+    /// complaint, one rung up).
+    #[error("this host is not encrypted, so a credential cannot be sent to it: {0:?}")]
+    InsecureBaseUrl(String),
     #[error("{0}")]
     Transport(String),
 }
@@ -180,6 +202,14 @@ impl ProxyRegistry {
             .is_ok_and(|url| matches!(url.scheme(), "http" | "https") && url.has_host());
         if !addressable {
             return Err(ProxyError::UnusableBaseUrl(connection.base_url));
+        }
+        // Checked here rather than at `request`, for the same reason the
+        // addressability test is: registration is the last moment the caller is
+        // still on the stack and can be told why. A per-request check would
+        // refuse each call individually, and the console renders that as a host
+        // that cannot be reached.
+        if connection.credential.is_present() && !may_carry_a_credential(&connection.base_url) {
+            return Err(ProxyError::InsecureBaseUrl(connection.base_url));
         }
         self.connections.write().await.insert(id, connection);
         Ok(())
@@ -360,6 +390,58 @@ const RESERVED_HEADERS: [&str; 4] = [
     "cookie",
     "proxy-authorization",
 ];
+
+/// Whether a secret may be sent to `base_url`.
+///
+/// **HTTPS, or a host that is this machine.** Plain HTTP to anything else puts
+/// the credential in front of every device on the path — and for the desktop
+/// that credential is a device session, which is a person's standing authority
+/// on a company rather than one request's.
+///
+/// Loopback is the exception and not a grudging one: `http://127.0.0.1:<port>`
+/// is how the embedded host is reached (`embedded.rs` binds `127.0.0.1:0`),
+/// those bytes never reach a network interface, and a certificate for an
+/// ephemeral port is not a thing that can exist. `localhost` is admitted with
+/// it because that is what a developer types into `?api=`; RFC 6761 reserves
+/// the name for exactly this.
+///
+/// Deliberately **not** an allowlist of private ranges. `10.0.0.0/8` and
+/// `192.168.0.0/16` are the networks this is meant to protect against — an
+/// office LAN is precisely where someone else is on the path — so treating
+/// them as trusted would invert the rule while looking like a refinement of it.
+///
+/// Public because the pairing claim in `commands.rs` needs the same answer and
+/// does not go through this registry. Two copies of one rule is how the console
+/// and the core came to disagree about addressability; one function is the fix.
+pub fn may_carry_a_credential(base_url: &str) -> bool {
+    let Ok(url) = reqwest::Url::parse(base_url) else {
+        return false;
+    };
+    url.scheme() == "https" || addresses_this_machine(&url)
+}
+
+/// Whether this url names the machine it is being requested from.
+///
+/// Reads the host as text rather than matching on `url::Host`, so this module
+/// does not take a direct dependency on `url` for one match arm; the `url`
+/// crate already lowercased and normalised it on the way in.
+fn addresses_this_machine(url: &reqwest::Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+    // `host_str` brackets an IPv6 literal, as it appears in the url.
+    let bare = host.trim_start_matches('[').trim_end_matches(']');
+    if let Ok(address) = bare.parse::<std::net::IpAddr>() {
+        // Canonicalised so that `::ffff:127.0.0.1` — which routes to loopback —
+        // is not refused for being spelled as IPv6. `to_canonical` leaves an
+        // ordinary v4 address alone.
+        return address.to_canonical().is_loopback();
+    }
+    // A name, not an address. Only the one RFC 6761 guarantees resolves to
+    // loopback, and the subdomains it guarantees with it — anything else is a
+    // DNS answer this process has not seen yet and cannot vouch for.
+    bare == "localhost" || bare.ends_with(".localhost")
+}
 
 /// Attaches whatever this connection authenticates with.
 fn apply_credential(
@@ -587,6 +669,137 @@ mod test {
         }
         // Refused means not registered, rather than registered and broken.
         assert!(registry.ids().await.is_empty());
+    }
+
+    /// A session must not be handed to a host anyone on the path can read.
+    ///
+    /// Every request for a connection carries `apply_credential`'s header, so a
+    /// device session registered against a plain-HTTP LAN address is on the
+    /// wire in the clear on every poll and for the whole life of the event
+    /// stream — and unlike a leaked request body, it is replayable (#731).
+    #[tokio::test]
+    async fn a_credential_is_refused_on_an_unencrypted_remote_host() {
+        let registry = ProxyRegistry::new();
+        for base in [
+            "http://192.168.1.20:8080",
+            "http://acme.example.com",
+            // Not loopback despite the name. A host may call itself whatever it
+            // likes, and only the reserved name resolves here by rule.
+            "http://localhost.acme.example.com",
+            // The private ranges are the ones this exists for, not exceptions
+            // to it: an office LAN is exactly where someone else is on the path.
+            "http://10.0.0.4:8080",
+        ] {
+            for credential in [
+                Credential::Device("acme.the-session".into()),
+                Credential::Platform("a-bearer".into()),
+            ] {
+                let error = registry
+                    .upsert(
+                        "primary".into(),
+                        Connection {
+                            base_url: base.into(),
+                            credential,
+                        },
+                    )
+                    .await
+                    .unwrap_err();
+                assert!(
+                    error.to_string().contains("this host is not encrypted"),
+                    "{base:?} must be refused for the reason it is refused: {error}"
+                );
+            }
+        }
+        assert!(registry.ids().await.is_empty());
+    }
+
+    /// The three ways a connection stays legitimate under that rule.
+    #[tokio::test]
+    async fn https_loopback_and_anonymous_http_all_still_register() {
+        let registry = ProxyRegistry::new();
+        let cases = [
+            // HTTPS carries a credential anywhere.
+            (
+                "https",
+                "https://acme.example.com",
+                Credential::Device("acme.s".into()),
+            ),
+            // Loopback is how the embedded host is reached, and it is the one
+            // address a certificate cannot be issued for — `embedded.rs` binds
+            // `127.0.0.1:0`, so the port is different every launch.
+            (
+                "v4",
+                "http://127.0.0.1:65364",
+                Credential::Device("acme.s".into()),
+            ),
+            // The rest of `127.0.0.0/8`, which a second local host may bind.
+            (
+                "v4-block",
+                "http://127.0.0.2:8080",
+                Credential::Device("acme.s".into()),
+            ),
+            (
+                "v6",
+                "http://[::1]:8080",
+                Credential::Device("acme.s".into()),
+            ),
+            // What a developer types into `?api=`.
+            (
+                "name",
+                "http://localhost:8080",
+                Credential::Device("acme.s".into()),
+            ),
+            // Anonymous HTTP anywhere: nothing is exposed that a passer-by
+            // could not have asked the host for themselves. This is the case
+            // the narrow rule exists to keep working — a home-lab or staging
+            // box without a certificate stays readable.
+            ("anonymous", "http://192.168.1.20:8080", Credential::None),
+        ];
+        for (id, base, credential) in cases {
+            registry
+                .upsert(
+                    id.into(),
+                    Connection {
+                        base_url: base.into(),
+                        credential,
+                    },
+                )
+                .await
+                .unwrap_or_else(|error| panic!("{base:?} must still register: {error}"));
+        }
+        assert_eq!(registry.ids().await.len(), 6);
+    }
+
+    /// The shorthand spellings of a loopback address, and of everything else.
+    ///
+    /// `Url::parse` normalises `127.1` and `0177.0.0.1` to `127.0.0.1`, so a
+    /// textual comparison cannot be walked past — asserted here because that is
+    /// a property of the parser rather than of this module, and a change to it
+    /// would otherwise turn into a silently widened rule.
+    #[test]
+    fn the_loopback_test_reads_addresses_rather_than_strings() {
+        for allowed in [
+            "http://127.1:8080",
+            "http://0177.0.0.1:8080",
+            "http://[::ffff:127.0.0.1]:8080",
+            "http://sub.localhost:8080",
+            "https://acme.example.com",
+        ] {
+            assert!(may_carry_a_credential(allowed), "{allowed} must be allowed");
+        }
+        for refused in [
+            "http://192.168.1.20:8080",
+            "http://127.0.0.1.acme.example.com",
+            "http://acme.example.com",
+            // Not a url at all, and not addressable either; `upsert` refuses it
+            // first, but this must not answer "yes" on its own.
+            "not-a-url",
+        ] {
+            assert!(
+                !may_carry_a_credential(refused),
+                "{refused} must be refused"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #731.

## The rule

**A credential travels over HTTPS, or to a host on this machine, and nowhere else.** Gated on the credential rather than on the scheme — option (2) from the issue — so an anonymous connection to an unencrypted LAN, home-lab or staging host still registers and still reads. Nothing is exposed by reading one that a passer-by could not have asked the host for themselves; the exposure is entirely in the credential.

Loopback is exempt because `http://127.0.0.1:<port>` is how the embedded host is reached, on an ephemeral port that can never carry a certificate. `localhost` and its subdomains come with it, per RFC 6761. The private ranges are deliberately **not** exempt — an office LAN is precisely where someone else is on the path.

## What the issue did not account for

Three things turned up while tracing it, and all three are in the diff:

1. **The pairing claim bypasses the proxy entirely, and it is the worse leak.** `oc_pair_device` builds its own client and never touches the registry, so `upsert`'s refusal would not have covered the one exchange in which a session token is *created* rather than replayed — the code goes out in the request, the token comes back in the response body. Its client also used `reqwest`'s default redirect policy: a 307 from an HTTPS base to an HTTP one re-sends the claim, body and all, over the wire the check just refused. Now `Policy::none()`, as `ProxyRegistry`'s client already was.

2. **`isAddressableBaseUrl` is not on the add-host path.** It has two callers — the bootstrap add and restore-time pruning — and the "Add a host" dialog uses neither. It is also the wrong lever here: it must not narrow, or the web build's same-origin discovery breaks. Left unchanged; the console-side twin is the new credential-aware `mayCarryACredential`, kept in the same file beside it.

3. **"The refusal names the reason" needed more than a check.** The core's refusal is discarded three times on the way up — `ProxyErrorWire` drops the transport's words by design, `registerConnection` catches the rejection into `console.error`, and `client.ts` flattens every transport failure into `cannot reach the company host at …`. So `probe` answers the same question console-side and marks the row `down` with the reason before contacting anything.

## Behaviour changes

| Setup | Before | After |
|---|---|---|
| Paired device on `http://<lan>` | session in cleartext on every request | refused, row says why |
| Anonymous `http://<lan>` | works | works, unchanged |
| Pairing against `http://<lan>` | code out and token back in cleartext | refused before a socket opens |
| Loopback `http://127.0.0.1:<port>` | works | works, unchanged |
| Anything on HTTPS | works | works, unchanged |

An existing profile paired over plain HTTP stops connecting and says why, rather than being silently dropped.

## Verification

Beyond the test suites, I ran the leak on a real socket — a capture server bound to this machine's actual LAN address, driven by the same test against pre-fix and post-fix source.

Pre-fix, the token came off the wire verbatim:

```
[wire] REGISTERED a credentialed connection to http://192.168.29.56:55404
GET /api/v1/companies HTTP/1.1
x-opencompany-session: acme.SUPER-SECRET-SESSION-TOKEN
[wire] VERDICT: connections=true leaked_secret=true
```

Post-fix, nothing connected at all:

```
[wire] refused at registration: this host is not encrypted, so a credential cannot be sent to it
[wire] VERDICT: connections=false leaked_secret=false
```

Against a live `opencompany serve`, `claim()` reached the host over loopback and was refused at the same host's LAN address. The real claim endpoint answers directly with no redirect, so `Policy::none()` costs nothing.

Commands run locally:

- `cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` in `src-tauri/` — 71 lib + 12 acp + 7 proxy_parity, all pass
- `npm test` — 469 pass across 41 files
- `npm run typecheck`, `typecheck:unit`, `typecheck:e2e` — clean
- `npm run e2e` — 108 pass, 8 skipped (live-brain gated), 0 fail

`desktop-connections.spec.ts` and `desktop-embedded-identity.spec.ts` stay green, with two tests added: the rejection path, and the anonymous-HTTP path this option keeps working. I checked the first has teeth by neutering the `probe` guard and watching it fail.

## Unrelated bug found while testing

Not fixed here, and worth its own issue: **desktop device pairing has never worked against a real host.** `oc_pair_device` posts to `{base}/api/v1/devices/claim`, which has no route — the real one is company-scoped (`src/server/users/devices.rs:97` via `public_scoped`).

```
POST /api/v1/devices/claim         -> 404 Not Found
POST /api/v1/company/devices/claim -> 400 {"error":"invalid or expired pairing code"}
```

Present on `main` and independent of this change, which touches the guard and the client builder, not the path. Left out because the desktop has no company id at pairing time, so choosing between the single-company alias and the scoped form is a real decision rather than a typo fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Credentialed connections now require HTTPS or a loopback address.
  * Remote HTTP connections carrying credentials are blocked before network requests.
  * Redirects are disabled during device pairing to prevent unsafe credential transport.
  * Anonymous HTTP connections remain available where permitted.

* **Bug Fixes**
  * Improved validation for localhost, IPv4, and IPv6 loopback addresses.
  * Added clear errors when a connection or pairing attempt uses an unsafe transport.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->