### PR TITLE
test(desktop): fix the first-run sign-in e2e stub shape, un-red main (#632)

### DIFF
--- a/frontend/test/e2e/desktop-first-run-signin.spec.ts
+++ b/frontend/test/e2e/desktop-first-run-signin.spec.ts
@@ -34,7 +34,11 @@ async function asDesktop(
   config: { embedded: string; operatorEmail: string; discoveryDelayMs: number },
 ) {
   await page.addInitScript(
-    (cfg: { embedded: string; operatorEmail: string; discoveryDelayMs: number }) => {
+    (cfg: {
+      embedded: string;
+      operatorEmail: string;
+      discoveryDelayMs: number;
+    }) => {
       // The row a previous launch left behind, at the address this launch will
       // also serve. Restored synchronously, which is the point.
       window.localStorage.setItem(
@@ -52,59 +56,72 @@ async function asDesktop(
       );
 
       const hosts = new Map<string, string>();
+      // `withGlobalTauri` assigns the whole `@tauri-apps/api` bundle, and
+      // `invoke`/`Channel` live under `core` — the v2 shape `tauriCore()` reads.
+      // A shim that puts them at the top level is the v1 shape, which the bridge
+      // rejects, leaving every proxied request `no such connection`.
       (window as unknown as { __TAURI__: unknown }).__TAURI__ = {
-        Channel: class {
-          onmessage: ((message: string) => void) | null = null;
-        },
-        async invoke(command: string, args: Record<string, unknown>): Promise<unknown> {
-          switch (command) {
-            case "oc_connect":
-              hosts.set(args.connectionId as string, args.baseUrl as string);
-              return undefined;
-            case "oc_disconnect":
-              hosts.delete(args.connectionId as string);
-              return undefined;
-            case "oc_embedded":
-              await new Promise((resolve) => setTimeout(resolve, cfg.discoveryDelayMs));
-              return {
-                baseUrl: cfg.embedded,
-                dataDir: "/tmp/e2e-desktop",
-                instanceId: "e2e-embedded-instance",
-                operatorEmail: cfg.operatorEmail,
-              };
-            case "oc_request": {
-              const base = hosts.get(args.connectionId as string);
-              if (base === undefined) {
-                throw new Error(`no such connection: ${args.connectionId as string}`);
+        core: {
+          Channel: class {
+            onmessage: ((message: string) => void) | null = null;
+          },
+          async invoke(
+            command: string,
+            args: Record<string, unknown>,
+          ): Promise<unknown> {
+            switch (command) {
+              case "oc_connect":
+                hosts.set(args.connectionId as string, args.baseUrl as string);
+                return undefined;
+              case "oc_disconnect":
+                hosts.delete(args.connectionId as string);
+                return undefined;
+              case "oc_embedded":
+                await new Promise((resolve) =>
+                  setTimeout(resolve, cfg.discoveryDelayMs),
+                );
+                return {
+                  baseUrl: cfg.embedded,
+                  dataDir: "/tmp/e2e-desktop",
+                  instanceId: "e2e-embedded-instance",
+                  operatorEmail: cfg.operatorEmail,
+                };
+              case "oc_request": {
+                const base = hosts.get(args.connectionId as string);
+                if (base === undefined) {
+                  throw new Error(
+                    `no such connection: ${args.connectionId as string}`,
+                  );
+                }
+                const req = args.request as {
+                  method: string;
+                  path: string;
+                  headers: Record<string, string>;
+                  body?: string;
+                };
+                const response = await fetch(base + req.path, {
+                  method: req.method,
+                  headers: req.headers,
+                  body: req.body ?? undefined,
+                  credentials: "include",
+                });
+                const text = await response.text();
+                const headers: Record<string, string> = {};
+                response.headers.forEach((value, name) => {
+                  headers[name.toLowerCase()] = value;
+                });
+                return {
+                  status: response.status,
+                  statusText: response.statusText,
+                  url: response.url,
+                  text,
+                  headers,
+                };
               }
-              const req = args.request as {
-                method: string;
-                path: string;
-                headers: Record<string, string>;
-                body?: string;
-              };
-              const response = await fetch(base + req.path, {
-                method: req.method,
-                headers: req.headers,
-                body: req.body ?? undefined,
-                credentials: "include",
-              });
-              const text = await response.text();
-              const headers: Record<string, string> = {};
-              response.headers.forEach((value, name) => {
-                headers[name.toLowerCase()] = value;
-              });
-              return {
-                status: response.status,
-                statusText: response.statusText,
-                url: response.url,
-                text,
-                headers,
-              };
+              default:
+                return null;
             }
-            default:
-              return null;
-          }
+          },
         },
       };
     },
@@ -129,7 +146,9 @@ test("a signed-out desktop offers the operator its own host admits", async ({
   const email = page.getByLabel("Email");
   await expect(email).toBeVisible({ timeout: 30_000 });
   // THE assertion: the address arrives after the form did, and lands in it.
-  await expect(email).toHaveValue("operator@opencompany.local", { timeout: 30_000 });
+  await expect(email).toHaveValue("operator@opencompany.local", {
+    timeout: 30_000,
+  });
   await expect(page.getByTestId("suggested-email-hint")).toBeVisible();
 
   // A suggestion, not a lock. Somebody signing in as a teammate they invited to


### PR DESCRIPTION
## Summary

`test/e2e/desktop-first-run-signin.spec.ts` (added by #773 / #632) has failed on `main` since it landed — its first CI run on the merge commit went red and it never passed. This fixes the spec so the Console E2E lane is green again; it is blocking every open PR's CI (both frontend and pure-Rust PRs inherit the red lane).

Root cause: the spec's `asDesktop` stub assigned `invoke`/`Channel` at the **top level** of `window.__TAURI__` — the Tauri **v1** shape. The production bridge `tauriCore()` (`frontend/src/api/transport/bridge.ts`) reads the **v2** shape, `window.__TAURI__.core.invoke`, and explicitly rejects the bare top-level form. So `tauriCore()` returned `null`, `registerConnection` never issued `oc_connect`, and every proxied request failed `no such connection`. The remembered embedded connection showed **Unreachable** and the sign-in form never mounted — the test timed out on `getByLabel('Email')`.

The two sibling desktop specs (`desktop-embedded-identity.spec.ts`, `desktop-connections.spec.ts`) already nest their shim under `core` — the new spec simply diverged. This nests it the same way. Test-only change; no production code touched.

## API Or Behavior Changes

None. Test harness only — the shim is moved under `core` to match the real bridge shape.

## Tests

- [x] `npm run typecheck:e2e`
- [x] `npx prettier --check` (formatted)
- [x] `npx playwright test desktop-first-run-signin.spec.ts` — **1 passed** (was a 30s timeout on `main`, now 4.3s green)

Reproduced the failure on `main` first (deterministic, not a flake — DOM snapshot showed `This computer: Unreachable`), then confirmed the `core`-nesting fix turns it green.

## Documentation

None needed. Added an inline comment on the shim explaining the v1-vs-v2 `__TAURI__` shape so the next stub doesn't regress the same way.

## Related

Fixes the CI break introduced with #773 (#632). Unblocks the Console E2E lane for all open PRs.
