### PR TITLE
docs(harness): correct the claim that openhuman cannot resume a parked call (#561)

### DIFF
--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -39,9 +39,34 @@
 //! had to go back and ask for the same thing again — with the work having
 //! silently dead-ended in between.
 //!
-//! openhuman genuinely cannot be resumed here: it resolves a `RequireApproval`
-//! inline and the blocked call is gone by the time the operator sees it. So the
-//! call is not resumed, it is **re-issued**. Approving a parked harness effect
+//! The call is not resumed, it is **re-issued**, and the reason is narrower than
+//! this comment used to claim. It asserted openhuman "genuinely cannot be
+//! resumed"; that is false as a blanket statement and it is why nobody looked
+//! for years. openhuman never claimed impossibility — its own
+//! `ToolPolicyDecision::RequireApproval` doc says session execution
+//! *"currently"* treats the variant as fail-closed and that "callers that can
+//! prompt for approval may branch on this variant and retry". It even ships
+//! durable approval interrupt-and-resume already, for delegation, on tinyagents'
+//! graph executor. Two separate things are true (issue #561):
+//!
+//! * **Resolving inline is incidental.** openhuman blocks the call in one
+//!   `wrap_tool` middleware, and that hook is `async` and may call `next.run`
+//!   zero or more times — tinyagents' own `wrap_tool_retries_next_until_success`
+//!   pins that. Awaiting a verdict there and *then* dispatching is representable
+//!   today, with no upstream change.
+//! * **Durably suspending is structural.** The agent turn runs on
+//!   `AgentHarness`, which has no checkpointer; its `AgentRun` is not
+//!   `Serialize`; and the turn is a live async task holding the model context,
+//!   bounded by the run's wall-clock deadline.
+//!
+//! Which settles the design: an in-memory await survives neither a long approval
+//! nor a process restart, so against this crate's seven-day standing-grant
+//! ceiling it is a leak rather than a mechanism. Re-issuing is the honest answer
+//! here until the turn is checkpointable — see issue #561 for the full analysis,
+//! including why even the graph executor's `resume` *re-runs* its interrupted
+//! node rather than continuing a suspended call.
+//!
+//! Approving a parked harness effect
 //! mints a single-use [`GrantedCall`](crate::runtime::grants::GrantedCall)
 //! scoped to that agent, that tool and those exact arguments, and the
 //! [`HarnessBrain`](crate::harness::HarnessBrain) re-dispatches the granting


### PR DESCRIPTION
## Summary

**Comment only. No behaviour change.**

`src/harness/policy.rs` asserted that openhuman "genuinely cannot be resumed
here". That is false as a blanket statement, and the assertion is *why nobody
checked* — it reads as a settled fact while being an untested inference. Four
PRs (#612, #625, #633, #672) worked around the symptom without anyone verifying
the premise.

openhuman never claimed impossibility. Its own `ToolPolicyDecision::RequireApproval`
doc says session execution **currently** treats the variant as fail-closed, and
that "callers that can prompt for approval may branch on this variant and retry
after approval is granted". It also already ships durable approval
interrupt-and-resume — for delegation, on tinyagents' graph executor.

The comment now records the two things that are actually true, because only one
of them is a wall:

* **Resolving inline is incidental.** The block happens in a single `wrap_tool`
  middleware. That hook is `async` and may call `next.run` zero or more times —
  tinyagents pins exactly that with `wrap_tool_retries_next_until_success`.
  Awaiting a verdict there and *then* dispatching is representable today with no
  upstream change.
* **Durably suspending is structural.** The agent turn runs on `AgentHarness`,
  which has no checkpointer; `AgentRun` is not `Serialize`; and the turn is a
  live async task holding the model context, bounded by the run's wall-clock
  deadline.

And the sentence that decides the design, which is the one this correction
exists to put in front of the next reader: **an in-memory await survives neither
a long approval nor a process restart, so against this crate's seven-day
standing-grant ceiling it is a leak rather than a mechanism.** Re-issuing stays
correct here until the turn is checkpointable.

This PR deliberately **does not** implement suspend/resume and does not
recommend a shape. There are two candidate designs — a checkpointer on the agent
engine, versus a bounded in-memory await for short approvals — and that is a
human's decision, not one to take on the back of a comment fix.

Full analysis is on tinyhumansai/opencompany#561, including the detail that most
changes how that issue should be scoped: even the graph executor's `resume`
*re-runs* its interrupted node rather than continuing a suspended call. So
re-dispatch and the durable design are the same **kind** of mechanism at
different grain — the cost can be narrowed, but "approving costs a re-dispatch"
probably cannot be driven to zero.

Closes nothing. #561 stays open for the design decision; this only removes the
false premise that was standing in front of it.

## API Or Behavior Changes

None. Documentation comment only — no code, no signatures, no tests changed.

## Tests

- `cargo fmt --all -- --check` — exit 0
- `cargo check --locked --all-features --all-targets` — exit 0
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — exit 0
- `cargo test --features openhuman,tinycortex` — exit 0, **3388 passed, 0 failed**, 3 ignored

**No revert-and-check, stated deliberately rather than omitted.** This adds no
test and changes no behaviour, so there is nothing whose removal could turn a
test red; performing one would be exactly the vacuous green this repo's
process warns about. What was checked instead: the added text introduces **no**
`[...]` intra-doc links (verified against the added lines in isolation), so
rustdoc has no new reference to resolve and cannot break on it.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (run as the gated lane: `--locked --no-deps --features openhuman,tinycortex --all-targets`)
- [x] `cargo build --all-targets` (N/A as spelled — covered by `cargo check --locked --all-features --all-targets`, the stricter lane, which builds every target under every feature)
- [x] `cargo test` (run as `cargo test --features openhuman,tinycortex`)

## Documentation

This change *is* the documentation. Nothing under `docs/` states the
resume/re-dispatch rationale — it lives in this module header, which is where a
reader of the approval path arrives — so nothing there went stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified approval behavior in the harness, including that approval calls are re-issued rather than resumed.
  * Documented the distinction between inline approval handling and durable suspension across long waits or restarts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->