### PR TITLE
ci: keep main's post-merge verification instead of cancelling it (#770)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ on:
 # a MERGE QUEUE, which verifies the exact merged state before it becomes `main`
 # and makes this question moot; it needs a `merge_group` trigger plus a
 # branch-protection change no PR can make, and with a 26–30 minute critical path
-# it either serialises merges to ~2/hour or has to batch. Tracked separately.
+# it either serialises merges to ~2/hour or has to batch. Issue #793 carries that
+# evaluation; this block is the fix that does not need anyone's settings.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,50 @@ on:
   push:
   pull_request:
 
+# Issue #770. Cancellation is scoped to NON-DEFAULT refs, and the asymmetry is
+# the whole point: on a PR branch a new push makes the previous run's answer
+# worthless, so killing it is right; on `main` a new merge makes the previous
+# run's answer the ONLY evidence that the merge before it was safe, so killing
+# it destroys the one check standing between a bad merge and every branch cut
+# afterwards.
+#
+# It had already stopped working. Of the last fourteen runs on `main`, twelve
+# were `cancelled` and one succeeded — merges were landing minutes apart against
+# a `Rust (openhuman, tinycortex)` lane that takes ~26 minutes, so each merge
+# killed its predecessor's verification before it could conclude. The honest
+# state of `main` across that stretch was neither known-good nor known-broken.
+# Nothing was red; the signal simply was not there. Verification thinned out
+# precisely when the merge rate made it most valuable, which is the property
+# that makes this worse than a lane that is merely slow.
+#
+# `format('refs/heads/{0}', …default_branch)` rather than a literal
+# `'refs/heads/main'`: the literal silently reverts to cancel-everything the day
+# the default branch is renamed, and it would do so without failing anything —
+# the same class of quietly-vacuous check this file exists to argue against.
+# Both triggers populate `github.event.repository`, so the expression resolves
+# on `push` and `pull_request` alike.
+#
+# PR runs are UNAFFECTED. A `pull_request` run's `github.ref` is
+# `refs/pull/<n>/merge`, never `refs/heads/<default>`, so the expression is true
+# there and stale runs still die on a new push.
+#
+# WHAT THIS DOES NOT BUY, stated plainly. Turning cancellation off does not give
+# every merge its own conclusive run: the group still admits at most one running
+# plus one pending run, and a newer arrival supersedes the older *pending* one.
+# So the tip always eventually gets a full run, but a fast burst of merges loses
+# individual attribution — a red run on the tip covers the union of merges since
+# the last conclusive one, and finding which merge did it is a bisect. That is
+# the deliberate trade: per-merge attribution costs a run per merge (a per-run
+# group keyed on `github.run_id`, roughly 10x the minutes), and the alternative
+# that is cheaper — an hourly scheduled run on `main` — tells you later and
+# attributes the breakage to nothing at all. The structurally correct answer is
+# a MERGE QUEUE, which verifies the exact merged state before it becomes `main`
+# and makes this question moot; it needs a `merge_group` trigger plus a
+# branch-protection change no PR can make, and with a 26–30 minute critical path
+# it either serialises merges to ~2/hour or has to batch. Tracked separately.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

`ci.yml` set `cancel-in-progress: true` on a concurrency group keyed by workflow and ref,
for **all** refs. On a PR branch that is right — a new push makes the previous run's
answer worthless. On `main` it means every merge cancels the previous merge's
verification, so when merges land faster than the slowest lane takes, `main` is never
actually verified.

This scopes cancellation to non-default refs.

```yaml
cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
```

`format(…default_branch)` rather than a literal `'refs/heads/main'`: the literal silently
reverts to cancel-everything the day the default branch is renamed, and it would do so
without failing anything — the same class of quietly-vacuous check this file argues
against throughout. Both triggers (`push`, `pull_request`) populate
`github.event.repository`, so the expression resolves under either.

PR runs are unaffected: a `pull_request` run's `github.ref` is `refs/pull/<n>/merge`,
never `refs/heads/<default>`.

### It was worse than the issue reported

Re-measured independently on the current queue. Of the **last fourteen** runs on `main`:
**twelve cancelled, one success, one still in progress**. Merges were landing minutes
apart against a `Rust (openhuman, tinycortex)` lane that takes ~26 minutes, so each merge
killed its predecessor before it could conclude. Across that whole stretch `main` was
neither known-good nor known-broken — nothing was red, the signal simply was not there.

Verification thins out precisely when the merge rate makes it most valuable, which is what
makes this worse than a lane that is merely slow.

### Sibling workflows: reviewed, nothing owed

The issue asked for these to be reviewed rather than fixed blind. Verdicts, so the review
is not repeated:

| Workflow | Concurrency | Verdict |
|---|---|---|
| `deploy-staging.yml` | `cancel-in-progress: false` | **Already correct.** Never kill a mid-flight deploy — a cancelled rollout leaves the cluster in a state nobody chose. No change. |
| `release.yml` | none | `workflow_dispatch` only. No concurrency block, nothing to scope. |
| `diag-tenant.yml` | none | `workflow_dispatch` only. Same. |
| `patch-tenant-env.yml` | none | `workflow_dispatch` only. Same. |

`ci.yml` was the only workflow carrying the defect.

## API Or Behavior Changes

No product behavior changes. CI behavior changes on the default branch only.

**What this buys, and what it does not.** Turning cancellation off does not give every
merge its own conclusive run. The group still admits at most one running plus one pending
run, and a newer arrival supersedes the older *pending* one — verified below rather than
assumed. So the tip always eventually gets a full run, but a fast burst of merges still
loses individual attribution: a red run on the tip covers the **union** of merges since the
last conclusive one, and finding the culprit is a bisect. That is the deliberate trade,
and it is strictly better than today's "nothing concluded at all".

Cost is runner minutes: several merges in quick succession now mean several full runs
instead of one cancelled chain. That cost is the point — it buys the only proof that `main`
compiles and passes.

**Alternatives judged, so the roads not taken are visible:**

- **Hourly scheduled run on `main`** — cheaper, but tells you later and attributes the
  breakage to nothing at all. Rejected: attribution is most of the value.
- **Per-run group keyed on `github.run_id`** — full per-merge attribution, at roughly 10x
  the minutes. Rejected on cost for the benefit over a bisectable union.
- **Merge queue** — the structurally correct answer: it verifies the exact merged state
  *before* it becomes `main`, which makes the cancellation question moot rather than
  traded off. Needs a `merge_group` trigger plus a branch-protection change no PR can
  make, and with a 26-30 minute critical path it either serialises merges to ~2/hour or
  has to batch. Filed as #793 for maintainers to evaluate a batched queue.

## Tests

A broken concurrency expression would be **green by doing nothing**, so "CI is green" is
not evidence here. Two independent proofs:

**1. PR-branch cancellation still works.** Two commits pushed to this PR branch ~2 minutes
apart; the first run must be `cancelled`.

| Push | Commit | Run | Observed |
|---|---|---|---|
| 1 | `dbd5705` | [31611959776](https://github.com/tinyhumansai/opencompany/actions/runs/31611959776) | **`cancelled`** when push 2 arrived — stale-run cancellation preserved. |
| 2 | `2d3538b` | [31612182246](https://github.com/tinyhumansai/opencompany/actions/runs/31612182246) | Queued, then ran. |

Both proof runs above predate a rebase onto current `main` (the branch was cut from
`29d250f`, which had two E2E lanes already red — see below), so the commits they name are
the pre-rebase copies of the two commits now on the branch. The patch is byte-identical;
only the parent changed.

**The controlled comparison.** Commit `dbd5705` is the *same commit* in both proofs, and it
behaved oppositely by ref, which is exactly the asymmetry this PR introduces:

- on `refs/pull/794/merge` → **cancelled** by the next push (run `31611959776`)
- on `refs/heads/main` → **still running** through two later pushes (run `31611413434`)

One commit, one expression, two refs, two outcomes. That is the change working rather than
CI merely being green.

**2. Default-branch behavior, proven pre-merge.** `ci.yml` triggers on bare `push`, so it
runs on a fork. The change was pushed to `oxoxDev/opencompany`'s own `main` (default branch
`main`, so the expression resolves exactly as it will upstream), then two further commits
~1 and ~2 minutes later. A syntax error in the expression fails at workflow-parse time, so
this also catches that before upstream sees it.

| Push | Commit | Run | Observed |
|---|---|---|---|
| 1 | `dbd5705` | [31611413434](https://github.com/oxoxDev/opencompany/actions/runs/31611413434) | **`in_progress` throughout both later pushes — not cancelled.** This is the defect being fixed. |
| 2 | `adcda97` | [31611697602](https://github.com/oxoxDev/opencompany/actions/runs/31611697602) | `pending` behind run 1, then **`cancelled` when push 3 arrived** — superseded as the older *pending* run. |
| 3 | `b76c9ae` | [31611762797](https://github.com/oxoxDev/opencompany/actions/runs/31611762797) | `pending`. |

Push 3 exists to **confirm** the queue-of-one semantics claimed above rather than assume
them, and it did: the *running* run survived while the older *pending* one was discarded.

**On the earlier red run.** The first run on this branch failed `Console E2E` and
`Console E2E (live brain)`. Neither is reachable from a `concurrency:` block, and both were
**already failing on this branch's base commit** — run
[31608353806](https://github.com/tinyhumansai/opencompany/actions/runs/31608353806) on
`main` at `29d250f` shows the same two jobs red. The branch has since been rebased onto
`1117d1e`, where `Console E2E` is green again.

Worth noting what that says about this PR: the run that revealed the breakage was one of
the very few on `main` in that stretch that was *allowed to finish*. The twelve cancelled
ones on either side of it could not have told anyone.

Also: `actionlint .github/workflows/ci.yml` — clean.

- [x] N/A: `cargo fmt --all -- --check` — no Rust changed; this diff is one workflow file.
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — as above.
- [x] N/A: `cargo build --all-targets` — as above.
- [x] N/A: `cargo test` — as above. The change is to *when* CI runs, not to what it runs;
      the lanes themselves are untouched.

## Documentation

No docs change owed: the reasoning lives where the decision does. The `concurrency:` block
carries a comment block stating the asymmetry, the measured evidence, why `format()` beats
a literal, the queue-of-one semantics with the union-attribution trade named, and the three
alternatives with their costs — the same standard as the rest of this file, whose comments
are its institution.

## Related

Closes #770
- #793 — follow-up: evaluate a batched merge queue (the structural fix)
- #592, #475 — same defect family: a check quietly not doing what everyone assumes
