### PR TITLE
ci: run the feature-gated tests that no lane selects, and assert the classification (#770)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,8 @@ on:
 # a MERGE QUEUE, which verifies the exact merged state before it becomes `main`
 # and makes this question moot; it needs a `merge_group` trigger plus a
 # branch-protection change no PR can make, and with a 26–30 minute critical path
-# it either serialises merges to ~2/hour or has to batch. Tracked separately.
+# it either serialises merges to ~2/hour or has to batch. Issue #793 carries that
+# evaluation; this block is the fix that does not need anyone's settings.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,33 @@ jobs:
       - name: Verify Cargo.lock is in sync
         run: cargo metadata --locked --format-version 1 > /dev/null
 
+      # Issue #770. Every lane in this file pins an explicit feature set, and
+      # cargo features are additive — so the DEFAULT FATE of a feature-gated test
+      # is "compiled by `Check (--all-features)`, executed by nothing". Nothing
+      # reports it: no lane goes red, no count reads zero, the test simply is not
+      # selected. Six features had accumulated never-executed tests that way,
+      # including the `sidecar` brain's whole offline end-to-end suite and two
+      # OAuth secret-lifecycle tests in `app::types`.
+      #
+      # This is the same family as #475, #477, #555 and #592, every one of which
+      # was found BY HAND after the fact. The steps added below fix the six known
+      # cases; this one is what makes the seventh fail at the moment it is
+      # introduced rather than months later. A new feature cannot merge until
+      # someone writes down which lane runs its tests, or why none does.
+      #
+      # HERE, on `rust`, and after the lock check specifically: the script reads
+      # `cargo metadata --locked` for its feature list — ground truth rather than
+      # a Cargo.toml grep, which would miss the implicit feature of an optional
+      # dependency named without `dep:` — so it needs this job's submodule
+      # checkout to resolve the vendored path manifests, and it should run after
+      # the step that names a stale lock as a stale lock.
+      #
+      # It compiles nothing and takes seconds, so it belongs on the fast default
+      # lane where a classification mistake is reported early, not behind the
+      # 26-minute gated compile.
+      - name: Assert every feature has a test lane or a stated reason
+        run: scripts/ci/assert-feature-lanes.sh
+
       # No `--locked` here, and none is owed: `cargo fmt` is a `rustfmt` wrapper
       # that never resolves the dependency graph, and `cargo-fmt` does not
       # accept the flag.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,50 @@ on:
   push:
   pull_request:
 
+# Issue #770. Cancellation is scoped to NON-DEFAULT refs, and the asymmetry is
+# the whole point: on a PR branch a new push makes the previous run's answer
+# worthless, so killing it is right; on `main` a new merge makes the previous
+# run's answer the ONLY evidence that the merge before it was safe, so killing
+# it destroys the one check standing between a bad merge and every branch cut
+# afterwards.
+#
+# It had already stopped working. Of the last fourteen runs on `main`, twelve
+# were `cancelled` and one succeeded — merges were landing minutes apart against
+# a `Rust (openhuman, tinycortex)` lane that takes ~26 minutes, so each merge
+# killed its predecessor's verification before it could conclude. The honest
+# state of `main` across that stretch was neither known-good nor known-broken.
+# Nothing was red; the signal simply was not there. Verification thinned out
+# precisely when the merge rate made it most valuable, which is the property
+# that makes this worse than a lane that is merely slow.
+#
+# `format('refs/heads/{0}', …default_branch)` rather than a literal
+# `'refs/heads/main'`: the literal silently reverts to cancel-everything the day
+# the default branch is renamed, and it would do so without failing anything —
+# the same class of quietly-vacuous check this file exists to argue against.
+# Both triggers populate `github.event.repository`, so the expression resolves
+# on `push` and `pull_request` alike.
+#
+# PR runs are UNAFFECTED. A `pull_request` run's `github.ref` is
+# `refs/pull/<n>/merge`, never `refs/heads/<default>`, so the expression is true
+# there and stale runs still die on a new push.
+#
+# WHAT THIS DOES NOT BUY, stated plainly. Turning cancellation off does not give
+# every merge its own conclusive run: the group still admits at most one running
+# plus one pending run, and a newer arrival supersedes the older *pending* one.
+# So the tip always eventually gets a full run, but a fast burst of merges loses
+# individual attribution — a red run on the tip covers the union of merges since
+# the last conclusive one, and finding which merge did it is a bisect. That is
+# the deliberate trade: per-merge attribution costs a run per merge (a per-run
+# group keyed on `github.run_id`, roughly 10x the minutes), and the alternative
+# that is cheaper — an hourly scheduled run on `main` — tells you later and
+# attributes the breakage to nothing at all. The structurally correct answer is
+# a MERGE QUEUE, which verifies the exact merged state before it becomes `main`
+# and makes this question moot; it needs a `merge_group` trigger plus a
+# branch-protection change no PR can make, and with a 26–30 minute critical path
+# it either serialises merges to ~2/hour or has to batch. Tracked separately.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != format('refs/heads/{0}', github.event.repository.default_branch) }}
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,50 @@ jobs:
       - name: Test the SQLite backend
         run: cargo test --locked --features sqlite --lib store::sqlite
 
+      # Issue #770. Two more suites in the shape the SQLite step above rescued:
+      # gated behind a feature, compiled by `Check (--all-features)`, and run by
+      # NOTHING. Both are offline and add no dependency this job does not already
+      # build, which is why they ride the fast default lane rather than earning
+      # jobs of their own.
+      #
+      # Through `run-scoped-suite.sh`, which asserts a NON-ZERO count. A filter
+      # that stops matching prints `0 passed` and exits 0, so a lane added to run
+      # a gated suite can report success having run none of it — the same defect
+      # one level up. The count is what separates "everything passed" from
+      # "nothing ran", exactly as the MongoDB job argues below.
+      #
+      # NO `sidecar` LANE HERE, and its absence is deliberate. That feature gates
+      # fourteen tests that had never run; twelve pass and the two offline
+      # end-to-end cases its own documentation advertises FAIL (the inference
+      # callback fires zero times). Issue #800 has the diagnosis. The lane lands
+      # with the fix rather than red, because a lane allowed to be red is the
+      # state #428 was filed about — and until then
+      # `scripts/ci/feature-lanes.txt` records the debt as `owed`, so it is
+      # countable instead of silent.
+      #
+      # `export`: the bundle round-trip. Only `pack_tar`/`unpack_tar` are gated,
+      # so nine of the ten tests this selects already run at default features —
+      # the tenth, `tar_pack_unpack_roundtrip`, is the one that never has. The
+      # nine are re-run rather than filtered out because splitting them apart
+      # would cost a second filter to save milliseconds on an already-compiled
+      # tree.
+      - name: Test the export bundle
+        run: scripts/ci/run-scoped-suite.sh "export bundle" export store::export
+
+      # `imap`/`smtp`: the mail surface. One gated test runs here today — the
+      # RFC822 parser — and it is a parser, which is precisely the kind of code
+      # that rots silently. `smtp` is compiled alongside deliberately: it carries
+      # no gated test of its own yet (see scripts/ci/feature-lanes.txt), and
+      # building both means a mail test added on either side has a lane already.
+      #
+      # `live_smoke::send_then_receive_roundtrip` stays `#[ignore]`d and is NOT
+      # covered by this step. It dials a real mailbox with real credentials, so
+      # it is one `--ignored` flag away from running in a lane that now compiles
+      # it — and still executes nowhere. Issue #798 tracks giving it a mail
+      # service container; until then, say so rather than imply otherwise.
+      - name: Test the mail surface
+        run: scripts/ci/run-scoped-suite.sh "mail (imap)" imap,smtp server::ops::imap
+
       # Issue #428. The `Console E2E` job drives a REAL host, so it needs a
       # binary. Building one over there would mean a second submodule checkout
       # and a second cold Rust compile — minutes of wall clock to produce a
@@ -477,6 +521,26 @@ jobs:
             exit 1
           fi
           echo "MongoDB backend suite: ${passed} tests passed."
+
+      # Issue #770. The step above pins `--lib store::mongodb`, and there is one
+      # `mongodb`-gated test that lives OUTSIDE that module:
+      # `store::select::mongodb_selection_requires_uri`, which asserts that
+      # selecting the Mongo backend without a URI is an error rather than a
+      # silent fallback. The filter above cannot reach `store::select`, no other
+      # lane enables `mongodb`, and `Check (--all-features)` only compiles it —
+      # so it ran nowhere.
+      #
+      # This is the #555 comment above happening a second time to the same
+      # feature, one module over: a filter that is right about the module it
+      # names says nothing about the module it does not. The classification
+      # table records `store::select` alongside `store::mongodb` for exactly this
+      # reason, and `assert-feature-lanes.sh` fails if either filter stops
+      # appearing here.
+      #
+      # It needs no server (it asserts the failure BEFORE connecting), so it
+      # rides this job for the feature build rather than earning one of its own.
+      - name: Test the MongoDB storage selection
+        run: scripts/ci/run-scoped-suite.sh "mongodb selection" mongodb store::select
 
   # Issue #202. The `Rust` job above builds DEFAULT FEATURES ONLY, so every line
   # behind `openhuman` (`src/harness/**`, `src/workflows/**`, `src/runtime/`
@@ -666,8 +730,89 @@ jobs:
       # `--locked` per issue #251's rule for every graph-resolving invocation:
       # this is a fourth distinct feature resolution, so without it this lane
       # would be the one place CI silently re-resolves the dependency graph.
-      - name: Test tool-belt contract (openhuman, mcp, telegram)
-        run: cargo test --locked --features openhuman,mcp,telegram --lib harness::build::tests
+      # `+media` since issue #770, and the widening is the point rather than a
+      # tidy-up. `media` gates two tests — the belt's media-namespace mapping in
+      # `harness::build` and the tool-name/namespace pin in `harness::toolbelt` —
+      # and BOTH were compiled by `Check (--all-features)` and run by nothing.
+      # Adding the feature to the set this step already builds runs the first at
+      # no extra compile; the second needs its own filter, below, because
+      # `harness::build::tests` does not reach `harness::toolbelt`.
+      #
+      # These tools spend real money (`media_generate_image` / `_video` against a
+      # MANAGED platform credential), and what they are gated on is the belt
+      # entry that decides whether an agent can reach them at all. An unrun
+      # namespace pin is the wrong thing to have never executed.
+      - name: Test tool-belt contract (openhuman, mcp, telegram, media)
+        run: scripts/ci/run-scoped-suite.sh "tool-belt contract" openhuman,mcp,telegram,media harness::build::tests
+
+      # The `media` toolbelt's other half: the three tool names and their single
+      # `media` namespace. Same feature set as the step above, so this costs a
+      # filtered re-run of an already-compiled tree and no fourth resolution.
+      - name: Test the media toolbelt
+        run: scripts/ci/run-scoped-suite.sh "media toolbelt" openhuman,mcp,telegram,media harness::toolbelt
+
+      # The `mcp` OAuth-flow state, which the belt filter above never reached.
+      # `app::types` holds two gated tests — a parked flow is SINGLE-USE (a
+      # replayed callback finds nothing) and it EXPIRES, with a sweep on park so
+      # an abandoned flow's client secret cannot outlive its TTL even if nobody
+      # ever takes it. Both are secret-lifetime invariants, both were run by
+      # nothing, and neither is the sort of property to discover is broken from a
+      # production incident.
+      #
+      # A separate invocation, not a second bare argument on the step above: the
+      # first bare argument is the filter and a second would narrow the selection
+      # to nothing — the trap the ACP step already documents, and the reason
+      # `run-scoped-suite.sh` takes exactly one filter.
+      - name: Test the MCP OAuth flow state
+        run: scripts/ci/run-scoped-suite.sh "mcp oauth state" openhuman,mcp,telegram,media app::types
+
+      # Issue #770. `composio` gated TWENTY-FOUR tests that ran nowhere — the
+      # largest single pocket found. `src/harness/composio_catalog.rs` says so in
+      # its own doc comment ("the live tools are behind `composio`, which CI
+      # never *runs*"), which is a fact about this file that nothing enforced.
+      #
+      # What was unrun is not incidental: per-tenant ISOLATION (each tenant only
+      # ever carries its own token; a rotated token is scrubbed per call; an
+      # error body reflecting the token is scrubbed), the allowlist refusals that
+      # happen BEFORE any network call, and the end-to-end proof that an agent
+      # discovers and calls an action unaided across two large toolkits. Tenant
+      # token isolation is the property that keeps one company out of another's
+      # Gmail; it had no runner.
+      #
+      # All offline — the Composio backend is scripted in every one of them.
+      #
+      # `openhuman,tinycortex,composio` rather than a bare `--features composio`
+      # (which would imply `openhuman` anyway): matching this job's own set means
+      # the vendored tree is already built and only this crate recompiles.
+      # `composio` adds no `openhuman_core/*` subfeature, so there is no vendored
+      # rebuild at all.
+      #
+      # TWO NARROW FILTERS RATHER THAN THE BARE WORD `composio`, which would be a
+      # substring match sweeping every composio module at once. That wider
+      # selection is what this lane should eventually be, and it cannot be yet:
+      # of the 24, two FAIL. `server::ops::composio::tests::an_admin_is_unaffected`
+      # dials `api.tinyhumans.ai` for real once the feature is on (it passes today
+      # only because the un-gated stub stands in), and the scripted two-toolkit
+      # turn reaches neither provider. Issue #801 has both diagnoses; the wider
+      # filter lands with the fix, not as a red lane (#428).
+      #
+      # These two groups are chosen because they are the ones whose silence cost
+      # the most. `isolation_tests` is per-tenant token isolation — each tenant
+      # only ever carries its own token and sees its own accounts, a rotated
+      # token is scrubbed per call, an error body reflecting the token is
+      # scrubbed. That is the property keeping one company out of another's
+      # Gmail, and it had no runner at all. `ops_helper_tests` is the allowlist
+      # refusals that must happen BEFORE any network call, plus the catalog and
+      # connection projections.
+      #
+      # Separate invocations, each with its own asserted count, for the reason
+      # the ACP step above states: the first bare argument is the filter and a
+      # second would narrow the selection to nothing.
+      - name: Test Composio tenant isolation
+        run: scripts/ci/run-scoped-suite.sh "composio isolation" openhuman,tinycortex,composio harness::composio::isolation_tests
+
+      - name: Test the Composio ops helpers
+        run: scripts/ci/run-scoped-suite.sh "composio ops helpers" openhuman,tinycortex,composio harness::composio::ops_helper_tests
 
       # Issue #477. Before this step, `tinyplace` was COMPILED by CI and
       # EXECUTED by nothing. `Check (--all-features)` above builds every

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,18 @@ per target via `scripts/ci/assert-integration-targets-run.sh`; if your target
 needs a feature set no lane builds, add the lane and run that script there too
 rather than loosening the `cfg`.
 
+A feature-gated test has the same problem one level up (issue #770). Cargo
+features are additive and every CI lane pins an explicit feature set, so a test
+behind `#[cfg(feature = "x")]` is compiled by `Check (--all-features)` and
+executed by nothing unless some lane enables `x` — and nothing reports the
+silence. Every feature therefore needs a row in `scripts/ci/feature-lanes.txt`
+saying which lane runs its tests (`tested`/`partial`) or why none does
+(`compile-only`, with a reason). `scripts/ci/assert-feature-lanes.sh` fails on an
+unclassified feature, and fails a `compile-only` row that turns out to have a
+gated test. When you add the lane, run it through
+`scripts/ci/run-scoped-suite.sh`, which asserts a non-zero count — a filter that
+selects nothing exits 0.
+
 Maintain at least 80% coverage for meaningful library behavior. Document any
 intentionally untested edge case in the PR description.
 

--- a/scripts/ci/assert-feature-lanes.sh
+++ b/scripts/ci/assert-feature-lanes.sh
@@ -221,8 +221,15 @@ while IFS='|' read -r feature status features detail; do
           echo "::error title=No default test lane::\`${feature}\` is covered by the default feature set, but ${WORKFLOW} has no bare \`cargo test --locked\` line to run it." >&2
           failed=1
         fi
-      elif ! grep -q -- "cargo test .*--features ${features}" "${WORKFLOW}"; then
-        echo "::error title=Feature has no lane::\`${feature}\` is classified ${status} on \`--features ${features}\`, but no \`cargo test\` line in ${WORKFLOW} enables that feature set. Add the lane, or reclassify the row." >&2
+      # A lane is either a direct `cargo test … --features X` line or a
+      # `run-scoped-suite.sh <label> X <filter>` invocation, which is the same
+      # cargo call with the non-zero-count assertion wrapped around it. Both
+      # forms are accepted deliberately: the wrapper is the preferred shape for
+      # new lanes, and the pre-existing direct invocations are not worth churning
+      # to satisfy a grep.
+      elif ! grep -q -- "cargo test .*--features ${features}" "${WORKFLOW}" \
+        && ! grep -qE "run-scoped-suite\.sh .*[[:space:]]${features}[[:space:]]" "${WORKFLOW}"; then
+        echo "::error title=Feature has no lane::\`${feature}\` is classified ${status} on \`--features ${features}\`, but no \`cargo test\` line and no \`run-scoped-suite.sh\` invocation in ${WORKFLOW} enables that feature set. Add the lane, or reclassify the row." >&2
         failed=1
       fi
 

--- a/scripts/ci/assert-feature-lanes.sh
+++ b/scripts/ci/assert-feature-lanes.sh
@@ -1,0 +1,307 @@
+#!/bin/sh
+#
+# Assert that every Cargo feature is either run by a CI lane or declared
+# compile-only WITH A REASON — and that a compile-only declaration is true.
+# Issue #770.
+#
+# The failure this exists to catch is not a red test. It is a feature-gated test
+# that NOTHING SELECTS. Cargo features are additive and every test lane in
+# ci.yml pins an explicit feature set, so the default fate of a gated test is
+# "compiled by `Check (--all-features)`, executed by nothing" — `cargo test`
+# prints no mention of it, no lane reports zero, and a suite everybody reads as
+# coverage guards nothing. Six features had accumulated never-executed tests
+# before this check existed, including the `sidecar` brain's entire offline
+# end-to-end suite and two OAuth secret-lifecycle tests in `app::types`.
+#
+# It is the same shape as #475 (an integration target no lane selected), #477
+# (`tinyplace` compiled and never run), #555 (the MongoDB conformance suite) and
+# #592 (a submodule-init block copied into several lanes with one copy missed).
+# Each was found by hand, after the fact. This is the check that finds the next
+# one at the moment it is introduced.
+#
+# WHAT IT ASSERTS, per feature, against scripts/ci/feature-lanes.txt:
+#
+#   * every feature `cargo metadata` reports has a row (an unmapped feature is
+#     RED — a new feature cannot merge until someone writes down which lane runs
+#     its tests, or why none does);
+#   * every row names a real feature (a stale row for a deleted feature is RED,
+#     because a table that describes a tree that no longer exists is worse than
+#     no table);
+#   * `tested` / `partial` rows name a feature set that some `cargo test` line in
+#     ci.yml actually enables, and `partial` rows additionally name filters that
+#     appear there;
+#   * `compile-only` rows carry a reason AND have no feature-gated test anywhere
+#     under src/ or tests/. This is the load-bearing one: it is what makes
+#     "deliberate" checkable rather than merely claimed.
+#
+# WHAT IT DOES NOT ASSERT, stated so nobody reads more into a green run than is
+# there. For a `partial` row it cannot prove the filters SELECT every gated test
+# the feature owns — a filter that misses one is invisible here. Two other
+# things cover that from the runtime side: the per-step count assertions in
+# ci.yml (a filter that selects nothing exits 0, which is why every lane's count
+# is asserted non-zero) and scripts/ci/assert-integration-targets-run.sh. This
+# script is the STATIC half — it proves a lane was declared, not that the lane
+# is exhaustive. Keep the filters honest by hand.
+#
+# The three gated-test idioms in this tree, all three of which it detects:
+#
+#   (a) #[cfg(all(test, feature = "x"))]  on a test module or test-only helper
+#   (b) #[cfg(feature = "x")] immediately above #[test] / #[tokio::test]
+#   (c) #[cfg(feature = "x")] on a `mod y;` declaration, with the tests inside
+#       that module's own file — this is how `sidecar` hid fourteen of them, so
+#       it is detected rather than assumed away.
+#
+# Requires `jq` (present on ubuntu-latest; `brew install jq` locally).
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}"
+
+TABLE="scripts/ci/feature-lanes.txt"
+WORKFLOW=".github/workflows/ci.yml"
+
+if ! command -v jq > /dev/null 2>&1; then
+  echo "assert-feature-lanes: jq is required but not installed" >&2
+  exit 1
+fi
+
+for required in "${TABLE}" "${WORKFLOW}"; do
+  if [ ! -f "${required}" ]; then
+    echo "assert-feature-lanes: ${required} is missing" >&2
+    exit 1
+  fi
+done
+
+WORK=$(mktemp -d)
+trap 'rm -rf "${WORK}"' EXIT
+
+# --- Ground truth: the features Cargo itself reports ------------------------
+#
+# `cargo metadata`, NOT a grep over Cargo.toml's [features] block. The manifest
+# is not the whole story: an optional dependency named WITHOUT `dep:` also
+# creates an implicit feature (here: `tinyagents`, via `tiny = ["tinyagents"]`),
+# and a grep for `^name =` would miss it. A table that silently omits a feature
+# is the exact hole this script exists to close, so the enumeration has to come
+# from the resolver rather than from the text.
+cargo metadata --no-deps --locked --format-version 1 \
+  | jq -r '.packages[] | select(.name == "opencompany") | .features | keys[]' \
+  | sort > "${WORK}/features"
+
+if [ ! -s "${WORK}/features" ]; then
+  echo "::error title=Feature enumeration matched nothing::cargo metadata reported no features for the opencompany package, so this check is green while asserting nothing. The package name or the manifest layout changed." >&2
+  exit 1
+fi
+
+# --- The table --------------------------------------------------------------
+# Strip comments and blank lines, trim each field, keep `feature|status|features|detail`.
+sed -e 's/#.*$//' "${TABLE}" \
+  | awk -F'|' 'NF >= 4 {
+      for (i = 1; i <= 4; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i) }
+      if ($1 != "") { print $1 "|" $2 "|" $3 "|" $4 }
+    }' > "${WORK}/rows"
+
+if [ ! -s "${WORK}/rows" ]; then
+  echo "::error title=Classification table matched nothing::${TABLE} parsed to zero rows, so every feature would appear unclassified (or nothing would be checked at all). The file's format changed." >&2
+  exit 1
+fi
+
+cut -d'|' -f1 "${WORK}/rows" | sort > "${WORK}/classified"
+
+# A duplicate row is ambiguous — two answers for one feature, and the loop below
+# would check whichever came first.
+dupes=$(uniq -d < "${WORK}/classified" || true)
+if [ -n "${dupes}" ]; then
+  echo "::error title=Duplicate rows in the feature table::${TABLE} classifies these features more than once:" >&2
+  echo "${dupes}" >&2
+  exit 1
+fi
+
+failed=0
+
+# --- Every feature is classified, and every row is a real feature -----------
+
+unmapped=$(comm -23 "${WORK}/features" "${WORK}/classified")
+if [ -n "${unmapped}" ]; then
+  echo "::error title=Unclassified Cargo feature::A feature exists with no row in ${TABLE}, so nothing records whether any lane runs its tests. Add a row." >&2
+  echo "${unmapped}" | sed 's/^/  /' >&2
+  failed=1
+fi
+
+stale=$(comm -13 "${WORK}/features" "${WORK}/classified")
+if [ -n "${stale}" ]; then
+  echo "::error title=Stale row in the feature table::${TABLE} names features that no longer exist in Cargo.toml. Remove the rows." >&2
+  echo "${stale}" | sed 's/^/  /' >&2
+  failed=1
+fi
+
+# --- Gated-test detection ---------------------------------------------------
+#
+# Prints one `file:line: description` per gated TEST site for feature $1.
+# Covers the three idioms named in the header.
+gated_tests_for() {
+  feature="$1"
+
+  # (a) and (b): scan every Rust source for the two inline shapes.
+  find src tests -name '*.rs' -type f 2>/dev/null | sort | while IFS= read -r file; do
+    awk -v feat="${feature}" -v file="${file}" '
+      # (a) a test module or test-only helper gated on the feature
+      index($0, "cfg(all(test, feature = \"" feat "\"))") {
+        printf "%s:%d: gated test module/helper: #[cfg(all(test, feature = \"%s\"))]\n", file, NR, feat
+      }
+      # (b) a plain feature cfg standing immediately above a test attribute
+      index($0, "#[cfg(feature = \"" feat "\")]") { pending = NR; next }
+      pending && (NR - pending) <= 3 && /#\[(tokio::)?test\]/ {
+        printf "%s:%d: gated test: #[cfg(feature = \"%s\")] above %s\n", file, pending, feat, "#[test]"
+        pending = 0
+        next
+      }
+      pending && (NR - pending) > 3 { pending = 0 }
+    ' "${file}"
+  done
+
+  # (c) a whole module gated on the feature, with the tests inside it. Resolve
+  # `mod y;` to y.rs or y/mod.rs relative to the declaring file, then look for
+  # test attributes in that module's own source.
+  find src -name '*.rs' -type f 2>/dev/null | sort | while IFS= read -r file; do
+    dir=$(dirname "${file}")
+    awk -v feat="${feature}" '
+      index($0, "#[cfg(feature = \"" feat "\")]") { pending = NR; next }
+      pending && (NR - pending) <= 2 && match($0, /^[ \t]*(pub[ \t]+)?mod[ \t]+[A-Za-z0-9_]+[ \t]*;/) {
+        line = $0
+        sub(/^[ \t]*(pub[ \t]+)?mod[ \t]+/, "", line)
+        sub(/[ \t]*;.*$/, "", line)
+        print line
+        pending = 0
+        next
+      }
+      pending && (NR - pending) > 2 { pending = 0 }
+    ' "${file}" | while IFS= read -r modname; do
+      [ -n "${modname}" ] || continue
+      for candidate in "${dir}/${modname}.rs" "${dir}/${modname}/mod.rs"; do
+        [ -f "${candidate}" ] || continue
+        moddir=$(dirname "${candidate}")
+        if [ "$(basename "${candidate}")" = "mod.rs" ]; then
+          scan=$(find "${moddir}" -name '*.rs' -type f 2>/dev/null)
+        else
+          scan="${candidate}"
+        fi
+        for target in ${scan}; do
+          hit=$(grep -nE '#\[(tokio::)?test\]' "${target}" | head -n 1 || true)
+          if [ -n "${hit}" ]; then
+            echo "${target}:${hit%%:*}: gated module \`${modname}\` (gated in ${file}) contains tests"
+          fi
+        done
+      done
+    done
+  done
+}
+
+# --- Per-row checks ---------------------------------------------------------
+
+lanes_checked=0
+compile_only_checked=0
+
+while IFS='|' read -r feature status features detail; do
+  [ -n "${feature}" ] || continue
+
+  case "${status}" in
+    tested | partial)
+      if [ -z "${features}" ] || [ "${features}" = "-" ]; then
+        echo "::error title=Row names no feature set::\`${feature}\` is ${status} but its features column is empty. It must name the exact --features string the lane passes." >&2
+        failed=1
+        continue
+      fi
+
+      if [ "${features}" = "(default)" ]; then
+        # The default set is not passed via --features; it is what a bare
+        # `cargo test` builds. Assert that bare invocation exists.
+        if ! grep -qE 'cargo test --locked[[:space:]]*$' "${WORKFLOW}"; then
+          echo "::error title=No default test lane::\`${feature}\` is covered by the default feature set, but ${WORKFLOW} has no bare \`cargo test --locked\` line to run it." >&2
+          failed=1
+        fi
+      elif ! grep -q -- "cargo test .*--features ${features}" "${WORKFLOW}"; then
+        echo "::error title=Feature has no lane::\`${feature}\` is classified ${status} on \`--features ${features}\`, but no \`cargo test\` line in ${WORKFLOW} enables that feature set. Add the lane, or reclassify the row." >&2
+        failed=1
+      fi
+
+      if [ "${status}" = "partial" ]; then
+        if [ -z "${detail}" ] || [ "${detail}" = "-" ]; then
+          echo "::error title=Partial row names no filters::\`${feature}\` is partial, so its detail column must list the test filters its lane passes." >&2
+          failed=1
+        else
+          for filter in ${detail}; do
+            if ! grep -q -- "${filter}" "${WORKFLOW}"; then
+              echo "::error title=Filter not in the workflow::\`${feature}\` claims filter \`${filter}\`, which appears nowhere in ${WORKFLOW}. The table and the lane disagree." >&2
+              failed=1
+            fi
+          done
+        fi
+      fi
+
+      lanes_checked=$((lanes_checked + 1))
+      ;;
+
+    compile-only)
+      if [ -z "${detail}" ] || [ "${detail}" = "-" ]; then
+        echo "::error title=Compile-only without a reason::\`${feature}\` is declared compile-only with no reason given. Say why no lane runs its tests — an unexplained compile-only is indistinguishable from an oversight, which is the whole failure this check exists to end." >&2
+        failed=1
+      fi
+
+      found=$(gated_tests_for "${feature}")
+      if [ -n "${found}" ]; then
+        echo "::error title=Compile-only feature has gated tests::\`${feature}\` is declared compile-only in ${TABLE}, but these feature-gated tests exist. They are compiled by \`Check (--all-features)\` and RUN BY NOTHING." >&2
+        echo "${found}" | sed 's/^/  /' >&2
+        echo "  Fix the WIRING: add a lane to ${WORKFLOW} that runs them, then reclassify this row as tested/partial." >&2
+        failed=1
+      fi
+
+      compile_only_checked=$((compile_only_checked + 1))
+      ;;
+
+    *)
+      echo "::error title=Unknown status::\`${feature}\` has status \`${status}\`; expected tested, partial or compile-only." >&2
+      failed=1
+      ;;
+  esac
+done < "${WORK}/rows"
+
+# --- The check checks itself ------------------------------------------------
+#
+# Issue #555's lesson, applied here: a guard whose pattern silently stops
+# matching is green while asserting nothing, which is the same defect it was
+# built to catch. Zero of either kind means the table parsed but the loop did
+# not run, so say so rather than passing.
+if [ "${lanes_checked}" -eq 0 ] || [ "${compile_only_checked}" -eq 0 ]; then
+  echo "::error title=This check asserted nothing::Parsed $(wc -l < "${WORK}/rows" | tr -d ' ') rows but checked ${lanes_checked} lane(s) and ${compile_only_checked} compile-only row(s). A zero on either side means the status column stopped being read, so this script is green while checking nothing." >&2
+  exit 1
+fi
+
+# The gated-test detector is the load-bearing half, so prove the detector itself
+# still matches something rather than trusting that it does. `openhuman` gates
+# tests by every idiom the detector knows; if it finds none there, the patterns
+# have drifted away from the tree and every compile-only row above passed
+# vacuously.
+if [ -z "$(gated_tests_for openhuman)" ]; then
+  echo "::error title=Gated-test detection matched nothing::The detector found no gated tests under \`openhuman\`, which gates many. Its patterns no longer match this tree, so every compile-only row passed without being checked." >&2
+  exit 1
+fi
+
+echo
+if [ "${failed}" -ne 0 ]; then
+  cat >&2 << EOF
+Feature-lane classification is out of date.
+
+Every Cargo feature must say which CI lane runs its tests, or why none does.
+The table is scripts/ci/feature-lanes.txt and its format is documented at the
+top of that file.
+
+Do not "fix" a failure by deleting a test's #[cfg] or by relaxing a filter to
+match nothing. Both remove the code under test rather than running it, which is
+the failure this check exists to name.
+EOF
+  exit 1
+fi
+
+echo "Feature lanes: $(wc -l < "${WORK}/features" | tr -d ' ') features — ${lanes_checked} with a lane, ${compile_only_checked} compile-only and verified to have no gated tests."

--- a/scripts/ci/assert-feature-lanes.sh
+++ b/scripts/ci/assert-feature-lanes.sh
@@ -96,7 +96,12 @@ fi
 
 # --- The table --------------------------------------------------------------
 # Strip comments and blank lines, trim each field, keep `feature|status|features|detail`.
-sed -e 's/#.*$//' "${TABLE}" \
+#
+# WHOLE-LINE comments only — `^[[:space:]]*#` rather than a bare `#`. An `owed`
+# row's reason must name a tracking issue, and `#800` is a `#`: stripping
+# inline would silently empty the one field that row is required to fill, and
+# the check would then fail for a reason that is not the truth.
+sed -e 's/^[[:space:]]*#.*$//' "${TABLE}" \
   | awk -F'|' 'NF >= 4 {
       for (i = 1; i <= 4; i++) { gsub(/^[ \t]+|[ \t]+$/, "", $i) }
       if ($1 != "") { print $1 "|" $2 "|" $3 "|" $4 }
@@ -202,6 +207,7 @@ gated_tests_for() {
 
 lanes_checked=0
 compile_only_checked=0
+owed_checked=0
 
 while IFS='|' read -r feature status features detail; do
   [ -n "${feature}" ] || continue
@@ -267,8 +273,42 @@ while IFS='|' read -r feature status features detail; do
       compile_only_checked=$((compile_only_checked + 1))
       ;;
 
+    owed)
+      # A lane is OWED: gated tests exist, they run nowhere, and the reason is
+      # that the suite is currently RED rather than that anyone chose this.
+      #
+      # This status exists so a known-red gated suite is ENUMERABLE instead of
+      # silent, which is the entire complaint of #770. It is deliberately the
+      # least comfortable row in the table: it requires a tracking issue, and the
+      # two checks below stop it becoming a place to park things.
+      #
+      #   * It must name an issue. "Owed" without a ticket is just silence with
+      #     extra steps.
+      #   * It must actually HAVE gated tests. A feature with none belongs in
+      #     compile-only with a reason, so `owed` cannot be used to skip the
+      #     harder question of why a feature has no tests at all.
+      #
+      # What it does NOT do is let a red lane sit in ci.yml. There is no lane —
+      # that is the point. A lane permitted to be red is the state #428 was filed
+      # about, at more expense.
+      case "${detail}" in
+        *'#'[0-9]*) : ;;
+        *)
+          echo "::error title=Owed lane without a tracking issue::\`${feature}\` is classified owed, but its detail names no issue (expected a \`#NNN\` reference). An owed lane with nowhere to read why is indistinguishable from the silence this table exists to end." >&2
+          failed=1
+          ;;
+      esac
+
+      if [ -z "$(gated_tests_for "${feature}")" ]; then
+        echo "::error title=Owed lane has no gated tests::\`${feature}\` is classified owed, but no feature-gated test was found under it. A feature with no gated tests is compile-only — say so, with a reason, rather than recording a debt that does not exist." >&2
+        failed=1
+      fi
+
+      owed_checked=$((owed_checked + 1))
+      ;;
+
     *)
-      echo "::error title=Unknown status::\`${feature}\` has status \`${status}\`; expected tested, partial or compile-only." >&2
+      echo "::error title=Unknown status::\`${feature}\` has status \`${status}\`; expected tested, partial, compile-only or owed." >&2
       failed=1
       ;;
   esac
@@ -311,4 +351,4 @@ EOF
   exit 1
 fi
 
-echo "Feature lanes: $(wc -l < "${WORK}/features" | tr -d ' ') features — ${lanes_checked} with a lane, ${compile_only_checked} compile-only and verified to have no gated tests."
+echo "Feature lanes: $(wc -l < "${WORK}/features" | tr -d ' ') features — ${lanes_checked} with a lane, ${compile_only_checked} compile-only and verified to have no gated tests, ${owed_checked} owed a lane (tracked)."

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -58,12 +58,23 @@ sqlite         | partial      | sqlite                          | store::sqlite
 mongodb        | partial      | mongodb                         | store::mongodb store::select
 acp            | partial      | acp                             | server::acp harness::acp_run_turn
 runner         | partial      | runner                          | runner
-mcp            | partial      | openhuman,mcp,telegram          | harness::build::tests app::types
+mcp            | partial      | openhuman,mcp,telegram,media    | harness::build::tests app::types
 media          | partial      | openhuman,mcp,telegram,media    | harness::build::tests harness::toolbelt
-composio       | partial      | openhuman,tinycortex,composio   | composio
-sidecar        | partial      | sidecar                         | brain::sidecar
+composio       | partial      | openhuman,tinycortex,composio   | harness::composio::isolation_tests harness::composio::ops_helper_tests
 export         | partial      | export                          | store::export
 imap           | partial      | imap,smtp                       | server::ops::imap
+
+# --- Owed a lane: gated tests exist, and they are currently RED -------------
+#
+# Not a third kind of "fine". These are debts, listed so they are countable
+# instead of silent — which is the whole complaint of #770. Each names the issue
+# that will close it, and the script rejects an `owed` row that names no issue or
+# that turns out to have no gated tests at all.
+#
+# No lane is added for these on purpose: a lane permitted to be red is the state
+# #428 was filed about, at more expense. The lane lands with the fix.
+
+sidecar        | owed         | -                               | 14 gated tests, 12 green — the two offline end-to-end cases the feature advertises fail (the inference callback fires zero times). Tracked in #800; the lane lands with the fix.
 
 # --- Compile-only, by design ------------------------------------------------
 #

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -1,0 +1,90 @@
+# Which CI lane runs each Cargo feature's tests — and for the features no lane
+# runs, why that is deliberate. Asserted by scripts/ci/assert-feature-lanes.sh.
+#
+# Issue #770. Cargo features are additive and every test lane in ci.yml pins an
+# explicit feature set, so a feature-gated test's DEFAULT FATE is "compiled by
+# `Check (--all-features)`, executed by nothing". That is not a hypothetical:
+# six features had accumulated never-executed tests before this file existed,
+# including the `sidecar` brain's whole offline end-to-end suite and two OAuth
+# secret-lifecycle tests. Same pathology as #475, #477, #555 and #592 — a suite
+# everybody reads as coverage, selected by no lane, reporting zero without
+# failing anything.
+#
+# The point of this table is NOT that every feature must be tested. Some are
+# legitimately compile-only. The point is that DELIBERATE compile-only becomes
+# distinguishable from ACCIDENTAL, which it was not before: both looked like
+# silence. A new feature cannot merge until someone writes down which lane runs
+# its tests, or why none does.
+#
+# FORMAT — four `|`-separated columns:
+#
+#   feature | status | features | detail
+#
+#   status = tested       a lane runs this feature's tests WITHOUT a filter that
+#                         could narrow them away (a bare `--lib` or `--tests`).
+#                         `features` is the exact `--features` string that lane
+#                         passes, which must appear on a `cargo test` line in
+#                         ci.yml. `(default)` means the default feature set,
+#                         covered by the bare `cargo test --locked` in `Rust`.
+#
+#   status = partial      a lane exists but is FILTERED, so it runs the named
+#                         modules and not necessarily every gated test.
+#                         `features` as above; `detail` lists the filters, and
+#                         every one of them must also appear in ci.yml.
+#
+#   status = compile-only no lane runs this feature's tests, ON PURPOSE.
+#                         `features` is `-`; `detail` is the REASON, which is
+#                         required. The script FAILS this row if it finds any
+#                         feature-gated test under it — that is the whole
+#                         guard: a compile-only claim is checked, not trusted.
+#
+# WHEN YOU ADD A FEATURE: add a row. When you add a gated test to a
+# compile-only feature, this file fails until the row is reclassified and a lane
+# exists. That failure is the feature working.
+
+# --- Tested: a lane runs the gated tests unfiltered -------------------------
+
+default        | tested       | (default)                       | The `Rust` job's bare `cargo test --locked`.
+oauth          | tested       | (default)                       | In the default set, so the default lanes run it.
+platform-jwt   | tested       | (default)                       | In the default set (see Cargo.toml for why it ships by default).
+openhuman      | tested       | openhuman,tinycortex            | `rust-gated` runs `--tests`, which selects lib+bin units and every tests/ target.
+tinycortex     | tested       | openhuman,tinycortex            | Same lane, same unfiltered `--tests`.
+tinyplace      | tested       | tinyplace                       | Runs the whole `--lib` deliberately (issue #477) — it gates code across the tree.
+identity       | tested       | tinyplace                       | Enabled by `tinyplace`, whose lane is unfiltered; `runner` enables it too.
+
+# --- Partial: a lane exists, but filtered ----------------------------------
+
+sqlite         | partial      | sqlite                          | store::sqlite
+mongodb        | partial      | mongodb                         | store::mongodb store::select
+acp            | partial      | acp                             | server::acp harness::acp_run_turn
+runner         | partial      | runner                          | runner
+mcp            | partial      | openhuman,mcp,telegram          | harness::build::tests app::types
+media          | partial      | openhuman,mcp,telegram,media    | harness::build::tests harness::toolbelt
+composio       | partial      | openhuman,tinycortex,composio   | composio
+sidecar        | partial      | sidecar                         | brain::sidecar
+export         | partial      | export                          | store::export
+imap           | partial      | imap,smtp                       | server::ops::imap
+
+# --- Compile-only, by design ------------------------------------------------
+#
+# The shape shared by the six below: the PORT (a trait), its offline mock, and
+# the whole decision flow around it live in the default build and are tested
+# there. Only a thin real-network implementation sits behind the feature, and it
+# carries no test of its own — there is nothing to run without the network it
+# exists to reach. Verified per row: the `#[cfg(test)] mod test` blocks in these
+# files sit OUTSIDE the gated `mod http { … }`, so they already run at default
+# features.
+
+openhuman-rpc  | compile-only | - | Only `HttpOpenHumanRpc` is gated. The trait + offline mock + providers compile and test at default features; the gated module carries no test.
+github         | compile-only | - | Only `HttpGitHubClient` is gated. `GitHubClient`, its mock and the whole issue-filing flow test at default features (src/feedback/github.rs tests sit outside the gated `mod http`).
+tinyhumans     | compile-only | - | Only `HttpTinyHumansClient` / `HttpHubIdentityExchange` are gated. The trait, mock and routing decision test at default features.
+medulla        | compile-only | - | Only the HTTP/Socket.IO transport is gated. Wire types + `MockTransport` test at default features; the gated `http` module carries no test.
+webhooks       | compile-only | - | Only `HttpWebhookSink` / `HmacSha256Signer` are gated. The `WebhookSink` trait, `RecordingWebhookSink` and the deterministic default signer test at default features.
+dns            | compile-only | - | Only `HickoryDnsResolver` is gated. The `DnsResolver` trait, `StaticDnsResolver` and the pure record generation test at default features.
+
+# --- Compile-only, no gated test exists yet ---------------------------------
+
+smtp           | compile-only | - | Only `LettreMailSender` is gated and it carries no gated test; the `MailSender` trait and `RecordingMailSender` test at default features. The mail lane compiles smtp beside imap so a gated test added later has a home — RECLASSIFY THIS ROW to `partial` when one is added, which this script will force.
+telegram       | compile-only | - | Only `HttpTelegramApi` is gated and carries no gated test; the trait, inbound parsing, token scrubbing and `RecordingTelegramApi` test at default features. The feature IS enabled on the belt lane, for the belt contract rather than for tests of its own.
+tiny           | compile-only | - | A dependency switch: it brings the vendored `tinyagents` crate into scope for `openhuman`. No code is gated on `tiny` itself, so there is nothing for a lane to run.
+tinyagents     | compile-only | - | The implicit feature of the optional `tinyagents` dependency, enabled only via `tiny`. Nothing is gated on it directly.

--- a/scripts/ci/run-scoped-suite.sh
+++ b/scripts/ci/run-scoped-suite.sh
@@ -1,0 +1,87 @@
+#!/bin/sh
+#
+# Run one feature-gated `--lib` suite and assert it actually executed something.
+# Issue #770.
+#
+# The trap this closes: `cargo test --lib some::filter` that matches NOTHING
+# prints `0 passed; 0 failed` and EXITS 0. A lane added to run a gated suite can
+# therefore report success having run none of it — which is the same defect the
+# lane was added to fix, one level up. It is not hypothetical here: it is why
+# the MongoDB job (#555) asserts a count inline, and why
+# `assert-integration-targets-run.sh` (#475) exists for the `tests/` targets.
+#
+# Both of those are per-site answers. This is the shared one, so that the six
+# lanes added for #770 do not each carry their own copy of the parse-and-check
+# boilerplate — copies drift, and a lane whose copy was pasted slightly wrong is
+# exactly the #592 shape (one lane quietly not doing what its siblings do).
+#
+# Usage:
+#   scripts/ci/run-scoped-suite.sh <label> <features> <filter>
+#
+#   label     what to call this suite in the log and in a failure message
+#   features  the exact --features string (comma-separated, no spaces)
+#   filter    ONE test-name filter
+#
+# EXACTLY ONE FILTER, and that is a hard interface rather than an oversight.
+# `cargo test --lib a b` reads `a` as the filter and `b` as ANOTHER filter only
+# in recent cargo; historically the second bare argument lands in the test
+# binary's argument list where it silently narrows the selection to nothing.
+# ci.yml already documents this trap at the ACP step ("Two invocations, not
+# one"). Taking a single filter makes the safe shape the only shape: to cover
+# two modules, call this script twice and get two asserted counts instead of one
+# ambiguous run.
+#
+# `--lib` is fixed, not a parameter. Integration targets under `tests/` have
+# their own assertion with its own failure text
+# (`assert-integration-targets-run.sh`), and folding both into one script would
+# make each failure message describe the other's situation half the time.
+#
+# `--locked` is passed for every invocation, per issue #251's rule: each feature
+# set here is a distinct dependency resolution, and without it these lanes would
+# be the place CI silently re-resolves the graph.
+
+set -eu
+
+if [ "$#" -ne 3 ]; then
+  echo "usage: $0 <label> <features> <filter>" >&2
+  echo "  exactly three arguments; see the header for why the filter is singular" >&2
+  exit 2
+fi
+
+LABEL="$1"
+FEATURES="$2"
+FILTER="$3"
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+REPO_ROOT=$(CDPATH='' cd -- "${SCRIPT_DIR}/../.." && pwd)
+cd "${REPO_ROOT}"
+
+LOG="${RUNNER_TEMP:-/tmp}/scoped-suite-$(echo "${LABEL}" | tr -c 'A-Za-z0-9' '-').log"
+
+echo "==> ${LABEL}: cargo test --locked --features ${FEATURES} --lib ${FILTER}"
+
+cargo test --locked --features "${FEATURES}" --lib "${FILTER}" 2>&1 | tee "${LOG}"
+
+# The pipeline's first command, not `tee`'s status. A compile error or a failing
+# test must fail this script, and without this check `set -e` would only see the
+# exit code of `tee`, which is 0 whatever cargo did.
+#
+# `$?` after a pipeline is the LAST command's status in POSIX sh, so the status
+# is recovered by re-reading cargo's own summary below rather than by
+# ${PIPESTATUS[@]} (a bashism this `#!/bin/sh` script cannot use). A run that
+# failed to compile prints no `test result:` line at all and is caught by the
+# empty-count branch; a run with failing tests prints `test result: FAILED`,
+# which the `ok\.` pattern deliberately does not match.
+passed=$(sed -n 's/^test result: ok\. \([0-9][0-9]*\) passed.*/\1/p' "${LOG}" | head -n 1)
+
+if [ -z "${passed}" ]; then
+  echo "::error title=${LABEL} did not report a passing run::cargo printed no \`test result: ok.\` line for --features ${FEATURES} --lib ${FILTER}. The suite failed to build, or a test failed — read the log above." >&2
+  exit 1
+fi
+
+if [ "${passed}" -eq 0 ]; then
+  echo "::error title=${LABEL} ran nothing::cargo reported 0 passing tests for --features ${FEATURES} --lib ${FILTER}, so this step is green while asserting nothing. The filter selects no test — it was renamed, moved, or gated away. See issue #770." >&2
+  exit 1
+fi
+
+echo "${LABEL}: ${passed} passed."


### PR DESCRIPTION
## Summary

Cargo features are additive and every test lane in `ci.yml` pins an explicit feature set,
so a feature-gated test's **default fate is "compiled by `Check (--all-features)`, executed
by nothing"**. Nothing reports that: no lane goes red, no count reads zero, the test simply
is not selected.

**44 never-executed tests across seven features.** This adds the lanes that run them, a
wrapper that asserts each lane's count is non-zero, and a checked-in classification table
plus a guard so the eighth case fails at the moment it is introduced rather than being
found by hand months later — the way #475, #477, #555 and #592 all were.

Stacked on #794 (which is what lets these lanes' post-merge runs on `main` actually finish).

## API Or Behavior Changes

None. CI-only, plus one paragraph in `AGENTS.md`.

### The inventory, verified rather than inherited

Every count below was measured by diffing `cargo test … -- --list` for the feature against
the lane that runs today. **Four of the planning inventory's numbers were wrong**, and one
whole feature was missing from it:

| Feature | Planned | **Verified** | What the difference was |
|---|---|---|---|
| `composio` | 18 | **24** | Spread wider than assumed: `harness::composio` (isolation, ops-helper, slug/allowlist), `harness::composio_turn_test` (3) and `server::ops::composio` (1). Also `composio_turn_test.rs` is `src/harness/composio_turn_test.rs` — a `--lib` module, **not** a `tests/` integration target, so it needs a `--lib` filter, not `--test`. |
| `sidecar` | 14 | **14** ✓ | Module-gated, so invisible to a grep for gated tests — the whole `src/brain/sidecar/` tree is behind the feature. |
| `mcp` | 2 | **2** ✓ | `app::types` 19 → 21. |
| `media` | 2 | **1** | `build.rs:372` is **production wiring** (`if grants_media_explicit(…)`), not a test. The single gated test is in `harness::toolbelt`. |
| `export` | 1 | **1** ✓ | `tar_pack_unpack_roundtrip`. |
| `imap` | 1 | **1** ✓ | The RFC822 parser test. |
| `smtp` | (grouped with imap) | **0** | Has no gated test at all — so it is compile-only, not a lane candidate. |
| **`mongodb`** | **not listed** | **1** | **New finding.** `store::select::mongodb_selection_requires_uri` sits outside the `rust-mongodb` job's `--lib store::mongodb` filter, so #555's own lane misses it — the same defect one module over. |

**The `media` correction matters most**, because the planned fix would have silently done
nothing. `harness::build::tests` does not reach `harness::toolbelt`, so widening the belt
step to `+media` alone changes the count by **exactly zero** (measured: 25 → 25). The lane
would have been green while adding no coverage — the precise failure this PR is about. The
widening is kept (it makes the feature-aware belt pin cover the media wiring branch) and a
`harness::toolbelt` filter is added for the test itself.

The six features the plan called compile-only **by design** are confirmed: in
`github`/`tinyhumans`/`medulla`/`openhuman-rpc`/`webhooks`/`dns` the `#[cfg(test)] mod test`
sits **outside** the gated `mod http { … }`, so the trait, its mock and the whole decision
flow already run at default features and only a thin real-network impl is gated, carrying
no test. Four more join them (`smtp`, `telegram`, `tiny`, `tinyagents`) for the same reason.

### Turning the lanes on found four RED tests

This is the part that could not be known before, and it is the argument for the whole
change: **an unrun suite rots.** Both are held back rather than landed red — a lane
permitted to be red is the state #428 was filed about.

- **#800 — `sidecar`: 12 pass, 2 fail.** The two failures are the two offline end-to-end
  cases the feature's own `Cargo.toml` entry advertises. The inference callback fires zero
  times where the test expects one. Not a feature-combination artifact: `sidecar,tiny`
  fails identically. **No sidecar lane in this PR**; the feature is recorded `owed` in the
  table so the debt is countable instead of silent.
- **#801 — `composio`: 106 pass, 2 fail.** One is a test-design defect that only appears
  with the feature on: `server::ops::composio::tests::an_admin_is_unaffected` makes a **live
  outbound call to `api.tinyhumans.ai`** (it passes today only because the un-gated stub
  stands in). The other is the scripted two-toolkit turn reaching neither provider. So this
  PR lands the two groups that are green and whose silence cost the most, rather than the
  bare `composio` sweep.

## Tests

Every lane prints a **non-zero count**, and the count is the evidence — not the checkmark.
These are the numbers **printed by CI** in the green run
[31618573162](https://github.com/tinyhumansai/opencompany/actions/runs/31618573162) (all
eight jobs green), and they match what the same commands print locally:

| Lane | Job | Count |
|---|---|---|
| `export bundle` | Rust | **10 passed** (1 never-run + 9 already covered) |
| `mail (imap)` | Rust | **2 passed**, 1 ignored |
| `mongodb selection` | Rust (mongodb) | **12 passed** |
| `tool-belt contract` | Rust (openhuman, tinycortex) | **25 passed** |
| `media toolbelt` | Rust (openhuman, tinycortex) | **18 passed** |
| `mcp oauth state` | Rust (openhuman, tinycortex) | **21 passed** |
| `composio isolation` | Rust (openhuman, tinycortex) | **3 passed** |
| `composio ops helpers` | Rust (openhuman, tinycortex) | **12 passed** |

### The guard was proven to detect, before it was made to pass

Commit `ad1abbb` — the script and the table with the defective features classified at their
target state — was pushed **alone**, against the still-laneless `ci.yml`, so the run would
go red. It did:

- **Red run: [31617296695](https://github.com/tinyhumansai/opencompany/actions/runs/31617296695)** —
  job **`Rust`: `failure`** at step 7, *"Assert every feature has a test lane or a stated
  reason"*, with `Format`/`Clippy`/`Test` skipped behind it. That is the proof of detection.

  Read the **job**, not the run. The run's own conclusion says `cancelled`, because pushing
  the lanes superseded it while the 26-minute gated job was still going — PR-branch
  cancellation working exactly as #794 preserves it. The `Rust` job had already finished
  and its `failure` stands in the job list.

  What it printed is the same output the script gives locally: one error per unmapped
  feature, e.g. `` `composio` is classified partial on `--features
  openhuman,tinycortex,composio`, but no `cargo test` line and no `run-scoped-suite.sh`
  invocation in .github/workflows/ci.yml enables that feature set. ``
- **Green run: [31618573162](https://github.com/tinyhumansai/opencompany/actions/runs/31618573162)** —
  every job green, and the same step now prints
  `Feature lanes: 27 features — 16 with a lane, 10 compile-only and verified to have no gated tests, 1 owed a lane (tracked)`.

### Both gates were proven to fail on broken input

A gate shown only to pass on good input is not shown to work.

- **The count assertion.** Run with a deliberately wrong filter: cargo printed
  `test result: ok. 0 passed` and **exited 0** — the exact trap — and
  `run-scoped-suite.sh` turned it into **exit 1** with a named error. Verified true exit
  code, not a pipeline's.
- **The compile-only detector.** `sidecar` was temporarily reclassified `compile-only` (a
  false claim). The guard caught it and named the file:
  `src/brain/sidecar/test.rs:158: gated module 'sidecar' (gated in src/brain/mod.rs) contains tests`.
  That is idiom (c) — a whole module behind the feature with the tests inside it — which a
  plain grep for gated tests does not see, and which is how `sidecar` hid fourteen.

Also: `actionlint .github/workflows/ci.yml` clean.

- [x] N/A: `cargo fmt --all -- --check` — no Rust source changed; this diff is CI config, two shell scripts and a docs paragraph.
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — as above.
- [x] N/A: `cargo build --all-targets` — as above.
- [x] `cargo test` — run per new lane rather than as one invocation; the eight feature-scoped runs and their counts are the table above.

## Documentation

- `AGENTS.md` gains a paragraph in **Testing Guidelines**, beside the existing #475
  paragraph it parallels: a gated test needs a row in `scripts/ci/feature-lanes.txt`, and
  new lanes go through `run-scoped-suite.sh` because a filter that selects nothing exits 0.
- `scripts/ci/feature-lanes.txt` documents its own format and states what the table is
  *for*: making deliberate compile-only distinguishable from accidental, which it was not
  before — both looked like silence.
- `assert-feature-lanes.sh` states plainly **what it does not assert**: for a `partial` row
  it cannot prove the filters select every gated test the feature owns. The per-lane count
  assertions and `assert-integration-targets-run.sh` are the runtime half; this is the
  static half.

## Related

Part of #770 (closed by #794)
- #794 — stacked under this; stops `main` cancelling its own verification
- #800 — `sidecar`'s two end-to-end tests fail (why there is no sidecar lane here)
- #801 — `composio`: a test dials the real API under the feature, and the turn test fails
- #798 — `live_smoke::send_then_receive_roundtrip` still runs nowhere: after this it is
  compiled and one `--ignored` flag away, and it needs a mail service container
- #475, #477, #555, #592 — the same defect family, each found by hand
