### PR TITLE
docs(spec): land #702 review-doc fixes that missed the merge

### DIFF
--- a/docs/spec/runtime/api-graphql.md
+++ b/docs/spec/runtime/api-graphql.md
@@ -7,12 +7,15 @@ Split out of [`api.md`](api.md), which was over the repository's 500-line ceilin
 ## Read plane — GraphQL (`/graphql`)
 
 Every console **read** is served by a single async-graphql query surface at
-`POST /graphql` (with a `GET /graphql` GraphiQL explorer in development) — the
-sole exceptions being the two inbox `GET`s and the two workspace `GET`s above,
-which exist because the console ships no GraphQL client and those two views need
-a reachable read (issues #173 and #177 respectively). The schema is
-query-only — REST otherwise owns writes — and is **built once at startup** and
-stored on `AppState`; each request injects its resolved `GqlAuth` principal.
+`POST /graphql` (with a `GET /graphql` GraphiQL explorer in development). The
+REST **read exceptions** are the console reads that ship over REST instead —
+the two inbox `GET`s and the three workspace `GET`s, the task export, the
+skill-registry browse, the agent detail `GET`, the policy read, and the
+credential status `GET` — each because the console ships no GraphQL client and
+that view needs a reachable read (issues #173, #177, #607, #352, #264, #562;
+see the [write plane](api-write-plane.md)). The schema is query-only — REST
+otherwise owns writes — and is **built once at startup** and stored on
+`AppState`; each request injects its resolved `GqlAuth` principal.
 
 The schema is rooted at a **`Company` aggregation object** so a view fetches
 everything it needs in one round trip; the only top-level queries are
@@ -23,8 +26,10 @@ single-company mode), and `skillRegistry` (the unscoped shared library). Under
 `usage`, `finances`, `connections`, `domain`, and `smtp`. The authoritative
 contract is the SDL snapshot at
 [`src/server/graphql/schema.graphql`](../../../src/server/graphql/schema.graphql)
-(`graphql::sdl()` regenerates it). Mutations and subscriptions are out of
-scope; SSE (`/chat` streaming, the `/events` work feed) is not yet wired.
+(`graphql::sdl()` regenerates it). GraphQL mutations and subscriptions are out
+of scope — streaming is wired over REST instead: `/chat` (below, the one
+conversational surface) and the `/events` work feed
+([events.md](events.md)).
 
 - **`/chat`** enqueues an `OperatorMessage` event and streams the resulting
   cycle's channel responses over SSE. One conversational surface, one voice:

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -10,9 +10,14 @@ That file is the map of the API surface; this one is the write routes in detail.
 The console's writes are a REST router family under `src/server/ops/`, each
 route registered under **both** scope forms (`…/companies/{id}/…` and the
 `…/company/…` prosumer alias) by the `scoped` helper. These are the mutations,
-plus **two deliberate read exceptions**: the two inbox `GET`s at the end of the
-block below, and the two workspace `GET`s (#177). Every other console read goes
-through GraphQL (see the read plane below). Anything a build doesn't serve
+plus a deliberate set of **read exceptions** — reads the console must reach over
+REST because it ships no GraphQL client: the two inbox `GET`s and the three
+workspace `GET`s (tree, file, `search`), the task export
+(`GET …/tasks/{taskId}/export`), the skill-registry browse
+(`GET …/skills/registry`), the agent detail (`GET …/team/{agentId}`), the policy
+read (`GET …/policy`), and the credential status `GET` — every one detailed
+below or in the credential section. Every other console read goes through
+GraphQL (see the [read plane](api-graphql.md)). Anything a build doesn't serve
 `404`s — the console treats that as "not wired yet".
 
 ```text
@@ -62,9 +67,10 @@ reflects that store too. Messages come back in append order; the console sorts
 them newest-first. The GraphQL resolver stays the canonical read for any client
 that does speak GraphQL — these routes duplicate it, they do not replace it.
 
-The two workspace `GET`s are the same story one issue later (#177): the console
-had no reachable workspace read either, so the Workspace tab persisted to
-`localStorage` and the operator and the agents looked at two different trees —
+The two original workspace `GET`s (#177) are the same story one issue later:
+the console had no reachable workspace read either, so the Workspace tab
+persisted to `localStorage` and the operator and the agents looked at two
+different trees —
 a note written by an agent through its `workspace_*` tools (#237) was invisible
 to the operator, and vice versa. They are REST twins of `Company.workspaceTree`
 / `workspaceFile`, differing only in timestamp shape (epoch millis, matching
@@ -75,8 +81,9 @@ only — bodies are fetched per file, so a navigation read does not grow with th
 size of the workspace. Reading a folder id as a file is a `404`, never an empty
 note.
 
-`GET …/workspace/search?q=…` (#607) answers which notes mention a phrase, so
-discovery costs one call rather than a listing plus one read per candidate.
+`GET …/workspace/search?q=…` (#607) is the **third workspace read**: it answers
+which notes mention a phrase, so discovery costs one call rather than a listing
+plus one read per candidate.
 Matching is a plain **case-insensitive substring** over node names and text
 bodies — no tokenising, no stemming, no ranking — which is the only definition
 that answers identically on all three storage backends, and it is defined once
@@ -108,8 +115,9 @@ take it (#671), and sqlite and mongodb both accept such a name. An ambiguous
 root is a `409`, not a guess. Each removal announces its own
 `WorkspaceChanged{removed}` (#327); a second run removes nothing.
 
-Both workspace `GET`s — and the `POST` / `PATCH` node bodies — carry
-`createdBy` and `updatedBy` (#326), each `{"kind":"seed"|"operator"|"agent",
+All three workspace `GET`s — tree, file and `search` — and the `POST` / `PATCH`
+node bodies carry `createdBy` and `updatedBy` (#326), each
+`{"kind":"seed"|"operator"|"agent",
 "id"?}` with `id` present exactly when `kind` is `agent`. `createdBy` is fixed
 at creation; `updatedBy` follows content writes only, so an operator rename does
 not repaint an agent's authorship. The console renders the creator as a badge

--- a/docs/spec/runtime/memory-engine.md
+++ b/docs/spec/runtime/memory-engine.md
@@ -32,13 +32,17 @@ aborts boot, same as the storage backend.
 With the `tinycortex` feature and a data directory present, the overlay is
 `EngineCortex` (`src/store/tinycortex_engine.rs`): the OpenHuman `tinycortex`
 engine crate running **inside the pod** with durable local storage. Each company
-gets its own workspace at `<OPENCOMPANY_DATA_DIR>/memory/<company>/`, and the
-engine's canonical per-workspace SQLite database (opened + migrated through the
-crate's own shared connection) holds that company's traces, task results, and
-context chunks. The engine never makes a network call. When no data directory is
-present (tests, no-data-dir callers) the overlay falls back to the offline
-in-memory backend (`InMemoryCortex`), which is also the compiled fallback when a
-company workspace cannot be opened.
+gets its own workspace at `<OPENCOMPANY_DATA_DIR>/memory/<workspace-name>/` — the
+path-safe, stable name derived from the full company ID (`EngineCortex::workspace_name`
+sanitizes the id and appends a stable hash), the same `<workspace>` the config
+examples below render — and the engine's canonical per-workspace SQLite database
+(opened + migrated through the crate's own shared connection) holds that
+company's traces, task results, and context chunks. The local workspace
+persistence layer does not make network calls; a configured hosted embeddings
+backend may make outbound requests during embedding and recall. When no data
+directory is present (tests, no-data-dir callers) the overlay selects the
+offline in-memory backend (`InMemoryCortex`). An error opening a company
+workspace propagates to the caller rather than silently switching to in-memory.
 
 **Vector-first recall, with a loud lexical/recency fallback (188c2).** This
 slice builds the engine's `MemoryConfig` directly with `embedding.strict =
@@ -64,7 +68,8 @@ ingest/retrieval primitives, with the vector index layered beside it. Wiring
 the crate's own retrieval-scorer `Embedder` / summary-tree seal path (the
 hard-768-dim path, plus a full-corpus reconcile beyond the bounded backfill) is
 deferred to #198 — this slice injects only the `VectorStore` store+search
-compute, which is dimension-agnostic and runs at the backend's native 1024.
+compute, which is dimension-agnostic and runs at the configured embedding
+dimension (1024 by default).
 
 #### Embeddings configuration
 

--- a/docs/spec/runtime/workspace-layout.md
+++ b/docs/spec/runtime/workspace-layout.md
@@ -23,9 +23,15 @@ locations instead of ad-hoc paths:
   files/       ← instance-shared files (exports, attachments)
   logs/        ← instance logs
   tmp/         ← ephemeral scratch, cleared on startup by default
-  harness/     ← agent + workflow sandboxes (see below; minted on demand)
   openhuman/   ← the embedded OpenHuman runtime's own root (see below)
 ```
+
+Two runtime trees are **not** `DataLayout` directories and are absent from this
+tree: the agent + workflow sandboxes (`<home>/harness`, see below) and the MCP
+registry (`<home>/mcp`). They hang off the resolved *home*, which coincides with
+this root whenever `<home>` and `OPENCOMPANY_DATA_DIR` agree — as they do by
+default and in the hosted shape — and splits from it when `--home` diverges
+(see “`--home` moves the bundles and the runtime trees” below).
 
 Per-company state (each bundle's own `memory/`/`context/`) lives under
 `companies/<slug>/`; the top-level `memory/`/`store/`/`files/` are the shared,
@@ -39,8 +45,10 @@ per-tenant path prefix is needed.
 
 The vendored OpenHuman runtime resolves its own workspace, and its default is a
 subdirectory of the user's **home directory** — which in a tenant container is
-the read-only root filesystem. Its durable agent journal
-(`{workspace}/tinyagents_store/`) therefore failed to create its store root on
+the read-only root filesystem. Its durable agent journal lives at
+`<root>/workspace/tinyagents_store/`, where `<root>` is the value handed to it
+as `OPENHUMAN_WORKSPACE` and the vendored resolver nests a `workspace/` level
+under that root. It therefore failed to create its store root on
 every append, and the vendored append worker reported that to stderr once per
 event with no dedup or backoff, burying every other line in the container log
 (issue #446).
@@ -127,12 +135,15 @@ exactly the layout above, and exactly `DataLayout::companies_dir()`.
 
 One consequence worth knowing:
 
-- **`--home` moves the bundles but not the workspace.** It places company
-  bundles only; `memory/`, `store/`, `files/`, `logs/` and `tmp/` always follow
-  `OPENCOMPANY_DATA_DIR`. So two hosts isolated by `--home` alone still share one
-  workspace. `serve` prints an operator-visible warning naming both roots
-  whenever they are not aligned. Prefer `OPENCOMPANY_DATA_DIR`, which moves the
-  whole instance. A hosted tenant sets both to the same value
+- **`--home` moves the bundles and the runtime trees, but not the shared
+  workspace.** It places company bundles (`<home>/companies/`) and — since the
+  harness and MCP trees hang off the same resolved home — the agent sandboxes
+  and MCP registry (`<home>/harness`, `<home>/mcp`); `memory/`, `store/`,
+  `files/`, `logs/` and `tmp/` always follow `OPENCOMPANY_DATA_DIR`. So two hosts
+  isolated by `--home` alone still share one workspace. `serve` prints an
+  operator-visible warning naming both roots whenever they are not aligned.
+  Prefer `OPENCOMPANY_DATA_DIR`, which moves the whole instance. A hosted tenant
+  sets both to the same value
   (`docker/entrypoint.sh` passes `--home "$OPENCOMPANY_DATA_DIR"`), so it never
   warns — nor does the local default, whose home and data root are now the same
   path. Passing `--home ~/.opencompany/companies` by hand recreates the legacy


### PR DESCRIPTION
PR #702 split `storage.md` and `api.md` ([`dc4ae0b`](https://github.com/tinyhumansai/opencompany/commit/dc4ae0b)) but merged with its old head, before the documentation corrections tinysweeper and coderabbit flagged were pushed. This follow-up lands those fixes in `main`, verified against the code:

- **workspace-layout.md** — tinysweeper finding: the merged prose said the journal failed at `{workspace}/tinyagents_store/`, which contradicted the concrete path right below it. Now states that the vendored resolver nests a `workspace/` level under `OPENHUMAN_WORKSPACE`, so `<root>/workspace/tinyagents_store/` = `<data-dir>/openhuman/workspace/tinyagents_store/`. Matches `WORKSPACE_SUBDIR`/test in `src/app/journal.rs`.
- **api-write-plane.md** — tinysweeper finding: the intro named "two deliberate read exceptions" while the same file's route table lists far more. Now enumerates the full set (two inbox `GET`s, three workspace `GET`s incl. `search`, task export, skill-registry browse, agent detail, policy read, credential status). One prose spot and the line counts updated accordingly.
- **memory-engine.md** — coderabbit: `<workspace-name>` is now derived from `EngineCortex::workspace_name` (sanitized id + stable hash, matching `src/store/tinycortex_engine.rs`), the no-network-call claim is qualified to "the local workspace persistence layer", and the embedding dimension is stated (1024 by default).
- **api-graphql.md** — coderabbit: explicit link to the REST write plane, and the read-exception set is corrected to reference api-write-plane.md; GraphQL mutations/subscriptions are stated out of scope with streaming wired over REST.

Docs-only change; each file stays under the 500-line cap. Commands run: `git diff upstream/main...HEAD --stat` (4 files, +64/−35).