### PR TITLE
fix(desktop): give a fresh install a company it can sign into (#632)

### DIFF
--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -193,6 +193,48 @@ valid evidence about embedded mode too.
 data root. The console renders that as a row; the desktop still holds remote
 hosts, which is the point of holding several.
 
+### First run
+
+`embedded::start` calls `opencompany::desktop::bootstrap_companies` before it
+binds, because a host with an empty registry cannot be signed into
+([issue #632](https://github.com/tinyhumansai/opencompany/issues/632)). Sign-in
+is per-company — `/api/v1/companies/{id}/auth/…`, or the sole-company alias —
+so an empty registry leaves the console rendering a login form for a company
+that does not exist.
+
+The two ways a company normally reaches the registry are both closed to a
+packaged application. Nobody types `serve --company <dir>` at a double-clicked
+app, and `POST /api/v1/companies` demands the `platform` scope, which
+`PlatformScope` grants only against a configured `platform_auth` — a prosumer
+host has no machine credential to hand out, deliberately. So the desktop
+bootstraps its own:
+
+1. **Adopt** every company bundle the data root already holds, skipping
+   `archived` ones (archiving removes a company from the registry on purpose,
+   and re-registering it at the next launch would undo that quietly). The
+   bundle is the only authority — a desktop company has no source directory to
+   re-read — and `RuntimeBuilder::build` carries the persisted record's console
+   -created desks, agents and workflows forward.
+2. **Seed** the `DEFAULT_PRESET_ID` preset when there were none, stamping the
+   preset slug as the record's template provenance. Fallback rather than
+   unconditional: seeding on every launch would hand the operator a second
+   starter company per run.
+
+`AppConfig.admin_email` is set to `DESKTOP_OPERATOR_EMAIL` — the same seam the
+hosted control plane fills with `OPENCOMPANY_ADMIN_EMAIL`, and the reason a
+person is eligible to sign in at all (`eligibility` in `src/server/users/`
+admits an existing user, a bootstrap admin, or an invite, and a fresh install
+has none of the three). The seeded manifest names the same address in its own
+`[users].admins`, so the company is self-describing if it is ever served
+elsewhere.
+
+Nothing is mailed: the host binds loopback, so `is_local_only` holds and
+`auth/request` returns the login code in its own response (`dev_code`), which
+the console redeems in place. `oc_embedded` carries `operatorEmail` so the
+sign-in form can offer the address — a person cannot guess it, and every other
+address gets the same silent `202`. It is a suggestion, not a lock: the field
+stays editable, which is what an operator who invites someone else needs.
+
 ### One row, however many launches
 
 The ephemeral port is not free: it means the embedded host's *address* is

--- a/docs/spec/runtime/desktop.md
+++ b/docs/spec/runtime/desktop.md
@@ -213,8 +213,8 @@ bootstraps its own:
    `archived` ones (archiving removes a company from the registry on purpose,
    and re-registering it at the next launch would undo that quietly). The
    bundle is the only authority — a desktop company has no source directory to
-   re-read — and `RuntimeBuilder::build` carries the persisted record's console
-   -created desks, agents and workflows forward.
+   re-read — and `RuntimeBuilder::build` carries the persisted record's
+   console-created desks, agents and workflows forward.
 2. **Seed** the `DEFAULT_PRESET_ID` preset when there were none, stamping the
    preset slug as the record's template provenance. Fallback rather than
    unconditional: seeding on every launch would hand the operator a second

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -221,6 +221,7 @@ function Console() {
         id: host
           ? adoptEmbeddedHost({ baseUrl: host.baseUrl, instanceId: host.instanceId })
           : null,
+        operatorEmail: host?.operatorEmail,
       });
     });
     return () => {
@@ -415,6 +416,12 @@ function Console() {
             defaultCompany={active.defaultCompany}
             notice={active.id === bootstrapId ? auth.notice : undefined}
             forceLogin={active.id === bootstrapId && auth.failed === true}
+            // Only ever the embedded host's own operator. Offering it on a
+            // remote connection would put a local address in front of someone
+            // signing in to a server that has never heard of it.
+            suggestedEmail={
+              active.id === embedded.id ? embedded.operatorEmail : undefined
+            }
           />
         ) : (
           <NoConnection starting={!embedded.resolved} />
@@ -430,6 +437,17 @@ interface EmbeddedState {
   resolved: boolean;
   /** The connection it became, or `null` when there is no embedded host. */
   id: ConnectionId | null;
+  /**
+   * The address that host signs a person in as (#632).
+   *
+   * Held here rather than on the connection because it is a fact about the host
+   * running *inside this application* — the one host this client starts itself
+   * and can therefore be told about without asking. A remote host has no such
+   * answer, and offering it one would be inventing an address.
+   *
+   * Absent on a shell predating the field, exactly as `instanceId` is.
+   */
+  operatorEmail?: string;
 }
 
 function FullScreen({ children }: { children: React.ReactNode }) {

--- a/frontend/src/api/transport/desktop.ts
+++ b/frontend/src/api/transport/desktop.ts
@@ -42,6 +42,15 @@ export interface EmbeddedInfo {
    * behaviour rather than to a connection keyed on `undefined`.
    */
   instanceId?: string;
+  /**
+   * The address this host will sign a person in as (#632).
+   *
+   * A desktop install has one standing admin and no mail transport, so nobody
+   * could guess what to type and every other address gets the same silent
+   * acknowledgement. Optional for the same reason as `instanceId`: an older
+   * shell does not send it, and a blank sign-in form is the honest degrade.
+   */
+  operatorEmail?: string;
 }
 
 /**

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -43,6 +43,14 @@ interface Props {
   notice?: string;
   /** Forces the sign-in view — a magic link that failed to redeem, say. */
   forceLogin?: boolean;
+  /**
+   * An address to offer the sign-in form, when the caller knows one.
+   *
+   * Only the embedded host has one: this client starts it, so it can be told
+   * who that host admits (#632). Undefined everywhere else, and the form is
+   * blank as before.
+   */
+  suggestedEmail?: string;
 }
 
 export function ConnectionConsole({
@@ -51,6 +59,7 @@ export function ConnectionConsole({
   defaultCompany,
   notice,
   forceLogin,
+  suggestedEmail,
 }: Props) {
   const [phase, setPhase] = useState<Phase>(
     forceLogin ? { kind: "login", company: defaultCompany, notice } : { kind: "loading" },
@@ -166,6 +175,7 @@ export function ConnectionConsole({
         client={client}
         company={defaultCompany}
         notice={notice}
+        suggestedEmail={suggestedEmail}
         onSignedIn={reBoot}
       />
     );
@@ -187,6 +197,7 @@ export function ConnectionConsole({
           client={client}
           company={phase.company}
           notice={phase.notice}
+          suggestedEmail={suggestedEmail}
           onSignedIn={reBoot}
         />
       );

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -303,12 +303,19 @@ export function Login({
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@company.com"
+                  aria-describedby={
+                    suggestedEmail && email === suggestedEmail ? "email-hint" : undefined
+                  }
                 />
                 {suggestedEmail && email === suggestedEmail ? (
                   // Otherwise the prefilled address reads as somebody else's,
                   // and the natural move is to clear it — which is the one
                   // address this host will not answer for.
-                  <p className="text-xs text-muted-foreground" data-testid="suggested-email-hint">
+                  <p
+                    id="email-hint"
+                    className="text-xs text-muted-foreground"
+                    data-testid="suggested-email-hint"
+                  >
                     The operator account on this computer. Nothing is mailed —
                     the link comes back here.
                   </p>

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -38,6 +38,18 @@ interface Props {
    * of this view refuses to be.
    */
   notice?: string;
+  /**
+   * An address to start the form with, when the caller knows one.
+   *
+   * Only the desktop's embedded host does: a packaged install admits one
+   * standing local operator and mails nothing, so a blank field asked a person
+   * to guess an address they have never seen, and every guess came back as the
+   * same silent acknowledgement (#632).
+   *
+   * A suggestion, not a lock — it seeds the field and the person can replace
+   * it, which matters as soon as they invite anyone else to their own host.
+   */
+  suggestedEmail?: string;
   /** A code lifted out of a magic-link URL, redeemed on mount by the caller. */
   onSignedIn: (me: Me) => void;
 }
@@ -57,7 +69,14 @@ type Mode = "link" | "password";
  *    keeps; there is nothing to put in localStorage and nothing for an XSS to
  *    steal.
  */
-export function Login({ client, company, companyName, notice, onSignedIn }: Props) {
+export function Login({
+  client,
+  company,
+  companyName,
+  notice,
+  suggestedEmail,
+  onSignedIn,
+}: Props) {
   const [mode, setMode] = useState<Mode>("link");
   /**
    * The ecosystem sign-in buttons this host offers, or `[]` if it offers none.
@@ -69,7 +88,19 @@ export function Login({ client, company, companyName, notice, onSignedIn }: Prop
    * not an error worth showing anyone.
    */
   const [hubProviders, setHubProviders] = useState<HubProvider[]>([]);
-  const [email, setEmail] = useState("");
+  const [email, setEmail] = useState(suggestedEmail ?? "");
+  // The suggestion usually arrives *after* this mounts. A relaunch restores the
+  // embedded connection from its remembered profile immediately, while the
+  // address and the operator come over IPC a moment later — so on every launch
+  // but the first, seeding the initial state alone would leave the field blank.
+  //
+  // Only into an empty field: a suggestion must never overwrite what somebody
+  // has typed, and clearing the prefilled address on purpose (to sign in as
+  // someone else) must not be undone — this runs when the *suggestion* changes,
+  // which it does once.
+  useEffect(() => {
+    if (suggestedEmail) setEmail((current) => (current === "" ? suggestedEmail : current));
+  }, [suggestedEmail]);
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -273,6 +304,15 @@ export function Login({ client, company, companyName, notice, onSignedIn }: Prop
                   onChange={(e) => setEmail(e.target.value)}
                   placeholder="you@company.com"
                 />
+                {suggestedEmail && email === suggestedEmail ? (
+                  // Otherwise the prefilled address reads as somebody else's,
+                  // and the natural move is to clear it — which is the one
+                  // address this host will not answer for.
+                  <p className="text-xs text-muted-foreground" data-testid="suggested-email-hint">
+                    The operator account on this computer. Nothing is mailed —
+                    the link comes back here.
+                  </p>
+                ) : null}
               </div>
 
               {mode === "password" ? (

--- a/frontend/test/e2e/desktop-first-run-signin.spec.ts
+++ b/frontend/test/e2e/desktop-first-run-signin.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Issue #632 — the sign-in form a desktop operator can actually complete.
+ *
+ * The host half of that bug (an embedded host with no company, and no way to
+ * create one) is fixed and proven in Rust, where a fresh data root is seeded and
+ * signed into over HTTP. This is the console half: a packaged install admits one
+ * standing local address, mails nothing, and answers every other address with
+ * the same silent `202` — so a blank field asked a person to guess a credential
+ * they have never seen, and guessing wrong looked exactly like guessing right.
+ *
+ * ## The launch this reproduces is the second one
+ *
+ * On a first launch the console has nothing remembered, so it waits for
+ * `oc_embedded` before it renders a console at all and the suggestion is there
+ * from the first paint. Every launch after that restores the embedded
+ * connection from its profile *immediately* — the address and the operator
+ * arrive over IPC a moment later — so the sign-in view mounts before either.
+ * Seeding a profile and delaying the bridge is what puts this spec on the
+ * ordinary path rather than the lucky one.
+ *
+ * The stub stands in for the packaged shell exactly as the sibling desktop
+ * specs' does: `isDesktopRuntime()` is `"__TAURI__" in window` and nothing else,
+ * and `oc_request` forwards to `fetch`, which is what the Rust proxy does. The
+ * host, the console bundle and the boot sequence are all real.
+ */
+
+/** Signed out on purpose: the suite's shared session would skip the view. */
+test.use({ storageState: { cookies: [], origins: [] } });
+
+async function asDesktop(
+  page: Page,
+  config: { embedded: string; operatorEmail: string; discoveryDelayMs: number },
+) {
+  await page.addInitScript(
+    (cfg: { embedded: string; operatorEmail: string; discoveryDelayMs: number }) => {
+      // The row a previous launch left behind, at the address this launch will
+      // also serve. Restored synchronously, which is the point.
+      window.localStorage.setItem(
+        "oc.connections.v1",
+        JSON.stringify([
+          {
+            id: "conn-embedded-remembered",
+            baseUrl: cfg.embedded,
+            label: "This computer",
+            defaultCompany: null,
+            credential: { kind: "cookie" },
+            origin: "embedded",
+          },
+        ]),
+      );
+
+      const hosts = new Map<string, string>();
+      (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
+        Channel: class {
+          onmessage: ((message: string) => void) | null = null;
+        },
+        async invoke(command: string, args: Record<string, unknown>): Promise<unknown> {
+          switch (command) {
+            case "oc_connect":
+              hosts.set(args.connectionId as string, args.baseUrl as string);
+              return undefined;
+            case "oc_disconnect":
+              hosts.delete(args.connectionId as string);
+              return undefined;
+            case "oc_embedded":
+              await new Promise((resolve) => setTimeout(resolve, cfg.discoveryDelayMs));
+              return {
+                baseUrl: cfg.embedded,
+                dataDir: "/tmp/e2e-desktop",
+                instanceId: "e2e-embedded-instance",
+                operatorEmail: cfg.operatorEmail,
+              };
+            case "oc_request": {
+              const base = hosts.get(args.connectionId as string);
+              if (base === undefined) {
+                throw new Error(`no such connection: ${args.connectionId as string}`);
+              }
+              const req = args.request as {
+                method: string;
+                path: string;
+                headers: Record<string, string>;
+                body?: string;
+              };
+              const response = await fetch(base + req.path, {
+                method: req.method,
+                headers: req.headers,
+                body: req.body ?? undefined,
+                credentials: "include",
+              });
+              const text = await response.text();
+              const headers: Record<string, string> = {};
+              response.headers.forEach((value, name) => {
+                headers[name.toLowerCase()] = value;
+              });
+              return {
+                status: response.status,
+                statusText: response.statusText,
+                url: response.url,
+                text,
+                headers,
+              };
+            }
+            default:
+              return null;
+          }
+        },
+      };
+    },
+    config,
+  );
+}
+
+test("a signed-out desktop offers the operator its own host admits", async ({
+  page,
+  baseURL,
+}) => {
+  const embedded = new URL(baseURL ?? "http://127.0.0.1:8080").origin;
+  await asDesktop(page, {
+    embedded,
+    operatorEmail: "operator@opencompany.local",
+    // Long enough that the remembered row is on screen first, which is what a
+    // relaunch does anyway — see the note above.
+    discoveryDelayMs: 750,
+  });
+  await page.goto("/#/tasks");
+
+  const email = page.getByLabel("Email");
+  await expect(email).toBeVisible({ timeout: 30_000 });
+  // THE assertion: the address arrives after the form did, and lands in it.
+  await expect(email).toHaveValue("operator@opencompany.local", { timeout: 30_000 });
+  await expect(page.getByTestId("suggested-email-hint")).toBeVisible();
+
+  // A suggestion, not a lock. Somebody signing in as a teammate they invited to
+  // their own host must be able to type over it, and the hint must go with it.
+  await email.fill("someone@else.test");
+  await expect(email).toHaveValue("someone@else.test");
+  await expect(page.getByTestId("suggested-email-hint")).toHaveCount(0);
+});

--- a/frontend/test/unit/desktop-bridge.test.ts
+++ b/frontend/test/unit/desktop-bridge.test.ts
@@ -269,6 +269,24 @@ describe("the embedded host", () => {
     });
   });
 
+  it("carries the operator the console should offer at sign-in", async () => {
+    // A packaged install admits one standing local address and mails nothing,
+    // so a console that did not carry this showed a blank form on a host where
+    // every other address is answered with the same silent acknowledgement
+    // (#632). Optional on the wire — an older shell omits it and the form is
+    // blank as before — which is exactly why nothing else would catch a rename.
+    installBridge({
+      embedded: {
+        baseUrl: "http://127.0.0.1:52341",
+        dataDir: "/tmp/oc",
+        instanceId: "0f9d8c7b6a5e4f3d2c1b0a9988776655",
+        operatorEmail: "operator@opencompany.local",
+      },
+    });
+    const host = await embeddedHost();
+    expect(host?.operatorEmail).toBe("operator@opencompany.local");
+  });
+
   it("is null when the core could not start one", async () => {
     // Most often the data root is already held — by another window, or by an
     // `opencompany serve` in a terminal. The desktop still holds remote hosts,

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -29,6 +29,16 @@ pub struct EmbeddedInfo {
     /// identity: keyed on the address, the console reads every launch as a
     /// first meeting and leaves the previous launch's row behind, dead (#615).
     pub instance_id: String,
+    /// The address this host admits, for the sign-in form to offer (#632).
+    ///
+    /// A desktop install has no mail transport and one standing admin, so the
+    /// person in front of it cannot discover what to type and the host will
+    /// answer every other address with the same silent 202. Carrying it is what
+    /// turns the login form from a guessing game into a click.
+    ///
+    /// Not a credential: it names who may sign in, and the code that actually
+    /// does it is minted per attempt and returned only on a loopback host.
+    pub operator_email: String,
 }
 
 /// Registers (or re-registers) a host this client talks to.
@@ -304,6 +314,7 @@ pub fn oc_embedded(state: State<'_, crate::AppHandleState>) -> Option<EmbeddedIn
         base_url: host.base_url(),
         data_dir: state.data_dir.display().to_string(),
         instance_id: host.instance_id().to_string(),
+        operator_email: host.operator_email().to_string(),
     })
 }
 
@@ -434,5 +445,27 @@ mod test {
         // The host's status, passed through — which is what "not followed"
         // looks like from here.
         assert!(error.contains("307"), "{error}");
+    }
+
+    /// The console reads these keys by name, and a rename here is silent on
+    /// both sides: TypeScript has nothing to check a Rust struct against, and
+    /// every field is optional in the console precisely so an older shell
+    /// degrades instead of failing. A wrong key would therefore land as "the
+    /// sign-in form is blank again" (#632) rather than as an error.
+    #[test]
+    fn the_embedded_record_answers_in_the_keys_the_console_reads() {
+        let wire = serde_json::to_value(EmbeddedInfo {
+            base_url: "http://127.0.0.1:1234".into(),
+            data_dir: "/data".into(),
+            instance_id: "inst-1".into(),
+            operator_email: "operator@opencompany.local".into(),
+        })
+        .expect("serialise");
+
+        let object = wire.as_object().expect("an object");
+        assert_eq!(
+            object.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec!["baseUrl", "dataDir", "instanceId", "operatorEmail"],
+        );
     }
 }

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -31,6 +31,7 @@ use opencompany::{AppConfig, AppState};
 pub struct EmbeddedHost {
     address: std::net::SocketAddr,
     instance_id: String,
+    companies: Vec<String>,
     /// Holds the data root's exclusive lock for as long as the host runs.
     /// Dropping it would release the root while this process kept writing.
     _instance: EmbeddedInstance,
@@ -57,6 +58,21 @@ impl EmbeddedHost {
     /// to knock; this says who answers.
     pub fn instance_id(&self) -> &str {
         &self.instance_id
+    }
+
+    /// The address this host will sign a person in as.
+    ///
+    /// The console has to be told, because nobody could guess it and the login
+    /// form is otherwise a blank field on a host that admits exactly one
+    /// address. Not a secret: it grants nothing without a code minted by this
+    /// host and returned over loopback.
+    pub fn operator_email(&self) -> &'static str {
+        opencompany::desktop::DESKTOP_OPERATOR_EMAIL
+    }
+
+    /// The companies registered at boot, in listing order.
+    pub fn companies(&self) -> &[String] {
+        &self.companies
     }
 }
 
@@ -85,6 +101,12 @@ pub async fn start(data_dir: PathBuf) -> opencompany::Result<EmbeddedHost> {
 
     let config = AppConfig {
         bind: "127.0.0.1:0".to_string(),
+        // The standing local admin, and the same seam the hosted control plane
+        // fills with `OPENCOMPANY_ADMIN_EMAIL`. Without an eligible address no
+        // company on this host can be signed into, whoever created it — the
+        // seeded one names the operator in its own manifest, but a company
+        // added later by any other means would name nobody (issue #632).
+        admin_email: Some(opencompany::desktop::DESKTOP_OPERATOR_EMAIL.to_string()),
         ..AppConfig::default()
     };
     let state = AppState::new(config).with_home(instance.home().to_path_buf());
@@ -93,6 +115,16 @@ pub async fn start(data_dir: PathBuf) -> opencompany::Result<EmbeddedHost> {
     // waiting to contact it — which is the whole point, since the address it
     // would contact is what changed.
     let instance_id = state.instance_id().to_string();
+    // Before the listener, not after: a console that reached a host with an
+    // empty registry would render the "no companies" dead end this exists to
+    // remove, and the race is winnable — the address is handed to the webview
+    // the moment `start` returns.
+    let companies =
+        opencompany::desktop::bootstrap_companies(&state, opencompany::desktop::DEFAULT_PRESET_ID)
+            .await?
+            .into_iter()
+            .map(|id| id.as_ref().to_string())
+            .collect::<Vec<_>>();
 
     let (address, serving) = opencompany::server::bind("127.0.0.1:0", state).await?;
     let server = tokio::spawn(async move {
@@ -104,12 +136,14 @@ pub async fn start(data_dir: PathBuf) -> opencompany::Result<EmbeddedHost> {
     tracing::info!(
         %address,
         %instance_id,
+        companies = companies.len(),
         home = %instance.home().display(),
         "embedded host listening"
     );
     Ok(EmbeddedHost {
         address,
         instance_id,
+        companies,
         _instance: instance,
         server,
     })
@@ -118,6 +152,110 @@ pub async fn start(data_dir: PathBuf) -> opencompany::Result<EmbeddedHost> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Issue #632, end to end: a packaged install must be enterable with no
+    /// terminal, no mail server and no platform credential.
+    ///
+    /// Over HTTP rather than against the registry, because every step here is
+    /// one the console actually takes and each has its own way to fail: the
+    /// company has to exist *and* be reachable through the sole-company alias
+    /// the console addresses before it knows any id, the operator has to be
+    /// eligible or no code is minted, and the host has to be local-only or the
+    /// code is withheld from the response. Asserting a company was registered
+    /// would prove none of it.
+    #[tokio::test]
+    async fn a_fresh_install_can_be_signed_into() {
+        let dir = tempfile::tempdir().unwrap();
+        let host = start(dir.path().to_path_buf()).await.expect("host starts");
+        let base = host.base_url();
+        let http = reqwest::Client::new();
+
+        assert_eq!(
+            host.companies().len(),
+            1,
+            "a fresh root gets exactly one starter company"
+        );
+
+        // Where the console starts, and where it used to stop: no session yet.
+        let listed = http
+            .get(format!("{base}/api/v1/companies"))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(listed.status(), 401);
+
+        // The sole-company alias — what the console addresses before it has
+        // discovered any company id.
+        let requested: serde_json::Value = http
+            .post(format!("{base}/api/v1/company/auth/request"))
+            .json(&serde_json::json!({ "email": host.operator_email() }))
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .unwrap();
+        let code = requested["dev_code"]
+            .as_str()
+            .unwrap_or_else(|| {
+                panic!("a loopback host with no mail transport echoes the code: {requested}")
+            })
+            .to_string();
+
+        let verified = http
+            .post(format!("{base}/api/v1/company/auth/verify"))
+            .json(&serde_json::json!({ "code": code }))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(verified.status(), 200, "the code redeems into a session");
+        let session = verified
+            .headers()
+            .get(reqwest::header::SET_COOKIE)
+            .and_then(|value| value.to_str().ok())
+            .and_then(|value| value.split(';').next())
+            .expect("a session cookie comes back")
+            .to_string();
+
+        // And the call that was refused above now answers.
+        let listed = http
+            .get(format!("{base}/api/v1/companies"))
+            .header(reqwest::header::COOKIE, session)
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(listed.status(), 200);
+        let companies: serde_json::Value = listed.json().await.unwrap();
+        assert_eq!(
+            companies.as_array().map(Vec::len),
+            Some(1),
+            "the signed-in operator sees their company: {companies}"
+        );
+    }
+
+    /// The starter company is seeded once, not per launch.
+    #[tokio::test]
+    async fn a_relaunch_reuses_the_company_the_root_already_holds() {
+        let dir = tempfile::tempdir().unwrap();
+        let first = start(dir.path().to_path_buf()).await.unwrap();
+        let seeded = first.companies().to_vec();
+        drop(first);
+
+        // Retried because the data root is released asynchronously; see the
+        // note in `stopping_a_host_frees_its_root_and_its_port`.
+        let mut last = None;
+        for _ in 0..50 {
+            match start(dir.path().to_path_buf()).await {
+                Ok(relaunched) => {
+                    assert_eq!(relaunched.companies(), seeded.as_slice());
+                    return;
+                }
+                Err(error) => last = Some(error),
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        panic!("a released root must become takeable: {last:?}");
+    }
 
     #[tokio::test]
     async fn an_embedded_host_answers_on_loopback() {

--- a/src-tauri/src/embedded.rs
+++ b/src-tauri/src/embedded.rs
@@ -241,20 +241,10 @@ mod test {
         let seeded = first.companies().to_vec();
         drop(first);
 
-        // Retried because the data root is released asynchronously; see the
-        // note in `stopping_a_host_frees_its_root_and_its_port`.
-        let mut last = None;
-        for _ in 0..50 {
-            match start(dir.path().to_path_buf()).await {
-                Ok(relaunched) => {
-                    assert_eq!(relaunched.companies(), seeded.as_slice());
-                    return;
-                }
-                Err(error) => last = Some(error),
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
-        }
-        panic!("a released root must become takeable: {last:?}");
+        // `take_root` retries because the data root is released asynchronously;
+        // see the note in `stopping_a_host_frees_its_root_and_its_port`.
+        let relaunched = take_root(dir.path().to_path_buf()).await;
+        assert_eq!(relaunched.companies(), seeded.as_slice());
     }
 
     #[tokio::test]

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -99,8 +99,19 @@ impl Drop for DesktopRuntime {
     }
 }
 
-/// Starts an offline, loopback-only runtime from a bundled preset.
-pub async fn start_local(home: impl Into<PathBuf>, preset_id: &str) -> Result<DesktopRuntime> {
+/// The manifest a first-run install starts from: a bundled preset, with the
+/// local operator added as a standing admin.
+///
+/// The admin entry is what makes the company signable-into. `eligibility` in
+/// `src/server/users/routes.rs` admits an address only if it is already a user,
+/// is named as a bootstrap admin, or holds a redeemable invite — and a manifest
+/// that names nobody satisfies none of the three, so a company created without
+/// this is a company nobody on this machine can enter (issue #632).
+///
+/// The address is local-only by construction: a desktop install has no mail
+/// transport, so it exists purely for the loopback magic link the shell
+/// redeems. It never leaves the device and grants a network caller nothing.
+fn first_run_manifest(preset_id: &str) -> Result<CompanyManifest> {
     let preset = preset(preset_id).ok_or_else(|| {
         crate::OpenCompanyError::Config(format!("unknown desktop preset `{preset_id}`"))
     })?;
@@ -109,9 +120,6 @@ pub async fn start_local(home: impl Into<PathBuf>, preset_id: &str) -> Result<De
             "bundled desktop preset `{preset_id}` is invalid: {error}"
         ))
     })?;
-    // A desktop install has no mail transport. This local-only address is a
-    // standing invite solely so the shell can redeem a loopback magic link; it
-    // never leaves the device or grant access to a network caller.
     if !manifest
         .users
         .admins
@@ -123,6 +131,111 @@ pub async fn start_local(home: impl Into<PathBuf>, preset_id: &str) -> Result<De
             .admins
             .push(DESKTOP_OPERATOR_EMAIL.to_string());
     }
+    Ok(manifest)
+}
+
+/// Registers every company this data root already holds, seeding the first-run
+/// company when it holds none. Returns the registered ids, in listing order.
+///
+/// ## Why an embedded host has to do this itself
+///
+/// A company reaches the registry one of two ways: `serve --company <dir>`
+/// names one on the command line, or the hosting control plane provisions one
+/// over `POST /api/v1/companies`. A packaged desktop has neither — nobody types
+/// a flag at a double-clicked application, and provisioning demands the
+/// `platform` scope, which `PlatformScope` grants only against a configured
+/// `platform_auth` that a prosumer host deliberately does not have.
+///
+/// So the desktop booted an empty registry, and an empty registry cannot be
+/// signed into: sign-in is per-company (`/api/v1/companies/{id}/auth/login`,
+/// or the sole-company alias), which leaves a fresh install with a login form
+/// addressing a company that does not exist and no way to create one. That is
+/// issue #632, and this function is the missing step.
+///
+/// ## Adoption before seeding
+///
+/// The persisted bundles are read first and the preset is a *fallback*, because
+/// seeding unconditionally would hand the operator a second copy of the starter
+/// company on every launch, and skipping adoption would make the one they
+/// already have unreachable. The bundle is the only authority here: a desktop
+/// company has no source directory to re-read, so what the store wrote at the
+/// last shutdown — including console-created desks, agents and workflows, which
+/// `RuntimeBuilder::build` carries forward from the persisted record — is what
+/// comes back.
+///
+/// An `archived` company is skipped. Archiving removes a company from the
+/// registry on purpose (`src/server/provision.rs`), and re-registering it at
+/// the next launch would undo that quietly.
+pub async fn bootstrap_companies(
+    state: &AppState,
+    preset_id: &str,
+) -> Result<Vec<crate::ports::types::CompanyId>> {
+    let store: std::sync::Arc<dyn crate::ports::CompanyStore> = match state.stores() {
+        Some(handles) => handles.company.clone(),
+        None => std::sync::Arc::new(crate::store::FsCompanyStore::new(
+            state.home().to_path_buf(),
+        )),
+    };
+
+    let mut registered = Vec::new();
+    for summary in store.list().await? {
+        if summary.lifecycle == "archived" {
+            continue;
+        }
+        let Some(record) = store.load(&summary.id).await? else {
+            continue;
+        };
+        // One unreadable bundle must not cost the operator every other company
+        // on the machine, so this warns and moves on rather than failing the
+        // boot. The seed below is what still runs if *nothing* could be adopted.
+        match register(state, summary.id.clone(), record.manifest, None).await {
+            Ok(()) => registered.push(summary.id),
+            Err(error) => {
+                tracing::warn!(company = %summary.id, %error, "could not adopt a stored company");
+            }
+        }
+    }
+    if !registered.is_empty() {
+        return Ok(registered);
+    }
+
+    let manifest = first_run_manifest(preset_id)?;
+    let id = company_id_from_name(&manifest.company.name);
+    // Issue #85: record which template this install started from. Only the
+    // slug, never a host path — there is no source directory on a packaged
+    // install, and provenance is exposed verbatim on the API surfaces.
+    let provenance = crate::ports::types::TemplateProvenance {
+        source_id: preset_id.to_string(),
+        version: None,
+        path: None,
+    };
+    register(state, id.clone(), manifest, Some(provenance)).await?;
+    tracing::info!(company = %id, preset = preset_id, "seeded the first-run company");
+    Ok(vec![id])
+}
+
+/// Builds one company over the instance home and puts it in the registry.
+async fn register(
+    state: &AppState,
+    id: crate::ports::types::CompanyId,
+    manifest: CompanyManifest,
+    provenance: Option<crate::ports::types::TemplateProvenance>,
+) -> Result<()> {
+    let mut builder = RuntimeBuilder::new(state.home().to_path_buf(), manifest).with_id(id.clone());
+    if let Some(stores) = state.stores() {
+        builder = builder.with_stores(stores);
+    }
+    if let Some(provenance) = provenance {
+        builder = builder.with_template_provenance(provenance);
+    }
+    let runtime = builder.build().await?;
+    state.registry().insert(id, std::sync::Arc::new(runtime));
+    Ok(())
+}
+
+/// Starts an offline, loopback-only runtime from a bundled preset.
+pub async fn start_local(home: impl Into<PathBuf>, preset_id: &str) -> Result<DesktopRuntime> {
+    let manifest = first_run_manifest(preset_id)?;
 
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let address: SocketAddr = listener.local_addr()?;
@@ -158,6 +271,8 @@ pub async fn start_local(home: impl Into<PathBuf>, preset_id: &str) -> Result<De
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use crate::ports::CompanyStore;
 
     #[test]
     fn ships_the_full_company_template_catalog() {
@@ -211,5 +326,118 @@ mod tests {
             .unwrap();
         assert!(runtime.config().api_url.starts_with("http://127.0.0.1:"));
         assert_eq!(runtime.config().operator_email, DESKTOP_OPERATOR_EMAIL);
+    }
+
+    /// A state over `home`, as an embedded host builds one.
+    fn state_over(home: &std::path::Path) -> AppState {
+        AppState::new(AppConfig::default()).with_home(home.to_path_buf())
+    }
+
+    fn store_over(home: &std::path::Path) -> crate::store::FsCompanyStore {
+        crate::store::FsCompanyStore::new(home.to_path_buf())
+    }
+
+    /// Issue #632: a fresh install must end up somewhere a person can sign in.
+    ///
+    /// Both halves matter. A company nobody is eligible for is the same dead end
+    /// as no company at all — the login form renders, the 202 comes back, and no
+    /// code is ever minted.
+    #[tokio::test]
+    async fn a_first_run_seeds_a_company_the_local_operator_can_enter() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_over(directory.path());
+
+        let ids = bootstrap_companies(&state, DEFAULT_PRESET_ID)
+            .await
+            .expect("a fresh root bootstraps");
+
+        assert_eq!(ids.len(), 1, "one starter company, not a fleet");
+        let runtime = state
+            .registry()
+            .sole()
+            .expect("the seeded company is registered, not merely written");
+        let record = runtime
+            .store()
+            .load(runtime.id())
+            .await
+            .unwrap()
+            .expect("the seeded company persists");
+        assert!(
+            record
+                .manifest
+                .users
+                .admins
+                .iter()
+                .any(|email| email == DESKTOP_OPERATOR_EMAIL),
+            "the seeded company must name somebody eligible: {:?}",
+            record.manifest.users.admins
+        );
+        assert_eq!(
+            record.template_provenance.map(|p| p.source_id),
+            Some(DEFAULT_PRESET_ID.to_string()),
+            "the install records which template it started from"
+        );
+    }
+
+    /// The second launch is the one that would go wrong quietly: seeding again
+    /// hands the operator a duplicate starter company, and every launch after
+    /// that another.
+    #[tokio::test]
+    async fn a_later_launch_adopts_what_the_root_already_holds() {
+        let directory = tempfile::tempdir().unwrap();
+        let first = bootstrap_companies(&state_over(directory.path()), DEFAULT_PRESET_ID)
+            .await
+            .unwrap();
+
+        // A wholly fresh state, as a relaunched application has.
+        let relaunched = state_over(directory.path());
+        let second = bootstrap_companies(&relaunched, DEFAULT_PRESET_ID)
+            .await
+            .unwrap();
+
+        assert_eq!(first, second, "the same company comes back");
+        assert_eq!(
+            std::fs::read_dir(directory.path().join("companies"))
+                .unwrap()
+                .count(),
+            1,
+            "and no second bundle was written"
+        );
+        assert!(relaunched.registry().sole().is_some());
+    }
+
+    /// Archiving removes a company from the registry deliberately. A boot that
+    /// re-registered every bundle on disk would undo that at the next launch,
+    /// silently, and the operator would find it back in the picker.
+    #[tokio::test]
+    async fn an_archived_company_is_not_brought_back() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_over(directory.path());
+        bootstrap_companies(&state, DEFAULT_PRESET_ID)
+            .await
+            .unwrap();
+        // A second company, so the archived one is skipped rather than merely
+        // replaced by the first-run seed.
+        let kept = first_run_manifest("agentic_law_firm").unwrap();
+        let kept_id = company_id_from_name(&kept.company.name);
+        register(&state, kept_id.clone(), kept, None).await.unwrap();
+
+        let store = store_over(directory.path());
+        let archived_id =
+            company_id_from_name(&first_run_manifest(DEFAULT_PRESET_ID).unwrap().company.name);
+        let mut record = store.load(&archived_id).await.unwrap().unwrap();
+        record.lifecycle = "archived".to_string();
+        store.save(&record).await.unwrap();
+
+        let relaunched = state_over(directory.path());
+        let ids = bootstrap_companies(&relaunched, DEFAULT_PRESET_ID)
+            .await
+            .unwrap();
+
+        assert_eq!(ids, vec![kept_id]);
+        assert!(
+            relaunched.registry().get(&archived_id).is_none(),
+            "an archived company must stay unaddressable"
+        );
     }
 }

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -182,12 +182,19 @@ pub async fn bootstrap_companies(
         if summary.lifecycle == "archived" {
             continue;
         }
-        let Some(record) = store.load(&summary.id).await? else {
-            continue;
-        };
         // One unreadable bundle must not cost the operator every other company
         // on the machine, so this warns and moves on rather than failing the
-        // boot. The seed below is what still runs if *nothing* could be adopted.
+        // boot — the load as much as the build below. The seed further down is
+        // what still runs if *nothing* could be adopted.
+        let record = match store.load(&summary.id).await {
+            Ok(Some(record)) => record,
+            // Listed a moment ago and gone now: a bundle removed under us.
+            Ok(None) => continue,
+            Err(error) => {
+                tracing::warn!(company = %summary.id, %error, "could not read a stored company");
+                continue;
+            }
+        };
         match register(state, summary.id.clone(), record.manifest, None).await {
             Ok(()) => registered.push(summary.id),
             Err(error) => {
@@ -404,6 +411,43 @@ mod tests {
             "and no second bundle was written"
         );
         assert!(relaunched.registry().sole().is_some());
+    }
+
+    /// A damaged bundle costs its own company and nothing else.
+    ///
+    /// The failure this rules out is the whole-desktop one: a boot that gave up
+    /// on the first unreadable bundle would leave an operator with no local host
+    /// at all — not even the companies that are perfectly intact — and the
+    /// console renders that as "no embedded host", which reads like the app is
+    /// broken rather than like one company is.
+    #[tokio::test]
+    async fn a_damaged_bundle_does_not_take_the_healthy_one_with_it() {
+        let directory = tempfile::tempdir().unwrap();
+        let state = state_over(directory.path());
+        let healthy = first_run_manifest(DEFAULT_PRESET_ID).unwrap();
+        let healthy_id = company_id_from_name(&healthy.company.name);
+        register(&state, healthy_id.clone(), healthy, None)
+            .await
+            .unwrap();
+
+        let damaged = directory.path().join("companies").join("broken");
+        std::fs::create_dir_all(&damaged).unwrap();
+        std::fs::write(
+            damaged.join("company.toml"),
+            "this is not manifest = toml {{",
+        )
+        .unwrap();
+
+        let relaunched = state_over(directory.path());
+        let ids = bootstrap_companies(&relaunched, DEFAULT_PRESET_ID)
+            .await
+            .expect("a damaged bundle must not fail the boot");
+
+        assert_eq!(ids, vec![healthy_id], "the intact company still comes up");
+        assert!(
+            relaunched.registry().sole().is_some(),
+            "and it is the only one, rather than joined by a second starter"
+        );
     }
 
     /// Archiving removes a company from the registry deliberately. A boot that


### PR DESCRIPTION
Closes #632.

## The dead end

A packaged desktop booted an empty registry, and an empty registry cannot be signed into. Sign-in is per-company (`/api/v1/companies/{id}/auth/…`, or the sole-company alias), so a fresh install rendered a login form addressing a company that did not exist — and neither way a company normally reaches the registry is open to it:

- nobody types `serve --company <dir>` at a double-clicked application;
- `POST /api/v1/companies` requires the `platform` scope, which `PlatformScope` grants only against a configured `platform_auth`. A prosumer host has no machine credential to hand out, deliberately (`src/server/platform_auth.rs`), so every provisioning attempt is a 401 by design rather than by accident.

## Root cause

The bootstrap existed and the desktop rewrite orphaned it. `src/desktop.rs::start_local` still loads a bundled preset and adds `DESKTOP_OPERATOR_EMAIL` as a standing admin, and `tests/desktop_e2e.rs` still proves that path signs in end to end. Its only caller is `frontend/src-tauri/` — the *old* shell (`ai.opencompany.desktop`). The packaged app is the root `src-tauri/` (`ai.tinyhumans.opencompany`, the only one the `Desktop` CI job builds), which carried over the host, proxy, keychain and ACP but not the company bootstrap. #616 is why nobody saw it.

## The fix

**`bootstrap_companies` (`src/desktop.rs`)** — adopts every bundle the data root already holds, then seeds the default preset only when it holds none:

- adoption before seeding, because seeding unconditionally hands the operator a second starter company per launch, and skipping adoption makes the one they have unreachable;
- `archived` companies are skipped — archiving removes a company from the registry on purpose, and re-registering it next launch would undo that quietly;
- the bundle is the only authority (a desktop company has no source directory), and `RuntimeBuilder::build` carries the persisted record's console-created desks, agents and workflows forward.

**`embedded::start`** calls it before binding and sets `admin_email` to the local operator — the same seam the hosted control plane fills with `OPENCOMPANY_ADMIN_EMAIL`. Without an eligible address, `eligibility` admits nobody and the seeded company would still be unenterable.

**`oc_embedded` + the console** carry `operatorEmail`, offered on the embedded connection only. Adopted through an effect rather than initial state: a relaunch restores the connection from its profile before the bridge answers, so on every launch but the first the form mounts first. Only ever into an empty field, so it never overwrites what someone typed and never undoes a deliberate clear.

Nothing else changed: the host binds loopback, so `auth/request` already returns the code in its own response and the console already redeems it.

## Testing

- `cargo test` (2215 pass), `cargo test --manifest-path src-tauri/Cargo.toml --locked` (87 pass), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` on both crates.
- `cargo test --manifest-path src-tauri/Cargo.toml` adds `a_fresh_install_can_be_signed_into`, which drives a real embedded host over HTTP: fresh root → 401 on `/api/v1/companies` → `auth/request` → `dev_code` → `auth/verify` → 200 → the refused call answers. Plus `a_relaunch_reuses_the_company_the_root_already_holds`.
- Console: 3 typecheck configs, 523 unit tests, and a new Playwright spec (`desktop-first-run-signin.spec.ts`) covering the late-arriving suggestion. Confirmed it is a real regression test — with the prefill disabled it fails `Expected "operator@opencompany.local", Received ""`.
- **Manually, against the built `opencompany-desktop` binary on a fresh data root:** it logs `seeded the first-run company`, the root gains `companies/agentic-marketing-agency`, the issue's own curl repro now completes (401 → `dev_code` → 200 → `/api/v1/companies` lists the company), and the real console bundle in a real browser against that host signs in and lands on the org graph. A relaunch on the same root re-adopts (`companies=1`, no second bundle) and signs in again.

## Notes

- Not covered: the packaged `.app` was not launched and clicked (that is #616's gap). The console half was driven in a real browser against a real embedded host with only `window.__TAURI__` shimmed, since that object exists nowhere else.
- `src-tauri/Cargo.lock` is deliberately left at `main`. `--locked` fails locally, wanting `url` under the `opencompany` entry, while the `Desktop` lane passes — a floating `stable` toolchain disagreeing with the runner's cargo, not a real drift. The desktop suite was run without `--locked` here.
- Out of scope, worth their own issues: the embedded host still starts no schedulers or mailbox pollers for its companies, and `frontend/src-tauri/` is now fully orphaned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Desktop startup now automatically prepares the default company on first launch.
  - Existing non-archived companies are reused across relaunches.
  - Local sign-in forms can suggest the desktop operator’s email address, which remains editable.
  - Sign-in now provides a local login code without sending email.
  - Company listings are available after signing in.

- **Documentation**
  - Added documentation describing first-run desktop setup and embedded-host sign-in behavior.

- **Tests**
  - Added coverage for first-run setup, relaunch persistence, sign-in suggestions, and archived-company handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->