### PR TITLE
fix(chat): anchor a channel instantly, and stop stealing the scroll (#757)

### DIFF
--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
 import { cn } from "@/lib/utils";
@@ -39,12 +39,32 @@ interface Props {
 }
 
 /**
+ * How close to the bottom still counts as "parked at the bottom", in CSS
+ * pixels. Sub-pixel layout and a fractional `clientHeight` mean the arithmetic
+ * rarely lands on exactly zero, so a strict test would read a view that is
+ * visibly at the bottom as scrolled away and stop following.
+ */
+const BOTTOM_SLACK_PX = 32;
+
+/**
  * The scrolling body of a channel.
  *
  * Rows are bottom-anchored: the view sticks to the newest message, which is
  * what a chat log wants and what a plain scroll container does not do on its
  * own. Day dividers ride along as sticky pills so the date stays legible while
  * you scroll through it.
+ *
+ * Anchoring is two rules, not one (issue #757):
+ *
+ * 1. **Arriving at a channel jumps, it does not travel.** Opening a channel
+ *    anchors instantly in a layout effect, before the browser paints, so the
+ *    first frame the operator sees is already the newest message. Animating
+ *    here would be animating from a position that was never theirs — and the
+ *    longer the transcript, the longer the slide.
+ * 2. **Growth follows, but only if they are already at the bottom.** A tool row
+ *    or reply arriving while they watch should glide into view; the same row
+ *    arriving while they have scrolled up to read history must not yank the
+ *    viewport away from what they are reading.
  */
 export function MessageTimeline({
   channel,
@@ -61,18 +81,59 @@ export function MessageTimeline({
 }: Props) {
   const scroller = useRef<HTMLDivElement>(null);
   const liveStepCount = liveSteps?.length ?? 0;
+  /**
+   * Is the view parked at the bottom, and therefore still following?
+   *
+   * A ref rather than state on purpose: it is read inside effects and written
+   * from a scroll handler that fires at frame rate. Making it state would
+   * re-render the whole transcript on every wheel tick to compute a value no
+   * rendered output depends on.
+   */
+  const following = useRef(true);
+  /** The channel the growth effect has already settled on. See rule 2. */
+  const settledOn = useRef<string | null>(null);
 
+  const trackFollowing = useCallback(() => {
+    const el = scroller.current;
+    if (!el) return;
+    const fromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    following.current = fromBottom <= BOTTOM_SLACK_PX;
+  }, []);
+
+  // Rule 1 — arriving at a channel. `useLayoutEffect` so the jump happens
+  // before paint: with `useEffect` the browser paints the un-anchored position
+  // first, which is the flash this issue is about. `channel.id` is the
+  // dependency, not `items.length` — two channels can hold the same number of
+  // rows, and an effect keyed on the count would not fire for that switch at
+  // all, leaving the new channel wearing the old one's scroll offset.
+  useLayoutEffect(() => {
+    const el = scroller.current;
+    if (!el) return;
+    el.scrollTop = el.scrollHeight;
+    following.current = true;
+  }, [channel.id]);
+
+  // Rule 2 — growth while the channel is open. Each new tool row grows the
+  // block at the bottom, so the scroll has to follow it as the turn works, not
+  // only when the reply lands. A card arriving counts too — it is the thing the
+  // operator has to act on. Skipped entirely when they have scrolled away.
+  //
+  // `channel.id` is a dependency so the first pass after a switch can *defer*:
+  // the layout effect above has already anchored this channel, and animating on
+  // top of that is the very travel rule 1 removes.
   useEffect(() => {
     const el = scroller.current;
     if (!el) return;
+    if (settledOn.current !== channel.id) {
+      settledOn.current = channel.id;
+      return;
+    }
+    if (!following.current) return;
     el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-    // Each new tool row grows the block at the bottom, so the scroll has to
-    // follow it as the turn works, not only when the reply lands. A card
-    // arriving counts too — it is the thing the operator has to act on.
-  }, [items.length, typing, liveStepCount]);
+  }, [channel.id, items.length, typing, liveStepCount]);
 
   return (
-    <div ref={scroller} className="flex-1 overflow-y-auto">
+    <div ref={scroller} onScroll={trackFollowing} className="flex-1 overflow-y-auto">
       <div className="flex min-h-full flex-col justify-end pb-4">
         <ChannelIntro channel={channel} empty={items.length === 0} />
         {items.map((item) =>

--- a/frontend/test/unit/chat-scroll-anchor.test.ts
+++ b/frontend/test/unit/chat-scroll-anchor.test.ts
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ChatMessage } from "@/lib/chat";
+import { MessageTimeline } from "@/views/chat/MessageTimeline";
+import {
+  buildTimeline,
+  buildTimelineItems,
+  type Channel,
+  type TimelineItem,
+} from "@/views/chat/model";
+
+/**
+ * Where a channel opens, and what is allowed to move it (issue #757).
+ *
+ * The transcript used to animate to the bottom on arrival: one effect, always
+ * `behavior: "smooth"`, firing on mount as well as on growth. Opening a channel
+ * therefore painted an un-anchored position and then slid down, and the longer
+ * the transcript the longer the slide.
+ *
+ * jsdom performs no layout, so `scrollHeight` and `clientHeight` are 0 and
+ * `scrollTo` does not exist. The geometry below is stubbed on the prototype for
+ * exactly that reason — these tests are about *which* anchoring call the
+ * component makes and when, which is the part that was wrong. They cannot and
+ * do not claim anything about real pixel positions.
+ */
+
+const CONTENT_HEIGHT = 4000;
+const VIEWPORT_HEIGHT = 800;
+/** Every `scrollTo` the component made, in order. */
+let calls: Array<{ top: number; behavior?: string }> = [];
+let scrollTop = 0;
+let container: HTMLDivElement;
+let root: Root;
+
+/** What each stubbed property looked like before, so it can be put back. */
+const saved = new Map<string, PropertyDescriptor | undefined>();
+
+const STUBS: Record<string, PropertyDescriptor> = {
+  scrollHeight: { get: () => CONTENT_HEIGHT, configurable: true },
+  clientHeight: { get: () => VIEWPORT_HEIGHT, configurable: true },
+  scrollTop: {
+    get: () => scrollTop,
+    set: (v: number) => {
+      scrollTop = v;
+    },
+    configurable: true,
+  },
+  scrollTo: {
+    value: (opts: { top: number; behavior?: string }) => {
+      calls.push(opts);
+      scrollTop = opts.top;
+    },
+    configurable: true,
+    writable: true,
+  },
+};
+
+function stubGeometry() {
+  for (const [prop, desc] of Object.entries(STUBS)) {
+    saved.set(prop, Object.getOwnPropertyDescriptor(Element.prototype, prop));
+    Object.defineProperty(Element.prototype, prop, desc);
+  }
+}
+
+/**
+ * Put the prototype back. Without this the stubs outlive the file inside a
+ * shared worker, and the next suite to touch a scroll container inherits a
+ * 4000px document it never asked for.
+ */
+function restoreGeometry() {
+  for (const [prop, desc] of saved) {
+    if (desc) Object.defineProperty(Element.prototype, prop, desc);
+    else delete (Element.prototype as unknown as Record<string, unknown>)[prop];
+  }
+  saved.clear();
+}
+
+function channel(id: string): Channel {
+  return { id, name: id, kind: "channel", purpose: "" };
+}
+
+/**
+ * `n` message rows, built through the real timeline constructors so the rows
+ * render as the app renders them. Only the count matters to the effects under
+ * test, but a hand-rolled row shape would drift from `TimelineEntry` and fail
+ * inside `MessageRow` rather than in an assertion.
+ */
+function items(n: number, ch: Channel): TimelineItem[] {
+  const messages: ChatMessage[] = Array.from({ length: n }, (_, i) => ({
+    id: `m${i}`,
+    from: "you",
+    text: `line ${i}`,
+    at: 1_700_000_000_000 + i * 1_000,
+  }));
+  return buildTimelineItems(buildTimeline(messages, ch), []);
+}
+
+// `createElement` rather than JSX because the unit suite's vitest `include` is
+// `*.test.ts` — a `.tsx` file is silently not collected, which reads as a
+// passing suite.
+function render(ch: Channel, rows: TimelineItem[]) {
+  act(() => {
+    root.render(
+      createElement(MessageTimeline, {
+        channel: ch,
+        items: rows,
+        openThreadId: null,
+        typing: false,
+        onOpenThread: () => {},
+        onReact: () => {},
+      }),
+    );
+  });
+}
+
+/** The scrolling body is the component's outermost element. */
+function scroller(): HTMLElement {
+  return container.firstElementChild as HTMLElement;
+}
+
+beforeEach(() => {
+  // React only treats `act` as a real boundary when this is set; without it
+  // effects still run but React warns, and the warning is the honest signal
+  // that the flush is not being awaited the way the app flushes it.
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  calls = [];
+  scrollTop = 0;
+  stubGeometry();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  restoreGeometry();
+});
+
+describe("channel arrival", () => {
+  it("anchors instantly and never animates on the way in", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+
+    // The jump is a direct `scrollTop` write, not an animated `scrollTo`.
+    expect(scrollTop).toBe(CONTENT_HEIGHT);
+    expect(calls).toHaveLength(0);
+  });
+
+  it("re-anchors on a switch between channels holding the same number of rows", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+    // Simulate the operator having scrolled up in the first channel.
+    scrollTop = 0;
+
+    // Same row count on purpose: the old effect keyed on `items.length` alone,
+    // so this switch produced no effect at all and the new channel inherited
+    // the previous scroll offset.
+    const next = channel("product-design");
+    render(next, items(40, next));
+
+    expect(scrollTop).toBe(CONTENT_HEIGHT);
+  });
+});
+
+describe("growth while the channel is open", () => {
+  it("follows a new row when the operator is parked at the bottom", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+    calls = [];
+
+    render(ch, items(41, ch));
+
+    expect(calls).toEqual([{ top: CONTENT_HEIGHT, behavior: "smooth" }]);
+  });
+
+  it("leaves the viewport alone when the operator has scrolled up to read", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+    calls = [];
+
+    // Scrolled well away from the bottom, and the component told so by the
+    // scroll event its own handler listens for.
+    scrollTop = 100;
+    act(() => {
+      scroller().dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+
+    render(ch, items(41, ch));
+
+    expect(calls).toHaveLength(0);
+    expect(scrollTop).toBe(100);
+  });
+
+  it("resumes following once the operator returns to the bottom", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+
+    scrollTop = 100;
+    act(() => {
+      scroller().dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    render(ch, items(41, ch));
+    expect(calls).toHaveLength(0);
+
+    // Back to the bottom. `scrollHeight - scrollTop - clientHeight` is 0 here,
+    // comfortably inside the slack the component allows.
+    scrollTop = CONTENT_HEIGHT - VIEWPORT_HEIGHT;
+    act(() => {
+      scroller().dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    render(ch, items(42, ch));
+
+    expect(calls).toEqual([{ top: CONTENT_HEIGHT, behavior: "smooth" }]);
+  });
+
+  it("still follows when the view is a few pixels short of the bottom", () => {
+    const ch = channel("engineering");
+    render(ch, items(40, ch));
+    calls = [];
+
+    // Sub-pixel layout leaves a small remainder in a real browser; a strict
+    // equality test would read this as "scrolled away" and stop following.
+    scrollTop = CONTENT_HEIGHT - VIEWPORT_HEIGHT - 8;
+    act(() => {
+      scroller().dispatchEvent(new Event("scroll", { bubbles: true }));
+    });
+    render(ch, items(41, ch));
+
+    expect(calls).toEqual([{ top: CONTENT_HEIGHT, behavior: "smooth" }]);
+  });
+});


### PR DESCRIPTION
## Summary

Opening a channel did not *start* at the newest message — it painted higher up and then visibly slid down, replaying on every channel switch. The longer the transcript, the longer the slide.

One effect was doing two different jobs:

```ts
useEffect(() => {
  el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
}, [items.length, typing, liveStepCount]);
```

`behavior: "smooth"` is right for a tool row or reply arriving *while you watch* — the movement shows you something changed. It is wrong on mount, where there is no prior position worth animating from and the animation is the whole complaint.

Split into the two rules that were conflated:

1. **Arrival anchors instantly**, in a `useLayoutEffect` so the jump lands before paint rather than after it.
2. **Growth still follows smoothly**, but only while the view is already at the bottom.

## API Or Behavior Changes

Console only; no host change, no API change.

Three behaviour changes, all in `MessageTimeline`:

- Opening a channel paints at the newest message with no animation.
- **The dependency list gains `channel.id`.** It was `[items.length, typing, liveStepCount]`, so switching between two channels holding the *same number of rows* fired no effect at all and the new channel inherited the previous one's scroll offset. That is a second, quieter bug this fixes.
- **A message arriving while you have scrolled up no longer moves the viewport.** There was no at-bottom check, so any inbound row yanked the view back down mid-read. Following resumes as soon as you return to the bottom, within a 32px slack — sub-pixel layout rarely leaves the arithmetic at exactly zero, and a strict test would read a view that is visibly at the bottom as scrolled away.

`following` is a ref rather than state on purpose: it is read inside effects and written from a scroll handler that fires at frame rate, and making it state would re-render the transcript on every wheel tick to compute a value no rendered output depends on.

## Tests

`frontend/test/unit/chat-scroll-anchor.test.ts` — 6 tests, jsdom + real React:

- arrival writes `scrollTop` directly and makes **zero** `scrollTo` calls
- a switch between two channels with equal row counts still re-anchors
- growth follows when parked at the bottom
- growth does **not** move the viewport when scrolled up
- following resumes on return to the bottom
- a few pixels short of the bottom still counts as at-bottom

**Negative control, run for real:** against the previous effect, **4 of the 6 fail**. The other two ("follows a new row", "still follows near the bottom") pass on the old code too — the old code always followed, so those two guard against over-correction rather than proving the fix. Stating that rather than claiming 6/6 caught it.

jsdom performs no layout, so `scrollHeight` / `clientHeight` are 0 and `scrollTo` does not exist; the geometry is stubbed on the prototype and restored afterwards. These tests assert *which* anchoring call is made and when — the part that was wrong — and claim nothing about real pixel positions.

Commands run locally, all green:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npx vitest run` — 535 passed
- [x] `npm run build`
- [x] `./scripts/ci/assert-design-tokens.sh`
- [ ] `cargo` gates — N/A: no Rust changed.

**Not verified by eye.** I could not complete a browser walk: the local console kept showing the sign-in wall, and I stopped rather than keep guessing at the session mechanism. The behaviour is proven at the effect level by the tests above, not by watching a long channel open.

The test file is `.test.ts` using `createElement` rather than `.tsx` with JSX, because the unit suite's vitest `include` is `*.test.ts` — a `.tsx` file is silently not collected, which reads as a passing suite. Widening that glob felt out of scope for a bugfix.

## Documentation

The component's doc comment now states both rules and why arrival differs from growth. No `docs/` page covers chat scroll behaviour.

## Related

Closes #757

- #412 — leaving and returning lands on the first channel rather than the one you were in; same surface, different symptom
- #367 — added the growing live tool rows this effect follows
