### PR TITLE
test(repo_manager): isolate the git fixtures from the developer's environment (#748)

### DIFF
--- a/src/runtime/repo_manager/test.rs
+++ b/src/runtime/repo_manager/test.rs
@@ -156,17 +156,62 @@ impl Drop for Scratch {
     }
 }
 
-/// Runs git in `cwd`, panicking with its stderr on failure.
+/// Runs git in `cwd`, panicking with its exit status and output on failure.
+///
+/// **Starts from an empty environment**, the same posture [`super::git::run`]
+/// takes for a host-side fetch (see its `env_clear` and the module header).
+/// These fixtures inherited the developer's whole environment, so every one of
+/// these tests read that machine's global git config — they were strictly less
+/// isolated than the code they exercise. On the machine where issue #748's
+/// flake was recorded, that config supplied both a `core.hooksPath` (the exact
+/// setting #727 showed silently disables hooks repo-wide) and the git-lfs
+/// filter triplet, so each fixture checkout also span up a `git-lfs
+/// filter-process` child. Under a full-suite run that is many such children at
+/// once, which fits #748's signature — a failure carrying *empty* stderr — far
+/// better than any git refusal does.
+///
+/// Treat that as the motivation, not a proven cause: what is verified is that
+/// the fixtures no longer read any of it, and that the flake did not recur in
+/// five consecutive full-suite runs against a baseline of three failures in
+/// four. The reason to make the change regardless is that a fixture reading the
+/// developer's config is testing the developer.
+///
+/// `PATH` is the one thing carried over, because `git` itself has to be
+/// findable. Everything else is supplied here:
+///
+/// * `GIT_CONFIG_NOSYSTEM` / `GIT_CONFIG_GLOBAL=/dev/null` — no system or user
+///   config, so no `core.hooksPath`, no `init.templateDir`, no alias.
+/// * `HOME` inside the scratch tree — anything that still resolves a home finds
+///   an empty one rather than the developer's.
+/// * `GIT_TERMINAL_PROMPT=0` — a fixture must fail, never block on a prompt.
+/// * A fixed identity, so a machine without `user.email` set is not a failure.
+///
+/// The panic reports the **status** as well as both streams: the failures in
+/// #748 arrived with empty stderr, which says nothing on its own but is exactly
+/// what a signal-killed child looks like — `status` is what distinguishes
+/// "git refused" from "git was killed".
 fn git_at(cwd: &Path, args: &[&str]) -> String {
-    let out = std::process::Command::new("git")
-        .current_dir(cwd)
-        .args(args)
-        .output()
-        .unwrap_or_else(|e| panic!("git {args:?}: {e}"));
+    let mut cmd = std::process::Command::new("git");
+    cmd.current_dir(cwd).args(args);
+    cmd.env_clear();
+    if let Some(path) = std::env::var_os("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd.env("HOME", cwd);
+    cmd.env("GIT_CONFIG_NOSYSTEM", "1");
+    cmd.env("GIT_CONFIG_GLOBAL", "/dev/null");
+    cmd.env("GIT_TERMINAL_PROMPT", "0");
+    cmd.env("GIT_AUTHOR_NAME", "oc-test");
+    cmd.env("GIT_AUTHOR_EMAIL", "oc-test@example.invalid");
+    cmd.env("GIT_COMMITTER_NAME", "oc-test");
+    cmd.env("GIT_COMMITTER_EMAIL", "oc-test@example.invalid");
+    let out = cmd.output().unwrap_or_else(|e| panic!("git {args:?}: {e}"));
     assert!(
         out.status.success(),
-        "git {args:?} failed: {}",
-        String::from_utf8_lossy(&out.stderr)
+        "git {args:?} failed ({}): stderr={} stdout={}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr).trim(),
+        String::from_utf8_lossy(&out.stdout).trim()
     );
     String::from_utf8_lossy(&out.stdout).trim().to_string()
 }


### PR DESCRIPTION
## Summary

The `repo_manager` fixtures were **less isolated than the production code they
test**, which is the shape behind the intermittent failures in #748.

`git::run` — the host-side fetch these tests stand in for — clears the
environment on purpose and rebuilds a minimal one (`GIT_CONFIG_NOSYSTEM`,
`GIT_CONFIG_GLOBAL=/dev/null`, a scoped `HOME`, `GIT_TERMINAL_PROMPT=0`), under
the module header's own "start from nothing, then add back only what git
needs". The fixture helper `git_at` did none of that: it inherited the whole
ambient environment, so every one of these tests read the developer's global
git config.

This takes the same posture in the fixtures. `PATH` is the one thing carried
over, because `git` itself has to be findable; everything else is supplied
explicitly, including a fixed author/committer identity so a machine with no
`user.email` configured is not a test failure.

It also reports the **exit status** alongside both streams. That is the useful
part of the diagnostic, and it corrects my own suggestion in #748: I wrote
there that the helper "discards git's stderr", which was wrong — it already
printed stderr. The failures arrive with stderr *empty*, and status is what
separates "git refused" from "git was killed".

### On the cause

Worth stating plainly, because the evidence is uneven.

On the machine where the flake was recorded, the inherited global config
supplied both a `core.hooksPath` (the setting #727 showed silently disables
hooks repo-wide) and the git-lfs filter triplet — so every fixture checkout
also spawned a `git-lfs filter-process` child. Under a full-suite run that is
many such children at once, which fits the observed signature (a failure
carrying *empty* stderr) better than any git refusal does.

That is the motivation, not a proven cause. What is verified:

- The fixtures no longer read any of it. Probed directly — inherited
  environment resolves `core.hooksPath` and `filter.lfs.process`; the cleared
  environment resolves neither (`rc=1` for both).
- The flake did not recur in **five consecutive full-suite runs**, against a
  recorded baseline of **three failures across four runs** (0 / 2 / 0 / 1).

Five runs is statistical, not a repro, and I am not claiming more than that.
The change stands on its own regardless: a fixture that reads the developer's
config is testing the developer.

## API Or Behavior Changes

None. Test-only — a single fixture helper in `src/runtime/repo_manager/test.rs`.
No production path, no route, no public type.

## Tests

Run locally in this worktree:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — 2223 passed, 0 failed
- [x] `cargo test --features openhuman,mcp,telegram` — 3336 passed, 0 failed
- [x] `cargo test --lib runtime::repo_manager` — 37 passed, 0 failed
- [x] Flake measurement — 5 consecutive full-suite runs, 2223 passed / 0 failed each

No new test is added: the change makes the existing 37 `repo_manager` tests
mean what they were always meant to mean. There is no assertion to write for
"the fixture no longer reads your global config" that would not just be a
restatement of the `env_clear` call itself.

Note that `--features openhuman,mcp,telegram` is built by no CI lane, so that
run is local-only.

## Documentation

The helper's doc comment carries the reasoning — why the environment is
cleared, what each variable is for, why `PATH` survives, and the honest limits
of the flake evidence. No spec or module doc changes: nothing about the
runtime's behavior changed.

## Related

Closes #748
