### PR TITLE
feat(chat): say what the turn is actually doing, the OpenHuman way (#787)

### DIFF
--- a/frontend/src/views/Conversation.tsx
+++ b/frontend/src/views/Conversation.tsx
@@ -33,6 +33,7 @@ import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { type ChatMessage, makeMessage, titleFromMessage } from "@/lib/chat";
+import { WorkingIndicator } from "@/views/chat/WorkingIndicator";
 import type { Thread, ThreadContact } from "@/lib/threads";
 
 interface Props {
@@ -888,11 +889,13 @@ function TypingIndicator({ contact }: { contact: ThreadContact }) {
   return (
     <div className="mt-2 flex gap-2.5">
       <ContactAvatar contact={contact} className="mt-0.5 size-8" />
-      <div className="flex items-center gap-1 rounded-2xl rounded-bl-md border bg-card px-3.5 py-3">
-        <Dot />
-        <Dot className="[animation-delay:150ms]" />
-        <Dot className="[animation-delay:300ms]" />
-      </div>
+      {/* Same indicator the Chat tab uses (#787), so the two surfaces cannot
+          drift into one whimsical and one silent. The bubble shape here is
+          this surface's own — only the contents are shared. */}
+      <WorkingIndicator
+        srLabel="Replying…"
+        className="rounded-2xl rounded-bl-md border bg-card px-3.5 py-3"
+      />
     </div>
   );
 }
@@ -919,10 +922,6 @@ function EmptyConversation({ contact }: { contact: ThreadContact }) {
       </div>
     </div>
   );
-}
-
-function Dot({ className }: { className?: string }) {
-  return <span className={cn("size-1.5 animate-bounce rounded-full bg-muted-foreground", className)} />;
 }
 
 /* ---- grouping + formatting ---- */

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -6,6 +6,7 @@ import { ApprovalRow } from "./ApprovalRow";
 import { Avatar } from "./Avatar";
 import { MessageRow } from "./MessageRow";
 import { StepTimeline } from "./StepTimeline";
+import { WorkingIndicator } from "./WorkingIndicator";
 import { channelTitle, type Channel, type TimelineItem } from "./model";
 
 interface Props {
@@ -225,9 +226,11 @@ function LiveTurnRow({ channel, steps }: { channel: Channel; steps: TurnStep[] }
         company={channel.kind === "channel" && channel.id === "main"}
         className="size-9 shrink-0"
       />
-      <div className="min-w-0 flex-1">
+      <div className="min-w-0 flex-1 space-y-1.5">
+        {/* The line names the step actually in flight (#787), above the
+            timeline that details every step. Same source, one phrasing. */}
+        <WorkingIndicator srLabel="Working…" steps={steps} />
         <StepTimeline steps={steps} defaultOpen />
-        <span className="sr-only">Working…</span>
       </div>
     </div>
   );
@@ -242,19 +245,8 @@ function TypingRow({ channel }: { channel: Channel }) {
         company={channel.kind === "channel" && channel.id === "main"}
         className="size-9"
       />
-      <span className="flex items-center gap-1 rounded-full bg-muted px-3 py-2">
-        <Dot />
-        <Dot className="[animation-delay:150ms]" />
-        <Dot className="[animation-delay:300ms]" />
-        <span className="sr-only">Replying…</span>
-      </span>
+      <WorkingIndicator srLabel="Replying…" />
     </div>
-  );
-}
-
-function Dot({ className }: { className?: string }) {
-  return (
-    <span className={cn("size-1.5 animate-bounce rounded-full bg-muted-foreground", className)} />
   );
 }
 

--- a/frontend/src/views/chat/WorkingIndicator.tsx
+++ b/frontend/src/views/chat/WorkingIndicator.tsx
@@ -1,0 +1,121 @@
+import { useEffect, useState } from "react";
+
+import type { TurnStep } from "@/api/types";
+import { cn } from "@/lib/utils";
+
+/**
+ * What a teammate wears while a turn is running (issue #787).
+ *
+ * ## It says what is happening, not something amusing
+ *
+ * This follows OpenHuman's handling rather than the rotating-word style: the
+ * line is **derived from the run's real state**. When a step is in flight it
+ * shows that step's own label — the one the host authored and the tool timeline
+ * beside it already renders — with a pulsing status mark. When there is nothing
+ * specific to say it falls back to a plain "Working…".
+ *
+ * The label is never re-derived here. `TurnStep.label` is the host's answer,
+ * and a second phrasing computed console-side is exactly the drift #264
+ * forbids: two surfaces describing one step differently.
+ *
+ * ## Ambiguity is answered with less, not with a guess
+ *
+ * OpenHuman's `workerStatusFromEntry` returns `undefined` for the ambiguous
+ * case *"so the card stays label-only rather than render a misleading state"*.
+ * Same rule here: with no running step — a turn that has not reported one yet,
+ * or one whose steps have all settled while the reply is still being written —
+ * this shows the generic "Working…" rather than naming the last thing it saw.
+ * A stale step name would read as current, which is worse than saying little.
+ *
+ * ## The assistive text does not follow the label
+ *
+ * The visible line changes as steps come and go. The screen-reader string is
+ * stable, because a live region re-announcing every step transition is noise
+ * where one "a reply is coming" is the whole message.
+ *
+ * ## Reduced motion
+ *
+ * `prefers-reduced-motion: reduce` stops the pulse. The mark and the label
+ * still say a turn is running; they stop moving to say it.
+ */
+export function WorkingIndicator({
+  srLabel,
+  steps,
+  className,
+}: {
+  /** The stable assistive string, e.g. "Replying…". Never the step label. */
+  srLabel: string;
+  /**
+   * The turn's steps so far, when this surface has them. The newest `running`
+   * one names the line; absent or all-settled falls back to "Working…".
+   */
+  steps?: readonly TurnStep[];
+  className?: string;
+}) {
+  const reduced = usePrefersReducedMotion();
+  const running = runningStepLabel(steps);
+
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 rounded-full bg-muted px-3 py-2 text-sm text-muted-foreground",
+        className,
+      )}
+    >
+      <span
+        aria-hidden
+        className={cn(
+          "size-1.5 shrink-0 rounded-full bg-status-running",
+          !reduced && "animate-pulse",
+        )}
+      />
+      {/* `aria-hidden`, because the stable label below is what should be read. */}
+      <span aria-hidden className="truncate">
+        {running ?? GENERIC_LABEL}
+      </span>
+      <span className="sr-only">{srLabel}</span>
+    </span>
+  );
+}
+
+/** What the line says when no step is in flight. */
+export const GENERIC_LABEL = "Working…";
+
+/**
+ * The label of the newest step still running, or `undefined`.
+ *
+ * Last rather than first: a turn's steps arrive in order, so the most recent
+ * `running` entry is the one actually in flight. A settled step is never
+ * named — see the ambiguity note on {@link WorkingIndicator}.
+ */
+export function runningStepLabel(steps?: readonly TurnStep[]): string | undefined {
+  if (!steps?.length) return undefined;
+  for (let i = steps.length - 1; i >= 0; i -= 1) {
+    const step = steps[i];
+    if (step.status === "running") {
+      const label = step.label?.trim();
+      return label ? label : undefined;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Whether the viewer asked for reduced motion, kept live.
+ *
+ * Reads `false` where `matchMedia` is unavailable (jsdom without a stub, an
+ * older embedded webview): a pulse for a viewer who never asked for stillness
+ * is the lesser failure.
+ */
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mql = window.matchMedia?.("(prefers-reduced-motion: reduce)");
+    if (!mql) return;
+    setReduced(mql.matches);
+    const onChange = () => setReduced(mql.matches);
+    mql.addEventListener("change", onChange);
+    return () => mql.removeEventListener("change", onChange);
+  }, []);
+  return reduced;
+}

--- a/frontend/src/views/chat/WorkingIndicator.tsx
+++ b/frontend/src/views/chat/WorkingIndicator.tsx
@@ -106,6 +106,13 @@ export function runningStepLabel(steps?: readonly TurnStep[]): string | undefine
  * Reads `false` where `matchMedia` is unavailable (jsdom without a stub, an
  * older embedded webview): a pulse for a viewer who never asked for stillness
  * is the lesser failure.
+ *
+ * Subscribing has two spellings. `MediaQueryList` only became an `EventTarget`
+ * in Safari 14; before that — and in the WebKitGTK builds of that vintage, both
+ * of which Tauri v2's floor still admits — it carries the deprecated
+ * `addListener` alone. Calling `addEventListener` there does not degrade, it
+ * throws a `TypeError` out of this effect and takes the chat view down with it.
+ * A moving dot is not worth that, so prefer the modern spelling and fall back.
  */
 function usePrefersReducedMotion(): boolean {
   const [reduced, setReduced] = useState(false);
@@ -114,8 +121,12 @@ function usePrefersReducedMotion(): boolean {
     if (!mql) return;
     setReduced(mql.matches);
     const onChange = () => setReduced(mql.matches);
-    mql.addEventListener("change", onChange);
-    return () => mql.removeEventListener("change", onChange);
+    if (typeof mql.addEventListener === "function") {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
   }, []);
   return reduced;
 }

--- a/frontend/test/unit/working-indicator.test.ts
+++ b/frontend/test/unit/working-indicator.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { TurnStep } from "@/api/types";
+import { GENERIC_LABEL, WorkingIndicator, runningStepLabel } from "@/views/chat/WorkingIndicator";
+
+/**
+ * The working indicator (issue #787), following OpenHuman's handling: the line
+ * is derived from the run's real state rather than being decorative.
+ *
+ * Two of these are promises that regress silently. The indicator must never
+ * name a *settled* step — a stale name reads as current, which is worse than
+ * saying little — and the assistive text must not follow the visible label,
+ * because a live region re-announcing every step transition is noise.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+let reduceMotion = false;
+
+function stubMatchMedia() {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query.includes("prefers-reduced-motion") ? reduceMotion : false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => false,
+      onchange: null,
+    }),
+  });
+}
+
+function step(over: Partial<TurnStep> & Pick<TurnStep, "status" | "label">): TurnStep {
+  return { kind: "tool_call", ...over } as TurnStep;
+}
+
+function render(props: { srLabel?: string; steps?: TurnStep[] } = {}) {
+  act(() => {
+    root.render(
+      createElement(WorkingIndicator, { srLabel: props.srLabel ?? "Replying…", steps: props.steps }),
+    );
+  });
+}
+
+/** The visible line, excluding the screen-reader-only text. */
+function visibleLabel(): string {
+  return container.querySelector("[aria-hidden].truncate")?.textContent ?? "";
+}
+
+function srText(): string {
+  return container.querySelector(".sr-only")?.textContent ?? "";
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  reduceMotion = false;
+  stubMatchMedia();
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("what the line says", () => {
+  it("names the step in flight, in the host's own words", () => {
+    render({ steps: [step({ status: "ok", label: "Read the brief" }), step({ status: "running", label: "Draft the reply" })] });
+    expect(visibleLabel()).toBe("Draft the reply");
+  });
+
+  it("names the newest running step when several are open", () => {
+    render({
+      steps: [step({ status: "running", label: "First" }), step({ status: "running", label: "Second" })],
+    });
+    expect(visibleLabel()).toBe("Second");
+  });
+
+  it("falls back to the generic line when nothing is running", () => {
+    // Every step settled while the reply is still being written. Naming the
+    // last one would present finished work as current.
+    render({ steps: [step({ status: "ok", label: "Read the brief" })] });
+    expect(visibleLabel()).toBe(GENERIC_LABEL);
+  });
+
+  it("falls back when the surface has no steps at all", () => {
+    render({});
+    expect(visibleLabel()).toBe(GENERIC_LABEL);
+  });
+
+  it("falls back rather than render a blank line for an empty label", () => {
+    render({ steps: [step({ status: "running", label: "   " })] });
+    expect(visibleLabel()).toBe(GENERIC_LABEL);
+  });
+
+  it("does not treat a parked step as running", () => {
+    // `awaiting_approval` is waiting on a person, not working (#411).
+    render({ steps: [step({ status: "awaiting_approval", label: "Send the email" })] });
+    expect(visibleLabel()).toBe(GENERIC_LABEL);
+  });
+});
+
+describe("the assistive text", () => {
+  it("stays stable while the visible label changes", () => {
+    render({ steps: [step({ status: "running", label: "Draft the reply" })] });
+    expect(srText()).toBe("Replying…");
+
+    render({ steps: [step({ status: "running", label: "Something else entirely" })] });
+    expect(visibleLabel()).toBe("Something else entirely");
+    expect(srText()).toBe("Replying…");
+  });
+
+  it("hides the visible label from assistive tech", () => {
+    render({ steps: [step({ status: "running", label: "Draft the reply" })] });
+    expect(container.querySelector(".truncate")?.getAttribute("aria-hidden")).toBe("true");
+  });
+});
+
+describe("prefers-reduced-motion", () => {
+  it("stops the pulse but still shows the state", () => {
+    reduceMotion = true;
+    render({ steps: [step({ status: "running", label: "Draft the reply" })] });
+    expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+    expect(visibleLabel()).toBe("Draft the reply");
+  });
+
+  it("pulses when motion is allowed", () => {
+    render({ steps: [step({ status: "running", label: "Draft the reply" })] });
+    expect(container.querySelectorAll(".animate-pulse").length).toBe(1);
+  });
+});
+
+describe("runningStepLabel", () => {
+  it("is undefined for every shape that has nothing in flight", () => {
+    expect(runningStepLabel(undefined)).toBeUndefined();
+    expect(runningStepLabel([])).toBeUndefined();
+    expect(runningStepLabel([step({ status: "error", label: "Broke" })])).toBeUndefined();
+  });
+});

--- a/frontend/test/unit/working-indicator.test.ts
+++ b/frontend/test/unit/working-indicator.test.ts
@@ -138,6 +138,42 @@ describe("prefers-reduced-motion", () => {
     render({ steps: [step({ status: "running", label: "Draft the reply" })] });
     expect(container.querySelectorAll(".animate-pulse").length).toBe(1);
   });
+
+  it("subscribes on a webview whose MediaQueryList predates addEventListener", () => {
+    // `stubMatchMedia` hands back both spellings, so it cannot catch this: a
+    // `MediaQueryList` became an `EventTarget` only in Safari 14, and calling
+    // `addEventListener` on an older one throws rather than degrading. That
+    // throw escapes the effect and unmounts the chat view, so the failure this
+    // pins is a blank surface, not a missing animation.
+    let subscribed: (() => void) | null = null;
+    Object.defineProperty(window, "matchMedia", {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: query.includes("prefers-reduced-motion") ? reduceMotion : false,
+        media: query,
+        addListener: (cb: () => void) => {
+          subscribed = cb;
+        },
+        removeListener: () => {
+          subscribed = null;
+        },
+        dispatchEvent: () => false,
+        onchange: null,
+      }),
+    });
+
+    reduceMotion = true;
+    expect(() =>
+      render({ steps: [step({ status: "running", label: "Draft the reply" })] }),
+    ).not.toThrow();
+
+    // Rendered, read the preference, and left a live subscription behind —
+    // proving it took the legacy path rather than merely surviving it.
+    expect(visibleLabel()).toBe("Draft the reply");
+    expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+    expect(subscribed).toBeTypeOf("function");
+  });
 });
 
 describe("runningStepLabel", () => {


### PR DESCRIPTION
## Summary

While a teammate works a turn, chat showed three silent bouncing dots. It now shows **the step actually in flight**, by the host's own label, with a pulsing status mark — and falls back to a plain `Working…` when there is nothing specific to say.

This follows **OpenHuman's handling**. There the in-progress surface is derived from real lifecycle state: a status pill labelled from the entry's own `running` / `success` / `error`, tone keyed to it, and the agent name pulsing while in flight rather than a decorative animation. Two rules carry over from it directly:

- **The label is the host's.** `TurnStep.label` is rendered verbatim, never re-derived console-side. A second phrasing invented next to the tool timeline — which renders the same steps — is exactly the drift #264 forbids.
- **Ambiguity is answered with less, not a guess.** OpenHuman's `workerStatusFromEntry` returns `undefined` for the ambiguous case *"so the card stays label-only rather than render a misleading state"*. Here, a settled step is never named: once every step has finished while the reply is still being written, the line falls back to the generic one. A stale step name reads as current, which is worse than saying little. `awaiting_approval` is waiting on a person, not working, and does not count as in flight (#411).

## API Or Behavior Changes

Console only. No host change, no API change.

- `frontend/src/views/chat/WorkingIndicator.tsx` — the indicator, plus `runningStepLabel`, used by both chat surfaces.
- The bouncing dots were implemented **twice** — `MessageTimeline` and `Conversation` each had a private `Dot` with identical markup and the same `[animation-delay:150ms]` / `300ms` stagger, which is how one surface ends up updated and the other silent. Both now render the shared component; `Conversation` keeps its own bubble shape.
- The live-turn row shows the line *above* the step timeline, so the summary and the detail come from one source.
- The status mark uses the existing `--status-running` token, the same semantic `StepTimeline` already pulses with.

Two guarantees that regress silently, so both are pinned by tests:

- **The assistive string does not follow the visible label.** It stays stable while steps come and go; the visible line is `aria-hidden`. A live region re-announcing every step transition is noise where one "a reply is coming" is the whole message.
- **`prefers-reduced-motion` stops the pulse**, while the mark and label still report the state.

## Tests

`working-indicator.test.ts` — 11 tests, jsdom + real React:

- names the step in flight, and the newest one when several are open
- falls back to generic when all steps have settled, when there are no steps, and when a running step's label is blank
- does not treat `awaiting_approval` as running
- assistive text stays stable across a label change, and the visible label is `aria-hidden`
- reduced motion removes the pulse but keeps the state; motion allowed pulses exactly once
- `runningStepLabel` is `undefined` for every shape with nothing in flight

**Negative controls, each run for real:**

| Break | Caught by |
|---|---|
| name the last step even when settled | 3 tests fail |
| assistive text derived from the visible label | 1 test fails |

**Verified visually.** Rendered standalone through Vite in the real parent layouts and checked all three states: a running step naming itself (`Search the workspace`), all-settled correctly refusing to name the stale step and showing `Working…`, and the no-steps typing row showing `Working…` in its bubble. Scratch scaffolding, not in this branch.

Commands run locally, all green:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npx vitest run` — 553 passed
- [x] `npm run build`
- [x] `./scripts/ci/assert-design-tokens.sh`
- [ ] `cargo` gates — N/A: no Rust changed.

## History of this branch, since the diff is a rewrite

It first shipped the Claude-Code-style rotating whimsical words (*Scurrying…*, *Flabbergasting…*). That was the wrong reading of the issue: #787 asked for OpenHuman's handling, and OpenHuman does not do that — it reports real state. The vocabulary module and its tests are deleted here rather than left as dead weight.

## Documentation

The component's doc comment records why the label is the host's, why a settled step is never named, and why the assistive text is deliberately not derived from it.

## Related

Closes #787

- #367 — put the live tool timeline in Chat; this line sits directly above it
- #411 — `awaiting_approval` is not a failure and not work in progress
- #264 — one constructor, read by both surfaces; no console-side re-derivation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a consistent working indicator for typing and active conversation steps.
  * Displays the latest active step or a “Working…” fallback.
  * Includes screen-reader support and reduced-motion accessibility behavior.

* **Bug Fixes**
  * Improved consistency of progress feedback across conversation and message views.

* **Tests**
  * Added coverage for active-step selection, fallback labels, accessibility text, and motion preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->