### PR TITLE
fix(team): authorise a tools edit after the existence check, not before

### DIFF
--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -365,6 +365,10 @@ async fn agent_detail(
 /// working exactly as before, and adding this field must not quietly take an
 /// existing capability away from members.
 ///
+/// Being conditional is also what fixes its **position**: it runs after the
+/// `409`/`404` checks, so an unknown id answers `404` whether or not the body
+/// carried `tools`. See the comment at the check itself.
+///
 /// Narrow-only-for-members was considered and rejected: it makes the scope a
 /// one-way ratchet, so a teammate scoped too tightly could never be loosened by
 /// anyone, and the only way back would be delete-and-recreate — which orphans
@@ -377,12 +381,6 @@ async fn edit_agent(
     Path(AgentPath { agent_id }): Path<AgentPath>,
     Json(body): Json<EditAgent>,
 ) -> Result<Json<AgentDetailDto>, Response> {
-    // Authority before the write lock: a refused edit must not hold the lock,
-    // and must not have looked at the record either.
-    if body.tools.is_some() {
-        require_admin(&headers, &state, &company.runtime).await?;
-    }
-
     // Serialize with every other write to `overlay_agents`, so a console edit
     // and a concurrent `add_agent` cannot clobber one another's roster.
     let write_lock = company_write_lock(company.id());
@@ -411,6 +409,30 @@ async fn edit_agent(
             "teammate {agent_id}"
         )))
         .into_response());
+    }
+
+    // Authority **after** existence, and this ordering is forced rather than
+    // preferred (review of #745).
+    //
+    // The check is conditional on `tools`, so putting it first would make one
+    // route give two answers about whether a teammate exists: `{"name": "x"}`
+    // on an unknown id would 404 while `{"tools": […]}` on the same id would
+    // 403. Nothing about an unrelated field should decide that, and the
+    // non-`tools` path cannot be moved to match — a name edit is member-open
+    // and has no authority check to run first. So this is the only order in
+    // which the two paths agree.
+    //
+    // The usual reason to authorise first — refusing to confirm a resource
+    // exists — does not apply: `GET {scope}/team/{agent_id}` is open to any
+    // signed-in member and already 404s on an unknown id, so ordering 403
+    // ahead of 404 here would hide nothing from the very caller it would
+    // inconvenience.
+    //
+    // Deliberately unlike `set_budget`, which authorises first: that route is
+    // admin-only in full, so admin-first is self-consistent there. This one is
+    // admin-only *per field*, which is what makes the ordering load-bearing.
+    if body.tools.is_some() {
+        require_admin(&headers, &state, &company.runtime).await?;
     }
 
     let name = trimmed_field(body.name.as_deref(), "name").map_err(|e| e.into_response())?;
@@ -1411,6 +1433,59 @@ members = ["writer", "ceo"]
             strings(&unchanged["tools"]["requested"]),
             vec!["workspace"],
             "the scope an admin set must survive both refusals: {unchanged}"
+        );
+    }
+
+    /// **Review of #745.** An unknown id answers the same way whether or not
+    /// the body carries `tools`.
+    ///
+    /// The invariant, stated independently of which ordering is "right": one
+    /// route must not give two answers about whether a teammate exists,
+    /// decided by an unrelated field. Putting the conditional admin check
+    /// before the existence lookup did exactly that — `{"name": "x"}` on an
+    /// unknown id returned `404` while `{"tools": […]}` on the same id
+    /// returned `403`.
+    ///
+    /// Driven as a **member**, because that is the only actor for whom the two
+    /// orderings differ: an admin passes the check either way and would see
+    /// `404` regardless, so a test written as an admin would pass against the
+    /// broken ordering too.
+    #[tokio::test]
+    async fn an_unknown_teammate_is_a_404_whether_or_not_tools_are_sent() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+        crate::server::test_support::seed_fixed_member(&state, "acme").await;
+
+        let uri = "/api/v1/company/team/nobody";
+        let member = || crate::server::test_support::member_cookie("acme");
+
+        let (without_tools, _) = send_as(
+            &state,
+            "PATCH",
+            uri,
+            Some(json!({"role": "Ghost"})),
+            member(),
+        )
+        .await;
+        let (with_tools, _) = send_as(
+            &state,
+            "PATCH",
+            uri,
+            Some(json!({"tools": ["workspace"]})),
+            member(),
+        )
+        .await;
+
+        assert_eq!(
+            with_tools, without_tools,
+            "an unrelated field must not change whether a teammate is reported \
+             as existing"
+        );
+        assert_eq!(
+            with_tools,
+            StatusCode::NOT_FOUND,
+            "and the shared answer is 404: existence is already readable by any \
+             member through GET, so 403-first would hide nothing"
         );
     }
 


### PR DESCRIPTION
## Summary

**Follow-up to #745 that missed the merge.** #745 was merged at 10:09 against head `18fd2b13`, while @tinysweeper's review thread on `src/server/ops/team_agent.rs:382` was still open. The fix for it — `8f1ab438` — had been pushed but GitHub had not yet advanced the PR head, so the merge carried the finding but not the fix. This lands that commit.

Verified against `upstream/main` before opening:

```
git merge-base --is-ancestor 8f1ab438 upstream/main   → not in main
grep an_unknown_teammate_is_a_404_whether_or_not_tools_are_sent  → 0 occurrences
team_agent.rs:382  require_admin(...)   ← above the record load at :391
```

So the defect is live on `main`.

## The defect

#745 added a conditional admin check to `PATCH {scope}/team/{agent_id}` — `tools` is admin-only because an empty list means *the company's standard grant*, making `{"tools": []}` a widening. That check was placed **above** the lookup that turns a non-existent id into a `404`, which made one route give two answers about whether a teammate exists:

| request on an unknown id, as a non-admin | before | after |
|---|---|---|
| `{"name": "x"}` | `404` | `404` |
| `{"tools": […]}` | **`403`** | `404` |

An unrelated field decided whether the thing was there.

## The invariant

**A non-admin sending a request for a non-existent id must get the same status whether or not `tools` is present.**

The test pins that, not the choice of status — so it survives a future decision to flip the ordering, provided both paths flip together.

## Why the ordering is forced, not preferred

- **The other path cannot move to match.** A `name`/`role`/`description` edit is member-open and has no authority check to run first, so it must stay `404`. Authorising after existence is the only order in which the two agree.
- **The usual reason to authorise first does not apply here.** Ordering `403` ahead of `404` protects against leaking existence to an unauthorised caller — but `GET {scope}/team/{agent_id}` is open to any signed-in member and already `404`s on an unknown id. So `403`-first would hide nothing from the very caller it inconveniences.
- **Deliberately unlike `set_budget`**, which authorises first. That route is admin-only *in full*, so admin-first is self-consistent there. This one is admin-only *per field*, which is exactly what makes the position load-bearing. Both facts are in the code comment so the divergence is not "harmonised" away later.

## Tests

One test added, `an_unknown_teammate_is_a_404_whether_or_not_tools_are_sent`. Driven as a **member** deliberately — the only actor for whom the two orderings differ. An admin passes the check either way and sees `404` regardless, so an admin-driven test would pass against the broken ordering too.

```
cargo fmt --all -- --check                                                                     → 0
cargo check  --locked --all-features --all-targets                                             → 0
cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings   → 0
cargo test   --features openhuman,tinycortex   → 3389 + 10 + 1 + 11 + 2 = 3413 passed, 0 failed, 3 ignored
```

**Revert-checked** — the check hoisted back above the record load:

```
filters passed: 1   tests ran: 1   cargo exit: 101
test …::an_unknown_teammate_is_a_404_whether_or_not_tools_are_sent ... FAILED
test result: FAILED. 0 passed; 1 failed
assertion `left == right` failed: an unrelated field must not change whether a
teammate is reported as existing    left: 403   right: 404
```

That reproduces the exact `403`/`404` disagreement from the review thread. Tree restored afterwards.

Related test coverage on the same route, re-run on this branch and passing: `a_member_cannot_widen_a_teammates_scope`, `a_member_may_still_edit_a_teammates_name_and_role`, `editable_names_tools_only_for_an_admin`, `an_overlay_teammate_can_be_scoped_after_creation` — **5 filters passed, 5 tests ran, 5 passed.**

## How the escape was caught, since it is reusable

Re-running the #619 evidence set on `main` after #745 merged, I passed **11** test filters and only **10** ran. The missing one was the test added in the commit that never landed. A filter that silently matches nothing reports `ok` and looks like a pass — comparing *filters passed* against *tests actually run* is what turned a green-looking run into a shipped defect.

## API Or Behavior Changes

`PATCH {scope}/team/{agentId}` with a `tools` key on an **unknown** teammate id now answers `404` instead of `403`. The authority rule itself is unchanged: `tools` is still admin-only, still conditional, and a member editing only `name`/`role`/`description` is unaffected.

Closes the open review thread on #745. References #619.
