### PR TITLE
security: agent-isolation threat model, and fail closed on the fs secret backend (#752 C0+C3)

### DIFF
--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -54,6 +54,8 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 - **Runtime engineering**: [runtime/](runtime/README.md) →
   [company-brain/](company-brain/README.md) →
   [integrations/](integrations/README.md)
+- **Security**: [security/agent-isolation.md](security/agent-isolation.md) —
+  read this before assuming any agent capability is contained
 - **Where this is going**: [roadmap.md](roadmap.md) →
   [feature audit](feature-audit/README.md) →
   [vision/](vision/README.md)
@@ -94,6 +96,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/repos.md](runtime/repos.md) | Bound repositories: mirror cache, credential handling, quota |
 | [runtime/data-root.md](runtime/data-root.md) | Data-root resolution, the single-writer lock, instance identity |
 | [runtime/desktop.md](runtime/desktop.md) | The desktop client: connections, transport seam, embedded host |
+| [security/agent-isolation.md](security/agent-isolation.md) | What confines an agent and what does not — enforced controls, the gaps, and the capability that survives every planned control |
 | [company-as-agent/README.md](company-as-agent/README.md) | Companies as economy citizens |
 | [company-as-agent/identity.md](company-as-agent/identity.md) | Wallet, handle, Agent Card |
 | [company-as-agent/commerce.md](company-as-agent/commerce.md) | Selling, hiring, delegated signers, ledger |

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -68,6 +68,10 @@ Supporting docs:
   credential reaches git without entering argv, the environment or any file, the
   alternates-not-hardlinks and refuse-not-evict departures, and the honest limit
   of same-user confinement
+- [../security/agent-isolation.md](../security/agent-isolation.md) — the threat
+  model behind that limit: what confines an agent today, what does not, and what
+  a prompt-injected agent with `shell` can still do after every planned control
+  lands
 - [users.md](users.md) — human collaborators: magic-link/password sign-in,
   sessions, invites, and chat attribution
 

--- a/docs/spec/runtime/repos.md
+++ b/docs/spec/runtime/repos.md
@@ -147,6 +147,11 @@ different ones, and they are named rather than implied:
 - container-level egress policy and per-agent user namespaces, which are the
   real fix and are a follow-up, not a claim made here.
 
+That follow-up is issue #752, and the threat model it owed is now written:
+[../security/agent-isolation.md](../security/agent-isolation.md). Read it before
+concluding that any of the above adds up to confinement. Its residual section
+is the part that matters — it holds after every control #752 tracks has landed.
+
 ### Repository configuration decides what runs
 
 Issue #459 reclassified `read_workspace_state` for exactly this reason: it
@@ -334,6 +339,16 @@ of knowing what the company is, and the body carries no credential material.
 
 ### Intake rules
 
+- **The host must keep secrets off its own disk** (issue #752). On
+  `OPENCOMPANY_STORAGE=fs` or `sqlite` the credential would land as plaintext
+  under the company's data directory, readable by the uid the agent shell runs
+  as, so the bind is refused with `409 Conflict` before anything is parsed or
+  written. The same condition refuses **boot** for a company whose roster grants
+  `repo`, and withholds the repo tools at agent build. Remedies:
+  `OPENCOMPANY_STORAGE=mongodb` with a Mongo URI, or drop the `repo` grant.
+  This is a breaking change for `fs` deployments that already bound one — see
+  [storage.md](storage.md) and, for why a warning would not have been honest,
+  [../security/agent-isolation.md](../security/agent-isolation.md).
 - **https://github.com/&lt;owner&gt;/&lt;repo&gt; only.** Another forge, `http`,
   `ssh`, a userinfo section, a port, extra path segments, a query string, a `..`
   — each is refused rather than normalized. A URL is the thing a credential is

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -39,6 +39,41 @@ MongoDB settings:
 - `OPENCOMPANY_TENANT_ID` — tenant identity for **shared-single-DB** mode
   (default unset). See [Shared single database](#shared-single-database-mode).
 
+## Secrets at rest, and what that costs (issue #752)
+
+`fs` writes one **plaintext** file per secret under
+`<data-dir>/companies/<slug>/secrets/`; `sqlite` puts the same bytes in a
+database file on the same disk. Both are readable by the uid the server runs
+as — which is the uid an agent's `shell` tool runs as, in the same container.
+There is no boundary in between; see
+[../security/agent-isolation.md](../security/agent-isolation.md). `mongodb` is
+the only backend that keeps secrets out of the container, in the tenant
+database.
+
+**Repository credentials therefore require `OPENCOMPANY_STORAGE=mongodb`.**
+This is enforced, not advised, in three places:
+
+| Where | What happens |
+| --- | --- |
+| `POST …/repos` (bind) | `409 Conflict` with the refusal message; nothing is stored |
+| Company boot / rebuild | The company does not come up — `OpenCompanyError::Config` — when its **effective roster** grants `repo`, including an agent naming `repo` under a wildcard company allow-list |
+| Agent build | Repo tools are withheld (fail-closed, with a warning), which covers a teammate added through the console on a live runtime |
+
+The refusal names both remedies: set `OPENCOMPANY_STORAGE=mongodb` with
+`OPENCOMPANY_MONGODB_URI`, or drop the `repo` grant.
+
+**This is a breaking change for `fs` and `sqlite` deployments that have already
+bound a repository.** That is deliberate. Those are precisely the deployments
+carrying a plaintext repository token on a disk their agents can read, so a
+warning would leave the exposure in place and call it handled. Migration is one
+of the two remedies above; a bound credential on an fs host should also be
+**revoked at the forge**, since it has been readable for as long as it has been
+installed.
+
+Every *other* secret on an `fs` or `sqlite` host is still plaintext next to it.
+This gate closes one credential on one path; it does not make the filesystem
+safe.
+
 ## The root itself
 
 How the data root is resolved, why only one process may write it, and what

--- a/docs/spec/security/agent-isolation.md
+++ b/docs/spec/security/agent-isolation.md
@@ -1,0 +1,243 @@
+# Agent isolation: what confines an agent, and what does not
+
+**Status: current, and deliberately uncomfortable.** This is the threat model
+[repos.md](../runtime/repos.md) deferred when the bound-repository read tier
+shipped (issue #245), filed as issue #752 C0. It exists to be read *before*
+someone concludes from a closed child issue that the agent shell is contained.
+It is not.
+
+Scope: what confines an agent running inside one OpenCompany tenant, with an
+emphasis on the agent that holds `shell`. Not in scope: authentication of
+humans ([users.md](../runtime/users.md)), cross-tenant isolation in
+shared-single-database mode ([storage.md](../runtime/storage.md), which states
+its own limit), or the console's own authorization model
+([api.md](../runtime/api.md)).
+
+## The claim, in one paragraph
+
+**One container per tenant is the only hard boundary OpenCompany has.**
+Everything inside that container — the server process, every agent's workspace,
+every stored credential, the shell an agent runs commands through — is one
+uid, one filesystem and one network namespace. The controls described below are
+real and worth having, but they are *policy applied to a cooperative
+component*, not a boundary between an attacker and the thing they want. An
+agent that has been prompt-injected is not a cooperative component.
+
+## Attacker model
+
+The attacker does not have an account. They write text that an agent reads:
+an issue body, a pull-request description, a web page fetched by `web_fetch`,
+a file in a repository the company bound, an inbound email, a Telegram message,
+a Composio trigger payload. Any of those can carry instructions, and the agent
+that reads them is the one holding the grants.
+
+Assume, therefore: **the attacker can issue any tool call the agent is granted,
+with any arguments.** The question this document answers is what that buys
+them. It is not "can the model be tricked" — assume yes — but "what is on the
+other side of the tool call when it is."
+
+## What is actually enforced today
+
+Each of these is real. None of them is a sandbox.
+
+| Control | Mechanism | Where |
+| --- | --- | --- |
+| One container per tenant | The `opencompany-manager` control plane builds and runs a per-tenant container | superproject, not this repo |
+| Database per tenant | `OPENCOMPANY_MONGODB_URI` is scoped to that tenant's database | [storage.md](../runtime/storage.md) |
+| Tool grants are per agent, and `repo` needs naming | `grants_repo_explicit` — the catch-all `*` does **not** confer `repo`, `media`, `composio` or `search` | `src/company/types.rs` |
+| Repo tools need a grant, a wired manager **and** a binding | Three gates in `build_agent`, each fail-closed with a warning | `src/harness/build.rs` |
+| Repo credentials refused on a plaintext secret backend | Issue #752 C3 — bind and boot both refuse unless `OPENCOMPANY_STORAGE=mongodb` | `src/store/select.rs`, `src/runtime/repo_manager.rs` |
+| Classic PATs refused at intake | `ghp_…` reads every repository the account can reach; the route refuses it and says how to make a fine-grained one | `src/server/ops/repos.rs` |
+| The credential never reaches argv, the environment or a file | A git credential helper on stdin, with an emptied environment | [repos.md](../runtime/repos.md) |
+| A checkout cannot reach the mirror it came from | Full object copy over `file://`, no hardlinks, no `alternates`, every back-reference severed | `src/harness/repo.rs` |
+| A push at a mirror is refused by the mirror | A `pre-receive` hook installed in every mirror | `install_push_refusal` |
+| Checkouts do not survive a turn | Orphaned checkouts swept at boot, tenant-scoped | `sweep_orphaned_checkouts` |
+| Repository configuration cannot make git run programs | `core.hooksPath=/dev/null`, no system/global config, scratch `$HOME`, deadline on every invocation | [repos.md](../runtime/repos.md) |
+| A publish is host-shaped and human-approved | Host-generated branch name, never the default branch, no force, all inside `RepoManager` | issue #735 |
+| Shell without an audit logger is no shell | `workspace_audit` returns `None` → the whole `shell` namespace is withheld | `src/harness/toolbelt.rs` |
+| Copilot turns reach nothing | `ConfinedToolPolicy` denies every tool call by name, empty belt, empty memory | `src/harness/confine.rs` |
+| Web tools reject private and metadata IPs | OpenHuman's `url_guard`, always, regardless of allowlist | `src/harness/toolbelt.rs` |
+| Per-company web allowlist, when set | `[tools].web_allowed_domains`; empty means allow-any-public | `src/harness/toolbelt.rs` |
+
+Two of those deserve their honest reading rather than their headline.
+
+**The approval gate on publish (#735) is adequate for what it guards, and it
+guards a tool.** A push is low-frequency, high-consequence and irreversible,
+which is exactly the shape an approval gate is for, and its constraints are
+structural rather than prompt-reachable. But it runs in the same process and
+gates `repo_publish`. An injected agent moving data out does not call
+`repo_publish`. It calls `shell` and runs `git push` — or `curl`.
+
+**The exec `SecurityPolicy` is advisory.** `workspace_only`,
+`block_high_risk_commands` and `require_approval_for_medium_risk` are read by
+filesystem tools and by a command classifier. `workspace_dir` and `action_dir`
+set the shell's **working directory**. A working directory is not a jail.
+
+## What is not enforced
+
+### 1. There is no sandbox. The shell runs directly.
+
+OpenHuman's `ShellTool` routes execution through a sandbox backend only when
+the agent's sandbox mode is `Sandboxed`
+(`vendor/openhuman/src/openhuman/tools/impl/system/shell.rs`). `SandboxMode`
+defaults to `None`, and **OpenCompany never sets one** — grepping `src/` for
+`SandboxMode`, `jail` or `landlock` returns doc comments and nothing else. Every
+shell command an agent runs is a direct child of the server process, with the
+server's uid, the server's filesystem and the server's network.
+
+The `cwd_jail` / Landlock subsystem exists in `vendor/openhuman` but is neither
+wired nor compiled: `sandbox-landlock` is absent from the tenant feature set in
+`deploy-staging.yml`.
+
+### 2. Wiring Landlock would not close the exfiltration channel.
+
+From `vendor/openhuman/src/openhuman/sandbox/cwd_jail/README.md`, verbatim:
+*"Landlock does not gate network at all."* Egress isolation in OpenHuman exists
+only through the Docker sandbox backend's `--network`, which needs
+docker-in-docker and is not available in a tenant pod.
+
+So a filesystem jail is worth having and does nothing for token exfiltration on
+its own. This is why C4 is secondary and why closing it would not close #752.
+
+### 3. On `fs` and `sqlite`, secrets are plaintext on the container's disk.
+
+`FsSecretStore` writes one plaintext file per secret under
+`<data-dir>/companies/<slug>/secrets/` and says so in its own doc comment;
+`sqlite` puts the same bytes in a database file on the same disk. Both are
+readable by the uid the shell runs as.
+
+Since #752 C3 this specific exposure is refused rather than documented: binding
+a repository credential, and booting a company that grants `repo`, both fail
+closed unless `OPENCOMPANY_STORAGE=mongodb`. That closes the *repository*
+credential on that path. It does not make the filesystem safe — every other
+secret on an `fs` host is still plaintext next to it.
+
+### 4. There is no egress policy.
+
+A tenant pod can open a connection to any host that resolves. Nothing in this
+repo can change that, and no test in this repo can demonstrate otherwise: a
+manifest lint is not proof, a blocked packet is. This is C1, it lives in
+`opencompany-microservice`, and it is the load-bearing control in the whole set.
+
+### 5. There is no per-agent uid separation.
+
+Every agent in a tenant is the same uid, in the same process. Agent A's
+workspace is a directory agent B can `cat`. The grant system decides which
+*tools* an agent is offered; it does not decide what the shell can reach once
+one of them is `shell`.
+
+### 6. The audit trail does not survive its own subject.
+
+The shell audit log is `<workspace>/audit.log` — the agent's own workspace,
+which is the shell's working directory. An agent holding `shell` can truncate
+or delete the record of what it did. Withholding shell when the logger cannot
+initialize (which the toolbelt does) makes the log's *existence* fail-closed; it
+does nothing for its *integrity*.
+
+## Residual capability after every control in #752 lands
+
+**Read this section as if C0–C5 are already done, because that is when it
+matters.** It is written in the present tense on purpose: nothing below is
+fixed by the work #752 tracks.
+
+One container per tenant remains the only hard boundary. Inside a tenant, a
+prompt-injected agent holding `shell` that can reach an allowlisted host can
+still:
+
+1. **Exfiltrate any repository content it can read, to an attacker-controlled
+   repository on that same allowlisted git host.** Default-deny egress (C1)
+   allowlists the git host — it has to, or checkout and publish stop working.
+   The agent pushes to `github.com/attacker/drop` instead of
+   `github.com/acme/widgets`. Same host, same port, same protocol, same TLS
+   certificate authority. Nothing in the allowlist distinguishes them.
+2. **Cause writes anywhere the credential's scope reaches**, under the write
+   tier. The approval gate constrains what `repo_publish` may do; it does not
+   constrain what `git push` may do from a shell that holds the token.
+3. **Read every secret the tenant holds that is on the container's disk**, and
+   every agent's workspace in that tenant.
+4. **Destroy its own audit trail.**
+
+What C1–C5 actually buy: the number of hosts reachable drops from "the
+internet" to "a handful", raw sockets stop working (C2), the repository
+credential stops being a file on disk (C3), the filesystem an escaped process
+sees shrinks (C4), and a stolen token expires in an hour and reaches one
+repository (C5). Each of those raises cost and narrows a channel. **None of
+them puts a boundary between the agent and the credential, or between the agent
+and its egress.**
+
+The honest one-line summary, which belongs in any report on this work: *we
+narrowed the channels and shortened the credential's life; we did not contain
+the shell.*
+
+## An unresolved tension: egress policy versus the web tools
+
+Default-deny egress (C1) and `[tools].web_allowed_domains` pull in opposite
+directions, and both are load-bearing.
+
+- C1 wants the pod to reach a short, fixed list: the git host, the model API,
+  the TinyHumans backend, DNS. Everything else refused at the network layer.
+- The web tools want broad public reach. An empty `web_allowed_domains` means
+  *allow any public host*, and that is the default because a company doing
+  research, competitive analysis or customer support is expected to read the
+  web. Narrowing it to a per-company allowlist is a real product cost: an agent
+  that cannot open the page it was asked about is not doing the job.
+
+These cannot both be maximal. A pod-level allowlist that admits the public web
+so `web_fetch` keeps working is a pod-level allowlist that admits the attacker's
+collection endpoint, and C1 has bought approximately nothing. A pod-level
+allowlist tight enough to be a boundary breaks `web_fetch` for every company
+that has not enumerated its domains in advance.
+
+There is no resolution recorded here because none has been decided. The shapes
+worth considering, none of them free:
+
+- Route the web tools through an egress proxy inside the allowlist, and enforce
+  the per-company domain list at the proxy rather than in-process. Moves the
+  decision to a component the agent cannot talk around, and adds a component.
+- Split the tiers: companies that hold a repository credential get the tight
+  allowlist and lose open web; companies that want open web do not get `repo`.
+  Honest, and it makes the two capabilities mutually exclusive.
+- Accept broad egress and stop describing C1 as containment — treat it as
+  blocking raw sockets and non-HTTP protocols only.
+
+Whoever closes C1 must state which of these they chose, and what it costs.
+
+## What must never be claimed
+
+Not in a commit message, not in a PR body, not in a release note, not in this
+directory:
+
+- "The shell is sandboxed." It is not. No sandbox mode is set.
+- "Egress is locked down", without naming the allowlist and conceding that
+  exfiltration to an allowlisted host is unaffected.
+- "The agent cannot reach the credential." On `fs` it is a file it can read; on
+  `mongodb` it is in a process it is running inside.
+- "#752 is fixed." #752 cannot be closed by work in this repo. C3 and C4 are
+  the in-repo children; the load-bearing ones are C1, C2 and C5, and they are
+  in `opencompany-microservice`.
+- Any claim about egress justified by a passing test in this repository. No
+  test here can demonstrate that a packet was blocked.
+
+## The children of #752
+
+| ID | Scope | Repo | State |
+| --- | --- | --- | --- |
+| C0 | This document | opencompany | done |
+| C1 | Default-deny egress for tenant pods | `opencompany-microservice` / k8s | open — **highest priority** |
+| C2 | Pod `securityContext`: seccomp `RuntimeDefault`, drop all caps including `NET_RAW`, no privilege escalation | `opencompany-microservice` / k8s | open |
+| C3 | Fail closed on the fs secret backend for `repo` | opencompany | done |
+| C4 | Wire `cwd_jail` Landlock for the agent shell, plus a CI lane that builds the feature | opencompany | open — secondary |
+| C5 | Short-lived single-repository installation tokens instead of a long-lived write PAT | `opencompany-microservice` | open — before the write tier ships broadly |
+
+A suggested precondition, not a code dependency: **the write tier should not
+reach a tenant whose pod lacks default-deny egress.**
+
+## Related
+
+- [repos.md](../runtime/repos.md) — "The honest limit", which this document is
+  the deferred follow-up to.
+- [storage.md](../runtime/storage.md) — backend selection, and the repository
+  credential requirement C3 added.
+- [ports-state.md](../runtime/ports-state.md) — the `SecretStore` contract.
+- [company-brain/approvals.md](../company-brain/approvals.md) — the approval
+  model the publish gate sits in.

--- a/docs/spec/security/agent-isolation.md
+++ b/docs/spec/security/agent-isolation.md
@@ -46,32 +46,40 @@ Each of these is real. None of them is a sandbox.
 | Database per tenant | `OPENCOMPANY_MONGODB_URI` is scoped to that tenant's database | [storage.md](../runtime/storage.md) |
 | Tool grants are per agent, and `repo` needs naming | `grants_repo_explicit` — the catch-all `*` does **not** confer `repo`, `media`, `composio` or `search` | `src/company/types.rs` |
 | Repo tools need a grant, a wired manager **and** a binding | Three gates in `build_agent`, each fail-closed with a warning | `src/harness/build.rs` |
-| Repo credentials refused on a plaintext secret backend | Issue #752 C3 — bind and boot both refuse unless `OPENCOMPANY_STORAGE=mongodb` | `src/store/select.rs`, `src/runtime/repo_manager.rs` |
+| Repo credentials refused on a plaintext secret backend | Issue #752 C3 — bind, company boot and agent build all refuse unless `OPENCOMPANY_STORAGE=mongodb` | `src/store/select.rs`, `src/runtime/repo_manager.rs`, `src/runtime/builder.rs`, `src/harness/build.rs` |
 | Classic PATs refused at intake | `ghp_…` reads every repository the account can reach; the route refuses it and says how to make a fine-grained one | `src/server/ops/repos.rs` |
 | The credential never reaches argv, the environment or a file | A git credential helper on stdin, with an emptied environment | [repos.md](../runtime/repos.md) |
 | A checkout cannot reach the mirror it came from | Full object copy over `file://`, no hardlinks, no `alternates`, every back-reference severed | `src/harness/repo.rs` |
 | A push at a mirror is refused by the mirror | A `pre-receive` hook installed in every mirror | `install_push_refusal` |
 | Checkouts do not survive a turn | Orphaned checkouts swept at boot, tenant-scoped | `sweep_orphaned_checkouts` |
 | Repository configuration cannot make git run programs | `core.hooksPath=/dev/null`, no system/global config, scratch `$HOME`, deadline on every invocation | [repos.md](../runtime/repos.md) |
-| A publish is host-shaped and human-approved | Host-generated branch name, never the default branch, no force, all inside `RepoManager` | issue #735 |
 | Shell without an audit logger is no shell | `workspace_audit` returns `None` → the whole `shell` namespace is withheld | `src/harness/toolbelt.rs` |
 | Copilot turns reach nothing | `ConfinedToolPolicy` denies every tool call by name, empty belt, empty memory | `src/harness/confine.rs` |
 | Web tools reject private and metadata IPs | OpenHuman's `url_guard`, always, regardless of allowlist | `src/harness/toolbelt.rs` |
 | Per-company web allowlist, when set | `[tools].web_allowed_domains`; empty means allow-any-public | `src/harness/toolbelt.rs` |
 
-Two of those deserve their honest reading rather than their headline.
-
-**The approval gate on publish (#735) is adequate for what it guards, and it
-guards a tool.** A push is low-frequency, high-consequence and irreversible,
-which is exactly the shape an approval gate is for, and its constraints are
-structural rather than prompt-reachable. But it runs in the same process and
-gates `repo_publish`. An injected agent moving data out does not call
-`repo_publish`. It calls `shell` and runs `git push` — or `curl`.
-
 **The exec `SecurityPolicy` is advisory.** `workspace_only`,
 `block_high_risk_commands` and `require_approval_for_medium_risk` are read by
 filesystem tools and by a command classifier. `workspace_dir` and `action_dir`
 set the shell's **working directory**. A working directory is not a jail.
+
+### On the write tier's approval gate, which is not here yet
+
+The repository **write** tier (#247, #734–#738) is in flight and is **not on
+`main`** as this is written — there is no `repo_publish` in the tree. When it
+lands, its approval gate is adequate for what it guards: a push is
+low-frequency, high-consequence and irreversible, exactly the shape an approval
+gate is for, and its constraints (host-generated branch name, never the default
+branch, no force, all inside `RepoManager`) are structural rather than
+prompt-reachable.
+
+It is still not a shell boundary. It runs in the same process and gates a
+*tool*. An injected agent moving data out does not call `repo_publish` — it
+calls `shell` and runs `git push`, or `curl`. So the gate does not lower the
+priority of anything in this document, and it must not be cited as if it did.
+
+A suggested precondition, not a code dependency: **the write tier should not
+reach a tenant whose pod lacks default-deny egress.**
 
 ## What is not enforced
 
@@ -229,8 +237,8 @@ directory:
 | C4 | Wire `cwd_jail` Landlock for the agent shell, plus a CI lane that builds the feature | opencompany | open — secondary |
 | C5 | Short-lived single-repository installation tokens instead of a long-lived write PAT | `opencompany-microservice` | open — before the write tier ships broadly |
 
-A suggested precondition, not a code dependency: **the write tier should not
-reach a tenant whose pod lacks default-deny egress.**
+The write tier (#247, #734–#738) is a separate line of work, not a child of
+this one — but see the precondition above.
 
 ## Related
 

--- a/docs/spec/security/agent-isolation.md
+++ b/docs/spec/security/agent-isolation.md
@@ -45,7 +45,7 @@ Each of these is real. None of them is a sandbox.
 | One container per tenant | The `opencompany-manager` control plane builds and runs a per-tenant container | superproject, not this repo |
 | Database per tenant | `OPENCOMPANY_MONGODB_URI` is scoped to that tenant's database | [storage.md](../runtime/storage.md) |
 | Tool grants are per agent, and `repo` needs naming | `grants_repo_explicit` — the catch-all `*` does **not** confer `repo`, `media`, `composio` or `search` | `src/company/types.rs` |
-| Repo tools need a grant, a wired manager **and** a binding | Three gates in `build_agent`, each fail-closed with a warning | `src/harness/build.rs` |
+| Repo tools need a grant, a wired manager **and** a binding | Three of the four gates in `build_agent`, each fail-closed with a warning (the fourth is the row below) | `src/harness/build.rs` |
 | Repo credentials refused on a plaintext secret backend | Issue #752 C3 — bind, company boot and agent build all refuse unless `OPENCOMPANY_STORAGE=mongodb` | `src/store/select.rs`, `src/runtime/repo_manager.rs`, `src/runtime/builder.rs`, `src/harness/build.rs` |
 | Classic PATs refused at intake | `ghp_…` reads every repository the account can reach; the route refuses it and says how to make a fine-grained one | `src/server/ops/repos.rs` |
 | The credential never reaches argv, the environment or a file | A git credential helper on stdin, with an emptied environment | [repos.md](../runtime/repos.md) |
@@ -115,10 +115,11 @@ its own. This is why C4 is secondary and why closing it would not close #752.
 readable by the uid the shell runs as.
 
 Since #752 C3 this specific exposure is refused rather than documented: binding
-a repository credential, and booting a company that grants `repo`, both fail
-closed unless `OPENCOMPANY_STORAGE=mongodb`. That closes the *repository*
-credential on that path. It does not make the filesystem safe — every other
-secret on an `fs` host is still plaintext next to it.
+a repository credential, booting a company whose roster grants `repo`, and
+wiring the repo tools for an agent all fail closed unless
+`OPENCOMPANY_STORAGE=mongodb`. That closes the *repository* credential on that
+path. It does not make the filesystem safe — every other secret on an `fs` host
+is still plaintext next to it, and nothing here touches the shell.
 
 ### 4. There is no egress policy.
 

--- a/src/app/types.rs
+++ b/src/app/types.rs
@@ -528,6 +528,17 @@ impl AppState {
         self
     }
 
+    /// Which storage backend is serving the durable ports.
+    ///
+    /// Read by `/spec` and — since issue #752 — by every company builder, which
+    /// passes it down to the repository-credential gates. Those refuse on `fs`
+    /// and `sqlite`, so this is a security-relevant value and not only a
+    /// reporting one: a host that forgets to set it is treated as the refusing
+    /// case, which is the safe direction.
+    pub fn storage_kind(&self) -> crate::store::StorageKind {
+        self.storage_kind
+    }
+
     /// This host's stable public identity, minted on first use.
     ///
     /// See [`crate::app::instance`] for why it is random rather than derived

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -283,6 +283,11 @@ fn company_builder(
     .with_default_mcp_servers(state.config().default_mcp_servers.clone())
     .with_host_base_url(state.config().host_base_url())
     .with_workspace_quota(state.config().workspace_quota)
+    // Issue #752: the backend that serves this host's secrets, which the
+    // repository-credential gates refuse on. Threaded through `company_builder`
+    // rather than read from the environment further down, so a rebuild gets the
+    // same answer boot got.
+    .with_storage_kind(state.storage_kind())
     // Issue #661 / M8: the deployment's standing bootstrap admin, normalized,
     // so a fresh tenant's `owner` report reaches its creator before that first
     // sign-in mints a user record. `None` (self-hosted, no injected address) is

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -457,8 +457,8 @@ pub fn build_agent(
     }
 
     // Bound repositories (issue #245, agent half) — `repo_checkout` / `repo_pr`
-    // over the company's own mirrored source. THREE hard gates, and the third is
-    // not redundant:
+    // over the company's own mirrored source. FOUR hard gates, and none of them
+    // is redundant:
     //
     //  1. an **EXPLICIT** `repo` grant (`grants_repo_explicit`) — the catch-all
     //     `*` does NOT confer it, following `media` / `composio` / `search`.
@@ -472,6 +472,16 @@ pub fn build_agent(
     //     refusal listing an empty set. Wiring nothing and warning is the
     //     honest state, and it is what the console's "granted but nothing
     //     bound" notice is telling the operator to fix.
+    //  4. a secret backend that does **not** keep the credential as plaintext on
+    //     this container's disk (issue #752). `RuntimeBuilder::build` refuses to
+    //     bring a repo-granted company up at all on `fs`/`sqlite`, so in a
+    //     normal boot this arm is unreachable — and it is here for the case that
+    //     is not a boot. A teammate added through the console lands in
+    //     `overlay_agents` on a **live** runtime; `HarnessPool::ensure` rebuilds
+    //     that agent's belt on the next turn without going back through
+    //     `build`, so the boot check never sees it. Without this arm, adding an
+    //     agent that names `repo` would hand it a checkout tool over a
+    //     credential sitting in a file the same agent can `cat`.
     //
     // NOT feature-gated, like `search` and unlike `media` / `composio`: the
     // mirror and the git runner are always compiled, and with no forge client
@@ -481,6 +491,16 @@ pub fn build_agent(
     // how #288 / #281 / #297 each happened.
     if crate::company::grants_repo_explicit(grants) {
         match (&deps.repos, deps.repo_bindings.is_empty()) {
+            // Gate 4 first: on a plaintext backend there is no shape of this
+            // that is safe to wire, so the binding count does not get a vote.
+            (Some(repos), _) if repos.secrets_are_plaintext_on_disk() => tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                "[build] agent explicitly grants `repo` but this host keeps secrets on its own \
+                 filesystem, where the credential is readable by the shell; repo tools NOT wired \
+                 (fail-closed, issue #752) — set OPENCOMPANY_STORAGE=mongodb or drop the `repo` \
+                 grant"
+            ),
             (Some(repos), false) => {
                 tools.extend(crate::harness::repo::repo_tools(
                     crate::harness::repo::RepoToolContext {
@@ -1588,14 +1608,30 @@ mod tests {
     /// `deps.repo_bindings` — so the difference between the two is exactly
     /// "the operator bound something", which is two of the four gate states.
     fn built_tool_names_with_repos(grants: &[&str], bindings: usize) -> Vec<String> {
+        built_tool_names_with_repos_on(grants, bindings, crate::store::StorageKind::Mongodb)
+    }
+
+    /// [`built_tool_names_with_repos`], with the secret backend spelled out —
+    /// the fourth gate (issue #752). Mongodb is what the plain helper passes,
+    /// because a host that cannot hold a repository credential safely cannot
+    /// reach the other three gates at all, and every assertion about them would
+    /// otherwise be passing for the #752 reason instead of its own.
+    fn built_tool_names_with_repos_on(
+        grants: &[&str],
+        bindings: usize,
+        storage_kind: crate::store::StorageKind,
+    ) -> Vec<String> {
         use crate::runtime::repo_manager::types::RepoBinding;
         let dir = tempfile::tempdir().expect("tempdir");
         let mut deps = pin_deps(dir.path().to_path_buf());
-        deps.repos = Some(std::sync::Arc::new(crate::runtime::RepoManager::new(
-            CompanyId::new("acme"),
-            dir.path().join("repos"),
-            std::sync::Arc::new(crate::store::FsSecretStore::new(dir.path())),
-        )));
+        deps.repos = Some(std::sync::Arc::new(
+            crate::runtime::RepoManager::new(
+                CompanyId::new("acme"),
+                dir.path().join("repos"),
+                std::sync::Arc::new(crate::store::FsSecretStore::new(dir.path())),
+            )
+            .with_storage_kind(storage_kind),
+        ));
         deps.repo_bindings = (0..bindings)
             .map(|n| RepoBinding {
                 key: format!("acme-widgets-{n:012}"),
@@ -1703,6 +1739,31 @@ mod tests {
             built_tool_names(&["repo"], false),
             "the unbound state must differ from the unwired state by nothing"
         );
+
+        // Gate 4 (issue #752): explicit `repo` + manager + binding, on a host
+        // whose secrets are plaintext on its own disk → absent. This is the
+        // console-added-teammate path, which never goes back through the boot
+        // check. The binding exists, so nothing but the backend is refusing.
+        for kind in [
+            crate::store::StorageKind::Fs,
+            crate::store::StorageKind::Sqlite,
+        ] {
+            let plaintext = built_tool_names_with_repos_on(&["repo"], 1, kind);
+            for tool in &pair {
+                assert!(
+                    !plaintext.contains(tool),
+                    "a repo grant on {} must wire nothing: {plaintext:?}",
+                    kind.as_str()
+                );
+            }
+            // Again, a withheld family and not a broken agent.
+            assert_eq!(
+                plaintext,
+                built_tool_names(&["repo"], false),
+                "the {} state must differ from the unwired state by nothing",
+                kind.as_str()
+            );
+        }
     }
 
     /// Granting `repo` must not quietly hand over anything *else*: the bound

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -5227,11 +5227,19 @@ budget_usd_daily = 0.0
             // pass while never having looked at them, which is the exact way
             // `describe_workflow` stayed invisible here while parking in
             // production.
-            deps.repos = Some(Arc::new(crate::runtime::RepoManager::new(
-                CompanyId::new("acme"),
-                dir.path().join("repos"),
-                Arc::new(crate::store::FsSecretStore::new(dir.path())),
-            )));
+            // Issue #752 added a fourth gate: a backend that keeps the
+            // credential off this container's disk. Declared here for the same
+            // reason the binding below is — without it the belt would be
+            // missing `repo_checkout` / `repo_pr` and this check would pass
+            // while never having looked at them.
+            deps.repos = Some(Arc::new(
+                crate::runtime::RepoManager::new(
+                    CompanyId::new("acme"),
+                    dir.path().join("repos"),
+                    Arc::new(crate::store::FsSecretStore::new(dir.path())),
+                )
+                .with_storage_kind(crate::store::StorageKind::Mongodb),
+            ));
             deps.repo_bindings = vec![crate::runtime::repo_manager::types::RepoBinding {
                 key: "acme-widgets-000000000000".to_string(),
                 url: "https://github.com/acme/widgets".to_string(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1568,6 +1568,48 @@ impl RuntimeBuilder {
             .or_else(|| self.template_provenance.clone());
         let ledger = existing.map(|r| r.ledger).unwrap_or_default();
 
+        // Issue #752: a company whose roster holds `repo` does not come up on a
+        // backend that keeps secrets as plaintext on this container's disk.
+        //
+        // The bind-time refusal in `RepoManager::bind` covers new credentials.
+        // It cannot cover a company that bound one *before* this gate existed —
+        // that credential is already sitting on `/data`, and its agents would
+        // keep checking out under it forever. So the same condition is asked
+        // again here, where the answer is "this company does not start", and an
+        // operator restarting a tenant finds out at the moment they can still
+        // act on it.
+        //
+        // Read over the **effective roster**, not `[tools].allow` alone: an
+        // agent naming `tools = ["repo"]` under a company allow-list of `["*"]`
+        // holds an explicit `repo` grant that `grants_repo_explicit(&allow)`
+        // does not see, because the wildcard deliberately does not confer the
+        // namespace. Checking only the company line would miss exactly the
+        // configuration a wildcard company is most likely to have.
+        //
+        // NOT feature-gated, for the reason `build_agent` states about the repo
+        // tools themselves: a control compiled only under `openhuman` is a
+        // control most CI lanes never type-check.
+        if self.storage_kind.secrets_are_plaintext_on_disk() {
+            let roster_holds_repo =
+                crate::company::grants_repo_explicit(&self.manifest.tools.allow)
+                    || self
+                        .manifest
+                        .agents
+                        .iter()
+                        .map(|agent| {
+                            agent_effective_grants(&self.manifest.tools.allow, &agent.tools)
+                        })
+                        .chain(overlay_agents.iter().map(|overlay| {
+                            agent_effective_grants(&self.manifest.tools.allow, &overlay.tools)
+                        }))
+                        .any(|grants| crate::company::grants_repo_explicit(&grants));
+            if roster_holds_repo {
+                return Err(crate::error::OpenCompanyError::Config(
+                    crate::store::plaintext_secret_refusal(self.storage_kind),
+                ));
+            }
+        }
+
         // Issue #245: the company's repository mirror cache, rooted at the same
         // `companies/<slug>/` prefix the bundle uses so a company's whole
         // footprint sits in one subtree — and therefore inside the one quota
@@ -3346,6 +3388,120 @@ mod test {
 
     fn parse(toml_src: &str) -> CompanyManifest {
         toml::from_str(toml_src).expect("valid manifest")
+    }
+
+    // ---- issue #752: `repo` needs a backend that keeps secrets off disk ----
+
+    /// A company that already bound a repository predates the bind-time gate,
+    /// so the *restart* is where it has to be caught. A repo-granted company on
+    /// an fs host does not come up.
+    #[tokio::test]
+    async fn a_repo_granted_company_does_not_boot_on_a_plaintext_secret_backend() {
+        let home = tmp_home("oc-752-boot-");
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Acme"
+            [policy]
+            mode = "full"
+            [tools]
+            allow = ["repo", "shell"]
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            "#,
+        );
+        let err = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(CompanyId::new("acme"))
+            // The default, spelled out: this is what a local `serve` is.
+            .with_storage_kind(crate::store::StorageKind::Fs)
+            .build()
+            .await
+            .expect_err("an fs host must refuse to bring up a repo-granted company");
+        let message = err.to_string();
+        assert!(message.contains("OPENCOMPANY_STORAGE=fs"), "{message}");
+        assert!(message.contains("OPENCOMPANY_STORAGE=mongodb"), "{message}");
+        assert!(message.contains("`repo` grant"), "{message}");
+    }
+
+    /// The wildcard case, which a check against `[tools].allow` alone would let
+    /// through: `*` deliberately does **not** confer `repo`, so the company line
+    /// reads as ungranted while the agent naming `repo` explicitly holds it.
+    #[tokio::test]
+    async fn an_agent_that_names_repo_under_a_wildcard_company_is_caught_too() {
+        let home = tmp_home("oc-752-boot-wildcard-");
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Acme"
+            [policy]
+            mode = "full"
+            [tools]
+            allow = ["*"]
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            tools = ["repo"]
+            "#,
+        );
+        // The company line itself is not an explicit grant — if it were, this
+        // test would pass for the wrong reason.
+        assert!(!crate::company::grants_repo_explicit(&manifest.tools.allow));
+        let err = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(CompanyId::new("acme"))
+            .with_storage_kind(crate::store::StorageKind::Fs)
+            .build()
+            .await
+            .expect_err("an agent-level `repo` grant must be caught at boot");
+        assert!(err.to_string().contains("OPENCOMPANY_STORAGE=fs"), "{err}");
+    }
+
+    /// The other side, without which the two above only prove the check is on:
+    /// the same company boots on the backend that keeps secrets out of the
+    /// container, and a company that grants no `repo` boots on fs unaffected.
+    #[tokio::test]
+    async fn the_same_company_boots_where_secrets_leave_the_container() {
+        let home = tmp_home("oc-752-boot-ok-");
+        let granted = parse(
+            r#"
+            [company]
+            name = "Acme"
+            [policy]
+            mode = "full"
+            [tools]
+            allow = ["repo", "shell"]
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            "#,
+        );
+        RuntimeBuilder::new(home.path().to_path_buf(), granted)
+            .with_id(CompanyId::new("acme"))
+            .with_storage_kind(crate::store::StorageKind::Mongodb)
+            .build()
+            .await
+            .expect("mongodb-backed secrets must clear the #752 boot gate");
+
+        let ungranted_home = tmp_home("oc-752-boot-ungranted-");
+        let ungranted = parse(
+            r#"
+            [company]
+            name = "Acme"
+            [policy]
+            mode = "full"
+            [tools]
+            allow = ["shell", "web"]
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            "#,
+        );
+        RuntimeBuilder::new(ungranted_home.path().to_path_buf(), ungranted)
+            .with_id(CompanyId::new("acme"))
+            .with_storage_kind(crate::store::StorageKind::Fs)
+            .build()
+            .await
+            .expect("a company without `repo` is untouched by this gate");
     }
 
     // ---- `[policy]` override across a rebuild (issue #562) ----------------

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -294,6 +294,12 @@ pub struct RuntimeBuilder {
     /// 256 MiB per-file cap and an unlimited tree, so a runtime built without
     /// naming a quota is still not a way to write an unbounded file.
     workspace_quota: crate::runtime::WorkspaceQuota,
+    /// Issue #752: which storage backend is serving this host's secrets. Only
+    /// the repository-credential gates read it, and the default is the refusing
+    /// side (`fs`) — a runtime built without naming a backend is assumed to keep
+    /// secrets as plaintext on disk, because that is what
+    /// [`with_stores`](Self::with_stores) not being called actually means.
+    storage_kind: crate::store::StorageKind,
     facts: Option<Arc<dyn FactStore>>,
     artifacts: Option<Arc<dyn ArtifactStore>>,
     runs: Option<Arc<dyn RunStore>>,
@@ -390,6 +396,7 @@ impl RuntimeBuilder {
             tasks: None,
             workspace: None,
             workspace_quota: crate::runtime::WorkspaceQuota::default(),
+            storage_kind: crate::store::StorageKind::default(),
             facts: None,
             artifacts: None,
             runs: None,
@@ -573,6 +580,18 @@ impl RuntimeBuilder {
     /// tree). See [`QuotaEnforcedWorkspace`](crate::runtime::QuotaEnforcedWorkspace).
     pub fn with_workspace_quota(mut self, quota: crate::runtime::WorkspaceQuota) -> Self {
         self.workspace_quota = quota;
+        self
+    }
+
+    /// Records which storage backend serves this host's secrets (issue #752).
+    ///
+    /// Separate from [`with_stores`](Self::with_stores) because the two answer
+    /// different questions: `with_stores` hands over port *implementations*,
+    /// while this is the deployment's own name for the backend — the string an
+    /// operator set in `OPENCOMPANY_STORAGE` and the one the refusal quotes back
+    /// at them. Defaults to `fs`, the refusing side.
+    pub fn with_storage_kind(mut self, kind: crate::store::StorageKind) -> Self {
+        self.storage_kind = kind;
         self
     }
 
@@ -1569,7 +1588,11 @@ impl RuntimeBuilder {
                 Bundle::new(home.clone(), &id).repos_dir(),
                 secrets.clone(),
             )
-            .with_quota(self.workspace_quota.tree_quota_bytes);
+            .with_quota(self.workspace_quota.tree_quota_bytes)
+            // Issue #752: the manager refuses a bind when a credential would
+            // land as plaintext on this container's disk, so it has to be told
+            // which backend is actually serving secrets.
+            .with_storage_kind(self.storage_kind);
             // The forge REST client (pull-request metadata + diff). Without the
             // feature there is no HTTP client to give it, and the PR route says
             // so rather than answering with an empty diff. Shadowed rather than

--- a/src/runtime/repo_manager.rs
+++ b/src/runtime/repo_manager.rs
@@ -118,6 +118,14 @@ pub struct RepoManager {
     /// would otherwise each persist a document built from a snapshot taken
     /// before the other's entry existed, and one binding would vanish.
     index_lock: Mutex<()>,
+    /// Which storage backend is serving this host's [`SecretStore`] (issue
+    /// #752). Read only to answer one question — does a bound credential end up
+    /// as plaintext on a disk the agent shell can read — and it defaults to the
+    /// refusing side, so a manager assembled without being told is treated as
+    /// unsafe rather than as safe.
+    ///
+    /// [`SecretStore`]: crate::ports::SecretStore
+    storage_kind: crate::store::StorageKind,
 }
 
 impl std::fmt::Debug for RepoManager {
@@ -145,6 +153,7 @@ impl RepoManager {
             quota_bytes: None,
             host: None,
             index_lock: Mutex::new(()),
+            storage_kind: crate::store::StorageKind::default(),
         }
     }
 
@@ -159,6 +168,24 @@ impl RepoManager {
     pub fn with_host(mut self, host: Arc<dyn RepoHost>) -> Self {
         self.host = Some(host);
         self
+    }
+
+    /// Records which storage backend serves this host's secrets (issue #752),
+    /// which is what [`bind`](Self::bind) refuses on.
+    pub fn with_storage_kind(mut self, kind: crate::store::StorageKind) -> Self {
+        self.storage_kind = kind;
+        self
+    }
+
+    /// Whether a credential bound here would be stored as plaintext on a disk
+    /// the agent shell can read (issue #752).
+    ///
+    /// Public because the harness asks the same question before wiring the repo
+    /// tools: an already-bound company predates this gate, so the bind-time
+    /// refusal alone would leave its agents holding `repo_checkout` over a
+    /// credential that is still sitting on `/data`.
+    pub fn secrets_are_plaintext_on_disk(&self) -> bool {
+        self.storage_kind.secrets_are_plaintext_on_disk()
     }
 
     /// Whether a forge client is wired, i.e. whether
@@ -270,6 +297,10 @@ impl RepoManager {
     /// alternative is the state that makes this class of feature miserable: a
     /// binding that exists, cannot fetch, and holds a credential nobody
     /// remembers installing.
+    ///
+    /// **Refused outright on a plaintext secret backend (issue #752)** — see
+    /// [`bind_validated`](Self::bind_validated), which is where that gate sits so
+    /// that no path into the credentialed half can miss it.
     pub async fn bind(&self, request: BindRequest) -> Result<RepoBinding> {
         let coords = parse_repo_url(&request.url)?;
         let token = request.token.trim().to_string();
@@ -303,6 +334,29 @@ impl RepoManager {
     /// parameter rather than deriving it lets a test drive the *real* path —
     /// token write, rollback and all — against a local `file://` fixture with no
     /// network, which is the only way the interleaving below can be exercised.
+    ///
+    /// ## The plaintext-secret refusal (issue #752)
+    ///
+    /// The first thing this does is ask *where the credential would live*. On
+    /// `fs` or `sqlite` the answer is "a file on this container's own disk", and
+    /// an agent holding `shell` runs as the uid that can read it — so binding
+    /// would hand a prompt-injected agent the credential directly, around every
+    /// tool gate the host has. There is no boundary in between and none planned
+    /// inside a tenant; `docs/spec/security/agent-isolation.md` says so at
+    /// length.
+    ///
+    /// It sits **here** rather than in [`bind`](Self::bind) precisely because
+    /// this is the one funnel every bind path reaches, including the one a test
+    /// drives directly. A gate in the public wrapper would be a gate the most
+    /// realistic exercise of the code walks straight past, which is how a
+    /// control ends up proven only against itself.
+    ///
+    /// It runs before the duplicate check and long before `secrets.set`, so a
+    /// refusal is not something the rollback has to clean up: nothing was
+    /// written to undo. The refusal is the operator's, not the request's — the
+    /// URL and the token can be perfect and this still refuses — so it reports
+    /// the deployment condition and both ways out of it rather than blaming the
+    /// input.
     async fn bind_validated(
         &self,
         coords: &RepoCoordinates,
@@ -310,6 +364,11 @@ impl RepoManager {
         token: &str,
         branches: Vec<String>,
     ) -> Result<RepoBinding> {
+        if self.secrets_are_plaintext_on_disk() {
+            return Err(OpenCompanyError::Conflict(
+                crate::store::plaintext_secret_refusal(self.storage_kind),
+            ));
+        }
         let key = coords.key();
         // Held across the duplicate check, the token write, the mirror build and
         // the index commit — the entire span in which two binds of one key can

--- a/src/runtime/repo_manager/test.rs
+++ b/src/runtime/repo_manager/test.rs
@@ -267,7 +267,13 @@ fn manager(scratch: &Scratch) -> (RepoManager, Arc<MemSecrets>) {
         CompanyId::new("acme"),
         scratch.join("data/companies/acme/repos"),
         secrets.clone(),
-    );
+    )
+    // Issue #752: `bind` refuses outright on a backend that keeps secrets as
+    // plaintext on the container's disk, and `RepoManager::new` defaults to
+    // that refusing side. These tests exercise the credentialed path *past*
+    // that gate, so they stand in a deployment that clears it — which is also
+    // what `MemSecrets` actually is: secrets that never touch the disk.
+    .with_storage_kind(crate::store::StorageKind::Mongodb);
     (mgr, secrets)
 }
 
@@ -559,6 +565,109 @@ async fn a_classic_pat_is_refused_with_a_usable_instruction() {
         secrets
             .get_now("acme", &repo_token_key(&widgets_key()))
             .is_none()
+    );
+}
+
+// -- issue #752: the plaintext-secret-backend gate -----------------------------
+
+/// The attack this gate exists to stop, run as an attack rather than as a unit
+/// test of the guard: on a host whose secrets are plaintext files on the
+/// container's own disk, install a repository credential — and then go looking
+/// for it as the agent shell would, by reading the disk.
+///
+/// It must not be there, because the bind must not have happened.
+#[tokio::test]
+async fn a_credential_cannot_be_installed_where_the_agent_shell_could_read_it() {
+    let scratch = Scratch::new("plaintext-secret-bind");
+    let url = fixture_remote(&scratch);
+    // A *real* filesystem secret store rooted in the scratch home — not the
+    // in-memory fake — so "the token is on disk" is a claim about actual bytes
+    // in an actual file, which is the only version of it worth asserting.
+    let home = scratch.join("data");
+    let secrets = Arc::new(crate::store::FsSecretStore::new(home.clone()));
+    let mgr = RepoManager::new(
+        CompanyId::new("acme"),
+        scratch.join("data/companies/acme/repos"),
+        secrets.clone(),
+    )
+    .with_storage_kind(crate::store::StorageKind::Fs);
+
+    // Exactly the call the accepted-case test makes, against the same fixture
+    // remote. The only difference between the two is which backend is holding
+    // the secrets — which is the whole claim.
+    let coords = parse_repo_url(WIDGETS_URL).unwrap();
+    let err = mgr
+        .bind_validated(&coords, &url, SENTINEL, vec!["main".into()])
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, OpenCompanyError::Conflict(_)), "{err:?}");
+    let message = err.to_string();
+    assert!(message.contains("OPENCOMPANY_STORAGE=fs"), "{message}");
+    assert!(message.contains("OPENCOMPANY_STORAGE=mongodb"), "{message}");
+    assert!(message.contains("`repo` grant"), "{message}");
+    // The refusal must not quote the credential back into an error string that
+    // ends up in a log line or a console toast.
+    assert!(!message.contains(SENTINEL), "{message}");
+
+    // The attack: walk the company's whole on-disk footprint the way a shell
+    // with `cat`/`grep` would, and find nothing.
+    let leaked: Vec<_> = all_files(&home)
+        .into_iter()
+        .filter(|(_, bytes)| String::from_utf8_lossy(bytes).contains(SENTINEL))
+        .map(|(path, _)| path)
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "a refused credential is readable on disk: {leaked:?}"
+    );
+    // And no binding exists to hang a later fetch off.
+    assert!(mgr.list().await.unwrap().is_empty());
+}
+
+/// The other half, without which the test above only proves the feature is off:
+/// the identical credential install is *accepted* on the backend that keeps
+/// secrets out of the container, and the token really does land. Driven through
+/// `bind_validated` against the `file://` fixture — the same way every other
+/// successful-bind test here runs the real path with no network — which is also
+/// the funnel the gate sits in. `sqlite` is refused alongside `fs`: same disk,
+/// same uid.
+#[tokio::test]
+async fn the_same_bind_is_accepted_where_secrets_leave_the_container() {
+    let scratch = Scratch::new("mongodb-secret-bind");
+    let url = fixture_remote(&scratch);
+    let (mgr, secrets) = manager(&scratch);
+    let coords = parse_repo_url(WIDGETS_URL).unwrap();
+    let binding = mgr
+        .bind_validated(&coords, &url, SENTINEL, vec!["main".into()])
+        .await
+        .expect("mongodb-backed secrets must clear the #752 gate");
+    assert_eq!(
+        secrets
+            .get_now("acme", &repo_token_key(&binding.key))
+            .as_deref(),
+        Some(SENTINEL)
+    );
+    assert_eq!(mgr.list().await.unwrap().len(), 1);
+
+    // Sqlite is on the same disk as fs and is refused with the same message.
+    // Driven against the same fixture remote rather than the canonical GitHub
+    // URL: if this gate is ever removed, this assertion must fail *fast* on an
+    // unexpected success, not sit for five minutes waiting out a `ls-remote` to
+    // a host the test suite has no business contacting.
+    let sqlite_mgr = RepoManager::new(
+        CompanyId::new("acme"),
+        scratch.join("data/companies/acme/repos-sqlite"),
+        Arc::new(MemSecrets::default()),
+    )
+    .with_storage_kind(crate::store::StorageKind::Sqlite);
+    let err = sqlite_mgr
+        .bind_validated(&coords, &url, SENTINEL, vec!["main".into()])
+        .await
+        .unwrap_err();
+    assert!(
+        err.to_string().contains("OPENCOMPANY_STORAGE=sqlite"),
+        "{err}"
     );
 }
 

--- a/src/server/ops/repos.rs
+++ b/src/server/ops/repos.rs
@@ -355,6 +355,53 @@ mod test {
         assert!(stored.is_none(), "a refused credential was stored");
     }
 
+    /// Issue #752: the operator-facing half of the plaintext-secret gate. This
+    /// host is fs-backed (the [`AppState`] default, which is what a local or
+    /// self-hosted `serve` actually is), so the route refuses the bind and says
+    /// what to do about it — rather than accepting a credential that would sit
+    /// in a file the agent shell can read.
+    #[tokio::test]
+    async fn binding_is_refused_on_a_host_that_keeps_secrets_on_its_own_disk() {
+        let home = tempfile::Builder::new()
+            .prefix("oc-repos-plaintext-")
+            .tempdir()
+            .unwrap();
+        let state = state_with(home.path()).await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+
+        let response = router(state.clone())
+            .oneshot(post(
+                "/api/v1/company/repos",
+                serde_json::json!({
+                    "url": "https://github.com/acme/widgets",
+                    "token": SENTINEL,
+                }),
+            ))
+            .await
+            .unwrap();
+        // 409 rather than 400: the request is fine, the deployment is not, and
+        // the operator fixes it by changing the host or the grant and retrying.
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = body_json(response).await;
+        let message = body["error"].as_str().unwrap_or_default().to_string();
+        assert!(message.contains("OPENCOMPANY_STORAGE=fs"), "{message}");
+        assert!(message.contains("OPENCOMPANY_STORAGE=mongodb"), "{message}");
+        assert!(message.contains("`repo` grant"), "{message}");
+        // The refusal must not echo the credential into a response body.
+        assert!(!message.contains(SENTINEL), "{message}");
+
+        let key =
+            crate::runtime::repo_manager::types::parse_repo_url("https://github.com/acme/widgets")
+                .unwrap()
+                .key();
+        let stored = runtime
+            .secrets()
+            .get(runtime.id(), &repo_token_key(&key))
+            .await
+            .unwrap();
+        assert!(stored.is_none(), "a refused credential was stored");
+    }
+
     #[tokio::test]
     async fn a_non_github_url_is_refused_at_the_route() {
         let home = tempfile::Builder::new()

--- a/src/server/provision.rs
+++ b/src/server/provision.rs
@@ -252,6 +252,10 @@ async fn provision(
         .with_id(id.clone())
         .with_tinyplace_api_url(state.config().tinyplace_api_url.clone())
         .with_host_base_url(state.config().host_base_url())
+        // Issue #752: a provisioned tenant is a company like any other, so it
+        // inherits the same repository-credential gates — which need to know
+        // which backend is holding this host's secrets.
+        .with_storage_kind(state.storage_kind())
         .with_skills_registry(skills_registry);
     if let Some(stores) = state.stores() {
         builder = builder.with_stores(stores);

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -88,7 +88,7 @@ pub use migrate::migrate_legacy_nest_announced;
 pub use paths::{Bundle, DATA_DIR_ENV, home_divergence_warning, resolve_home};
 pub use select::{
     MemoryBackend, MemoryOverlay, StorageHandles, StorageKind, StorageSettings,
-    open_memory_overlay, open_storage,
+    open_memory_overlay, open_storage, plaintext_secret_refusal,
 };
 
 #[cfg(feature = "sqlite")]

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -61,6 +61,61 @@ impl StorageKind {
             Self::Mongodb => "mongodb",
         }
     }
+
+    /// Whether this backend keeps [`SecretStore`] material as **plaintext on
+    /// the container's own filesystem** (issue #752).
+    ///
+    /// `fs` writes one plaintext file per secret under
+    /// `<data-dir>/companies/<slug>/secrets/` — [`FsSecretStore`] says so in its
+    /// own doc comment, and `sqlite` puts the same bytes in a database file on
+    /// the same disk. `mongodb` is the only backend that keeps them out of the
+    /// container, in the tenant database.
+    ///
+    /// This matters because of who else is on that filesystem. An agent holding
+    /// `shell` runs as the same uid as the server process, in the same
+    /// container, so "plaintext on disk" means "readable by a prompt-injected
+    /// agent" — there is no boundary in between, and
+    /// `docs/spec/security/agent-isolation.md` is explicit that none is planned
+    /// inside a tenant. A repository credential parked there is a credential the
+    /// agent can read and use directly, without going through any tool the host
+    /// gates.
+    ///
+    /// New backends default to the safe answer by being added to the `true` arm
+    /// unless they demonstrably keep secrets off the local disk.
+    ///
+    /// [`FsSecretStore`]: crate::store::FsSecretStore
+    /// [`SecretStore`]: crate::ports::SecretStore
+    pub fn secrets_are_plaintext_on_disk(self) -> bool {
+        match self {
+            Self::Fs | Self::Sqlite => true,
+            Self::Mongodb => false,
+        }
+    }
+}
+
+/// The refusal every repository-credential gate raises on a backend that keeps
+/// secrets as plaintext on the container's disk (issue #752).
+///
+/// One function rather than a message per call site: the bind route, the boot
+/// check and the agent-build gate all refuse the *same* deployment condition,
+/// and an operator who reads it in the console then reads it again in the boot
+/// log should not have to work out whether they are two problems.
+///
+/// Written to be self-service — it names the condition, the risk in one clause,
+/// and both ways out — because the operator hitting it is mid-task with a token
+/// in their clipboard, and "storage backend not supported" would send them to
+/// the issue tracker instead of to a fix.
+pub fn plaintext_secret_refusal(kind: StorageKind) -> String {
+    format!(
+        "this host keeps secrets on its own filesystem (OPENCOMPANY_STORAGE={}), so a \
+         repository credential would sit there in plaintext — readable by the same uid the \
+         agent shell runs as, which is not a boundary this deployment has. Repository \
+         credentials are refused here. Either point this host at MongoDB \
+         (OPENCOMPANY_STORAGE=mongodb plus OPENCOMPANY_MONGODB_URI, which keeps secrets in \
+         the tenant database), or drop the `repo` grant from the company's [tools] allow \
+         list and from every agent that names it. See docs/spec/runtime/storage.md.",
+        kind.as_str()
+    )
 }
 
 impl std::str::FromStr for StorageKind {
@@ -500,6 +555,34 @@ mod test {
             StorageKind::Mongodb
         );
         assert!("postgres".parse::<StorageKind>().is_err());
+    }
+
+    /// Issue #752: only MongoDB keeps secret material off the container's own
+    /// disk, so only MongoDB clears the repository-credential gates.
+    #[test]
+    fn only_mongodb_keeps_secrets_off_the_local_disk() {
+        assert!(StorageKind::Fs.secrets_are_plaintext_on_disk());
+        assert!(StorageKind::Sqlite.secrets_are_plaintext_on_disk());
+        assert!(!StorageKind::Mongodb.secrets_are_plaintext_on_disk());
+        // The default is the refusing side: a host that never resolved a
+        // backend must not be treated as one that keeps secrets safely.
+        assert!(StorageKind::default().secrets_are_plaintext_on_disk());
+    }
+
+    /// The refusal has to be actionable on its own — an operator reading it in
+    /// a console toast has nothing else to go on.
+    #[test]
+    fn the_refusal_names_the_condition_and_both_remedies() {
+        let message = plaintext_secret_refusal(StorageKind::Fs);
+        assert!(message.contains("OPENCOMPANY_STORAGE=fs"), "{message}");
+        assert!(message.contains("OPENCOMPANY_STORAGE=mongodb"), "{message}");
+        assert!(message.contains("OPENCOMPANY_MONGODB_URI"), "{message}");
+        assert!(message.contains("`repo` grant"), "{message}");
+        assert!(message.contains("plaintext"), "{message}");
+        // The named kind is the one actually in force, not a hard-coded "fs".
+        assert!(
+            plaintext_secret_refusal(StorageKind::Sqlite).contains("OPENCOMPANY_STORAGE=sqlite"),
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The in-repo half of #752: the threat model **C0**, and the fail-closed check
**C3**. `Part of #752` — the issue stays open. The load-bearing children (C1
default-deny egress, C2 pod `securityContext`, C5 short-lived installation
tokens) are in `opencompany-microservice` and cannot be closed from here.

**C0 — `docs/spec/security/agent-isolation.md`.** The threat model #245
deferred when the repo read tier shipped ("should be filed as a follow-up, not
claimed here") and nobody filed. It states what is enforced today and where,
what is not, and — the section that is the point — the attacker capability that
survives **every** control C1–C5, written as if they have all landed. That
section exists so nobody reads a closed child issue as "the shell is contained
now".

Three findings behind it, each re-verified in this branch:

1. **OpenCompany never sets a sandbox mode.** `ShellTool` routes to a sandbox
   backend only when the mode is `Sandboxed`
   (`vendor/openhuman/.../tools/impl/system/shell.rs`); `SandboxMode::default()`
   is `None` and grepping `src/` for `SandboxMode` / `jail` / `landlock` returns
   doc comments only. Every shell command is a direct child of the server
   process. `cwd_jail` is neither wired nor compiled — `sandbox-landlock` is
   absent from the tenant feature set in `deploy-staging.yml`.
2. **Landlock would not close the exfiltration channel.** From
   `vendor/openhuman/src/openhuman/sandbox/cwd_jail/README.md`, verbatim:
   *"Landlock does not gate network at all."*
3. **Secrets are plaintext on `/data`.** `FsSecretStore` says so in its own doc
   comment; `sqlite` puts the same bytes on the same disk. Readable by the uid
   the shell runs as.

A fourth turned up while writing it and is in the doc: **the shell audit log is
`<workspace>/audit.log`** — the agent's own working directory. Withholding
shell when the logger cannot initialise makes the log's *existence*
fail-closed; nothing makes its *integrity* so. An agent holding `shell` can
truncate the record of what it did.

**C3 — a repository credential requires `OPENCOMPANY_STORAGE=mongodb`.**

### Where the refusal went, and why

Three places, because each catches a case the others structurally cannot:

| Where | Catches | Why not the others |
| --- | --- | --- |
| `RepoManager::bind_validated` → `409 Conflict` | A new credential | The last moment the operator is still holding the token and can act — the same argument the classic-PAT refusal already makes one line below. In `bind_validated`, not `bind`, because that is the one funnel every bind path reaches including the one tests drive; a gate in the public wrapper is a gate the most realistic exercise walks past. |
| `RuntimeBuilder::build` → the company does not come up | A tenant that bound a credential **before** this gate existed | Bind-time cannot see it — that token is already on `/data` and its agents would keep checking out under it forever. Read over the **effective roster**, not `[tools].allow` alone: an agent naming `tools = ["repo"]` under a company `allow = ["*"]` holds an explicit grant the company line does not show, because the wildcard deliberately does not confer the namespace. |
| `build_agent` → repo tools withheld (gate 4 of 4) | A teammate added through the console on a **live** runtime | `HarnessPool::ensure` rebuilds that agent's belt each turn without going back through `build`, so the boot check never sees it. |

Bind-time alone leaves an already-bound tenant running. Boot alone is a worse
operator experience and misses the console path. The condition is asked once, in
`StorageKind::secrets_are_plaintext_on_disk`, and the message comes from one
function so an operator who meets it in a console toast and again in a boot log
does not have to work out whether they are two problems.

Deliberately **not** proposed: a shell command allowlist or regex blocklist.
That is this codebase's documented rejected anti-pattern and would be the wrong
centrepiece. Nothing here sandboxes or contains the shell, and the doc says so
in as many words.

## API Or Behavior Changes

**Breaking, and intended.** A deployment on `OPENCOMPANY_STORAGE=fs` (the
default) or `sqlite` that has bound a repository, or whose roster grants `repo`,
**will stop working**:

- `POST …/repos` answers `409 Conflict` instead of binding.
- A company whose effective roster grants `repo` **fails to start**, with
  `OpenCompanyError::Config`.
- On a live runtime, an agent granted `repo` gets no `repo_checkout` /
  `repo_pr`, with an `error`-visible warning.

Migration, named in the refusal itself: set `OPENCOMPANY_STORAGE=mongodb` with
`OPENCOMPANY_MONGODB_URI`, **or** drop the `repo` grant from the company's
`[tools]` allow list and from every agent naming it.

This is failing closed rather than warning on purpose. The deployments it
breaks are exactly the ones carrying a plaintext repository token on a disk
their own agents can read; a warning would leave that in place and call it
handled. Operators hitting it should also **revoke the bound credential at the
forge** — it has been readable for as long as it has been installed.

Hosted tenants are unaffected: the manager injects
`OPENCOMPANY_STORAGE=mongodb`.

New public API: `StorageKind::secrets_are_plaintext_on_disk()`,
`store::plaintext_secret_refusal()`, `RuntimeBuilder::with_storage_kind()`,
`RepoManager::with_storage_kind()` / `::secrets_are_plaintext_on_disk()`,
`AppState::storage_kind()`. `RuntimeBuilder` and `RepoManager` default to `Fs`
— the refusing side — so a caller that forgets to thread the backend through is
treated as unsafe rather than as safe.

## Tests

Modelled on #245's own `a_checkout_cannot_reach_the_mirror_it_came_from`: an
attack that must fail, not a unit test of the guard.

- `a_credential_cannot_be_installed_where_the_agent_shell_could_read_it` —
  installs a credential on a real `FsSecretStore`, then walks the company's
  whole on-disk footprint the way a shell with `cat`/`grep` would and finds
  nothing. Same call, same fixture remote as the accepted case; the only
  difference is the backend.
- `the_same_bind_is_accepted_where_secrets_leave_the_container` — the other
  half, without which the first only proves the feature is off. `sqlite` is
  refused alongside `fs` in the same test.
- `a_repo_granted_company_does_not_boot_on_a_plaintext_secret_backend` and
  `an_agent_that_names_repo_under_a_wildcard_company_is_caught_too`, against
  `the_same_company_boots_where_secrets_leave_the_container`.
- `binding_is_refused_on_a_host_that_keeps_secrets_on_its_own_disk` — the route,
  asserting `409`, the message, and that nothing was stored.
- Gate 4 folded into
  `repo_tools_are_wired_only_by_explicit_grant_a_manager_and_a_binding`.
- `only_mongodb_keeps_secrets_off_the_local_disk` and
  `the_refusal_names_the_condition_and_both_remedies`.

No test asserts on a real credential; every fixture token is an obvious dummy,
and two tests assert the refusal does **not** echo it.

**Teeth proof.** Each refusal was reverted in turn and every test observed
going RED, then restored. Verbatim:

```
---- runtime::repo_manager::test::a_credential_cannot_be_installed_where_the_agent_shell_could_read_it stdout ----
called `Result::unwrap_err()` on an `Ok` value: RepoBinding { key: "acme-widgets-…", … }

---- runtime::builder::test::a_repo_granted_company_does_not_boot_on_a_plaintext_secret_backend stdout ----
an fs host must refuse to bring up a repo-granted company: CompanyRuntime { id: CompanyId("acme"), … }

---- runtime::builder::test::an_agent_that_names_repo_under_a_wildcard_company_is_caught_too stdout ----
an agent-level `repo` grant must be caught at boot: CompanyRuntime { id: CompanyId("acme"), … }

---- harness::build::tests::repo_tools_are_wired_only_by_explicit_grant_a_manager_and_a_binding stdout ----
a repo grant on fs must wire nothing: [… "repo_checkout", "repo_pr"]
```

The accepted-case tests stayed green throughout, which is what makes the red
ones mean something.

Gate 4 also narrowed `every_registered_tool_is_declared`, whose widest-belt
fixture built its `RepoManager` with the default backend — and that test caught
it by name ("the belt builder stopped wiring `repo_checkout`, so this check has
narrowed without anyone deciding to narrow it"). The fixture now declares a
mongodb backend for the same reason it already declares a binding. Worth
recording: the coverage guard did exactly the job it was written for.

Commands run locally, with counts (a filter selecting nothing exits 0, so the
counts are the receipt):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings` — clean
- [x] `cargo build --all-targets` — via `cargo check --all-targets` and the test builds below
- [x] `cargo test --locked` — **2259 passed, 0 failed, 2 ignored** (2248 lib + 10 bin + 1 `desktop_e2e`)
- [x] `cargo test --features openhuman,mcp,telegram` — **3398 passed, 0 failed, 4 ignored** (3374 lib + 10 bin + 1 `desktop_e2e` + 11 `one_card_per_message` + 2 `product_identity`) (no CI lane builds this combo)

The MongoDB lane is not exercised: it skips silently without
`OPENCOMPANY_TEST_MONGODB_URI` while still exiting 0. Every "accepted on
mongodb" assertion here is against the **selection**, not a live MongoDB — which
is the right level, since the gate is on `OPENCOMPANY_STORAGE` and nothing else.

## Documentation

- `docs/spec/security/agent-isolation.md` — new (243 lines, under the 500-line
  cap). Linked from `docs/spec/README.md` (index + a Security reading path) and
  `docs/spec/runtime/README.md`.
- `docs/spec/runtime/storage.md` — a "Secrets at rest, and what that costs"
  section: the three enforcement points, the breaking change, and the migration.
- `docs/spec/runtime/repos.md` — the requirement as an intake rule, and its
  "The honest limit" section now points at the threat model it was owed.

`docs/spec/security/` has no `README.md`. The repo convention asks for one when
a topic *outgrows a file and splits into a directory*; this is one file. Happy
to add one if maintainers would rather every `docs/spec/` subdirectory have an
entrypoint.

Part of #752
