### PR TITLE
users: mail an invited address and report delivery (#584)

### DIFF
--- a/docs/spec/runtime/ports-state.md
+++ b/docs/spec/runtime/ports-state.md
@@ -213,6 +213,10 @@ pub trait UserStore: Send + Sync {
     async fn find_invite_by_email(&self, company: &CompanyId, email: &str)
         -> Result<Option<InviteRecord>>;
     async fn upsert_invite(&self, company: &CompanyId, invite: &InviteRecord) -> Result<()>;
+    /// Stamps `notified_at_millis` on an invite that still exists, leaving
+    /// every other field alone. Returns whether one was updated.
+    async fn mark_invite_notified(&self, company: &CompanyId, id: &str, at_millis: u64)
+        -> Result<bool>;
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool>;
 }
 
@@ -249,6 +253,11 @@ Normative requirements beyond the usual per-company isolation:
 - Email lookup is **exact**. Stores never normalize on the caller's behalf, so
   a caller that skips `normalize_email` misses rather than silently matching an
   address it did not ask for.
+- `UserStore::mark_invite_notified` MUST NOT insert. It is called after an
+  invite mail is sent, from a record read before the send, so a revocation that
+  lands during delivery must leave it nothing to update — a backend that
+  upserted here would restore an address the admin had just removed from the
+  allowlist.
 - `LoginCodeStore::consume` MUST make its check-and-mark a **single atomic
   step**. It is the only place single-use is enforced; a read-then-write in a
   handler would be a check-time/use-time gap.

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -159,7 +159,8 @@ addressing forms work: `/api/v1/companies/{id}/…` and `/api/v1/company/…`.
 | `GET …/auth/me` | Who this session belongs to |
 | `POST …/auth/logout` | Revoke this session |
 | `GET …/users` | The roster (admin) |
-| `GET/POST …/users/invites` | List/send invites (admin) |
+| `GET …/users/invites` | List outstanding invites (admin) |
+| `POST …/users/invites` | Invite an address, and mail them (admin). Answers `delivery: "sent" \| "no_transport" \| "failed"` alongside the invite |
 | `DELETE …/users/invites/{id}` | Revoke an invite (admin) |
 | `PATCH …/users/{id}` | Role, status, display name (admin) |
 | `POST …/users/{id}/password` | Set a temporary password (admin) |
@@ -306,6 +307,32 @@ Login mail uses the host-level provider (`OPENCOMPANY_MAIL_*`, see
 the company's. With no transport configured, `auth/request` returns the code in
 a `dev_code` field and logs a warning, so local development works; a host that
 can send mail never echoes it.
+
+**Invite mail** goes out over that same host-level provider, gated on the same
+"is a transport wired" predicate. Not the company's own `__smtp` secret, and
+deliberately: an invite mailed from a host whose platform mail is unwired
+invites someone into a dead flow, because the sign-in link they then ask for
+cannot be sent. One transport, one truthful answer.
+
+An invite mail is a **notification, not a credential**. It names the company,
+the inviter (display name or the email's local part, never the full address,
+per [Chat attribution](#chat-attribution)), and the sign-in URL — no code, no
+token, not even the invite id. The recipient still goes through
+`auth/request` like anyone else, so the roster stays the only gate. That is
+what makes it safe to send to an address a human typed and may have typed
+wrongly.
+
+`POST …/users/invites` **reports delivery** rather than assuming it. Unlike
+`auth/request`, this route is admin-authenticated and the caller supplied the
+address, so there is no enumeration oracle to protect and nothing the response
+could disclose that the caller did not already know. The mail is sent strictly
+*after* the invite record is written — a refusal (already a member, already
+invited) must mail nobody — and a failed send never rolls the grant back, since
+a mail outage should not become a silent refusal to add people. A sent invite
+stamps `notifiedAtMillis` on the record, which the console reads to say whether
+the person was actually told; absent means nobody was, and the operator owes
+them a message. Issue #584: the route previously wrote the record and mailed
+nobody while the console reported unconditional success.
 
 ## Abuse and exposure
 

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -331,8 +331,15 @@ invited) must mail nobody — and a failed send never rolls the grant back, sinc
 a mail outage should not become a silent refusal to add people. A sent invite
 stamps `notifiedAtMillis` on the record, which the console reads to say whether
 the person was actually told; absent means nobody was, and the operator owes
-them a message. Issue #584: the route previously wrote the record and mailed
-nobody while the console reported unconditional success.
+them a message. That stamp is an **update, never an insert**: an admin who
+spots a mistyped address and revokes the invite while its mail is still in
+flight wins, and the stamp quietly does nothing rather than putting the revoked
+address back on the roster. Issue #584: the route previously wrote the record
+and mailed nobody while the console reported unconditional success.
+
+Sending is bounded (30s) in the SMTP adapter, so a relay that accepts a
+connection and then stalls reports a failed delivery instead of holding the
+admin's request open.
 
 ## Abuse and exposure
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -180,7 +180,25 @@ export interface Invite {
   createdAtMillis: number;
   expiresAtMillis: number;
   acceptedAtMillis?: number;
+  /**
+   * When the invite email was accepted by the transport, if it was sent.
+   *
+   * Absent means no mail reached anyone — the host has no transport, the send
+   * failed, or the invite predates invite mail. The roster says so rather than
+   * implying delivery, because "invited" and "told they were invited" are
+   * different facts and only the operator can close the gap.
+   */
+  notifiedAtMillis?: number;
 }
+
+/**
+ * What happened to the invite email.
+ *
+ * Reported by the server rather than assumed by the console: an invite lands
+ * on a host with no mail transport just as readily as on one with, and the
+ * difference decides whether the operator still has to go and tell the person.
+ */
+export type InviteDelivery = "sent" | "no_transport" | "failed";
 
 /** Whether an invite comes from the manifest rather than a stored record. */
 export function isManifestInvite(invite: Invite): boolean {
@@ -203,14 +221,23 @@ export async function listInvites(
   return client.get<Invite[]>(`${client.scopeFor(company)}/users/invites`);
 }
 
-/** Invites an address. */
+/**
+ * Invites an address, and reports whether they were actually emailed.
+ *
+ * A 2xx here means the grant landed — it does **not** mean anyone was told.
+ * Callers must branch on `delivery` rather than treating success as delivery,
+ * which is the bug in issue #584.
+ */
 export async function invite(
   client: OpenCompanyClient,
   company: string | null,
   email: string,
   role: UserRole,
-): Promise<Invite> {
-  return client.post<Invite>(`${client.scopeFor(company)}/users/invites`, { email, role });
+): Promise<Invite & { delivery: InviteDelivery }> {
+  return client.post<Invite & { delivery: InviteDelivery }>(
+    `${client.scopeFor(company)}/users/invites`,
+    { email, role },
+  );
 }
 
 /** Revokes an invite. */

--- a/frontend/src/views/PeopleView.tsx
+++ b/frontend/src/views/PeopleView.tsx
@@ -126,6 +126,47 @@ export function PeopleView({ client, company }: Props) {
     }
   }
 
+  /**
+   * Invites someone and reports what actually reached them (issue #584).
+   *
+   * Deliberately not routed through `act`, which toasts unconditional success
+   * on any 2xx. That is right for revoking or suspending, where the write is
+   * the whole outcome, and wrong here: the grant landing and the person being
+   * told are two different things, and a host with no mail transport does the
+   * first without the second. Reporting them as one is what sent QA looking
+   * for an email nobody had sent.
+   *
+   * Every outcome reloads, because the invite exists in all of them — only the
+   * follow-up the operator owes differs.
+   */
+  async function inviteAndReport(email: string, role: UserRole) {
+    try {
+      const result = await sendInvite(client, company, email, role);
+      await load();
+      if (result.delivery === "sent") {
+        toast.success(`Invited ${email}`, {
+          description: "They've been emailed a link to sign in.",
+        });
+      } else if (result.delivery === "no_transport") {
+        toast.warning(`${email} can now sign in — but nothing was emailed`, {
+          description:
+            "This host has no email set up, so you'll need to tell them yourself. " +
+            "They sign in with this address on the login page.",
+        });
+      } else {
+        toast.warning(`${email} was invited, but the email didn't send`, {
+          description:
+            "They can still sign in with this address — tell them, or revoke and " +
+            "re-invite to try sending again.",
+        });
+      }
+    } catch (err) {
+      // A real refusal: already a member, already invited, or not an address.
+      // The server's wording is the useful part.
+      toast.error(err instanceof ApiError ? err.message : `Couldn't invite ${email}.`);
+    }
+  }
+
   if (loading) {
     return (
       <div className="space-y-3 p-6">
@@ -256,7 +297,7 @@ export function PeopleView({ client, company }: Props) {
         open={inviteOpen}
         onOpenChange={setInviteOpen}
         onInvite={async (email, role) => {
-          await act(`Invited ${email}`, () => sendInvite(client, company, email, role));
+          await inviteAndReport(email, role);
           setInviteOpen(false);
         }}
       />
@@ -377,10 +418,18 @@ function InviteRow({ invite, onRevoke }: { invite: Invite; onRevoke: () => void 
           {invite.role === "admin" ? <Badge variant="secondary">Admin</Badge> : null}
           {fromManifest ? <Badge variant="outline">From manifest</Badge> : null}
         </div>
-        <p className="truncate text-xs text-muted-foreground">
+        <p className="truncate text-xs text-muted-foreground" data-testid="invite-meta">
           {fromManifest
             ? "Listed in the company manifest — remove them from [users].admins there"
-            : `Invited ${relative(invite.createdAtMillis)} · expires ${relative(invite.expiresAtMillis)}`}
+            : `Invited ${relative(invite.createdAtMillis)} · expires ${relative(invite.expiresAtMillis)} · ${
+                // Whether anyone actually told them. A row that said only
+                // "invited" reads as "we contacted them", which is the
+                // assumption issue #584 is about; on a host with no mail the
+                // follow-up is the operator's and they need to know it.
+                invite.notifiedAtMillis
+                  ? "invite email sent"
+                  : "no invite email sent — let them know"
+              }`}
         </p>
       </div>
       {/* A manifest invite has no record to delete, and the manifest would
@@ -413,8 +462,9 @@ function InviteDialog({
         <DialogHeader>
           <DialogTitle>Invite someone</DialogTitle>
           <DialogDescription>
-            They'll be able to sign in with a magic link. Nothing is emailed now —
-            an invite just makes the address eligible.
+            We'll email them a link to the sign-in page, and they'll be able to
+            sign in with this address. If this host has no email set up, we'll
+            tell you so you can pass it on yourself.
           </DialogDescription>
         </DialogHeader>
         <form

--- a/frontend/test/e2e/people-invite.spec.ts
+++ b/frontend/test/e2e/people-invite.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Proof for issue #584: inviting someone reports what actually reached them.
+ *
+ * The bug was not a delivery failure — there was no invite email at all, and
+ * the console toasted unconditional success over it. QA went looking for a mail
+ * nobody had sent. The dialog even carried a "Nothing is emailed now"
+ * disclaimer at the time, and the misunderstanding happened anyway: the success
+ * toast was the louder signal, and it was the wrong one.
+ *
+ * The first case here is verifiable end to end against the real host, which is
+ * the point of putting it in this suite rather than in a unit test. `host.sh`
+ * brings the host up with `env -i` and no `OPENCOMPANY_MAIL_*` transport (it
+ * has to — the magic-link `dev_code` echo that global-setup signs in with is
+ * gated on exactly that). So this host genuinely cannot send mail, and the
+ * `no_transport` path is exercised for real rather than simulated.
+ *
+ * The `sent` rendering has no such luxury: no environment in CI speaks SMTP.
+ * It is asserted against a stubbed response, which proves the console renders
+ * the outcome correctly but proves nothing about the wire. The backend suite
+ * covers the send itself at the `MailSender` seam; final proof that mail leaves
+ * the building is manual, on a mail-wired host.
+ */
+
+/**
+ * The first-run product tour opens a modal over a fresh console and would
+ * swallow every click. `src/tour/state.ts` keys "seen" per company in
+ * localStorage, so pre-seed every key this host could use before the app boots,
+ * and click the dialog away if one still slips through.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const seen = JSON.stringify({ skipped: true, seenAt: Date.now() });
+    for (const key of ["oc-tour:single", "oc-tour:e2e-harness-co", "oc-tour:null"]) {
+      window.localStorage.setItem(key, seen);
+    }
+  });
+});
+
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (!(await skip.isVisible().catch(() => false))) return;
+    await skip.click({ force: true }).catch(() => {});
+    await page.waitForTimeout(300);
+  }
+  await expect(skip).toHaveCount(0);
+}
+
+/** A fresh address per run, so a re-run never collides with its own invite. */
+function unusedAddress(tag: string): string {
+  return `invite-${tag}-${Date.now()}@example.test`;
+}
+
+async function openPeople(page: Page) {
+  await page.goto("/#/settings/people");
+  await dismissTour(page);
+  await expect(page.getByRole("heading", { name: "People" })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+async function inviteFromTheDialog(page: Page, email: string) {
+  await page.getByRole("button", { name: "Invite" }).first().click();
+  const dialog = page.getByRole("dialog");
+  await expect(dialog).toBeVisible();
+
+  // The dialog must no longer promise the opposite of what the button does.
+  // "Nothing is emailed now" was true when it was written and is a lie now.
+  await expect(dialog).not.toContainText("Nothing is emailed now");
+
+  await dialog.getByLabel("Email").fill(email);
+  await dialog.getByRole("button", { name: "Invite" }).click();
+}
+
+test("a host that cannot send email says so instead of reporting success", async ({
+  page,
+}) => {
+  await openPeople(page);
+  const email = unusedAddress("notransport");
+  await inviteFromTheDialog(page, email);
+
+  // The operator is told the grant landed AND that nobody was emailed. Both
+  // halves matter: reporting only the failure would suggest the invite did not
+  // take, and reporting only the success is the bug.
+  const notice = page.getByText(/nothing was emailed/i);
+  await expect(notice).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText(/tell them yourself/i)).toBeVisible();
+
+  // And the roster row carries the same fact after the toast is gone, because
+  // the follow-up the operator owes outlives a four-second notification.
+  const row = page
+    .locator("div")
+    .filter({ hasText: email })
+    .locator('[data-testid="invite-meta"]')
+    .first();
+  await expect(row).toContainText("no invite email sent");
+  await expect(row).toContainText("let them know");
+
+  // Host-backed, not a client-side guess: it survives a reload.
+  await page.reload();
+  await openPeople(page);
+  await expect(
+    page
+      .locator("div")
+      .filter({ hasText: email })
+      .locator('[data-testid="invite-meta"]')
+      .first(),
+  ).toContainText("no invite email sent");
+});
+
+test("a delivered invite is reported as emailed, and the roster says so", async ({
+  page,
+}) => {
+  const email = unusedAddress("sent");
+
+  // Stubbed, and labelled as such: this host has no transport, so `sent` is
+  // not reachable here. What is under test is the console's rendering of the
+  // outcome, not the send.
+  await page.route("**/users/invites", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "i-stub",
+        email,
+        role: "member",
+        invitedBy: "u-stub",
+        createdAtMillis: Date.now(),
+        expiresAtMillis: Date.now() + 14 * 24 * 60 * 60 * 1000,
+        notifiedAtMillis: Date.now(),
+        delivery: "sent",
+      }),
+    });
+  });
+
+  await openPeople(page);
+  await inviteFromTheDialog(page, email);
+
+  await expect(page.getByText(/emailed a link to sign in/i)).toBeVisible({
+    timeout: 15_000,
+  });
+  // No warning language on the happy path.
+  await expect(page.getByText(/nothing was emailed/i)).toHaveCount(0);
+});

--- a/src/ports/users.rs
+++ b/src/ports/users.rs
@@ -247,6 +247,46 @@ mod test {
         assert!(!invite.is_redeemable(60), "a redeemed invite is single-use");
     }
 
+    /// The no-migration claim for issue #584, asserted rather than assumed.
+    ///
+    /// Every store persists invites as a JSON blob, so the only thing standing
+    /// between an existing deployment and a boot failure is `serde(default)`.
+    /// This is a blob in the shape written *before* the field existed.
+    #[test]
+    fn an_invite_stored_before_invite_mail_loads_as_unmailed() {
+        let legacy = serde_json::json!({
+            "id": "i1",
+            "email": "ada@example.com",
+            "role": "member",
+            "invitedBy": "u1",
+            "createdAtMillis": 1,
+            "expiresAtMillis": 100,
+        });
+        let invite: InviteRecord = serde_json::from_value(legacy).expect("a pre-#584 row loads");
+        assert_eq!(
+            invite.notified_at_millis, None,
+            "a row written before invite mail must read as un-mailed, not as sent"
+        );
+
+        // And an unmailed invite serializes exactly as it did before the field
+        // existed, so nothing downstream sees a new key it did not expect.
+        let json = serde_json::to_value(&invite).unwrap();
+        assert!(
+            json.get("notifiedAtMillis").is_none(),
+            "an unmailed invite must not emit the key: {json}"
+        );
+
+        let mailed = InviteRecord {
+            notified_at_millis: Some(7),
+            ..invite
+        };
+        assert_eq!(
+            serde_json::to_value(&mailed).unwrap()["notifiedAtMillis"],
+            7,
+            "a mailed invite must report when"
+        );
+    }
+
     #[test]
     fn user_record_round_trips_as_camel_case() {
         let user = UserRecord {

--- a/src/ports/users.rs
+++ b/src/ports/users.rs
@@ -128,6 +128,21 @@ pub struct InviteRecord {
     /// Epoch-millis timestamp of redemption; `None` while still outstanding.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub accepted_at_millis: Option<u64>,
+    /// Epoch-millis timestamp of when the invite mail was accepted by the
+    /// transport; `None` if no mail was sent.
+    ///
+    /// `None` is the honest answer for three different situations, and the
+    /// console says so rather than implying delivery: the host has no mail
+    /// transport wired, the send was attempted and failed, or the record
+    /// predates invite mail existing at all. Every store persists invites as a
+    /// JSON blob, so `serde(default)` is the whole migration — an older row
+    /// loads as `None`, which is true of it.
+    ///
+    /// It records that the transport *accepted* the message, which is the
+    /// furthest thing this process can honestly claim to know. A bounce after
+    /// that point happens somewhere this code cannot see.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notified_at_millis: Option<u64>,
 }
 
 impl InviteRecord {
@@ -221,6 +236,7 @@ mod test {
             created_at_millis: 0,
             expires_at_millis: 100,
             accepted_at_millis: None,
+            notified_at_millis: None,
         };
         assert!(invite.is_redeemable(99));
         // Expiry is exclusive: at the boundary the invite is already dead.

--- a/src/ports/users.rs
+++ b/src/ports/users.rs
@@ -199,6 +199,24 @@ pub trait UserStore: Send + Sync {
     ) -> Result<Option<InviteRecord>>;
     /// Inserts or replaces an invite by id.
     async fn upsert_invite(&self, company: &CompanyId, invite: &InviteRecord) -> Result<()>;
+    /// Stamps [`InviteRecord::notified_at_millis`] on an invite that still
+    /// exists, leaving every other field alone. Returns whether one was
+    /// updated.
+    ///
+    /// Deliberately narrower than [`UserStore::upsert_invite`], and the
+    /// narrowness is the point. The stamp is written *after* the invite mail
+    /// leaves, which is a network round trip — long enough for an admin who
+    /// mistyped the address to revoke the invite in the meantime. Writing the
+    /// pre-send record back through an upsert would recreate the row they just
+    /// revoked, silently restoring an address to the allowlist. A no-op is the
+    /// correct outcome there: the revocation stands, and nothing claims a mail
+    /// landed for a grant that no longer exists.
+    async fn mark_invite_notified(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        at_millis: u64,
+    ) -> Result<bool>;
     /// Deletes an invite by id; returns whether one was removed.
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool>;
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2811,6 +2811,7 @@ mod test {
                     created_at_millis: 1,
                     expires_at_millis: 10,
                     accepted_at_millis: None,
+                    notified_at_millis: None,
                 },
             )
             .await

--- a/src/server/ops/smtp.rs
+++ b/src/server/ops/smtp.rs
@@ -289,11 +289,39 @@ async fn test_smtp(
 #[cfg(feature = "smtp")]
 pub struct LettreMailSender;
 
+/// Upper bound on one delivery (connect through the final response).
+///
+/// `lettre`'s own timeout bounds individual phases and not reliably all of
+/// them, so a relay that accepts a connection and then stalls — mid-TLS, mid
+/// -write, or before its reply — can hold a caller far longer than the caller
+/// budgeted for. Every send here happens inside an HTTP request an operator is
+/// waiting on, so the bound lives next to the socket rather than at each call
+/// site: one place, and no call site can forget it. Same placement, and same
+/// reason, as `IMAP_TIMEOUT` in `imap.rs`.
+#[cfg(feature = "smtp")]
+const SMTP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 #[cfg(feature = "smtp")]
 #[async_trait::async_trait]
 impl crate::server::ops::mailer::MailSender for LettreMailSender {
     async fn send(
         &self,
+        creds: &MailCredentials,
+        email: &OutboundEmail,
+    ) -> Result<(), OpenCompanyError> {
+        match tokio::time::timeout(SMTP_TIMEOUT, Self::send_inner(creds, email)).await {
+            Ok(result) => result,
+            // The same variant a refused send reports, because it means the
+            // same thing to every caller: the message was not accepted, and
+            // nothing may be recorded as delivered.
+            Err(_) => Err(OpenCompanyError::Store("smtp send: timed out".into())),
+        }
+    }
+}
+
+#[cfg(feature = "smtp")]
+impl LettreMailSender {
+    async fn send_inner(
         creds: &MailCredentials,
         email: &OutboundEmail,
     ) -> Result<(), OpenCompanyError> {

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -29,7 +29,10 @@ use crate::ports::{
 };
 use crate::server::error::ApiError;
 use crate::server::graphql::auth::UserPrincipal;
-use crate::server::users::routes::{current_user, manifest_admin_invites};
+use crate::server::ops::mailer::OutboundEmail;
+use crate::server::users::routes::{
+    current_user, load_manifest, mail_transport_wired, manifest_admin_invites,
+};
 use crate::server::users::scope::{PublicCompany, public_scoped};
 use crate::server::users::{password, token};
 
@@ -192,13 +195,122 @@ struct InviteBody {
     role: UserRole,
 }
 
+/// What actually happened to the invite mail (issue #584).
+///
+/// The invite record is written either way — this reports delivery, it does not
+/// gate the grant. It is reported to the caller rather than swallowed because
+/// this route, unlike `auth/request`, has no enumeration oracle to protect: it
+/// is admin-authenticated and the caller typed the address in themselves, so
+/// there is nothing here they could learn that they did not already supply.
+/// A success toast over a mail that never left is the entire bug in the issue.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum InviteDelivery {
+    /// The transport accepted the message.
+    Sent,
+    /// This host has no mail transport wired, so nothing was attempted.
+    NoTransport,
+    /// A transport was wired and refused the message.
+    Failed,
+}
+
+/// The invite, plus what happened to the mail.
+///
+/// `flatten` keeps every existing [`InviteRecord`] field at the top level, so
+/// this is additive on the wire — an older client reading `id` / `email` /
+/// `role` sees exactly what it saw before.
+#[derive(Debug, Serialize)]
+struct InviteResult {
+    #[serde(flatten)]
+    invite: InviteRecord,
+    delivery: InviteDelivery,
+}
+
+/// Mails an invited address, returning what happened.
+///
+/// The mail carries **no credential** — no code, no token, not even the invite
+/// id. The recipient still goes through `auth/request` like anyone else, so the
+/// roster remains the only gate and this stays a notification. That is why it
+/// is safe to send to an address a human typed, possibly wrongly: the worst
+/// case is a stranger learning that a company they cannot enter exists.
+///
+/// The transport is the **host-level** one — the same seam the magic link uses,
+/// asked through the same predicate. Falling back to the company's own `__smtp`
+/// secret was considered and rejected: it would mail an invite from a host that
+/// cannot then mail the sign-in link, inviting someone into a dead flow.
+async fn send_invite_mail(
+    state: &AppState,
+    runtime: &CompanyRuntime,
+    invite: &InviteRecord,
+    inviter: &str,
+) -> InviteDelivery {
+    if !mail_transport_wired(state) {
+        return InviteDelivery::NoTransport;
+    }
+    let connections = state.connections();
+    let (Some(sender), Some(creds)) = (&connections.mail, &connections.mail_credentials) else {
+        return InviteDelivery::NoTransport;
+    };
+    let company_name = load_manifest(runtime)
+        .await
+        .ok()
+        .flatten()
+        .map(|m| m.company.name)
+        .unwrap_or_else(|| runtime.id().as_ref().to_string());
+    let base = state.config().host_base_url();
+    let link = format!("{base}/login?company={}", runtime.id().as_ref());
+    let days = INVITE_TTL_MILLIS / (24 * 60 * 60 * 1000);
+    let mail = OutboundEmail {
+        to: invite.email.clone(),
+        subject: format!("You're invited to {company_name}"),
+        body: format!(
+            "{inviter} invited you to {company_name}.\n\n\
+             To get in, sign in with this email address at:\n\n{link}\n\n\
+             You'll be sent a sign-in link by email — this message isn't one, \
+             and there's nothing in it to keep. The invitation is good for {days} days.\n\n\
+             If you weren't expecting this, you can ignore it. Nothing has been \
+             created for you and no one can act as you.\n"
+        ),
+    };
+    match sender.send(creds, &mail).await {
+        Ok(()) => InviteDelivery::Sent,
+        Err(err) => {
+            // The error, never the message: a body echoed into a log or into
+            // telemetry carries the recipient's address off this host.
+            tracing::warn!(company = %runtime.id(), "invite mail failed: {err}");
+            InviteDelivery::Failed
+        }
+    }
+}
+
+/// How to name the person who sent an invite, in mail the invitee reads.
+///
+/// A display name if they set one, otherwise the **local part** of their
+/// address — never the full address. Same rule as chat attribution (see
+/// `docs/spec/runtime/users.md`): being invited somewhere should not hand you
+/// an admin's mailbox. Falls back to a role noun if the inviter cannot be
+/// resolved, which is what a manifest- or platform-bootstrapped id looks like.
+async fn inviter_label(runtime: &CompanyRuntime, user_id: &str) -> String {
+    let found = runtime.users().get_user(runtime.id(), user_id).await.ok();
+    let Some(user) = found.flatten() else {
+        return "An admin".to_string();
+    };
+    if let Some(name) = user.display_name.filter(|n| !n.trim().is_empty()) {
+        return name;
+    }
+    match user.email.split('@').next() {
+        Some(local) if !local.is_empty() => local.to_string(),
+        _ => "An admin".to_string(),
+    }
+}
+
 /// `POST …/users/invites` — invite an address.
 async fn invite(
     company: PublicCompany,
     State(state): State<AppState>,
     headers: HeaderMap,
     Json(body): Json<InviteBody>,
-) -> Result<Json<InviteRecord>, Response> {
+) -> Result<Json<InviteResult>, Response> {
     let runtime = company.runtime.clone();
     let admin = require_admin(&headers, &state, &runtime).await?;
     let email = normalize_email(&body.email);
@@ -221,7 +333,7 @@ async fn invite(
         )))
         .into_response());
     }
-    let record = InviteRecord {
+    let mut record = InviteRecord {
         id: generate_id(),
         email,
         role: body.role,
@@ -229,6 +341,7 @@ async fn invite(
         created_at_millis: now,
         expires_at_millis: now + INVITE_TTL_MILLIS,
         accepted_at_millis: None,
+        notified_at_millis: None,
     };
     // The store enforces one invite per address; a clash surfaces as 409.
     runtime
@@ -236,7 +349,29 @@ async fn invite(
         .upsert_invite(runtime.id(), &record)
         .await
         .map_err(|e| ApiError(e).into_response())?;
-    Ok(Json(record))
+
+    // Strictly after the grant lands. Mailing first would tell someone they
+    // were invited by a request that then 409'd on a duplicate or failed in the
+    // store — an invitation to a company that never invited them.
+    let inviter = inviter_label(&runtime, &admin.user_id).await;
+    let delivery = send_invite_mail(&state, &runtime, &record, &inviter).await;
+    if delivery == InviteDelivery::Sent {
+        record.notified_at_millis = Some(now_millis());
+        // Best effort: the mail is already gone, so a failure to record that
+        // must not fail the request. The roster row simply reads as un-mailed,
+        // which understates rather than overstates what happened.
+        if let Err(err) = runtime.users().upsert_invite(runtime.id(), &record).await {
+            tracing::warn!(
+                company = %runtime.id(),
+                "invite mail sent but the record could not be stamped: {err}"
+            );
+            record.notified_at_millis = None;
+        }
+    }
+    Ok(Json(InviteResult {
+        invite: record,
+        delivery,
+    }))
 }
 
 /// `DELETE …/users/invites/{invite_id}` — revoke an invite.

--- a/src/server/users/admin.rs
+++ b/src/server/users/admin.rs
@@ -356,16 +356,31 @@ async fn invite(
     let inviter = inviter_label(&runtime, &admin.user_id).await;
     let delivery = send_invite_mail(&state, &runtime, &record, &inviter).await;
     if delivery == InviteDelivery::Sent {
-        record.notified_at_millis = Some(now_millis());
-        // Best effort: the mail is already gone, so a failure to record that
-        // must not fail the request. The roster row simply reads as un-mailed,
-        // which understates rather than overstates what happened.
-        if let Err(err) = runtime.users().upsert_invite(runtime.id(), &record).await {
-            tracing::warn!(
+        let at = now_millis();
+        // A stamp, not a re-write of the record: `record` was read before the
+        // send and the send is a network round trip, so an admin who mistyped
+        // the address has a real window to revoke this invite while the mail is
+        // in flight. Writing the stale record back would restore the row they
+        // just revoked — the address would be on the allowlist again with
+        // nothing on screen to say so.
+        match runtime
+            .users()
+            .mark_invite_notified(runtime.id(), &record.id, at)
+            .await
+        {
+            Ok(true) => record.notified_at_millis = Some(at),
+            // Revoked mid-flight. The revocation wins; the mail that already
+            // left is a message about an invitation that no longer exists,
+            // which is the lesser of the two wrongs available here.
+            Ok(false) => {}
+            // Best effort: the mail is already gone, so a failure to record
+            // that must not fail the request. The roster row simply reads as
+            // un-mailed, which understates rather than overstates what
+            // happened.
+            Err(err) => tracing::warn!(
                 company = %runtime.id(),
                 "invite mail sent but the record could not be stamped: {err}"
-            );
-            record.notified_at_millis = None;
+            ),
         }
     }
     Ok(Json(InviteResult {

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -962,6 +962,10 @@ pub(crate) async fn manifest_admin_invites(
                 created_at_millis: now,
                 expires_at_millis: now + MANIFEST_INVITE_TTL_MILLIS,
                 accepted_at_millis: None,
+                // A bootstrapped admin is eligible because configuration says
+                // so; nothing was ever mailed to them, and no row exists to
+                // stamp if it were.
+                notified_at_millis: None,
             }
         })
         .collect())

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -534,7 +534,13 @@ async fn request_code(
 ///
 /// Not "will this send succeed" — a wired transport that errors still counts,
 /// because the attempt is what the resend throttle rate-limits.
-fn mail_transport_wired(state: &AppState) -> bool {
+///
+/// Shared with the admin invite route (issue #584) so "can this host mail at
+/// all" keeps one answer. It matters there for a reason beyond tidiness: an
+/// invite mailed through some *other* transport would invite someone into a
+/// dead flow, because the magic link they then ask for is gated on exactly
+/// this predicate. One transport, one truthful answer.
+pub(crate) fn mail_transport_wired(state: &AppState) -> bool {
     let connections = state.connections();
     connections.mail.is_some() && connections.mail_credentials.is_some()
 }

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -1476,6 +1476,54 @@ async fn state_refusing_mail_to(
     (state_with(home, connections).await, accepted)
 }
 
+/// A transport that revokes the invite it is delivering, mid-send.
+///
+/// The race being modelled is an admin pressing Revoke while the SMTP round
+/// trip is still in flight — the exact window the route's post-send stamp sits
+/// in. Revoking from inside `send` reproduces that window deterministically:
+/// no sleep, no second task, and the route is provably still holding its
+/// pre-send copy of the record when the revocation lands.
+#[derive(Clone)]
+struct RevokingMailSender {
+    /// Filled once the state exists, since the runtime this revokes through is
+    /// the one the state owns — and the state cannot be built until the sender
+    /// it borrows is already wired into its connections.
+    runtime: Arc<std::sync::OnceLock<Arc<crate::runtime::CompanyRuntime>>>,
+    revoke_for: String,
+    accepted: RecordingMailSender,
+}
+
+#[async_trait::async_trait]
+impl crate::server::ops::mailer::MailSender for RevokingMailSender {
+    async fn send(
+        &self,
+        creds: &MailCredentials,
+        email: &crate::server::ops::mailer::OutboundEmail,
+    ) -> Result<(), crate::error::OpenCompanyError> {
+        if email.to == self.revoke_for {
+            let runtime = self
+                .runtime
+                .get()
+                .expect("the runtime is wired before any invite is sent");
+            let invite = runtime
+                .users()
+                .find_invite_by_email(runtime.id(), &self.revoke_for)
+                .await
+                .unwrap()
+                .expect("the grant lands before the mail goes out");
+            assert!(
+                runtime
+                    .users()
+                    .delete_invite(runtime.id(), &invite.id)
+                    .await
+                    .unwrap(),
+                "the revocation this models must actually remove the invite"
+            );
+        }
+        self.accepted.send(creds, email).await
+    }
+}
+
 /// Signs an admin in on a host with no mail transport, via the dev echo.
 async fn login_via_dev_code(state: &AppState, email: &str) -> String {
     let code = request_dev_code(state, email)
@@ -1681,6 +1729,70 @@ async fn a_failing_transport_is_reported_and_never_rolls_back_the_invite() {
             .iter()
             .any(|i| i["email"] == "bob@example.com"),
         "the invite must survive a failed send: {invites}"
+    );
+}
+
+#[tokio::test]
+async fn an_invite_revoked_while_its_mail_is_in_flight_stays_revoked() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let accepted = RecordingMailSender::new();
+    let runtime_cell = Arc::new(std::sync::OnceLock::new());
+    let connections = ConnectionsRuntime::new()
+        .with_mail(Arc::new(RevokingMailSender {
+            runtime: runtime_cell.clone(),
+            revoke_for: "bob@example.com".to_string(),
+            accepted: accepted.clone(),
+        }))
+        .with_mail_credentials(MailCredentials::Smtp(SmtpCredentials {
+            host: "smtp.test".into(),
+            port: 587,
+            security: SmtpSecurity::Starttls,
+            username: "u".into(),
+            password: "p".into(),
+            from_name: "Acme".into(),
+            from_email: "noreply@acme.test".into(),
+        }));
+    let state = state_with(&home, connections).await;
+    let _ = runtime_cell.set(
+        state
+            .registry()
+            .get(&CompanyId::new("acme"))
+            .expect("the company is registered"),
+    );
+    let admin = login_via_link(&state, &accepted, "ada@example.com").await;
+
+    let (status, body) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body["delivery"], "sent",
+        "the message really did leave, and reporting otherwise would be a lie: {body}"
+    );
+    assert!(
+        body["notifiedAtMillis"].is_null(),
+        "an invite revoked mid-send has nothing left to stamp: {body}"
+    );
+
+    // The property this test exists for. The stamp is written from a record
+    // read before the send, so an upsert would put the revoked invite back —
+    // silently returning an address to the allowlist after an admin removed it,
+    // with nothing on screen to say so.
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    let invites = body_json(response).await;
+    assert!(
+        !invites
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["email"] == "bob@example.com"),
+        "the mailed stamp must not restore a revoked invite: {invites}"
     );
 }
 

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -1403,3 +1403,326 @@ async fn the_env_admin_shows_on_the_invite_page_and_cannot_be_revoked() {
             .contains("OPENCOMPANY_ADMIN_EMAIL")
     );
 }
+
+// ---------------------------------------------------------------------------
+// Invite mail (issue #584)
+//
+// Adding a person used to write a record and mail nobody, while the console
+// reported unconditional success. These turn on both halves: that a mail
+// actually goes out, and that when it does not the caller is told so rather
+// than being congratulated.
+// ---------------------------------------------------------------------------
+
+/// A wired transport that refuses mail to one address and delivers the rest.
+///
+/// "No mail configured" is not the only way an invite fails to arrive, and it
+/// is the less dangerous one — it is at least visible in configuration. A
+/// wired transport that rejects the message is the case where a success toast
+/// is a lie, so it needs a mock of its own.
+///
+/// Refusal is per-recipient rather than global, for a reason that is not
+/// convenience: a sender that failed everything would also fail the admin's own
+/// login mail, leaving no way to reach the admin-authenticated route under
+/// test. It is also the truer model — a transport rejects a *message*, not a
+/// process.
+#[derive(Clone)]
+struct RefusingMailSender {
+    refuse: String,
+    accepted: RecordingMailSender,
+}
+
+#[async_trait::async_trait]
+impl crate::server::ops::mailer::MailSender for RefusingMailSender {
+    async fn send(
+        &self,
+        creds: &MailCredentials,
+        email: &crate::server::ops::mailer::OutboundEmail,
+    ) -> Result<(), crate::error::OpenCompanyError> {
+        if email.to == self.refuse {
+            // The same variant the real SMTP sender reports a rejected send
+            // with, so this exercises the branch production actually takes.
+            return Err(crate::error::OpenCompanyError::Store(
+                "smtp send: the transport refused the message".to_string(),
+            ));
+        }
+        self.accepted.send(creds, email).await
+    }
+}
+
+/// State whose transport works except for mail addressed to `refuse`.
+///
+/// Returns the recorder of everything it *did* accept, so a test can assert
+/// that the refused message is genuinely absent rather than merely unreported.
+async fn state_refusing_mail_to(
+    home: &std::path::Path,
+    refuse: &str,
+) -> (AppState, RecordingMailSender) {
+    let accepted = RecordingMailSender::new();
+    let sender = RefusingMailSender {
+        refuse: refuse.to_string(),
+        accepted: accepted.clone(),
+    };
+    let connections = ConnectionsRuntime::new()
+        .with_mail(Arc::new(sender))
+        .with_mail_credentials(MailCredentials::Smtp(SmtpCredentials {
+            host: "smtp.test".into(),
+            port: 587,
+            security: SmtpSecurity::Starttls,
+            username: "u".into(),
+            password: "p".into(),
+            from_name: "Acme".into(),
+            from_email: "noreply@acme.test".into(),
+        }));
+    (state_with(home, connections).await, accepted)
+}
+
+/// Signs an admin in on a host with no mail transport, via the dev echo.
+async fn login_via_dev_code(state: &AppState, email: &str) -> String {
+    let code = request_dev_code(state, email)
+        .await
+        .expect("a loopback host with no transport echoes the code");
+    let app = router(state.clone());
+    let response = app
+        .oneshot(post(
+            "/api/v1/companies/acme/auth/verify",
+            serde_json::json!({ "code": code }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    session_cookie(&response)
+}
+
+/// Invites `email` as `admin`, returning the status and decoded body.
+async fn invite_as(state: &AppState, admin: &str, email: &str) -> (StatusCode, serde_json::Value) {
+    let app = router(state.clone());
+    let response = app
+        .oneshot(post_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            serde_json::json!({ "email": email }),
+            admin,
+        ))
+        .await
+        .unwrap();
+    let status = response.status();
+    (status, body_json(response).await)
+}
+
+#[tokio::test]
+async fn inviting_someone_mails_them_a_credential_free_invitation() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) = state_with_mail(&home).await;
+    let admin = login_via_link(&state, &sender, "ada@example.com").await;
+    let before = sender.sent().len();
+
+    let (status, body) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["delivery"], "sent");
+    // The record's own fields stay top level: the response is additive.
+    assert_eq!(body["email"], "bob@example.com");
+    assert!(
+        body["notifiedAtMillis"].is_number(),
+        "a sent invite must record when: {body}"
+    );
+
+    let sent = sender.sent();
+    assert_eq!(
+        sent.len() - before,
+        1,
+        "inviting once must send exactly one mail"
+    );
+    let mail = &sent.last().unwrap().1;
+    assert_eq!(mail.to, "bob@example.com");
+    assert!(
+        mail.subject.contains("Acme"),
+        "the subject must name the company: {}",
+        mail.subject
+    );
+    assert!(
+        mail.body.contains("/login?company=acme"),
+        "the mail must say where to sign in: {}",
+        mail.body
+    );
+
+    // The property the issue's acceptance criteria turn on: this is a
+    // notification, not a credential. The allowlist plus the magic link stays
+    // the only way in, so nothing redeemable may appear in the body.
+    let invite_id = body["id"].as_str().expect("an invite id");
+    assert!(
+        !mail.body.contains(invite_id),
+        "the invite id must not travel in the mail: {}",
+        mail.body
+    );
+    assert!(
+        !mail.body.contains("code="),
+        "the mail must carry no login code: {}",
+        mail.body
+    );
+    // The inviter is named by local part, never by full address.
+    assert!(
+        mail.body.contains("ada"),
+        "the mail must name who invited them: {}",
+        mail.body
+    );
+    assert!(
+        !mail.body.contains("ada@example.com"),
+        "the inviter's full address must not be disclosed: {}",
+        mail.body
+    );
+
+    // And the stamp is durable, not just echoed in the response.
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    let invites = body_json(response).await;
+    let row = invites
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|i| i["email"] == "bob@example.com")
+        .expect("the invite must be listed");
+    assert!(
+        row["notifiedAtMillis"].is_number(),
+        "the mailed stamp must survive the store: {row}"
+    );
+}
+
+#[tokio::test]
+async fn inviting_on_a_host_with_no_mail_says_so_instead_of_reporting_success() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    // No transport at all — the shape the issue calls out as "fails quietly".
+    let state = state_with(&home, ConnectionsRuntime::new()).await;
+    let admin = login_via_dev_code(&state, "ada@example.com").await;
+
+    let (status, body) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(status, StatusCode::OK, "the grant still succeeds");
+    assert_eq!(
+        body["delivery"], "no_transport",
+        "the operator must be told nothing was mailed: {body}"
+    );
+    assert!(
+        body["notifiedAtMillis"].is_null(),
+        "nothing was mailed, so nothing may be stamped: {body}"
+    );
+
+    // The invite itself is real — the person can sign in, they just have to be
+    // told out of band. Reporting no_transport must not have skipped the grant.
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    let invites = body_json(response).await;
+    assert!(
+        invites
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["email"] == "bob@example.com"),
+        "the invite must exist regardless of mail: {invites}"
+    );
+}
+
+#[tokio::test]
+async fn a_failing_transport_is_reported_and_never_rolls_back_the_invite() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, accepted) = state_refusing_mail_to(&home, "bob@example.com").await;
+    let admin = login_via_link(&state, &accepted, "ada@example.com").await;
+    let before = accepted.sent().len();
+
+    let (status, body) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "a mail failure must not fail the grant"
+    );
+    assert_eq!(
+        body["delivery"], "failed",
+        "a refused message must be reported, not swallowed: {body}"
+    );
+    assert!(
+        body["notifiedAtMillis"].is_null(),
+        "nothing arrived, so nothing may be stamped as sent: {body}"
+    );
+    assert_eq!(
+        accepted.sent().len(),
+        before,
+        "the refused message must not appear as delivered"
+    );
+
+    // The grant survives the failed send. This is the half that must not
+    // regress: rolling the invite back would turn a mail outage into a silent
+    // refusal to add people, and re-inviting would then 409 against a record
+    // the operator was told did not exist.
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_cookie(
+            "/api/v1/companies/acme/users/invites",
+            &admin,
+        ))
+        .await
+        .unwrap();
+    let invites = body_json(response).await;
+    assert!(
+        invites
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|i| i["email"] == "bob@example.com"),
+        "the invite must survive a failed send: {invites}"
+    );
+}
+
+#[tokio::test]
+async fn a_refused_invite_mails_nobody() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let (state, sender) = state_with_mail(&home).await;
+    let admin = login_via_link(&state, &sender, "ada@example.com").await;
+
+    // Already a member: Ada bootstraps from the manifest and has signed in.
+    let before = sender.sent().len();
+    let (status, _) = invite_as(&state, &admin, "ada@example.com").await;
+    assert_eq!(status, StatusCode::CONFLICT);
+    assert_eq!(
+        sender.sent().len(),
+        before,
+        "an invite refused as already-a-member must mail nobody"
+    );
+
+    // And a duplicate outstanding invite is refused by the store, also silently
+    // as far as the mailbox is concerned — one invitation per address, not one
+    // per click. Without this, the button is a mail cannon aimed at whoever an
+    // admin most recently typed.
+    let (status, _) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(status, StatusCode::OK);
+    let after_first = sender.sent().len();
+
+    let (status, _) = invite_as(&state, &admin, "bob@example.com").await;
+    assert_eq!(status, StatusCode::CONFLICT, "one invite per address");
+    assert_eq!(
+        sender.sent().len(),
+        after_first,
+        "a duplicate invite must not re-mail"
+    );
+
+    // A malformed address never reaches a transport either.
+    let (status, _) = invite_as(&state, &admin, "not-an-email").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        sender.sent().len(),
+        after_first,
+        "a rejected address must mail nobody"
+    );
+}

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1148,6 +1148,7 @@ pub async fn assert_user_store(users: Arc<dyn UserStore>) {
         created_at_millis: at,
         expires_at_millis: at + 1_000,
         accepted_at_millis: None,
+        notified_at_millis: None,
     };
 
     users

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1235,9 +1235,37 @@ pub async fn assert_user_store(users: Arc<dyn UserStore>) {
         "clearing notified_at_millis must persist as cleared"
     );
 
+    // Stamping is an update, never an upsert. Mail delivery is a network round
+    // trip, and the record the route holds across it goes stale the moment an
+    // admin revokes the invite — so a backend that implemented the stamp as a
+    // full-record write would restore an address the admin had just removed
+    // from the allowlist.
+    assert!(
+        users.mark_invite_notified(&alpha, "i1", 12).await.unwrap(),
+        "stamping an outstanding invite must report that it landed"
+    );
+    let stamped = users
+        .find_invite_by_email(&alpha, "carol@example.com")
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(stamped.notified_at_millis, Some(12));
+    assert_eq!(
+        stamped.email, "carol@example.com",
+        "stamping must leave every other field alone"
+    );
+    assert_eq!(stamped.created_at_millis, 1);
+
     assert!(users.delete_invite(&alpha, "i1").await.unwrap());
     assert!(!users.delete_invite(&alpha, "i1").await.unwrap());
-    assert!(users.list_invites(&alpha).await.unwrap().is_empty());
+    assert!(
+        !users.mark_invite_notified(&alpha, "i1", 13).await.unwrap(),
+        "stamping a revoked invite must report that nothing was updated"
+    );
+    assert!(
+        users.list_invites(&alpha).await.unwrap().is_empty(),
+        "stamping must never recreate a revoked invite"
+    );
 }
 
 /// Asserts the [`SessionStore`] contract: per-company isolation, token-hash

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -1202,6 +1202,39 @@ pub async fn assert_user_store(users: Arc<dyn UserStore>) {
         Some(9)
     );
 
+    // The mailed stamp round-trips through the backend, both ways (issue
+    // #584). It is what the console reads to say "invite email sent", so a
+    // backend that dropped it would render every invite as un-mailed.
+    let mut notified = invite("i1", "carol@example.com", 1);
+    notified.notified_at_millis = Some(11);
+    users.upsert_invite(&alpha, &notified).await.unwrap();
+    assert_eq!(
+        users
+            .find_invite_by_email(&alpha, "carol@example.com")
+            .await
+            .unwrap()
+            .unwrap()
+            .notified_at_millis,
+        Some(11),
+        "a stored notified_at_millis must survive the round trip"
+    );
+    // And back to unset: a store that only ever wrote the field when present
+    // would leave a stale timestamp behind on a re-invite.
+    users
+        .upsert_invite(&alpha, &invite("i1", "carol@example.com", 1))
+        .await
+        .unwrap();
+    assert_eq!(
+        users
+            .find_invite_by_email(&alpha, "carol@example.com")
+            .await
+            .unwrap()
+            .unwrap()
+            .notified_at_millis,
+        None,
+        "clearing notified_at_millis must persist as cleared"
+    );
+
     assert!(users.delete_invite(&alpha, "i1").await.unwrap());
     assert!(!users.delete_invite(&alpha, "i1").await.unwrap());
     assert!(users.list_invites(&alpha).await.unwrap().is_empty());

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -218,6 +218,27 @@ impl UserStore for FsOps {
         write_atomic(&path, &serde_json::to_string(&invites)?).await
     }
 
+    async fn mark_invite_notified(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        at_millis: u64,
+    ) -> Result<bool> {
+        let path = self.bundle(company).user_invites_json();
+        // The same lock `delete_invite` takes, which is what makes the
+        // read-modify-write atomic against a concurrent revocation rather than
+        // merely unlikely to race with one.
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut invites = load_json_vec::<InviteRecord>(&path).await?;
+        let Some(existing) = invites.iter_mut().find(|i| i.id == id) else {
+            return Ok(false);
+        };
+        existing.notified_at_millis = Some(at_millis);
+        write_atomic(&path, &serde_json::to_string(&invites)?).await?;
+        Ok(true)
+    }
+
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let path = self.bundle(company).user_invites_json();
         let lock = path_lock(&path);

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -1223,6 +1223,41 @@ impl crate::ports::users::UserStore for MongoStore {
         Ok(())
     }
 
+    async fn mark_invite_notified(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        at_millis: u64,
+    ) -> Result<bool> {
+        let found = self
+            .collection("user_invites")
+            .find_one(doc! {"company_id": company.as_ref(), "invite_id": id})
+            .await
+            .map_err(mongo_err)?;
+        let Some(found) = found else {
+            return Ok(false);
+        };
+        let current = get_str(&found, "invite_json")?;
+        let mut invite: InviteRecord = serde_json::from_str(&current)?;
+        invite.notified_at_millis = Some(at_millis);
+        // No `upsert` option, and the filter pins the document we just read: a
+        // revocation that lands between the two calls leaves nothing to match,
+        // so the stamp becomes a no-op instead of resurrecting the row.
+        let res = self
+            .collection("user_invites")
+            .update_one(
+                doc! {
+                    "company_id": company.as_ref(),
+                    "invite_id": id,
+                    "invite_json": &current,
+                },
+                doc! {"$set": {"invite_json": serde_json::to_string(&invite)?}},
+            )
+            .await
+            .map_err(mongo_err)?;
+        Ok(res.matched_count > 0)
+    }
+
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let res = self
             .collection("user_invites")

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -1257,6 +1257,44 @@ impl crate::ports::users::UserStore for SqliteStore {
         Ok(())
     }
 
+    async fn mark_invite_notified(
+        &self,
+        company: &CompanyId,
+        id: &str,
+        at_millis: u64,
+    ) -> Result<bool> {
+        let conn = self.conn();
+        let current: Option<String> = conn
+            .query_row(
+                "SELECT invite_json FROM user_invites WHERE company_id = ?1 AND id = ?2",
+                params![company.as_ref(), id],
+                |r| r.get(0),
+            )
+            .optional()
+            .map_err(sql_err)?;
+        let Some(current) = current else {
+            return Ok(false);
+        };
+        let mut invite: InviteRecord = serde_json::from_str(&current)?;
+        invite.notified_at_millis = Some(at_millis);
+        // UPDATE, never INSERT, and matched against the row we just read: a
+        // revocation that lands between the two statements leaves nothing to
+        // match, so the stamp becomes a no-op instead of resurrecting the row.
+        let n = conn
+            .execute(
+                "UPDATE user_invites SET invite_json = ?3 \
+                 WHERE company_id = ?1 AND id = ?2 AND invite_json = ?4",
+                params![
+                    company.as_ref(),
+                    id,
+                    serde_json::to_string(&invite)?,
+                    current
+                ],
+            )
+            .map_err(sql_err)?;
+        Ok(n > 0)
+    }
+
     async fn delete_invite(&self, company: &CompanyId, id: &str) -> Result<bool> {
         let conn = self.conn();
         let n = conn

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1736,6 +1736,14 @@ admins = [{list}]
         ) -> crate::Result<()> {
             unreachable!("owner delivery reads only list_users")
         }
+        async fn mark_invite_notified(
+            &self,
+            _company: &CompanyId,
+            _id: &str,
+            _at_millis: u64,
+        ) -> crate::Result<bool> {
+            unreachable!("owner delivery reads only list_users")
+        }
         async fn delete_invite(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
             unreachable!("owner delivery reads only list_users")
         }


### PR DESCRIPTION
## Summary

Adding a person wrote an invite record and mailed nobody, while the console
toasted unconditional success on any 2xx. QA reported it as "invited someone,
they never got an invite" — not a delivery failure, but the absence of any
invite email at all.

This takes **Option A** from the issue: send the invite. The issue offered
Option B (relabel the control) as the cheap alternative, and the evidence
settles against it — the dialog *already* carried a "Nothing is emailed now"
disclaimer, and the misunderstanding happened anyway. The success toast was
the louder signal and the wrong one. Option B's honesty is kept as the
degraded mode: when no mail can go out, the console says so.

Three decisions worth naming:

- **Host-level transport**, gated on the same `mail_transport_wired` predicate
  the magic link uses — not the per-company `__smtp` secret. An invite sent
  from a host whose platform mail is unwired invites someone into a dead flow:
  they arrive at `auth/request` and the sign-in link cannot be mailed. One
  transport, one truthful answer.
- **Delivery is reported, not assumed.** Unlike `auth/request`, this route is
  admin-authenticated and the caller typed the address themselves, so there is
  no enumeration oracle to protect and nothing the response could disclose that
  the caller did not already supply.
- **The mail carries no credential** — no code, no token, not even the invite
  id. It names the company, the inviter (display name or email *local part*,
  never the full address, matching the existing chat-attribution rule), and the
  sign-in URL. The recipient still goes through `auth/request`, so the roster
  stays the only gate.

Mail is sent strictly *after* the invite record is written, so a 409 (already a
member, already invited) or a store failure mails nobody. A failed send never
rolls the grant back — a mail outage must not become a silent refusal to add
people.

## API Or Behavior Changes

- `POST …/users/invites` now returns `delivery: "sent" | "no_transport" |
  "failed"` alongside the invite. **Additive**: the `InviteRecord` fields stay
  at the top level via `#[serde(flatten)]`, so an existing client reading
  `id` / `email` / `role` sees exactly what it saw before.
- `InviteRecord` gains `notified_at_millis: Option<u64>`. **No migration**: all
  three stores persist invites as JSON blobs, and a row written before this
  change loads as `None` — which is true of it. An unmailed invite still
  serializes without the key (asserted, not assumed).
- `mail_transport_wired` becomes `pub(crate)`. No behaviour change to any auth
  route.
- Console: the invite submit path branches on `delivery` instead of toasting
  unconditional success; the pending-invite row appends "invite email sent" /
  "no invite email sent — let them know"; the dialog description no longer
  claims nothing is emailed.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test` — **2245 passed, 0 failed, 1 ignored**

Also run:

- `cargo check --all-features --all-targets` — clean (the feature-gated store
  backends touch `InviteRecord`).
- Console: `npm run typecheck`, `typecheck:unit`, `typecheck:e2e`,
  `npx vitest run` (**529 passed / 43 files**), `npm run build`.
- Playwright, full suite against the live host: **119 passed, 10 skipped, 0
  failed**, including the two new specs.

New coverage:

- All three delivery outcomes end to end through the router, including a
  `RefusingMailSender` mock for the failing-transport case — the proof that a
  send failure propagates rather than being swallowed. Refusal is modelled
  per-recipient rather than globally, because a globally-failing sender would
  also fail the admin's own login mail and leave the admin-authenticated route
  unreachable.
- The credential-free property is asserted explicitly: the mail body contains
  neither the invite id nor anything code-shaped, and names the inviter without
  disclosing their full address.
- Refusals mail nobody: existing-member 409, duplicate-invite 409, and a
  malformed address all leave the recorder empty.
- Store conformance round-trips `notified_at_millis` both ways (set, and back
  to cleared).
- A pre-change JSON blob is asserted to load as unmailed.
- `frontend/test/e2e/people-invite.spec.ts`. The e2e host binds loopback with
  **no** mail transport (it must — the `dev_code` echo global-setup signs in
  with is gated on exactly that), so the `no_transport` path is exercised for
  real, end to end.

Each new gate was checked for teeth by reverting the code it guards:

- Restoring the original bug (write the record, mail nobody, report `sent`)
  turns three backend tests RED, e.g.
  `assertion left == right failed: a refused message must be reported, not
  swallowed: {…,"delivery":"sent"}` and `inviting once must send exactly one
  mail`.
- Removing `skip_serializing_if` turns the port test RED:
  `an unmailed invite must not emit the key: {…,"notifiedAtMillis":null}`.
- Restoring the unconditional success toast turns the e2e spec RED:
  `waiting for getByText(/nothing was emailed/i)`.

### Honest gaps

- **No environment here sends real SMTP mail.** The `sent` branch is proven at
  the `MailSender` seam, not over the wire, and the e2e `sent` rendering is
  asserted against a stubbed response (labelled as such in the spec). Final
  verification that mail actually leaves the building is manual, on a
  mail-wired host.
- `notified_at_millis` records that the *transport accepted* the message, which
  is the furthest this process can honestly claim to know. A bounce after that
  point happens somewhere this code cannot see.
- The store-conformance round-trip is a contract assertion whose teeth were not
  separately proven — doing so would mean deliberately corrupting a backend.
- `#[serde(default)]` on the new field is belt-and-braces: serde already maps a
  missing `Option` to `None`, so the legacy-load guarantee comes from the type
  choice, not the attribute. Kept for consistency with the sibling fields.

## Documentation

`docs/spec/runtime/users.md`: the route table now distinguishes `GET` from
`POST …/users/invites` and records the `delivery` field, and the **Mail**
section gains a description of invite mail — which transport it uses and why
not the per-company one, that it is a notification rather than a credential,
the ordering guarantee against the store write, and what `notifiedAtMillis`
means.

Closes #584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Invitations now report whether email delivery was sent, unavailable, or failed.
  * Invitation emails include notification details without exposing credentials.
  * Invitation records show when notification was successfully delivered.
  * Invitations remain available even when email delivery fails.
  * Updated invitation messaging clarifies email delivery behavior.

* **Bug Fixes**
  * Prevented invalid or duplicate invitation emails from being sent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->