### PR TITLE
feat(journal): back the runtime journal with a storage port (#726)

### DIFF
--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -20,6 +20,10 @@ Supporting docs:
   - [ports-console.md](ports-console.md) — the WS3 console-surface stores
   - [ports-runs.md](ports-runs.md) — `RunStore`: one attempt at a task, its
     trace, and who writes it
+  - [journal.md](journal.md) — `JournalStore`: the runtime journal's durable
+    sink (at-most-once effect keys, parked approvals, grants, cycle brackets),
+    the per-backend shapes, and the one-time receipt-gated import off the old
+    `journal.jsonl` (issue #726)
 - [storage.md](storage.md) — how a backend is chosen at boot, the shipped
   backends, and the conformance suite that pins them to identical answers
   - [workspace-layout.md](workspace-layout.md) — the on-disk layout inside the

--- a/docs/spec/runtime/data-root.md
+++ b/docs/spec/runtime/data-root.md
@@ -47,6 +47,15 @@ on `<root>/.lock` (`flock`/`LockFileEx` via `fs2`) and hold it for the life of
 the process. A second instance is refused immediately with a message naming the
 directory and `OPENCOMPANY_DATA_DIR`.
 
+Since issue #726 the journal's *bytes* may live in the storage backend rather
+than under this root (see [journal.md](journal.md)), and that changes nothing
+here: single-writer-per-company is still the contract. Two live hosts on one
+tenant database no longer corrupt each other's records — sequences are allocated
+server-side, so appends interleave without collision — but each keeps its own
+in-memory replay of the executed-key set, so neither sees the other's commits
+until it reloads. That gap is pre-existing and unchanged; the root lock above is
+still what a single-node deployment relies on.
+
 An OS advisory lock rather than a pid file: the lock belongs to the open file
 description, so the kernel drops it when the process exits for any reason —
 clean exit, panic, `SIGKILL`, power loss. There is no stale state to detect and

--- a/docs/spec/runtime/journal.md
+++ b/docs/spec/runtime/journal.md
@@ -1,0 +1,167 @@
+# The runtime journal and its storage port
+
+The runtime journal (`src/runtime/journal.rs`) holds four things no other store
+holds:
+
+- the **at-most-once effect set** — the idempotency key of every side effect that
+  was committed to run;
+- the **parked-approval queue**, with each approval's original `ApprovalId`, the
+  effect it parked, its board task and its conversation;
+- **single-use and standing grants**, minted when an operator approves a tool
+  call;
+- **cycle brackets**, which is how a cycle interrupted by a host restart is
+  recognised and settled at the next boot.
+
+It is deliberately not the [`EventLog`](events.md). `CompanyEvent` is a closed,
+binding enum with no marker variants, and the event log is *pruned* under a
+retention policy — rotating away an `EffectExecuted` key would silently
+un-commit it and let an at-most-once effect fire a second time.
+
+## Why it is a port (issue #726)
+
+The journal used to be constructed unconditionally on the filesystem, at
+`<home>/companies/<slug>/journal.jsonl`, outside the port surface
+`StorageHandles` swaps for every other durable store.
+
+On a hosted tenant with `OPENCOMPANY_STORAGE=mongodb` the container's `/data` is
+documented **ephemeral scratch** — the same fact the TinyCortex boot refusal
+exists for (see
+[memory-engine.md](memory-engine.md#durability-contract--the-data-is-scratch-caveat)).
+Container replacement — a deploy, a reschedule, a node drain, an OOM kill —
+discarded the file. Every previously executed effect became eligible to fire
+again, and every parked approval, grant and standing grant silently vanished.
+
+That is a data-integrity defect, not log noise, so the fix is the port
+(`src/ports/journal.rs`) rather than a warning.
+
+## `JournalStore` — two byte-level operations
+
+```rust
+async fn append_journal(&self, id: &CompanyId, line: &str) -> Result<()>;
+async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>>;
+async fn journal_imported(&self, id: &CompanyId) -> Result<bool>;
+async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()>;
+```
+
+Not a mirror of `RuntimeJournal`'s ~25 methods. The journal's whole persistence
+contract is "append one opaque line, read every line back in order". Everything
+semantic — the record enum with its `#[serde(default)]` archaeology, the
+corrupt-line skip, the merged-line recovery, the replayed in-memory state — stays
+in `RuntimeJournal` and is backend-agnostic by construction. A backend stores
+strings and never learns what a `JournalRecord` is, so a new record variant needs
+no backend change.
+
+Two obligations a backend must not weaken:
+
+- **Durability before return.** The at-most-once guarantee is that a key is
+  durable *before* the side effect runs. An `Err` therefore reaches the caller
+  before the effect, which fails closed. The residual case — a timeout on a write
+  the server did commit — leaves a committed key with no effect, the contract's
+  documented safe direction.
+- **Bytes and order.** A rewritten, trimmed or re-encoded line no longer parses,
+  and a skipped `EffectExecuted` un-commits its key. A park read back *after* the
+  resolution that drained it resurrects a resolved approval.
+
+`src/store/conformance.rs` holds every backend to both:
+`assert_journal_store` (all three backends) and `assert_journal_import`
+(sqlite and mongodb — the fs backend has nothing to import). Both levels of
+`Durability` are exercised there, because a backend that ignored the parameter
+would otherwise pass every assertion.
+
+## Durability travels through the port (issue #392)
+
+Durability is chosen **per record kind**, not once for the journal:
+`EffectExecuted`, `GrantConsumed` and `StandingGrantRevoked` must survive losing
+the machine, because losing them makes the runtime repeat an external action; the
+other ten need only survive the process, because losing them makes it *re-ask*.
+The per-record decision and its reasoning live in
+[lifecycle.md](lifecycle.md#which-crash-a-journal-record-survives-issue-392).
+
+`append_journal` therefore carries a `Durability`, and a backend MUST NOT flatten
+the two levels into one. Flattening upward taxes the journal's highest-volume
+records with a flush they do not need; flattening downward silently drops the
+guarantee that keeps an already-fired effect from firing again after a power
+loss, which is the one thing the split was bought for.
+
+The fs backend's directory handling is part of that contract rather than an
+implementation detail: a `Host` append into a fresh data directory creates the
+parent chain through `create_dir_all_durable`, which flushes each created
+directory's own parent. A record flushed under directory entries that were never
+written down is lost with them — on exactly the crash the flush was bought for,
+with the record's own `sync_data` still passing its own test. That is why the
+`RuntimeJournal` → `JournalStore` move kept both halves of the branch together.
+
+## Backend shapes
+
+| Backend | Shape | Ordering | Durability |
+|---|---|---|---|
+| `fs` | `<home>/companies/<slug>/journal.jsonl` | file order; one whole-line `O_APPEND` write per record, serialised on a process-wide per-path lock | `Process`: the write syscall has completed. `Host`: plus `sync_data`, plus a flushed parent chain |
+| `sqlite` | `journal(company_id, seq, line, PK(company_id, seq))` + `journal_imports` | `seq` from `COALESCE(MAX(seq)+1, 0)` in the insert statement | `Process`: WAL commit under `synchronous=NORMAL`. `Host`: the commit runs under `synchronous=FULL` |
+| `mongodb` | `journal` collection `{company_id, seq, line}`, unique `(company_id, seq)` + `journal_imports` | `seq` from the atomic `counters` allocator `EventLog` already uses | `Process`: an acknowledged `insert_one`. `Host`: the same with `j:true` write concern |
+
+The mongodb collection is **not capped**. Capping drops the oldest documents, and
+the oldest documents are the at-most-once keys of effects that ran months ago;
+un-committing one re-arms that effect. Bounding the journal is a retention
+question with a correctness argument attached, not a storage-shape default.
+
+## Migration: one-time, receipt-gated, verbatim
+
+The fs implementation *is* today's file at today's path, so the default backend
+migrates nothing.
+
+For sqlite and mongodb, `RuntimeBuilder` runs a one-time import at construction:
+
+1. ask the sink whether this company has an import receipt;
+2. if not, read `journal.jsonl` — **raw strings, in file order**, so a corrupt or
+   merged line migrates byte-for-byte and the journal's own recovery still
+   applies to it;
+3. `complete_import` **clears, copies, then writes the receipt**, in that order.
+
+The order carries the safety argument. An import interrupted anywhere leaves the
+gate open, so the next boot re-runs the whole clear-and-copy. What must never
+happen is a *partial* copy behind a *closed* gate: a journal missing its tail is
+a set of at-most-once keys that quietly went missing — the exact bug the port
+exists to fix. On sqlite the three steps are one transaction; on mongodb they are
+not, and the receipt landing last is what makes the non-atomic case safe.
+
+A failed import is **fatal to boot**. Coming up with an empty journal is
+indistinguishable, to every effect the company then runs, from having never
+executed anything.
+
+Two deliberate choices around the gate:
+
+- **The source file stays in place.** The receipt makes a second import
+  impossible, and a rollback to an older binary still finds the history it knows
+  how to read. Renaming it would hand that binary an *empty* at-most-once set.
+- **The gate closes even with nothing to import** (an import of zero lines), so a
+  `journal.jsonl` that appears *later* — a rollback, a stray copy into the data
+  dir — can never wipe and replace a journal the backend has since accumulated.
+
+On a tenant whose container was already replaced there is nothing on disk to
+import, and nothing can retroactively recover keys that were already lost.
+
+## Concurrency
+
+- **Within one `RuntimeJournal`**, appends serialise on a write lock held across
+  the store call — which is what keeps a backend's sequence allocation in call
+  order, and therefore keeps a park from replaying after its resolution.
+- **Across instances in one process**, the fs backend's per-path lock still
+  applies. A database backend allocates sequences server-side, so two live hosts
+  interleave without collision: the same physics as `O_APPEND`.
+- **Single writer per company remains the documented contract**
+  ([data-root.md](data-root.md#single-writer-enforced)). One gap is *pre-existing*
+  and out of scope here: `RuntimeJournal`'s `is_executed` set is per-process
+  in-memory state, so two simultaneously live containers on one tenant database
+  would each answer from their own replay. Moving the journal into a shared
+  backend does not create that gap and does not close it.
+
+## No interim boot refusal
+
+The TinyCortex refusal ([memory-engine.md](memory-engine.md)) guards an *opt-in*
+engine that has alternatives to point at. The journal is unconditional and has no knob, every
+staging tenant runs mongodb, and a refusal would take the hosted fleet down to
+protect it from a risk it is already living with — while stranding tenants with
+no remedy. What is adopted from that precedent instead is **fail-loud
+selection**: under a database backend the journal sink comes from the backend
+handles, never a silent fs fallback, matching the rule `open_storage` already
+states for every other port. The boot log names the sink it resolved.

--- a/docs/spec/runtime/lifecycle.md
+++ b/docs/spec/runtime/lifecycle.md
@@ -117,15 +117,16 @@ record means no effect, so the failure cannot produce the duplicate it guards
 against. The flush is never retried, because a failed `fsync` may already have
 dropped the dirty pages and a retry would report success over lost data.
 
-**This guarantee is bounded by the volume underneath.** The journal is built on
-the filesystem path unconditionally, outside the storage ports, so a hosted
-tenant whose `/data` is ephemeral scratch — the documented arrangement under
-`OPENCOMPANY_STORAGE=mongodb`, see
-[storage.md](storage.md) — loses its journal to a container replacement and
-gains nothing from these flushes. Where the data directory is a real volume (the
-reference ECS deployment mounts EFS at `/data`, whose NFS client page cache is
-exactly what `sync_data` forces through) the flush buys real durability. Moving
-the journal behind the ports is tracked separately as issue #726.
+**The volume underneath used to bound this guarantee, and no longer does**
+(issue #726). The journal was built on the filesystem path unconditionally,
+outside the storage ports, so a hosted tenant whose `/data` is ephemeral scratch
+— the documented arrangement under `OPENCOMPANY_STORAGE=mongodb` — lost its
+journal to a container replacement and gained nothing from these flushes. The
+sink is now a port (`JournalStore`), selected from the same backend handles as
+every other durable store, and the two levels above travel through it: the fs
+backend answers them with `sync_data` and a flushed directory chain, sqlite with
+`synchronous=FULL` against `NORMAL`, mongodb with a `j:true` write concern
+against the default. See [journal.md](journal.md).
 
 ## The fs bundle (default store)
 

--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -38,6 +38,7 @@ event vocabulary those traits carry moved to [`events.md`](events.md)
 | `InboxStore` | [ports-console.md](ports-console.md#inboxstore) | per-teammate email inboxes |
 | `RunStore` | [ports-runs.md](ports-runs.md#runstore) | one attempt at a task, and its trace |
 | `WorkflowRevisionStore` | [`src/ports/workflow_revisions.rs`](../../../src/ports/workflow_revisions.rs) | a bounded per-workflow edit-history ring for rollback (issue #274) |
+| `JournalStore` | [journal.md](journal.md) | the runtime journal's durable sink: at-most-once effect keys, parked approvals, grants, cycle brackets (issue #726) |
 
 ## Assembly
 
@@ -76,6 +77,7 @@ the multi-tenant platform case with the same type.
 | `TaskStore`, `WorkspaceStore`, `FactStore`, `UsageMeter`, `SkillStateStore`, `InboxStore` | fs bundle | sqlite, mongodb |
 | `UserStore`, `SessionStore`, `LoginCodeStore` | fs bundle | sqlite, mongodb |
 | `ArtifactStore`, `RunStore`, `WorkflowRevisionStore` | fs bundle (JSONL) | sqlite, mongodb |
+| `JournalStore` | fs bundle (`journal.jsonl`) | sqlite, mongodb |
 
 ### `WorkflowRevisionStore` (issue #274)
 

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -27,6 +27,13 @@ records as inspectable TOML/JSONL bundles and the WS3 console-surface stores
 under a sibling `ops/` layout (`src/store/fs_ops.rs`); sqlite and mongodb add
 one collection/table per store.
 
+A fifteenth, `JournalStore`, joined them in issue #726. The runtime journal was
+built on the filesystem unconditionally until then, so on a mongodb tenant the
+at-most-once effect set and the parked-approval queue lived on `/data` —
+ephemeral scratch, discarded on every container replacement. It is now selected
+from the same handles as every other store, with a one-time receipt-gated import
+off the old file: [journal.md](journal.md).
+
 Three of those fourteen — `UserStore`, `SessionStore`, `LoginCodeStore` — back
 [human user authentication](users.md). Sessions and login codes are credential
 material: they hold **hashes only**, and they must never be added to the
@@ -63,9 +70,9 @@ from a `counters` collection via atomic `findOneAndUpdate {$inc}`.
 
 Collections (all uniquely indexed on `company_id` + their key):
 `companies`, `ledger`, `events`, `memory_traces`, `memory_tasks`,
-`context_chunks`, `secrets`, plus `counters` and `owners`; and the WS3
-console-surface collections `tasks`, `workspace`, `facts`, `usage`, `skills`,
-and `inboxes`. The `usage` collection is trimmed to the 90-day retention window
+`context_chunks`, `secrets`, `journal` and `journal_imports`, plus `counters`
+and `owners`; and the WS3 console-surface collections `tasks`, `workspace`,
+`facts`, `usage`, `skills`, and `inboxes`. The `usage` collection is trimmed to the 90-day retention window
 on each `record` (see [`UsageMeter`](ports-console.md#usagemeter)).
 
 ### Multi-tenant isolation (two layers)

--- a/src/ports/journal.rs
+++ b/src/ports/journal.rs
@@ -1,0 +1,118 @@
+//! The [`JournalStore`] port: the durable sink under the runtime journal
+//! (issue #726).
+//!
+//! [`RuntimeJournal`](crate::runtime::journal::RuntimeJournal) holds the
+//! at-most-once effect set, the parked-approval queue, single-use and standing
+//! grants, and the cycle brackets. Until this port existed it wrote all of that
+//! to a `journal.jsonl` inside the company bundle **unconditionally** — outside
+//! the port surface [`StorageHandles`](crate::store::StorageHandles) swaps for
+//! every other durable store. On a hosted tenant with
+//! `OPENCOMPANY_STORAGE=mongodb` the container's `/data` is documented ephemeral
+//! scratch (see `docs/spec/runtime/storage.md`), so container replacement — a
+//! deploy, a reschedule, a node drain, an OOM kill — discarded the file: every
+//! previously executed effect became eligible to fire again, and every parked
+//! approval and grant silently vanished.
+//!
+//! ## Two byte-level operations, and no semantics
+//!
+//! This trait is deliberately *not* a mirror of `RuntimeJournal`'s ~25 methods.
+//! The journal's entire persistence contract is: append one opaque line, and
+//! read every line back in the order they were appended. Everything semantic —
+//! the record enum with its `#[serde(default)]` archaeology, the corrupt-line
+//! skip, the merged-line recovery, the in-memory replay state — stays in
+//! `RuntimeJournal` and is therefore backend-agnostic by construction. A
+//! backend stores strings; it never learns what a `JournalRecord` is, and a new
+//! record variant needs no backend change.
+//!
+//! ## Why not ride [`EventLog`](crate::ports::EventLog)
+//!
+//! [`CompanyEvent`](crate::ports::CompanyEvent) is a closed, binding enum with
+//! no marker variants, which is the reason the journal exists as a separate log
+//! in the first place. And the event log is *pruned* under a retention policy —
+//! rotating away an `EffectExecuted` key would silently un-commit it and let an
+//! at-most-once effect fire a second time. The journal is append-only with no
+//! retention, and those two contracts cannot share one log.
+//!
+//! ## Migration is a one-time, receipt-gated, verbatim import
+//!
+//! The fs implementation *is* today's file at today's path, so the default
+//! backend migrates nothing. For sqlite and mongodb the builder copies an
+//! existing `journal.jsonl` in **file order, verbatim** (raw strings — a corrupt
+//! or merged line migrates byte-for-byte, so `RuntimeJournal`'s own recovery
+//! still applies to it), then writes a receipt.
+//!
+//! The receipt is what makes a crash mid-import safe:
+//! [`complete_import`](JournalStore::complete_import) clears whatever a previous
+//! attempt wrote before re-copying, and only then records the receipt — so an
+//! interrupted import re-runs the whole wipe-and-copy instead of replaying a
+//! truncated prefix. A truncated prefix is precisely the bug this port exists to
+//! fix: it would drop at-most-once keys.
+//!
+//! The source file is left in place. The receipt makes a second import
+//! impossible, and a rollback to an older binary still finds the history it
+//! knows how to read — where renaming the file would hand that binary an
+//! *empty* at-most-once set.
+
+use async_trait::async_trait;
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// The durable byte sink under one company's runtime journal.
+#[async_trait]
+pub trait JournalStore: Send + Sync {
+    /// Appends one opaque record line, which MUST be durable before this
+    /// returns.
+    ///
+    /// The at-most-once guarantee is that an effect's key reaches durable
+    /// storage *before* the side effect runs, so a backend that acknowledges a
+    /// buffered or unjournaled write breaks the contract this port carries. The
+    /// fs backend performs a single `O_APPEND` `write_all` and waits on the
+    /// syscall; the mongodb backend inserts with `j:true` write concern.
+    ///
+    /// `line` never contains a newline — the caller serialises one JSON record
+    /// per call — and a backend must preserve it byte-for-byte.
+    ///
+    /// Errors are fail-closed: an `Err` reaches the caller *before* the side
+    /// effect, so the effect does not run. The residual ambiguity (a timeout on
+    /// a write the server did commit) leaves a committed key with no effect,
+    /// which is the at-most-once contract's documented safe direction.
+    async fn append_journal(&self, id: &CompanyId, line: &str) -> Result<()>;
+
+    /// Every line ever appended for `id`, in append order.
+    ///
+    /// Order is load-bearing rather than cosmetic: replay folds records in
+    /// sequence, so a park read back after the resolution that drains it would
+    /// resurrect a resolved approval.
+    ///
+    /// Damaged lines are returned as they are stored, not filtered — deciding
+    /// what a line means is the journal's job, and a backend that silently
+    /// dropped one would be un-committing an effect key on the caller's behalf.
+    async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>>;
+
+    /// Whether this backend has already taken (or does not need) a one-time
+    /// import of a pre-existing filesystem journal.
+    ///
+    /// `true` closes the gate forever: the builder never imports again, so a
+    /// `journal.jsonl` reappearing later — a rollback, a stray copy into the
+    /// data dir — cannot wipe and replace the backend's own history.
+    ///
+    /// The fs backend answers `true` unconditionally: its store *is* the file,
+    /// so there is nothing to import and [`complete_import`](Self::complete_import)
+    /// is unreachable for it.
+    async fn journal_imported(&self, id: &CompanyId) -> Result<bool>;
+
+    /// Replaces this company's journal with `lines` and records the import
+    /// receipt.
+    ///
+    /// Clear-then-copy-then-receipt, in that order, and the order is the whole
+    /// safety argument — see the module docs. Implementations do it atomically
+    /// where the backend allows (sqlite: one transaction); where it does not
+    /// (mongodb), the receipt landing last still makes an interrupted attempt
+    /// re-run from the top rather than leave a truncated journal behind a
+    /// closed gate.
+    ///
+    /// An empty `lines` is a legitimate call, not a no-op to optimise away: it
+    /// is how a company with no prior filesystem journal closes its gate.
+    async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()>;
+}

--- a/src/ports/journal.rs
+++ b/src/ports/journal.rs
@@ -58,17 +58,48 @@ use async_trait::async_trait;
 use crate::Result;
 use crate::ports::types::CompanyId;
 
+/// The failure a journal record is written to outlast (issue #392).
+///
+/// The journal's own per-record decision — which record kind needs which level,
+/// and why — lives on `JournalRecord::durability` in
+/// [`crate::runtime::journal`]. This is only the vocabulary the decision is
+/// expressed in, and it lives here because the sink is what has to honour it.
+///
+/// A backend MUST NOT flatten the two into one level. Flattening upward taxes
+/// the journal's highest-volume records with a flush they do not need;
+/// flattening downward silently drops the guarantee that keeps an already-fired
+/// effect from firing again after a power loss, which is the one thing the split
+/// was bought for.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Durability {
+    /// Durable against the process dying, not against the machine dying: in the
+    /// kernel's page cache (or the server's memory) when the append returns.
+    Process,
+    /// On stable storage when the append returns, at the cost of one flush.
+    Host,
+}
+
 /// The durable byte sink under one company's runtime journal.
 #[async_trait]
 pub trait JournalStore: Send + Sync {
-    /// Appends one opaque record line, which MUST be durable before this
+    /// Appends one opaque record line, durable to `durability` before this
     /// returns.
     ///
     /// The at-most-once guarantee is that an effect's key reaches durable
     /// storage *before* the side effect runs, so a backend that acknowledges a
-    /// buffered or unjournaled write breaks the contract this port carries. The
-    /// fs backend performs a single `O_APPEND` `write_all` and waits on the
-    /// syscall; the mongodb backend inserts with `j:true` write concern.
+    /// write it has not yet made durable to the requested level breaks the
+    /// contract this port carries. What each shipped backend does:
+    ///
+    /// | | [`Durability::Process`] | [`Durability::Host`] |
+    /// |---|---|---|
+    /// | fs | one `O_APPEND` `write_all`, awaited | the same, plus `sync_data`, and the parent chain created with each new directory's parent flushed |
+    /// | sqlite | commit under `synchronous=NORMAL` (WAL) | commit under `synchronous=FULL` |
+    /// | mongodb | acknowledged insert | insert with `j:true` write concern |
+    ///
+    /// The fs backend's directory handling is not incidental: a record flushed
+    /// under ancestors that were never written down is lost with them, so a
+    /// [`Durability::Host`] append into a fresh data directory must flush the
+    /// chain it creates (issue #392).
     ///
     /// `line` never contains a newline — the caller serialises one JSON record
     /// per call — and a backend must preserve it byte-for-byte.
@@ -77,7 +108,12 @@ pub trait JournalStore: Send + Sync {
     /// effect, so the effect does not run. The residual ambiguity (a timeout on
     /// a write the server did commit) leaves a committed key with no effect,
     /// which is the at-most-once contract's documented safe direction.
-    async fn append_journal(&self, id: &CompanyId, line: &str) -> Result<()>;
+    async fn append_journal(
+        &self,
+        id: &CompanyId,
+        line: &str,
+        durability: Durability,
+    ) -> Result<()>;
 
     /// Every line ever appended for `id`, in append order.
     ///
@@ -115,4 +151,78 @@ pub trait JournalStore: Send + Sync {
     /// An empty `lines` is a legitimate call, not a no-op to optimise away: it
     /// is how a company with no prior filesystem journal closes its gate.
     async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()>;
+}
+
+/// An in-memory [`JournalStore`], for tests that need a durable sink which is
+/// **not** the filesystem.
+///
+/// It stands in for a database backend in the one place that matters: a test can
+/// delete a company's bundle directory — the simulated container replacement
+/// this port exists to survive — and this store still holds every record. Doing
+/// that against the real sqlite or mongodb backend would tie the proof to a
+/// cargo feature (and, for mongodb, to a live server), so the invariant would go
+/// unasserted in the default build.
+///
+/// Deliberately holds the same *strings* the real backends hold, so a record
+/// crossing it is exercised through the identical serialise/parse path.
+#[cfg(test)]
+#[derive(Default)]
+pub struct MemoryJournalStore {
+    inner: std::sync::Mutex<MemoryJournalState>,
+}
+
+#[cfg(test)]
+#[derive(Default)]
+struct MemoryJournalState {
+    lines: std::collections::HashMap<CompanyId, Vec<String>>,
+    imported: std::collections::HashSet<CompanyId>,
+}
+
+#[cfg(test)]
+impl MemoryJournalStore {
+    fn lock(&self) -> std::sync::MutexGuard<'_, MemoryJournalState> {
+        self.inner.lock().expect("memory journal poisoned")
+    }
+
+    /// Drops the import receipt for `id`, so the next boot imports again.
+    ///
+    /// The shape of a crash *between* the copy and the receipt: a partial
+    /// journal sitting behind an open gate. Tests use it to prove the retry
+    /// wipes rather than appends.
+    pub fn forget_receipt(&self, id: &CompanyId) {
+        self.lock().imported.remove(id);
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl JournalStore for MemoryJournalStore {
+    async fn append_journal(
+        &self,
+        id: &CompanyId,
+        line: &str,
+        _durability: Durability,
+    ) -> Result<()> {
+        self.lock()
+            .lines
+            .entry(id.clone())
+            .or_default()
+            .push(line.to_string());
+        Ok(())
+    }
+
+    async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {
+        Ok(self.lock().lines.get(id).cloned().unwrap_or_default())
+    }
+
+    async fn journal_imported(&self, id: &CompanyId) -> Result<bool> {
+        Ok(self.lock().imported.contains(id))
+    }
+
+    async fn complete_import(&self, id: &CompanyId, lines: Vec<String>) -> Result<()> {
+        let mut state = self.lock();
+        state.lines.insert(id.clone(), lines);
+        state.imported.insert(id.clone());
+        Ok(())
+    }
 }

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -49,7 +49,7 @@ pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_pr
 pub use facts::{FactKind, FactRecord, FactStore};
 pub use ids::{AGENT_SLUG_FALLBACK, agent_slug, generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
-pub use journal::JournalStore;
+pub use journal::{Durability, JournalStore};
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;
 pub use run_output::{

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -17,6 +17,7 @@ pub mod economy;
 pub mod events;
 pub mod facts;
 pub mod inbox;
+pub mod journal;
 pub mod login_codes;
 pub mod memory;
 pub mod run_output;
@@ -48,6 +49,7 @@ pub use events::{EventLog, PruneReport, RetentionClass, RetentionPolicy, plan_pr
 pub use facts::{FactKind, FactRecord, FactStore};
 pub use ids::{AGENT_SLUG_FALLBACK, agent_slug, generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
+pub use journal::JournalStore;
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;
 pub use run_output::{
@@ -112,6 +114,7 @@ mod test {
         _schedule_fires: &dyn crate::ports::schedule_fires::ScheduleFireStore,
         _run_output: &dyn crate::ports::run_output::WorkflowRunOutputStore,
         _workflow_runner: &dyn crate::ports::workflow_runner::WorkflowRunner,
+        _journal: &dyn crate::ports::journal::JournalStore,
     ) {
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -305,6 +305,15 @@ pub struct RuntimeBuilder {
     users: Option<Arc<dyn UserStore>>,
     sessions: Option<Arc<dyn SessionStore>>,
     login_codes: Option<Arc<dyn LoginCodeStore>>,
+    /// The runtime journal's durable sink (issue #726).
+    ///
+    /// `None` selects the filesystem default below — the company bundle's
+    /// `journal.jsonl`, which is where the journal has always lived. Set from
+    /// [`with_stores`](Self::with_stores) on every backend, because on a hosted
+    /// mongodb tenant the bundle directory is ephemeral scratch and a journal
+    /// left there loses every committed effect key and every parked approval on
+    /// the next container replacement.
+    journal_store: Option<Arc<dyn crate::ports::journal::JournalStore>>,
     seed_dir: Option<PathBuf>,
     /// The repo-level shared skill library, passed to the harness so a pre-fix
     /// registry install (whose stored `SKILL.md` is a one-line stub) is healed
@@ -401,6 +410,7 @@ impl RuntimeBuilder {
             users: None,
             sessions: None,
             login_codes: None,
+            journal_store: None,
             seed_dir: None,
             skills_registry: Arc::from([]),
             template_provenance: None,
@@ -520,6 +530,7 @@ impl RuntimeBuilder {
         self.users = Some(handles.users.clone());
         self.sessions = Some(handles.sessions.clone());
         self.login_codes = Some(handles.login_codes.clone());
+        self.journal_store = Some(handles.journal.clone());
         self.with_store(handles.company.clone())
             .with_events(handles.events.clone())
             .with_memory(handles.memory.clone())
@@ -537,6 +548,22 @@ impl RuntimeBuilder {
     pub fn with_memory_overlay(self, overlay: &crate::store::MemoryOverlay) -> Self {
         self.with_memory(overlay.memory.clone())
             .with_context(overlay.context.clone())
+    }
+
+    /// Swaps just the runtime journal's durable sink (default: the company
+    /// bundle's `journal.jsonl`).
+    ///
+    /// [`with_stores`](Self::with_stores) sets this alongside every other port,
+    /// so production never calls it. It exists for the same reason
+    /// [`with_memory_overlay`](Self::with_memory_overlay) does — one port,
+    /// swapped on its own — and it is what lets a test put the at-most-once set
+    /// somewhere the company bundle is not.
+    pub fn with_journal_store(
+        mut self,
+        store: Arc<dyn crate::ports::journal::JournalStore>,
+    ) -> Self {
+        self.journal_store = Some(store);
+        self
     }
 
     /// Swaps the task board store (default: fs-backed).
@@ -1137,10 +1164,79 @@ impl RuntimeBuilder {
         let journal = match handover.as_ref() {
             Some(h) => h.journal.clone(),
             None => {
-                let journal = Arc::new(RuntimeJournal::new(
-                    Bundle::new(home.clone(), &id).journal_jsonl(),
-                ));
+                // Issue #726: the journal's sink comes from the selected backend
+                // whenever one is open, and falls back to the company bundle's
+                // `journal.jsonl` only when it is not. Never a silent fs
+                // fallback under a database backend — that is the rule
+                // `open_storage` already states for every other durable port,
+                // and the journal was the one store outside it. On a hosted
+                // mongodb tenant `/data` is documented ephemeral scratch, so a
+                // journal left there loses every committed effect key and every
+                // parked approval on the next container replacement: previously
+                // executed effects become eligible to fire again, and parked
+                // approvals and grants silently vanish.
+                let (sink, sink_name) = match self.journal_store.clone() {
+                    Some(store) => (store, "backend"),
+                    None => (
+                        Arc::new(crate::store::FsJournalStore::new(home.clone()))
+                            as Arc<dyn crate::ports::journal::JournalStore>,
+                        "filesystem",
+                    ),
+                };
+
+                // The one-time import off the filesystem, gated on the sink's
+                // own receipt. Verbatim and in file order, raw strings — so a
+                // corrupt or merged line migrates byte-for-byte and the journal's
+                // own recovery still applies to it downstream.
+                //
+                // The receipt is what makes this safe to retry: `complete_import`
+                // clears before it copies and records the receipt last, so an
+                // interrupted import re-runs the whole copy instead of leaving a
+                // truncated prefix behind a closed gate. A truncated prefix is
+                // the bug itself — it drops at-most-once keys.
+                //
+                // Fatal on failure, deliberately. Booting with an empty journal
+                // because the import errored is indistinguishable, to every
+                // effect the company then runs, from having never executed
+                // anything.
+                //
+                // The gate is closed even when there is no file to import (an
+                // import of zero lines). That is one step stronger than "import
+                // if the file exists", and the step is load-bearing: it makes a
+                // `journal.jsonl` that appears *later* — a rollback, a stray copy
+                // into the data dir — unable to wipe and replace a journal the
+                // backend has since accumulated.
+                if !sink.journal_imported(&id).await? {
+                    let legacy = Bundle::new(home.clone(), &id).journal_jsonl();
+                    let lines: Vec<String> = crate::store::fs::read_lines_lossy(&legacy)
+                        .await?
+                        .into_iter()
+                        .filter(|line| !line.trim().is_empty())
+                        .collect();
+                    let count = lines.len();
+                    sink.complete_import(&id, lines).await?;
+                    if count > 0 {
+                        tracing::info!(
+                            company = %id,
+                            lines = count,
+                            "imported the filesystem journal into the storage backend; \
+                             the source file is left in place",
+                        );
+                    }
+                }
+
+                let journal = Arc::new(RuntimeJournal::with_store(sink, id.clone()));
                 journal.load().await?;
+                // Which sink the at-most-once guarantee is actually resting on.
+                // Worth one line at boot: "filesystem" under
+                // `OPENCOMPANY_STORAGE=mongodb` would mean the guarantee is
+                // resting on scratch, and that is not a thing an operator can
+                // otherwise see.
+                tracing::info!(
+                    company = %id,
+                    sink = sink_name,
+                    "runtime journal ready",
+                );
                 // Issue #386: a damaged line no longer fails the boot, which
                 // means the company can come up on an incomplete history. That
                 // is the right trade — an operator cannot repair a journal
@@ -2560,6 +2656,7 @@ mod test {
     use super::*;
     use crate::openhuman::MockOpenHumanRpc;
     use crate::ports::types::ToolCall;
+    use crate::runtime::journal::ExecutedEffect;
 
     fn tmp_home(prefix: &str) -> tempfile::TempDir {
         tempfile::Builder::new()
@@ -2673,6 +2770,254 @@ mod test {
             steps[1].step.status,
             TurnStepStatus::Running,
             "the call that was in flight when the host died reads as in flight"
+        );
+    }
+
+    /// **Issue #726, the headline**: a company whose data directory is destroyed
+    /// keeps its at-most-once set and its parked approvals, because the journal
+    /// lives in the storage backend rather than on the filesystem.
+    ///
+    /// This is the hosted failure, reproduced: on a mongodb tenant `/data` is
+    /// documented ephemeral scratch, so container replacement — a deploy, a
+    /// reschedule, a node drain, an OOM kill — takes `journal.jsonl` with it.
+    /// Before this change every effect that had already executed became eligible
+    /// to fire a second time and every parked approval, grant and standing grant
+    /// silently vanished. The `remove_dir_all` below IS that container
+    /// replacement.
+    #[tokio::test]
+    async fn a_backend_journal_survives_the_loss_of_the_whole_data_directory() {
+        use crate::ports::journal::MemoryJournalStore;
+        use crate::ports::types::EffectGroup;
+        use crate::runtime::journal::{ApprovalConversation, TaskLink};
+
+        let home = tmp_home("opencompany-journal-durability-");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = CompanyId::new("acme");
+        // One sink, shared across both boots — the database that outlives the
+        // container, standing in for sqlite/mongodb so the proof holds in the
+        // default build rather than only behind a cargo feature.
+        let sink = Arc::new(MemoryJournalStore::default());
+        let approval = crate::ports::types::ApprovalId::new("ap-1");
+        let effect = crate::ports::types::Effect {
+            kind: "filing.submit".into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+
+        // --- boot 1: an effect executes at most once, and an approval parks.
+        {
+            let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest.clone())
+                .with_id(id.clone())
+                .with_journal_store(sink.clone())
+                .build()
+                .await
+                .expect("first boot");
+            crate::runtime::cycle::execute_effect_once(&rt, "k", &effect, Some("t-1"))
+                .await
+                .expect("execute the effect once");
+            rt.journal
+                .record_parked(
+                    &approval,
+                    &effect,
+                    1_000,
+                    TaskLink::Task { id: "t-1".into() },
+                    ApprovalConversation::default(),
+                    None,
+                )
+                .await
+                .expect("park an approval");
+            assert!(rt.journal.is_executed("k"));
+        }
+
+        // --- the container is replaced: `/data` is gone, every byte of it.
+        std::fs::remove_dir_all(home.path()).expect("destroy the data directory");
+        assert!(
+            !Bundle::new(home.path().to_path_buf(), &id)
+                .journal_jsonl()
+                .exists(),
+            "the filesystem journal must really be gone for this to prove anything"
+        );
+
+        // --- boot 2: same backend, brand new (empty) data directory.
+        let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_journal_store(sink)
+            .build()
+            .await
+            .expect("second boot");
+
+        assert!(
+            rt.journal.is_executed("k"),
+            "the committed key must survive the container: without it the effect \
+             is eligible to fire a second time"
+        );
+        let pending = rt.journal.pending();
+        assert_eq!(pending.len(), 1, "the parked approval must survive too");
+        assert_eq!(
+            pending[0].id, approval,
+            "and with its original id, so the operator's console link still resolves"
+        );
+        assert_eq!(
+            pending[0].task,
+            Some(TaskLink::Task { id: "t-1".into() }),
+            "and still linked to the card it was parked for"
+        );
+    }
+
+    /// A company's journal file, as a previous host left it: `keys` committed in
+    /// order, at the bundle path the fs journal has always used.
+    async fn seed_filesystem_journal(home: &std::path::Path, id: &CompanyId, keys: &[&str]) {
+        let journal = RuntimeJournal::new(Bundle::new(home.to_path_buf(), id).journal_jsonl());
+        for (n, key) in keys.iter().enumerate() {
+            journal
+                .record_executed(
+                    key,
+                    ExecutedEffect {
+                        kind: "filing.submit".into(),
+                        amount_usd: None,
+                        task_id: Some("t-1".into()),
+                        at_millis: 1_000 + n as u64,
+                        irreversible: true,
+                    },
+                )
+                .await
+                .expect("seed a legacy journal line");
+        }
+    }
+
+    /// **Issue #726**: an existing filesystem journal is imported into the
+    /// backend exactly **once**, and the receipt is what makes the second boot a
+    /// no-op.
+    ///
+    /// The re-import is not a cosmetic inefficiency. `complete_import` clears
+    /// before it copies, so a second import would delete every key the backend
+    /// accumulated after the first one — un-committing effects that have already
+    /// run. The gate is the only thing standing between the migration and that.
+    #[tokio::test]
+    async fn a_filesystem_journal_is_imported_once_and_the_receipt_blocks_the_rest() {
+        use crate::ports::journal::MemoryJournalStore;
+
+        let home = tmp_home("opencompany-journal-import-");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = CompanyId::new("acme");
+        seed_filesystem_journal(home.path(), &id, &["k-legacy"]).await;
+
+        let sink = Arc::new(MemoryJournalStore::default());
+        let legacy_path = Bundle::new(home.path().to_path_buf(), &id).journal_jsonl();
+
+        // --- boot 1: the file is imported, and left where it was.
+        {
+            let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest.clone())
+                .with_id(id.clone())
+                .with_journal_store(sink.clone())
+                .build()
+                .await
+                .expect("first boot");
+            assert!(
+                rt.journal.is_executed("k-legacy"),
+                "the pre-existing at-most-once key must reach the backend"
+            );
+            assert!(
+                legacy_path.exists(),
+                "the source file stays in place: a rollback to an older binary \
+                 must still find the history it knows how to read"
+            );
+            // A key committed after the migration — this is what a second import
+            // would destroy.
+            rt.journal
+                .record_executed(
+                    "k-after",
+                    ExecutedEffect {
+                        kind: "payment.send".into(),
+                        amount_usd: Some(12.0),
+                        task_id: Some("t-2".into()),
+                        at_millis: 2_000,
+                        irreversible: true,
+                    },
+                )
+                .await
+                .expect("commit a key against the backend");
+        }
+
+        // --- boot 2: the receipt is closed, so nothing is re-imported.
+        let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_journal_store(sink)
+            .build()
+            .await
+            .expect("second boot");
+        assert!(
+            rt.journal.is_executed("k-after"),
+            "a re-import would have cleared this key and re-armed an effect that \
+             has already run"
+        );
+        assert!(rt.journal.is_executed("k-legacy"));
+    }
+
+    /// **Issue #726**: an import interrupted between the copy and the receipt is
+    /// re-run whole, not resumed.
+    ///
+    /// A partial copy behind a closed gate is the bug the receipt exists to
+    /// prevent — it is a set of at-most-once keys that quietly went missing. So
+    /// the retry must **replace** what the interrupted attempt wrote rather than
+    /// append to it: no duplicates, and nothing from the source left behind.
+    #[tokio::test]
+    async fn an_import_interrupted_before_its_receipt_is_re_run_whole() {
+        use crate::ports::journal::{JournalStore, MemoryJournalStore};
+
+        let home = tmp_home("opencompany-journal-partial-");
+        let manifest: CompanyManifest = toml::from_str(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n",
+        )
+        .expect("manifest");
+        let id = CompanyId::new("acme");
+        seed_filesystem_journal(home.path(), &id, &["k-0", "k-1", "k-2"]).await;
+
+        // A crash mid-import: the first line copied, the receipt never written.
+        let sink = Arc::new(MemoryJournalStore::default());
+        let source = crate::store::fs::read_lines_lossy(
+            &Bundle::new(home.path().to_path_buf(), &id).journal_jsonl(),
+        )
+        .await
+        .expect("read the source journal");
+        sink.complete_import(&id, vec![source[0].clone()])
+            .await
+            .expect("a partial copy");
+        sink.forget_receipt(&id);
+
+        let rt = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
+            .with_journal_store(sink.clone())
+            .build()
+            .await
+            .expect("boot after the interrupted import");
+
+        for key in ["k-0", "k-1", "k-2"] {
+            assert!(
+                rt.journal.is_executed(key),
+                "{key} must be present after the retry: a resumed-rather-than-restarted \
+                 import is how at-most-once keys go missing"
+            );
+        }
+        assert_eq!(
+            sink.read_journal(&id).await.expect("read back").len(),
+            3,
+            "the retry replaces the partial copy; it must not append a second one"
+        );
+        assert!(
+            sink.journal_imported(&id).await.expect("gate"),
+            "and the retry closes the gate"
         );
     }
 

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -15,33 +15,28 @@
 //!   most once) rather than repeating it.
 //! * **Durable approvals.** Parked effects are journaled and rehydrated on boot,
 //!   so an approval survives a restart with its original [`ApprovalId`].
+//!
+//! Both guarantees are only as durable as what the records are written to, which
+//! is why the sink is a port ([`JournalStore`], issue #726) rather than a file
+//! path. On a hosted mongodb tenant the container's `/data` is ephemeral scratch,
+//! so a journal pinned to the filesystem there lost every committed key and every
+//! parked approval on container replacement. Everything semantic — the record
+//! enum, replay, corrupt-line recovery — lives here and is backend-agnostic; the
+//! store below it only keeps opaque lines in order.
 
 use std::collections::{HashMap, HashSet};
-use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex as StdMutex};
 
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::Result;
-use crate::error::OpenCompanyError;
-use crate::ports::types::{Actor, ApprovalId, Effect, EventSeq};
+use crate::ports::journal::{Durability, JournalStore};
+use crate::ports::types::{Actor, ApprovalId, CompanyId, Effect, EventSeq};
 use crate::runtime::grants::{GrantId, GrantedCall, StandingGrant};
 pub use crate::runtime::types::TaskLink;
-use crate::store::fs::{PathLocks, append_line, append_line_durable, create_dir_all_durable};
-
-/// Journal append locks, keyed by path, shared by every [`RuntimeJournal`] in
-/// the process (issue #386).
-///
-/// The lock this replaced was a field on `RuntimeJournal`, so two journals over
-/// one file serialised against nothing — which is the state the type has always
-/// been in, and which nothing stopped a caller reaching. A `static` is the only
-/// thing two independently-constructed instances can share.
-///
-/// In-process only, and deliberately so: a second *process* on the same
-/// `OPENCOMPANY_DATA_DIR` is outside any lock's reach. What keeps that case from
-/// tearing is [`append_line`]'s single `O_APPEND` write, not this.
-static JOURNAL_WRITE_LOCKS: LazyLock<PathLocks> = LazyLock::new(PathLocks::default);
+use crate::store::fs::FsJournalStore;
 
 /// One durable journal record.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -290,17 +285,6 @@ enum JournalRecord {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         error: Option<String>,
     },
-}
-
-/// The failure a journal record is written to outlast (issue #392).
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum Durability {
-    /// In the kernel's page cache when [`RuntimeJournal::append`] returns. A
-    /// killed process cannot lose the record; a host crash or power loss can.
-    Process,
-    /// On stable storage when [`RuntimeJournal::append`] returns, at the cost of
-    /// one flush per append.
-    Host,
 }
 
 impl JournalRecord {
@@ -599,7 +583,13 @@ pub struct ExecutedEffect {
 /// (short), and the parse error names the column without quoting it.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CorruptLine {
-    /// The line's 1-based number in the journal file.
+    /// The record's 1-based position in what the [`JournalStore`] read back.
+    ///
+    /// For the filesystem backend that is the line's number in `journal.jsonl`,
+    /// unchanged — the fs store returns every `\n`-separated segment, blanks
+    /// included, so a blank line does not shift the count. For a database
+    /// backend there is no file to open, and the number locates the record in
+    /// append order.
     pub line: usize,
     /// The line's length in bytes.
     pub bytes: usize,
@@ -748,37 +738,67 @@ impl State {
 /// A per-company append-only journal backing at-most-once effects and the
 /// durable approval queue.
 ///
-/// One process should own a given journal file, but [`append`](Self::append) no
-/// longer depends on that for integrity (issue #386). Every record is written
-/// whole — terminator included — in a single `O_APPEND` write that has reached
-/// the kernel before the call returns, so a concurrent writer can land a record
-/// before or after but never inside one. Writers in *this* process additionally
-/// serialise on [`JOURNAL_WRITE_LOCKS`], which keeps records in call order, so a
-/// park cannot be replayed after the resolution that drains it.
+/// One process should own a given company's journal, but [`append`](Self::append)
+/// no longer depends on that for integrity (issue #386). The filesystem store
+/// writes every record whole — terminator included — in a single `O_APPEND`
+/// write that has reached the kernel before the call returns, so a concurrent
+/// writer can land a record before or after but never inside one, and it
+/// serialises writers within the process on a per-path lock. A database backend
+/// gets the same property more cheaply: a row or document insert is atomic, and
+/// its sequence comes from the server, so two live hosts interleave without
+/// collision.
+///
+/// Writers through *one* `RuntimeJournal` additionally serialise on
+/// [`write_lock`](Self::write_lock), which keeps records in call order — so a
+/// park cannot be replayed after the resolution that drains it. That lock is
+/// held across the store call, which is what keeps a backend's sequence
+/// allocation in call order too.
+/// The company id a [`file-pinned`](RuntimeJournal::new) journal reports.
+///
+/// The store behind that constructor addresses one named file and never looks at
+/// the id, so this is what shows up in a log line rather than a key anything
+/// resolves. Named instead of empty so a stray appearance in a trace is
+/// self-explaining.
+const FILE_PINNED_COMPANY: &str = "<file-pinned journal>";
+
 pub struct RuntimeJournal {
-    path: PathBuf,
+    store: Arc<dyn JournalStore>,
+    company: CompanyId,
     state: StdMutex<State>,
-    write_lock: Arc<TokioMutex<()>>,
+    write_lock: TokioMutex<()>,
 }
 
 impl RuntimeJournal {
-    /// Opens (or prepares) the journal at `path` without loading it.
+    /// Opens the journal for `company` over `store`, without loading it.
     ///
     /// Call [`load`](Self::load) to replay an existing journal into memory.
-    ///
-    /// Two journals over one path share an append lock. The key is the
-    /// absolutised path, so a relative and an absolute spelling of one file
-    /// match; a symlinked or `..`-laden spelling still does not, and falls back
-    /// on the atomic write for its safety.
-    pub fn new(path: impl Into<PathBuf>) -> Self {
-        let path = path.into();
-        let write_lock =
-            JOURNAL_WRITE_LOCKS.get(&std::path::absolute(&path).unwrap_or_else(|_| path.clone()));
+    pub fn with_store(store: Arc<dyn JournalStore>, company: CompanyId) -> Self {
         Self {
-            path,
+            store,
+            company,
             state: StdMutex::new(State::default()),
-            write_lock,
+            write_lock: TokioMutex::new(()),
         }
+    }
+
+    /// Opens (or prepares) a filesystem journal at `path` without loading it.
+    ///
+    /// The convenience constructor over [`with_store`](Self::with_store) for the
+    /// case where a caller has a file rather than a backend — every test in the
+    /// crate, and nothing in production, which resolves its store from the
+    /// selected backend in `RuntimeBuilder`.
+    ///
+    /// The store is pinned to the named file and ignores the company id, so the
+    /// id here is a label rather than a key. Two journals over one path still
+    /// share an append lock: the key is the absolutised path, so a relative and
+    /// an absolute spelling of one file match; a symlinked or `..`-laden
+    /// spelling still does not, and falls back on the atomic write for its
+    /// safety.
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self::with_store(
+            Arc::new(FsJournalStore::at_file(path)),
+            CompanyId::new(FILE_PINNED_COMPANY),
+        )
     }
 
     /// Replays the on-disk journal into memory, reconstructing the executed-key
@@ -800,24 +820,17 @@ impl RuntimeJournal {
     /// about is exactly the recoverable kind, and skipping it is the outcome
     /// worth working to avoid.
     pub async fn load(&self) -> Result<()> {
-        // Read bytes, not a `String`. A torn write can split a multi-byte
-        // codepoint, and `read_to_string` would fail the whole load on that one
-        // bad byte — failing the boot for exactly the damage this function
-        // exists to survive. Decoding per line instead keeps a single mangled
-        // line on the `CorruptLine` path with the rest of the journal intact.
-        let contents = match tokio::fs::read(&self.path).await {
-            Ok(contents) => contents,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
-            Err(e) => return Err(self.io_err(e)),
-        };
+        // The store hands back lines, never bytes, and decodes lossily on the
+        // way: a torn write can split a multi-byte codepoint, and a whole-file
+        // UTF-8 decode would fail the entire load on that one bad byte — failing
+        // the boot for exactly the damage this function exists to survive.
+        // Per-line decoding keeps a single mangled line on the `CorruptLine`
+        // path with the rest of the journal intact.
+        let lines = self.store.read_journal(&self.company).await?;
 
         let mut state = State::default();
-        for (index, raw) in contents.split(|b| *b == b'\n').enumerate() {
-            // Lossy on purpose: invalid bytes become U+FFFD, the line then fails
-            // to parse as JSON, and it lands on the same skip-and-log path as
-            // any other unrecoverable line rather than aborting the replay.
-            let line = String::from_utf8_lossy(raw);
-            let line = line.as_ref();
+        for (index, line) in lines.iter().enumerate() {
+            let line = line.as_str();
             if line.trim().is_empty() {
                 continue;
             }
@@ -830,7 +843,7 @@ impl RuntimeJournal {
                         message,
                     };
                     tracing::error!(
-                        journal = %self.path.display(),
+                        company = %self.company,
                         line = corrupt.line,
                         bytes = corrupt.bytes,
                         error = %corrupt.message,
@@ -842,11 +855,11 @@ impl RuntimeJournal {
             };
             if records.len() > 1 {
                 // Recovered, not lost — so not a `CorruptLine`. Still worth
-                // saying out loud: the file carries damage from a host that
+                // saying out loud: the journal carries damage from a host that
                 // predates the write fix, and a reader looking at it by hand
                 // should know why one line holds several records.
                 tracing::warn!(
-                    journal = %self.path.display(),
+                    company = %self.company,
                     line = index + 1,
                     records = records.len(),
                     "journal line holds several records with no separator; \
@@ -1113,7 +1126,7 @@ impl RuntimeJournal {
         let mut settled = 0;
         for cycle in open {
             tracing::info!(
-                journal = %self.path.display(),
+                company = %self.company,
                 cycle = %cycle.cycle_id,
                 trigger = %cycle.trigger,
                 started_at = cycle.at_millis,
@@ -1128,7 +1141,7 @@ impl RuntimeJournal {
             {
                 Ok(()) => settled += 1,
                 Err(err) => tracing::warn!(
-                    journal = %self.path.display(),
+                    company = %self.company,
                     cycle = %cycle.cycle_id,
                     %err,
                     "could not settle an interrupted cycle; it stays open in the journal"
@@ -1687,93 +1700,53 @@ impl RuntimeJournal {
         out
     }
 
-    /// Appends one record, whole, and does not return until the write syscall
-    /// has completed — and, for the record kinds that need it, until the bytes
-    /// are on stable storage.
+    /// Appends one record, whole, and does not return until the sink has made it
+    /// durable to the level the record asked for.
     ///
     /// **Durability is per record kind, by decision (issue #392).** Every record
     /// declares which failure it must outlast through
     /// [`JournalRecord::durability`], and this is the single choke point that
-    /// honours it, exactly as it is the single choke point for
-    /// [`JOURNAL_WRITE_LOCKS`]:
+    /// passes that decision to the sink:
     ///
     /// * The three [`Durability::Host`] kinds — `EffectExecuted`,
-    ///   `GrantConsumed` and `StandingGrantRevoked` — go through
-    ///   [`append_line_durable`](crate::store::fs::append_line_durable) and are
-    ///   flushed to stable storage before this returns. So the at-most-once
-    ///   contract holds against **losing the machine** for precisely the records
-    ///   whose loss would repeat an external action, and a failed flush fails
-    ///   the append — which aborts `execute_effect_once` before `perform_effect`
-    ///   and so cannot produce the duplicate it is guarding against.
-    /// * The other ten are page-cache durable: killing the process cannot
+    ///   `GrantConsumed` and `StandingGrantRevoked` — are on stable storage
+    ///   before this returns. So the at-most-once contract holds against
+    ///   **losing the machine** for precisely the records whose loss would
+    ///   repeat an external action, and a failed flush fails the append — which
+    ///   aborts `execute_effect_once` before `perform_effect` and so cannot
+    ///   produce the duplicate it is guarding against.
+    /// * The other ten are [`Durability::Process`]: killing the process cannot
     ///   lose them, a host crash can. That is the decision, not a gap left open.
     ///   Losing any of them makes the runtime **re-ask** — an approval is parked
     ///   again, an operator is prompted again, a cycle bracket reads as
     ///   interrupted — and never re-fire. Flushing them would tax the journal's
     ///   highest-volume records to protect against a re-asked question.
     ///
-    /// **This is bounded by the volume underneath.** The journal is constructed
-    /// unconditionally on the filesystem path, outside the storage ports, so a
-    /// hosted tenant whose `/data` is ephemeral scratch (the documented
-    /// arrangement under `OPENCOMPANY_STORAGE=mongodb` — see
-    /// `docs/spec/runtime/storage.md`) does not keep its journal across a
-    /// container replacement, let alone a host crash, and gains nothing from
-    /// this flush. Where the data directory is a real volume — the reference ECS
-    /// deployment mounts EFS at `/data`, whose NFS client page cache is exactly
-    /// what `sync_data` forces through — it buys real durability. Moving the
-    /// journal behind the ports is issue #726 and is not attempted here.
+    /// What each backend does to honour the two levels is its own business and
+    /// is documented on [`append_journal`](JournalStore::append_journal): an
+    /// `O_APPEND` write with (or without) a `sync_data`, a sqlite commit under
+    /// `synchronous=FULL` (or `NORMAL`), a mongodb insert with (or without)
+    /// `j:true`.
     ///
-    /// Delegates to [`append_line`](crate::store::fs::append_line), which emits
-    /// the record **and** its newline in a single blocking `write_all` under
-    /// `O_APPEND`. This used to open a `tokio::fs::File` and write the two
-    /// halves separately, then drop the handle without flushing — and tokio's
-    /// async `File` returns from `write_all` once the write is *queued* on a
-    /// blocking task, not once it lands. Measured on this code, 199 of 200
-    /// appends returned with their bytes still in flight. Two consequences, both
-    /// live:
+    /// Issue #726 removed the bound this used to carry. The journal was
+    /// constructed unconditionally on the filesystem, so a hosted tenant whose
+    /// `/data` is ephemeral scratch did not keep its journal across a container
+    /// replacement — let alone a host crash — and gained nothing from the flush.
+    /// The sink now comes from the selected storage backend, so the flush is
+    /// bought on a volume that outlives the container.
     ///
-    /// * The queued newline could be overtaken by the next append's opening
-    ///   brace, putting two records on one physical line — the
-    ///   `serde_json` "trailing characters" failure this issue was filed for.
-    /// * `Ok(())` meant "queued", not "written". A commit that `record_executed`
-    ///   had already reported durable could still be lost to a crash, and an
-    ///   `ENOSPC` on the real write was never reported to anyone. The
-    ///   at-most-once guarantee rests on that record being on disk *before* the
-    ///   side effect runs, so this was the more serious half.
-    ///
-    /// Identical to the corruption PR #43 removed from `store::fs::append_line`
-    /// and the feedback store's copy of it; the journal was the last twin.
+    /// The write lock is taken **around the store call**, not merely around the
+    /// serialisation, and that is load-bearing: a backend that allocates a
+    /// sequence number inside the append would otherwise be free to allocate two
+    /// concurrent appends out of call order, and a park replayed after the
+    /// resolution that drains it resurrects a resolved approval.
     async fn append(&self, record: &JournalRecord) -> Result<()> {
         let line = serde_json::to_string(record)?;
         let durability = record.durability();
         let _guard = self.write_lock.lock().await;
-        if let Some(parent) = self.path.parent() {
-            match durability {
-                // The directories are part of what makes the flushed record
-                // findable. A journal's first append into a fresh data directory
-                // creates the whole chain, and a record flushed under ancestors
-                // that were never written down is lost with them.
-                Durability::Host => create_dir_all_durable(parent).await?,
-                Durability::Process => tokio::fs::create_dir_all(parent)
-                    .await
-                    .map_err(|e| self.io_err_at(parent, e))?,
-            }
-        }
-        match durability {
-            Durability::Host => append_line_durable(&self.path, &line).await,
-            Durability::Process => append_line(&self.path, &line).await,
-        }
-    }
-
-    fn io_err(&self, source: std::io::Error) -> OpenCompanyError {
-        self.io_err_at(&self.path, source)
-    }
-
-    fn io_err_at(&self, path: &Path, source: std::io::Error) -> OpenCompanyError {
-        OpenCompanyError::StoreIo {
-            path: path.to_path_buf(),
-            source,
-        }
+        self.store
+            .append_journal(&self.company, &line, durability)
+            .await
     }
 }
 
@@ -1812,13 +1785,14 @@ fn replay_line(line: &str) -> std::result::Result<Vec<JournalRecord>, String> {
 impl std::fmt::Debug for RuntimeJournal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RuntimeJournal")
-            .field("path", &self.path)
+            .field("company", &self.company)
             .finish_non_exhaustive()
     }
 }
 
 #[cfg(test)]
 mod test {
+    use std::path::Path;
     use std::sync::Arc;
 
     use super::*;
@@ -1890,6 +1864,89 @@ mod test {
         // The re-commit is also what keeps the description list free of
         // duplicates: one key, one entry, however many times it is committed.
         assert_eq!(reloaded.irreversible_effects("t-1").len(), 1);
+    }
+
+    /// **Issue #726**: a journal over a non-filesystem store replays exactly
+    /// what the same records replay over a file — and survives the loss of the
+    /// bundle directory, which is the whole point.
+    ///
+    /// Every semantic decision (the record enum, replay, the parked queue, the
+    /// grant sets) lives above the store, so this is what proves the split is
+    /// real rather than merely stated: the same call sequence through two
+    /// different sinks must produce identical state, and the sink that is not a
+    /// file must still hold it after `/data` is gone.
+    #[tokio::test]
+    async fn a_journal_over_a_non_filesystem_store_replays_identically() {
+        use crate::ports::journal::MemoryJournalStore;
+
+        let company = CompanyId::new("acme");
+        let store = Arc::new(MemoryJournalStore::default());
+
+        let dir = tmp_dir();
+        let path = dir.path().join("journal.jsonl");
+
+        // The same call sequence through both sinks: a committed key, a parked
+        // approval, a minted grant, a resolution.
+        let approval = ApprovalId::new("ap-1");
+        for journal in [
+            RuntimeJournal::with_store(store.clone(), company.clone()),
+            RuntimeJournal::new(&path),
+        ] {
+            journal
+                .record_executed("cyc:0", executed(1_000))
+                .await
+                .unwrap();
+            journal
+                .record_parked(
+                    &approval,
+                    &effect(),
+                    2_000,
+                    TaskLink::Task { id: "t-1".into() },
+                    ApprovalConversation::default(),
+                    None,
+                )
+                .await
+                .unwrap();
+            journal.record_granted(&grant("g-1", 3_000)).await.unwrap();
+        }
+
+        // The bundle directory is gone — a container replacement on a tenant
+        // whose `/data` is ephemeral scratch. The file-backed journal loses
+        // everything; the ported one loses nothing.
+        drop(dir);
+
+        let over_store = RuntimeJournal::with_store(store.clone(), company.clone());
+        over_store.load().await.unwrap();
+        let over_file = RuntimeJournal::new(&path);
+        over_file.load().await.unwrap();
+
+        assert!(
+            over_store.is_executed("cyc:0"),
+            "the at-most-once key must survive the loss of the data dir"
+        );
+        assert!(
+            !over_file.is_executed("cyc:0"),
+            "the file-backed journal is exactly what this issue is about: \
+             losing /data un-commits every key"
+        );
+        assert_eq!(
+            over_store.pending().len(),
+            1,
+            "the parked approval must survive too"
+        );
+        assert_eq!(over_store.pending()[0].id, approval, "with its original id");
+        assert_eq!(
+            over_store.replayed_grants().len(),
+            1,
+            "and so must a live grant"
+        );
+        assert!(over_store.corruption().is_empty());
+
+        // Isolation: another company on the same store sees none of it.
+        let other = RuntimeJournal::with_store(store, CompanyId::new("globex"));
+        other.load().await.unwrap();
+        assert!(!other.is_executed("cyc:0"));
+        assert!(other.pending().is_empty());
     }
 
     /// **Issue #351**: the executed record says what ran, for which card, and

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -3488,3 +3488,172 @@ pub async fn assert_schedule_fire_store(
         "exactly one of {N} concurrent claimers may win the key"
     );
 }
+
+/// Every backend's [`JournalStore`](crate::ports::journal::JournalStore) must
+/// keep opaque lines byte-identically, in append order, per company (#726).
+///
+/// The runtime journal carries the at-most-once effect set and the durable
+/// approval queue, and it decides what a line *means* above this port — so all a
+/// backend owes is bytes and order. Both halves are load-bearing:
+///
+/// * **Bytes.** A line the store rewrote, trimmed or re-encoded is a record
+///   `serde_json` no longer parses, which the journal reports as corruption and
+///   skips. A skipped `EffectExecuted` un-commits its key and lets an
+///   at-most-once effect fire a second time.
+/// * **Order.** Replay folds records in sequence. A park read back *after* the
+///   resolution that drains it resurrects a resolved approval.
+///
+/// Isolation is asserted for the same reason it is everywhere else, with a
+/// sharper consequence here: one company reading another's executed keys would
+/// suppress its own effects.
+pub async fn assert_journal_store(journal: Arc<dyn crate::ports::journal::JournalStore>) {
+    use crate::ports::journal::Durability;
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    assert!(
+        journal.read_journal(&alpha).await.unwrap().is_empty(),
+        "a company that has never journaled reads back nothing"
+    );
+
+    // Deliberately awkward payloads: a backend that stores these unchanged is not
+    // quietly normalising anything. No `\n` anywhere — the port's contract is one
+    // record per call, and the caller never puts a terminator inside a line.
+    let lines = [
+        r#"{"record":"EffectExecuted","key":"cyc:0"}"#,
+        r#"{"record":"EffectExecuted","key":"cyc:1","effect":{"kind":"payment.send"}}"#,
+        r#"  {"record":"leading and trailing space"}  "#,
+        "{\"record\":\"unicode\",\"memo\":\"caf\u{e9} \u{2014} \u{65e5}\u{672c}\u{8a9e}\t tabbed\"}",
+        "not json at all, and it must survive anyway",
+        "",
+    ];
+    // Both durability levels, alternating: a backend that honours only one of
+    // them (or ignores the parameter) must still store and order every record
+    // identically, and one that errored on the level it does not implement would
+    // fail here rather than in production.
+    for (n, line) in lines.iter().enumerate() {
+        let durability = if n % 2 == 0 {
+            Durability::Host
+        } else {
+            Durability::Process
+        };
+        journal
+            .append_journal(&alpha, line, durability)
+            .await
+            .unwrap();
+    }
+
+    assert_eq!(
+        journal.read_journal(&alpha).await.unwrap(),
+        lines,
+        "every line must read back byte-identically and in append order"
+    );
+
+    // Isolation, both ways.
+    journal
+        .append_journal(&beta, "beta-only", Durability::Host)
+        .await
+        .unwrap();
+    assert_eq!(
+        journal.read_journal(&beta).await.unwrap(),
+        vec!["beta-only".to_string()],
+        "one company's journal must hold only its own records"
+    );
+    assert_eq!(
+        journal.read_journal(&alpha).await.unwrap().len(),
+        lines.len(),
+        "and another company's append must not land in it"
+    );
+
+    // Appending after a read keeps going from the end, not from zero — a backend
+    // whose sequence restarted would overwrite the first record.
+    journal
+        .append_journal(&alpha, "later", Durability::Process)
+        .await
+        .unwrap();
+    let after = journal.read_journal(&alpha).await.unwrap();
+    assert_eq!(after.len(), lines.len() + 1);
+    assert_eq!(after.last().unwrap(), "later", "and it lands at the end");
+}
+
+/// The one-time filesystem import and the receipt that gates it (#726).
+///
+/// Only for backends that can actually *hold* an import — sqlite and mongodb.
+/// The fs backend reports itself permanently imported (its store is the file an
+/// import would copy from), so running this against it would assert nothing.
+///
+/// The receipt is not bookkeeping. `complete_import` **clears** before it copies,
+/// so a second import deletes every record the backend accumulated after the
+/// first one — un-committing effect keys that have already run. And it records
+/// the receipt **last**, so an import interrupted anywhere leaves the gate open
+/// and the next boot re-runs the whole copy rather than resuming into a truncated
+/// prefix. A truncated prefix is the failure this port exists to prevent.
+pub async fn assert_journal_import(journal: Arc<dyn crate::ports::journal::JournalStore>) {
+    use crate::ports::journal::Durability;
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    assert!(
+        !journal.journal_imported(&alpha).await.unwrap(),
+        "a company the backend has never seen has not been imported"
+    );
+
+    let source = vec![
+        r#"{"record":"EffectExecuted","key":"cyc:0"}"#.to_string(),
+        r#"{"record":"EffectExecuted","key":"cyc:1"}"#.to_string(),
+        "a corrupt line, migrated byte-for-byte".to_string(),
+    ];
+    journal
+        .complete_import(&alpha, source.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        journal.read_journal(&alpha).await.unwrap(),
+        source,
+        "the import copies verbatim and in file order"
+    );
+    assert!(
+        journal.journal_imported(&alpha).await.unwrap(),
+        "and closes the gate"
+    );
+    assert!(
+        !journal.journal_imported(&beta).await.unwrap(),
+        "the receipt is per company, not per database"
+    );
+
+    // Appends after the import continue the sequence rather than colliding with
+    // (or overwriting) the copied records.
+    journal
+        .append_journal(&alpha, "after-import", Durability::Host)
+        .await
+        .unwrap();
+    let after = journal.read_journal(&alpha).await.unwrap();
+    assert_eq!(
+        after.len(),
+        source.len() + 1,
+        "an append after the import must not collide with a copied record's key"
+    );
+    assert_eq!(after[..source.len()], source[..]);
+    assert_eq!(after.last().unwrap(), "after-import");
+
+    // A retry — the shape of an import interrupted before its receipt — replaces
+    // rather than appends.
+    journal
+        .complete_import(&alpha, source.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        journal.read_journal(&alpha).await.unwrap(),
+        source,
+        "a re-run import clears the partial copy; it must never append a second one"
+    );
+
+    // The empty import is how a company with no prior filesystem journal closes
+    // its gate, and it must be a real (clearing) import, not a skipped no-op.
+    journal.complete_import(&beta, Vec::new()).await.unwrap();
+    assert!(journal.journal_imported(&beta).await.unwrap());
+    assert!(journal.read_journal(&beta).await.unwrap().is_empty());
+}

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1450,8 +1450,23 @@ impl crate::ports::journal::JournalStore for FsJournalStore {
         }
     }
 
+    /// Every `\n`-separated segment of the file, minus the empty one the final
+    /// terminator produces.
+    ///
+    /// Splitting `"a\nb\n"` yields a third, empty segment that is an artefact of
+    /// the terminator rather than a record. Dropping exactly that one — the last,
+    /// and only when it is empty — is what makes this backend's read agree
+    /// element-for-element with a database backend's, which is what
+    /// `assert_journal_store` holds every backend to. It shifts no line number:
+    /// the discarded segment is past every record in the file, and a genuinely
+    /// blank line in the middle is still returned so a corruption report counts
+    /// it.
     async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {
-        read_lines_lossy(&self.path(id)).await
+        let mut lines = read_lines_lossy(&self.path(id)).await?;
+        if lines.last().is_some_and(String::is_empty) {
+            lines.pop();
+        }
+        Ok(lines)
     }
 
     /// Always imported: this store *is* the file an import would copy from.
@@ -1481,6 +1496,34 @@ mod test {
             .prefix("opencompany-test-")
             .tempdir()
             .expect("tempdir")
+    }
+
+    #[tokio::test]
+    async fn conformance_journal_store() {
+        let root = tmp_root();
+        conformance::assert_journal_store(Arc::new(FsJournalStore::new(root.path()))).await;
+    }
+
+    /// The fs backend reports itself permanently imported, so
+    /// `assert_journal_import` does not apply to it: its store IS the file an
+    /// import would copy from, and the builder therefore never imports on this
+    /// backend. Asserted here rather than left implicit — a backend that
+    /// answered `false` would have the builder wipe and re-copy a company's
+    /// journal on every single boot.
+    #[tokio::test]
+    async fn the_filesystem_backend_never_needs_an_import() {
+        use crate::ports::journal::JournalStore;
+        let root = tmp_root();
+        let store = FsJournalStore::new(root.path());
+        let id = CompanyId::new("alpha");
+        assert!(store.journal_imported(&id).await.unwrap());
+        store
+            .append_journal(&id, "kept", crate::ports::journal::Durability::Host)
+            .await
+            .unwrap();
+        // And the unreachable import is the identity, not a wipe.
+        store.complete_import(&id, Vec::new()).await.unwrap();
+        assert_eq!(store.read_journal(&id).await.unwrap(), vec!["kept"]);
     }
 
     #[tokio::test]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -536,6 +536,31 @@ where
     Ok((out, skipped))
 }
 
+/// Splits `path` into lines, decoding each **lossily and separately**. An absent
+/// file reads as no lines.
+///
+/// Bytes, not a `String`, for the reason [`read_jsonl_lenient`] states above: a
+/// torn write can split a multi-byte codepoint, and a whole-file UTF-8 decode
+/// fails on that one bad byte. Decoding per line turns whole-file loss into one
+/// mangled line the caller can quarantine.
+///
+/// Deliberately returns **every** segment the split produced, blank ones
+/// included, and parses nothing. Both are what the runtime journal needs: it
+/// numbers corrupt lines by position, so dropping blanks here would shift every
+/// report after one, and it owns the decision about what a line means (see
+/// [`JournalStore`](crate::ports::journal::JournalStore)).
+pub(crate) async fn read_lines_lossy(path: &Path) -> Result<Vec<String>> {
+    let contents = match tokio::fs::read(path).await {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(io_err(path, e)),
+    };
+    Ok(contents
+        .split(|b| *b == b'\n')
+        .map(|raw| String::from_utf8_lossy(raw).into_owned())
+        .collect())
+}
+
 /// Atomically writes `contents` to `path` via a temp file + rename.
 pub(crate) async fn write_atomic(path: &Path, contents: &str) -> Result<()> {
     if let Some(parent) = path.parent() {
@@ -1322,6 +1347,75 @@ impl InboxStore for FsInboxStore {
         };
         write_atomic(&path, &body).await?;
         Ok(unread)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JournalStore
+// ---------------------------------------------------------------------------
+
+/// The filesystem [`JournalStore`]: the `journal.jsonl` inside each company's
+/// [`Bundle`], which is exactly where the runtime journal has always lived
+/// (issue #726).
+///
+/// So the default backend migrates nothing — same path, same bytes, same
+/// per-path locking. This type is the port surface around behaviour that already
+/// existed, not new behaviour.
+pub struct FsJournalStore {
+    home: PathBuf,
+}
+
+impl FsJournalStore {
+    /// A store over every company bundle under the OpenCompany home `home`.
+    pub fn new(home: impl Into<PathBuf>) -> Self {
+        Self { home: home.into() }
+    }
+
+    fn path(&self, id: &CompanyId) -> PathBuf {
+        Bundle::new(&self.home, id).journal_jsonl()
+    }
+}
+
+#[async_trait]
+impl crate::ports::journal::JournalStore for FsJournalStore {
+    /// One whole-line `O_APPEND` write, serialised on the process-wide per-path
+    /// lock (issue #386, now reached through [`path_lock`]).
+    ///
+    /// The journal used to keep a `JOURNAL_WRITE_LOCKS` registry of its own,
+    /// which was a second `PathLocks` holding the same kind of key for the same
+    /// reason as [`FS_WRITE_LOCKS`]. One registry keyed on the absolutised path
+    /// is what two independently-constructed stores over one file actually
+    /// share, and there is no file both registries would have contended for —
+    /// `journal.jsonl` is written here and nowhere else.
+    async fn append_journal(&self, id: &CompanyId, line: &str) -> Result<()> {
+        let path = self.path(id);
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| io_err(parent, e))?;
+        }
+        append_line(&path, line).await
+    }
+
+    async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {
+        read_lines_lossy(&self.path(id)).await
+    }
+
+    /// Always imported: this store *is* the file an import would copy from.
+    async fn journal_imported(&self, _id: &CompanyId) -> Result<bool> {
+        Ok(true)
+    }
+
+    /// Unreachable, and a no-op if reached.
+    ///
+    /// [`journal_imported`](Self::journal_imported) never opens the gate, so the
+    /// builder never calls this. If some future caller does, copying the file's
+    /// own lines back over itself is the identity — so doing nothing is the
+    /// correct answer rather than a swallowed write.
+    async fn complete_import(&self, _id: &CompanyId, _lines: Vec<String>) -> Result<()> {
+        Ok(())
     }
 }
 

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1362,17 +1362,45 @@ impl InboxStore for FsInboxStore {
 /// per-path locking. This type is the port surface around behaviour that already
 /// existed, not new behaviour.
 pub struct FsJournalStore {
-    home: PathBuf,
+    root: JournalRoot,
+}
+
+/// How an [`FsJournalStore`] resolves a company's journal file.
+enum JournalRoot {
+    /// A company-scoped store over an OpenCompany home:
+    /// `<home>/companies/<slug>/journal.jsonl`. The production shape, and the
+    /// only one that upholds the port's per-company isolation contract.
+    Home(PathBuf),
+    /// One fixed file, whatever company is asked for.
+    ///
+    /// Backs [`RuntimeJournal::new`](crate::runtime::journal::RuntimeJournal::new),
+    /// the path-taking convenience constructor the test suite builds journals
+    /// with. Single-company by construction — the caller named the file — so the
+    /// id it is handed is not consulted, and the conformance suite's isolation
+    /// assertions run against [`Home`](JournalRoot::Home) instead.
+    File(PathBuf),
 }
 
 impl FsJournalStore {
     /// A store over every company bundle under the OpenCompany home `home`.
     pub fn new(home: impl Into<PathBuf>) -> Self {
-        Self { home: home.into() }
+        Self {
+            root: JournalRoot::Home(home.into()),
+        }
+    }
+
+    /// A store pinned to one journal file — see [`JournalRoot::File`].
+    pub(crate) fn at_file(path: impl Into<PathBuf>) -> Self {
+        Self {
+            root: JournalRoot::File(path.into()),
+        }
     }
 
     fn path(&self, id: &CompanyId) -> PathBuf {
-        Bundle::new(&self.home, id).journal_jsonl()
+        match &self.root {
+            JournalRoot::Home(home) => Bundle::new(home, id).journal_jsonl(),
+            JournalRoot::File(path) => path.clone(),
+        }
     }
 }
 
@@ -1387,16 +1415,39 @@ impl crate::ports::journal::JournalStore for FsJournalStore {
     /// is what two independently-constructed stores over one file actually
     /// share, and there is no file both registries would have contended for —
     /// `journal.jsonl` is written here and nowhere else.
-    async fn append_journal(&self, id: &CompanyId, line: &str) -> Result<()> {
+    ///
+    /// **Both branches of issue #392 live here now**, moved from
+    /// `RuntimeJournal::append` when the sink became a port (#726), and the
+    /// directory half is the one that is easy to lose in the move:
+    /// [`Durability::Host`] creates the parent chain through
+    /// [`create_dir_all_durable`], which flushes each created directory's own
+    /// parent. Plain `create_dir_all` here would leave a flushed record under
+    /// directory entries that were never written down — lost with them on
+    /// exactly the crash the flush was bought for, with the record's own
+    /// `sync_data` still passing its test.
+    async fn append_journal(
+        &self,
+        id: &CompanyId,
+        line: &str,
+        durability: crate::ports::journal::Durability,
+    ) -> Result<()> {
+        use crate::ports::journal::Durability;
+
         let path = self.path(id);
         let lock = path_lock(&path);
         let _guard = lock.lock().await;
         if let Some(parent) = path.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| io_err(parent, e))?;
+            match durability {
+                Durability::Host => create_dir_all_durable(parent).await?,
+                Durability::Process => tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(|e| io_err(parent, e))?,
+            }
         }
-        append_line(&path, line).await
+        match durability {
+            Durability::Host => append_line_durable(&path, line).await,
+            Durability::Process => append_line(&path, line).await,
+        }
     }
 
     async fn read_journal(&self, id: &CompanyId) -> Result<Vec<String>> {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -76,7 +76,8 @@ pub mod tinycortex_engine;
 pub mod conformance;
 
 pub use fs::{
-    FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsMemoryStore, FsSecretStore,
+    FsCompanyStore, FsContextStore, FsEventLog, FsInboxStore, FsJournalStore, FsMemoryStore,
+    FsSecretStore,
 };
 pub use fs_ops::FsOps;
 pub use layout::DataLayout;

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -37,7 +37,10 @@ use async_trait::async_trait;
 use futures::stream::BoxStream;
 use futures::stream::TryStreamExt;
 use mongodb::bson::{Document, doc};
-use mongodb::options::{FindOneAndUpdateOptions, IndexOptions, ReturnDocument, UpdateOptions};
+use mongodb::options::{
+    CollectionOptions, FindOneAndUpdateOptions, IndexOptions, ReturnDocument, UpdateOptions,
+    WriteConcern,
+};
 use mongodb::{Client, Collection, Database, IndexModel};
 use tokio::sync::broadcast;
 
@@ -180,6 +183,13 @@ fn node_path_key(node: &crate::ports::workspace::WorkspaceNode) -> Option<String
     (node.kind == crate::ports::workspace::NodeKind::File)
         .then(|| file_path_key(node.parent_id.as_deref(), &node.name))
 }
+
+/// The runtime journal's collection: one document per record (issue #726).
+const JOURNAL: &str = "journal";
+
+/// One document per company recording that its filesystem journal has been
+/// imported — the gate that makes the import happen exactly once.
+const JOURNAL_IMPORTS: &str = "journal_imports";
 
 /// A single MongoDB database implementing all five storage ports.
 #[derive(Clone)]
@@ -337,11 +347,45 @@ impl MongoStore {
             .create_index(nonunique(doc! {"company_id": 1, "at_ms": -1}))
             .await
             .map_err(mongo_err)?;
+        // Issue #726: the runtime journal. `(company_id, seq)` is unique because
+        // two records sharing a sequence would order arbitrarily on replay, and
+        // an at-most-once key replayed before the resolution that consumed it is
+        // the failure the journal exists to prevent. The import receipt is one
+        // document per company. Created outside the fixed array above so adding
+        // them does not disturb its length.
+        self.collection(JOURNAL)
+            .create_index(unique(doc! {"company_id": 1, "seq": 1}))
+            .await
+            .map_err(mongo_err)?;
+        self.collection(JOURNAL_IMPORTS)
+            .create_index(unique(doc! {"company_id": 1}))
+            .await
+            .map_err(mongo_err)?;
         Ok(())
     }
 
     fn collection(&self, name: &str) -> Collection<Document> {
         self.db.collection::<Document>(name)
+    }
+
+    /// A collection handle whose writes are acknowledged only once the server
+    /// has committed them to its on-disk journal (`j:true`).
+    ///
+    /// Scoped to the runtime-journal collections rather than set database-wide,
+    /// and within them to the records that ask for it
+    /// ([`Durability::Host`](crate::ports::journal::Durability::Host)), because
+    /// it is bought for one specific contract and costs a disk flush per write:
+    /// the at-most-once guarantee is that an effect's key is durable *before* the
+    /// side effect runs, and the default acknowledgement returns as soon as the
+    /// primary has the write in memory — which a primary crash in the wrong
+    /// millisecond loses, re-arming an effect that already fired.
+    fn journaled(&self, name: &str) -> Collection<Document> {
+        self.db.collection_with_options::<Document>(
+            name,
+            CollectionOptions::builder()
+                .write_concern(WriteConcern::builder().journal(true).build())
+                .build(),
+        )
     }
 
     /// Atomically allocates the next 0-based sequence for `(company, kind)`.
@@ -2001,6 +2045,148 @@ impl crate::ports::schedule_fires::ScheduleFireStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// JournalStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::journal::JournalStore for MongoStore {
+    /// One journaled `insert_one` per record, sequenced by the same atomic
+    /// `counters` allocator [`EventLog`] uses.
+    ///
+    /// A document insert is atomic server-side, so the torn/merged-line class
+    /// the filesystem backend had to be fixed for (#386) cannot arise here at
+    /// all. The seq comes from the server rather than from a read-then-write, so
+    /// two hosts of one tenant overlapping across a rolling deploy interleave
+    /// without colliding — the same physics as `O_APPEND`, and the reason a
+    /// cross-process lock is not the missing piece.
+    ///
+    /// Fail-closed: an errored or timed-out insert returns `Err` before the
+    /// caller runs the side effect. The residual case — a timeout on a write the
+    /// server did commit — leaves a committed key with no effect, which is the
+    /// at-most-once contract's documented safe direction.
+    ///
+    /// Both durability levels are honoured (issue #392):
+    /// [`Durability::Host`](crate::ports::journal::Durability::Host) writes with
+    /// `j:true`, so the server has committed the insert to its own on-disk
+    /// journal before it acknowledges; `Process` takes the default
+    /// acknowledgement, which returns once the primary holds the write in
+    /// memory. Flattening these together would either tax the journal's
+    /// highest-volume records with a disk flush each, or drop the guarantee that
+    /// keeps an already-fired effect from firing again after a primary crash.
+    async fn append_journal(
+        &self,
+        company: &CompanyId,
+        line: &str,
+        durability: crate::ports::journal::Durability,
+    ) -> Result<()> {
+        use crate::ports::journal::Durability;
+
+        let seq = self.next_seq(company, JOURNAL).await?;
+        let collection = match durability {
+            Durability::Host => self.journaled(JOURNAL),
+            Durability::Process => self.collection(JOURNAL),
+        };
+        collection
+            .insert_one(doc! {
+                "company_id": company.as_ref(),
+                "seq": seq as i64,
+                "line": line,
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    /// One ordered scan of this company's records, cursor-batched by the driver.
+    ///
+    /// Deliberately unbounded, and **not** a capped collection: capping would
+    /// silently drop the oldest records, and the oldest records are exactly the
+    /// at-most-once keys an effect from months ago committed. Un-committing one
+    /// re-arms that effect. Bounding the journal is a retention question with a
+    /// correctness argument attached (#575/#275 territory), not something a
+    /// storage-shape default gets to decide.
+    async fn read_journal(&self, company: &CompanyId) -> Result<Vec<String>> {
+        let mut cursor = self
+            .collection(JOURNAL)
+            .find(doc! {"company_id": company.as_ref()})
+            .sort(doc! {"seq": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(get_str(&doc, "line")?);
+        }
+        Ok(out)
+    }
+
+    async fn journal_imported(&self, company: &CompanyId) -> Result<bool> {
+        Ok(self
+            .collection(JOURNAL_IMPORTS)
+            .find_one(doc! {"company_id": company.as_ref()})
+            .await
+            .map_err(mongo_err)?
+            .is_some())
+    }
+
+    /// Clear, copy, receipt — in that order, and the order carries the whole
+    /// safety argument.
+    ///
+    /// MongoDB gives no transaction across three collections without a replica
+    /// set, so this cannot be atomic the way the sqlite backend's import is.
+    /// It does not need to be: the receipt is written **last**, so an import
+    /// interrupted anywhere leaves the gate open and the next boot re-runs the
+    /// clear-and-copy from the top. What must never happen is a *partial* copy
+    /// behind a *closed* gate — a journal missing its tail is a set of
+    /// at-most-once keys that quietly went missing — and writing the receipt
+    /// last is what makes that unreachable.
+    ///
+    /// The copy is one **ordered** `insert_many`, so the records land in the
+    /// order they were read and the sequence numbers mean what they say.
+    async fn complete_import(&self, company: &CompanyId, lines: Vec<String>) -> Result<()> {
+        let journal = self.journaled(JOURNAL);
+        journal
+            .delete_many(doc! {"company_id": company.as_ref()})
+            .await
+            .map_err(mongo_err)?;
+        if !lines.is_empty() {
+            let docs: Vec<Document> = lines
+                .iter()
+                .enumerate()
+                .map(|(seq, line)| {
+                    doc! {
+                        "company_id": company.as_ref(),
+                        "seq": seq as i64,
+                        "line": line.as_str(),
+                    }
+                })
+                .collect();
+            journal.insert_many(docs).await.map_err(mongo_err)?;
+        }
+        // The counter has to move too, or the first append after an import would
+        // hand out seq 0 and collide with the copy's first row on the unique
+        // index. `$max` rather than `$set`, so a counter that is somehow already
+        // ahead is never wound back.
+        self.collection("counters")
+            .update_one(
+                doc! {"_id": format!("{}:{JOURNAL}", company.as_ref())},
+                doc! {"$max": {"next": lines.len() as i64}},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        self.journaled(JOURNAL_IMPORTS)
+            .update_one(
+                doc! {"company_id": company.as_ref()},
+                doc! {"$set": {"at_ms": now_millis() as i64, "lines": lines.len() as i64}},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -3026,6 +3212,60 @@ mod test {
                 .and_then(|options| options.unique)
                 .unwrap_or(false),
             "a partial filter without uniqueness would guard nothing at all"
+        );
+    }
+
+    /// **Issue #392 through the port**: the host-durable append asks the server
+    /// for `j:true`, and the process-durable one does not.
+    ///
+    /// `assert_journal_store` cannot catch this — a backend that ignored the
+    /// `Durability` argument stores and orders every record identically and
+    /// passes the whole suite, silently dropping the guarantee that keeps an
+    /// already-fired effect from firing again after a primary crash. So the
+    /// constructed handles are asserted directly, the same way
+    /// `the_partial_filter_is_keyed_on_the_field_not_the_parameter_name` asserts
+    /// a built `IndexModel` rather than the reasoning behind it.
+    ///
+    /// Needs no server: `Client::with_options` resolves lazily and
+    /// `collection_with_options` builds a handle locally, so this runs on the
+    /// `mongodb` feature alone and cannot pass vacuously the way the URI-gated
+    /// tests can. (It is a `tokio::test` only because the driver's constructor
+    /// spawns a cleanup task, not because anything here awaits the network.)
+    #[tokio::test]
+    async fn only_the_host_durable_journal_write_asks_for_j_true() {
+        // A client handle, not a connection: `with_options` resolves lazily and
+        // never touches the network, so this stays a pure shape assertion.
+        let client = Client::with_options(
+            mongodb::options::ClientOptions::builder()
+                .hosts(vec![mongodb::options::ServerAddress::Tcp {
+                    host: "localhost".into(),
+                    port: Some(27017),
+                }])
+                .build(),
+        )
+        .expect("build a client handle");
+        let store = MongoStore {
+            db: client.database("oc_test_shape"),
+            senders: Arc::new(StdMutex::new(HashMap::new())),
+        };
+
+        let host = store.journaled(JOURNAL);
+        assert_eq!(
+            host.write_concern().and_then(|concern| concern.journal),
+            Some(true),
+            "a host-durable record must be committed to the server's journal \
+             before the insert is acknowledged"
+        );
+
+        let process = store.collection(JOURNAL);
+        assert!(
+            process
+                .write_concern()
+                .and_then(|concern| concern.journal)
+                .is_none(),
+            "the process-durable level must NOT pay a disk flush: these are the \
+             journal's highest-volume records, and losing one makes the runtime \
+             re-ask rather than re-fire"
         );
     }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3722,6 +3722,20 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_journal_store() {
+        let Some(s) = store().await else { return };
+        conformance::assert_journal_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_journal_import() {
+        let Some(s) = store().await else { return };
+        conformance::assert_journal_import(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
     async fn conformance_run_store() {
         let Some(s) = store().await else { return };
         conformance::assert_run_store(s.clone()).await;

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -22,6 +22,7 @@ use crate::ports::context::ContextStore;
 use crate::ports::events::EventLog;
 use crate::ports::facts::FactStore;
 use crate::ports::inbox::InboxStore;
+use crate::ports::journal::JournalStore;
 use crate::ports::login_codes::LoginCodeStore;
 use crate::ports::memory::MemoryStore;
 use crate::ports::run_output::WorkflowRunOutputStore;
@@ -162,6 +163,16 @@ pub struct StorageHandles {
     pub users: Arc<dyn UserStore>,
     pub sessions: Arc<dyn SessionStore>,
     pub login_codes: Arc<dyn LoginCodeStore>,
+    /// The runtime journal's durable sink (#726): at-most-once effect keys, the
+    /// parked-approval queue, grants, and cycle brackets.
+    ///
+    /// Not `Option`, unlike [`ownership`](Self::ownership): a backend that
+    /// cannot hold the journal cannot host a company at all, and a `None` here
+    /// would be an invitation to fall back to the filesystem — which is exactly
+    /// the bug (#726). On a mongodb tenant `/data` is ephemeral scratch, so a
+    /// silent fs journal there loses every committed key and every parked
+    /// approval the next time the container is replaced.
+    pub journal: Arc<dyn JournalStore>,
     /// Present when the backend persists company → tenant ownership.
     pub ownership: Option<Arc<dyn OwnershipStore>>,
 }
@@ -418,7 +429,8 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         skills: store.clone(),
         users: store.clone(),
         sessions: store.clone(),
-        login_codes: store,
+        login_codes: store.clone(),
+        journal: store,
         ownership: None,
     }))
 }
@@ -459,6 +471,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         users: store.clone(),
         sessions: store.clone(),
         login_codes: store.clone(),
+        journal: store.clone(),
         ownership: Some(store),
     }))
 }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3126,6 +3126,16 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_journal_store() {
+        conformance::assert_journal_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_journal_import() {
+        conformance::assert_journal_import(store()).await;
+    }
+
+    #[tokio::test]
     async fn conformance_run_store() {
         conformance::assert_run_store(store()).await;
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -256,6 +256,17 @@ CREATE TABLE IF NOT EXISTS schedule_fires (
 );
 CREATE INDEX IF NOT EXISTS schedule_fires_by_schedule
     ON schedule_fires (company_id, schedule_id, scheduled_for);
+CREATE TABLE IF NOT EXISTS journal (
+    company_id TEXT NOT NULL,
+    seq        INTEGER NOT NULL,
+    line       TEXT NOT NULL,
+    PRIMARY KEY (company_id, seq)
+);
+CREATE TABLE IF NOT EXISTS journal_imports (
+    company_id TEXT PRIMARY KEY,
+    at_ms      INTEGER NOT NULL,
+    lines      INTEGER NOT NULL
+);
 "#;
 
 /// Maps a `rusqlite` failure onto the crate error type without a bare `?` on
@@ -295,6 +306,25 @@ fn add_column_if_missing(conn: &Connection, table: &str, column: &str, decl: &st
     }
     conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {decl}"))
         .map_err(sql_err)
+}
+
+/// Runs `write` with `synchronous=FULL`, so its commit is fsynced, and restores
+/// `NORMAL` afterwards no matter how `write` ended.
+///
+/// The restore is unconditional on purpose. Leaving `FULL` set would silently
+/// buy a flush for every later write on this connection — a permanent cost from
+/// a per-record decision — and restoring only on success would leave it set
+/// exactly when something has already gone wrong. A failure to restore is
+/// reported, but never masks the write's own error: the write's result is what
+/// the caller acts on.
+fn with_full_sync<T>(conn: &Connection, write: impl FnOnce(&Connection) -> Result<T>) -> Result<T> {
+    conn.pragma_update(None, "synchronous", "FULL")
+        .map_err(sql_err)?;
+    let written = write(conn);
+    let restored = conn.pragma_update(None, "synchronous", "NORMAL");
+    let value = written?;
+    restored.map_err(sql_err)?;
+    Ok(value)
 }
 
 /// Translates a `usize` limit into a SQLite `LIMIT` value. `usize::MAX` (the
@@ -2117,6 +2147,138 @@ impl crate::ports::schedule_fires::ScheduleFireStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// JournalStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::journal::JournalStore for SqliteStore {
+    /// One row per record, ordered by a per-company sequence.
+    ///
+    /// Sequence and insert are one statement against the `(company_id, seq)`
+    /// primary key, so the allocation cannot be observed half-done and a
+    /// duplicate seq is a constraint violation rather than a silently
+    /// overwritten record — losing a row here would un-commit an at-most-once
+    /// key. Same `COALESCE(MAX(..)+1, 0)` shape the event and ledger tables use.
+    ///
+    /// Both durability levels are honoured (issue #392), because flattening them
+    /// here would silently weaken the contract for a company moved onto sqlite:
+    ///
+    /// * [`Durability::Process`](crate::ports::journal::Durability::Process) is
+    ///   the connection's standing `synchronous=NORMAL` under WAL (see
+    ///   [`apply_pragmas`](SqliteStore::apply_pragmas)) — the write is in the WAL
+    ///   and survives process death, and a power loss can still take the last
+    ///   commits. Exactly what the filesystem backend's unflushed append gives.
+    /// * [`Durability::Host`](crate::ports::journal::Durability::Host) raises the
+    ///   pragma to `FULL` for this one statement, which fsyncs the WAL on commit.
+    ///   The pragma is restored **whatever the insert did** — leaving `FULL` set
+    ///   would silently fsync every later write on this connection, and leaving
+    ///   it set only on the error path would be worse still.
+    ///
+    /// `synchronous` is settable at any time and takes effect at the next commit;
+    /// only `journal_mode` is transaction-bound. The whole sequence runs under the
+    /// connection mutex, so no other statement can commit between the raise and
+    /// the restore.
+    async fn append_journal(
+        &self,
+        company: &CompanyId,
+        line: &str,
+        durability: crate::ports::journal::Durability,
+    ) -> Result<()> {
+        use crate::ports::journal::Durability;
+
+        let conn = self.conn();
+        let insert = |conn: &Connection| {
+            conn.execute(
+                "INSERT INTO journal (company_id, seq, line) VALUES \
+                 (?1, COALESCE((SELECT MAX(seq) + 1 FROM journal WHERE company_id = ?1), 0), ?2)",
+                params![company.as_ref(), line],
+            )
+            .map(|_| ())
+            .map_err(sql_err)
+        };
+        match durability {
+            Durability::Process => insert(&conn),
+            Durability::Host => with_full_sync(&conn, insert),
+        }
+    }
+
+    async fn read_journal(&self, company: &CompanyId) -> Result<Vec<String>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare("SELECT line FROM journal WHERE company_id = ?1 ORDER BY seq ASC")
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref()], |r| r.get::<_, String>(0))
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(sql_err)?);
+        }
+        Ok(out)
+    }
+
+    async fn journal_imported(&self, company: &CompanyId) -> Result<bool> {
+        let conn = self.conn();
+        Ok(conn
+            .query_row(
+                "SELECT 1 FROM journal_imports WHERE company_id = ?1",
+                params![company.as_ref()],
+                |_| Ok(true),
+            )
+            .optional()
+            .map_err(sql_err)?
+            .unwrap_or(false))
+    }
+
+    /// Clear, copy, receipt — in **one transaction**, so the gate and the rows
+    /// it guards can never disagree.
+    ///
+    /// An interrupted import therefore leaves no rows and no receipt, and the
+    /// next boot re-runs the whole copy. The alternative — a partial copy behind
+    /// a written receipt — is the failure this port exists to prevent: a journal
+    /// missing its tail is a set of at-most-once keys that quietly went missing.
+    async fn complete_import(&self, company: &CompanyId, lines: Vec<String>) -> Result<()> {
+        let mut guard = self.conn();
+        // Host-durable, and by the same reasoning `EffectExecuted` is: what is
+        // being copied *is* the at-most-once key set, and a migration a power
+        // loss can take back has not migrated anything. Raised and restored
+        // exactly as `with_full_sync` does it — inline because the transaction
+        // needs `&mut Connection` and that helper hands out `&Connection`.
+        guard
+            .pragma_update(None, "synchronous", "FULL")
+            .map_err(sql_err)?;
+        let result = (|| {
+            let tx = guard
+                .transaction_with_behavior(TransactionBehavior::Immediate)
+                .map_err(sql_err)?;
+            tx.execute(
+                "DELETE FROM journal WHERE company_id = ?1",
+                params![company.as_ref()],
+            )
+            .map_err(sql_err)?;
+            for (seq, line) in lines.iter().enumerate() {
+                tx.execute(
+                    "INSERT INTO journal (company_id, seq, line) VALUES (?1, ?2, ?3)",
+                    params![company.as_ref(), seq as i64, line],
+                )
+                .map_err(sql_err)?;
+            }
+            tx.execute(
+                "INSERT OR REPLACE INTO journal_imports (company_id, at_ms, lines) \
+                 VALUES (?1, ?2, ?3)",
+                params![company.as_ref(), now_millis() as i64, lines.len() as i64],
+            )
+            .map_err(sql_err)?;
+            tx.commit().map_err(sql_err)
+        })();
+        let restored = guard.pragma_update(None, "synchronous", "NORMAL");
+        result?;
+        restored.map_err(sql_err)?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
 // UsageMeter
 // ---------------------------------------------------------------------------
 
@@ -2911,6 +3073,56 @@ mod test {
             "INTEGER NOT NULL DEFAULT 0",
         )
         .expect("adding an existing column is a no-op, not an error");
+    }
+
+    /// **Issue #392 through the port**: the host-durable append really does
+    /// commit under `synchronous=FULL`, and really does put it back.
+    ///
+    /// `assert_journal_store` cannot see this — a backend that ignored the
+    /// `Durability` argument entirely stores and orders every record identically
+    /// and passes the whole suite. So the raise and the restore are asserted
+    /// here, from inside and outside the closure.
+    ///
+    /// The restore matters as much as the raise. `synchronous` is connection
+    /// state, not statement state: leaving `FULL` set would silently buy an
+    /// fsync for every later write on this connection — a permanent cost from a
+    /// per-record decision — and restoring only on success would leave it set
+    /// exactly when something has already gone wrong.
+    #[test]
+    fn the_host_durable_write_runs_under_full_sync_and_restores_normal() {
+        /// `PRAGMA synchronous`: 1 = NORMAL, 2 = FULL.
+        fn synchronous(conn: &Connection) -> i64 {
+            conn.query_row("PRAGMA synchronous", [], |r| r.get(0))
+                .expect("read the pragma")
+        }
+
+        let store = SqliteStore::open_in_memory().expect("open");
+        let conn = store.conn();
+        assert_eq!(synchronous(&conn), 1, "the standing setting is NORMAL");
+
+        let seen = with_full_sync(&conn, |c| Ok(synchronous(c))).expect("the write runs");
+        assert_eq!(
+            seen, 2,
+            "the write must commit under FULL, or the host-durable level is a no-op"
+        );
+        assert_eq!(
+            synchronous(&conn),
+            1,
+            "and the connection must be left as it was found"
+        );
+
+        // A failing write restores it too, and reports its own error rather than
+        // the restore's.
+        let err = with_full_sync(&conn, |_| {
+            Err::<(), _>(OpenCompanyError::Store("the write failed".into()))
+        })
+        .expect_err("the write's error reaches the caller");
+        assert!(err.to_string().contains("the write failed"));
+        assert_eq!(
+            synchronous(&conn),
+            1,
+            "a failed write must not strand the connection on FULL"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

`RuntimeJournal` was constructed unconditionally on the filesystem, outside the port surface `StorageHandles` swaps for every other durable store. The journal is where the **at-most-once** contract lives — the `EffectExecuted` key is committed *before* a side effect runs. On a hosted mongodb tenant `/data` is documented ephemeral scratch, so container replacement (deploy, reschedule, node drain, OOM kill) discarded the whole set: every previously executed effect became eligible to fire again, and every parked approval, single-use grant and standing grant silently vanished.

This adds a `JournalStore` port with fs / sqlite / mongodb backings, a receipt-gated one-time import of an existing `journal.jsonl`, and conformance coverage across all three.

The port is deliberately two byte-level operations (append one opaque line, read every line in append order) rather than a mirror of `RuntimeJournal`'s ~25 methods. Everything semantic — the record enum, the corrupt-line skip, the merged-line recovery, the in-memory replay — stays in `RuntimeJournal` and is backend-agnostic by construction, so a new record variant needs no backend change. It does not ride `EventLog`: `CompanyEvent` is a closed enum, and the event log is *pruned* under a retention policy — rotating away an `EffectExecuted` key would silently un-commit it.

### `Durability` had to become part of the port — the most important thing to review

#730 (#392, journal host durability) merged mid-implementation and rewrote both files this PR rewires. It had made `RuntimeJournal::append` branch on a per-record `Durability` **twice** — `create_dir_all_durable` vs `create_dir_all`, then `append_line_durable` vs `append_line`. A port with a plain `(id, line)` signature would have flattened that to `Process` and **silently reverted #392**.

So `Durability` now lives in `src/ports/journal.rs` and `append_journal` carries it; the per-record *decision* stayed on `JournalRecord::durability`. Both halves of the fs branch — including `create_dir_all_durable` — moved into `FsJournalStore::append_journal` intact, and #730's two tests still fail if it is flattened.

**Reviewers: `FsJournalStore::append_journal` in `src/store/fs.rs` is the place to look hardest.**

### Two durability decisions the plan did not anticipate

Taken because the alternative was a silent weakening:

- **sqlite** honours `Host` by running the insert under `PRAGMA synchronous=FULL`, and `Process` under the standing `NORMAL` (sound only under WAL). The import transaction is `Host`-durable for the same reason `EffectExecuted` is.
- **mongodb** applies `j:true` **only to `Host` records**, not to every journal write. Blanket `j:true` would tax `CycleStarted`/`CycleFinished` — a pair per cycle — with a disk flush each, which is exactly the trade #392 declined.

### The import gate closes even when there is no `journal.jsonl`

An import of zero lines still writes the receipt. Without that, a file appearing *later* — a rollback, a stray copy into the data dir — would wipe and replace a journal the backend had since accumulated, because `complete_import` clears before it copies. The source file is left in place: the receipt makes a second import impossible, and a rollback to an older binary still finds history it can read, where renaming the file would hand it an *empty* at-most-once set.

## API Or Behavior Changes

- **New port**: `crate::ports::journal::{JournalStore, Durability}` — `append_journal`, `read_journal`, `journal_imported`, `complete_import`.
- **Breaking for in-flight PRs**: `StorageHandles` gains a **non-optional** `journal: Arc<dyn JournalStore>` field, so any open PR constructing it will fail to compile until it adds one. Deliberate — an `Option` would invite the silent fs fallback this issue exists to remove.
- **Behavior**: with `OPENCOMPANY_STORAGE=sqlite|mongodb` the journal now lives in the backend rather than in the company bundle. First boot performs a one-time verbatim import of any existing `journal.jsonl`, then records a receipt. The fs backend is unchanged — its store *is* the file at today's path, so it migrates nothing and answers `journal_imported` `true` unconditionally.
- **Errors stay fail-closed**: an `Err` from `append_journal` reaches the caller *before* the side effect, so the effect does not run. The residual ambiguity (a timeout on a write the server did commit) leaves a committed key with no effect — the at-most-once contract's documented safe direction.

### One honest limitation

An invalid-UTF-8 line cannot round-trip byte-for-byte through a sqlite `TEXT` column or a BSON string. Such a line migrates as a corrupt line that still fails to parse and is still reported — the same outcome as today — but "verbatim" is approximate in that one case.

### A residual coverage gap, named rather than left implicit

The durability *level implementations* are pinned on all three backends (`the_host_durable_write_runs_under_full_sync_and_restores_normal`, `only_the_host_durable_journal_write_asks_for_j_true`, and #730's fs `append_probe` counts). But the per-call **branch selection** inside sqlite's and mongodb's `append_journal` is not directly observable — there is no database equivalent of the fs `append_probe`. A mutation swapping those two arms would go undetected.

## Tests

Run locally on this branch, rebased on `main` @ `cae21623`:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets` (covered by the `--all-targets` clippy lanes below)
- [x] `cargo test`

| Lane | Result |
|---|---|
| `cargo fmt --all -- --check` | clean |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings` | clean |
| `cargo test --locked` | **2246 passed**, 0 failed, 1 ignored (lib) |
| `cargo test --locked --features sqlite --lib store::sqlite` | **34 passed**, 0 failed, 2247 filtered out |
| `cargo test --locked --features openhuman,mcp,telegram` | **3372 passed**, 0 failed, 3 ignored (lib) |
| `cargo test --locked --features mongodb --lib store::mongodb` | **31 passed**, 0 failed, 2248 filtered out |

The mongodb lane ran against a local `mongo:7` with `OPENCOMPANY_TEST_MONGODB_URI=mongodb://localhost:27017` and `OPENCOMPANY_TEST_MONGODB_REQUIRED=1`. `REQUIRED=1` matters: without it a missing server skips silently and still exits 0. `conformance_journal_import` is in the 31 that ran, so the server-backed path is genuinely covered rather than vacuously green.

### Teeth

Each was verified by reverting the production change, observing RED, and restoring.

The headline one: with the builder ignoring the backend sink, `a_backend_journal_survives_the_loss_of_the_whole_data_directory` fails with *"the committed key must survive the container: without it the effect is eligible to fire a second time"*. It boots, executes an effect and parks an approval, deletes the entire data directory (asserting the file is really gone first), then boots again on the same sink.

Also covered: `a_filesystem_journal_is_imported_once_and_the_receipt_blocks_the_rest` (a second import would clear a key committed after the migration and re-arm an effect), and `an_import_interrupted_before_its_receipt_is_re_run_whole` (a crash between the copy and the receipt re-runs the whole wipe-and-copy rather than replaying a truncated prefix).

One test's teeth are structural rather than demonstrated: `a_journal_over_a_non_filesystem_store_replays_identically` cannot be written against pre-change code at all, since the seam it uses does not exist there. Its non-vacuity comes from a paired negative assertion in the same test.

`assert_journal_store` holds fs, sqlite and mongodb to identical read-back semantics — including that the fs backend's trailing-newline artefact is dropped so its read agrees element-for-element with a database backend's.

### Manual verification

Real host on `OPENCOMPANY_STORAGE=mongodb` against `mongo:7`, console built and served. Boot logged `sink="backend"` with no `journal.jsonl` anywhere under the data dir. A chat turn parked an approval; `kill -9` plus `rm -rf` of the entire data dir (simulating container replacement); re-serve.

In the browser: the Approvals badge showed 1 and the page named the approval parked before the wipe, under its original id and timestamp. Approving it from the console produced `ApprovalResolved` then `EffectExecuted`. A second wipe-and-restart confirmed the resolution survived and the effect had fired **exactly once**.

## Documentation

- `docs/spec/runtime/journal.md` — new: the port, the two durability levels and what each backend does for them, and the migration's clear-copy-receipt ordering with the safety argument.
- `docs/spec/runtime/ports.md` — `JournalStore` added to the port surface.
- `docs/spec/runtime/storage.md` — the journal is no longer an exception to backend selection.
- `docs/spec/runtime/data-root.md` — `journal.jsonl` is the fs backend's file, not an unconditional one.
- `docs/spec/runtime/lifecycle.md` — boot-time import step.
- `docs/spec/runtime/README.md` — links the new page.

Rustdoc on `src/ports/journal.rs` carries the per-backend durability table and the "why not `EventLog`" reasoning.

Closes #726
