### PR TITLE
feat(chat): a durable per-person unread floor, so a reload stops marking everything read (#755)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,6 +13,8 @@ import type { StreamHandlers, Transport, TransportResponse } from "./transport";
 import {
   type AgentDetailDto,
   ApiError,
+  type ReadMarker,
+  type ReadStateResponse,
   type ApiErrorBody,
   type AppSpec,
   type ApprovalSummary,
@@ -475,6 +477,35 @@ export class OpenCompanyClient {
       "GET",
       `${this.scope(company)}/chat/history${qs}`,
     );
+  }
+
+  /**
+   * Where the signed-in person has read to, per channel (issue #755).
+   *
+   * A host that predates this route answers 404; the caller treats that as "no
+   * markers" and falls back to the in-browser floor, so an older host degrades
+   * to the previous behaviour rather than throwing on load.
+   */
+  readState(company?: string | null): Promise<ReadStateResponse> {
+    return this.request<ReadStateResponse>("GET", `${this.scope(company)}/chat/read-state`);
+  }
+
+  /**
+   * Moves one channel's read floor forward.
+   *
+   * The host's write is monotonic, and it answers with where the marker
+   * actually stands — which is not always what was sent, because two tabs of
+   * one person race constantly.
+   */
+  markChannelRead(
+    channelId: string,
+    lastReadAt: number,
+    company?: string | null,
+  ): Promise<ReadMarker> {
+    return this.request<ReadMarker>("PUT", `${this.scope(company)}/chat/read-state`, {
+      channelId,
+      lastReadAt,
+    });
   }
 
   /** The approvals awaiting the operator. */

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -1102,3 +1102,22 @@ export class ApiError extends Error {
     this.name = "ApiError";
   }
 }
+
+/**
+ * `GET {scope}/chat/read-state` — one channel's floor for the signed-in person
+ * (issue #755).
+ *
+ * A channel with no marker is **absent** from the response rather than zero.
+ * "Never opened" and "opened before anything was said" are different states,
+ * and only the console knows which floor a never-opened channel deserves.
+ */
+export interface ReadMarker {
+  channelId: string;
+  /** Milliseconds since the epoch. At or before this is read. */
+  lastReadAt: number;
+}
+
+/** Response of `GET {scope}/chat/read-state`. */
+export interface ReadStateResponse {
+  markers: ReadMarker[];
+}

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -417,6 +417,31 @@ export function AppShell({
     setLastViewedChannel({});
     setUnreadSince(Date.now());
     activeChatChannelRef.current = null;
+
+    // Then replace that mount-time floor with the one the host remembers for
+    // this person (issue #755). Until this lands the browser floor stands, so
+    // the first paint is the old behaviour rather than a blank badge; when it
+    // lands, channels this person left unread come back unread.
+    //
+    // Merged into whatever the operator has viewed since, rather than
+    // assigned: this request is in flight while the console is usable, and a
+    // channel opened in that window must not have its fresh floor overwritten
+    // by an older stored one.
+    client
+      .readState(company)
+      .then(({ markers }) => {
+        if (cancelled || markers.length === 0) return;
+        setLastViewedChannel((viewed) => {
+          const merged = { ...viewed };
+          for (const m of markers) {
+            merged[m.channelId] = Math.max(merged[m.channelId] ?? 0, m.lastReadAt);
+          }
+          return merged;
+        });
+      })
+      .catch(() => {
+        /* host without `/chat/read-state`, or offline — the browser floor stands */
+      });
     // Another company's approval ids are another namespace, and a settled card
     // must not survive the switch as a ghost in the new company's channels.
     setDecidedApprovals({});
@@ -548,14 +573,23 @@ export function AppShell({
   const onChannelViewed = useCallback(
     (channelId: string) => {
       activeChatChannelRef.current = channelId;
-      setLastViewedChannel((v) => ({ ...v, [channelId]: Date.now() }));
+      const at = Date.now();
+      setLastViewedChannel((v) => ({ ...v, [channelId]: at }));
+      // The durable half (issue #755). Fire-and-forget on purpose: the local
+      // floor above has already cleared the badge, so a failed write costs a
+      // stale marker on the next load, not a wrong badge now. The host's write
+      // is monotonic, so the many calls this makes while a live channel grows
+      // are idempotent and cannot move the floor backwards.
+      void client.markChannelRead(channelId, at, company).catch(() => {
+        /* older host, or offline — the in-browser floor still holds this session */
+      });
       // The same fact, persisted, so re-entering Chat returns to the channel
       // the operator was reading instead of whichever sorts first (issue #412).
       // The ref above cannot do it: it dies with this mount, and a reload is
       // exactly one of the trips that has to survive.
       writeLastChannel(scope, channelId);
     },
-    [scope],
+    [scope, client, company],
   );
 
   const setThreadMessages = (

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -58,6 +58,7 @@ import {
 } from "@/lib/chat";
 import { CONNECTION_PROVIDERS } from "@/lib/connections";
 import { defaultDesks, type Desk } from "@/lib/desks";
+import { mergeReadFloors, unreadCount } from "@/lib/unread";
 import { writeLastChannel } from "@/lib/last-channel";
 import { fromDto, type TeamMember } from "@/lib/team";
 import { agentDmThreads, defaultThreads, threadsFromDesks } from "@/lib/threads";
@@ -431,13 +432,7 @@ export function AppShell({
       .readState(company)
       .then(({ markers }) => {
         if (cancelled || markers.length === 0) return;
-        setLastViewedChannel((viewed) => {
-          const merged = { ...viewed };
-          for (const m of markers) {
-            merged[m.channelId] = Math.max(merged[m.channelId] ?? 0, m.lastReadAt);
-          }
-          return merged;
-        });
+        setLastViewedChannel((viewed) => mergeReadFloors(viewed, markers));
       })
       .catch(() => {
         /* host without `/chat/read-state`, or offline — the browser floor stands */
@@ -559,7 +554,7 @@ export function AppShell({
     const counts: Record<string, number> = {};
     for (const [channelId, messages] of Object.entries(transcripts)) {
       const since = lastViewedChannel[channelId] ?? unreadSince;
-      const count = messages.filter((m) => m.from !== "you" && m.at > since).length;
+      const count = unreadCount(messages, since);
       if (count > 0) counts[channelId] = count;
     }
     return counts;

--- a/frontend/src/lib/unread.ts
+++ b/frontend/src/lib/unread.ts
@@ -1,0 +1,49 @@
+import type { ChatMessage } from "@/lib/chat";
+import type { ReadMarker } from "@/api/types";
+
+/**
+ * How the console decides what is unread (issue #755).
+ *
+ * Both rules live here rather than inline in the shell so a test can exercise
+ * *this* code instead of a copy of it. A private re-implementation in a test
+ * file passes whether or not the shipped rule still agrees with it, which is
+ * the failure mode this module exists to remove.
+ */
+
+/**
+ * Merge the read floors the host remembers into the ones this tab has observed,
+ * taking the later of each pair.
+ *
+ * Never an assignment. The host's markers arrive asynchronously while the
+ * console is already usable, so a channel opened in that window has a *fresher*
+ * floor than anything stored — overwriting it would re-raise a badge the
+ * operator just cleared.
+ *
+ * A channel the host said nothing about keeps whatever this tab had, and a
+ * channel this tab has never opened adopts the stored floor outright.
+ */
+export function mergeReadFloors(
+  viewed: Readonly<Record<string, number>>,
+  markers: readonly ReadMarker[],
+): Record<string, number> {
+  const merged = { ...viewed };
+  for (const m of markers) {
+    merged[m.channelId] = Math.max(merged[m.channelId] ?? 0, m.lastReadAt);
+  }
+  return merged;
+}
+
+/**
+ * How many messages in a channel count as unread against a floor.
+ *
+ * Your own lines never count — a badge for what you just typed is noise. The
+ * comparison is strictly `>`, so a message landing on the same millisecond as
+ * the floor reads as *seen*: the floor is stamped when the channel is viewed,
+ * and a row already on screen at that instant has been.
+ */
+export function unreadCount(
+  messages: readonly Pick<ChatMessage, "from" | "at">[],
+  floor: number,
+): number {
+  return messages.filter((m) => m.from !== "you" && m.at > floor).length;
+}

--- a/frontend/test/unit/chat-read-state.test.ts
+++ b/frontend/test/unit/chat-read-state.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import type { ReadMarker } from "@/api/types";
+import type { ChatMessage } from "@/lib/chat";
+import { mergeReadFloors, unreadCount } from "@/lib/unread";
 
 /**
  * How the host's read markers meet the console's own floor (issue #755).
@@ -11,46 +12,28 @@ import type { ReadMarker } from "@/api/types";
  * in flight, and a channel opened in that window already has a fresher floor
  * than anything stored.
  *
- * So the two are merged by taking the later of each pair, never assigned. This
- * is the rule the shell applies on load, extracted so it can be asserted
- * without standing up the shell.
+ * These import the shipped rules from `@/lib/unread`, the same module the shell
+ * calls. An earlier version of this file re-implemented them locally, which
+ * would have passed whether or not the shipped code still agreed with the copy.
  */
-function mergeFloors(
-  viewed: Record<string, number>,
-  markers: ReadMarker[],
-): Record<string, number> {
-  const merged = { ...viewed };
-  for (const m of markers) {
-    merged[m.channelId] = Math.max(merged[m.channelId] ?? 0, m.lastReadAt);
-  }
-  return merged;
-}
-
-/** Unread as the shell derives it: not yours, and newer than the floor. */
-function unreadCount(
-  messages: Array<{ from: string; at: number }>,
-  floor: number,
-): number {
-  return messages.filter((m) => m.from !== "you" && m.at > floor).length;
-}
 
 describe("merging the host's floor with the browser's", () => {
   it("adopts a stored floor for a channel this tab has not opened", () => {
-    const merged = mergeFloors({}, [{ channelId: "engineering", lastReadAt: 5_000 }]);
+    const merged = mergeReadFloors({}, [{ channelId: "engineering", lastReadAt: 5_000 }]);
     expect(merged.engineering).toBe(5_000);
   });
 
   it("keeps a fresher local floor when a channel was opened mid-flight", () => {
     // The operator opened the channel while the read-state request was still
     // in the air. Overwriting here would re-raise a badge they just cleared.
-    const merged = mergeFloors({ engineering: 9_000 }, [
+    const merged = mergeReadFloors({ engineering: 9_000 }, [
       { channelId: "engineering", lastReadAt: 5_000 },
     ]);
     expect(merged.engineering).toBe(9_000);
   });
 
   it("leaves channels the host said nothing about untouched", () => {
-    const merged = mergeFloors({ "dm:pm": 3_000 }, [
+    const merged = mergeReadFloors({ "dm:pm": 3_000 }, [
       { channelId: "engineering", lastReadAt: 5_000 },
     ]);
     expect(merged["dm:pm"]).toBe(3_000);
@@ -58,24 +41,25 @@ describe("merging the host's floor with the browser's", () => {
   });
 
   it("treats an empty marker list as leaving the browser floor alone", () => {
-    const merged = mergeFloors({ engineering: 1_234 }, []);
+    const merged = mergeReadFloors({ engineering: 1_234 }, []);
     expect(merged).toEqual({ engineering: 1_234 });
   });
 });
 
 describe("what the merged floor means for a badge", () => {
-  const transcript = [
-    { from: "them", at: 1_000 },
+  // `from` is a union on `ChatMessage`; "company" is the not-you case.
+  const transcript: Array<Pick<ChatMessage, "from" | "at">> = [
+    { from: "company", at: 1_000 },
     { from: "you", at: 2_000 },
-    { from: "them", at: 3_000 },
-    { from: "them", at: 4_000 },
+    { from: "company", at: 3_000 },
+    { from: "company", at: 4_000 },
   ];
 
   it("counts what arrived after the stored floor, across a reload", () => {
     // The regression this issue is about: on load the browser floor is `now`,
     // which reads the whole transcript as caught up. The stored floor restores
     // the two messages that arrived after the operator last looked.
-    const floor = mergeFloors({}, [{ channelId: "c", lastReadAt: 2_500 }]).c;
+    const floor = mergeReadFloors({}, [{ channelId: "c", lastReadAt: 2_500 }]).c;
     expect(unreadCount(transcript, floor)).toBe(2);
   });
 

--- a/frontend/test/unit/chat-read-state.test.ts
+++ b/frontend/test/unit/chat-read-state.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import type { ReadMarker } from "@/api/types";
+
+/**
+ * How the host's read markers meet the console's own floor (issue #755).
+ *
+ * Unread used to be measured from a floor stamped when the tab mounted, so a
+ * reload marked every channel read. The host now remembers a per-person floor,
+ * but it arrives *asynchronously* — the console is usable while that request is
+ * in flight, and a channel opened in that window already has a fresher floor
+ * than anything stored.
+ *
+ * So the two are merged by taking the later of each pair, never assigned. This
+ * is the rule the shell applies on load, extracted so it can be asserted
+ * without standing up the shell.
+ */
+function mergeFloors(
+  viewed: Record<string, number>,
+  markers: ReadMarker[],
+): Record<string, number> {
+  const merged = { ...viewed };
+  for (const m of markers) {
+    merged[m.channelId] = Math.max(merged[m.channelId] ?? 0, m.lastReadAt);
+  }
+  return merged;
+}
+
+/** Unread as the shell derives it: not yours, and newer than the floor. */
+function unreadCount(
+  messages: Array<{ from: string; at: number }>,
+  floor: number,
+): number {
+  return messages.filter((m) => m.from !== "you" && m.at > floor).length;
+}
+
+describe("merging the host's floor with the browser's", () => {
+  it("adopts a stored floor for a channel this tab has not opened", () => {
+    const merged = mergeFloors({}, [{ channelId: "engineering", lastReadAt: 5_000 }]);
+    expect(merged.engineering).toBe(5_000);
+  });
+
+  it("keeps a fresher local floor when a channel was opened mid-flight", () => {
+    // The operator opened the channel while the read-state request was still
+    // in the air. Overwriting here would re-raise a badge they just cleared.
+    const merged = mergeFloors({ engineering: 9_000 }, [
+      { channelId: "engineering", lastReadAt: 5_000 },
+    ]);
+    expect(merged.engineering).toBe(9_000);
+  });
+
+  it("leaves channels the host said nothing about untouched", () => {
+    const merged = mergeFloors({ "dm:pm": 3_000 }, [
+      { channelId: "engineering", lastReadAt: 5_000 },
+    ]);
+    expect(merged["dm:pm"]).toBe(3_000);
+    expect(merged.engineering).toBe(5_000);
+  });
+
+  it("treats an empty marker list as leaving the browser floor alone", () => {
+    const merged = mergeFloors({ engineering: 1_234 }, []);
+    expect(merged).toEqual({ engineering: 1_234 });
+  });
+});
+
+describe("what the merged floor means for a badge", () => {
+  const transcript = [
+    { from: "them", at: 1_000 },
+    { from: "you", at: 2_000 },
+    { from: "them", at: 3_000 },
+    { from: "them", at: 4_000 },
+  ];
+
+  it("counts what arrived after the stored floor, across a reload", () => {
+    // The regression this issue is about: on load the browser floor is `now`,
+    // which reads the whole transcript as caught up. The stored floor restores
+    // the two messages that arrived after the operator last looked.
+    const floor = mergeFloors({}, [{ channelId: "c", lastReadAt: 2_500 }]).c;
+    expect(unreadCount(transcript, floor)).toBe(2);
+  });
+
+  it("never counts your own lines, whatever the floor says", () => {
+    expect(unreadCount(transcript, 1_500)).toBe(2);
+  });
+
+  it("reports nothing once the floor is past the newest line", () => {
+    expect(unreadCount(transcript, 4_000)).toBe(0);
+  });
+});

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -29,9 +29,9 @@ use crate::ports::types::{
 };
 use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
-    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, RunStore, SecretStore,
-    SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter, UserStore,
-    WorkflowRevisionStore, WorkspaceStore,
+    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, ReadStateStore, RunStore,
+    SecretStore, SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter,
+    UserStore, WorkflowRevisionStore, WorkspaceStore,
 };
 // Separate line (#241) so this addition is a pure append, not a reflow of the
 // grouped import that sibling store-seam branches (#274, #596) also edit.
@@ -141,6 +141,8 @@ pub struct OpsStores {
     pub usage: Arc<dyn UsageMeter>,
     /// Operator deltas over the company's skills.
     pub skills: Arc<dyn SkillStateStore>,
+    /// Per-person, per-channel read markers (#755).
+    pub read_state: Arc<dyn ReadStateStore>,
     /// The company's human collaborators and their outstanding invites.
     pub users: Arc<dyn UserStore>,
     /// Live browser sessions for those users.
@@ -917,6 +919,11 @@ impl CompanyRuntime {
     /// This company's skill-state deltas.
     pub fn skills(&self) -> &Arc<dyn SkillStateStore> {
         &self.ops.skills
+    }
+
+    /// Where each person has read to, per channel (#755).
+    pub fn read_state(&self) -> &Arc<dyn ReadStateStore> {
+        &self.ops.read_state
     }
 
     /// This company's human collaborators and their invites.

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -19,6 +19,7 @@ pub mod facts;
 pub mod inbox;
 pub mod login_codes;
 pub mod memory;
+pub mod read_state;
 pub mod run_output;
 pub mod runs;
 pub mod schedule_fires;
@@ -50,6 +51,7 @@ pub use ids::{AGENT_SLUG_FALLBACK, agent_slug, generate_id, now_millis};
 pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;
+pub use read_state::{ChannelRead, ReadStateStore};
 pub use run_output::{
     MAX_RUN_OUTPUTS_PER_COMPANY, WorkflowRunOutputRecord, WorkflowRunOutputStore, bound_node_output,
 };
@@ -104,6 +106,7 @@ mod test {
         _facts: &dyn crate::ports::facts::FactStore,
         _usage: &dyn crate::ports::usage::UsageMeter,
         _skills: &dyn crate::ports::skills_state::SkillStateStore,
+        _read_state: &dyn crate::ports::read_state::ReadStateStore,
         _users: &dyn crate::ports::users::UserStore,
         _sessions: &dyn crate::ports::sessions::SessionStore,
         _login_codes: &dyn crate::ports::login_codes::LoginCodeStore,

--- a/src/ports/read_state.rs
+++ b/src/ports/read_state.rs
@@ -47,6 +47,12 @@ pub trait ReadStateStore: Send + Sync {
     /// A channel with no marker is absent rather than zero — "never opened" and
     /// "opened before any message existed" are different states, and only the
     /// caller knows which floor to apply to a channel it has never seen.
+    ///
+    /// **Ordered by `channel_id`, ascending.** Part of the contract rather than
+    /// an accident of each backend: insertion order differs between a document
+    /// store and a table, and a caller diffing two reads would see spurious
+    /// churn. The conformance suite asserts it, so a backend that returns
+    /// insertion order fails rather than passing quietly.
     async fn list(&self, company: &CompanyId, user: &str) -> Result<Vec<ChannelRead>>;
 
     /// Moves one channel's marker forward, and returns where it now stands.

--- a/src/ports/read_state.rs
+++ b/src/ports/read_state.rs
@@ -1,0 +1,67 @@
+//! The [`ReadStateStore`] port: how far each person has read each channel.
+//!
+//! The console used to answer "is there anything new here?" entirely in the
+//! browser, from a floor stamped at mount. Anything older than the instant the
+//! tab opened counted as read, so a reload marked every channel caught up —
+//! failing exactly the case unread exists for, and disagreeing between two
+//! tabs of the same person (issue #755).
+//!
+//! This store holds the other half: a durable, per-person, per-channel marker
+//! that survives the tab. The console still derives the *count* locally — it is
+//! the only side holding the transcript — but it derives it from a floor the
+//! host remembers rather than one the browser invented.
+//!
+//! **Per person, not per company.** Two operators on one company have read
+//! different things, and a marker keyed only by channel would let one person's
+//! reading clear another's badge.
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// How far one person has read one channel.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ChannelRead {
+    /// The channel this marker is for, in the console's own channel-id space
+    /// (`engineering`, `dm:product_manager`).
+    pub channel_id: String,
+    /// Milliseconds since the epoch. Everything at or before this instant is
+    /// read; everything after it is not.
+    ///
+    /// A timestamp rather than a message id because the console's unread
+    /// derivation is already a time comparison against `message.at`, and
+    /// because a channel's rows come from more than one writer — there is no
+    /// single sequence to point at.
+    pub last_read_at: i64,
+}
+
+/// Durable read markers. One person's markers MUST be invisible to another,
+/// and one company's MUST be invisible to another.
+#[async_trait]
+pub trait ReadStateStore: Send + Sync {
+    /// Every marker this person holds in this company.
+    ///
+    /// A channel with no marker is absent rather than zero — "never opened" and
+    /// "opened before any message existed" are different states, and only the
+    /// caller knows which floor to apply to a channel it has never seen.
+    async fn list(&self, company: &CompanyId, user: &str) -> Result<Vec<ChannelRead>>;
+
+    /// Moves one channel's marker forward, and returns where it now stands.
+    ///
+    /// **Monotonic.** An `at` at or before the stored marker leaves it alone.
+    /// Two tabs of the same person race constantly — one viewing an old channel
+    /// while another reads a live one — and a late request carrying the earlier
+    /// instant would otherwise resurrect messages the person has already read.
+    /// Making the write a max rather than a set means the order requests land
+    /// in cannot change the outcome.
+    async fn mark(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        channel_id: &str,
+        at: i64,
+    ) -> Result<ChannelRead>;
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -302,6 +302,7 @@ pub struct RuntimeBuilder {
     run_output_store: Option<Arc<dyn WorkflowRunOutputStore>>,
     usage: Option<Arc<dyn UsageMeter>>,
     skills: Option<Arc<dyn SkillStateStore>>,
+    read_state: Option<Arc<dyn crate::ports::read_state::ReadStateStore>>,
     users: Option<Arc<dyn UserStore>>,
     sessions: Option<Arc<dyn SessionStore>>,
     login_codes: Option<Arc<dyn LoginCodeStore>>,
@@ -398,6 +399,7 @@ impl RuntimeBuilder {
             run_output_store: None,
             usage: None,
             skills: None,
+            read_state: None,
             users: None,
             sessions: None,
             login_codes: None,
@@ -517,6 +519,7 @@ impl RuntimeBuilder {
         self.run_output_store = Some(handles.run_outputs.clone());
         self.usage = Some(handles.usage.clone());
         self.skills = Some(handles.skills.clone());
+        self.read_state = Some(handles.read_state.clone());
         self.users = Some(handles.users.clone());
         self.sessions = Some(handles.sessions.clone());
         self.login_codes = Some(handles.login_codes.clone());
@@ -625,6 +628,15 @@ impl RuntimeBuilder {
     }
 
     /// Swaps the skill-state store (default: fs-backed).
+    /// Overrides the per-person channel read markers (#755).
+    pub fn with_read_state(
+        mut self,
+        read_state: Arc<dyn crate::ports::read_state::ReadStateStore>,
+    ) -> Self {
+        self.read_state = Some(read_state);
+        self
+    }
+
     pub fn with_skills(mut self, skills: Arc<dyn SkillStateStore>) -> Self {
         self.skills = Some(skills);
         self
@@ -967,6 +979,7 @@ impl RuntimeBuilder {
                     .unwrap_or_else(|| fs_ops.clone()),
                 usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
                 skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
+                read_state: self.read_state.unwrap_or_else(|| fs_ops.clone()),
                 users: self.users.unwrap_or_else(|| fs_ops.clone()),
                 sessions: self.sessions.unwrap_or_else(|| fs_ops.clone()),
                 login_codes: self.login_codes.unwrap_or_else(|| fs_ops.clone()),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -627,8 +627,7 @@ impl RuntimeBuilder {
         self
     }
 
-    /// Swaps the skill-state store (default: fs-backed).
-    /// Overrides the per-person channel read markers (#755).
+    /// Swaps the per-person channel read markers (default: fs-backed).
     pub fn with_read_state(
         mut self,
         read_state: Arc<dyn crate::ports::read_state::ReadStateStore>,
@@ -637,6 +636,7 @@ impl RuntimeBuilder {
         self
     }
 
+    /// Swaps the skill-state store (default: fs-backed).
     pub fn with_skills(mut self, skills: Arc<dyn SkillStateStore>) -> Self {
         self.skills = Some(skills);
         self

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -33,6 +33,7 @@ pub mod mailer;
 pub mod mcp;
 pub mod memory;
 pub mod policy;
+pub mod read_state;
 /// Issue #245 (operator half): bind a real repository to a company, list what
 /// is bound, revoke one. The whole credential path, with **no agent surface**
 /// behind it — no grant, no tool. See [`repos`].
@@ -174,6 +175,7 @@ pub fn router() -> Router<AppState> {
         .merge(workspace::router())
         .merge(skills::router())
         .merge(mcp::router())
+        .merge(read_state::router())
         .merge(repos::router())
         .merge(inference::router())
         .merge(team::router())

--- a/src/server/ops/read_state.rs
+++ b/src/server/ops/read_state.rs
@@ -141,3 +141,238 @@ fn unauthorized() -> Response {
     )
         .into_response()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::Request;
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::store::FsCompanyStore;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = "[company]\nname = \"Acme\"\n\
+         [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n";
+
+    fn home() -> tempfile::TempDir {
+        tempfile::Builder::new()
+            .prefix("oc-read-state-")
+            .tempdir()
+            .expect("tempdir")
+    }
+
+    async fn state(home: &std::path::Path) -> AppState {
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    /// A request carrying the signed-in admin's cookie, or none at all.
+    async fn call(
+        state: &AppState,
+        method: &str,
+        body: Option<Value>,
+        signed_in: bool,
+    ) -> (StatusCode, Value) {
+        let mut request = Request::builder()
+            .method(method)
+            .uri("/api/v1/company/chat/read-state")
+            .header("content-type", "application/json");
+        if signed_in {
+            request = request.header("cookie", crate::server::test_support::fixed_cookie("acme"));
+        }
+        let request = match body {
+            Some(value) => request.body(Body::from(value.to_string())).unwrap(),
+            None => request.body(Body::empty()).unwrap(),
+        };
+        let response = router(state.clone()).oneshot(request).await.unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+        )
+    }
+
+    /// The happy path, so the failure cases below are not the only coverage:
+    /// a marker round-trips, and the write answers with where it stands.
+    #[tokio::test]
+    async fn a_marker_round_trips_for_a_signed_in_person() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        let (status, listed) = call(&state, "GET", None, true).await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(listed["markers"].as_array().unwrap().len(), 0);
+
+        let (status, marked) = call(
+            &state,
+            "PUT",
+            Some(json!({"channelId": "engineering", "lastReadAt": 2_000})),
+            true,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(marked["lastReadAt"], 2_000);
+
+        // Monotonic at the HTTP boundary too, not only in the store: the reply
+        // is the stored marker, not the number that was sent.
+        let (_, back) = call(
+            &state,
+            "PUT",
+            Some(json!({"channelId": "engineering", "lastReadAt": 500})),
+            true,
+        )
+        .await;
+        assert_eq!(back["lastReadAt"], 2_000);
+    }
+
+    /// A **machine** credential — authenticated, owns the company, but names no
+    /// person — must not read or write markers. Otherwise one tenant's
+    /// automation could clear a real operator's badges.
+    ///
+    /// The token is the point. An *unauthenticated* request also answers 401,
+    /// but from the auth layer above this module, so asserting that would pass
+    /// with this handler's own guard deleted. This drives the platform scope so
+    /// the request reaches the handler with `actor: None`.
+    #[tokio::test]
+    async fn a_machine_credential_naming_no_person_is_refused_on_both_verbs() {
+        use crate::server::platform_auth::{
+            PlatformAuthConfig, PlatformClaims, UnsignedTenantVerifier,
+        };
+        use std::collections::HashSet;
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let verifier = std::sync::Arc::new(UnsignedTenantVerifier::new("plat-secret"));
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).unwrap();
+        let id = CompanyId::new("acme");
+        let store = FsCompanyStore::new(home.clone());
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default())
+            .with_home(home.clone())
+            .with_platform_auth(PlatformAuthConfig::new(verifier));
+        state
+            .registry()
+            .insert(id.clone(), std::sync::Arc::new(runtime));
+        state.set_owner(id.clone(), "tenant:acme".to_string());
+
+        let token = UnsignedTenantVerifier::tenant_token(&PlatformClaims {
+            tenant: "tenant:acme".to_string(),
+            scopes: HashSet::from(["operator".to_string()]),
+            companies: None,
+        });
+
+        let send = async |method: &str, body: Option<Value>| {
+            let mut request = Request::builder()
+                .method(method)
+                .uri("/api/v1/companies/acme/chat/read-state")
+                .header("authorization", format!("Bearer {token}"))
+                .header("content-type", "application/json");
+            let _ = &mut request;
+            let request = match body {
+                Some(v) => request.body(Body::from(v.to_string())).unwrap(),
+                None => request.body(Body::empty()).unwrap(),
+            };
+            let response = router(state.clone()).oneshot(request).await.unwrap();
+            let status = response.status();
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            (
+                status,
+                serde_json::from_slice::<Value>(&bytes).unwrap_or(Value::Null),
+            )
+        };
+
+        let (status, body) = send("GET", None).await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(body["code"], "unauthorized");
+
+        let (status, _) = send(
+            "PUT",
+            Some(json!({"channelId": "engineering", "lastReadAt": 1})),
+        )
+        .await;
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    /// A blank channel id is refused rather than stored — a marker on `""`
+    /// would be unreachable from the console and invisible in the list.
+    #[tokio::test]
+    async fn a_blank_channel_id_is_refused() {
+        let home = home();
+        let state = state(home.path()).await;
+
+        for blank in ["", "   "] {
+            let (status, body) = call(
+                &state,
+                "PUT",
+                Some(json!({"channelId": blank, "lastReadAt": 1})),
+                true,
+            )
+            .await;
+            assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY, "blank {blank:?}");
+            assert_eq!(body["code"], "invalid_request");
+        }
+
+        // Nothing was stored by the refused writes.
+        let (_, listed) = call(&state, "GET", None, true).await;
+        assert_eq!(listed["markers"].as_array().unwrap().len(), 0);
+    }
+}

--- a/src/server/ops/read_state.rs
+++ b/src/server/ops/read_state.rs
@@ -1,0 +1,143 @@
+//! Per-person channel read markers: `GET`/`PUT {scope}/chat/read-state`
+//! (issue #755).
+//!
+//! Unread used to be decided entirely in the browser, against a floor stamped
+//! when the tab mounted. Everything older than that instant counted as read, so
+//! a reload marked every channel caught up and two tabs of the same person
+//! disagreed. This is the durable half: where each person has read to, per
+//! channel, remembered by the host.
+//!
+//! **The count stays in the console.** Only the browser holds the transcript,
+//! so only the browser can say how many messages sit past a marker. What moves
+//! here is the *floor* that count is measured from — which is the part that has
+//! to outlive the tab. Splitting it the other way would mean shipping every
+//! channel's message count to the host on every poll.
+//!
+//! **Signed-in humans only.** A marker answers "how far has *this person*
+//! read", and a machine credential is not a person — the platform scope reaches
+//! these routes with [`ScopedCompany::actor`] as `None`. Rather than invent a
+//! shared pseudo-user for it (which would let one tenant's automation clear a
+//! real operator's badges), both routes answer `401` for a caller with no
+//! person behind it.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::AppState;
+use crate::ports::read_state::ChannelRead;
+use crate::server::error::ApiError;
+use crate::server::ops::scope::{ScopedCompany, scoped};
+
+pub fn router() -> Router<AppState> {
+    scoped("/chat/read-state", get(list_read_state).put(mark_read))
+}
+
+/// One channel's marker, as the console reads it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReadMarkerDto {
+    channel_id: String,
+    last_read_at: i64,
+}
+
+impl From<ChannelRead> for ReadMarkerDto {
+    fn from(r: ChannelRead) -> Self {
+        Self {
+            channel_id: r.channel_id,
+            last_read_at: r.last_read_at,
+        }
+    }
+}
+
+/// `GET {scope}/chat/read-state` — every marker this person holds.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct ReadStateDto {
+    /// Channels this person has opened, each with its floor.
+    ///
+    /// A channel absent from this list has never been opened by this person.
+    /// The console decides what that means — it is the only side that knows
+    /// whether the channel even has messages — rather than the host guessing a
+    /// zero that would render a lifetime of history as unread.
+    markers: Vec<ReadMarkerDto>,
+}
+
+/// `PUT {scope}/chat/read-state` — move one channel's floor forward.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct MarkReadBody {
+    channel_id: String,
+    /// Milliseconds since the epoch, from the newest row the person has seen.
+    last_read_at: i64,
+}
+
+async fn list_read_state(company: ScopedCompany) -> Result<Json<ReadStateDto>, Response> {
+    let Some(user) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    let markers = company
+        .runtime
+        .read_state()
+        .list(company.id(), &user)
+        .await
+        .map_err(|e| ApiError(e).into_response())?
+        .into_iter()
+        .map(ReadMarkerDto::from)
+        .collect();
+    Ok(Json(ReadStateDto { markers }))
+}
+
+async fn mark_read(
+    company: ScopedCompany,
+    Json(body): Json<MarkReadBody>,
+) -> Result<Json<ReadMarkerDto>, Response> {
+    let Some(user) = actor_id(&company) else {
+        return Err(unauthorized());
+    };
+    if body.channel_id.trim().is_empty() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(json!({ "error": "channelId must not be empty", "code": "invalid_request" })),
+        )
+            .into_response());
+    }
+    // The stored marker is returned rather than the requested one, because
+    // `mark` is monotonic: a late request carrying an earlier instant leaves the
+    // marker where it was, and the console must see where it actually stands
+    // rather than assume its own value took.
+    let settled = company
+        .runtime
+        .read_state()
+        .mark(company.id(), &user, &body.channel_id, body.last_read_at)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
+    Ok(Json(settled.into()))
+}
+
+/// The signed-in person behind the request, if there is one.
+///
+/// `Option` rather than `Result<_, Response>`: an axum `Response` is a large
+/// error variant to carry through a helper, and the two call sites want the
+/// same `401` anyway — so they build it once, from [`unauthorized`].
+fn actor_id(company: &ScopedCompany) -> Option<String> {
+    company.actor.as_ref().map(|a| a.id.clone())
+}
+
+/// The `401` for a caller with no person behind it.
+///
+/// See the module note: a machine credential has no person to attribute a
+/// marker to, and inventing one would let automation clear a human's badges.
+fn unauthorized() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({
+            "error": "read state is per person, and this credential names none",
+            "code": "unauthorized",
+        })),
+    )
+        .into_response()
+}

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2149,6 +2149,87 @@ pub async fn assert_usage_retention(usage: Arc<dyn UsageMeter>) {
 }
 
 /// Asserts the [`SkillStateStore`] contract: isolation, set/upsert, and remove.
+/// Every [`ReadStateStore`] must agree on these (issue #755).
+///
+/// The two properties worth pinning are the ones a backend can plausibly get
+/// wrong: **monotonicity** (a marker never moves backwards, however requests
+/// interleave) and **isolation** (per person as well as per company — a marker
+/// keyed only by channel would let one operator's reading clear another's
+/// badges).
+pub async fn assert_read_state_store(reads: Arc<dyn crate::ports::read_state::ReadStateStore>) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    // A channel never opened has no marker — absent, not zero.
+    assert!(reads.list(&alpha, "ada").await.unwrap().is_empty());
+
+    let first = reads
+        .mark(&alpha, "ada", "engineering", 1_000)
+        .await
+        .unwrap();
+    assert_eq!(first.last_read_at, 1_000);
+    assert_eq!(first.channel_id, "engineering");
+
+    // Forward moves.
+    assert_eq!(
+        reads
+            .mark(&alpha, "ada", "engineering", 2_000)
+            .await
+            .unwrap()
+            .last_read_at,
+        2_000
+    );
+
+    // Backwards does NOT. A late request carrying an earlier instant must not
+    // resurrect messages already read, and the call answers with where the
+    // marker actually stands rather than what was asked for.
+    assert_eq!(
+        reads
+            .mark(&alpha, "ada", "engineering", 500)
+            .await
+            .unwrap()
+            .last_read_at,
+        2_000
+    );
+    // Equal is not a move either, and must not error.
+    assert_eq!(
+        reads
+            .mark(&alpha, "ada", "engineering", 2_000)
+            .await
+            .unwrap()
+            .last_read_at,
+        2_000
+    );
+
+    // Per person: Grace's marker on the same channel is her own, and reading it
+    // to the past does not disturb Ada's.
+    reads
+        .mark(&alpha, "grace", "engineering", 42)
+        .await
+        .unwrap();
+    let ada = reads.list(&alpha, "ada").await.unwrap();
+    assert_eq!(ada.len(), 1);
+    assert_eq!(ada[0].last_read_at, 2_000);
+    let grace = reads.list(&alpha, "grace").await.unwrap();
+    assert_eq!(grace.len(), 1);
+    assert_eq!(grace[0].last_read_at, 42);
+
+    // Per company: the same person in another company starts empty.
+    assert!(reads.list(&beta, "ada").await.unwrap().is_empty());
+    reads.mark(&beta, "ada", "engineering", 9).await.unwrap();
+    assert_eq!(
+        reads.list(&alpha, "ada").await.unwrap()[0].last_read_at,
+        2_000
+    );
+
+    // Several channels for one person, listed in a stable order.
+    reads.mark(&alpha, "ada", "dm:pm", 7).await.unwrap();
+    let all = reads.list(&alpha, "ada").await.unwrap();
+    assert_eq!(all.len(), 2);
+    assert_eq!(all[0].channel_id, "dm:pm");
+    assert_eq!(all[1].channel_id, "engineering");
+}
+
 pub async fn assert_skill_state_store(skills: Arc<dyn SkillStateStore>) {
     let alpha = CompanyId::new("alpha");
     let beta = CompanyId::new("beta");

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2222,7 +2222,9 @@ pub async fn assert_read_state_store(reads: Arc<dyn crate::ports::read_state::Re
         2_000
     );
 
-    // Several channels for one person, listed in a stable order.
+    // Several channels for one person, ordered by channel id ascending — the
+    // order the trait documents, not each backend's insertion order.
+    // `engineering` was written first and still sorts second.
     reads.mark(&alpha, "ada", "dm:pm", 7).await.unwrap();
     let all = reads.list(&alpha, "ada").await.unwrap();
     assert_eq!(all.len(), 2);

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -985,6 +985,78 @@ impl SkillStateStore for FsOps {
 }
 
 // ---------------------------------------------------------------------------
+// ReadStateStore
+// ---------------------------------------------------------------------------
+
+/// One stored marker. The user is part of the row rather than the file name, so
+/// the whole company's markers stay one readable document.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct StoredRead {
+    user_id: String,
+    channel_id: String,
+    last_read_at: i64,
+}
+
+#[async_trait]
+impl crate::ports::read_state::ReadStateStore for FsOps {
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::read_state::ChannelRead>> {
+        let rows = load_json_vec::<StoredRead>(&self.bundle(company).read_state_json()).await?;
+        let mut out: Vec<_> = rows
+            .into_iter()
+            .filter(|r| r.user_id == user)
+            .map(|r| crate::ports::read_state::ChannelRead {
+                channel_id: r.channel_id,
+                last_read_at: r.last_read_at,
+            })
+            .collect();
+        out.sort_by(|a, b| a.channel_id.cmp(&b.channel_id));
+        Ok(out)
+    }
+
+    async fn mark(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        channel_id: &str,
+        at: i64,
+    ) -> Result<crate::ports::read_state::ChannelRead> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.read_state_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut rows = load_json_vec::<StoredRead>(&path).await?;
+        // Monotonic, as the port promises — see `ReadStateStore::mark`.
+        let settled = match rows
+            .iter_mut()
+            .find(|r| r.user_id == user && r.channel_id == channel_id)
+        {
+            Some(existing) => {
+                existing.last_read_at = existing.last_read_at.max(at);
+                existing.last_read_at
+            }
+            None => {
+                rows.push(StoredRead {
+                    user_id: user.to_string(),
+                    channel_id: channel_id.to_string(),
+                    last_read_at: at,
+                });
+                at
+            }
+        };
+        write_atomic(&path, &serde_json::to_string(&rows)?).await?;
+        Ok(crate::ports::read_state::ChannelRead {
+            channel_id: channel_id.to_string(),
+            last_read_at: settled,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -1998,6 +2070,13 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_skill_state_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_read_state_store() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_read_state_store(Arc::new(FsOps::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3588,6 +3588,12 @@ mod test {
     async fn conformance_skill_state_store() {
         let Some(s) = store().await else { return };
         conformance::assert_skill_state_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_read_state_store() {
+        let Some(s) = store().await else { return };
         conformance::assert_read_state_store(s.clone()).await;
         drop_db(&s).await;
     }

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2103,6 +2103,67 @@ impl crate::ports::skills_state::SkillStateStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// ReadStateStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::read_state::ReadStateStore for MongoStore {
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::read_state::ChannelRead>> {
+        let mut cursor = self
+            .collection("channel_read_state")
+            .find(doc! {"company_id": company.as_ref(), "user_id": user})
+            .sort(doc! {"channel_id": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(d) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(crate::ports::read_state::ChannelRead {
+                channel_id: get_str(&d, "channel_id")?,
+                last_read_at: d.get_i64("last_read_ms").unwrap_or_default(),
+            });
+        }
+        Ok(out)
+    }
+
+    async fn mark(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        channel_id: &str,
+        at: i64,
+    ) -> Result<crate::ports::read_state::ChannelRead> {
+        let key = doc! {
+            "company_id": company.as_ref(),
+            "user_id": user,
+            "channel_id": channel_id,
+        };
+        // `$max` rather than `$set`, for the monotonicity the port promises —
+        // and on an upsert it seeds the field, so no `$setOnInsert` twin (which
+        // Mongo would reject as a conflicting path anyway).
+        self.collection("channel_read_state")
+            .update_one(key.clone(), doc! {"$max": {"last_read_ms": at}})
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        let settled = self
+            .collection("channel_read_state")
+            .find_one(key)
+            .await
+            .map_err(mongo_err)?
+            .and_then(|d| d.get_i64("last_read_ms").ok())
+            .unwrap_or(at);
+        Ok(crate::ports::read_state::ChannelRead {
+            channel_id: channel_id.to_string(),
+            last_read_at: settled,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -3527,6 +3588,7 @@ mod test {
     async fn conformance_skill_state_store() {
         let Some(s) = store().await else { return };
         conformance::assert_skill_state_store(s.clone()).await;
+        conformance::assert_read_state_store(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -412,6 +412,11 @@ impl Bundle {
         self.dir.join("skills.json")
     }
 
+    /// Path to the per-person channel read markers (`read-state.json`, #755).
+    pub fn read_state_json(&self) -> PathBuf {
+        self.dir.join("read-state.json")
+    }
+
     /// The workspace subdirectory holding the seeded/edited file tree.
     pub fn workspace_dir(&self) -> PathBuf {
         self.dir.join("workspace")

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -24,6 +24,7 @@ use crate::ports::facts::FactStore;
 use crate::ports::inbox::InboxStore;
 use crate::ports::login_codes::LoginCodeStore;
 use crate::ports::memory::MemoryStore;
+use crate::ports::read_state::ReadStateStore;
 use crate::ports::run_output::WorkflowRunOutputStore;
 use crate::ports::runs::RunStore;
 use crate::ports::schedule_fires::ScheduleFireStore;
@@ -159,6 +160,8 @@ pub struct StorageHandles {
     pub run_outputs: Arc<dyn WorkflowRunOutputStore>,
     pub usage: Arc<dyn UsageMeter>,
     pub skills: Arc<dyn SkillStateStore>,
+    /// Per-person, per-channel read markers (#755).
+    pub read_state: Arc<dyn ReadStateStore>,
     pub users: Arc<dyn UserStore>,
     pub sessions: Arc<dyn SessionStore>,
     pub login_codes: Arc<dyn LoginCodeStore>,
@@ -416,6 +419,7 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         run_outputs: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
+        read_state: store.clone(),
         users: store.clone(),
         sessions: store.clone(),
         login_codes: store,
@@ -456,6 +460,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         run_outputs: store.clone(),
         usage: store.clone(),
         skills: store.clone(),
+        read_state: store.clone(),
         users: store.clone(),
         sessions: store.clone(),
         login_codes: store.clone(),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -192,6 +192,13 @@ CREATE TABLE IF NOT EXISTS skill_state (
     state_json TEXT NOT NULL,
     PRIMARY KEY (company_id, slug)
 );
+CREATE TABLE IF NOT EXISTS channel_read_state (
+    company_id   TEXT NOT NULL,
+    user_id      TEXT NOT NULL,
+    channel_id   TEXT NOT NULL,
+    last_read_ms INTEGER NOT NULL,
+    PRIMARY KEY (company_id, user_id, channel_id)
+);
 CREATE TABLE IF NOT EXISTS workspace_nodes (
     company_id TEXT NOT NULL,
     id         TEXT NOT NULL,
@@ -2230,6 +2237,73 @@ impl crate::ports::skills_state::SkillStateStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// ReadStateStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::read_state::ReadStateStore for SqliteStore {
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::read_state::ChannelRead>> {
+        let conn = self.conn();
+        let mut stmt = conn
+            .prepare(
+                "SELECT channel_id, last_read_ms FROM channel_read_state \
+                 WHERE company_id = ?1 AND user_id = ?2 ORDER BY channel_id",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref(), user], |r| {
+                Ok(crate::ports::read_state::ChannelRead {
+                    channel_id: r.get::<_, String>(0)?,
+                    last_read_at: r.get::<_, i64>(1)?,
+                })
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            out.push(row.map_err(sql_err)?);
+        }
+        Ok(out)
+    }
+
+    async fn mark(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        channel_id: &str,
+        at: i64,
+    ) -> Result<crate::ports::read_state::ChannelRead> {
+        let conn = self.conn();
+        // `max(excluded, existing)` in the conflict arm is the monotonicity the
+        // port promises: a late request carrying an earlier instant must not
+        // move the marker back and resurrect messages already read.
+        conn.execute(
+            "INSERT INTO channel_read_state (company_id, user_id, channel_id, last_read_ms) \
+             VALUES (?1, ?2, ?3, ?4) \
+             ON CONFLICT(company_id, user_id, channel_id) DO UPDATE SET \
+             last_read_ms = max(excluded.last_read_ms, channel_read_state.last_read_ms)",
+            params![company.as_ref(), user, channel_id, at],
+        )
+        .map_err(sql_err)?;
+        let settled: i64 = conn
+            .query_row(
+                "SELECT last_read_ms FROM channel_read_state \
+                 WHERE company_id = ?1 AND user_id = ?2 AND channel_id = ?3",
+                params![company.as_ref(), user, channel_id],
+                |r| r.get(0),
+            )
+            .map_err(sql_err)?;
+        Ok(crate::ports::read_state::ChannelRead {
+            channel_id: channel_id.to_string(),
+            last_read_at: settled,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -2966,6 +3040,11 @@ mod test {
     #[tokio::test]
     async fn conformance_skill_state_store() {
         conformance::assert_skill_state_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_read_state_store() {
+        conformance::assert_read_state_store(store()).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Unread was decided entirely in the browser, against a floor stamped when the tab mounted:

```ts
const [unreadSince, setUnreadSince] = useState(() => Date.now());
```

Everything older than that instant counted as read, and the rail said so in its own copy — *"Estimated in this browser — unread is not tracked on the company."* So the feature failed exactly the case it exists for: close the console overnight, reopen it, and everything that arrived reads as seen. It was also per-tab rather than per-person, so two devices disagreed, and it reset on every company switch.

The badge rendering was already there (#364). What was missing was a floor that outlives the tab. This adds a durable, per-person, per-channel read marker on the host.

**The count stays in the console.** Only the browser holds the transcript, so only the browser can say how many rows sit past a marker. What moves over the wire is the floor that count is measured from. Splitting it the other way would mean shipping every channel's message count to the host on every poll.

## API Or Behavior Changes

**New port** `ReadStateStore` (`src/ports/read_state.rs`), keyed by company **and** person. A marker keyed only by channel would let one operator's reading clear another's badges.

`mark` is specified **monotonic**: an `at` at or before the stored marker leaves it alone. Two tabs of one person race constantly — one viewing an old channel while another reads a live one — and a late request carrying the earlier instant would otherwise resurrect messages already read. Making the write a max rather than a set means the order requests land in cannot change the outcome.

**Implemented on all three backends:** fs (`read-state.json`), sqlite (`channel_read_state`, `max(excluded, existing)` in the conflict arm), mongodb (`$max`, which also seeds the field on upsert, so no conflicting `$setOnInsert` twin).

**New routes**, additive:

- `GET {scope}/chat/read-state` → `{ markers: [{ channelId, lastReadAt }] }`
- `PUT {scope}/chat/read-state` with `{ channelId, lastReadAt }` → the **stored** marker

The write answers with where the marker actually stands rather than echoing the request, because the write is monotonic and the console must not assume its own value took.

**A channel with no marker is absent from the response, not zero.** "Never opened" and "opened before anything was said" are different states, and only the console knows which floor a never-opened channel deserves.

**Signed-in humans only.** A machine credential reaches these routes with `ScopedCompany::actor` as `None`. Rather than invent a shared pseudo-user — which would let one tenant's automation clear a real operator's badges — both routes answer `401`. An empty `channelId` is `422`.

**Console:** the stored floor is *merged* with the local one by taking the later of each pair, never assigned. The request is in flight while the console is usable, and a channel opened in that window must not have its fresh floor overwritten by an older stored one. A `404` from an older host leaves the browser floor standing, so this degrades to the previous behaviour instead of throwing on load. Marking is fire-and-forget: the local floor has already cleared the badge, so a failed write costs a stale marker on the next load rather than a wrong badge now.

## Tests

**Shared conformance suite** (`assert_read_state_store`), run against every backend, pinning what a backend can plausibly get wrong: markers move forward, never backwards, an equal write is not an error, and one person's reading never disturbs another's — nor one company's.

- fs — passes
- sqlite — passes
- mongodb — needs a live server, so **not run locally**; CI's `Rust (mongodb)` lane runs it against a real MongoDB and passes. The server log shows `channel_read_state` created, used and dropped, so the assertion genuinely executed rather than being skipped.

  It first ran *inside* `conformance_skill_state_store` — real coverage under a test named for a different port, which is the kind of green CI reports for the wrong reason. Split into its own `conformance_read_state_store` so the name matches what it asserts.

**Negative control, run for real:** breaking the sqlite conflict arm to a plain `set` fails the backwards assertion — `left: 500, right: 2000`.

**Console** (`frontend/test/unit/chat-read-state.test.ts`, 7 tests): the merge adopts a stored floor for an unopened channel, keeps a fresher local floor for one opened mid-flight, leaves unmentioned channels alone, and treats an empty marker list as a no-op — plus what the merged floor means for a badge across a reload.

**Verified end-to-end against a running host** (`companies/e2e_harness`, authenticated through the e2e suite's own dev-code path), not only in unit tests:

| Step | Result |
|---|---|
| list before any marker | `{"markers":[]}` |
| mark `engineering` → 1000 | `1000` |
| forward → 2000 | `2000` |
| **backwards → 500** | **stays `2000`** |
| second channel | independent marker |
| empty `channelId` | `422` |
| unauthenticated | `401` |
| **kill the host, restart, list** | **both markers still there** |

That last row is the point of the issue, and it is the one I most wanted off a unit test.

Commands run locally, all green:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo check --all-features`
- [x] `cargo test --lib store::` — 110 passed
- [x] `cargo test --lib server::` — 725 passed
- [x] `npm run typecheck`, `typecheck:unit`, `npx vitest run` (536 passed), `npm run build`
- [x] `./scripts/ci/assert-design-tokens.sh`

A clippy `result_large_err` warning appeared on the first pass (an axum `Response` carried through a helper's `Err`) and is fixed by returning `Option` and building the `401` once. CI runs `-D warnings`, so it would have failed.

## Documentation

Port, route module and both DTOs carry doc comments covering the monotonicity rule, the absent-vs-zero distinction, and why markers are per person. The rail's "estimated in this browser" disclaimer is **left in place** — see below.

## Related

Closes #755

- #364 — the badge rendering this builds the floor for
- #577 / #749 — durable notifications with per-user read state. **Overlaps this deliberately.** #749 is a notification record and out-of-browser delivery; this is the channel list telling the truth after a reload. Worth deciding whether one read-state port serves both before #749 is built, rather than ending up with two.

**Deliberately not in scope:** the rail still renders its "estimated in this browser" note. It becomes false once markers are durable, but removing it is a copy change on a surface #749 may rework, and I would rather that land with whoever reconciles the two read-state models than have this PR quietly contradict a note it did not update everywhere.
