### PR TITLE
approvals: assert every gated tool reads differently, not just the four (#743)

### DIFF
--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -2128,7 +2128,7 @@ mod tests {
     /// the same file.
     const LANGUAGE_TS: &str = "frontend/src/lib/language.ts";
 
-    /// The keys of one object literal in [`LANGUAGE_TS`].
+    /// One object literal in [`LANGUAGE_TS`], read as `key -> sentence`.
     ///
     /// A line parser rather than the two alternatives, and the reasons are the
     /// same ones that make this a `cargo test` at all:
@@ -2146,7 +2146,22 @@ mod tests {
     /// parser that silently reads nothing turns this test into a green light
     /// for the exact regression it exists to catch — see the vacuity guards in
     /// [`every_consequence_tool_has_a_console_label`].
-    fn label_keys(source: &str, decl: &str) -> Vec<String> {
+    ///
+    /// It returns pairs rather than keys (issue #743) because the distinctness
+    /// half needs the sentences, and one parse feeding both halves is the point:
+    /// this test exists because a hand-maintained restatement of the declared
+    /// set drifts from it, and a second parser over the same file would be that
+    /// same mistake one level down.
+    ///
+    /// Values are taken literally — the text between the first `:` and the
+    /// trailing comma, unquoted. Every entry in both tables is a plain string
+    /// literal on one line today; a template literal or a concatenation would
+    /// arrive here as its own source text and, being unequal to any other
+    /// entry, would pass the distinctness check without asserting anything about
+    /// what an operator reads. That is the one shape to reject rather than
+    /// tolerate, and the `>=` floors below are what would catch a table that
+    /// reshaped into it wholesale.
+    fn label_pairs(source: &str, decl: &str) -> Vec<(String, String)> {
         let mut lines = source.lines();
         let opened = lines.any(|line| {
             let line = line.trim_start();
@@ -2158,19 +2173,27 @@ mod tests {
              renamed or reshaped, update this parser — do not delete the test"
         );
 
-        let mut keys = Vec::new();
+        let mut pairs = Vec::new();
         for line in lines {
             let line = line.trim();
             if line == "};" {
-                return keys;
+                return pairs;
             }
             if line.is_empty() || line.starts_with("//") || line.starts_with('*') {
                 continue;
             }
-            let Some((key, _)) = line.split_once(':') else {
+            let Some((key, value)) = line.split_once(':') else {
                 continue;
             };
-            keys.push(key.trim().trim_matches('"').to_string());
+            pairs.push((
+                key.trim().trim_matches('"').to_string(),
+                value
+                    .trim()
+                    .trim_end_matches(',')
+                    .trim()
+                    .trim_matches('"')
+                    .to_string(),
+            ));
         }
         panic!("`const {decl}` in {LANGUAGE_TS} is never closed by a `}};` line");
     }
@@ -2199,8 +2222,13 @@ mod tests {
             env!("CARGO_MANIFEST_DIR"),
             "/frontend/src/lib/language.ts"
         ));
-        let effects = label_keys(source, "EFFECT_LABELS");
-        let tools = label_keys(source, "TOOL_LABELS");
+        // Read as pairs, not keys: the distinctness half below needs the
+        // sentences. `label_keys` is the same parse, so the two halves cannot
+        // disagree about what the tables hold.
+        let effect_labels = label_pairs(source, "EFFECT_LABELS");
+        let tool_labels = label_pairs(source, "TOOL_LABELS");
+        let effects: Vec<&str> = effect_labels.iter().map(|(k, _)| k.as_str()).collect();
+        let tools: Vec<&str> = tool_labels.iter().map(|(k, _)| k.as_str()).collect();
 
         // Vacuity guards. A parse that quietly returned nothing would report
         // every gated tool as unlabelled — noisy, and therefore self-correcting.
@@ -2210,14 +2238,14 @@ mod tests {
         // to move, so a reformat of `language.ts` breaks here loudly instead.
         for anchor in ["payment.send", "workflow.approve"] {
             assert!(
-                effects.iter().any(|k| k == anchor),
+                effects.contains(&anchor),
                 "parsed EFFECT_LABELS from {LANGUAGE_TS} without `{anchor}` — \
                  the parser is reading the wrong block, not the table shrinking"
             );
         }
         for anchor in ["shell", "workspace_create"] {
             assert!(
-                tools.iter().any(|k| k == anchor),
+                tools.contains(&anchor),
                 "parsed TOOL_LABELS from {LANGUAGE_TS} without `{anchor}` — \
                  the parser is reading the wrong block, not the table shrinking"
             );
@@ -2231,8 +2259,31 @@ mod tests {
             tools.len()
         );
 
-        let mut unlabelled: Vec<&str> = declared_tools()
+        let gated: Vec<&str> = declared_tools()
             .filter(|tool| c(tool).reach.parks_under_supervision())
+            .collect();
+
+        // The walk's own vacuity guard (issue #743). A distinctness check over
+        // an empty or truncated set passes having asserted nothing, which is
+        // precisely the fail-open shape the guards above exist to refuse — and
+        // the shape that made #706's reproduction wrong by half.
+        //
+        // A floor rather than an exact count, matching the `>=` idiom above: the
+        // gated set is 25 today and grows whenever a `Reach::Consequence` line
+        // is declared, so pinning it exactly would fail every such commit for
+        // being correct. What must never happen is the walk *shrinking* toward
+        // the four hardcoded names this widened.
+        assert!(
+            gated.len() >= 20,
+            "only {} tools were selected as gated; the declaration table holds \
+             far more `Reach::Consequence` entries than that, so the walk is \
+             selecting almost nothing and everything below it is vacuous",
+            gated.len()
+        );
+
+        let mut unlabelled: Vec<&str> = gated
+            .iter()
+            .copied()
             .filter(|tool| !effects.iter().any(|k| k == tool) && !tools.iter().any(|k| k == tool))
             .collect();
         unlabelled.sort_unstable();
@@ -2245,6 +2296,46 @@ mod tests {
              EFFECT_LABELS entries do not assume and why its \
              EFFECT_DONE_LABELS mirror would demand a past-tense twin these \
              kinds never reach"
+        );
+
+        // ...and no two of them read the same sentence (issue #743).
+        //
+        // Checked after the unlabelled walk on purpose: an unlabelled pair would
+        // collide here too, on the fallback, and reporting that as "these two
+        // read alike" would name the symptom while the assertion above names the
+        // cause. Ordering the two is what keeps one failure message honest.
+        //
+        // Resolved through the console's own rung order — `EFFECT_LABELS` then
+        // `TOOL_LABELS` — because that is what `toolAction` does, and a tool
+        // present in both resolves to the effect sentence. Comparing the tables
+        // separately would miss exactly the collision that ordering creates.
+        let sentence = |tool: &str| -> &str {
+            effect_labels
+                .iter()
+                .chain(tool_labels.iter())
+                .find(|(key, _)| key == tool)
+                .map(|(_, value)| value.as_str())
+                .expect("every gated tool is labelled — asserted directly above")
+        };
+
+        let mut by_sentence: std::collections::BTreeMap<&str, Vec<&str>> = Default::default();
+        for tool in &gated {
+            by_sentence.entry(sentence(tool)).or_default().push(tool);
+        }
+        let collisions: Vec<String> = by_sentence
+            .iter()
+            .filter(|(_, sharing)| sharing.len() > 1)
+            .map(|(reads, sharing)| format!("{sharing:?} all read {reads:?}"))
+            .collect();
+        assert!(
+            collisions.is_empty(),
+            "two gated tools render the same sentence: {}. The Standing \
+             permissions list (#374) puts no payload block under a row, so two \
+             rows reading alike are two permissions an operator cannot choose \
+             between — and on an approval card the payload only disambiguates \
+             them if they happen to carry different arguments. Give each its own \
+             words in {LANGUAGE_TS}",
+            collisions.join("; ")
         );
     }
 }


### PR DESCRIPTION
## Summary

#721 shipped the eleven operator labels and a distinctness check, but scoped that check to the **four grantable** tools by mapping over a hardcoded `GRANTABLE` in the console test. Its own argument is not scoped that way:

> The Standing permissions list (#374) has no payload block underneath a row, so two rows reading the same sentence are two permissions an operator cannot choose between.

That failure is available to **any pair of the gated set**, not to four of them. This widens the assertion to the whole set, derived from the declaration table.

### The set is 25, not 22

The issue estimated 22 `Reach::Consequence` tools out of 50 declared. Counted from the declaration table itself rather than from a grep: **53 declared, 25 gated.** The table grew since the issue was filed.

Two independent cross-checks that the count is not a parser failing open — the failure mode that made #706's reproduction wrong by half:

- `Reach::parks_under_supervision()` is exactly `matches!(self, Reach::Consequence)`, so the filter this test already used selects precisely that set;
- the parse yields 17 `EFFECT_LABELS` + 25 `TOOL_LABELS` pairs, consistent with the shipped `>= 15` / `>= 10` floors.

### No collision exists today — this is a pure guard widening

Resolving all 25 through the console's real rung order (`EFFECT_LABELS ?? TOOL_LABELS`) gives **25 distinct sentences, zero duplicates, zero unlabelled**. Nothing is being silently fixed; this is a guard catching up with its own reasoning. The next tool added is the one it exists for.

### How wide the gap actually was

Of the 25 gated tools, the console test names **11** and its distinctness check covers **4**. **Fourteen are invisible to it entirely:**

`shell` · `web_fetch` · `workspace_write` · `workspace_create` · `workspace_delete` · `workspace_rename` · `memory_store` · `repo_checkout` · `repo_pr` · `media_generate_image` · `media_generate_video` · `mcp_registry_tool_call` · `composio_authorize` · `composio_execute`

## API Or Behavior Changes

None. Test-only, in `src/policy/consequence.rs`.

## Implementation notes

**Derived, never restated.** The walk is `declared_tools()` filtered by reach. A hardcoded list is how this got to four in the first place, so adding a second one — even a longer one — would reproduce the defect with a bigger number.

**One parser, not two.** `label_keys` returned keys only; the distinctness half needs sentences. It became `label_pairs` returning `key -> sentence`, which left `label_keys` with no callers, so it is **deleted** rather than kept as a thin wrapper. Two parsers over one file would be this issue's own mistake one level down. Its rationale moved onto `label_pairs` intact.

**Resolution mirrors `toolAction`** — `EFFECT_LABELS` then `TOOL_LABELS`. A tool present in both resolves to the effect sentence, so comparing the two tables separately would miss exactly the collision that rung order creates.

**Ordered after the unlabelled walk, deliberately.** An unlabelled pair collides here too, on the shared fallback. Reporting that as "these two read alike" would name the symptom while the assertion above names the cause. Sequencing them is what keeps one failure message honest.

**The message names names.** It reports the colliding tools *and* the sentence they share, so a red build says what to fix rather than that a set and a vec had different lengths.

## Tests

### Vacuity guard

`assert!(gated.len() >= 20)` runs before anything consumes the walk — a distinctness check over an empty set passes having asserted nothing.

A **floor, not an exact count**, matching this file's existing `>= 15` / `>= 10` idiom. Pinning 25 exactly would fail every future `Reach::Consequence` declaration for being correct. What must never happen is the walk *shrinking* back toward the four names this widens.

### Revert-and-check

Re-run in full **after** the rebase onto current `main`. Each revert was `cmp`-verified to have actually changed the file, so none is a silent no-op.

| # | Revert | Result |
|---|---|---|
| **A** | point `web_fetch`'s label at `shell`'s sentence | **FAILS** — `["shell", "web_fetch"] all read "Run a terminal command"` |
| **B** | *the same duplicate*, with the walk narrowed to the old four grantable names | **PASSES**, 0 failed |
| **C** | walk selects nothing | **FAILS** — `only 0 tools were selected as gated` |

**A versus B is the proof the widening does something.** The duplicate is identical in both runs; the only variable is the scope of the walk. Widened, it is caught. At the old four-tool scope it is **silently green** — which is the state `main` is in today.

B is also why this was verified in Rust rather than by running the console suite: it isolates scope as the single variable inside one test binary, instead of comparing across two runners. (`frontend/node_modules` is not installed here, and installing it costs disk that is currently tight.)

### Lanes

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — ran as `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`; exit 0.
- [x] `cargo build --all-targets` — N/A as written; ran the stronger `cargo check --locked --all-features --all-targets`, exit 0.
- [x] `cargo test` — ran as `cargo test --features openhuman,tinycortex`; exit 0. **3362 passed, 0 failed, 3 ignored**, plus the integration targets.

## Documentation

None needed — no behaviour or public API changed. The argument lives on the test and its parser, where the next person to add a gated tool will meet it.

## Not fixed here, deliberately

The console test's `PER_CALL` / `GRANTABLE` maps are a **hand-maintained restatement of the Rust declaration table** and can drift from it silently — the same class of defect this PR closes, one layer up. Its per-kind assertions still guard the TypeScript resolution path that the Rust test cannot reach, so it is kept rather than deleted. Worth its own issue; not folded in here, so a small obviously-correct change is not held up by a larger argument.

Closes #743
