### PR TITLE
fix(workflows): purge the schedule fire ledger when a workflow is deleted (#708)

### DIFF
--- a/docs/spec/runtime/ports.md
+++ b/docs/spec/runtime/ports.md
@@ -39,6 +39,7 @@ event vocabulary those traits carry moved to [`events.md`](events.md)
 | `RunStore` | [ports-runs.md](ports-runs.md#runstore) | one attempt at a task, and its trace |
 | `WorkflowRevisionStore` | [`src/ports/workflow_revisions.rs`](../../../src/ports/workflow_revisions.rs) | a bounded per-workflow edit-history ring for rollback (issue #274) |
 | `JournalStore` | [journal.md](journal.md) | the runtime journal's durable sink: at-most-once effect keys, parked approvals, grants, cycle brackets (issue #726) |
+| `ScheduleFireStore` | [`src/ports/schedule_fires.rs`](../../../src/ports/schedule_fires.rs) | durable per-`(company, schedule, minute)` fire claims: at-most-once firing across replicas and restarts, purged per schedule on workflow delete (issues #241, #708) |
 
 ## Assembly
 
@@ -78,6 +79,7 @@ the multi-tenant platform case with the same type.
 | `UserStore`, `SessionStore`, `LoginCodeStore` | fs bundle | sqlite, mongodb |
 | `ArtifactStore`, `RunStore`, `WorkflowRevisionStore` | fs bundle (JSONL) | sqlite, mongodb |
 | `JournalStore` | fs bundle (`journal.jsonl`) | sqlite, mongodb |
+| `ScheduleFireStore` | fs bundle (`O_EXCL` marker files, single-node) | sqlite, mongodb (the hosted arbiter) |
 
 ### `WorkflowRevisionStore` (issue #274)
 

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -158,7 +158,6 @@ use crate::company::{
     required_config_problems,
 };
 use crate::error::{OpenCompanyError, Result};
-use crate::ports::CompanyStore;
 use crate::ports::events::EventLog;
 use crate::ports::now_millis;
 use crate::ports::store::company_write_lock;
@@ -166,6 +165,8 @@ use crate::ports::types::{
     CompanyEvent, CompanyId, CompanyRecord, OverlayWorkflow, WorkflowEnabledReason,
 };
 use crate::ports::workflow_revisions::{WorkflowRevisionRecord, WorkflowRevisionStore};
+use crate::ports::{CompanyStore, ScheduleFireStore};
+use crate::runtime::workflow_schedule_id;
 use crate::server::ops::language;
 
 /// Max nodes a freshly authored graph may declare. A larger graph is refused
@@ -1346,13 +1347,28 @@ pub(crate) async fn set_company_workflow_enabled(
 /// version token, so "delete the thing I was looking at" can't remove something
 /// that changed underneath the operator.
 ///
+/// After the committed save, three best-effort cascades tear down what the
+/// workflow leaves behind: its durable scheduler fire ledger (issue #708), its
+/// revision history (issue #274), and an audit-journal entry. The fire-ledger
+/// purge runs **first** and **only after** the save has committed and the write
+/// lock is dropped: purging before a successful save could strip a still-live
+/// workflow's claim rows on a save failure (a #241-class cross-replica
+/// double-fire); purging after means a delete+recreate of the same id — which
+/// reuses the restart-stable `workflow-<id>` schedule key — starts against an
+/// empty ledger, with no inherited anchor and every past minute claimable
+/// again. A purge failure is logged, never rolled back: the workflow is already
+/// gone, and the worst case is one bounded, logged reinstatement of the old
+/// pre-fix behaviour — the same contract as the revision cascade below.
+///
 /// Returns the removed workflow's display name for the audit journal (falling
 /// back to the id when the stored body no longer parses).
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn delete_company_workflow(
     company: &CompanyId,
     source_dir: Option<&Path>,
     store: &Arc<dyn CompanyStore>,
     revisions: &Arc<dyn WorkflowRevisionStore>,
+    schedule_fires: Option<&Arc<dyn ScheduleFireStore>>,
     events: Option<&Arc<dyn EventLog>>,
     wid: &str,
     expected_version: Option<&str>,
@@ -1391,6 +1407,35 @@ pub(crate) async fn delete_company_workflow(
     store.save(&record).await?;
 
     drop(_lock);
+
+    // Issue #708: purge the schedule's durable fire ledger, minting the key at
+    // the ONE authoritative site (`workflow_schedule_id`) so this key can never
+    // drift from the scheduler's. This runs AFTER the committed save on purpose
+    // (see the doc): purging before a save that then fails would strip a
+    // still-live workflow's claim rows and risk a #241-class double-fire.
+    // Best-effort, exactly like the revision cascade below: the workflow is
+    // already gone, so a failure is logged rather than rolled back — a leftover
+    // ledger merely re-instates the bounded pre-fix behaviour once, on a
+    // recreate of the same id.
+    //
+    // `schedule_fires` is `Option` for the same reason `events` is: not every
+    // caller wires it. The HTTP delete path passes the runtime store (`Some`) —
+    // that is the path a scheduled workflow can be deleted from, so it is the
+    // only one that can orphan a ledger. The agent `delete_workflow` tool passes
+    // `None`, and correctly: it refuses to delete a scheduled workflow at all
+    // (`refuse_scheduled`), so no fire ledger can exist for it to leave behind.
+    if let Some(fires) = schedule_fires {
+        let schedule_id = workflow_schedule_id(wid);
+        if let Err(err) = fires.delete_schedule_fires(company, &schedule_id).await {
+            tracing::warn!(
+                company = %company,
+                workflow = %wid,
+                schedule = %schedule_id,
+                error = %err,
+                "workflow deleted but its schedule fire ledger could not be purged"
+            );
+        }
+    }
 
     // Issue #274: cascade the workflow's revision history away with it, so a
     // removed workflow leaves no orphaned snapshots behind. Best-effort in the
@@ -1637,6 +1682,88 @@ mod tests {
     /// hold their own `Arc<MemRevisions>` so they can read it back.
     fn revs() -> Arc<dyn WorkflowRevisionStore> {
         Arc::new(MemRevisions::default())
+    }
+
+    /// An in-memory [`ScheduleFireStore`] so the delete-time fire-ledger purge
+    /// (issue #708) can be asserted without a real backend. Only the verbs the
+    /// delete path exercises need real behaviour; `claim_fire` seeds a ledger
+    /// and `delete_schedule_fires` purges one schedule's rows.
+    #[derive(Default)]
+    struct MemFires {
+        /// `(company, schedule_id) -> claimed minutes`.
+        rows: StdMutex<std::collections::HashMap<(String, String), std::collections::HashSet<u64>>>,
+        /// Arm the next `delete_schedule_fires` call to error, to prove the
+        /// delete succeeds even when the purge cascade fails.
+        fail_delete: std::sync::atomic::AtomicBool,
+    }
+
+    impl MemFires {
+        fn seed(&self, company: &CompanyId, schedule_id: &str, minute: u64) {
+            self.rows
+                .lock()
+                .unwrap()
+                .entry((company.as_ref().to_string(), schedule_id.to_string()))
+                .or_default()
+                .insert(minute);
+        }
+        fn minutes(&self, company: &CompanyId, schedule_id: &str) -> Vec<u64> {
+            let rows = self.rows.lock().unwrap();
+            let mut ms: Vec<u64> = rows
+                .get(&(company.as_ref().to_string(), schedule_id.to_string()))
+                .map(|set| set.iter().copied().collect())
+                .unwrap_or_default();
+            ms.sort_unstable();
+            ms
+        }
+        fn arm_delete_failure(&self) {
+            self.fail_delete
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait]
+    impl ScheduleFireStore for MemFires {
+        async fn claim_fire(&self, c: &CompanyId, s: &str, m: u64) -> Result<bool> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .entry((c.as_ref().to_string(), s.to_string()))
+                .or_default()
+                .insert(m))
+        }
+        async fn latest_fire(&self, c: &CompanyId, s: &str) -> Result<Option<u64>> {
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .get(&(c.as_ref().to_string(), s.to_string()))
+                .and_then(|set| set.iter().max().copied()))
+        }
+        async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> Result<usize> {
+            Ok(0)
+        }
+        async fn delete_schedule_fires(&self, c: &CompanyId, s: &str) -> Result<usize> {
+            if self
+                .fail_delete
+                .swap(false, std::sync::atomic::Ordering::SeqCst)
+            {
+                return Err(OpenCompanyError::Store("flaky fire-ledger purge".into()));
+            }
+            Ok(self
+                .rows
+                .lock()
+                .unwrap()
+                .remove(&(c.as_ref().to_string(), s.to_string()))
+                .map_or(0, |set| set.len()))
+        }
+    }
+
+    /// A throwaway fire store for delete tests that do not assert on the purge —
+    /// the common case. Tests that DO assert the purge hold their own
+    /// `Arc<MemFires>` so they can read it back.
+    fn fires() -> Arc<dyn ScheduleFireStore> {
+        Arc::new(MemFires::default())
     }
 
     // --- fixtures ------------------------------------------------------------
@@ -2561,6 +2688,7 @@ to = "done"
             None,
             &store,
             &revs(),
+            Some(&fires()),
             Some(&log_dyn),
             "greeter",
             Some(&version),
@@ -2598,6 +2726,79 @@ to = "done"
         }
     }
 
+    /// #708: a committed delete purges the schedule's durable fire ledger under
+    /// the exact `workflow-<id>` key, so a recreated same-id workflow inherits
+    /// no anchor and no stale claim.
+    #[tokio::test]
+    async fn deleting_a_workflow_purges_its_schedule_fire_ledger() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        // A ledger for greeter's schedule, plus a sibling schedule's row to
+        // prove the purge is scoped to exactly the deleted workflow's key.
+        let fires = Arc::new(MemFires::default());
+        let greeter_key = workflow_schedule_id("greeter");
+        fires.seed(&company, &greeter_key, 100);
+        fires.seed(&company, &greeter_key, 101);
+        fires.seed(&company, &workflow_schedule_id("other"), 100);
+        let fires_dyn: Arc<dyn ScheduleFireStore> = fires.clone();
+
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires_dyn),
+            None,
+            "greeter",
+            None,
+        )
+        .await
+        .expect("deletes");
+
+        assert!(
+            fires.minutes(&company, &greeter_key).is_empty(),
+            "the deleted workflow's whole fire ledger is purged"
+        );
+        assert_eq!(
+            fires.minutes(&company, &workflow_schedule_id("other")),
+            vec![100],
+            "a sibling workflow's schedule ledger is untouched"
+        );
+    }
+
+    /// #708: the purge is best-effort. A purge failure is logged, never rolled
+    /// back — the workflow is already gone, so the delete still succeeds.
+    #[tokio::test]
+    async fn a_failing_fire_ledger_purge_still_deletes_the_workflow() {
+        let company = CompanyId::new("acme");
+        let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
+
+        let fires = Arc::new(MemFires::default());
+        fires.seed(&company, &workflow_schedule_id("greeter"), 100);
+        fires.arm_delete_failure();
+        let fires_dyn: Arc<dyn ScheduleFireStore> = fires.clone();
+
+        let name = delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires_dyn),
+            None,
+            "greeter",
+            None,
+        )
+        .await
+        .expect("delete succeeds even when the purge cascade errors");
+        assert_eq!(name, "Greeter");
+
+        // The graph is gone despite the purge error.
+        let record = store.load(&company).await.unwrap().unwrap();
+        assert!(record.overlay_workflows.is_empty(), "body must be gone");
+        assert!(record.manifest.workflows.enabled.is_empty());
+    }
+
     /// The delete is durable across the #208 boot rebuild *because* the overlay
     /// body is gone: `merge_enabled_workflows` re-derives `enabled` from seed
     /// ids ∪ surviving overlay ids, so there is nothing left to resurrect. This
@@ -2606,9 +2807,18 @@ to = "done"
     async fn a_deleted_workflow_has_nothing_left_for_the_boot_merge_to_re_enable() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        delete_company_workflow(&company, None, &store, &revs(), None, "greeter", None)
-            .await
-            .expect("deletes");
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            None,
+            "greeter",
+            None,
+        )
+        .await
+        .expect("deletes");
 
         let record = store.load(&company).await.unwrap().unwrap();
         let surviving: Vec<&str> = record
@@ -2634,11 +2844,20 @@ to = "done"
             .await
             .expect("someone edits first");
 
+        // A held fire store, seeded under the workflow's schedule key, proves the
+        // refused delete purges NOTHING — the purge runs only after a committed
+        // save, so a version-refused delete (which never saves) leaves the live
+        // workflow's ledger intact (#708).
+        let fires = Arc::new(MemFires::default());
+        fires.seed(&company, &workflow_schedule_id("greeter"), 42);
+        let fires_dyn: Arc<dyn ScheduleFireStore> = fires.clone();
+
         let err = delete_company_workflow(
             &company,
             None,
             &store,
             &revs(),
+            Some(&fires_dyn),
             None,
             "greeter",
             Some(&stale),
@@ -2649,6 +2868,11 @@ to = "done"
 
         let record = store.load(&company).await.unwrap().unwrap();
         assert_eq!(record.overlay_workflows.len(), 1, "nothing was removed");
+        assert_eq!(
+            fires.minutes(&company, &workflow_schedule_id("greeter")),
+            vec![42],
+            "a version-refused delete never reaches the purge — the ledger is intact"
+        );
     }
 
     /// Deleting a source-defined workflow is refused: `merge_enabled_workflows`
@@ -2672,6 +2896,7 @@ to = "done"
             Some(dir.path()),
             &store,
             &revs(),
+            Some(&fires()),
             None,
             "seeded",
             None,
@@ -2688,9 +2913,18 @@ to = "done"
     async fn deleting_an_unknown_workflow_is_not_found() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        let err = delete_company_workflow(&company, None, &store, &revs(), None, "ghost", None)
-            .await
-            .expect_err("unknown id");
+        let err = delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            None,
+            "ghost",
+            None,
+        )
+        .await
+        .expect_err("unknown id");
         assert!(
             matches!(err, OpenCompanyError::CompanyNotFound(_)),
             "{err:?}"
@@ -2701,10 +2935,18 @@ to = "done"
     async fn deleting_a_traversal_id_is_invalid() {
         let company = CompanyId::new("acme");
         let (store, _) = with_one_workflow(&company, "greeter", "Greeter").await;
-        let err =
-            delete_company_workflow(&company, None, &store, &revs(), None, "../secrets", None)
-                .await
-                .expect_err("traversal id");
+        let err = delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            None,
+            "../secrets",
+            None,
+        )
+        .await
+        .expect_err("traversal id");
         assert!(
             matches!(err, OpenCompanyError::InvalidRequest(_)),
             "{err:?}"
@@ -2726,9 +2968,18 @@ to = "done"
                 .expect("seed");
         }
 
-        delete_company_workflow(&company, None, &store, &revs(), None, "b", None)
-            .await
-            .expect("deletes the middle one");
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            None,
+            "b",
+            None,
+        )
+        .await
+        .expect("deletes the middle one");
 
         let record = store.load(&company).await.unwrap().unwrap();
         let ids: Vec<&str> = record
@@ -2753,9 +3004,18 @@ to = "done"
         rec.manifest.workflows.enabled.push("greeter".to_string());
         let store = store_of(MemStore::failing(rec));
 
-        delete_company_workflow(&company, None, &store, &revs(), None, "greeter", None)
-            .await
-            .expect_err("save fails");
+        delete_company_workflow(
+            &company,
+            None,
+            &store,
+            &revs(),
+            Some(&fires()),
+            None,
+            "greeter",
+            None,
+        )
+        .await
+        .expect_err("save fails");
 
         let record = store.load(&company).await.unwrap().unwrap();
         assert_eq!(record.overlay_workflows.len(), 1, "nothing was removed");

--- a/src/harness/workflow_admin.rs
+++ b/src/harness/workflow_admin.rs
@@ -791,6 +791,11 @@ impl Tool for DeleteWorkflowTool {
             self.admin.source_dir.as_deref(),
             &self.admin.store,
             &revisions,
+            // Issue #708: no fire-ledger purge from the tool path, and none is
+            // owed — this tool refuses to delete a scheduled workflow at all
+            // (`refuse_scheduled` above), so it can never orphan a ledger. Only
+            // the HTTP delete path (which permits scheduled deletes) wires `Some`.
+            None,
             self.admin.events.as_ref(),
             &wid,
             expected_version.as_deref(),

--- a/src/ports/schedule_fires.rs
+++ b/src/ports/schedule_fires.rs
@@ -69,11 +69,11 @@ use crate::ports::types::CompanyId;
 /// Durable per-company claims that one schedule fired at one UTC epoch minute.
 ///
 /// Company A's claims MUST be invisible to company B, exactly like every other
-/// per-company port. The three methods are storage verbs only: the schedulers
+/// per-company port. The four methods are storage verbs only: the schedulers
 /// own the claim *policy* (claim before side effect, fail closed on error, one
 /// bounded catch-up), and a backend only ever sees "insert this key if absent",
 /// "what is the max minute for this schedule", "delete minutes below this
-/// cutoff".
+/// cutoff", "delete every minute for one schedule".
 #[async_trait]
 pub trait ScheduleFireStore: Send + Sync {
     /// Atomically records that `schedule_id` fired at epoch `minute` for
@@ -110,4 +110,21 @@ pub trait ScheduleFireStore: Send + Sync {
     /// [`PRUNE_CUTOFF_MINUTES`](crate::runtime::PRUNE_CUTOFF_MINUTES) vs
     /// [`CATCHUP_WINDOW_MINUTES`](crate::runtime::CATCHUP_WINDOW_MINUTES)).
     async fn prune_fires_before(&self, company: &CompanyId, cutoff_minute: u64) -> Result<usize>;
+
+    /// Removes *every* claim row for `(company, schedule_id)`, whatever its
+    /// minute, returning how many rows were removed.
+    ///
+    /// Called when a schedule's identity is retired — a workflow is deleted
+    /// (issue #708) — so a later schedule that mints the *same* `schedule_id`
+    /// (a delete+recreate of a workflow reuses `"workflow-<id>"`, which is
+    /// deliberately restart-stable and NOT re-keyed) starts with an empty
+    /// ledger: no [`latest_fire`](ScheduleFireStore::latest_fire) anchor to
+    /// mis-anchor its catch-up on, and every past minute claimable again so the
+    /// first tick after recreation fires instead of losing to a stale claim.
+    ///
+    /// A `schedule_id` that never fired removes nothing and returns `Ok(0)`;
+    /// the call is idempotent (a second delete of the same id also returns
+    /// `Ok(0)`). Unlike [`claim_fire`](ScheduleFireStore::claim_fire), this is
+    /// not a race arbiter — it is a one-shot purge on the delete path.
+    async fn delete_schedule_fires(&self, company: &CompanyId, schedule_id: &str) -> Result<usize>;
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -136,6 +136,7 @@ pub use workflow_outcome::{
 };
 pub use workflow_resume::WORKFLOW_APPROVE_KIND;
 pub use workflow_scheduler::WorkflowScheduler;
+pub(crate) use workflow_scheduler::workflow_schedule_id;
 pub use workflow_spawn::WorkflowSpawn;
 pub use workspace_events::WorkspaceAnnouncer;
 pub use workspace_quota::{

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1041,6 +1041,9 @@ mod test {
         async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> Result<usize> {
             Err(OpenCompanyError::Store("claim store is down".into()))
         }
+        async fn delete_schedule_fires(&self, _c: &CompanyId, _s: &str) -> Result<usize> {
+            Err(OpenCompanyError::Store("claim store is down".into()))
+        }
     }
 
     #[test]
@@ -1307,6 +1310,14 @@ mod test {
         }
         async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> Result<usize> {
             Ok(0)
+        }
+        async fn delete_schedule_fires(&self, c: &CompanyId, s: &str) -> Result<usize> {
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .remove(&(c.as_ref().to_string(), s.to_string()))
+                .map_or(0, |set| set.len()))
         }
     }
 

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -652,12 +652,11 @@ impl WorkflowScheduler {
         // out of the registry is never visited again, so its entries would be
         // orphaned forever. Swept here beside the others. (A deleted-but-company-
         // still-present workflow leaves one stale entry, harmless: it is only a
-        // "have I run catch-up for this" bit and a re-created workflow of the same
-        // id is a first sight again only after this sweep — acceptable, since a
-        // re-created workflow's anchor is whatever it last durably fired. That the
-        // anchor survives a delete+recreate is the durable-identity reuse issue
-        // #708 documents on `workflow_schedule_id` — bounded by the catch-up
-        // window, fixed by purging the fire ledger at delete time, not re-keying.)
+        // "have I run catch-up for this" bit, cleared on the next sight. A
+        // re-created workflow of the same id is a genuine first sight against an
+        // EMPTY ledger, because the delete path purges the fire rows under
+        // `workflow_schedule_id` (issue #708) — so there is no inherited anchor
+        // for this re-armed latch to catch up against.)
         self.caught_up
             .retain(|(company, _)| registry.get(company).is_some());
 
@@ -795,23 +794,18 @@ fn lock_in_flight(
 /// # Identity reuse across delete+recreate (issue #708)
 ///
 /// Because this key is the workflow id alone, deleting a workflow and recreating
-/// one with the **same id** makes the new workflow **inherit the old one's fire
-/// ledger** — its durable `claim_fire` / [`latest_fire`] rows survive the delete
-/// (`delete_workflow` in `src/server/ops/workflows.rs` tears down the graph,
-/// revisions, and events, but not the schedule's claim rows). Two effects, each
-/// bounded by [`CATCHUP_WINDOW_MINUTES`]:
+/// one with the **same id** would make the new workflow inherit the old one's
+/// fire ledger — the durable `claim_fire` / [`latest_fire`] rows outlive the
+/// graph. So the delete path purges those rows: `delete_company_workflow`
+/// (`src/company/workflow_create.rs`) calls
+/// [`delete_schedule_fires`](crate::ports::ScheduleFireStore::delete_schedule_fires)
+/// under this exact key after the graph, revisions, and events are gone, so a
+/// recreated same-id workflow starts against an empty ledger — no stale anchor
+/// to mis-anchor a catch-up on, and every past minute claimable again.
 ///
-/// * **one suppressed minute** — if the recreated schedule matches a minute the
-///   old id already claimed, `claim_fire` returns `false` and that single
-///   occurrence is skipped; and
-/// * **one inherited make-up** — the first-sight catch-up reads the stale anchor,
-///   so it may fire (or decline) a make-up on the *deleted* workflow's history.
-///   The `caught_up` sweep note in [`tick`](WorkflowScheduler::tick) already
-///   spells this out: a re-created workflow's anchor is whatever it last durably
-///   fired, so it is a first sight against a non-empty ledger.
-///
-/// The key is **deliberately not re-keyed** to erase that history, for three
-/// reasons — the re-key was considered for #661 and rejected:
+/// The key is **deliberately not re-keyed** to force that separation — the
+/// re-key was considered for #661 and rejected for three reasons, which is why
+/// the fix lives on the delete path, not in this id:
 ///
 /// 1. **Per-deploy catch-up loss** — a new key orphans every deployed tenant's
 ///    existing anchors, so the first boot after the change treats every armed
@@ -823,12 +817,12 @@ fn lock_in_flight(
 /// 3. It is the natural, restart-stable `(company, workflow)` identity that
 ///    survives a restart without depending on a positional index.
 ///
-/// The real fix purges the fire-ledger rows at delete time instead (a new
-/// [`ScheduleFireStore`](crate::ports::ScheduleFireStore) delete method, called
-/// from `delete_company_workflow`), leaving the key as-is. Tracked in issue #708.
+/// Minted here at the one authoritative site and re-exported (`pub(crate)`) so
+/// the delete path forms the same key from the same code, never a duplicated
+/// format string.
 ///
 /// [`latest_fire`]: crate::ports::ScheduleFireStore::latest_fire
-fn workflow_schedule_id(workflow_id: &str) -> String {
+pub(crate) fn workflow_schedule_id(workflow_id: &str) -> String {
     format!("workflow-{workflow_id}")
 }
 
@@ -3502,6 +3496,84 @@ to = "done"
         assert_eq!(started.lock().unwrap()[0].input["catchUp"], true);
     }
 
+    /// #708: a workflow deleted and recreated with the SAME id must not inherit
+    /// the old one's fire ledger. Driven against the real per-company store (not
+    /// a double), in two phases in one test so the stale-fixture guard holds:
+    ///
+    /// * Phase 1 — with the inherited claim still present, minute M is suppressed
+    ///   (`claim_fire` loses to the stale row). This is exactly the bug a
+    ///   delete+recreate exhibited before this fix.
+    /// * Phase 2 — after `delete_schedule_fires` (what `delete_company_workflow`
+    ///   now calls on delete) purges the ledger, the SAME minute is claimable
+    ///   again and the recreated workflow fires.
+    ///
+    /// Phase 1 proves the seeded claim genuinely suppresses, so phase 2's fire
+    /// can only come from the purge actually removing the row — a no-op purge
+    /// leaves phase 2 asserting `0` and fails the test.
+    #[tokio::test]
+    async fn a_recreated_workflow_does_not_inherit_the_deleted_fire_ledger() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let (runner, started, _completed) = RecordingRunner::new();
+        let registry = company_with_overlays(
+            &home,
+            "acme",
+            vec![overlay("digest", Some("* * * * *"))],
+            Some(runner),
+            "running",
+        )
+        .await;
+        let company = CompanyId::new("acme");
+        let runtime = registry.get(&company).unwrap();
+        let schedule_id = workflow_schedule_id("digest");
+
+        // The OLD workflow already fired minute M; its durable claim survives the
+        // delete because the key is the restart-stable `workflow-<id>`.
+        let m = minute_at(2026, 7, 14, 9, 0);
+        runtime
+            .schedule_fires()
+            .claim_fire(&company, &schedule_id, m)
+            .await
+            .unwrap();
+
+        // A recreated workflow is, to the durable ledger, a fresh scheduler view
+        // over the same store (the in-process minute dedup is empty on the new
+        // sighting — most starkly across a restart). So each phase uses its own
+        // scheduler instance, exactly like `two_schedulers_over_one_store_fire_once`,
+        // isolating the DURABLE ledger as the only variable between them.
+        let clock = || Arc::new(FakeClock::new(millis_at(2026, 7, 14, 9, 0)));
+
+        // Phase 1 — WITHOUT the purge: the inherited claim suppresses minute M.
+        // This is exactly the #708 bug a delete+recreate exhibited.
+        let mut before = WorkflowScheduler::new(registry.clone(), clock());
+        assert_eq!(
+            before.tick().await,
+            0,
+            "an inherited claim suppresses the recreated workflow's fire (the #708 bug)"
+        );
+        assert!(started.lock().unwrap().is_empty());
+
+        // Phase 2 — WITH the purge (what `delete_company_workflow` now does): the
+        // ledger is cleared, so the SAME minute is claimable again and the
+        // recreated workflow fires. A no-op purge would leave this asserting 0.
+        let removed = runtime
+            .schedule_fires()
+            .delete_schedule_fires(&company, &schedule_id)
+            .await
+            .unwrap();
+        assert_eq!(removed, 1, "the purge removes exactly the inherited claim");
+
+        let mut after = WorkflowScheduler::new(registry.clone(), clock());
+        assert_eq!(
+            after.tick().await,
+            1,
+            "after the purge the recreated workflow fires the same minute"
+        );
+        wait_for(|| started.lock().unwrap().len() == 1).await;
+
+        drain(&after).await;
+    }
+
     // --- issue #661 (F2): a transient failure DEFERS the first-sight catch-up,
     // it does not forfeit it ----------------------------------------------------
 
@@ -3578,6 +3650,14 @@ to = "done"
         }
         async fn prune_fires_before(&self, _c: &CompanyId, _m: u64) -> crate::Result<usize> {
             Ok(0)
+        }
+        async fn delete_schedule_fires(&self, c: &CompanyId, s: &str) -> crate::Result<usize> {
+            Ok(self
+                .claims
+                .lock()
+                .unwrap()
+                .remove(&(c.as_ref().to_string(), s.to_string()))
+                .map_or(0, |set| set.len()))
         }
     }
 

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -806,6 +806,7 @@ async fn delete_workflow(
         company.runtime.source_dir(),
         company.runtime.store(),
         company.runtime.workflow_revisions(),
+        Some(company.runtime.schedule_fires()),
         Some(company.runtime.events()),
         &wid,
         query.expected_version.as_deref(),

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -3632,6 +3632,66 @@ pub async fn assert_schedule_fire_store(
         winners, 1,
         "exactly one of {N} concurrent claimers may win the key"
     );
+
+    // -- delete_schedule_fires: purge one schedule's whole ledger (issue #708) --
+    //
+    // Fresh schedule ids so this block never disturbs the prune-count assertions
+    // above. `del-a` gets three minutes, `del-b` one, and beta a same-named row,
+    // to prove the delete is scoped to exactly `(company, schedule_id)`.
+    for m in [200_u64, 201, 202] {
+        assert!(fires.claim_fire(&alpha, "del-a", m).await.unwrap());
+    }
+    assert!(fires.claim_fire(&alpha, "del-b", 200).await.unwrap());
+    assert!(fires.claim_fire(&beta, "del-a", 200).await.unwrap());
+
+    let removed = fires.delete_schedule_fires(&alpha, "del-a").await.unwrap();
+    assert_eq!(
+        removed, 3,
+        "delete removes every row for the schedule, whatever its minute"
+    );
+    assert_eq!(
+        fires.latest_fire(&alpha, "del-a").await.unwrap(),
+        None,
+        "a purged schedule has no anchor left — the recreate starts fresh"
+    );
+    // The recreate case: a purged minute is no longer claimed, so the first tick
+    // after a same-id recreate wins it again instead of losing to a stale claim.
+    assert!(
+        fires.claim_fire(&alpha, "del-a", 201).await.unwrap(),
+        "a purged minute is claimable again (delete+recreate fires, not suppressed)"
+    );
+
+    // Scoped: the sibling schedule and the other company are untouched.
+    assert_eq!(
+        fires.latest_fire(&alpha, "del-b").await.unwrap(),
+        Some(200),
+        "a sibling schedule's rows survive another schedule's delete"
+    );
+    assert_eq!(
+        fires.latest_fire(&beta, "del-a").await.unwrap(),
+        Some(200),
+        "company A's delete never reaches company B's identically-named schedule"
+    );
+
+    // A never-fired id removes nothing, and the call is idempotent.
+    assert_eq!(
+        fires
+            .delete_schedule_fires(&alpha, "del-never")
+            .await
+            .unwrap(),
+        0,
+        "deleting a schedule that never fired removes nothing"
+    );
+    assert_eq!(
+        fires.delete_schedule_fires(&alpha, "del-b").await.unwrap(),
+        1,
+        "del-b's single row is removed"
+    );
+    assert_eq!(
+        fires.delete_schedule_fires(&alpha, "del-b").await.unwrap(),
+        0,
+        "a second delete of the same schedule is idempotent — nothing left to remove"
+    );
 }
 
 /// Every backend's [`JournalStore`](crate::ports::journal::JournalStore) must

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -923,6 +923,53 @@ impl crate::ports::schedule_fires::ScheduleFireStore for FsOps {
         .await
         .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
     }
+
+    async fn delete_schedule_fires(&self, company: &CompanyId, schedule_id: &str) -> Result<usize> {
+        let dir = self
+            .bundle(company)
+            .schedule_fires_dir()
+            .join(hashed_schedule_component(schedule_id));
+        tokio::task::spawn_blocking(move || {
+            let markers = match std::fs::read_dir(&dir) {
+                Ok(entries) => entries,
+                // No directory means the schedule never fired — nothing to
+                // purge, the same NotFound-is-empty rule the other verbs use.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+                Err(e) => return Err(io_err(&dir, e)),
+            };
+            let mut removed = 0usize;
+            for marker in markers {
+                let marker = marker.map_err(|e| io_err(&dir, e))?;
+                // Only our minute markers count as claim rows; a filename that
+                // does not parse is not one of ours, so it is left in place
+                // (and will simply keep the best-effort `remove_dir` below from
+                // succeeding, which is harmless).
+                let Some(_minute) = marker
+                    .file_name()
+                    .to_str()
+                    .and_then(|name| name.parse::<u64>().ok())
+                else {
+                    continue;
+                };
+                let path = marker.path();
+                match std::fs::remove_file(&path) {
+                    Ok(()) => removed += 1,
+                    // A racing prune already removed it — not our removal to
+                    // count, but not an error either.
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(e) => return Err(io_err(&path, e)),
+                }
+            }
+            // Best-effort: drop the now-empty schedule directory so a purged
+            // schedule leaves no directory behind. Ignored if it is not empty
+            // (a stray non-marker file) or already gone — the rows are what the
+            // count and the contract are about, not the directory.
+            let _ = std::fs::remove_dir(&dir);
+            Ok(removed)
+        })
+        .await
+        .map_err(|e| OpenCompanyError::Store(format!("spawn_blocking failed: {e}")))?
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2077,6 +2077,21 @@ impl crate::ports::schedule_fires::ScheduleFireStore for MongoStore {
             .map_err(mongo_err)?;
         Ok(result.deleted_count as usize)
     }
+
+    async fn delete_schedule_fires(&self, company: &CompanyId, schedule_id: &str) -> Result<usize> {
+        // Every row for one schedule, whatever its minute — the delete-time
+        // purge (#708). A never-fired id matches nothing, so `deleted_count`
+        // is 0.
+        let result = self
+            .collection("schedule_fires")
+            .delete_many(doc! {
+                "company_id": company.as_ref(),
+                "schedule_id": schedule_id,
+            })
+            .await
+            .map_err(mongo_err)?;
+        Ok(result.deleted_count as usize)
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2189,6 +2189,20 @@ impl crate::ports::schedule_fires::ScheduleFireStore for SqliteStore {
             .map_err(sql_err)?;
         Ok(removed)
     }
+
+    async fn delete_schedule_fires(&self, company: &CompanyId, schedule_id: &str) -> Result<usize> {
+        let conn = self.conn();
+        // Every row for one schedule, whatever its minute — the delete-time
+        // purge (#708). A never-fired id matches nothing, so `changes()` is 0.
+        let removed = conn
+            .execute(
+                "DELETE FROM schedule_fires \
+                 WHERE company_id = ?1 AND schedule_id = ?2",
+                params![company.as_ref(), schedule_id],
+            )
+            .map_err(sql_err)?;
+        Ok(removed)
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Deleting a scheduled workflow left its durable per-`(company, schedule, minute)` fire ledger behind. Recreating a workflow under the **same id** then inherited those stale claim rows: the scheduler saw the minute as already-fired and either suppressed a legitimate tick or (across the #241 replica arbiter) skewed at-most-once accounting. This wires a per-schedule purge into the delete path so a recreate always starts clean.

Changes:

- **New store verb** `ScheduleFireStore::delete_schedule_fires(company, schedule_id) -> Result<usize>` (required trait method, no default impl), implemented across all three backends — sqlite (`DELETE … WHERE company_id AND schedule_id`), mongodb (`delete_many`), fs (`O_EXCL` marker-dir removal, `NotFound → Ok(0)`, tolerant like `prune_fires_before`).
- **Purge wired into `delete_company_workflow`**, keyed via `workflow_schedule_id(wid)` re-exported from the one authoritative site (`src/runtime/workflow_scheduler.rs`) so the delete key can never drift from the scheduler's. It runs **after** the committed save + lock drop, best-effort (warn, never roll back) — mirroring the existing #274 revision cascade. Purging before a save that then failed would strip a still-live workflow's rows and risk a #241 double-fire.
- The `schedule_fires` parameter is `Option`, for the same reason `events`/`revisions` already are: not every caller wires it. The **HTTP delete** path passes `Some(runtime.schedule_fires())` — it is the only path from which a *scheduled* workflow can be deleted, so the only one that can orphan a ledger. The **agent `delete_workflow` tool** (#661 M7) passes `None`, and correctly: it refuses to delete a scheduled workflow at all (`refuse_scheduled`), so no ledger can exist for it to leave behind.

## API Or Behavior Changes

- **Port contract**: `ScheduleFireStore` gains a required `delete_schedule_fires`. Any out-of-tree implementor must add it (no default). Contract pinned in `conformance.rs`.
- **Behavior**: an HTTP workflow-delete now purges that schedule's fire ledger. A same-id recreate no longer inherits stale fire claims. Failure to purge is logged, not fatal (bounded pre-fix behavior re-instated once).
- No change to the agent tool's observable behavior (it could not delete scheduled workflows before, and still can't).

## Tests

Union-built against current `main` (`29d250f7`), which merged #726 (`JournalStore` port — `ports.md` conflict resolved additively) and #776/#661-M7 (the second `delete_company_workflow` caller — resolved by threading the `Option` arg):

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo check --all-targets` / `--all-features` (feature-gated sqlite + mongodb impls compile)
- [x] `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests` — **3469 passed, 0 failed** (lib) + all integration targets green
- [x] `conformance_schedule_fire_store` passes for **fs, sqlite, and mongodb** (`--features …,sqlite,mongodb`)

Regression proof: `a_recreated_workflow_does_not_inherit_the_deleted_fire_ledger` runs two scheduler instances over one real store — phase 1 (no purge) → tick suppressed (0); phase 2 (after purge) → fires (1). Confirmed it fails on pre-fix behavior by temporarily neutering the fs purge to `Ok(0)` (`left: 0, right: 1`), then reverting.

## Documentation

`docs/spec/runtime/ports.md` — added the `ScheduleFireStore` rows (port table + default-impl table). Purge ordering + the `Option`-caller rationale are documented inline in `delete_company_workflow` and `workflow_schedule_id`.

Closes #708
