### PR TITLE
feat(workflows): a workflow run can open and re-own board cards (#661 M5, PR2)

### DIFF
--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -674,6 +674,7 @@ mod test {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         };
 
         let wired = wire_event(7, &event);
@@ -713,6 +714,7 @@ mod test {
             error: None,
             cancelled: true,
             notices: Vec::new(),
+            board: Vec::new(),
         };
 
         let wired = wire_event(7, &event);

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2210,6 +2210,8 @@ mod tests {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
 
         let first = runtime.open_run(&card).await.expect("an attempt is minted");
@@ -2300,6 +2302,8 @@ mod tests {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
 
         // Positive control: on a live runtime the cycle runs, so the row is

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2024,6 +2024,8 @@ impl HarnessBrain {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         // The card is written **first**: an artifact's `task_id` must name a
         // card that exists. If the artifact writes then fail, the failure
@@ -3703,6 +3705,8 @@ members = ["engineer"]
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 
@@ -6766,6 +6770,8 @@ members = ["eng1", "eng2"]
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 

--- a/src/harness/lifecycle.rs
+++ b/src/harness/lifecycle.rs
@@ -425,6 +425,8 @@ mod test {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4393,6 +4393,7 @@ mod tests {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         });
 
         assert!(!summary.contains(RECIPIENT), "{summary}");
@@ -4420,6 +4421,7 @@ mod tests {
             error: None,
             cancelled: true,
             notices: Vec::new(),
+            board: Vec::new(),
         });
 
         assert!(summary.contains("stopped"), "{summary}");
@@ -6621,6 +6623,7 @@ name = "Morning"
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             })
         }
     }
@@ -6745,6 +6748,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         });
         let calls = runner_impl.calls.clone();
         let runner: Arc<dyn WorkflowRunner> = Arc::new(runner_impl);
@@ -6789,6 +6793,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -6888,6 +6893,7 @@ name = "Morning"
             cancelled: true,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -6923,6 +6929,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7125,6 +7132,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7191,6 +7199,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7267,6 +7276,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7366,6 +7376,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7982,6 +7993,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         };
         let md = summarize_run(&file, &run, "run-xyz", RunOutputStored::Stored);
         assert!(md.contains("last of 3 items — third"), "{md}");
@@ -7996,6 +8008,7 @@ name = "Morning"
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         };
         let md = summarize_run(&file, &run_one, "run-1", RunOutputStored::Stored);
         assert!(md.contains("1 item(s) — only"), "{md}");
@@ -8032,6 +8045,7 @@ name = "Morning"
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -8060,6 +8074,7 @@ name = "Morning"
                 cancelled: true,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cancel_cache.clone(),
@@ -8095,6 +8110,7 @@ name = "Morning"
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -8156,6 +8172,7 @@ name = "Morning"
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -751,6 +751,8 @@ fn card(id: &str, assignee: &str) -> TaskRecord {
         // to link to (issue #339). Load-bearing rather than a default: the
         // re-plan test below starts from a card that HAS an output.
         output: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     }
 }
 

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -410,6 +410,8 @@ fn card(id: &str) -> TaskRecord {
         plan: None,
         deliverable: crate::ports::tasks::TaskDeliverable::Once,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     }
 }
 

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -326,6 +326,8 @@ fn card(id: &str, plan: Option<crate::ports::tasks::TaskPlan>) -> TaskRecord {
         plan,
         deliverable: TaskDeliverable::Workflow,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     }
 }
 

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -319,6 +319,8 @@ fn card(id: &str, assignee: &str) -> TaskRecord {
         plan: None,
         deliverable: crate::ports::tasks::TaskDeliverable::Once,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     }
 }
 

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -75,8 +75,8 @@ pub use workflow_revisions::{
     MAX_WORKFLOW_REVISIONS, WorkflowRevisionRecord, WorkflowRevisionStore,
 };
 pub use workflow_runner::{
-    DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowRun, WorkflowRunContext,
-    WorkflowRunNodeRow, WorkflowRunner,
+    DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowBoardAction, WorkflowRun,
+    WorkflowRunBoardRow, WorkflowRunContext, WorkflowRunNodeRow, WorkflowRunner,
 };
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -849,6 +849,51 @@ pub struct TaskRecord {
     /// no stored board needs migrating. See [`TaskWorkflowProposal`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workflow_proposal: Option<TaskWorkflowProposal>,
+    /// The workflow **run** whose agent node opened this card (issue #661 / M5).
+    ///
+    /// A workflow node's turn may reach `spawn_task` like any other turn, but a
+    /// run has no card and no conversation behind it — so the two lineage fields
+    /// above have nothing to say about where the card came from, and before this
+    /// nothing did. This is that provenance: a **reference**, not a parent.
+    ///
+    /// # Why a reference rather than a parent
+    ///
+    /// The alternative was minting a card for the run itself and parenting
+    /// spawned cards to it. A daily schedule would then leave 365 operator-facing
+    /// run-cards a year, most of them empty ceremony, and it would duplicate a
+    /// surface the run already has first-class — the runs history panel and the
+    /// `WorkflowRunStarted`/`WorkflowRunFinished` journal pair. So the card is a
+    /// lineage **root**: [`parent_task_id`](Self::parent_task_id) and
+    /// [`origin_chat_id`](Self::origin_chat_id) are both `None` by construction on
+    /// this path, and machine provenance rides these two fields instead.
+    ///
+    /// # A sub-workflow child stamps its **parent** run's id
+    ///
+    /// `StoreWorkflowResolver` runs a `sub_workflow` child inside the engine under
+    /// the parent's capability bundle — same runner, same run id, and the child
+    /// journals no started/finished pair of its own (which is why issue #617
+    /// exists). The parent's is therefore the only run identity that exists on
+    /// that path, and the only run row a console can navigate to. Pinned by test
+    /// rather than left to be rediscovered.
+    ///
+    /// `None` for every card opened from chat, from a dispatched card, straight
+    /// on the board, and for every card written before this field existed —
+    /// additive on the wire like [`Self::parent_task_id`], so no stored board
+    /// needs migrating.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_run_id: Option<String>,
+    /// The workflow graph whose run opened this card (issue #661 / M5).
+    ///
+    /// Carried beside [`origin_run_id`](Self::origin_run_id) rather than derived
+    /// from it, for the same reason `WorkflowRunFinished` carries both: a run id
+    /// is only resolvable to a workflow by folding the journal, and the journal is
+    /// trimmable while the board is not. A card outliving its run's rows must
+    /// still be able to say *which workflow* opened it.
+    ///
+    /// Always `Some` when [`origin_run_id`](Self::origin_run_id) is, and `None`
+    /// whenever it is — the two are stamped together by the one call site.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin_workflow_id: Option<String>,
 }
 
 /// Durable per-company task board. Company A's tasks MUST be invisible to
@@ -1265,6 +1310,8 @@ mod test {
             plan: None,
             deliverable: TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -1315,6 +1315,47 @@ mod test {
         }
     }
 
+    /// Issue #661 (M5): the run reference round-trips as camelCase, and — the
+    /// part that matters — a card written before it existed still loads.
+    ///
+    /// The legacy half is the load-bearing one. All three backends persist a card
+    /// as an opaque JSON blob, so `#[serde(default)]` is the entire migration:
+    /// a board written yesterday must deserialize today with both ids `None`,
+    /// not fail to load. And a card that carries no run reference must serialize
+    /// **without the keys at all**, so every existing card's stored bytes are
+    /// unchanged rather than merely equivalent.
+    #[test]
+    fn a_run_reference_round_trips_and_is_absent_on_a_legacy_card() {
+        let mut card = plain_card();
+        card.origin_run_id = Some("run-9".to_string());
+        card.origin_workflow_id = Some("digest".to_string());
+
+        let json = serde_json::to_string(&card).expect("serialize");
+        assert!(json.contains("\"originRunId\":\"run-9\""), "{json}");
+        assert!(json.contains("\"originWorkflowId\":\"digest\""), "{json}");
+        let back: TaskRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back, card);
+
+        // A card with no run reference keeps the pre-#661 wire shape exactly.
+        let plain = plain_card();
+        let json = serde_json::to_string(&plain).expect("serialize");
+        assert!(!json.contains("originRunId"), "{json}");
+        assert!(!json.contains("originWorkflowId"), "{json}");
+
+        // And a payload written before the fields existed still loads.
+        let legacy = serde_json::json!({
+            "id": "t-legacy",
+            "title": "Older card",
+            "column": "todo",
+            "priority": "medium",
+            "assignee": "",
+            "updatedAtMillis": 3
+        });
+        let loaded: TaskRecord = serde_json::from_value(legacy).expect("a pre-#661 card loads");
+        assert_eq!(loaded.origin_run_id, None);
+        assert_eq!(loaded.origin_workflow_id, None);
+    }
+
     /// Issue #339: the whole stamp round-trips as camelCase, and — the part
     /// that matters — a card written before it existed still loads, with
     /// `None`. All three backends persist a card as an opaque JSON blob, so a

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::company::{CompanyManifest, POLICY_MODES, Policy};
 use crate::ports::ids::{agent_slug, generate_id, now_millis};
-use crate::ports::workflow_runner::DeliveryReport;
+use crate::ports::workflow_runner::{DeliveryReport, WorkflowRunBoardRow};
 
 // ---------------------------------------------------------------------------
 // Identifiers
@@ -1023,6 +1023,28 @@ pub enum CompanyEvent {
         /// did before — which is every run that did not overflow.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         notices: Vec<String>,
+        /// One row per board write this run's agent nodes performed (issue #661
+        /// / M5) — the same rows the synchronous run response hands back.
+        ///
+        /// This is what makes a **scheduled** run's board writes readable at
+        /// all: nobody was watching the response, so without this the only
+        /// evidence a 3am run opened a card is the card itself, with nothing
+        /// saying which run put it there.
+        ///
+        /// Rides the `Ok` arm only, like
+        /// [`cancelled`](Self::WorkflowRunFinished) and
+        /// [`notices`](Self::WorkflowRunFinished): a run that returned nothing
+        /// carries no rows here. **The cards themselves are unaffected** — a
+        /// board write is durable the moment the drain performs it, so a run
+        /// that later failed outright still leaves every card it opened on the
+        /// board. What an `Err` loses is the row *listing* them, not the work.
+        ///
+        /// `#[serde(default)]` + `skip_serializing_if` so a line written before
+        /// this field existed replays, and a run that touched no card
+        /// serializes byte-for-byte as it did before — which is nearly all of
+        /// them.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        board: Vec<WorkflowRunBoardRow>,
     },
     /// A workflow run began (issue #371) — the opening bracket of a run's
     /// per-node progress trail.
@@ -4990,6 +5012,7 @@ mod test {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -5007,6 +5030,7 @@ mod test {
             error: Some("agent node `worker` had no inference source".to_string()),
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -5036,6 +5060,7 @@ mod test {
                 error: None,
                 cancelled: false,
                 notices: Vec::new(),
+                board: Vec::new(),
             }
         );
         // …and serializing it back emits nothing extra.
@@ -5068,6 +5093,7 @@ mod test {
             error: None,
             cancelled: true,
             notices: Vec::new(),
+            board: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
 
@@ -5181,6 +5207,7 @@ mod test {
                 error: None,
                 cancelled: false,
                 notices: Vec::new(),
+                board: Vec::new(),
             }
         );
     }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -5128,9 +5128,9 @@ mod test {
         // And a line written before the field existed replays as empty.
         let legacy = serde_json::json!({
             "kind": "WorkflowRunFinished",
-            "workflowId": "digest",
+            "workflow_id": "digest",
             "scheduled": true,
-            "runId": "run-1"
+            "run_id": "run-1"
         });
         let loaded: CompanyEvent =
             serde_json::from_value(legacy).expect("a pre-#661 journal line replays");

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -5075,6 +5075,71 @@ mod test {
         assert!(!out.contains("cancelled"), "{out}");
     }
 
+    /// Issue #661 (M5): a run's board rows round-trip, and a line written before
+    /// they existed still replays.
+    ///
+    /// Three claims, and the last two are what make this additive rather than a
+    /// migration: the rows survive the round trip in camelCase; a run that touched
+    /// no card serializes with **no `board` key at all**, so every already-written
+    /// journal line stays byte-identical; and a pre-#661 line decodes as empty
+    /// rather than failing to decode.
+    #[test]
+    fn workflow_run_finished_round_trips_board_rows() {
+        use crate::ports::workflow_runner::WorkflowBoardAction;
+
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: Some("run-1".to_string()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: vec![WorkflowRunBoardRow {
+                action: WorkflowBoardAction::Spawned,
+                task_id: Some("card-1".to_string()),
+                title: Some("Reply to the auditor".to_string()),
+                assignee: None,
+            }],
+        };
+        assert_eq!(round_trip(&event), event);
+        let out = serde_json::to_string(&event).expect("serialize");
+        assert!(out.contains("\"action\":\"spawned\""), "{out}");
+        assert!(out.contains("\"taskId\":\"card-1\""), "{out}");
+        // Absent rather than null on the arm that has nothing to say.
+        assert!(!out.contains("assignee"), "{out}");
+
+        // A run that touched no card is byte-unchanged from pre-#661.
+        let untouched = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: true,
+            run_id: Some("run-1".to_string()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+        };
+        let out = serde_json::to_string(&untouched).expect("serialize");
+        assert!(!out.contains("board"), "{out}");
+
+        // And a line written before the field existed replays as empty.
+        let legacy = serde_json::json!({
+            "kind": "WorkflowRunFinished",
+            "workflowId": "digest",
+            "scheduled": true,
+            "runId": "run-1"
+        });
+        let loaded: CompanyEvent =
+            serde_json::from_value(legacy).expect("a pre-#661 journal line replays");
+        let CompanyEvent::WorkflowRunFinished { board, .. } = loaded else {
+            panic!("expected a WorkflowRunFinished");
+        };
+        assert!(board.is_empty());
+    }
+
     /// Issue #383: a cancelled run round-trips, and is distinguishable from a
     /// failed one by more than the absence of an error.
     ///

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -95,6 +95,26 @@ pub struct WorkflowRun {
     /// loads, as empty — and empty is the overwhelmingly common case.
     #[serde(default)]
     pub notices: Vec<String>,
+    /// One row per board write this run's agent nodes performed (issue #661 /
+    /// M5), in the order they were executed.
+    ///
+    /// A workflow node's turn may open a card and set who owns it — that is the
+    /// whole of what a run may do to the board, and it is what makes the shipped
+    /// `→ task cards` seed able to produce one. Every other lifecycle move stays
+    /// the operator's, refused at the tool boundary; see
+    /// [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim).
+    ///
+    /// **A card is real once written, so a row is a receipt rather than an
+    /// intention.** A `spawned` row means the `TaskStore` took the write; a
+    /// `spawnFailed` row means it did not, and the run still succeeded — a board
+    /// write that failed must not discard a completed turn's work, so the
+    /// failure is reported here instead of failing the node.
+    ///
+    /// Empty for every run whose nodes touched no card, which is nearly all of
+    /// them — hence `#[serde(default)]`, which also loads a `WorkflowRun`
+    /// deserialized from a payload written before this field existed.
+    #[serde(default)]
+    pub board: Vec<WorkflowRunBoardRow>,
 }
 
 /// One node's structural outcome inside a run (issue #542).
@@ -113,6 +133,105 @@ pub struct WorkflowRunNodeRow {
     pub status: WorkflowNodeStatus,
     /// Wall-clock duration of the node's execution, in milliseconds.
     pub elapsed_ms: u64,
+}
+
+/// What a workflow run's node did to the task board, as a closed set (issue
+/// #661 / M5).
+///
+/// Four arms rather than a `bool` beside a kind, because the two axes are not
+/// independent in any way a reader benefits from: an operator looking at a run
+/// wants "opened a card" / "could not open a card" / "set an owner" / "could not
+/// set an owner", and those are exactly the four sentences a console renders.
+///
+/// **The failure arms are not run failures.** They record that the store refused
+/// a write the node's turn had already been told would happen — the same class of
+/// honesty [`DeliveryStatus::Failed`] provides for a report that did not send. A
+/// run whose every board write failed still finished its graph and still returns
+/// `Ok`.
+///
+/// Carries no payload by construction, so nothing a model or a transport wrote
+/// can ride an action into a log. The row beside it carries the ids.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkflowBoardAction {
+    /// A card was opened in To-do (`spawn_task`). The row's `taskId` is that
+    /// card's id, so a console can link straight to it.
+    Spawned,
+    /// An existing card's owner was set or cleared (`assign_task`). **No column
+    /// moved** — see [`WorkflowRun::board`].
+    Assigned,
+    /// `spawn_task` did not produce a card: the store refused the write, or this
+    /// runtime has no task board wired at all. No `taskId`, because there is no
+    /// card to point at.
+    SpawnFailed,
+    /// `assign_task` did not change the card's owner: the store refused the
+    /// write, the card is no longer on the board, or the name did not resolve to
+    /// anybody on the roster (issue #205 — an unresolvable owner is deliberately
+    /// not written, leaving the previous one in place).
+    AssignFailed,
+}
+
+impl WorkflowBoardAction {
+    /// Whether this row records a write that did **not** land.
+    ///
+    /// Used to decide whether the row is worth a `tracing::error` beside it: a
+    /// board write the node was told would happen and that did not is the one
+    /// thing on this path an operator cannot infer from the card itself.
+    pub fn failed(&self) -> bool {
+        matches!(self, Self::SpawnFailed | Self::AssignFailed)
+    }
+}
+
+/// One board write a workflow run's agent node performed (issue #661 / M5).
+///
+/// **Structural only**, and deliberately the same discipline
+/// [`WorkflowRunNodeRow`] keeps: the action, the ids involved, and nothing else.
+/// No error string, no note text, no instruction the model wrote — so a row
+/// cannot become a channel for a node's prose into the journal, the run
+/// response, or a host log.
+///
+/// One shape rides all three surfaces — the `WorkflowRunFinished` journal event,
+/// `GET …/workflows/runs`, and the synchronous run response — which is why the
+/// serde renaming is camelCase here rather than at each HTTP DTO: the
+/// [`DeliveryReport`] precedent, for the same reason. A console reads the same
+/// keys wherever it finds a run.
+///
+/// # `title` is the only field that carries authored text, and it is the card's own
+///
+/// A spawned card's title is what the operator will read off their board a
+/// moment later, so it is not new exposure — the board read already serves it
+/// under the same `ScopedCompany` guard. It is present only on the spawn arms,
+/// where the delegation named it; an assign row leaves it absent rather than
+/// re-transcribing a card the console can already resolve by id.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunBoardRow {
+    /// What was attempted, and whether it landed.
+    pub action: WorkflowBoardAction,
+    /// The card the row is about.
+    ///
+    /// Absent on [`SpawnFailed`](WorkflowBoardAction::SpawnFailed) — no card was
+    /// written, so there is no id, and synthesizing one would name a card that
+    /// is not on the board. Present on every other arm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    /// The title the node asked for, on the two spawn arms.
+    ///
+    /// Absent on the assign arms: `assign_task` names a card by id and never
+    /// carries a title, so anything here would be a second transcription of a
+    /// card the reader can already look up — the drift `plan` avoids by being
+    /// projected verbatim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    /// The owner the node asked for, as the node wrote it.
+    ///
+    /// `None` when the node named nobody (a `spawn_task` with no assignee, which
+    /// lands unowned in To-do). Deliberately the **requested** name rather than
+    /// the resolved roster id: on an `assignFailed` row the requested name is the
+    /// only thing that explains the failure, and on a successful row the two
+    /// agree.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub assignee: Option<String>,
 }
 
 /// What became of one attempt to deliver an `output` node's report.

--- a/src/runtime/advance.rs
+++ b/src/runtime/advance.rs
@@ -230,6 +230,8 @@ mod test {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 

--- a/src/runtime/board_events.rs
+++ b/src/runtime/board_events.rs
@@ -261,6 +261,8 @@ mod test {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         }
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -3411,6 +3411,8 @@ mod test {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
 
         let first_boot = RuntimeBuilder::new(home.clone(), manifest.clone())

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1913,6 +1913,8 @@ impl<'a> CycleHostImpl<'a> {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
         Ok(ToolResult {
@@ -2007,6 +2009,8 @@ impl<'a> CycleHostImpl<'a> {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         self.rt.tasks().upsert(&self.company, &card).await?;
         Ok(ToolResult {
@@ -2510,6 +2514,8 @@ mod test {
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
                 },
             )
             .await
@@ -2569,6 +2575,8 @@ mod test {
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
                 },
             )
             .await
@@ -5571,6 +5579,8 @@ mod test {
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
                 },
             )
             .await
@@ -5641,6 +5651,8 @@ mod test {
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
                 },
             )
             .await

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -150,6 +150,115 @@ pub(crate) struct DelegationOutcome {
     /// `None` for every other delegation kind, and for a `spawn_task` that
     /// found no task store to write to.
     pub(crate) spawned_task: Option<String>,
+    /// Whether an `assign_task` actually wrote an owner onto a card (issue #661
+    /// / M5).
+    ///
+    /// `spawn_task` reports its result through
+    /// [`spawned_task`](Self::spawned_task); `assign_task` had nothing to report
+    /// through, because its arm returns an empty outcome on **three** distinct
+    /// paths — the write landed, the card is no longer on the board, or the name
+    /// did not resolve to anybody on the roster (issue #205 deliberately leaves
+    /// the previous owner in place then). Those are not the same fact, and a
+    /// board row that called all three `assigned` would be exactly the confident
+    /// falsehood the drain commitment exists to prevent.
+    ///
+    /// `false` for every other delegation kind, so the chat and task paths — which
+    /// never read it — are unaffected.
+    pub(crate) assigned: bool,
+}
+
+/// Which workflow run a board write belongs to (issue #661 / M5).
+///
+/// Stamped onto every card a run's node opens
+/// ([`TaskRecord::origin_run_id`](crate::ports::TaskRecord::origin_run_id) /
+/// [`origin_workflow_id`](crate::ports::TaskRecord::origin_workflow_id)) and used
+/// as the voice a run's note is recorded under, so a card the board shows says
+/// *which machine act* put it there instead of borrowing the CEO's name.
+///
+/// Both ids together rather than the run alone: see `origin_workflow_id` for why
+/// a run id on its own is not resolvable to a workflow once the journal is
+/// trimmed.
+///
+/// # A sub-workflow child carries its parent's ids
+///
+/// `StoreWorkflowResolver` runs a `sub_workflow` child inside the engine under the
+/// parent's capability bundle — one runner, one run id, one collector — so a child
+/// node's card is stamped with the parent's run. That is the only run identity that
+/// exists on that path, and the only run row a console can navigate to.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct WorkflowRunRef {
+    /// The run whose node performed the write.
+    pub(crate) run_id: String,
+    /// The workflow graph that run is of.
+    pub(crate) workflow_id: String,
+}
+
+/// The [`RunTurn`] a workflow-run drain is wired with: one that cannot run a turn.
+///
+/// A board drain never needs one. The only delegation that runs a turn is
+/// [`Delegation::DelegateToDesk`], and a run holds a
+/// [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim) claim, under
+/// which a hand-off is refused at the tool boundary and can never be staged — so
+/// nothing this drain executes reaches these methods.
+///
+/// **It errors rather than returning an empty turn**, and that is the point of
+/// having it at all. A silent empty `TurnOutcome` would make a future path that
+/// somehow staged a hand-off look like a desk that answered with nothing; an
+/// `Err` is loud, lands in the log, and cannot be mistaken for an answer. Defense
+/// in depth behind a guarantee that already holds one layer up.
+struct NoTurn;
+
+/// The single promoted instance [`DelegationRunner::for_workflow_run`] borrows.
+///
+/// A `const` so the borrow is `'static` and coerces to the runner's `&'a dyn
+/// RunTurn` for any caller lifetime — the runner holds a reference, and a
+/// temporary built inside the constructor would not outlive it.
+const NO_TURN: NoTurn = NoTurn;
+
+#[async_trait]
+impl RunTurn for NoTurn {
+    async fn run(
+        &self,
+        _company: &CompanyId,
+        _agent_id: &str,
+        _message: &str,
+        _chat_id: Option<&str>,
+    ) -> Result<TurnOutcome> {
+        Err(no_turn_error())
+    }
+
+    async fn run_steered(
+        &self,
+        _company: &CompanyId,
+        _agent_id: &str,
+        _message: &str,
+        _control: &SteerControl,
+        _chat_id: Option<&str>,
+        _run_sink: Option<Arc<RunTraceSink>>,
+    ) -> Result<TurnOutcome> {
+        Err(no_turn_error())
+    }
+
+    async fn run_steered_background(
+        &self,
+        _company: &CompanyId,
+        _agent_id: &str,
+        _message: &str,
+        _control: &SteerControl,
+        _run_sink: Option<Arc<RunTraceSink>>,
+    ) -> Result<TurnOutcome> {
+        Err(no_turn_error())
+    }
+}
+
+/// The one error [`NoTurn`] returns, in one place so the three arms cannot drift.
+fn no_turn_error() -> crate::error::OpenCompanyError {
+    crate::error::OpenCompanyError::Harness(
+        "a workflow run's board drain cannot run a turn: a hand-off is refused at the tool \
+         boundary under a board claim, so reaching here means a delegation was staged that this \
+         path may not execute"
+            .to_string(),
+    )
 }
 
 /// A synchronous desk-lead answer captured for the orchestrator to relay: which
@@ -308,6 +417,13 @@ pub(crate) struct DelegationRunner<'a> {
     /// tests stay untouched; `None` reads as "nothing parked", which is the
     /// pre-#465 behaviour and correct for any runner that cannot park.
     approvals: Option<&'a ApprovalRequestQueue>,
+    /// The workflow run this drain belongs to, when it is one (issue #661 / M5).
+    ///
+    /// `None` for every pre-existing constructor and therefore for every chat and
+    /// task path — which is what makes this field a pure addition: the two arms
+    /// that read it fall back to exactly the behaviour they had (no origin stamp,
+    /// the orchestrator's voice on a note).
+    workflow_run: Option<WorkflowRunRef>,
 }
 
 impl<'a> DelegationRunner<'a> {
@@ -333,6 +449,51 @@ impl<'a> DelegationRunner<'a> {
             task: None,
             run_sink: None,
             approvals: None,
+            workflow_run: None,
+        }
+    }
+
+    /// Wires a runner for one **workflow run's** board drain (issue #661 / M5).
+    ///
+    /// A separate constructor rather than a builder method on
+    /// [`new`](Self::new), because the two differ in what they can do rather than
+    /// only in what they know: this one has no way to run a turn (see
+    /// [`NoTurn`]), and it stamps run provenance onto everything it opens. The
+    /// only thing it is ever asked to execute is
+    /// [`execute_board_writes`](Self::execute_board_writes).
+    ///
+    /// `steer` is threaded because the shared runner needs one and there is no
+    /// honest way to pass nothing — **it is never touched on this path**: the only
+    /// registration site is the [`Delegation::DelegateToDesk`] arm, which a board
+    /// claim makes unstageable. Passing the company's own registry rather than a
+    /// fresh one keeps it that way by accident-proofing: were the arm ever
+    /// reachable, the run would appear in the operator's in-flight list rather
+    /// than in a registry nobody can see.
+    ///
+    /// No approval queue is wired: `with_approvals` exists so a *settle* can tell
+    /// whether the turn it is recording parked (issue #465), and this runner
+    /// settles nothing — a run's gated calls are parked by
+    /// `HarnessAgentRunner::park_gated_calls` on the run's own approval scope.
+    pub(crate) fn for_workflow_run(
+        record: &'a CompanyRecord,
+        tasks: Option<&'a Arc<dyn TaskStore>>,
+        steer: &'a InflightRegistry,
+        company: &'a CompanyId,
+        queue: &'a DelegationQueue,
+        run: WorkflowRunRef,
+    ) -> Self {
+        Self {
+            run_turn: &NO_TURN,
+            record,
+            tasks,
+            steer,
+            company,
+            queue,
+            max_delegations: orchestrator::MAX_DELEGATIONS_PER_TURN,
+            task: None,
+            run_sink: None,
+            approvals: None,
+            workflow_run: Some(run),
         }
     }
 
@@ -351,6 +512,136 @@ impl<'a> DelegationRunner<'a> {
     /// wired. Differenced across a turn to attribute parks to *that* turn.
     fn approvals_queued(&self) -> usize {
         self.approvals.map_or(0, ApprovalRequestQueue::queued)
+    }
+
+    /// Executes a workflow run's drained board writes, reporting one row each
+    /// (issue #661 / M5).
+    ///
+    /// # Infallible on purpose — the signature *is* the guarantee
+    ///
+    /// A board write must never fail the node that made it. The turn already
+    /// happened, the graph is mid-walk, and discarding a completed node's work
+    /// over a `TaskStore` hiccup would be the worst available trade. So this
+    /// returns `Vec<WorkflowRunBoardRow>` and not a `Result`: there is no `?` for
+    /// a future edit to add, and the requirement holds by construction rather than
+    /// by every caller remembering it. Same stance
+    /// [`park_gated_calls`](crate::workflows::caps::HarnessAgentRunner) takes one
+    /// queue over, for the same reason.
+    ///
+    /// A failed write is loud in two places instead: a `*Failed` row an operator
+    /// reads on the run, and a `tracing::error` for whoever is watching the host.
+    ///
+    /// # What it may be handed
+    ///
+    /// Only [`Delegation::SpawnTask`] and [`Delegation::AssignTask`] — everything
+    /// else is refused at the tool boundary under
+    /// [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim). A third
+    /// kind arriving here is a wiring defect, so it is logged at `error` and
+    /// contributes no row: fabricating one would put a write on the run's record
+    /// that this path did not perform.
+    pub(crate) async fn execute_board_writes(
+        &self,
+        delegations: Vec<Delegation>,
+    ) -> Vec<crate::ports::WorkflowRunBoardRow> {
+        use crate::ports::{WorkflowBoardAction, WorkflowRunBoardRow};
+
+        let mut rows = Vec::with_capacity(delegations.len());
+        for delegation in delegations {
+            // Read the row's structural fields off the delegation BEFORE it is
+            // consumed by the drain. Nothing here is the model's prose beyond the
+            // card's own title and the owner it named — see `WorkflowRunBoardRow`.
+            let (spawn, task_id, title, assignee) = match &delegation {
+                Delegation::SpawnTask {
+                    title, assignee, ..
+                } => (true, None, Some(title.clone()), assignee.clone()),
+                Delegation::AssignTask {
+                    task_id, assignee, ..
+                } => (false, Some(task_id.clone()), None, Some(assignee.clone())),
+                other => {
+                    // `kind_label`, never `{other:?}`: a `Delegation`'s Debug
+                    // carries the model's own instruction and note text, and this
+                    // line goes to host stdout — which on a hosted deployment is
+                    // the platform rather than the operator. Same split
+                    // `DeliveryReason` draws against `DeliveryReport::detail`.
+                    tracing::error!(
+                        company = %self.company,
+                        run_id = %self.run_id_label(),
+                        kind = kind_label(other),
+                        "[delegation] a workflow run's board drain was handed a delegation it may \
+                         not perform; the tool boundary should have refused it before it was \
+                         staged"
+                    );
+                    continue;
+                }
+            };
+            // The SAME arm the chat path runs — which is what makes the
+            // no-column-move invariant inherited rather than re-promised here.
+            let outcome = self
+                .run_delegation(delegation, None, MessageContext::default())
+                .await;
+            let row = match (spawn, outcome) {
+                // A card id comes back only after the store took the write
+                // (issue #246), so `Some` here means the card is genuinely on
+                // the board.
+                (true, Ok(outcome)) => match outcome.spawned_task {
+                    Some(id) => WorkflowRunBoardRow {
+                        action: WorkflowBoardAction::Spawned,
+                        task_id: Some(id),
+                        title,
+                        assignee,
+                    },
+                    // `Ok` with no id: this runtime wired no task board. Not an
+                    // error the node should fail on, and not a card either.
+                    None => WorkflowRunBoardRow {
+                        action: WorkflowBoardAction::SpawnFailed,
+                        task_id: None,
+                        title,
+                        assignee,
+                    },
+                },
+                (false, Ok(outcome)) => WorkflowRunBoardRow {
+                    action: if outcome.assigned {
+                        WorkflowBoardAction::Assigned
+                    } else {
+                        WorkflowBoardAction::AssignFailed
+                    },
+                    task_id,
+                    title,
+                    assignee,
+                },
+                (spawn, Err(err)) => {
+                    tracing::error!(
+                        company = %self.company,
+                        run_id = %self.run_id_label(),
+                        spawn,
+                        %err,
+                        "[delegation] a workflow run's board write failed; the run is unaffected \
+                         and the failure is reported on its board rows"
+                    );
+                    WorkflowRunBoardRow {
+                        action: if spawn {
+                            WorkflowBoardAction::SpawnFailed
+                        } else {
+                            WorkflowBoardAction::AssignFailed
+                        },
+                        task_id,
+                        title,
+                        assignee,
+                    }
+                }
+            };
+            if row.action.failed() {
+                tracing::error!(
+                    company = %self.company,
+                    run_id = %self.run_id_label(),
+                    action = ?row.action,
+                    "[delegation] a workflow node was told its board write would happen and it \
+                     did not"
+                );
+            }
+            rows.push(row);
+        }
+        rows
     }
 
     /// Scopes this runner to a dispatched card, so anything the turn spawns
@@ -942,6 +1233,8 @@ impl<'a> DelegationRunner<'a> {
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         tasks.upsert(self.company, &card).await?;
         tracing::debug!(
@@ -1242,6 +1535,13 @@ impl<'a> DelegationRunner<'a> {
                     // Issue #151 §3.2: remember which conversation asked for this,
                     // so the completion can answer there instead of only landing in
                     // the note.
+                    // Issue #661 (M5): `None` on the workflow path, and that is
+                    // the lineage-root decision rather than a gap. A run has no
+                    // conversation behind it, so there is nowhere for a
+                    // completion to post back to — and stamping the chat that
+                    // *scheduled* the workflow hours earlier would make the card
+                    // answer into a conversation the operator has left. The run
+                    // reference below is the provenance instead.
                     origin_chat_id: chat_id.map(str::to_string),
                     // Lineage (#185): the dispatched card whose turn queued this
                     // one, when the drain is running inside a task
@@ -1257,6 +1557,20 @@ impl<'a> DelegationRunner<'a> {
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    // Issue #661 (M5): machine provenance for a card a workflow
+                    // node opened — a reference to the run, never a parent. Both
+                    // ids or neither; `None` on every chat and task path, which is
+                    // every caller that did not go through `for_workflow_run`.
+                    //
+                    // A `sub_workflow` child's node stamps the PARENT run's ids:
+                    // the resolver runs the child inside the engine under the
+                    // parent's bundle, so there is exactly one run id in
+                    // existence and it is the only one a console can navigate to.
+                    origin_run_id: self.workflow_run.as_ref().map(|run| run.run_id.clone()),
+                    origin_workflow_id: self
+                        .workflow_run
+                        .as_ref()
+                        .map(|run| run.workflow_id.clone()),
                 };
                 tasks.upsert(self.company, &card).await?;
                 // Issue #246: report the card so the caller can surface it. The
@@ -1467,6 +1781,8 @@ impl<'a> DelegationRunner<'a> {
                 // along and get folded onto the relayed operator bubble.
                 Ok(DelegationOutcome {
                     bubble: None,
+                    // Not a board write; see `DelegationOutcome::assigned`.
+                    assigned: false,
                     desk_reply: Some(DeskReply {
                         member,
                         reply,
@@ -1528,6 +1844,10 @@ impl<'a> DelegationRunner<'a> {
                 // the board neither shows a phantom owner nor loses the fact
                 // that an assignment was attempted.
                 let resolved = assignee::resolve(self.record, &assignee);
+                // Issue #661 (M5): whether an owner was actually written, which
+                // is the one thing the three `Ok` paths out of this arm disagree
+                // about — see `DelegationOutcome::assigned`.
+                let mut assigned = false;
                 let entry = match resolved.canonical() {
                     // A blank or whitespace-only `assignee` resolves to
                     // `Unassigned`, whose canonical form is `""`. Clearing the
@@ -1538,6 +1858,11 @@ impl<'a> DelegationRunner<'a> {
                     // effect instead, so the timeline says what happened.
                     Some("") => {
                         card.assignee = String::new();
+                        // Clearing an owner IS an ownership write, so it counts as
+                        // `assigned` for the run's board row — the row records
+                        // that the run set who owns the card, and "nobody" is an
+                        // answer to that.
+                        assigned = true;
                         match note {
                             Some(note) => format!("cleared the assignee — {note}"),
                             None => "cleared the assignee".to_string(),
@@ -1545,6 +1870,7 @@ impl<'a> DelegationRunner<'a> {
                     }
                     Some(canonical) => {
                         card.assignee = canonical.to_string();
+                        assigned = true;
                         match note {
                             Some(note) => format!("assigned to {assignee} — {note}"),
                             None => format!("assigned to {assignee}"),
@@ -1559,16 +1885,29 @@ impl<'a> DelegationRunner<'a> {
                 };
                 card.note = Some(append_note(
                     card.note.as_deref(),
-                    &self.orchestrator_id(),
+                    // Issue #661 (M5): `workflow:<id>` when a run drove this,
+                    // the orchestrator otherwise. See `note_author`.
+                    &self.note_author(),
                     &entry,
                 ));
                 // The column is untouched on purpose: dispatch fires from
                 // `CompanyRuntime::upsert_task`, which this port cannot reach.
                 // Assignment records ownership; the board's
                 // `column → in_progress` PATCH still starts the work.
+                //
+                // Issue #661 (M5) inherits that invariant rather than restating
+                // it: a workflow run's board drain executes THIS arm, so a run
+                // cannot move a card between columns even though it may set the
+                // card's owner. That is what bounds run → card → dispatch → run
+                // cycles — every dispatch still needs an operator drag. The bound
+                // holds one level deeper too: the write goes through the
+                // `TaskStore` port, which cannot trigger dispatch at all.
                 card.updated_at_millis = now_millis();
                 tasks.upsert(self.company, &card).await?;
-                Ok(DelegationOutcome::default())
+                Ok(DelegationOutcome {
+                    assigned,
+                    ..DelegationOutcome::default()
+                })
             }
             Delegation::ReviewTask {
                 task_id,
@@ -1632,6 +1971,44 @@ impl<'a> DelegationRunner<'a> {
     /// which `orchestrator_id` already tolerates.
     fn orchestrator_id(&self) -> String {
         orchestrator::orchestrator_id(&self.record.manifest.agents).unwrap_or_default()
+    }
+
+    /// The voice a note this drain appends is recorded under.
+    ///
+    /// The orchestrator on every chat and task path, unchanged. On a **workflow
+    /// run** it is `workflow:<workflow_id>` instead (issue #661 / M5), because
+    /// attributing the note to the CEO would say a person's agent decided
+    /// something an authored graph did — and an operator reading the card's
+    /// timeline has no other way to tell the two apart. The `workflow:` prefix is
+    /// the same label `SearchMetering` already attributes a run's search spend
+    /// under, so one convention names a run across the surfaces.
+    fn note_author(&self) -> String {
+        match &self.workflow_run {
+            Some(run) => format!("workflow:{}", run.workflow_id),
+            None => self.orchestrator_id(),
+        }
+    }
+
+    /// This drain's run id for a log field, or `""` off the workflow path.
+    fn run_id_label(&self) -> &str {
+        self.workflow_run
+            .as_ref()
+            .map_or("", |run| run.run_id.as_str())
+    }
+}
+
+/// A [`Delegation`]'s kind as a fixed label, safe to log.
+///
+/// Every arm is a literal and the type carries no `String` payload out through
+/// here, so — unlike `{delegation:?}` — nothing a model wrote can ride this into
+/// a host log. The [`DeliveryReason`](crate::ports::DeliveryReason) split, one
+/// seam over.
+fn kind_label(delegation: &Delegation) -> &'static str {
+    match delegation {
+        Delegation::SpawnTask { .. } => "spawn_task",
+        Delegation::DelegateToDesk { .. } => "delegate_to_desk",
+        Delegation::AssignTask { .. } => "assign_task",
+        Delegation::ReviewTask { .. } => "review_task",
     }
 }
 
@@ -2495,6 +2872,8 @@ members = ["designer"]
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         fx.tasks
             .upsert(&fx.record.id, &card)
@@ -2932,6 +3311,8 @@ members = ["designer"]
                     plan: None,
                     deliverable: crate::ports::tasks::TaskDeliverable::Once,
                     workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
                 },
             )
             .await
@@ -3796,6 +4177,8 @@ members = ["designer"]
             plan: None,
             deliverable: crate::ports::tasks::TaskDeliverable::Once,
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         fx.tasks.upsert(&fx.record.id, &card).await.expect("seed");
 

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -44,7 +44,7 @@ use std::sync::Arc;
 
 use crate::ports::EventLog;
 use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
-use crate::ports::workflow_runner::{DeliveryReport, WorkflowRun};
+use crate::ports::workflow_runner::{DeliveryReport, WorkflowRun, WorkflowRunBoardRow};
 use crate::runtime::workflow_resume::DeliveredReport;
 
 /// The error stamped on a run the host never got to finish (issue #371).
@@ -91,12 +91,20 @@ pub async fn record_run_finished(
     // Issue #638: `notices` rides the Ok arm for the same reason `cancelled`
     // does — a run that never returned produced no notices, and an `Err` is
     // already fully described by `error`.
-    let (deliveries, pending_approvals, error, cancelled, notices): (
+    // Issue #661 (M5): `board` rides the Ok arm too, and here the limitation is
+    // worth stating rather than inheriting. A card is durable the moment the
+    // drain writes it, so a run that opened two cards and then failed at a later
+    // node leaves both cards on the board — but returns no `WorkflowRun`, so this
+    // event lists neither. The work survives; the listing does not. The board
+    // itself is the record in that case, which is the same trade `notices`
+    // already makes.
+    let (deliveries, pending_approvals, error, cancelled, notices, board): (
         Vec<DeliveryReport>,
         Vec<String>,
         Option<String>,
         bool,
         Vec<String>,
+        Vec<WorkflowRunBoardRow>,
     ) = match outcome {
         Ok(run) => (
             run.deliveries.clone(),
@@ -104,12 +112,14 @@ pub async fn record_run_finished(
             None,
             run.cancelled,
             run.notices.clone(),
+            run.board.clone(),
         ),
         Err(err) => (
             Vec::new(),
             Vec::new(),
             Some(err.to_string()),
             false,
+            Vec::new(),
             Vec::new(),
         ),
     };
@@ -126,6 +136,7 @@ pub async fn record_run_finished(
         error,
         cancelled,
         notices,
+        board,
     };
 
     if let Err(err) = events.append(company, event).await {
@@ -382,6 +393,7 @@ mod test {
             cancelled: false,
             nodes: Vec::new(),
             notices: Vec::new(),
+            board: Vec::new(),
         }
     }
 
@@ -747,6 +759,7 @@ mod test {
                     error: None,
                     cancelled: false,
                     notices: Vec::new(),
+                    board: Vec::new(),
                 },
             )
             .await

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -75,6 +75,61 @@ pub const INTERRUPTED_BY_RESTART: &str = concat!(
 /// in fact the most important thing here — today's `Err` arm on the scheduled
 /// path only warns to host stdout, so **the worst outcome is currently the
 /// quietest**.
+/// The six fields a settled run contributes to its journal row, split out of
+/// [`record_run_finished`] so the Ok/Err fold is one named thing rather than a
+/// six-wide tuple.
+///
+/// Which fields ride which arm is the whole content of this type — see
+/// [`Settled::from`].
+struct Settled {
+    deliveries: Vec<DeliveryReport>,
+    pending_approvals: Vec<String>,
+    error: Option<String>,
+    cancelled: bool,
+    notices: Vec<String>,
+    board: Vec<WorkflowRunBoardRow>,
+}
+
+impl From<Result<&WorkflowRun, &str>> for Settled {
+    /// # Why four of the six ride the `Ok` arm only
+    ///
+    /// Issue #383: `cancelled` does, and that is not an oversight. A run the
+    /// runner never returned from cannot have been *stopped by an operator* — the
+    /// stop signal resolves into an `Ok(cancelled)`, never into an `Err` — so the
+    /// error arm is unambiguously a failure or the boot sweep's synthetic one.
+    ///
+    /// Issue #638: `notices` does, for the same reason — a run that never
+    /// returned produced none, and an `Err` is already fully described by
+    /// `error`.
+    ///
+    /// Issue #661 (M5): `board` does too, and here the limitation is worth
+    /// stating rather than inheriting. A card is durable the moment the drain
+    /// writes it, so a run that opened two cards and then failed at a later node
+    /// leaves **both cards on the board** — but returns no `WorkflowRun`, so this
+    /// event lists neither. The work survives; the listing does not, and the board
+    /// itself is the record in that case. Same trade `notices` already makes.
+    fn from(outcome: Result<&WorkflowRun, &str>) -> Self {
+        match outcome {
+            Ok(run) => Self {
+                deliveries: run.deliveries.clone(),
+                pending_approvals: run.pending_approvals.clone(),
+                error: None,
+                cancelled: run.cancelled,
+                notices: run.notices.clone(),
+                board: run.board.clone(),
+            },
+            Err(err) => Self {
+                deliveries: Vec::new(),
+                pending_approvals: Vec::new(),
+                error: Some(err.to_string()),
+                cancelled: false,
+                notices: Vec::new(),
+                board: Vec::new(),
+            },
+        }
+    }
+}
+
 pub async fn record_run_finished(
     events: &Arc<dyn EventLog>,
     company: &CompanyId,
@@ -83,46 +138,8 @@ pub async fn record_run_finished(
     run_id: &str,
     outcome: Result<&WorkflowRun, &str>,
 ) {
-    // Issue #383: `cancelled` rides the Ok arm only, and that is not an
-    // oversight. A run the runner never returned from cannot have been stopped
-    // by an operator — the stop signal resolves *into* an `Ok(cancelled)`, never
-    // into an `Err` — so the error arm is unambiguously a failure or the boot
-    // sweep's synthetic one.
-    // Issue #638: `notices` rides the Ok arm for the same reason `cancelled`
-    // does — a run that never returned produced no notices, and an `Err` is
-    // already fully described by `error`.
-    // Issue #661 (M5): `board` rides the Ok arm too, and here the limitation is
-    // worth stating rather than inheriting. A card is durable the moment the
-    // drain writes it, so a run that opened two cards and then failed at a later
-    // node leaves both cards on the board — but returns no `WorkflowRun`, so this
-    // event lists neither. The work survives; the listing does not. The board
-    // itself is the record in that case, which is the same trade `notices`
-    // already makes.
-    let (deliveries, pending_approvals, error, cancelled, notices, board): (
-        Vec<DeliveryReport>,
-        Vec<String>,
-        Option<String>,
-        bool,
-        Vec<String>,
-        Vec<WorkflowRunBoardRow>,
-    ) = match outcome {
-        Ok(run) => (
-            run.deliveries.clone(),
-            run.pending_approvals.clone(),
-            None,
-            run.cancelled,
-            run.notices.clone(),
-            run.board.clone(),
-        ),
-        Err(err) => (
-            Vec::new(),
-            Vec::new(),
-            Some(err.to_string()),
-            false,
-            Vec::new(),
-            Vec::new(),
-        ),
-    };
+    // Which fields ride which arm, and why, is documented on `Settled::from`.
+    let settled = Settled::from(outcome);
 
     let event = CompanyEvent::WorkflowRunFinished {
         workflow_id: workflow_id.to_string(),
@@ -131,12 +148,12 @@ pub async fn record_run_finished(
         // wire shape is unchanged — it has always carried an optional `run_id` —
         // so a reader predating #371 still decodes every line it could before.
         run_id: Some(run_id.to_string()),
-        deliveries,
-        pending_approvals,
-        error,
-        cancelled,
-        notices,
-        board,
+        deliveries: settled.deliveries,
+        pending_approvals: settled.pending_approvals,
+        error: settled.error,
+        cancelled: settled.cancelled,
+        notices: settled.notices,
+        board: settled.board,
     };
 
     if let Err(err) = events.append(company, event).await {

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1138,6 +1138,7 @@ mod decide_tests {
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             })
         }
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1232,6 +1232,7 @@ mod test {
                             cancelled: true,
                             nodes: Vec::new(),
                             notices: Vec::new(),
+                            board: Vec::new(),
                         });
                     }
                 }
@@ -1244,6 +1245,7 @@ mod test {
                 cancelled: false,
                 nodes: Vec::new(),
                 notices: Vec::new(),
+                board: Vec::new(),
             })
         }
     }
@@ -2090,6 +2092,7 @@ to = "done"
                 error,
                 cancelled,
                 notices: _,
+                board: _,
             } = event
             else {
                 unreachable!("filtered above")

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -747,6 +747,8 @@ async fn tasks_page_reflects_upserts_and_column_filter() {
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -923,6 +923,7 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             error,
             cancelled,
             notices,
+            board,
         } => {
             let mut o = envelope("workflow_run_finished");
             o["workflowId"] = json!(workflow_id);
@@ -950,6 +951,18 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             // without having to compare against an empty list.
             if !notices.is_empty() {
                 o["notices"] = json!(notices);
+            }
+            // Issue #661 (M5): the same presence-check discipline once more, and
+            // the same widens-nothing argument as `deliveries` above — in fact a
+            // weaker claim, because a board row is structural by construction (see
+            // `WorkflowRunBoardRow`) rather than by this arm choosing what to
+            // forward. It carries ids and the card's own title, which the board
+            // read already serves this same console under the same guard.
+            //
+            // Projected so a console watching a run live learns it opened a card at
+            // the moment it settles, rather than only on the next history read.
+            if !board.is_empty() {
+                o["board"] = json!(board);
             }
             o
         }
@@ -1216,6 +1229,8 @@ async fn run_chat(
             // here infers the choice from the text (decision D2a).
             deliverable: message.deliverable.unwrap_or_default(),
             workflow_proposal: None,
+            origin_run_id: None,
+            origin_workflow_id: None,
         };
         if let Err(err) = runtime.upsert_task(&record).await {
             tracing::warn!(error = %err, "failed to open task card for chat request");
@@ -5041,6 +5056,7 @@ mod test {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["type"], "workflow_run_finished");
@@ -5084,6 +5100,7 @@ mod test {
             error: Some("no inference source for agent node `worker`".into()),
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["error"], "no inference source for agent node `worker`");
@@ -5196,6 +5213,7 @@ mod test {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         }))
         .expect("projected");
         assert_eq!(with_id["runId"], "run-9");
@@ -5209,6 +5227,7 @@ mod test {
             error: None,
             cancelled: false,
             notices: Vec::new(),
+            board: Vec::new(),
         }))
         .expect("projected");
         assert!(legacy.get("runId").is_none(), "{legacy}");

--- a/src/server/ops/task_export/test.rs
+++ b/src/server/ops/task_export/test.rs
@@ -40,6 +40,8 @@ fn card(title: &str) -> TaskCard {
         updated_at: T0 + 600_000,
         parent_task_id: None,
         origin_chat_id: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
         // The export document is deliberately link-free (issue #339): it is
         // read offline, by people who never saw the board, so a console hash
         // route would be a dead address in it. The deliverable itself is what

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -141,6 +141,27 @@ pub(crate) struct TaskCard {
     /// so the existing wire shape is unchanged for every card without one.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) workflow_proposal: Option<TaskWorkflowProposal>,
+    /// The workflow run whose agent node opened this card (issue #661 / M5).
+    ///
+    /// Projected because a card with no parent and no origin chat is otherwise
+    /// unexplained on the board: an operator finding a card they did not open, and
+    /// that no conversation asked for, has nothing to look at. With this the console
+    /// can link straight to the run in the workflow history panel.
+    ///
+    /// Omitted when absent — which is every card not opened by a run, i.e. every
+    /// card that existed before this — so the board's existing wire shape is
+    /// unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) origin_run_id: Option<String>,
+    /// The workflow graph that run is of (issue #661 / M5).
+    ///
+    /// Carried beside the run id rather than resolved from it, for the reason
+    /// [`TaskRecord::origin_workflow_id`](crate::ports::TaskRecord::origin_workflow_id)
+    /// gives: the journal is trimmable and the board is not, so a card must be able
+    /// to name its workflow after its run's rows are gone. Omitted when absent, in
+    /// lockstep with `originRunId`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) origin_workflow_id: Option<String>,
 }
 
 impl From<TaskRecord> for TaskCard {
@@ -159,6 +180,8 @@ impl From<TaskRecord> for TaskCard {
             plan: t.plan,
             deliverable: t.deliverable,
             workflow_proposal: t.workflow_proposal,
+            origin_run_id: t.origin_run_id,
+            origin_workflow_id: t.origin_workflow_id,
         }
     }
 }
@@ -410,6 +433,8 @@ async fn create_task(
         // one.
         deliverable: body.deliverable.unwrap_or_default(),
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     };
     company.runtime.upsert_task(&record).await?;
     Ok(Json(record.into()))

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1115,6 +1115,17 @@ struct RunWorkflowResponse {
     /// check, and its absence a loud signal that the run was REAL.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     dry_run: bool,
+    /// The board writes this run's agent nodes performed (issue #661 / M5).
+    ///
+    /// The same rows `GET …/workflows/runs` returns and the same rows the
+    /// `WorkflowRunFinished` event carries — one shape across all three, so the
+    /// console reads a run's board effects identically whether it awaited the run
+    /// or found it in the history.
+    ///
+    /// Omitted when empty, so an existing caller's body is byte-unchanged for every
+    /// run that touched no card.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    board: Vec<crate::ports::WorkflowRunBoardRow>,
 }
 
 /// The `detach: true` response (issue #383): the run's id, handed back before
@@ -1309,6 +1320,10 @@ async fn run_workflow(
             // discriminator a console pointed at an old host would never see.
             nodes: run.nodes.into_iter().map(WorkflowRunNode::from).collect(),
             dry_run,
+            // Issue #661 (M5): carried on the synchronous path too, so a console
+            // that pressed Run learns what the run did to the board without a
+            // second read of the history.
+            board: run.board,
         })),
         Ok(Err(err)) => Err(ApiError(err).into_response()),
         Err(join) => {
@@ -1730,6 +1745,18 @@ struct WorkflowRunOutcome {
     /// Omitted when empty, like `nodes` — which is nearly every run.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     notices: Vec<String>,
+    /// The board writes this run's agent nodes performed (issue #661 / M5) — one
+    /// row per card opened or re-owned.
+    ///
+    /// The port row is projected **verbatim** rather than reshaped: it is already
+    /// camelCase and already structural (see
+    /// [`WorkflowRunBoardRow`](crate::ports::WorkflowRunBoardRow)), so a second
+    /// transcription here would only be a place for the journal's shape and the
+    /// console's to drift apart. Same choice `deliveries` makes one field up.
+    ///
+    /// Omitted when empty, like `notices` — which is nearly every run.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    board: Vec<crate::ports::WorkflowRunBoardRow>,
 }
 
 /// One node's outcome inside a run (issue #371).
@@ -1849,6 +1876,10 @@ async fn list_runs(
                     // wound down yet.
                     cancelled: false,
                     notices: Vec::new(),
+                    // Only a finish carries these, so a run in flight lists none —
+                    // even one whose nodes have already opened cards. The rows
+                    // arrive with the settle below.
+                    board: Vec::new(),
                 });
             }
             CompanyEvent::WorkflowNodeFinished {
@@ -1881,6 +1912,7 @@ async fn list_runs(
                 error,
                 cancelled,
                 notices,
+                board,
             } => {
                 if !matches(&workflow_id) {
                     continue;
@@ -1899,6 +1931,7 @@ async fn list_runs(
                     entry.running = false;
                     entry.cancelled = cancelled;
                     entry.notices = notices;
+                    entry.board = board;
                     continue;
                 }
                 // …else stand alone. Two ways to get here, both legitimate: a
@@ -1920,6 +1953,7 @@ async fn list_runs(
                     running: false,
                     cancelled,
                     notices,
+                    board,
                 });
             }
             _ => {}
@@ -2468,6 +2502,7 @@ mod tests {
             cancelled: false,
             nodes: Vec::new(),
             dry_run: false,
+            board: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["node"], "done");
@@ -2500,6 +2535,7 @@ mod tests {
             cancelled: false,
             nodes: Vec::new(),
             dry_run: false,
+            board: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["status"], "pending");
@@ -2517,6 +2553,7 @@ mod tests {
             cancelled: false,
             nodes: Vec::new(),
             dry_run: false,
+            board: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"], serde_json::json!([]));
@@ -3085,6 +3122,7 @@ mod tests {
                         error: error.map(str::to_string),
                         cancelled: false,
                         notices: Vec::new(),
+                        board: Vec::new(),
                     },
                 )
                 .await
@@ -3319,6 +3357,7 @@ mod tests {
                         error: error.map(str::to_string),
                         cancelled: false,
                         notices: Vec::new(),
+                        board: Vec::new(),
                     },
                 )
                 .await
@@ -4455,6 +4494,7 @@ mod tests {
                             cancelled: true,
                             nodes: Vec::new(),
                             notices: Vec::new(),
+                            board: Vec::new(),
                         });
                     }
                 }
@@ -4466,6 +4506,7 @@ mod tests {
                     cancelled: false,
                     nodes: Vec::new(),
                     notices: Vec::new(),
+                    board: Vec::new(),
                 })
             }
         }
@@ -5094,6 +5135,7 @@ label = "ok"
                         elapsed_ms: 3,
                     }],
                     notices: Vec::new(),
+                    board: Vec::new(),
                 })
             }
         }

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2480,6 +2480,56 @@ mod tests {
         }
     }
 
+    /// Issue #661 (M5): the synchronous run response carries the run's board
+    /// rows, in the same camelCase shape the journal event and the history route
+    /// use — so a console that pressed Run learns what the run did to the board
+    /// without a second read.
+    ///
+    /// The omission half matters as much: a run that touched no card must send no
+    /// `board` key, so every existing caller's body is byte-unchanged.
+    #[test]
+    fn the_run_response_carries_board_rows_and_omits_them_when_empty() {
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: serde_json::json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            run_id: "run-1".into(),
+            cancelled: false,
+            nodes: Vec::new(),
+            dry_run: false,
+            board: vec![crate::ports::WorkflowRunBoardRow {
+                action: crate::ports::WorkflowBoardAction::Assigned,
+                task_id: Some("card-1".into()),
+                title: None,
+                assignee: Some("ceo".into()),
+            }],
+        })
+        .expect("serialize");
+        assert_eq!(json["board"][0]["action"], "assigned");
+        assert_eq!(json["board"][0]["taskId"], "card-1");
+        assert_eq!(json["board"][0]["assignee"], "ceo");
+        assert!(
+            json["board"][0].get("title").is_none(),
+            "an assign row names no title — the console resolves it by id: {json}"
+        );
+
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: serde_json::json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            run_id: "run-2".into(),
+            cancelled: false,
+            nodes: Vec::new(),
+            dry_run: false,
+            board: Vec::new(),
+        })
+        .expect("serialize");
+        assert!(
+            json.get("board").is_none(),
+            "a run that touched no card sends no board key: {json}"
+        );
+    }
+
     /// The run response carries `deliveries` in camelCase — this is the ONLY
     /// place an operator learns a report was not delivered, since a delivery
     /// failure never fails the run.

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -8401,3 +8401,136 @@ async fn the_export_document_is_built_from_the_redacted_detail() {
         "the exported document must not carry an amount this reader may not read"
     );
 }
+
+// ── Issue #661 (M5): the console's two new reads ───────────────────────────
+
+/// A run's board rows reach `GET …/workflows/runs`.
+///
+/// This is the surface PR3's console history panel consumes, and the only one a
+/// **scheduled** run has: nobody awaited its response, so without this the sole
+/// evidence a 3am run opened a card is the card itself, with nothing saying
+/// which run put it there.
+///
+/// Asserted through the real route and the real group-by-run fold, because the
+/// fold is where a row can be dropped — a `WorkflowRunFinished` that settles an
+/// open entry writes every field across, and one missing line there is invisible
+/// to a serialization test.
+#[tokio::test]
+async fn the_run_history_carries_a_runs_board_rows() {
+    use crate::ports::types::CompanyEvent;
+    use crate::ports::{WorkflowBoardAction, WorkflowRunBoardRow};
+
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+
+    for event in [
+        CompanyEvent::WorkflowRunStarted {
+            workflow_id: "digest".into(),
+            run_id: "run-1".into(),
+            scheduled: true,
+        },
+        CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: true,
+            run_id: Some("run-1".into()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: vec![WorkflowRunBoardRow {
+                action: WorkflowBoardAction::Spawned,
+                task_id: Some("card-1".into()),
+                title: Some("Reply to the auditor".into()),
+                assignee: None,
+            }],
+        },
+        // A second run that touched no card, so the omission is asserted on a
+        // real row rather than on an absence that could be the fold failing.
+        CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: false,
+            run_id: Some("run-2".into()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+        },
+    ] {
+        runtime.events().append(&company, event).await.unwrap();
+    }
+
+    let (status, runs) = send(&state, "GET", "/api/v1/company/workflows/runs", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let runs = runs.as_array().expect("an array of runs");
+
+    let settled = runs
+        .iter()
+        .find(|r| r["runId"] == "run-1")
+        .unwrap_or_else(|| panic!("run-1 must be in the history: {runs:?}"));
+    assert_eq!(settled["board"][0]["action"], "spawned");
+    assert_eq!(settled["board"][0]["taskId"], "card-1");
+    assert_eq!(settled["board"][0]["title"], "Reply to the auditor");
+
+    let untouched = runs
+        .iter()
+        .find(|r| r["runId"] == "run-2")
+        .unwrap_or_else(|| panic!("run-2 must be in the history: {runs:?}"));
+    assert!(
+        untouched["board"].is_null(),
+        "a run that touched no card must omit the key entirely, so every existing history row's \
+         wire shape is unchanged: {untouched}"
+    );
+}
+
+/// A card opened by a run carries its provenance onto the board read, and a card
+/// opened any other way is byte-unchanged.
+///
+/// The second half is the compatibility claim and needs its own card rather than
+/// a re-read of the first: `skip_serializing_if` is what keeps every card the
+/// board rendered before #661 identical, and only an actually-absent field
+/// proves it.
+#[tokio::test]
+async fn a_card_opened_by_a_run_projects_its_provenance() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_company(&home).await;
+    let company = CompanyId::new("acme");
+    let runtime = state.registry().get(&company).unwrap();
+
+    let mut from_run = discussion_card("t-run", "Reply to the auditor");
+    from_run.origin_run_id = Some("run-1".to_string());
+    from_run.origin_workflow_id = Some("digest".to_string());
+    runtime.tasks().upsert(&company, &from_run).await.unwrap();
+    runtime
+        .tasks()
+        .upsert(&company, &discussion_card("t-hand", "Opened by hand"))
+        .await
+        .unwrap();
+
+    let (status, body) = send(&state, "GET", "/api/v1/company/tasks", None).await;
+    assert_eq!(status, StatusCode::OK);
+    let cards = body["tasks"].as_array().expect("an array of cards");
+
+    let from_run = cards
+        .iter()
+        .find(|c| c["id"] == "t-run")
+        .unwrap_or_else(|| panic!("the run's card must be on the board: {cards:?}"));
+    assert_eq!(from_run["originRunId"], "run-1");
+    assert_eq!(from_run["originWorkflowId"], "digest");
+
+    let by_hand = cards
+        .iter()
+        .find(|c| c["id"] == "t-hand")
+        .unwrap_or_else(|| panic!("the hand-opened card must be on the board: {cards:?}"));
+    assert!(
+        by_hand["originRunId"].is_null() && by_hand["originWorkflowId"].is_null(),
+        "a card no run opened must carry neither key, so the board's existing wire shape is \
+         unchanged: {by_hand}"
+    );
+}

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -713,6 +713,8 @@ async fn steer_task_validates_statuses_and_journals_acceptance() {
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await
@@ -4160,6 +4162,8 @@ async fn task_detail_assembles_timeline_and_lineage() {
         plan: None,
         deliverable: crate::ports::tasks::TaskDeliverable::Once,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     };
     for t in [
         card("t-parent", "Parent", None),
@@ -4347,6 +4351,8 @@ fn discussion_card(id: &str, title: &str) -> TaskRecord {
         plan: None,
         deliverable: crate::ports::tasks::TaskDeliverable::Once,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     }
 }
 
@@ -5012,6 +5018,8 @@ async fn task_export_serves_a_readable_document_and_alters_nothing() {
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await
@@ -5129,6 +5137,8 @@ async fn task_timeline_scopes_approvals_to_the_run_window() {
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await
@@ -5232,6 +5242,8 @@ async fn dispatched_task(
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await
@@ -5688,6 +5700,8 @@ async fn a_second_task_in_the_same_window_does_not_absorb_the_first_s_approvals(
                 plan: None,
                 deliverable: crate::ports::tasks::TaskDeliverable::Once,
                 workflow_proposal: None,
+                origin_run_id: None,
+                origin_workflow_id: None,
             },
         )
         .await
@@ -6972,6 +6986,8 @@ async fn seed_proposal_card(state: &AppState, ops: Value) -> String {
             generated_at_millis: 1,
             run_id: "run-build-1".to_string(),
         }),
+        origin_run_id: None,
+        origin_workflow_id: None,
     };
     runtime
         .tasks()

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -8515,7 +8515,7 @@ async fn a_card_opened_by_a_run_projects_its_provenance() {
 
     let (status, body) = send(&state, "GET", "/api/v1/company/tasks", None).await;
     assert_eq!(status, StatusCode::OK);
-    let cards = body["tasks"].as_array().expect("an array of cards");
+    let cards = body.as_array().expect("an array of cards");
 
     let from_run = cards
         .iter()

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -917,6 +917,8 @@ pub async fn assert_task_store(tasks: Arc<dyn TaskStore>) {
         plan: None,
         deliverable: crate::ports::tasks::TaskDeliverable::Once,
         workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
     };
 
     tasks.upsert(&alpha, &task("t1", "todo", 1)).await.unwrap();

--- a/src/workflows/board_turn_test.rs
+++ b/src/workflows/board_turn_test.rs
@@ -1,0 +1,715 @@
+//! Issue #661 / M5 — end-to-end proof that a workflow node can put work on the
+//! board, and that everything it may **not** do stays refused.
+//!
+//! # Why these are turn tests rather than unit tests
+//!
+//! Every piece already existed and had tests. `SpawnTaskTool` staged a
+//! delegation — tested. The queue scoped buckets per claimant — tested (#771).
+//! `DelegationRunner`'s `SpawnTask` arm wrote a card — tested since #185. What
+//! was missing was the *join*: nothing on the workflow path ever claimed or
+//! drained the queue, so a run's `spawn_task` got an honest in-turn refusal and
+//! the shipped `→ task cards` seed could not make a card. A unit test over any
+//! one of those parts stays green through that.
+//!
+//! So these drive the **real** path — real graph, real `run_workflow`, real
+//! `HarnessAgentRunner`, real `HarnessPool`, real orchestrator toolbelt, real
+//! `TaskStore` — and stub exactly one thing, at the one boundary that needs a
+//! credential: the model's *choices*, via a scripted OpenAI-compatible endpoint
+//! on loopback. That is the shape
+//! [`gated_tool_turn_test`](crate::workflows::gated_tool_turn_test) established
+//! for #395, and it is reused here down to the `deps`/`record` fixtures.
+
+use std::sync::{Arc, Mutex};
+
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::parse_workflow;
+use crate::harness::HarnessPool;
+use crate::ports::types::CompanyId;
+use crate::ports::{RunCancel, TaskRecord, TaskStore, WorkflowBoardAction, WorkflowRunContext};
+use crate::store::FsOps;
+
+use super::gated_tool_turn_test::{Turn, record, spawn_script};
+
+/// The one-agent graph these tests run: trigger → agent → output. The same
+/// shape a company authors when it wants a teammate to do something on a
+/// schedule, and the shape the shipped `→ task cards` seed has.
+const AGENT_GRAPH: &str = r#"
+id = "board"
+name = "Board"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Triage the inbox."
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "done"
+"#;
+
+/// A parent graph whose only working node resolves a **child** workflow by id.
+/// The child is the one with the agent node, so its `spawn_task` is what stamps
+/// the card — see [`a_sub_workflow_childs_card_carries_the_parent_runs_ids`].
+const PARENT_GRAPH: &str = r#"
+id = "parent"
+name = "Parent"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "child"
+kind = "sub_workflow"
+name = "Child"
+[node.config]
+workflow_id = "board"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "child"
+[[edge]]
+from = "child"
+to = "done"
+"#;
+
+/// The company's board, wired onto `deps.tasks` the way the runtime builder
+/// does — without it a run has nothing to write to.
+fn tasks(dir: &std::path::Path) -> Arc<dyn TaskStore> {
+    Arc::new(FsOps::new(dir))
+}
+
+/// Runs `graph` once against `turns`, with a real task board.
+///
+/// Returns the run's outcome, the board, and the run id, so a test can assert on
+/// all three halves of the claim: what the run reported, what actually landed,
+/// and that the two name the same run.
+async fn run_with_board(
+    dir: &std::path::Path,
+    graph: &str,
+    turns: Vec<Turn>,
+    seed: Option<TaskRecord>,
+) -> (crate::ports::WorkflowRun, Arc<dyn TaskStore>, String) {
+    let base_url = spawn_script(turns).await;
+    let (mut deps, _journal) = super::gated_tool_turn_test::deps(base_url, dir);
+    let store = tasks(dir);
+    deps.tasks = Some(store.clone());
+    let record = record();
+    if let Some(card) = seed {
+        store
+            .upsert(&record.id, &card)
+            .await
+            .expect("seed the card");
+    }
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(graph).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    let run = super::runner::run_workflow(
+        pool,
+        deps.clone(),
+        &record,
+        &file,
+        json!({ "request": "triage the inbox" }),
+        &ctx,
+    )
+    .await
+    .expect("the run completes");
+    (run, store, run_id)
+}
+
+/// A board card as the tests want to read it: one card, or a panic naming what
+/// was there instead.
+async fn only_card(store: &Arc<dyn TaskStore>, company: &CompanyId) -> TaskRecord {
+    let cards = store.list(company).await.expect("list the board");
+    assert_eq!(cards.len(), 1, "expected exactly one card, got {cards:?}");
+    cards.into_iter().next().expect("checked above")
+}
+
+// ── 1. The headline: a run can open a card, stamped with the run ────────────
+
+/// The whole point of M5. A workflow node calls `spawn_task`, and a card exists
+/// on the board afterwards — in To-do, unparented, and carrying a reference back
+/// to the run that opened it.
+///
+/// Four assertions and each is a separate claim:
+///
+/// * the card **exists** (the drain ran at all — before this the tool was
+///   refused in-turn and nothing was written);
+/// * it is in **To-do** (a run may open work, never move it — the column rule
+///   that bounds run → card → dispatch → run cycles);
+/// * `parent_task_id` / `origin_chat_id` are **None** (the lineage-root
+///   decision: a run has no card and no conversation behind it, so machine
+///   provenance is a reference rather than a parent);
+/// * both origin ids are **stamped** (that reference actually being written —
+///   without it the card is unexplained on the board).
+#[tokio::test]
+async fn a_workflow_node_opens_a_card_stamped_with_its_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, store, run_id) = run_with_board(
+        dir.path(),
+        AGENT_GRAPH,
+        vec![
+            Turn::Call {
+                tool: "spawn_task",
+                args: json!({ "title": "Reply to the auditor", "assignee": "ceo" }),
+            },
+            Turn::Say("Opened a card for it."),
+        ],
+        None,
+    )
+    .await;
+
+    let card = only_card(&store, &CompanyId::new("acme")).await;
+    assert_eq!(card.title, "Reply to the auditor");
+    assert_eq!(
+        card.column,
+        crate::ports::tasks::COLUMN_TODO,
+        "a run opens work; only an operator moves it"
+    );
+    assert_eq!(
+        card.parent_task_id, None,
+        "a run has no card behind it, so the card it opens is a lineage root"
+    );
+    assert_eq!(
+        card.origin_chat_id, None,
+        "a run has no conversation behind it, so there is nowhere to post back to"
+    );
+    assert_eq!(
+        card.origin_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "the card must name the run that opened it — this is the provenance M5 adds"
+    );
+    assert_eq!(
+        card.origin_workflow_id.as_deref(),
+        Some("board"),
+        "and the workflow, so the card survives the journal being trimmed"
+    );
+
+    // …and the run reports it, which is how a console learns without polling
+    // the board.
+    assert_eq!(run.board.len(), 1, "one write, one row: {:?}", run.board);
+    assert_eq!(run.board[0].action, WorkflowBoardAction::Spawned);
+    assert_eq!(run.board[0].task_id.as_deref(), Some(card.id.as_str()));
+    assert_eq!(run.board[0].title.as_deref(), Some("Reply to the auditor"));
+    assert_eq!(run.board[0].assignee.as_deref(), Some("ceo"));
+}
+
+// ── 2. Assign sets the owner and moves nothing ─────────────────────────────
+
+/// A run may set who owns an existing card. It may **not** move it, and the note
+/// it leaves must not be attributed to the CEO.
+///
+/// The column assertion is the load-bearing one: `todo → planning` is an
+/// operator drag and `planning → in_progress` is the dispatch gate, so run →
+/// card → dispatch → run cycles are bounded precisely because every dispatch
+/// needs a person. A run that could move a column would take that bound with it.
+#[tokio::test]
+async fn a_workflow_node_assigns_an_existing_card_without_moving_it() {
+    let dir = tempfile::tempdir().unwrap();
+    let seed = TaskRecord {
+        id: "card-1".to_string(),
+        title: "Quarterly close".to_string(),
+        note: None,
+        column: crate::ports::tasks::COLUMN_TODO.to_string(),
+        priority: "medium".to_string(),
+        assignee: String::new(),
+        updated_at_millis: 1,
+        origin_chat_id: None,
+        parent_task_id: None,
+        output: None,
+        plan: None,
+        deliverable: crate::ports::tasks::TaskDeliverable::Once,
+        workflow_proposal: None,
+        origin_run_id: None,
+        origin_workflow_id: None,
+    };
+    let (run, store, _run_id) = run_with_board(
+        dir.path(),
+        AGENT_GRAPH,
+        vec![
+            Turn::Call {
+                tool: "assign_task",
+                args: json!({ "task_id": "card-1", "assignee": "ceo", "note": "you own this" }),
+            },
+            Turn::Say("Assigned it."),
+        ],
+        Some(seed),
+    )
+    .await;
+
+    let card = only_card(&store, &CompanyId::new("acme")).await;
+    assert_eq!(card.assignee, "ceo", "the owner must actually be written");
+    assert_eq!(
+        card.column,
+        crate::ports::tasks::COLUMN_TODO,
+        "assignment records ownership and NEVER starts the work — the loop bound"
+    );
+    let note = card.note.unwrap_or_default();
+    assert!(
+        note.contains("[workflow:board]"),
+        "the note must be in the workflow's voice, not the CEO's: {note}"
+    );
+    assert!(
+        !note.contains("[ceo]"),
+        "attributing a machine write to a person is the misattribution this fixes: {note}"
+    );
+
+    assert_eq!(run.board.len(), 1, "{:?}", run.board);
+    assert_eq!(run.board[0].action, WorkflowBoardAction::Assigned);
+    assert_eq!(run.board[0].task_id.as_deref(), Some("card-1"));
+    assert_eq!(run.board[0].assignee.as_deref(), Some("ceo"));
+}
+
+// ── 3. A failed write reports, and does not fail the node ──────────────────
+
+/// A [`TaskStore`] whose `upsert` always fails, so the drain's error arm is
+/// reachable without corrupting anything.
+struct FailingTasks;
+
+#[async_trait::async_trait]
+impl TaskStore for FailingTasks {
+    async fn list(&self, _company: &CompanyId) -> crate::Result<Vec<TaskRecord>> {
+        Ok(Vec::new())
+    }
+    async fn upsert(&self, _company: &CompanyId, _task: &TaskRecord) -> crate::Result<()> {
+        Err(crate::error::OpenCompanyError::Harness(
+            "the board is unavailable".to_string(),
+        ))
+    }
+    async fn delete(&self, _company: &CompanyId, _id: &str) -> crate::Result<bool> {
+        Ok(false)
+    }
+}
+
+/// The requirement `execute_board_writes` holds by signature: a board write that
+/// fails must never fail the node that made it.
+///
+/// The turn already happened and the graph is mid-walk; discarding a completed
+/// node's work over a store hiccup would be the worst available trade. So the
+/// run **succeeds**, and the failure is loud in the two places an operator
+/// actually reads — a `spawnFailed` row and a run notice.
+#[tokio::test]
+async fn a_board_write_that_fails_reports_a_row_and_does_not_fail_the_node() {
+    let dir = tempfile::tempdir().unwrap();
+    let base_url = spawn_script(vec![
+        Turn::Call {
+            tool: "spawn_task",
+            args: json!({ "title": "Reply to the auditor" }),
+        },
+        Turn::Say("Opened a card for it."),
+    ])
+    .await;
+    let (mut deps, _journal) = super::gated_tool_turn_test::deps(base_url, dir.path());
+    deps.tasks = Some(Arc::new(FailingTasks));
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let run = super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        Value::Null,
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("a failed board write must NOT fail the run");
+
+    assert_eq!(run.board.len(), 1, "{:?}", run.board);
+    assert_eq!(
+        run.board[0].action,
+        WorkflowBoardAction::SpawnFailed,
+        "the row must say the write did not land"
+    );
+    assert_eq!(
+        run.board[0].task_id, None,
+        "no card exists, so naming one would point at a card that is not on the board"
+    );
+    assert!(
+        run.notices.iter().any(|n| n.contains("could not")),
+        "the operator needs telling: {:?}",
+        run.notices
+    );
+}
+
+// ── 4. An ungrounded hand-off surfaces on the run's OWN notices ────────────
+
+/// The live half of the defect PR #771 identified, closed end-to-end.
+///
+/// `DelegateToDeskTool` calls `push_refusal` **before** it consults the claim, so
+/// a workflow node naming a desk the company does not have wrote into the shared
+/// `refused` vector — and a concurrent chat turn's `drain_refusals` took it,
+/// recorded the hand-off on *that* turn's card, and cleared it. A hand-off
+/// attempt nobody on that turn made, attributed to that turn, and destroyed for
+/// the run that actually made it.
+///
+/// Two assertions, and they are different facts: the refusal reaches **this
+/// run's** notices, and the `Unscoped` bucket a chat turn drains is left
+/// untouched.
+#[tokio::test]
+async fn an_ungrounded_hand_off_surfaces_on_the_runs_own_notices() {
+    let dir = tempfile::tempdir().unwrap();
+    let base_url = spawn_script(vec![
+        Turn::Call {
+            tool: "delegate_to_desk",
+            args: json!({ "desk": "legal", "instruction": "review the contract" }),
+        },
+        Turn::Say("I could not hand that off."),
+    ])
+    .await;
+    let (mut deps, _journal) = super::gated_tool_turn_test::deps(base_url, dir.path());
+    deps.tasks = Some(tasks(dir.path()));
+    let record = record();
+    // The record has to be READABLE from the store, because `delegate_to_desk`
+    // grounds its target against the company's real desks at call time. Without
+    // it the orchestrator fails open (issue #272's deliberate stance) and the
+    // hand-off is refused by the board claim instead — which is a different
+    // refusal, on a path that records nothing, and would leave this test green
+    // for the wrong reason.
+    crate::ports::CompanyStore::save(&*deps.store, &record)
+        .await
+        .expect("the company record is readable");
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let run = super::runner::run_workflow(
+        pool,
+        deps.clone(),
+        &record,
+        &file,
+        Value::Null,
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("the run completes");
+
+    assert!(
+        run.notices.iter().any(|n| n.contains("legal")),
+        "the run that attempted the hand-off is the one that must hear about it: {:?}",
+        run.notices
+    );
+    // Nothing was left in the bucket a chat turn drains — which is where this
+    // used to land and be stolen from.
+    assert!(
+        deps.delegations
+            .drain_refusals(crate::harness::orchestrator::MAX_DELEGATIONS_PER_TURN)
+            .is_empty(),
+        "an unscoped chat turn must find nothing of this run's to record on its own card"
+    );
+    // And the hand-off itself never became a card: a run has nowhere to put a
+    // synchronous reply, so the tool refused before staging anything.
+    assert!(run.board.is_empty(), "{:?}", run.board);
+}
+
+// ── 7. A dry run writes nothing, by construction ───────────────────────────
+
+/// Issue #542's discipline applied to the board: a dry run of a graph whose node
+/// calls `spawn_task` must leave no card, no row and no journal line.
+///
+/// **Empty by construction rather than by a check.** The dry bundle wires
+/// `DryRunAgent`, so `HarnessAgentRunner` — the only thing that ever takes a
+/// board claim or drains one — is never built. This pins that, so a future edit
+/// that moved the claim out of the live arm would be caught rather than
+/// discovered by a test run mutating a real board.
+#[tokio::test]
+async fn a_dry_run_of_a_spawning_graph_writes_no_card() {
+    let dir = tempfile::tempdir().unwrap();
+    let base_url = spawn_script(vec![
+        Turn::Call {
+            tool: "spawn_task",
+            args: json!({ "title": "Reply to the auditor" }),
+        },
+        Turn::Say("Opened a card for it."),
+    ])
+    .await;
+    let (mut deps, journal) = super::gated_tool_turn_test::deps(base_url, dir.path());
+    let store = tasks(dir.path());
+    deps.tasks = Some(store.clone());
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let mut ctx = WorkflowRunContext::new(false);
+    ctx.dry_run = true;
+    let run = super::runner::run_workflow(pool, deps, &record, &file, Value::Null, &ctx)
+        .await
+        .expect("the dry run completes");
+
+    assert!(run.board.is_empty(), "a test run reports no board writes");
+    assert!(
+        store.list(&record.id).await.expect("list").is_empty(),
+        "a test run must not put a card on a real board"
+    );
+    assert!(
+        journal.pending().is_empty(),
+        "a test run journals nothing at all"
+    );
+}
+
+// ── 8. A sub-workflow child stamps the PARENT run's ids ────────────────────
+
+/// Pins the finding that contradicts the original design: a `sub_workflow`
+/// child has **no run identity of its own**.
+///
+/// `StoreWorkflowResolver` resolves and runs the child *inside the engine under
+/// the parent's capability bundle* — same runner, same `run_id`, same
+/// collectors — and a child journals no `WorkflowRunStarted`/`Finished` pair
+/// (which is also why issue #617 exists). So the parent's run id is the only run
+/// identity in existence on that path, and the only run row a console can
+/// navigate to.
+///
+/// The design said a child's cards would reference the child run. They cannot.
+/// This pins the actual behaviour rather than leaving it to be rediscovered:
+/// the card carries the **parent's** run id and the **parent's** workflow id.
+#[tokio::test]
+async fn a_sub_workflow_childs_card_carries_the_parent_runs_ids() {
+    let dir = tempfile::tempdir().unwrap();
+    let source = dir.path().join("company");
+    std::fs::create_dir_all(source.join("workflows")).unwrap();
+    std::fs::write(source.join("workflows").join("board.toml"), AGENT_GRAPH).unwrap();
+
+    let base_url = spawn_script(vec![
+        Turn::Call {
+            tool: "spawn_task",
+            args: json!({ "title": "Child's card" }),
+        },
+        Turn::Say("Opened a card for it."),
+    ])
+    .await;
+    let (mut deps, _journal) = super::gated_tool_turn_test::deps(base_url, dir.path());
+    let store = tasks(dir.path());
+    deps.tasks = Some(store.clone());
+    deps.workflow_source_dir = Some(source);
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(PARENT_GRAPH).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let parent_run = ctx.run_id.clone();
+    let run = super::runner::run_workflow(pool, deps, &record, &file, Value::Null, &ctx)
+        .await
+        .expect("the parent run completes");
+
+    let card = only_card(&store, &record.id).await;
+    assert_eq!(
+        card.origin_run_id.as_deref(),
+        Some(parent_run.as_str()),
+        "a child runs under the parent's bundle and has no run id of its own — the parent's is \
+         the only one a console can navigate to"
+    );
+    assert_eq!(
+        card.origin_workflow_id.as_deref(),
+        Some("parent"),
+        "and the workflow id is the parent's for the same reason: the bundle was built for it"
+    );
+    // The rows land on the parent's run too — one collector, one run.
+    assert_eq!(run.board.len(), 1, "{:?}", run.board);
+    assert_eq!(run.board[0].action, WorkflowBoardAction::Spawned);
+}
+
+// ── The claim never reaches the chat path ──────────────────────────────────
+
+/// A run's claim is on its own scope, so the bucket a chat cycle claims is
+/// untouched — the property #771's scoping bought, asserted from the workflow
+/// side now that the workflow side actually claims something.
+#[tokio::test]
+async fn a_runs_board_claim_leaves_the_unscoped_bucket_alone() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _store, _run_id) = run_with_board(
+        dir.path(),
+        AGENT_GRAPH,
+        vec![
+            Turn::Call {
+                tool: "spawn_task",
+                args: json!({ "title": "Reply to the auditor" }),
+            },
+            Turn::Say("Opened a card for it."),
+        ],
+        None,
+    )
+    .await;
+    assert_eq!(run.board.len(), 1, "precondition: the run wrote the board");
+
+    // A fresh queue read from an unscoped task: nothing committed, nothing
+    // staged. The run's claim was released with its bundle and never named this
+    // bucket in the first place.
+    let queue = crate::harness::orchestrator::DelegationQueue::default();
+    assert!(
+        !queue.drain_committed(),
+        "a chat turn must still find the unscoped bucket unclaimed"
+    );
+}
+
+/// A [`Script`]-driven turn that calls nothing writes no rows. The drain must be
+/// invisible to every run that was already working.
+#[tokio::test]
+async fn a_node_that_touches_no_card_reports_no_rows() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, store, _run_id) = run_with_board(
+        dir.path(),
+        AGENT_GRAPH,
+        vec![Turn::Say("Nothing to do.")],
+        None,
+    )
+    .await;
+    assert!(run.board.is_empty());
+    assert!(
+        store
+            .list(&CompanyId::new("acme"))
+            .await
+            .expect("list")
+            .is_empty()
+    );
+}
+
+// ── 5. A cancelled run's card survives, and stays listed ───────────────────
+
+/// The scripted endpoint again, but with a hook fired on each request — the one
+/// thing the shared helper cannot do, and the only deterministic way to cancel a
+/// run at a known point in its graph walk.
+///
+/// The hook fires *inside* the model call, so by the time it returns the node's
+/// turn is still running: the drain below it has not happened yet, and the
+/// engine has not reached its next node boundary. That ordering is what makes
+/// this a **clean** cancel of a run that has already written the board, rather
+/// than a race.
+async fn spawn_script_with_hook(
+    turns: Vec<Turn>,
+    hook: Arc<dyn Fn(usize) + Send + Sync>,
+) -> String {
+    let turns = Arc::new(Mutex::new(turns));
+    let seen = Arc::new(Mutex::new(0usize));
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(_body): Json<Value>| {
+            let turns = Arc::clone(&turns);
+            let seen = Arc::clone(&seen);
+            let hook = Arc::clone(&hook);
+            async move {
+                let n = {
+                    let mut seen = seen.lock().unwrap();
+                    *seen += 1;
+                    *seen
+                };
+                hook(n);
+                let next = {
+                    let mut turns = turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                let message = match next.unwrap_or(Turn::Say("done")) {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => json!({
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": format!("call-{tool}"),
+                            "type": "function",
+                            "function": { "name": tool, "arguments": args.to_string() }
+                        }]
+                    }),
+                };
+                Json(json!({
+                    "choices": [{ "index": 0, "message": message }],
+                    "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    format!("http://{addr}")
+}
+
+/// A card is real the moment the drain writes it, so stopping the run must not
+/// unmake it — and must not un-say it either.
+///
+/// This is the semantic touchpoint #675's cancel work needed agreeing: an
+/// operator who stops a run still has the card in front of them, so a cancelled
+/// run that drops its rows leaves a card on the board that no run admits to
+/// opening. The run reports `cancelled` **and** the row.
+#[tokio::test]
+async fn a_cancelled_runs_card_survives_and_stays_listed() {
+    let dir = tempfile::tempdir().unwrap();
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    let cancel: RunCancel = ctx.cancel.clone();
+
+    // Fired on the model's SECOND call — the one that closes the node's turn
+    // after the tool result came back. The turn is still in flight, so the drain
+    // that writes the card still runs; the engine sees the flipped token at the
+    // next node boundary and winds down cleanly.
+    let base_url = spawn_script_with_hook(
+        vec![
+            Turn::Call {
+                tool: "spawn_task",
+                args: json!({ "title": "Reply to the auditor" }),
+            },
+            Turn::Say("Opened a card for it."),
+        ],
+        Arc::new(move |n| {
+            if n == 2 {
+                cancel.cancel();
+            }
+        }),
+    )
+    .await;
+
+    let (mut deps, _journal) = super::gated_tool_turn_test::deps(base_url, dir.path());
+    let store = tasks(dir.path());
+    deps.tasks = Some(store.clone());
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(AGENT_GRAPH).expect("graph parses");
+    let run = super::runner::run_workflow(pool, deps, &record, &file, Value::Null, &ctx)
+        .await
+        .expect("a stopped run settles rather than failing");
+
+    assert!(run.cancelled, "precondition: the operator stopped this run");
+    let card = only_card(&store, &record.id).await;
+    assert_eq!(
+        card.origin_run_id.as_deref(),
+        Some(run_id.as_str()),
+        "the card is a durable write and outlives the stop"
+    );
+    assert_eq!(
+        run.board.len(),
+        1,
+        "and the stopped run must still LIST it — otherwise the board shows a card no run admits \
+         to opening: {:?}",
+        run.board
+    );
+    assert_eq!(run.board[0].action, WorkflowBoardAction::Spawned);
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -65,6 +65,7 @@ use tinyflows::caps::{
 };
 use tinyflows::error::{EngineError, Result as TfResult};
 
+use crate::harness::orchestrator::MAX_DELEGATIONS_PER_TURN;
 use crate::harness::policy::{ApprovalScope, MAX_APPROVAL_REQUESTS_PER_TURN, PolicyMode};
 use crate::harness::{HarnessDeps, HarnessPool, toolbelt};
 use crate::ports::types::{CompanyId, CompanyRecord};
@@ -105,6 +106,8 @@ pub struct RunContext<'a> {
     pub dry_run: bool,
     /// Where an agent node leaves an operator-facing notice (issue #638).
     pub notices: RunNotices,
+    /// Where an agent node's board writes are recorded (issue #661 / M5).
+    pub board: RunBoard,
 }
 
 /// Assembles the [`Capabilities`] bundle for a run of `workflow_id`.
@@ -156,6 +159,7 @@ pub async fn build_capabilities(
         run_request,
         dry_run,
         notices,
+        board,
     } = run;
     let company = record.id.clone();
     // Issue #562: the tier actually in force — the operator's console override
@@ -271,16 +275,46 @@ pub async fn build_capabilities(
             }
         };
 
+        // Issue #661 (M5): the run's board claim, taken ONCE here and held for the
+        // whole run rather than per node turn.
+        //
+        // **Per-run is the correctness requirement, not a convenience.** The
+        // engine runs same-superstep nodes concurrently (`with_parallel(true)`),
+        // and `claim_as` CLEARS the scope's bucket on acquire — so a second claim
+        // taken by a sibling node mid-superstep would destroy whatever the first
+        // node had staged and not yet drained. One claim per run, acquired before
+        // any node runs, is what makes the bucket safe for the concurrent nodes
+        // that share it.
+        //
+        // The consequence to know: siblings share one bucket, so node A's
+        // post-turn drain may execute (and report) a write node B staged. Nothing
+        // is lost or duplicated — every staged write is executed exactly once and
+        // contributes exactly one row — but a row is attributed to the RUN rather
+        // than to a node, which is why `WorkflowRunBoardRow` carries no node id.
+        // The per-turn `MAX_DELEGATIONS_PER_TURN` cap likewise becomes a per-drain
+        // bound over the shared bucket, refused honestly at the tool boundary.
+        //
+        // `Arc` because the runner is shared across the engine's node tasks and
+        // `DelegationClaim` is deliberately not `Clone` — one claim, one owner of
+        // the promise. It releases when the capability bundle drops, which on the
+        // hard-abort path is when the engine future is dropped: staged-but-undrained
+        // writes die with the run, exactly as `ApprovalClaim` treats gated calls.
+        let board_claim = Arc::new(deps.delegations.claim_board(run_id.to_string()));
+
         // `deps` moves in last — the borrows above (`deps.capabilities`,
-        // `deps.search`, `deps.meter`, `deps.secrets`, `deps.workspace_root`)
-        // are all done by here.
+        // `deps.search`, `deps.meter`, `deps.secrets`, `deps.workspace_root`,
+        // `deps.delegations`) are all done by here.
         let agent: Arc<dyn AgentRunner> = Arc::new(HarnessAgentRunner::new(
             pool,
             deps,
+            record.clone(),
             company.clone(),
+            workflow_id.to_string(),
             run_id.to_string(),
             run_request,
             notices,
+            board,
+            board_claim,
         ));
         (Arc::new(tools), Arc::new(http), state, Some(agent))
     };
@@ -350,32 +384,54 @@ fn hex_segment(value: &str) -> String {
 /// through [`HarnessPool::run`], which meters the turn's cost through `deps` — so
 /// a workflow step and a chat turn account identically.
 ///
-/// # It claims neither the publish queue nor the delegation queue — on purpose
+/// # It claims the delegation queue for board writes, and nothing else (issue #661 / M5)
 ///
 /// A node's turn carries the whole toolbelt, so an orchestrator-tier `agent_ref`
 /// can reach `review_task`, `assign_task`, `spawn_task` and `delegate_to_desk`,
-/// and a granted one can reach `publish_artifact`. Nothing here drains either
-/// queue: a workflow run has no board card behind it and no conversation to
-/// surface a delegation's answer into — the same absence that makes
+/// and a granted one can reach `publish_artifact`.
+///
+/// This path now holds a
+/// [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim) claim on the
+/// delegation queue for the whole run and drains it after every node turn, so a
+/// run may **open a card and set who owns it** — which is what makes the shipped
+/// `→ task cards` seed able to produce one, and what M5 was filed for. The card
+/// is a lineage root carrying a run reference
+/// ([`TaskRecord::origin_run_id`](crate::ports::TaskRecord::origin_run_id)):
+/// `parent_task_id` and `origin_chat_id` stay `None` because a run has neither a
+/// card nor a conversation behind it — the same absence that makes
 /// [`park_gated_calls`](HarnessAgentRunner::park_gated_calls) record approvals
 /// explicitly unlinked.
 ///
-/// So this path takes **no claim**, and that is the decision rather than an
-/// omission. What the agent gets is an honest in-turn refusal it can report —
-/// *"the card was NOT reviewed"* — instead of what it got before #453: a
-/// success receipt saying the card had moved to done, followed by the next
-/// turn's `clear()` destroying the delegation. Silent destruction replaced by a
-/// visible refusal.
+/// The two other delegations stay **refused at the tool boundary**, for unrelated
+/// reasons the queue reports separately: `review_task`'s `in_review → done` is the
+/// operator's accept lane, and a hand-off's only value is a synchronous reply a run
+/// has nowhere to land. `assign_task` moves no column either — the arm the drain
+/// reuses leaves it untouched — so **run → card → dispatch → run cycles stay
+/// bounded precisely because every dispatch still requires an operator act**. That
+/// is the loop bound, and relaxing the column rule would take it with it.
 ///
-/// Wiring a drain here would be a real feature (a workflow node that can move
-/// the board), and it is deliberately not this issue: it needs a decision about
-/// which card a node's `spawn_task` parents to and where a hand-off's reply
-/// goes. Until then, refusing is the truthful answer. Mirrors how this path
-/// already takes no [`PublishClaim`](crate::harness::publish::PublishClaim).
+/// The claim also closes a **live** misattribution defect PR #771 identified.
+/// `DelegateToDeskTool` calls `push_refusal` before it consults the claim, so an
+/// ungrounded hand-off from a workflow node landed in the shared bucket and a
+/// concurrent chat turn's `drain_refusals` took it, recorded it on *that* turn's
+/// card, and cleared it. The scoped claim files it into the run's own bucket, and
+/// the drain below surfaces it as this run's notice.
+///
+/// It still takes no [`PublishClaim`](crate::harness::publish::PublishClaim):
+/// `publish_artifact` needs a card to attach a version to, which a run does not
+/// have, so a refusal there remains the truthful answer.
 pub struct HarnessAgentRunner {
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
+    /// The company record, for the board drain's desk/assignee resolution (issue
+    /// #661 / M5) — the same record the rest of this bundle was built from, so a
+    /// node's board write and its tool grants cannot disagree about the roster.
+    record: CompanyRecord,
     company: CompanyId,
+    /// The workflow this run is of (issue #661 / M5): stamped onto every card the
+    /// run opens, and the voice its notes are recorded under
+    /// (`workflow:<workflow_id>`).
+    workflow_id: String,
     /// The run these agent nodes belong to (issue #395), stamped onto every
     /// approval this node's turn parks so the Approvals page can say which
     /// workflow run is waiting on the operator.
@@ -387,6 +443,16 @@ pub struct HarnessAgentRunner {
     run_request: Option<String>,
     /// Where this node leaves an operator-facing notice (issue #638).
     notices: RunNotices,
+    /// Where this node's board writes are recorded (issue #661 / M5).
+    board: RunBoard,
+    /// The run's [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim)
+    /// claim, taken once by [`build_capabilities`] and held for the whole run.
+    ///
+    /// Shared rather than per-turn because `claim_as` clears the scope's bucket on
+    /// acquire and the engine runs same-superstep nodes concurrently — a per-turn
+    /// claim would let one node destroy a sibling's staged writes. See the
+    /// acquisition site for the full reasoning.
+    board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
 }
 
 /// Where an agent node leaves a notice for the operator (issue #638).
@@ -420,26 +486,129 @@ impl RunNotices {
     }
 }
 
+/// Where an agent node's board writes are recorded (issue #661 / M5).
+///
+/// [`RunNotices`]' shape, beside it and for the same structural reason: a board
+/// row is not node output and must not become one — it would ride a downstream
+/// `=item` binding and land in the run's persisted output snapshot, where a
+/// card id is neither wanted nor meaningful. So the rows go sideways, out to the
+/// runner that owns the run, and land on [`WorkflowRun::board`].
+///
+/// Cheap to clone; every clone appends to the same list, which is what lets a
+/// run's several agent nodes — including concurrent siblings — each contribute.
+#[derive(Clone, Default)]
+pub struct RunBoard {
+    inner: Arc<std::sync::Mutex<Vec<crate::ports::WorkflowRunBoardRow>>>,
+}
+
+impl RunBoard {
+    /// Records the rows one post-turn drain produced, in order.
+    pub fn extend(&self, rows: Vec<crate::ports::WorkflowRunBoardRow>) {
+        if rows.is_empty() {
+            return;
+        }
+        self.inner.lock().expect("run board poisoned").extend(rows);
+    }
+
+    /// Takes everything recorded so far, leaving the collector empty.
+    pub fn take(&self) -> Vec<crate::ports::WorkflowRunBoardRow> {
+        std::mem::take(&mut *self.inner.lock().expect("run board poisoned"))
+    }
+}
+
 impl HarnessAgentRunner {
     /// Builds a runner over an already-populated pool for `company`, carrying
     /// the run's id (issue #395) and the operator's run request (issue #154)
     /// when one was supplied.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: Arc<HarnessPool>,
         deps: HarnessDeps,
+        record: CompanyRecord,
         company: CompanyId,
+        workflow_id: String,
         run_id: String,
         run_request: Option<String>,
         notices: RunNotices,
+        board: RunBoard,
+        board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
     ) -> Self {
         Self {
             pool,
             deps,
+            record,
             company,
+            workflow_id,
             run_id,
             run_request,
             notices,
+            board,
+            board_claim,
         }
+    }
+
+    /// Drains this run's delegation bucket after a node's turn and records what it
+    /// did (issue #661 / M5).
+    ///
+    /// Runs inside the run's board scope, so both drains read **this run's**
+    /// bucket rather than whatever `Unscoped` happens to hold.
+    ///
+    /// Two drains, in this order and both mandatory:
+    ///
+    /// 1. **Refusals** — desks a `delegate_to_desk` named that the company does not
+    ///    have. This is the live half of the defect PR #771 identified: the tool
+    ///    pushes these *before* consulting the claim, so before the scoped claim
+    ///    they landed in the shared bucket and a concurrent chat turn recorded them
+    ///    on its own card. Surfaced as a run notice — the run's own surface, and the
+    ///    only one it has.
+    /// 2. **Board writes** — executed through
+    ///    [`DelegationRunner::execute_board_writes`](crate::runtime::delegation),
+    ///    which is infallible by signature, so this cannot fail the node.
+    ///
+    /// # Never fails the node
+    ///
+    /// Nothing here returns a `Result`. The turn already happened and its output is
+    /// valid; a store hiccup must not discard it. Same stance
+    /// [`park_gated_calls`](Self::park_gated_calls) takes, arrived at the same way.
+    async fn drain_board_writes(&self) {
+        let queue = &self.deps.delegations;
+
+        // Issue #661: the run's own refusals, on the run's own surface.
+        for desk in queue.drain_refusals(MAX_DELEGATIONS_PER_TURN) {
+            tracing::warn!(
+                company = %self.company,
+                workflow = %self.workflow_id,
+                run_id = %self.run_id,
+                "workflow agent node: a hand-off named a desk this company does not have; nothing \
+                 was handed off"
+            );
+            self.notices.push(format!(
+                "A step in this workflow tried to hand work to the \"{desk}\" desk, which this \
+                 company does not have. Nothing was handed off."
+            ));
+        }
+
+        let staged = queue.drain(MAX_DELEGATIONS_PER_TURN);
+        if staged.is_empty() {
+            return;
+        }
+        let runner = crate::runtime::delegation::DelegationRunner::for_workflow_run(
+            &self.record,
+            self.deps.tasks.as_ref(),
+            // Never touched: the only registration site is the `delegate_to_desk`
+            // arm, which a board claim makes unstageable. Threaded because the
+            // shared runner needs one, and the company's own rather than a fresh
+            // one so a future reachable path would surface in the operator's
+            // in-flight list rather than in a registry nobody can see.
+            &self.deps.steer,
+            &self.company,
+            queue,
+            crate::runtime::delegation::WorkflowRunRef {
+                run_id: self.run_id.clone(),
+                workflow_id: self.workflow_id.clone(),
+            },
+        );
+        self.board.extend(runner.execute_board_writes(staged).await);
     }
 
     /// Parks every approval-gated tool call this node's turn just recorded
@@ -641,20 +810,38 @@ impl AgentRunner for HarnessAgentRunner {
             .deps
             .approval_requests
             .claim(ApprovalScope::Run(self.run_id.clone()));
-        let outcome = claim
-            .scoped(
-                self.pool
-                    .run_background(&self.company, agent_ref, &message, &self.deps),
-            )
-            .await;
-        // Drained on BOTH arms, deliberately. A turn that errored may still have
-        // had a tool call gated before it failed, and that request is just as
-        // real — dropping the claim without parking would discard it, which is
-        // the exact disappearance this issue is about.
+        // Issue #661 (M5): the turn AND its post-turn drains run inside the run's
+        // board scope, so a `spawn_task` the model calls files into this run's
+        // bucket and the drain below reads that same bucket back. The claim itself
+        // was taken once for the whole run (see `build_capabilities`); this only
+        // installs its ambient scope for the span of this node's turn.
         //
-        // Inside the scope, so the drain reads this run's bucket rather than
-        // whatever `Unscoped` happens to hold.
-        claim.scoped(self.park_gated_calls()).await;
+        // `Box::pin` because this nests one task-local scope inside another
+        // (`ApprovalScope` inside `DelegationScope`): the composed future is large
+        // enough that leaving it on the stack has blown CI's thread stack before.
+        let turn = Box::pin(async {
+            let outcome = claim
+                .scoped(
+                    self.pool
+                        .run_background(&self.company, agent_ref, &message, &self.deps),
+                )
+                .await;
+            // Drained on BOTH arms, deliberately. A turn that errored may still have
+            // had a tool call gated before it failed, and that request is just as
+            // real — dropping the claim without parking would discard it, which is
+            // the exact disappearance this issue is about.
+            //
+            // Inside the scope, so the drain reads this run's bucket rather than
+            // whatever `Unscoped` happens to hold.
+            claim.scoped(self.park_gated_calls()).await;
+            // Issue #661 (M5): likewise on both arms, and for the same reason. A
+            // turn that failed after calling `spawn_task` had already been told the
+            // card would be opened; refusing to drain would make that receipt false
+            // and destroy the write when the scope ends.
+            self.drain_board_writes().await;
+            outcome
+        });
+        let outcome = self.board_claim.scoped(turn).await;
         let outcome = outcome
             .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the
@@ -992,13 +1179,18 @@ mod tests {
         }
         let queue = deps.approval_requests.clone();
         let notices = RunNotices::default();
+        let board_claim = Arc::new(deps.delegations.claim_board("run-1"));
         let runner = HarnessAgentRunner::new(
             Arc::new(HarnessPool::new()),
             deps,
+            crate::workflows::gated_tool_turn_test::record(),
             CompanyId::new("acme"),
+            "wf-1".to_string(),
             "run-1".to_string(),
             None,
             notices.clone(),
+            RunBoard::default(),
+            board_claim,
         );
 
         // Pushed inside the run's own scope, exactly as its turn would.
@@ -1303,6 +1495,7 @@ mod tests {
                 run_request: None,
                 dry_run: false,
                 notices: RunNotices::default(),
+                board: RunBoard::default(),
             },
         )
         .await
@@ -1346,6 +1539,7 @@ mod tests {
                 run_request: None,
                 dry_run: true,
                 notices: RunNotices::default(),
+                board: RunBoard::default(),
             },
         )
         .await
@@ -1500,6 +1694,7 @@ mod tests {
                 run_request: None,
                 dry_run: false, // live: the workspace mkdir runs
                 notices: RunNotices::default(),
+                board: RunBoard::default(),
             },
         )
         .await
@@ -1550,6 +1745,7 @@ mod tests {
                 run_request: None,
                 dry_run: true, // dry: no workspace mkdir at all
                 notices: RunNotices::default(),
+                board: RunBoard::default(),
             },
         )
         .await

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -608,7 +608,32 @@ impl HarnessAgentRunner {
                 workflow_id: self.workflow_id.clone(),
             },
         );
-        self.board.extend(runner.execute_board_writes(staged).await);
+        let rows = runner.execute_board_writes(staged).await;
+        // Issue #661 (M5): a write that did not land is told to the operator, not
+        // only logged and rowed. A run has no conversation to say it in, so the
+        // notice channel is the only surface that reaches somebody — and this is
+        // the one board outcome an operator cannot infer from the board itself,
+        // because the evidence of it is precisely the card that is missing.
+        //
+        // Structural wording only: the card's own title, never the store's error
+        // text. Same split `DeliveryReason` keeps against `DeliveryReport::detail`.
+        for row in &rows {
+            let notice = match row.action {
+                crate::ports::WorkflowBoardAction::SpawnFailed => Some(format!(
+                    "A step in this workflow could not open the card \"{}\" on the board.",
+                    row.title.as_deref().unwrap_or("(untitled)")
+                )),
+                crate::ports::WorkflowBoardAction::AssignFailed => Some(format!(
+                    "A step in this workflow could not set the owner of card {}.",
+                    row.task_id.as_deref().unwrap_or("(unknown)")
+                )),
+                _ => None,
+            };
+            if let Some(notice) = notice {
+                self.notices.push(notice);
+            }
+        }
+        self.board.extend(rows);
     }
 
     /// Parks every approval-gated tool call this node's turn just recorded
@@ -816,15 +841,21 @@ impl AgentRunner for HarnessAgentRunner {
         // was taken once for the whole run (see `build_capabilities`); this only
         // installs its ambient scope for the span of this node's turn.
         //
-        // `Box::pin` because this nests one task-local scope inside another
-        // (`ApprovalScope` inside `DelegationScope`): the composed future is large
-        // enough that leaving it on the stack has blown CI's thread stack before.
+        // **Every layer here is `Box::pin`ed, and that is load-bearing.** This
+        // nests one task-local scope inside another (`ApprovalScope` inside
+        // `DelegationScope`), and `TaskLocalFuture` stores its inner future
+        // *inline* — so without boxing, an openhuman agent turn (already a very
+        // large future) is held by value inside two nested wrappers and the
+        // composed state blows the thread's stack. Verified: it overflows on the
+        // first spawning run without these.
         let turn = Box::pin(async {
             let outcome = claim
-                .scoped(
-                    self.pool
-                        .run_background(&self.company, agent_ref, &message, &self.deps),
-                )
+                .scoped(Box::pin(self.pool.run_background(
+                    &self.company,
+                    agent_ref,
+                    &message,
+                    &self.deps,
+                )))
                 .await;
             // Drained on BOTH arms, deliberately. A turn that errored may still have
             // had a tool call gated before it failed, and that request is just as
@@ -833,12 +864,12 @@ impl AgentRunner for HarnessAgentRunner {
             //
             // Inside the scope, so the drain reads this run's bucket rather than
             // whatever `Unscoped` happens to hold.
-            claim.scoped(self.park_gated_calls()).await;
+            claim.scoped(Box::pin(self.park_gated_calls())).await;
             // Issue #661 (M5): likewise on both arms, and for the same reason. A
             // turn that failed after calling `spawn_task` had already been told the
             // card would be opened; refusing to drain would make that receipt false
             // and destroy the write when the scope ends.
-            self.drain_board_writes().await;
+            Box::pin(self.drain_board_writes()).await;
             outcome
         });
         let outcome = self.board_claim.scoped(turn).await;

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -74,10 +74,19 @@ to = "done"
 "#;
 
 /// What the scripted model does on each successive call.
+///
+/// `pub(super)` alongside [`deps`] and [`record`] so the sibling
+/// [`board_turn_test`](crate::workflows::board_turn_test) drives the same
+/// scripted-model harness rather than duplicating it (issue #661).
 #[derive(Clone, Debug)]
-enum Turn {
+pub(super) enum Turn {
     /// Emit a native tool call the policy will gate.
-    Call { tool: &'static str, args: Value },
+    Call {
+        /// The tool the model asks for.
+        tool: &'static str,
+        /// Its arguments, verbatim.
+        args: Value,
+    },
     /// Finish with plain assistant text.
     Say(&'static str),
 }
@@ -143,7 +152,7 @@ async fn spawn_script_recording(turns: Vec<Turn>) -> (String, Arc<Script>) {
 }
 
 /// Serve the script on loopback and return its base URL.
-async fn spawn_script(turns: Vec<Turn>) -> String {
+pub(super) async fn spawn_script(turns: Vec<Turn>) -> String {
     spawn_script_recording(turns).await.0
 }
 

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -19,6 +19,10 @@
 /// downstream agent node's turn (an `agent -> agent` pipeline passes data).
 #[cfg(test)]
 mod agent_upstream_input_test;
+/// Issue #661 (M5): end-to-end proof that a workflow node can open and re-own a
+/// board card, and that everything it may not do stays refused.
+#[cfg(test)]
+mod board_turn_test;
 pub mod caps;
 pub mod delivery;
 /// Issue #460: the company's `ApprovalPolicy` decides which `tool_call` nodes

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -268,6 +268,13 @@ async fn run_workflow_inner(
     // here, by the run, because that is the only scope that outlives the nodes
     // and reaches `WorkflowRun`.
     let notices = super::caps::RunNotices::default();
+    // Issue #661 (M5): where the run's board writes are recorded. Owned here for
+    // the same reason `notices` is — the nodes come and go, and this is the only
+    // scope that outlives them and reaches `WorkflowRun`. Critically it is owned
+    // *outside* the capability bundle, so a hard abort that drops the engine future
+    // (and with it the bundle and its board claim) still leaves every row already
+    // collected readable here: a card is real once written, so it must stay listed.
+    let board = super::caps::RunBoard::default();
     let capabilities = super::caps::build_capabilities(
         pool,
         deps,
@@ -278,6 +285,7 @@ async fn run_workflow_inner(
             run_request,
             dry_run,
             notices: notices.clone(),
+            board: board.clone(),
         },
     )
     .await?;
@@ -513,7 +521,7 @@ async fn run_workflow_inner(
     // journal, not this return.
     let outcome = match outcome_opt {
         Some(outcome) => outcome.map_err(map_engine_error)?,
-        None => return Ok(cancelled_run()),
+        None => return Ok(cancelled_run(notices.take(), board.take())),
     };
 
     // Issue #398: the **clean** node-boundary cancel. The engine observed the
@@ -549,6 +557,14 @@ async fn run_workflow_inner(
             // refused before the stop, and withholding it would leave the
             // operator with fewer cards than were gated and no explanation.
             notices: notices.take(),
+            // Issue #661 (M5): a cancelled run's board writes SURVIVE and stay
+            // listed. A card is a durable write the moment the drain performs it,
+            // so an operator who stopped the run still has the card in front of
+            // them — dropping the row would leave a card on the board that no run
+            // admits to opening. (A run cancelled *mid-turn* staged writes that
+            // were never drained, so it has no card and no row: consistent, and the
+            // same judgement `park_gated_calls` documents for gated calls.)
+            board: board.take(),
         });
     }
 
@@ -566,6 +582,12 @@ async fn run_workflow_inner(
             cancelled: false,
             nodes,
             notices: notices.take(),
+            // Issue #661 (M5): empty by construction, not by this line. A dry run's
+            // bundle wires `DryRunAgent`, so `HarnessAgentRunner` — the only thing
+            // that ever takes a board claim or drains one — is never built. Taken
+            // rather than hard-coded empty so the claim is a *test's* to make (see
+            // `a_dry_run_of_a_spawning_graph_writes_no_card`), following #542.
+            board: board.take(),
         });
     }
 
@@ -673,6 +695,9 @@ async fn run_workflow_inner(
         // every run that did not overflow the approval cap, which is nearly all
         // of them.
         notices: notices.take(),
+        // Issue #661 (M5): every card this run's nodes opened or re-owned. Empty
+        // for every run whose nodes touched no card, which is nearly all of them.
+        board: board.take(),
     })
 }
 
@@ -898,8 +923,8 @@ async fn park_pending_gates(
 /// a real partial outcome and is settled inline in `run_workflow_inner`, carrying
 /// its collected node rows. This is only the dropped-future case.)
 ///
-/// Empty on every field but the flag, and each emptiness is a claim rather than
-/// a shrug:
+/// Empty on every field but the flag and the two the caller threads in, and each
+/// emptiness is a claim rather than a shrug:
 ///
 /// * **no `output`** — the engine future was dropped, so there is no final state
 ///   to report. A partial one would be a new shape nothing downstream parses;
@@ -910,7 +935,22 @@ async fn park_pending_gates(
 ///   journal-backed and independent of the run, so they stay in the queue and
 ///   an operator may still approve or deny them. Listing them here would imply
 ///   this run is still waiting on them, which it is not.
-fn cancelled_run() -> WorkflowRun {
+///
+/// # The two arguments are the exceptions, and they are the point
+///
+/// `notices` and `board` are **threaded in rather than emptied** (issue #661 /
+/// M5). Everything above is empty because it describes the run's *result*, which
+/// a dropped future does not have. These two describe what its nodes already
+/// **did** before it wedged, and both are durable facts by the time this is
+/// reached: a notice records tool calls that were already refused, and a board row
+/// records a card that is already on the operator's board. Emptying them would
+/// leave a card nothing admits to opening — which is why this signature changed
+/// instead of the constructor keeping its convenient `Vec::new()`s. (`notices` was
+/// dropped here before, silently; that is fixed by the same change.)
+fn cancelled_run(
+    notices: Vec<String>,
+    board: Vec<crate::ports::WorkflowRunBoardRow>,
+) -> WorkflowRun {
     WorkflowRun {
         output: Value::Null,
         pending_approvals: Vec::new(),
@@ -921,9 +961,8 @@ fn cancelled_run() -> WorkflowRun {
         // (the drain runs before this returns), so "how far did it get?" is
         // answered by the history, not by this settled body.
         nodes: Vec::new(),
-        // Nothing to say: this constructor is the pre-engine stop path, so no
-        // node ran and no node raised anything.
-        notices: Vec::new(),
+        notices,
+        board,
     }
 }
 

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1342,6 +1342,54 @@ to = "done"
         );
     }
 
+    /// Issue #661 (M5): the **hard-abort** arm lists the board writes its nodes
+    /// already performed.
+    ///
+    /// A wedged run's future is dropped, so there is no outcome to read and every
+    /// other field of `cancelled_run` is empty as a claim about the run's
+    /// *result*. Its board rows are not a result — they record a card that is
+    /// already on the operator's board by the time this is reached. Emptying them
+    /// would leave a card that no run admits to opening.
+    ///
+    /// Unit-level rather than a wedged end-to-end run on purpose: reaching this
+    /// arm for real means outlasting `CANCEL_HARD_ABORT_GRACE`, and a five-second
+    /// sleep in the suite buys nothing this does not pin — the arm's whole
+    /// behaviour is what it threads through.
+    ///
+    /// `notices` rides along for the same reason, and that half is a fix: this
+    /// constructor used to hard-code `Vec::new()` for it, so a wedged run silently
+    /// dropped notices its completed nodes had raised.
+    #[test]
+    fn a_hard_aborted_run_still_lists_its_board_writes() {
+        let row = crate::ports::WorkflowRunBoardRow {
+            action: crate::ports::WorkflowBoardAction::Spawned,
+            task_id: Some("card-1".to_string()),
+            title: Some("Reply to the auditor".to_string()),
+            assignee: None,
+        };
+        let run = cancelled_run(
+            vec!["something was discarded".to_string()],
+            vec![row.clone()],
+        );
+
+        assert!(run.cancelled);
+        assert_eq!(
+            run.board,
+            vec![row],
+            "the card is durable, so the stopped run must still list it"
+        );
+        assert_eq!(
+            run.notices,
+            vec!["something was discarded".to_string()],
+            "and the notices its nodes raised are not the run's result either"
+        );
+        // Everything that IS the run's result stays empty, unchanged.
+        assert_eq!(run.output, Value::Null);
+        assert!(run.deliveries.is_empty());
+        assert!(run.pending_approvals.is_empty());
+        assert!(run.nodes.is_empty());
+    }
+
     /// A dry run writes NOTHING durable — no output snapshot, matching its "the
     /// settled response body is the whole record" contract (#542).
     #[tokio::test]


### PR DESCRIPTION
## Summary

**PR2 of finding M5** on #661: a workflow run can now put work on the company's board.

PR1 (#771) built the mechanism — `claim_board(run_id)` → `DrainClaim::Board`, per-scope buckets — but nothing claimed or drained it, so `spawn_task` / `assign_task` from a run still got an in-turn refusal and the shipped `→ task cards` seed could not make a card. This wires the claim, the drain, the card's provenance and the server surface.

What a run may do, and may not:

| From a workflow node | |
|---|---|
| `spawn_task` → a card in **To-do** | ✅ |
| `assign_task` → set or clear the owner | ✅ (column untouched) |
| `review_task` → move through review | ❌ refused at the tool boundary — the operator's accept lane |
| `delegate_to_desk` → hand-off | ❌ refused — a run has nowhere for a synchronous reply to land |

A spawned card is a **lineage root carrying a run reference**: `parentTaskId` and `originChatId` stay `None`, and two additive fields — `originRunId` / `originWorkflowId` — say which machine act opened it. A run has no card and no conversation behind it, so machine provenance is a reference rather than a parent; the alternative (minting a card for the run itself) would leave a daily schedule 365 operator-facing run-cards a year and duplicate a surface the runs-history panel already owns.

### Two findings that contradicted the original design

Both verified against the code, both changed the plan rather than being worked around:

**1. A sub-workflow child has no run identity.** `StoreWorkflowResolver` runs a child *inside the engine under the parent's capability bundle* — same runner, same `run_id`, same collectors — and a child journals no `WorkflowRunStarted`/`Finished` pair of its own (which is also why #617 exists). So a child node's cards stamp the **parent's** run and workflow id: the only run identity that exists, and the only run row a console can navigate to. Pinned by test rather than left to be rediscovered.

**2. The engine runs same-superstep nodes concurrently** (`tinyflows/src/engine.rs` sets `.with_parallel(true)`), so a per-node-turn `claim_board` is unsafe — `claim_as` clears the scope's bucket on acquire, so a sibling's claim would destroy mid-turn staged items. **The Board claim is therefore held once per run**, taken in `build_capabilities`' live arm and released with the bundle. This changed the wiring, not the semantics. The consequence worth knowing: siblings share one bucket, so node A's drain may execute a write node B staged — nothing is lost or duplicated, but a row is attributed to the *run* rather than to a node, which is why `WorkflowRunBoardRow` carries no node id.

### It also closes a live defect

`DelegateToDeskTool` calls `push_refusal` **before** it consults the claim. A workflow node naming a desk the company does not have therefore wrote into the shared `refused` vector today, and a concurrent chat turn's `drain_refusals` took it, recorded the hand-off on *that* turn's card, and cleared it — an attempt nobody on that turn made, attributed to that turn, destroyed for the run that made it. The scoped claim files it into the run's own bucket and the drain surfaces it as that run's notice.

## API Or Behavior Changes

All additive; every existing wire shape is byte-unchanged, proven by round-trip tests that assert the **absence** of the new keys, not merely equivalence.

**Ports**
- `WorkflowRunBoardRow { action, taskId?, title?, assignee? }` + `WorkflowBoardAction` (`spawned` / `assigned` / `spawnFailed` / `assignFailed`). Structural only — no error or note text — mirroring `WorkflowRunNodeRow`. camelCase so one shape rides the journal event and both HTTP surfaces (the `DeliveryReport` precedent).
- `WorkflowRun.board` (`#[serde(default)]`).
- `TaskRecord.originRunId` / `.originWorkflowId` (`default`, `skip_serializing_if`), following the `origin_chat_id` (#151) / `parent_task_id` (#185) evolution pattern.
- `CompanyEvent::WorkflowRunFinished.board` (`default`, skip-if-empty).

**HTTP**
- `GET …/workflows/runs` → `board` on each run (omitted when empty).
- `POST …/workflows/{id}/run` → `board` on the synchronous response (omitted when empty).
- `TaskCard` → `originRunId` / `originWorkflowId` (omitted when absent). `task_export.rs` untouched.
- The `workflow_run_finished` SSE frame projects `board` on the same presence-check discipline `notices` uses — a weaker widens-nothing claim than `deliveries`, since a board row is structural by construction rather than by the arm choosing what to forward.

**Behaviour**
- A run's agent node holds a `DrainClaim::Board` claim for the run and drains refusals → run notices, then board writes → rows, after **every** node turn and on both its arms.
- `execute_board_writes(Vec<Delegation>) -> Vec<WorkflowRunBoardRow>` is **infallible by signature**, not by discipline: a board write must never fail the node that made it, so there is no `Result` for a future edit to add a `?` to. A failure is a `*Failed` row, a run notice and a `tracing::error`.
- `assign_task` notes are authored as `workflow:<workflow_id>` rather than being attributed to the CEO.
- `cancelled_run(...)` changes signature to take the board rows **and** the notices it was previously dropping silently.

**Known limitation, stated rather than inherited:** `board` rides the `Ok` arm of `record_run_finished`, like `cancelled` and `notices`. A run that opened two cards and then failed at a later node leaves **both cards on the board** but journals neither row — the work survives, the listing does not, and the board itself is the record in that case.

**Loop safety is unchanged and load-bearing.** `assign_task` never moves a column — the drain reuses the same arm the chat path does, so the invariant is inherited rather than re-promised, and it holds one level deeper too: the drain writes through the `TaskStore` port, which cannot trigger dispatch. Cards land in To-do; every dispatch still needs an operator drag. That is the bound on run → card → dispatch → run cycles, and no relaxation is proposed here.

## Tests

Ten guards, each proven by revert → observe RED → restore. The existing battery — PR1's scoping tests, #767's cancel tests, every chat-path `spawn_task` test — passes **unmodified**.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings` — clean
- [x] `cargo test --locked` — **2284 passed, 0 failed, 1 ignored**
- [x] `cargo test --locked --features openhuman,mcp,telegram` — **3459 passed, 0 failed, 3 ignored** (+ 10 + 1 + 11 + 2 across integration targets)
- [x] `cargo check --all-features` — clean

New coverage, in existing module files (no new `tests/` target, so nothing depends on a CI lane selecting it):

`src/workflows/board_turn_test.rs` — nine end-to-end turn tests over the real path (real graph, real `run_workflow`, real `HarnessAgentRunner`, real pool, real orchestrator toolbelt, real `TaskStore`), stubbing only the model's choices via the scripted loopback endpoint #395 established. A unit test over any single part stays green through the missing join this PR adds, which is why these are turn tests.

1. spawn happy path — card exists, `column == todo`, `parentTaskId`/`originChatId` `None`, both origin ids stamped, one `spawned` row
2. assign — owner written, **column unchanged**, note author `[workflow:board]` and not `[ceo]`, `assigned` row
3. failing `TaskStore.upsert` — run still `Ok`, `spawnFailed` row with no `taskId`, plus a run notice
4. ungrounded `delegate_to_desk` — refusal on the run's own notices, `Unscoped` bucket untouched
5. clean cancel — card survives, row still listed on the cancelled run
6. hard abort — `cancelled_run` lists the threaded rows *and* notices (unit-pinned: reaching that arm for real means outlasting `CANCEL_HARD_ABORT_GRACE`, and a five-second sleep buys nothing the arm's behaviour does not already show)
7. dry run of a spawning graph — store empty, board empty, journal empty
8. sub-workflow child — stamps the **parent's** ids (pins finding 1)
9. serde round-trips on pre-existing `TaskRecord` / `WorkflowRunFinished` payloads — new fields default, absent keys when unset
10. server — `list_runs` carries the rows through the real group-by-run fold, `TaskCard` JSON has the two ids when set and **absent** when `None`, sync response includes `board`

Two things worth flagging to a reviewer:

- The `*_turn_test` modules overflow the thread stack on macOS in a debug build **before this branch** (verified at `29d250f7`); they need `RUST_MIN_STACK=33554432` locally. Unrelated to this change, but this PR does add a second nested task-local scope, so every layer of a node's turn is now `Box::pin`ed — without that it overflows even on CI-sized stacks.
- `src/harness/orchestrator.rs` picks up 17 one-line `board: Vec::new(),` additions in test fixtures. Rust has no way to leave an exhaustive struct literal alone when a struct gains a field. No logic there is touched, and the mechanical updates across the tree are isolated into their own `chore:` commits so the behavioural ones stay readable.

## Documentation

Rewrote the `caps/mod.rs` doc block that recorded this as deliberately deferred ("it needs a decision about which card a node's `spawn_task` parents to and where a hand-off's reply goes") — that decision is now made and documented at the site, including why the two refused delegations are refused for *unrelated* reasons and why the column rule is load-bearing for loop safety. Every new field carries its rationale and its `None`/empty claim.

## Related

Part of #661 (finding M5).
Builds on #771 (PR1 — queue scoping + the board claim).
Interacts with #767 (a cancelled run's board writes survive and stay listed — the semantic touchpoint agreed on the issue).
Context for #617 (a sub-workflow child journals no run of its own — this PR pins that and works with it rather than around it).

**PR3 (console) follows, and needs no further server change.** It consumes, all shipped here:

- `board` rows on `GET …/workflows/runs` and on the synchronous `POST …/workflows/{id}/run` response
- `board` on the `WorkflowRunFinished` journal event and on the `workflow_run_finished` SSE frame
- `originRunId` / `originWorkflowId` on `TaskCard`

One shape across all of them, so the console reads a run's board effects identically whether it awaited the run, found it in the history, or watched it settle over the stream.
