### PR TITLE
ci: extract the vendored submodule init to one script, and un-break release.yml (#592)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,27 +165,18 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      # `openhuman_core` is an optional path dependency, so Cargo must resolve
-      # its vendored-crate manifests even for the default (offline) build where
-      # the `openhuman` feature is off. `submodules: true` is not recursive, so
-      # init the nested crates its manifest names.
+      # `submodules: true` is not recursive, so the crates nested under
+      # `vendor/openhuman` still have to be fetched. Required even for this
+      # default (offline) build, where the `openhuman` feature is off:
+      # `openhuman_core` is an optional path dependency, but Cargo reads every
+      # path dependency's manifest during resolution regardless of features.
       #
-      # `tinyhumans-sdk` is NOT one of the `[patch]` targets — openhuman consumes
-      # it as a plain unconditional path dependency because it is unpublished
-      # (issue #499). It still has to be on disk: Cargo reads every path
-      # dependency's manifest during resolution, so a missing checkout fails the
-      # DEFAULT build too, not just `--features openhuman`.
+      # The list of crates lives in the script and only there — add a submodule
+      # under `vendor/openhuman` there, not here (issue #592). The script also
+      # carries the rest of the reasoning, including why `tinyhumans-sdk` is in
+      # the list despite having no `[patch]` entry (issue #499).
       - name: Init vendored openhuman crate submodules
-        run: |
-          git -C vendor/openhuman submodule update --init --depth 1 \
-            vendor/tinyagents vendor/tinybus vendor/tinyflows vendor/tinycortex \
-            vendor/tinydocs vendor/tinymemory vendor/tinywallet \
-            vendor/tinyjuice vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
-          # tinycortex declares its own `tinyagents` path dependency, so its
-          # manifest must resolve too. Harmless for the default build; required
-          # for any `--features openhuman` build.
-          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
-            vendor/tinyagents
+        run: scripts/ci/init-vendored-submodules.sh
 
       # Issue #499: say out loud how far the vendored pin has drifted.
       #
@@ -406,14 +397,10 @@ jobs:
       # its manifest during resolution even where the feature selection excludes
       # `openhuman`. A missing checkout fails THIS build too, not just a gated
       # one. `submodules: true` is not recursive, hence the explicit init.
+      #
+      # The list lives in the script and only there (issue #592).
       - name: Init vendored openhuman crate submodules
-        run: |
-          git -C vendor/openhuman submodule update --init --depth 1 \
-            vendor/tinyagents vendor/tinybus vendor/tinyflows vendor/tinycortex \
-            vendor/tinydocs vendor/tinymemory vendor/tinywallet \
-            vendor/tinyjuice vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
-          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
-            vendor/tinyagents
+        run: scripts/ci/init-vendored-submodules.sh
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
@@ -497,20 +484,15 @@ jobs:
           submodules: true
 
       # Identical to the `rust` job's init, and for the same reason: `submodules:
-      # true` is not recursive. Keep it targeted to the crate submodules named
-      # by OpenHuman's manifest; see the rust job for why `tinyhumans-sdk` is in
-      # the list despite having no `[patch]` entry.
+      # true` is not recursive. This lane is the one that actually compiles the
+      # nested graph rather than only resolving it, `--features openhuman`
+      # reaching every vendored crate the script names, plus tinycortex's own
+      # `tinyagents`.
+      #
+      # The list lives in the script and only there (issue #592), including why
+      # the init is targeted rather than `--recursive`.
       - name: Init vendored openhuman crate submodules
-        run: |
-          git -C vendor/openhuman submodule update --init --depth 1 \
-            vendor/tinyagents vendor/tinybus vendor/tinyflows vendor/tinycortex \
-            vendor/tinydocs vendor/tinymemory vendor/tinywallet \
-            vendor/tinyjuice vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
-          # tinycortex declares its own `tinyagents` path dependency, so its
-          # manifest must resolve too. Harmless for the default build; required
-          # for any `--features openhuman` build.
-          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
-            vendor/tinyagents
+        run: scripts/ci/init-vendored-submodules.sh
 
       # `--features openhuman` links system libraries the default build does not.
       # Mirrors the builder stage of the repo `Dockerfile`: OpenSSL headers
@@ -1056,14 +1038,10 @@ jobs:
       # The desktop links the host crate by path, so its optional vendored
       # manifests must resolve here for the same reason they must in `rust` —
       # Cargo reads every path dependency's manifest during resolution.
+      #
+      # The list lives in the script and only there (issue #592).
       - name: Init vendored openhuman crate submodules
-        run: |
-          git -C vendor/openhuman submodule update --init --depth 1 \
-            vendor/tinyagents vendor/tinybus vendor/tinyflows vendor/tinycortex \
-            vendor/tinydocs vendor/tinymemory vendor/tinywallet \
-            vendor/tinyjuice vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
-          git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
-            vendor/tinyagents
+        run: scripts/ci/init-vendored-submodules.sh
 
       # Tauri's system dependencies. `wry` links webkit2gtk, so this is what
       # makes the desktop tree buildable at all — and it is precisely why the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,58 @@ jobs:
           fi
           echo "$count \`uses:\` references, all pinned to a commit SHA."
 
+      # Issue #592, and the same argument as the pin check above. The vendored
+      # openhuman submodule init was copied into four jobs in this file and a
+      # fifth in `release.yml`, ~340 lines apart here — far enough that a reader
+      # edits one copy and never learns the others exist. The copies then
+      # drifted: `release.yml` was missing `vendor/tinyhumans-sdk` and the
+      # nested `tinycortex` init, which fails `cargo build --locked` outright at
+      # manifest resolution. It stayed invisible only because that workflow is
+      # `workflow_dispatch`-only and had never run. This job's header records
+      # the general lesson — a comment is a guard only for people who read it,
+      # and one failed to stop the `Desktop` job landing unpinned. A grep is the
+      # cheapest thing that says no.
+      #
+      # The pattern is the inline-copy signature specifically: `git -C
+      # vendor/<path> submodule update`. It deliberately does NOT match the
+      # `Report vendored openhuman drift` step's `git -C vendor/openhuman
+      # rev-parse|fetch|merge-base|rev-list` — a different command that belongs
+      # inline — nor `deploy-staging.yml`'s root-level `git submodule update
+      # --init --recursive`, which is a different shape fetching a different set
+      # (it also takes `vendor/tinyagents`, and runs against a `submodules:
+      # false` checkout).
+      - name: Vendored submodule init is not inlined
+        run: |
+          set -euo pipefail
+          failed=0
+
+          inlined=$(grep -rnE 'git[[:space:]]+-C[[:space:]]+vendor/[^[:space:]]+[[:space:]]+submodule[[:space:]]+update' \
+            .github/workflows/ || true)
+          if [ -n "$inlined" ]; then
+            echo "::error title=Inlined vendored submodule init::A workflow initializes the vendored submodules inline, running a \`submodule update\` against a \`vendor/\` checkout. That list lives in exactly one place, scripts/ci/init-vendored-submodules.sh — call the script instead. Copies drift, and a lane missing a submodule then fails on its own while its siblings stay green." >&2
+            echo "$inlined" >&2
+            failed=1
+          fi
+
+          # Zero would pass the check above while asserting nothing — the
+          # failure mode issue #555 exists to remember. A rename or a mass
+          # delete must not leave this job green while checking nothing.
+          #
+          # Anchored to the whole `run:` line, so it counts CALL SITES and not
+          # mentions. An unanchored search would match the prose in this very
+          # step, which would make this check permanently and silently green —
+          # the same vacuity it exists to catch.
+          callers=$(grep -rlE '^[[:space:]]*run:[[:space:]]*scripts/ci/init-vendored-submodules\.sh[[:space:]]*$' \
+            .github/workflows/ || true)
+          if [ -z "$callers" ]; then
+            echo "::error title=Submodule init script unreferenced::No workflow calls scripts/ci/init-vendored-submodules.sh, so the check above is green while guarding nothing. Either the script was renamed and this job was not updated, or the call sites were removed. Restore the call: \`run: scripts/ci/init-vendored-submodules.sh\`." >&2
+            failed=1
+          fi
+
+          [ "$failed" -eq 0 ] || exit 1
+          echo "Vendored submodule init is inlined nowhere and called from:"
+          echo "$callers"
+
   rust:
     name: Rust
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,25 @@ jobs:
 
       # `openhuman_core` is an optional path dependency, so Cargo must resolve
       # its vendored-crate manifests even for the default build. `submodules:
-      # true` is not recursive, so init the nested crates the `[patch]` entries
-      # reference.
+      # true` is not recursive, hence the explicit init.
+      #
+      # BEHAVIOUR CHANGE, issue #592. This job's own copy of the init had
+      # drifted from the five in `ci.yml`: it fetched five submodules, omitting
+      # `vendor/tinyhumans-sdk`, and skipped the nested `tinycortex` init
+      # entirely. `tinyhumans-sdk` is an unconditional path dependency of the
+      # vendored openhuman crate (issue #499), so the `cargo build --locked`
+      # below could not have resolved the workspace manifest — it fails with
+      # "failed to read vendor/openhuman/vendor/tinyhumans-sdk/Cargo.toml"
+      # before compiling anything. That went unnoticed only because this
+      # workflow is `workflow_dispatch`-only and had never run; the next
+      # dispatch would have failed. The stale comment here still cited the
+      # `[patch]` entries as the rationale, which is what the missed sweep
+      # looked like.
+      #
+      # Calling the shared script both fixes that and makes the drift
+      # impossible to reintroduce. The list lives there and only there.
       - name: Init vendored openhuman crate submodules
-        run: |
-          git -C vendor/openhuman submodule update --init --depth 1 \
-            vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
-            vendor/tinychannels vendor/tinyplace
+        run: scripts/ci/init-vendored-submodules.sh
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:

--- a/scripts/ci/init-vendored-submodules.sh
+++ b/scripts/ci/init-vendored-submodules.sh
@@ -74,7 +74,8 @@ if [ ! -f vendor/openhuman/.gitmodules ]; then
 fi
 
 git -C vendor/openhuman submodule update --init --depth 1 \
-  vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
-  vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
+  vendor/tinyagents vendor/tinybus vendor/tinyflows vendor/tinycortex \
+  vendor/tinydocs vendor/tinymemory vendor/tinywallet \
+  vendor/tinyjuice vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
 git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
   vendor/tinyagents

--- a/scripts/ci/init-vendored-submodules.sh
+++ b/scripts/ci/init-vendored-submodules.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+#
+# Initialize the vendored openhuman crate's own submodules. Issue #592.
+#
+# THE ONE PLACE THE LIST LIVES. Adding a submodule under `vendor/openhuman`?
+# Add it here, nowhere else. Do not re-inline these commands into a workflow.
+#
+# This file exists because the block below was copied into four jobs of
+# `ci.yml` and a fifth in `release.yml`, ~340 lines apart in a file long enough
+# that a reader edits one copy and never learns the others exist. The failure
+# that shape produces is the one issue #555 was filed for: a lane quietly not
+# doing what its siblings do, found late and by accident. It had already
+# happened by the time #592 was written — `release.yml` was missing
+# `vendor/tinyhumans-sdk` and the nested `tinycortex` init entirely, and had
+# gone unnoticed only because that workflow is `workflow_dispatch`-only and had
+# never run.
+#
+# WHY THESE CRATES MUST BE ON DISK EVEN FOR A DEFAULT BUILD
+#
+# `openhuman_core` is an optional path dependency, but Cargo reads every path
+# dependency's manifest during resolution regardless of feature selection. So
+# the vendored crate's own path deps must resolve even for the default
+# (offline) build where the `openhuman` feature is off — a missing checkout
+# fails the DEFAULT build, not just `--features openhuman`.
+#
+# `tinyhumans-sdk` is the case that catches people out: it is NOT one of the
+# `[patch]` targets. The vendored openhuman crate consumes it as a plain
+# unconditional path dependency because it is unpublished (issue #499). Absent
+# from this list, every lane breaks — which is exactly how `release.yml` came
+# to be latently broken.
+#
+# `tinycortex` in turn declares its own `tinyagents` path dependency, so its
+# manifest must resolve too. Harmless for the default build; required for any
+# `--features openhuman` build.
+#
+# WHY TARGETED RATHER THAN `--recursive`
+#
+# A plain `--recursive` over `vendor/openhuman` additionally drags in the
+# desktop-only `tauri-cef` tree — a heavy CEF checkout that nothing in these
+# builds compiles.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO
+#
+# It does not initialize the TOP-LEVEL submodules. Each caller chooses its own
+# checkout strategy (`submodules: true` on `actions/checkout`, or an explicit
+# init), and quietly changing that from in here would be a surprise. This
+# script assumes `vendor/openhuman` is already checked out and only fills in
+# the crates nested beneath it.
+#
+# Idempotent: safe to run repeatedly, and a no-op once the submodules are
+# present at their pinned commits.
+#
+# Usage:
+#   scripts/ci/init-vendored-submodules.sh
+#
+# Runs from any working directory — it resolves the repository root itself.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}"
+
+# Without this, git emits a bare "not a git repository" that says nothing about
+# the actual mistake, which is a caller that never checked out the top level.
+if [ ! -f vendor/openhuman/.gitmodules ]; then
+  echo "init-vendored-submodules: vendor/openhuman/.gitmodules is missing, so" >&2
+  echo "vendor/openhuman itself was never checked out. This script initializes" >&2
+  echo "the crates NESTED under it and cannot create it." >&2
+  echo >&2
+  echo "In a workflow: pass \`submodules: true\` to actions/checkout." >&2
+  echo "Locally: git submodule update --init vendor/openhuman" >&2
+  exit 1
+fi
+
+git -C vendor/openhuman submodule update --init --depth 1 \
+  vendor/tinyflows vendor/tinycortex vendor/tinyjuice \
+  vendor/tinychannels vendor/tinyplace vendor/tinyhumans-sdk
+git -C vendor/openhuman/vendor/tinycortex submodule update --init --depth 1 \
+  vendor/tinyagents


### PR DESCRIPTION
## Summary

Extracts the vendored-openhuman submodule init into `scripts/ci/init-vendored-submodules.sh` and calls it from every lane, following the `scripts/ci/assert-integration-targets-run.sh` precedent. A grep in the `Actions pinned` meta job keeps it that way.

**Read this part first — the de-duplication is the smaller half of the change.**

The issue was filed against three copies. There are **five**, and the drift it warned about had already happened: **`release.yml` is latently broken on `main` today.** Its copy initializes five submodules, omitting `vendor/tinyhumans-sdk`, and skips the nested `tinycortex` init entirely. `tinyhumans-sdk` became an *unconditional* path dependency of the vendored openhuman crate in #499 (`vendor/openhuman/Cargo.toml:89`), and Cargo reads every path-dependency manifest during resolution — so that job's `cargo build --locked --all-targets` cannot resolve the workspace at all.

Reproduced locally by running `release.yml`'s exact command list against a checkout mirroring its CI state:

```
error: failed to load manifest for workspace member `.`
Caused by: failed to load manifest for dependency `openhuman`
Caused by: failed to load manifest for dependency `tinyhumans-sdk`
Caused by: failed to read vendor/openhuman/vendor/tinyhumans-sdk/Cargo.toml
```

It has never gone red only because the workflow is `workflow_dispatch`-only and has not run in retained history. **The next release dispatch would have failed.** Its step comment still cited the `[patch]` entries as the rationale — the signature of a missed sweep rather than a deliberate divergence.

This is exactly the defect shape #592 and #555 were filed for: a lane quietly not doing what its siblings do, found late and by accident.

### What changed

| Lane | Before | After |
|---|---|---|
| `ci.yml` — `rust`, `Rust (mongodb)`, `rust-gated`, `Desktop` | 4 character-identical inline copies (md5-verified), ~340 lines apart | call the script |
| `release.yml` | drifted copy: 5 submodules, no `tinyhumans-sdk`, no nested init | call the script — **behaviour change**, now fetches the same set as every other lane |
| `deploy-staging.yml` | root-level `--recursive` init over a `submodules: false` checkout, also taking `vendor/tinyagents` | **untouched** — different shape; converting it would change what the Docker build context fetches |

The script's command text is verbatim from the `ci.yml` block: same order, same paths, same `--depth 1`. The rationale scattered across the five step comments is consolidated into its header rather than deleted; lane-specific comments stay at their call sites.

### The guard, and the commit order that proves it

`Actions pinned` gains a step making the invariant enforceable, on that job's own stated argument — a comment is a guard only for people who read it, and its header already records a comment failing to stop the `Desktop` job landing unpinned.

1. Rejects the inline-copy signature `git -C vendor/<path> submodule update` in any workflow.
2. Anti-vacuity per #555: the script must be called by at least one workflow, so a rename or mass delete cannot leave check 1 green while guarding nothing.

**The commits are ordered so the guard is seen to fail on a real runner**, rather than asserted to work:

- `208fd2a6` — script only.
- `ddd29849` — guard only, landed **while all five inline copies still existed**. [**Red run — both checks bite**](https://github.com/oxoxDev/opencompany/actions/runs/31587863922/job/94085773260): annotations `Inlined vendored submodule init` (listing all 9 offending lines) and `Submodule init script unreferenced`.
- `aaecb421` — the conversion. Green.

Please keep both runs in the history when reviewing; the red one is the evidence.

Two precision notes on the pattern, both found by testing it rather than reasoning about it:

- It is deliberately narrower than `git -C vendor/`. That broader form also matches the `Report vendored openhuman drift` step's `rev-parse`/`fetch`/`merge-base`/`rev-list` (`ci.yml:169-172`), which belongs inline — the guard would have been permanently red and unfixable without deleting a good step.
- The anti-vacuity check is anchored to the whole `run:` line so it counts **call sites, not mentions**. Unanchored, it matched the prose inside the guard step itself and could never fail — the precise vacuity it exists to catch. The first draft of this PR had both bugs; the local dry-run caught them.

## API Or Behavior Changes

- **`release.yml` now fetches `vendor/tinyhumans-sdk` and the nested `tinycortex` → `tinyagents` submodule**, which it did not before. This un-breaks the release build. The nested init is harmless for a default build — seconds of shallow fetch.
- CI lane behaviour is otherwise unchanged: the four `ci.yml` copies were character-identical to the script's contents.
- The script deliberately does **not** initialize top-level submodules, so no caller's checkout strategy changes.
- New failure mode, on purpose: a workflow that inlines the init now fails `Actions pinned`.

## Tests

The script cannot silently no-op and stay green: without the fetch, Cargo fails manifest resolution before compiling anything. So green `rust` / `Rust (mongodb)` / `rust-gated` / `Desktop` on this head *is* proof it ran and fetched the right set. `rust-gated` additionally compiles all six crates plus nested `tinyagents` under `--features openhuman`.

Locally, in a scratch clone whose state mirrors CI's (`actions/checkout` with `submodules: true`, i.e. top level only, all nested submodules uninitialized):

- `sh -n` and `shellcheck` — clean.
- Ran it from a **subdirectory** (`src/server`) — resolves the repo root correctly, exit 0.
- `git -C vendor/openhuman submodule status` afterwards — all six at pinned commits, **SHA-for-SHA identical** to a known-good checkout. `tauri-cef` correctly left uninitialized.
- `cargo metadata --locked` — OK. A correct SHA in `submodule status` does not prove the objects landed; this does.
- Ran a **second time** — exit 0, idempotent.
- Precondition path: with `vendor/openhuman` unchecked-out, fails with the actual mistake named. Worth noting this is not hypothetical — during testing, `git -C vendor/openhuman submodule status` against an empty directory silently reported the *parent* repo's submodules, which is the confusing failure the check replaces.
- Guard dry-run: red against the unconverted tree (9 matches, both checks), green against the converted one (5 call sites).
- `actionlint` — clean on both workflow files.

`release.yml` cannot be exercised on this PR — it is dispatch-only and it publishes — so a YAML typo there is the residual risk. `actionlint` is the mitigation.

Not run: `cargo fmt` / `clippy` / `build` / `test` locally — this PR changes no Rust source. CI runs them.

- [ ] `cargo fmt --all -- --check` — N/A: no Rust source changed; CI runs it.
- [ ] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust source changed; CI runs it.
- [ ] `cargo build --all-targets` — N/A: no Rust source changed; CI's four lanes are the real assertion here.
- [ ] `cargo test` — N/A: no Rust source changed; CI runs it.

## Documentation

No docs change. The reasoning lives where the next person will hit it: the script header states plainly that adding a submodule under `vendor/openhuman` means editing that file and nothing else, and each call site points at it.

### Deliberately not done

- An objects-landed post-check inside the script (`submodule foreach 'test -f Cargo.toml'`) — one nested submodule is a JS repo with no `Cargo.toml`, and Cargo already fails loudly downstream on every converted lane.
- Converting `deploy-staging.yml`. Worth a follow-up look, but it is a genuinely different init and folding it in here would change the image build.

Closes #592
