### PR TITLE
fix(workflows): thread upstream node output into agent node turns (#782)

### DIFF
--- a/src/workflows/agent_upstream_input_test.rs
+++ b/src/workflows/agent_upstream_input_test.rs
@@ -1,0 +1,280 @@
+//! Issue #782 — end-to-end proof that an upstream node's output reaches a
+//! downstream **agent** node's turn.
+//!
+//! # Why a unit test could not have caught this
+//!
+//! Every part worked in isolation: `translate` lowered an agent node, the engine
+//! resolved config `=`-expressions, and the runner composed a turn message. What
+//! was missing was the *join* — an agent node lowered to only a static `prompt`,
+//! so an upstream step's output had **no channel** into the next agent's turn and
+//! was silently dropped. A `trigger -> agent(analyst) -> agent(copywriter)`
+//! pipeline ran the copywriter with its authored instruction and nothing else, so
+//! it truthfully reported that "nothing has been pasted into our conversation".
+//!
+//! So this drives the **real** path — real graph, real `translate`, real
+//! `run_workflow`, real `HarnessAgentRunner`, real `HarnessPool` — and stubs only
+//! the model, via a content-aware OpenAI-compatible endpoint on loopback (the
+//! shape [`gated_tool_turn_test`](super::gated_tool_turn_test) established). The
+//! endpoint answers by *which node is calling* (each node's prompt carries a
+//! marker), so the assertions do not depend on the order sibling branches run in.
+
+use std::sync::{Arc, Mutex};
+
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::harness::HarnessPool;
+use crate::ports::WorkflowRunContext;
+use crate::ports::types::{CompanyId, CompanyRecord};
+
+use super::gated_tool_turn_test::deps;
+
+/// A company whose roster carries **distinct** teammates for every node, so no
+/// two agent nodes share a session.
+///
+/// This is load-bearing for what these tests prove. The harness keeps one live
+/// session per roster agent, and history survives across a session's turns — so
+/// if two nodes ran the *same* teammate, the downstream turn would see the
+/// upstream reply through **conversation history** whether or not #782's binding
+/// exists, and the test would pass even with the bug present. Distinct teammates
+/// (which is also the real bug's shape: an `analyst -> copywriter` hand-off is
+/// two different people) means the only path from one node's output to the next
+/// is the `input = "=items"` fold under test.
+fn record_with_agents(agent_ids: &[&str]) -> CompanyRecord {
+    let mut src = String::from("[company]\nname = \"Acme\"\n\n[policy]\nmode = \"full\"\n");
+    for id in agent_ids {
+        src.push_str(&format!(
+            "\n[[agent]]\nid = \"{id}\"\nrole = \"Worker\"\ntier = \"orchestrator\"\n"
+        ));
+    }
+    let manifest: CompanyManifest = toml::from_str(&src).expect("manifest parses");
+    CompanyRecord {
+        id: CompanyId::new("acme"),
+        manifest,
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// A model endpoint that answers by which node is calling. Each agent node's
+/// prompt carries a distinctive marker (`NODE_A_PROMPT` / `NODE_A2_PROMPT` /
+/// `NODE_B_PROMPT`); the reply for A/A2 is a marker a downstream turn must carry,
+/// and B's reply is inert. Order-independent by construction: the answer is a
+/// function of the request, not a position in a script.
+///
+/// The recorded request bodies (`seen`) are where a test reads what a given node
+/// was actually sent — the composed turn message rides in the `messages` array,
+/// so a node that received its predecessor's output shows that output here.
+struct Endpoint {
+    seen: Mutex<Vec<Value>>,
+}
+
+/// Serves the content-aware endpoint on loopback, returning its base URL and the
+/// shared handle so a test can read what each node's turn was sent.
+async fn spawn_endpoint() -> (String, Arc<Endpoint>) {
+    let endpoint = Arc::new(Endpoint {
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&endpoint);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let endpoint = Arc::clone(&endpoint);
+            async move {
+                let blob = serde_json::to_string(&body).unwrap_or_default();
+                endpoint.seen.lock().unwrap().push(body);
+                // `NODE_A2_PROMPT` is checked before `NODE_A_PROMPT` — the latter
+                // is not a substring of the former, but ordering keeps the intent
+                // obvious. B's request carries the A/A2 *outputs* (the markers
+                // below), never their prompts, so it falls through to the inert
+                // reply.
+                let content = if blob.contains("NODE_A2_PROMPT") {
+                    "A2_OUTPUT_MARKER"
+                } else if blob.contains("NODE_A_PROMPT") {
+                    "A_OUTPUT_MARKER"
+                } else {
+                    "B_INERT_REPLY"
+                };
+                Json(json!({
+                    "choices": [{
+                        "index": 0,
+                        "message": { "role": "assistant", "content": content }
+                    }],
+                    "usage": { "prompt_tokens": 8, "completion_tokens": 2 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), handle)
+}
+
+/// The request body a node's turn produced, found by the marker in its prompt.
+/// Panics with the full transcript if no such turn was recorded — a node that
+/// never ran is a more useful failure than a silent `None`.
+fn turn_containing(seen: &[Value], marker: &str) -> String {
+    seen.iter()
+        .map(|body| serde_json::to_string(body).unwrap_or_default())
+        .find(|blob| blob.contains(marker))
+        .unwrap_or_else(|| panic!("no model turn carried {marker}; saw: {seen:?}"))
+}
+
+/// The headline: `trigger -> agent(A) -> agent(B)`. A emits text; B's turn must
+/// carry it. Before #782 B saw only its own authored prompt.
+#[tokio::test]
+async fn a_downstream_agent_receives_the_upstream_agents_output() {
+    const GRAPH: &str = r#"
+id = "pipeline"
+name = "Pipeline"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "analyst"
+kind = "agent"
+name = "Analyst"
+summary = "NODE_A_PROMPT"
+agent = "analyst"
+[[node]]
+id = "copywriter"
+kind = "agent"
+name = "Copywriter"
+summary = "NODE_B_PROMPT"
+agent = "copywriter"
+[[edge]]
+from = "start"
+to = "analyst"
+[[edge]]
+from = "analyst"
+to = "copywriter"
+"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, endpoint) = spawn_endpoint().await;
+    let (deps, _journal) = deps(base_url, dir.path());
+    let record = record_with_agents(&["analyst", "copywriter"]);
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(GRAPH).expect("graph parses");
+    super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        json!({ "request": "launch the product" }),
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("the pipeline runs to completion");
+
+    let seen = endpoint.seen.lock().unwrap().clone();
+    // The copywriter's turn is the one carrying its own prompt marker.
+    let copywriter_turn = turn_containing(&seen, "NODE_B_PROMPT");
+    assert!(
+        copywriter_turn.contains("A_OUTPUT_MARKER"),
+        "the copywriter's turn must carry the analyst's output — the exact channel #782 restores: {copywriter_turn}"
+    );
+    assert!(
+        copywriter_turn.contains("Input from the previous step"),
+        "…delivered under the labelled heading: {copywriter_turn}"
+    );
+}
+
+/// Fan-in: `A, A2 -> merge -> agent(B)`. BOTH predecessors' output must reach B —
+/// the `=items` (whole set) binding is what stops a fan-in from losing all but
+/// the first.
+#[tokio::test]
+async fn a_fan_in_agent_receives_every_predecessors_output() {
+    const GRAPH: &str = r#"
+id = "fanin"
+name = "Fan-in"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "a"
+kind = "agent"
+name = "A"
+summary = "NODE_A_PROMPT"
+agent = "research_a"
+[[node]]
+id = "a2"
+kind = "agent"
+name = "A2"
+summary = "NODE_A2_PROMPT"
+agent = "research_b"
+[[node]]
+id = "combine"
+kind = "merge"
+name = "Combine"
+[[node]]
+id = "b"
+kind = "agent"
+name = "B"
+summary = "NODE_B_PROMPT"
+agent = "editor"
+[[edge]]
+from = "start"
+to = "a"
+[[edge]]
+from = "start"
+to = "a2"
+[[edge]]
+from = "a"
+to = "combine"
+[[edge]]
+from = "a2"
+to = "combine"
+[[edge]]
+from = "combine"
+to = "b"
+"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, endpoint) = spawn_endpoint().await;
+    let (deps, _journal) = deps(base_url, dir.path());
+    let record = record_with_agents(&["research_a", "research_b", "editor"]);
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(GRAPH).expect("graph parses");
+    super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        json!({ "request": "combine the research" }),
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("the fan-in runs to completion");
+
+    let seen = endpoint.seen.lock().unwrap().clone();
+    let b_turn = turn_containing(&seen, "NODE_B_PROMPT");
+    assert!(
+        b_turn.contains("A_OUTPUT_MARKER"),
+        "the first predecessor's output must reach the fan-in agent: {b_turn}"
+    );
+    assert!(
+        b_turn.contains("A2_OUTPUT_MARKER"),
+        "the second predecessor's output must too — a fan-in must not lose all but the first: {b_turn}"
+    );
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -606,8 +606,15 @@ impl AgentRunner for HarnessAgentRunner {
         request: Value,
         _conn: Option<&str>,
     ) -> TfResult<Value> {
-        let message =
-            compose_turn_message(&message_from_request(&request), self.run_request.as_deref());
+        // Issue #782: fold the resolved upstream node output into the turn.
+        // `translate` binds `input = "=items"` on every agent node, so the engine
+        // resolves it to the previous step's output before calling us; without
+        // this fold that output had no channel into the agent's turn and was
+        // dropped (a `agent -> agent` pipeline's second teammate saw nothing).
+        // The static `prompt` still leads (`message_from_request`); the upstream
+        // input is appended under a labelled heading, then the #154 run topic.
+        let instruction = append_upstream_input(&message_from_request(&request), &request);
+        let message = compose_turn_message(&instruction, self.run_request.as_deref());
         tracing::debug!(
             company = %self.company,
             agent = agent_ref,
@@ -659,6 +666,109 @@ fn message_from_request(request: &Value) -> String {
         }
     }
     request.to_string()
+}
+
+/// The heading under which an agent node's turn carries its upstream step's
+/// output (issue #782).
+const UPSTREAM_INPUT_HEADING: &str = "## Input from the previous step";
+
+/// Folds the resolved upstream node output into `instruction`.
+///
+/// `translate` binds `input = "=items"` on every agent node, so by the time the
+/// engine calls [`run_agent`](AgentRunner::run_agent) the request's `input` field
+/// holds the `json` of every predecessor item (the `=items` set). This appends a
+/// rendering of that output under [`UPSTREAM_INPUT_HEADING`], *after* the node's
+/// static instruction, so both the standing job (`prompt`) and this run's actual
+/// upstream data reach the teammate.
+///
+/// # The byte-identical no-upstream path
+///
+/// When there is no renderable upstream output — the `input` key is absent (a
+/// hand-built request, or a node whose binding an author cleared), it resolved to
+/// `null`/`[]`, or every item was empty — `instruction` is returned **unchanged**.
+/// A single-agent workflow with no predecessor therefore composes exactly the
+/// message it did before #782, never a dangling empty heading. `message` shape is
+/// then decided by [`compose_turn_message`] alone, as before.
+fn append_upstream_input(instruction: &str, request: &Value) -> String {
+    let Some(section) = request.get("input").and_then(render_upstream_input) else {
+        return instruction.to_string();
+    };
+    let instruction = instruction.trim_end();
+    if instruction.is_empty() {
+        format!("{UPSTREAM_INPUT_HEADING}\n{section}")
+    } else {
+        format!("{instruction}\n\n{UPSTREAM_INPUT_HEADING}\n{section}")
+    }
+}
+
+/// Renders the upstream envelope(s) an agent node received (`request["input"]`,
+/// the resolved `=items` set) into the text the agent reads.
+///
+/// Each predecessor item is a stable `{ json, text, raw }` envelope (see the
+/// tinyflows `envelope` module), so the human-readable `text` (an upstream
+/// agent's prose) is preferred; a non-agent node whose output carries no `text`
+/// (a `tool_call` / `transform` / `output` node) is rendered as pretty JSON.
+/// Multiple predecessors — a fan-in (`merge -> agent`) or several edges into one
+/// agent — are all rendered, separated by a rule, so none is lost.
+///
+/// Returns `None` when nothing is renderable — an empty set, all-`null` items, or
+/// empty containers — which is what keeps the no-upstream path byte-identical.
+fn render_upstream_input(input: &Value) -> Option<String> {
+    let items: Vec<&Value> = match input {
+        Value::Array(items) => items.iter().collect(),
+        Value::Null => return None,
+        other => vec![other],
+    };
+    let rendered: Vec<String> = items.into_iter().filter_map(render_upstream_item).collect();
+    (!rendered.is_empty()).then(|| rendered.join("\n\n---\n\n"))
+}
+
+/// Renders one upstream item into the text an agent reads.
+///
+/// A capability node's output is the stable `{ json, text, raw }` envelope, so an
+/// envelope is unwrapped to its meaningful content — the prose `text` when it
+/// carries any, else the structured `json` — never the whole envelope (whose
+/// `raw` merely duplicates one of the two). A non-envelope value (a trigger
+/// payload, a bare scalar) is rendered directly. `None` for anything with nothing
+/// worth showing — a `null`, a blank string, an empty container, or an envelope
+/// whose text is blank AND whose json is empty — so it is skipped rather than
+/// emitting a blank block or an empty heading.
+fn render_upstream_item(item: &Value) -> Option<String> {
+    match item {
+        Value::Null => None,
+        Value::String(text) => {
+            let text = text.trim();
+            (!text.is_empty()).then(|| text.to_string())
+        }
+        // The `{ json, text, raw }` envelope: prefer prose, fall back to the
+        // structured payload, skip when both are empty.
+        Value::Object(map) if is_envelope(map) => {
+            if let Some(text) = map.get("text").and_then(Value::as_str) {
+                let text = text.trim();
+                if !text.is_empty() {
+                    return Some(text.to_string());
+                }
+            }
+            map.get("json").and_then(render_upstream_item)
+        }
+        Value::Object(map) => {
+            if map.is_empty() {
+                return None;
+            }
+            Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string()))
+        }
+        Value::Array(inner) if inner.is_empty() => None,
+        _ => Some(serde_json::to_string_pretty(item).unwrap_or_else(|_| item.to_string())),
+    }
+}
+
+/// Whether `map` is a capability node's stable `{ json, text, raw }` output
+/// envelope (the tinyflows `envelope` contract every capability node emits), so
+/// [`render_upstream_item`] can unwrap it to its content rather than dumping the
+/// redundant `raw`. A plain upstream object (a trigger payload) has no such shape
+/// and is rendered whole.
+fn is_envelope(map: &serde_json::Map<String, Value>) -> bool {
+    map.contains_key("json") && map.contains_key("text") && map.contains_key("raw")
 }
 
 /// Combines a node's authored instruction with the operator's run request
@@ -1010,6 +1120,127 @@ mod tests {
         // No known string key: fall back to the serialized object.
         let out = message_from_request(&json!({ "agent_ref": "x" }));
         assert!(out.contains("agent_ref"));
+    }
+
+    // ── Issue #782: the upstream node's output reaches the next agent's turn ──
+
+    /// The headline. An `agent -> agent` pipeline's second teammate must receive
+    /// the first's output. `translate` binds `input = "=items"`, the engine
+    /// resolves it to the predecessor envelope, and this proves the runner folds
+    /// that envelope's prose into the turn — under a heading, AFTER the node's
+    /// own instruction, so both survive.
+    #[test]
+    fn upstream_output_is_folded_into_the_turn() {
+        // The shape the engine hands us: `prompt` (the node's static job) plus
+        // `input` (the resolved `=items`) — one predecessor agent envelope.
+        let request = json!({
+            "prompt": "Write the launch post.",
+            "input": [{ "json": {}, "text": "The analyst found a 20% MoM jump.", "raw": {} }],
+        });
+        let message = append_upstream_input(&message_from_request(&request), &request);
+        // The node's own instruction still leads.
+        assert!(message.starts_with("Write the launch post."), "{message}");
+        // …the upstream output is present, under its heading…
+        assert!(message.contains(UPSTREAM_INPUT_HEADING), "{message}");
+        assert!(
+            message.contains("The analyst found a 20% MoM jump."),
+            "the previous step's output must reach the turn: {message}"
+        );
+    }
+
+    /// Fan-in: a `merge -> agent` (or several edges into one agent) resolves
+    /// `=items` to EVERY predecessor, and all of them must be delivered — the
+    /// "loses all but the first" failure is exactly what `=items` (not `=item`)
+    /// guards against.
+    #[test]
+    fn fan_in_delivers_every_predecessor() {
+        let request = json!({
+            "prompt": "Combine the research.",
+            "input": [
+                { "json": {}, "text": "Predecessor A: market is up.", "raw": {} },
+                { "json": {}, "text": "Predecessor B: sentiment is positive.", "raw": {} },
+            ],
+        });
+        let message = append_upstream_input(&message_from_request(&request), &request);
+        assert!(
+            message.contains("Predecessor A: market is up."),
+            "first predecessor missing: {message}"
+        );
+        assert!(
+            message.contains("Predecessor B: sentiment is positive."),
+            "second predecessor missing — a fan-in must not lose all but the first: {message}"
+        );
+    }
+
+    /// A non-agent predecessor (a `tool_call` / `transform` / `output` node) has
+    /// no prose `text`, so its structured output is rendered as JSON rather than
+    /// dropped.
+    #[test]
+    fn a_structured_predecessor_is_rendered_as_json() {
+        let request = json!({
+            "prompt": "Summarise the fetch.",
+            "input": [{ "json": { "rows": 3 }, "text": null, "raw": { "rows": 3 } }],
+        });
+        let message = append_upstream_input(&message_from_request(&request), &request);
+        assert!(message.contains(UPSTREAM_INPUT_HEADING), "{message}");
+        assert!(
+            message.contains("\"rows\""),
+            "structured output rendered: {message}"
+        );
+    }
+
+    /// The byte-identical guarantee. A single-agent workflow with no predecessor
+    /// (no `input`, or an empty / all-null / empty-container `input`) composes
+    /// exactly the pre-#782 message — never a dangling empty heading.
+    #[test]
+    fn no_upstream_output_is_byte_identical() {
+        let base = "Draft the launch post.";
+        for input in [
+            None,
+            Some(json!(null)),
+            Some(json!([])),
+            Some(json!([null])),
+            Some(json!([{}])),
+            Some(json!([{ "json": {}, "text": "   ", "raw": {} }])),
+        ] {
+            let mut request = serde_json::Map::new();
+            request.insert("prompt".to_string(), json!(base));
+            if let Some(input) = input.clone() {
+                request.insert("input".to_string(), input);
+            }
+            let request = Value::Object(request);
+            assert_eq!(
+                append_upstream_input(&message_from_request(&request), &request),
+                base,
+                "input {input:?} must not alter the message or add an empty heading"
+            );
+            // And the whole composition (including the #154 run topic) is
+            // unchanged from what `compose_turn_message` alone would produce.
+            let instruction = append_upstream_input(&message_from_request(&request), &request);
+            assert_eq!(
+                compose_turn_message(&instruction, Some("ship dark mode")),
+                compose_turn_message(base, Some("ship dark mode")),
+                "the no-upstream path must leave the run-topic composition untouched"
+            );
+        }
+    }
+
+    /// Upstream output and the #154 run topic coexist: the node's instruction
+    /// leads, the previous step's output follows under its heading, and the run's
+    /// subject follows under its own — all three reach the teammate.
+    #[test]
+    fn upstream_output_and_run_topic_coexist() {
+        let request = json!({
+            "prompt": "Write the post.",
+            "input": [{ "json": {}, "text": "ANALYST_SAID_THIS", "raw": {} }],
+        });
+        let instruction = append_upstream_input(&message_from_request(&request), &request);
+        let message = compose_turn_message(&instruction, Some("dark mode launch"));
+        assert!(message.starts_with("Write the post."), "{message}");
+        assert!(message.contains(UPSTREAM_INPUT_HEADING), "{message}");
+        assert!(message.contains("ANALYST_SAID_THIS"), "{message}");
+        assert!(message.contains("Request for this run:"), "{message}");
+        assert!(message.contains("dark mode launch"), "{message}");
     }
 
     #[test]

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -15,6 +15,10 @@
 //! registry, or backend-proxied model — the shared architecture rule for this
 //! epic. The default build links none of it.
 
+/// Issue #782: end-to-end proof that an upstream node's output reaches a
+/// downstream agent node's turn (an `agent -> agent` pipeline passes data).
+#[cfg(test)]
+mod agent_upstream_input_test;
 pub mod caps;
 pub mod delivery;
 /// Issue #460: the company's `ApprovalPolicy` decides which `tool_call` nodes

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -33,7 +33,10 @@
 //! An **agent** node's roster teammate id becomes the tinyflows `agent_ref` in
 //! node config, which the engine's `agent` node routes to the injected
 //! `AgentRunner` — that is how a step lands on the harness pool (see
-//! [`super::caps`]). `tool_call` and `http_request` nodes are mapped
+//! [`super::caps`]). It also carries an `input = "=items"` binding (issue #782)
+//! so the engine resolves the full set of upstream node outputs into the node's
+//! config at run time, giving the agent a channel to the previous step's result
+//! (the runner folds it into the turn message; fan-in delivers every predecessor). `tool_call` and `http_request` nodes are mapped
 //! structurally and both execute for real: a `tool_call` node runs a Cell A
 //! toolbelt tool, fail-closed on the company's `[tools].allow` grants, and an
 //! `http_request` node routes through the SSRF-guarded `GuardedHttpClient` —
@@ -142,6 +145,18 @@ fn translate_node(def: &WorkflowNodeDef) -> Node {
     // 1. Derived defaults.
     if def.kind == WorkflowNodeKind::Agent {
         config.insert("prompt".to_string(), json!(prompt_for(def)));
+        // Issue #782: bind the FULL upstream node output so the agent's turn can
+        // reference what the previous step produced. `=items` resolves (via the
+        // engine's `resolve_config_traced`) to the `json` of every input item —
+        // i.e. every direct-predecessor item, so a fan-in (`merge -> agent`, or
+        // several edges into one agent) delivers ALL predecessors rather than
+        // silently losing all but the first. The runner folds the resolved value
+        // into the turn message (see `super::caps`); before this an agent node
+        // lowered to only a static `prompt`, so an upstream node's output had no
+        // channel to the next agent and was dropped. Kept in the derived-default
+        // layer (like `prompt`), so an author can override the binding with their
+        // own expression (e.g. `=nodes.<id>.item.text`) via node config.
+        config.insert("input".to_string(), json!("=items"));
     }
 
     // 2. User config overlay.
@@ -336,6 +351,32 @@ mod tests {
         );
     }
 
+    /// **Issue #782.** Every agent node carries an `input = "=items"` binding so
+    /// the engine resolves the full set of upstream node outputs into its config
+    /// at run time — the only channel an upstream step's output has to the next
+    /// agent's turn. `=items` (not `=item`) is deliberate: it is the whole
+    /// predecessor set, so a fan-in (`merge -> agent`) delivers every predecessor
+    /// rather than only the first.
+    #[test]
+    fn agent_node_binds_the_full_upstream_output() {
+        let file = parse_workflow(CAMPAIGN).expect("campaign parses");
+        let graph = translate(&file);
+        // Every translated agent node carries the binding…
+        for node in graph.nodes.iter().filter(|n| n.kind == NodeKind::Agent) {
+            assert_eq!(
+                node.config["input"], "=items",
+                "agent node {} must bind the full upstream output set",
+                node.id
+            );
+        }
+        // …and a non-agent node does not (the binding is agent-specific).
+        let research = graph.nodes.iter().find(|n| n.id == "research").unwrap();
+        assert!(
+            research.config.get("input").is_none(),
+            "a tool_call node carries no upstream-output binding"
+        );
+    }
+
     /// A condition node's `yes`/`no` labels become `true`/`false` branch ports.
     #[test]
     fn condition_labels_map_to_true_false_ports() {
@@ -398,7 +439,12 @@ mod tests {
         assert_eq!(config("brief"), json!({}));
         assert_eq!(
             config("strategist"),
-            json!({ "agent_ref": "brand_strategist", "prompt": "Turns the brief into an angle + outline." })
+            json!({
+                "agent_ref": "brand_strategist",
+                "prompt": "Turns the brief into an angle + outline.",
+                // Issue #782: the upstream-output binding every agent node carries.
+                "input": "=items"
+            })
         );
         // The gate carries its boolean discriminant (issue #661): a condition
         // node must name the `field` it branches on.
@@ -415,7 +461,9 @@ mod tests {
             config("publish"),
             json!({
                 "agent_ref": "copywriter",
-                "prompt": "Assemble the publish-ready post and hero-image reference, then hand off for operator sign-off."
+                "prompt": "Assemble the publish-ready post and hero-image reference, then hand off for operator sign-off.",
+                // Issue #782: the upstream-output binding every agent node carries.
+                "input": "=items"
             })
         );
         assert_eq!(config("done"), json!({}));


### PR DESCRIPTION
## Summary

Agent nodes were being lowered to a static prompt only, so an upstream node's output never reached the next agent's turn. Multi-agent pipelines silently broke — observed live, a copywriter step reported that "nothing has been pasted into our conversation" even though an analyst node ran immediately before it.

The fix lives entirely in `src/workflows/` (no vendored change):

- `translate.rs` now binds upstream output onto agent nodes via `input="=items"`, so the full set of predecessor outputs is threaded in (fan-in safe — every predecessor is delivered, not just one).
- `caps/mod.rs` folds the resolved upstream input into the agent's turn under a heading, preserving the existing #154 run-topic behavior and keeping a byte-identical turn for the no-predecessor path.

Closes #782

## API Or Behavior Changes

Behavior change (no public API change): an agent node that has one or more predecessor nodes now receives those predecessors' outputs as part of its turn, under a heading, instead of only its static prompt. Fan-in nodes receive all predecessor outputs. An agent node with no predecessors produces a byte-identical turn to before this change.

## Tests

Gated lane run locally on the merged tree (base synced to `upstream/main` @ `644bedf7`), toolchain `1.96.1` (matches CI `dtolnay/rust-toolchain@stable`):

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean
- [x] `cargo check --all-targets` — clean
- [x] `cargo check --all-features` — clean
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — **3398 passed, 0 failed, 3 ignored** (lib) + all integration binaries green

New coverage added in `src/workflows/agent_upstream_input_test.rs`: end-to-end tests proving an analyst → copywriter chain flows the analyst's output into the copywriter's turn, and that a fan-in node delivers all of its predecessors' outputs.

Note on the test run: the lib test binary aborts with a stack overflow in an unrelated `harness::brain` test under the default debug thread-stack size; it passes cleanly under `RUST_MIN_STACK=16777216`. This is a local debug-stack artifact only — upstream CI on the same base SHA (`644bedf7`) is green, and this PR touches only `src/workflows/`.

**Honest note:** not verified on a live host — the tenant deploy was out of scope this pass. The deterministic end-to-end tests stand in for the live copywriter-pipeline reproduction.

## Documentation

No docs change needed — this restores intended agent-node data flow rather than introducing a new surface.
