### PR TITLE
fix(repo): hold a checkout across an approval park — supervised write-tier deadlock (#796)

### DIFF
--- a/docs/spec/runtime/repos.md
+++ b/docs/spec/runtime/repos.md
@@ -227,12 +227,25 @@ limit"](#the-honest-limit), and are not claimed here.
 
 ### The lifecycle
 
-A checkout's life is exactly one turn's. Every path the tools create is recorded
-on a per-turn ledger, and an RAII janitor claimed at each turn's entry point
-deletes them on the way out — success, error, steer cancel, redirect exhaustion
-and panic-unwind alike. A mid-loop redirect deletes the abandoned turn's
-checkout too, so a re-run starts from a fresh tree rather than one a discarded
-turn half-patched.
+A checkout's life is one turn's — with one deliberate exception the write tier
+needs (issue #796). Every path the tools create is recorded on a per-turn
+ledger, and an RAII janitor claimed at each turn's entry point deletes them on
+the way out — success, error, steer cancel, redirect exhaustion and panic-unwind
+alike. A mid-loop redirect deletes the abandoned turn's checkout too, so a re-run
+starts from a fresh tree rather than one a discarded turn half-patched.
+
+**The exception: surviving an approval park.** A write is not one turn's work —
+`repo_checkout` → edit → `git_operations` commit → `repo_publish` are each a
+`Reach::Consequence` step that parks under `supervised`, and a park ends the
+turn. So a checkout a *task* turn parked with is held on a task-keyed retained
+set the janitor does not touch, keyed by the task the parked approval carries
+(`GrantedCall::origin_task`); the approval's re-issue reclaims it, so the resumed
+step commits and publishes on the same tree — and the same commit — the parked
+step left. It is deleted when the task's resumed step finishes without parking
+again, or — if the approval is denied or expired — swept the next time any turn
+claims the janitor and no live grant still names the task. This is the "deleted
+at task end" this tier always promised; a per-turn delete made it a deadlock
+under supervision.
 
 A host killed mid-turn ends no turn, so boot sweeps
 `<harness>/<company>/*/workspace/repos` before the company starts. It is

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1499,6 +1499,10 @@ impl CompanyRuntime {
         let expired = self.approval_gate.sweep_expired(now);
         for id in &expired {
             self.journal.record_expired(id, now).await?;
+            // Issue #796: the parked approval is gone, so its work unit is no
+            // longer awaiting a resume — drop the pending mark so the checkout it
+            // was holding across the park becomes sweepable.
+            self.grants.clear_pending(id);
             // Issue #469: releasing the turn this approval was blocking, and
             // running its continuation when this expiry was the last thing it
             // waited on. Spawned rather than awaited: the continuation is a full

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -302,6 +302,10 @@ impl HarnessBrain {
             tool: String,
             instruction: String,
             origin_thread: Option<String>,
+            /// The task this approval was parked from (issue #796), so the
+            /// re-issue turn can reclaim its held-across-park checkout and stamp
+            /// the ledger so `repo_publish` can name the task branch.
+            origin_task: Option<String>,
         }
 
         let grants = self.deps.approval_requests.grants();
@@ -320,6 +324,7 @@ impl HarnessBrain {
                 tool: grant.tool,
                 agent: grant.agent,
                 origin_thread: grant.origin_thread,
+                origin_task: grant.origin_task,
             }
         } else if let Some(standing) = grants.peek_standing_by_approval(approval_id) {
             // No exact-arguments pin, and deliberately so: a standing grant
@@ -336,11 +341,15 @@ impl HarnessBrain {
                 tool: standing.tool,
                 agent: standing.agent,
                 origin_thread: standing.origin_thread,
+                origin_task: standing.origin_task,
             }
         } else {
             return Ok(None);
         };
         let instruction = grant.instruction.clone();
+        // Issue #796: the task (if any) this approval resumes. Bound before the
+        // struct's fields are moved into the run below.
+        let origin_task = grant.origin_task.clone();
 
         let guard = self.deps.steer.register(
             &self.record().id,
@@ -387,14 +396,30 @@ impl HarnessBrain {
                     .claim(publish::PublishDestination::Conversation)
             });
         // Issue #245: a re-dispatched approval is a full agent turn with the
-        // whole toolbelt, so it can check a repository out — and a checkout must
-        // not outlive the turn that asked for it. Unconditional: the janitor
-        // over an empty ledger is a no-op, which is what every turn that touches
-        // no repository does.
+        // whole toolbelt, so it can check a repository out, and the janitor
+        // claimed here deletes what this turn creates. Issue #796 refines what
+        // "this turn's checkout" is: a turn resuming a task first reclaims that
+        // task's held-across-park tree, so the resumed step operates on the same
+        // working tree — and the commit it needs — the parked step left behind.
         let _checkout_janitor = CheckoutJanitor::claim(&self.deps.checkouts);
-        // Issue #735: a re-dispatched grant is not a task card, so clear any task
-        // a prior turn stamped — `repo_publish` requires a task and refuses here.
-        self.deps.checkouts.set_task(None);
+        // Issue #796: at the claim, drop any task's retained checkout whose
+        // approval was denied or expired — no live grant names it, so nothing
+        // will ever resume it. `grants` is the same live set peeked above.
+        self.deps
+            .checkouts
+            .sweep_orphans(|task| grants.any_for_task(task));
+        // Issue #735/#796: stamp the task this grant resumes so `repo_publish`
+        // can name its branch, and reclaim the checkout the parked step left so
+        // the resumed step — a commit, a publish — finds its own work. A
+        // re-dispatch with no task (a plain operator-chat approval) clears the
+        // cell and reclaims nothing, exactly as #735 did.
+        self.deps.checkouts.set_task(origin_task.clone());
+        if let Some(task) = &origin_task {
+            self.deps.checkouts.reclaim(task);
+        }
+        // Issue #242/#796: where this turn's own approval requests begin, so a
+        // re-park can be told from a queue entry inherited from earlier.
+        let approvals_before = self.deps.approval_requests.queued();
         // Un-streamed, like a dispatched card: this turn is answered by the
         // bubble returned below, and its transient frames would otherwise
         // misattribute onto whichever chat thread the console is watching.
@@ -408,6 +433,15 @@ impl HarnessBrain {
             )
             .await;
         drop(guard);
+        // Issue #796: if this turn parked again — the resumed step, or a further
+        // one, needs another approval — hold the task's checkout across that park
+        // too. Otherwise the janitor's `Drop` deletes the reclaimed tree, which
+        // is this task's repo work finishing.
+        if let Some(task) = &origin_task
+            && self.deps.approval_requests.queued() > approvals_before
+        {
+            self.deps.checkouts.retain_for_task(task);
+        }
 
         let published = self.deps.pending_publishes.drain();
         if !published.is_empty()
@@ -636,9 +670,20 @@ impl HarnessBrain {
         // guard's `Drop` is what deletes the tree on every exit — success,
         // error, cancel, redirect exhaustion and panic-unwind alike.
         let _checkout_janitor = CheckoutJanitor::claim(&self.deps.checkouts);
+        // Issue #796: at the claim, drop any task's retained checkout whose
+        // approval was denied or expired — no live grant names it, so nothing
+        // will resume it.
+        {
+            let grants = self.deps.approval_requests.grants();
+            self.deps
+                .checkouts
+                .sweep_orphans(|task| grants.any_for_task(task));
+        }
         // Issue #735: this is a dispatched card, so `repo_publish` names its
         // branch `oc/<company>/<card>`. Stamped on the same per-turn cell the
-        // janitor above claims.
+        // janitor above claims. A parked step of this card resumes through the
+        // approval re-issue path (which reclaims the tree there, issue #796), not
+        // by re-running the card, so nothing is reclaimed here.
         self.deps.checkouts.set_task(Some(card.id.clone()));
         // Issue #339, same argument for staged workflow references: an operator
         // chat turn earlier in this cycle may have run a workflow through the
@@ -895,6 +940,17 @@ impl HarnessBrain {
                 }
             }
         };
+
+        // Issue #796: if this dispatch parked (a step it ran needs approval),
+        // hold whatever checkout it built across that park so the approved step
+        // resumes on the same tree. A dispatch that ended without parking keeps
+        // the pre-#796 behaviour — the janitor's `Drop` deletes its checkout.
+        // Orphan cleanup for the denied/expired case is the `sweep_orphans` at
+        // the next claim, which is safe against a still-pending approval in a way
+        // an unconditional purge here would not be.
+        if self.deps.approval_requests.queued() > approvals_before {
+            self.deps.checkouts.retain_for_task(&card.id);
+        }
 
         // ── Issue #244: the deliverable gate, and the one nudge ─────────────
         //
@@ -2466,6 +2522,15 @@ impl HarnessBrain {
                     // so it can clone a repository, and the guard's `Drop`
                     // removes it when this turn ends.
                     let _checkout_janitor = CheckoutJanitor::claim(&self.deps.checkouts);
+                    // Issue #796: sweep any task checkout orphaned by a
+                    // denied/expired approval, on this turn's claim like every
+                    // other.
+                    {
+                        let grants = self.deps.approval_requests.grants();
+                        self.deps
+                            .checkouts
+                            .sweep_orphans(|task| grants.any_for_task(task));
+                    }
                     // Issue #735: a conversation is not a task card, so clear any
                     // task a prior turn stamped — `repo_publish` requires a task
                     // and refuses on a chat turn (task turns only, this tier).
@@ -6467,6 +6532,7 @@ members = ["eng1", "eng2"]
                 at_millis: now_millis(),
                 origin_thread: None,
                 origin_parent: None,
+                origin_task: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 
@@ -6523,6 +6589,118 @@ members = ["eng1", "eng2"]
             .all(|e| !matches!(e.event, CompanyEvent::AgentReply { .. }))
     }
 
+    /// Issue #796: an approved grant that carries an origin task reclaims that
+    /// task's checkout held across the park, so the resumed step works on the
+    /// tree — and commit — the parked step left. A redispatch that then ends
+    /// without parking again lets the janitor delete it, the task's repo work
+    /// having finished.
+    ///
+    /// This is the deadlock #796 fixes: under `supervised` every step of
+    /// `repo_checkout` → commit → `repo_publish` parks, and a per-turn delete
+    /// wiped the checkout between them. `MockProvider` parks nothing, so the
+    /// assertion is the whole round trip — held before, reclaimed through the
+    /// turn, deleted after — never wiped early, never stranded.
+    #[tokio::test]
+    async fn an_approved_grant_reclaims_the_task_checkout_it_resumes() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        requests
+            .grants()
+            .grant(crate::runtime::grants::GrantedCall {
+                approval_id: ApprovalId::new("appr-1"),
+                agent: "ceo".into(),
+                tool: "git_operations".into(),
+                args: serde_json::json!({ "operation": "commit" }),
+                at_millis: now_millis(),
+                origin_thread: None,
+                origin_parent: None,
+                // The link that makes the resume reclaim the right tree.
+                origin_task: Some("t-1".into()),
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        // The checkout the parked commit step left, held under its task.
+        let tree = dir.path().join("held-checkout");
+        std::fs::create_dir_all(&tree).unwrap();
+        brain.deps.checkouts.record(tree.clone());
+        brain.deps.checkouts.retain_for_task("t-1");
+        assert_eq!(
+            brain.deps.checkouts.retained_tasks(),
+            vec!["t-1".to_string()]
+        );
+
+        brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        // Reclaimed onto the resuming turn, then deleted by its janitor — the
+        // turn parked nothing, so the task's repo work is finished. It must be
+        // neither wiped before the resume nor stranded in `retained` after.
+        assert!(
+            !tree.exists(),
+            "the reclaimed checkout outlived its finished task"
+        );
+        assert!(
+            brain.deps.checkouts.retained_tasks().is_empty(),
+            "the task's checkout was stranded in the retained set"
+        );
+    }
+
+    /// Issue #796: a checkout held for a task no live grant names — the
+    /// approval was denied or expired, so nothing will ever resume it — is swept
+    /// the next time any turn claims the janitor, rather than leaking to the boot
+    /// sweep. Here an unrelated approval drives that turn.
+    #[tokio::test]
+    async fn an_orphaned_task_checkout_is_swept_at_the_next_janitor_claim() {
+        let dir = tempfile::tempdir().unwrap();
+        let log: Arc<dyn crate::ports::EventLog> =
+            Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
+        let requests = crate::harness::policy::ApprovalRequestQueue::default();
+        // A live grant with no task of its own — an ordinary chat approval — to
+        // drive one redispatch turn. It names no task, so it cannot keep the
+        // orphan alive.
+        requests
+            .grants()
+            .grant(crate::runtime::grants::GrantedCall {
+                approval_id: ApprovalId::new("appr-1"),
+                agent: "ceo".into(),
+                tool: "composio_execute".into(),
+                args: serde_json::json!({}),
+                at_millis: now_millis(),
+                origin_thread: None,
+                origin_parent: None,
+                origin_task: None,
+            });
+        let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
+
+        // A tree held for a task whose approval is gone: no grant names it.
+        let tree = dir.path().join("orphaned-checkout");
+        std::fs::create_dir_all(&tree).unwrap();
+        brain.deps.checkouts.record(tree.clone());
+        brain.deps.checkouts.retain_for_task("t-gone");
+        assert!(tree.is_dir());
+
+        brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
+
+        assert!(
+            !tree.exists(),
+            "an orphaned task checkout was not swept at the janitor claim"
+        );
+        assert!(brain.deps.checkouts.retained_tasks().is_empty());
+    }
+
     // Issue #379's reply routing — a channel's continuation must resume in that
     // channel and not in its lead's private DM, and the mirror — used to be
     // pinned here, against a hand-built grant. It moved with the journaling
@@ -6563,6 +6741,7 @@ members = ["eng1", "eng2"]
                 expires_at_millis: now_millis() + 60 * 60 * 1000,
                 origin_thread: None,
                 origin_parent: None,
+                origin_task: None,
                 scope: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
@@ -6619,6 +6798,7 @@ members = ["eng1", "eng2"]
                 at_millis: now_millis(),
                 origin_thread: None,
                 origin_parent: None,
+                origin_task: None,
             });
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 
@@ -6805,6 +6985,7 @@ members = ["eng1", "eng2"]
             at_millis: now_millis(),
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         }
     }
 

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -417,9 +417,6 @@ impl HarnessBrain {
         if let Some(task) = &origin_task {
             self.deps.checkouts.reclaim(task);
         }
-        // Issue #242/#796: where this turn's own approval requests begin, so a
-        // re-park can be told from a queue entry inherited from earlier.
-        let approvals_before = self.deps.approval_requests.queued();
         // Un-streamed, like a dispatched card: this turn is answered by the
         // bubble returned below, and its transient frames would otherwise
         // misattribute onto whichever chat thread the console is watching.
@@ -433,13 +430,20 @@ impl HarnessBrain {
             )
             .await;
         drop(guard);
-        // Issue #796: if this turn parked again — the resumed step, or a further
-        // one, needs another approval — hold the task's checkout across that park
-        // too. Otherwise the janitor's `Drop` deletes the reclaimed tree, which
-        // is this task's repo work finishing.
-        if let Some(task) = &origin_task
-            && self.deps.approval_requests.queued() > approvals_before
-        {
+        // Issue #796: hold the task's checkout across the turn boundary on EVERY
+        // re-issue, not only one that parks a new approval.
+        //
+        // A write is a chain of separately-approved steps — checkout, edit,
+        // commit, publish — and an operator commonly approves them in a batch, so
+        // the grants exist up front. Re-issuing one grant then need NOT queue a
+        // new approval, yet the checkout it just materialized (or the commit it
+        // just made) must still be there when the next grant is re-issued in its
+        // own turn. Retaining only on a fresh park dropped exactly that tree the
+        // turn it was created. So retain unconditionally here; the checkout is
+        // reclaimed on the next re-issue, and `sweep_orphans` at the next claim
+        // deletes it once no live grant names the task — the flow finished, was
+        // denied, or expired.
+        if let Some(task) = &origin_task {
             self.deps.checkouts.retain_for_task(task);
         }
 
@@ -6589,48 +6593,49 @@ members = ["eng1", "eng2"]
             .all(|e| !matches!(e.event, CompanyEvent::AgentReply { .. }))
     }
 
-    /// Issue #796: an approved grant that carries an origin task reclaims that
-    /// task's checkout held across the park, so the resumed step works on the
-    /// tree — and commit — the parked step left. A redispatch that then ends
-    /// without parking again lets the janitor delete it, the task's repo work
-    /// having finished.
+    /// Issue #796: a task's checkout survives a whole BATCH of re-issues, the way
+    /// a supervised write actually runs — the operator approves `repo_checkout`,
+    /// the edit, the commit and the publish up front, and each grant is re-issued
+    /// in its own turn. The checkout the first re-issue materializes must still be
+    /// there when the next grant is re-issued, and the one after that.
     ///
-    /// This is the deadlock #796 fixes: under `supervised` every step of
-    /// `repo_checkout` → commit → `repo_publish` parks, and a per-turn delete
-    /// wiped the checkout between them. `MockProvider` parks nothing, so the
-    /// assertion is the whole round trip — held before, reclaimed through the
-    /// turn, deleted after — never wiped early, never stranded.
+    /// This is the exact loop the first cut of the fix still had: retaining the
+    /// tree only on a turn that parked a NEW approval dropped it the moment a
+    /// batched re-issue parked nothing, so the next approved step found the tree
+    /// gone. `MockProvider` parks and consumes nothing, so both grants stay live —
+    /// the task is in flight — and the tree must be held across every re-issue.
     #[tokio::test]
-    async fn an_approved_grant_reclaims_the_task_checkout_it_resumes() {
+    async fn a_task_checkout_survives_a_batch_of_re_issues() {
         let dir = tempfile::tempdir().unwrap();
         let log: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path().to_path_buf()));
         let requests = crate::harness::policy::ApprovalRequestQueue::default();
-        requests
-            .grants()
-            .grant(crate::runtime::grants::GrantedCall {
-                approval_id: ApprovalId::new("appr-1"),
-                agent: "ceo".into(),
-                tool: "git_operations".into(),
-                args: serde_json::json!({ "operation": "commit" }),
-                at_millis: now_millis(),
-                origin_thread: None,
-                origin_parent: None,
-                // The link that makes the resume reclaim the right tree.
-                origin_task: Some("t-1".into()),
-            });
+        // Two of the task's steps approved up front (a batch), both under t-1.
+        for (id, tool) in [("appr-1", "repo_checkout"), ("appr-2", "git_operations")] {
+            requests
+                .grants()
+                .grant(crate::runtime::grants::GrantedCall {
+                    approval_id: ApprovalId::new(id),
+                    agent: "ceo".into(),
+                    tool: tool.into(),
+                    args: serde_json::json!({}),
+                    at_millis: now_millis(),
+                    origin_thread: None,
+                    origin_parent: None,
+                    // The link that makes each re-issue reclaim the same tree.
+                    origin_task: Some("t-1".into()),
+                });
+        }
         let brain = brain_with_queue_and_events(dir.path(), requests, log.clone());
 
-        // The checkout the parked commit step left, held under its task.
+        // The checkout the task's first step materialized, held under its task.
         let tree = dir.path().join("held-checkout");
         std::fs::create_dir_all(&tree).unwrap();
         brain.deps.checkouts.record(tree.clone());
         brain.deps.checkouts.retain_for_task("t-1");
-        assert_eq!(
-            brain.deps.checkouts.retained_tasks(),
-            vec!["t-1".to_string()]
-        );
 
+        // Re-issue the first approved step. The tree must survive the turn — the
+        // task is not done, its other step is still granted.
         brain
             .run_cycle(
                 cycle_over(vec![approval_resolved("appr-1", Verdict::Approve)]),
@@ -6638,17 +6643,31 @@ members = ["eng1", "eng2"]
             )
             .await
             .expect("cycle runs");
-
-        // Reclaimed onto the resuming turn, then deleted by its janitor — the
-        // turn parked nothing, so the task's repo work is finished. It must be
-        // neither wiped before the resume nor stranded in `retained` after.
         assert!(
-            !tree.exists(),
-            "the reclaimed checkout outlived its finished task"
+            tree.is_dir(),
+            "the checkout was wiped between two batched re-issues — the loop is back"
         );
+        assert_eq!(
+            brain.deps.checkouts.retained_tasks(),
+            vec!["t-1".to_string()],
+            "the task's checkout must stay held while the task is in flight"
+        );
+
+        // Re-issue the second approved step. Still held.
+        brain
+            .run_cycle(
+                cycle_over(vec![approval_resolved("appr-2", Verdict::Approve)]),
+                &NoopHost,
+            )
+            .await
+            .expect("cycle runs");
         assert!(
-            brain.deps.checkouts.retained_tasks().is_empty(),
-            "the task's checkout was stranded in the retained set"
+            tree.is_dir(),
+            "the checkout did not survive the second re-issue"
+        );
+        assert_eq!(
+            brain.deps.checkouts.retained_tasks(),
+            vec!["t-1".to_string()]
         );
     }
 

--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -2806,6 +2806,7 @@ mod tests {
             at_millis: 1_000,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         }
     }
 
@@ -3012,6 +3013,7 @@ mod tests {
             at_millis: 1_000,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         });
 
         queue.clear();
@@ -3284,6 +3286,7 @@ mod tests {
             at_millis: 1_000,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         });
 
         {
@@ -3320,6 +3323,7 @@ mod tests {
             at_millis: 1_000,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         };
         shared.grant(call.clone());
 
@@ -3834,6 +3838,7 @@ mod tests {
             expires_at_millis,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
             scope: None,
         }
     }

--- a/src/harness/repo.rs
+++ b/src/harness/repo.rs
@@ -68,6 +68,7 @@
 //!   output, and #244's nudge must never ask an agent whether somebody else's
 //!   repository is a deliverable.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 
@@ -135,16 +136,46 @@ const HOST_TRUNCATION_MARKER: &str = "[truncated:";
 /// The default is an empty ledger. A path recorded on a ledger nobody claims is
 /// simply never deleted by the janitor — the boot sweep is the backstop for
 /// exactly that case, so the failure mode is disk, not correctness.
+///
+/// # A second list, because a checkout must outlive an approval park (issue #796)
+///
+/// The `inner` list is turn-scoped: the janitor drains it however the turn ends,
+/// which is right for a checkout a plain turn made and finished with. But the
+/// write tier (#247/#735) needs a checkout to survive across the operator
+/// approving intermediate steps — `repo_checkout` → edit → `git_operations`
+/// commit → `repo_publish` are each a `Reach::Consequence` step that **parks**
+/// under supervision, and a park ends the turn. With one list the commit the
+/// publish depends on is deleted between the parked steps, and the chain
+/// deadlocks (issue #796); the contract these tools state — "deleted at **task**
+/// end" (#245 §5, #247 §7) — was never actually honoured.
+///
+/// So a checkout a task turn parked with is moved from `inner` into `retained`
+/// under that task's id ([`retain_for_task`](Self::retain_for_task)), where the
+/// janitor cannot reach it; the resumed turn moves it back
+/// ([`reclaim`](Self::reclaim)); and it is deleted only when the task truly ends
+/// ([`purge_task`](Self::purge_task)) or its parked grant is denied/expired,
+/// caught lazily by [`sweep_orphans`](Self::sweep_orphans). Keying on the task
+/// is what stops an unrelated chat turn sharing this ledger from either purging
+/// or inheriting a parked task's tree.
 #[derive(Clone, Debug, Default)]
 pub struct CheckoutLedger {
     inner: Arc<Mutex<Vec<PathBuf>>>,
     /// The task the current turn runs under (issue #735) — what names the
     /// `oc/<company>/<task>` branch `repo_publish` pushes to. Held on the cell
     /// the repository tools already share and the turn's entry point already
-    /// claims, rather than as a second `HarnessDeps` field: the task and the
-    /// checkouts have the exact same per-turn lifetime. `None` on a turn with no
-    /// card, where `repo_publish` refuses (issue #735 ships task turns only).
+    /// claims, rather than as a second `HarnessDeps` field. `None` on a turn with
+    /// no card, where `repo_publish` refuses (issue #735 ships task turns only).
+    ///
+    /// The task and a turn-scoped checkout no longer share one lifetime: issue
+    /// #796 lets a task's checkout outlive the turn across an approval park, held
+    /// in `retained` under this same id.
     task: Arc<Mutex<Option<String>>>,
+    /// Checkouts held across an approval park, keyed by the task that parked
+    /// (issue #796). Off the turn-scoped `inner` list the janitor drains, so a
+    /// park cannot delete them; drained by [`purge_task`](Self::purge_task) at
+    /// task end and by [`sweep_orphans`](Self::sweep_orphans) when the grant that
+    /// would resume them is gone.
+    retained: Arc<Mutex<HashMap<String, Vec<PathBuf>>>>,
 }
 
 impl CheckoutLedger {
@@ -166,6 +197,19 @@ impl CheckoutLedger {
         if !guard.contains(&path) {
             guard.push(path);
         }
+    }
+
+    /// Whether `path` is already on the turn-scoped list (issue #796).
+    ///
+    /// True when a resumed step [`reclaim`](Self::reclaim)ed this checkout onto
+    /// the active list, or when the same turn already materialized it — either
+    /// way, re-cloning over it would delete the agent's own commits, so
+    /// `repo_checkout` reuses it instead.
+    pub fn has_active(&self, path: &Path) -> bool {
+        self.inner
+            .lock()
+            .expect("checkout ledger")
+            .contains(&path.to_path_buf())
     }
 
     /// The paths recorded so far, without emptying.
@@ -197,6 +241,121 @@ impl CheckoutLedger {
             }
         }
         removed
+    }
+
+    /// Moves the turn-scoped list into the retained set under `task` (issue
+    /// #796), so the turn's janitor no longer deletes it.
+    ///
+    /// Called when a task turn ends by **parking** — an approval it raised will
+    /// resume the same task in a later turn, and the checkout the resumed step
+    /// operates on must still be there. Idempotent and additive: a second park
+    /// of the same task merges the new paths in rather than replacing the set,
+    /// so a checkout retained by an earlier park survives a later one.
+    pub fn retain_for_task(&self, task: &str) {
+        let taken = {
+            let mut guard = self.inner.lock().expect("checkout ledger");
+            std::mem::take(&mut *guard)
+        };
+        if taken.is_empty() {
+            return;
+        }
+        let mut retained = self.retained.lock().expect("checkout ledger retained");
+        let slot = retained.entry(task.to_string()).or_default();
+        for path in taken {
+            if !slot.contains(&path) {
+                slot.push(path);
+            }
+        }
+    }
+
+    /// Moves a task's retained checkouts back onto the turn-scoped list (issue
+    /// #796), so the resuming turn owns them again and its janitor deletes them
+    /// if the task now finishes without parking again.
+    ///
+    /// The inverse of [`retain_for_task`](Self::retain_for_task). A no-op when
+    /// the task retained nothing, which is the ordinary case for a resumed step
+    /// that never touched a repository.
+    pub fn reclaim(&self, task: &str) {
+        let paths = self
+            .retained
+            .lock()
+            .expect("checkout ledger retained")
+            .remove(task)
+            .unwrap_or_default();
+        if paths.is_empty() {
+            return;
+        }
+        let mut guard = self.inner.lock().expect("checkout ledger");
+        for path in paths {
+            if !guard.contains(&path) {
+                guard.push(path);
+            }
+        }
+    }
+
+    /// Deletes a task's retained checkouts and forgets them (issue #796),
+    /// returning how many paths were removed.
+    ///
+    /// The task-end counterpart of [`purge`](Self::purge): where `purge` drains
+    /// the turn-scoped list, this drains one task's held-across-park set. Same
+    /// best-effort deletion — a path that will not delete is logged and
+    /// forgotten, and the boot sweep is the backstop.
+    pub fn purge_task(&self, task: &str) -> usize {
+        let paths = self
+            .retained
+            .lock()
+            .expect("checkout ledger retained")
+            .remove(task)
+            .unwrap_or_default();
+        let mut removed = 0;
+        for path in paths {
+            match remove_path(&path) {
+                Ok(()) => removed += 1,
+                Err(err) => tracing::warn!(
+                    path = %path.display(),
+                    task = %task,
+                    "[repo] could not remove a retained checkout at task end: {err}"
+                ),
+            }
+        }
+        removed
+    }
+
+    /// Deletes every retained checkout whose task no longer has a live grant
+    /// (issue #796), returning how many paths were removed.
+    ///
+    /// This is the deny/expire cleanup, done lazily from the harness rather than
+    /// coupled into the runtime's approval path: a task's tree sits in
+    /// `retained` **with no live grant** only after the parked approval was
+    /// denied or expired — while it is being resumed it has been
+    /// [`reclaim`](Self::reclaim)ed onto the turn-scoped list, and while it waits
+    /// for the operator its grant is live. So "retained, and `is_live` says no"
+    /// is exactly the orphaned set. Called at each turn's janitor claim, where
+    /// both this ledger and the live grant set are in reach.
+    pub fn sweep_orphans(&self, is_live: impl Fn(&str) -> bool) -> usize {
+        let orphaned: Vec<String> = {
+            let retained = self.retained.lock().expect("checkout ledger retained");
+            retained
+                .keys()
+                .filter(|task| !is_live(task))
+                .cloned()
+                .collect()
+        };
+        orphaned.iter().map(|task| self.purge_task(task)).sum()
+    }
+
+    /// The tasks currently holding a retained checkout (tests / observability).
+    #[cfg(test)]
+    pub fn retained_tasks(&self) -> Vec<String> {
+        let mut tasks: Vec<String> = self
+            .retained
+            .lock()
+            .expect("checkout ledger retained")
+            .keys()
+            .cloned()
+            .collect();
+        tasks.sort();
+        tasks
     }
 }
 
@@ -683,6 +842,31 @@ impl Tool for RepoCheckoutTool {
         }
 
         let dest = self.context.checkout_root().join(&binding.key);
+        // Issue #796: if this task already holds this checkout — reclaimed from
+        // an earlier parked step, or materialized earlier in this same turn —
+        // reuse it rather than re-cloning. `materialize` removes the destination
+        // first, which on a resumed step would delete exactly the commits the
+        // pending publish depends on. The guard is the ledger's active list, so a
+        // first checkout still clones and refreshes from the mirror as before.
+        if self.context.ledger.has_active(&dest)
+            && dest.is_dir()
+            && let Ok(out) = git::run(&dest, &["rev-parse", "HEAD"], None, None).await
+            && let Ok(head) = out.require("git rev-parse")
+        {
+            let relative = format!("{CHECKOUT_SUBDIR}/{}", binding.key);
+            tracing::debug!(
+                repo = %binding.key,
+                path = %relative,
+                head = %head,
+                "[repo] reused a checkout held across an approval"
+            );
+            return Ok(ToolResult::success(format!(
+                "You already have {}/{} checked out at commit {head} in `{relative}` — the working \
+                 tree from before the operator approved this step, with your commits intact. \
+                 Continue working there; do not re-clone. It is removed when this task ends.",
+                binding.owner, binding.repo
+            )));
+        }
         // Recorded BEFORE the clone, not after it: a materialize that fails
         // half-way has still created bytes, and a ledger written on the success
         // path only would leak exactly the checkouts nobody wants left behind.

--- a/src/harness/repo.rs
+++ b/src/harness/repo.rs
@@ -842,28 +842,95 @@ impl Tool for RepoCheckoutTool {
         }
 
         let dest = self.context.checkout_root().join(&binding.key);
+        // How this call names the ref it wants — reused below for the reuse
+        // notice and for the refusal when the held tree is on a different one. A
+        // `pr` detaches, so it is named first: with `pr` set `reference` still
+        // carries the default branch the clone used, but the tree is on the pull
+        // request, not that branch.
+        let at = match pull_request {
+            Some(number) => format!("pull request #{number}"),
+            None => match reference.as_deref() {
+                Some(name) => format!("branch {name}"),
+                None => "its default branch".to_string(),
+            },
+        };
         // Issue #796: if this task already holds this checkout — reclaimed from
         // an earlier parked step, or materialized earlier in this same turn —
-        // reuse it rather than re-cloning. `materialize` removes the destination
-        // first, which on a resumed step would delete exactly the commits the
-        // pending publish depends on. The guard is the ledger's active list, so a
-        // first checkout still clones and refreshes from the mirror as before.
+        // and it is on the ref this call asks for, reuse it rather than
+        // re-cloning: `materialize` removes the destination first, which on a
+        // resumed step would delete exactly the commits the pending publish
+        // depends on. A resume re-issues the *same* `repo_checkout`, so it always
+        // matches. A second checkout of the same repo at a **different** ref or
+        // pr does not: reusing would hand back the wrong tree and re-cloning
+        // would delete the reclaimed commits, so it is refused rather than
+        // either. The guard is the ledger's active list, so a first checkout
+        // still clones and refreshes from the mirror as before.
         if self.context.ledger.has_active(&dest)
             && dest.is_dir()
             && let Ok(out) = git::run(&dest, &["rev-parse", "HEAD"], None, None).await
             && let Ok(head) = out.require("git rev-parse")
         {
+            let head = head.trim();
             let relative = format!("{CHECKOUT_SUBDIR}/{}", binding.key);
-            tracing::debug!(
-                repo = %binding.key,
-                path = %relative,
-                head = %head,
-                "[repo] reused a checkout held across an approval"
-            );
-            return Ok(ToolResult::success(format!(
-                "You already have {}/{} checked out at commit {head} in `{relative}` — the working \
-                 tree from before the operator approved this step, with your commits intact. \
-                 Continue working there; do not re-clone. It is removed when this task ends.",
+            // The branch the held tree sits on, or "HEAD" when it is detached —
+            // which is how `materialize` leaves a pull-request checkout.
+            let abbrev =
+                match git::run(&dest, &["rev-parse", "--abbrev-ref", "HEAD"], None, None).await {
+                    Ok(out) => out
+                        .require("git rev-parse")
+                        .ok()
+                        .map(|s| s.trim().to_string()),
+                    Err(_) => None,
+                };
+            let on_target = if let Some(number) = pull_request {
+                // A pr checkout is detached at `refs/oc/pr/<n>`; on target iff
+                // HEAD is still that fetched head.
+                match git::run(
+                    &dest,
+                    &["rev-parse", &format!("refs/oc/pr/{number}")],
+                    None,
+                    None,
+                )
+                .await
+                {
+                    Ok(out) => out
+                        .require("git rev-parse")
+                        .map(|s| s.trim() == head)
+                        .unwrap_or(false),
+                    Err(_) => false,
+                }
+            } else {
+                // A branch checkout is on that branch; on target iff it still is.
+                abbrev.as_deref() == reference.as_deref()
+            };
+            if on_target {
+                tracing::debug!(
+                    repo = %binding.key,
+                    path = %relative,
+                    head = %head,
+                    "[repo] reused a checkout held across an approval"
+                );
+                return Ok(ToolResult::success(format!(
+                    "You already have {}/{} checked out at {at} (commit {head}) in `{relative}` — \
+                     the working tree from before the operator approved this step, with your \
+                     commits intact. Continue working there; do not re-clone. It is removed when \
+                     this task ends.",
+                    binding.owner, binding.repo
+                )));
+            }
+            // Held, but on a different ref than this call asked for. Name what it
+            // is on so the agent can tell, and refuse rather than silently return
+            // the wrong tree or clone over its own commits.
+            let held = match &abbrev {
+                Some(b) if b == "HEAD" => format!("a pull request head, detached at commit {head}"),
+                Some(b) => format!("branch {b}"),
+                None => format!("commit {head}"),
+            };
+            return Ok(ToolResult::error(format!(
+                "{}/{} is already checked out at {held} in `{relative}`, carrying this task's work \
+                 in progress. Checking it out again at {at} would either hand you the wrong tree \
+                 or delete those commits, so it is refused — keep working on the current checkout \
+                 and `repo_publish` it, or ask an admin to change the binding.",
                 binding.owner, binding.repo
             )));
         }
@@ -883,13 +950,6 @@ impl Tool for RepoCheckoutTool {
         attribute_checkout(&dest, &self.context.agent).await;
 
         let relative = format!("{CHECKOUT_SUBDIR}/{}", binding.key);
-        let at = match pull_request {
-            Some(number) => format!("pull request #{number}"),
-            None => match reference.as_deref() {
-                Some(name) => format!("branch {name}"),
-                None => "its default branch".to_string(),
-            },
-        };
         tracing::debug!(
             repo = %binding.key,
             path = %relative,

--- a/src/harness/repo/test.rs
+++ b/src/harness/repo/test.rs
@@ -551,6 +551,110 @@ fn purging_a_path_that_is_already_gone_succeeds() {
     assert_eq!(ledger.purge(), 1);
 }
 
+/// A checkout retained for a task survives the turn's purge, comes back on
+/// reclaim, and is deleted by the turn's janitor only once the task finishes —
+/// the lifecycle that lets a checkout outlive an approval park (issue #796).
+#[test]
+fn a_retained_checkout_survives_a_purge_and_returns_on_reclaim() {
+    let scratch = Scratch::new("retain");
+    let tree = scratch.join("held");
+    std::fs::create_dir_all(&tree).unwrap();
+
+    let ledger = CheckoutLedger::default();
+    ledger.record(tree.clone());
+    assert!(ledger.has_active(&tree));
+
+    // Parked: move it off the turn-scoped list, under the task.
+    ledger.retain_for_task("t-1");
+    assert!(
+        !ledger.has_active(&tree),
+        "retain left it on the active list"
+    );
+    assert_eq!(ledger.retained_tasks(), vec!["t-1".to_string()]);
+
+    // The turn's janitor now purges nothing — the tree is held.
+    assert_eq!(ledger.purge(), 0);
+    assert!(
+        tree.is_dir(),
+        "a retained checkout was purged with the turn"
+    );
+
+    // Resumed: reclaim brings it back under the turn's janitor.
+    ledger.reclaim("t-1");
+    assert!(ledger.has_active(&tree));
+    assert!(ledger.retained_tasks().is_empty());
+
+    // ...and now the janitor deletes it, the task having finished.
+    assert_eq!(ledger.purge(), 1);
+    assert!(!tree.exists());
+}
+
+/// `purge_task` deletes a task's held checkout directly — the task-end path,
+/// where the work resumed and finished rather than being reclaimed by a turn.
+/// A second call, or an unknown task, is a no-op.
+#[test]
+fn purge_task_deletes_a_held_checkout() {
+    let scratch = Scratch::new("purge-task");
+    let tree = scratch.join("held");
+    std::fs::create_dir_all(&tree).unwrap();
+    let ledger = CheckoutLedger::default();
+    ledger.record(tree.clone());
+    ledger.retain_for_task("t-1");
+
+    assert_eq!(ledger.purge_task("t-1"), 1);
+    assert!(!tree.exists());
+    assert!(ledger.retained_tasks().is_empty());
+    assert_eq!(ledger.purge_task("t-1"), 0);
+    assert_eq!(ledger.purge_task("nope"), 0);
+}
+
+/// `sweep_orphans` deletes a held checkout the moment no live grant names its
+/// task — the denied/expired cleanup — and leaves a task still awaiting its
+/// resume alone (issue #796).
+#[test]
+fn sweep_orphans_purges_only_tasks_with_no_live_grant() {
+    let scratch = Scratch::new("sweep-orphans");
+    let live = scratch.join("live");
+    let dead = scratch.join("dead");
+    std::fs::create_dir_all(&live).unwrap();
+    std::fs::create_dir_all(&dead).unwrap();
+
+    let ledger = CheckoutLedger::default();
+    ledger.record(live.clone());
+    ledger.retain_for_task("t-live");
+    ledger.record(dead.clone());
+    ledger.retain_for_task("t-dead");
+
+    // Only `t-live` still has a grant behind it.
+    let removed = ledger.sweep_orphans(|task| task == "t-live");
+    assert_eq!(removed, 1);
+    assert!(live.is_dir(), "a task still awaiting its resume was swept");
+    assert!(!dead.exists(), "an orphaned task's checkout survived");
+    assert_eq!(ledger.retained_tasks(), vec!["t-live".to_string()]);
+}
+
+/// A second park of the same task merges its paths in rather than replacing the
+/// set, so a checkout retained by the first park survives the second (issue
+/// #796).
+#[test]
+fn retaining_a_task_twice_keeps_both_checkouts() {
+    let scratch = Scratch::new("retain-twice");
+    let first = scratch.join("first");
+    let second = scratch.join("second");
+    std::fs::create_dir_all(&first).unwrap();
+    std::fs::create_dir_all(&second).unwrap();
+
+    let ledger = CheckoutLedger::default();
+    ledger.record(first.clone());
+    ledger.retain_for_task("t-1");
+    ledger.record(second.clone());
+    ledger.retain_for_task("t-1");
+
+    assert_eq!(ledger.purge_task("t-1"), 2);
+    assert!(!first.exists());
+    assert!(!second.exists());
+}
+
 /// The boot sweep removes every agent's `workspace/repos` under **this**
 /// company and leaves its siblings — the tenant-scoping that keeps one
 /// company's boot from deleting another's bytes.

--- a/src/harness/repo/test.rs
+++ b/src/harness/repo/test.rs
@@ -633,6 +633,50 @@ fn sweep_orphans_purges_only_tasks_with_no_live_grant() {
     assert_eq!(ledger.retained_tasks(), vec!["t-live".to_string()]);
 }
 
+/// A parked-but-unresolved approval mints no grant, yet the checkout its step is
+/// holding must survive an unrelated turn's sweep. `any_for_task` counts a
+/// pending approval as live, so `sweep_orphans` spares the task until the
+/// operator decides — closing the window between a park and its resolution that
+/// would otherwise reopen the #796 deadlock one turn upstream. Once the approval
+/// resolves (here, denied — clearing the mark), the next sweep reclaims it.
+#[test]
+fn sweep_orphans_spares_a_task_whose_approval_is_still_parked() {
+    use crate::ports::types::ApprovalId;
+    use crate::runtime::grants::GrantSet;
+
+    let scratch = Scratch::new("sweep-pending");
+    let held = scratch.join("held");
+    std::fs::create_dir_all(&held).unwrap();
+
+    let ledger = CheckoutLedger::default();
+    ledger.record(held.clone());
+    ledger.retain_for_task("t-parked");
+
+    // The task parked a new step: an approval awaits the operator, so no grant
+    // names the task yet. The shared grant set is the sweep's liveness oracle.
+    let grants = GrantSet::default();
+    let approval = ApprovalId::new("appr-parked");
+    grants.mark_pending(&approval, "t-parked".to_string());
+
+    // An unrelated turn claims the janitor and sweeps. The parked task has no
+    // grant, but its pending approval keeps it live — the checkout survives.
+    let removed = ledger.sweep_orphans(|task| grants.any_for_task(task));
+    assert_eq!(removed, 0, "a task with a parked approval was swept");
+    assert!(held.is_dir(), "the parked step's checkout was deleted");
+    assert_eq!(ledger.retained_tasks(), vec!["t-parked".to_string()]);
+
+    // The operator denies it: the mark clears, nothing names the task, and the
+    // next sweep reclaims the disk.
+    grants.clear_pending(&approval);
+    let removed = ledger.sweep_orphans(|task| grants.any_for_task(task));
+    assert_eq!(removed, 1);
+    assert!(
+        !held.exists(),
+        "a denied task's checkout survived the sweep"
+    );
+    assert!(ledger.retained_tasks().is_empty());
+}
+
 /// A second park of the same task merges its paths in rather than replacing the
 /// set, so a checkout retained by the first park survives the second (issue
 /// #796).
@@ -824,6 +868,65 @@ async fn a_successful_checkout_reports_a_relative_path_and_records_it() {
     // And the janitor's contract, end to end.
     ledger.purge();
     assert!(!tree.exists());
+}
+
+/// A second `repo_checkout` of a repo the task already holds is reused only when
+/// it asks for the **same** ref. A different branch — or a pull request — is
+/// refused by name rather than silently returning the held tree (the wrong ref)
+/// or cloning over the commits the parked step is holding (issue #796).
+#[tokio::test]
+async fn a_second_checkout_at_a_different_ref_is_refused_not_silently_reused() {
+    let scratch = Scratch::new("reuse-ref");
+    let (manager, binding) = bound(&scratch, &["main", "topic"]).await;
+    let ctx = context(&scratch, manager, vec![binding]);
+    let tools = repo_tools(ctx);
+    let checkout = &tools[tool_named(&tools, REPO_CHECKOUT_TOOL)];
+
+    // First checkout materializes `main` and records it on the shared ledger.
+    let first = checkout
+        .execute(json!({ "repo": "fixture", "ref": "main" }))
+        .await
+        .unwrap();
+    assert!(!first.is_error, "{first:?}");
+
+    // Same ref: the held tree is on `main`, so it is reused, not re-cloned.
+    let same = checkout
+        .execute(json!({ "repo": "fixture", "ref": "main" }))
+        .await
+        .unwrap();
+    assert!(!same.is_error, "same ref must reuse: {same:?}");
+    assert!(
+        same.text().contains("already have") && same.text().contains("branch main"),
+        "the reuse notice must name the ref: {}",
+        same.text()
+    );
+
+    // A different branch: refused, naming both what it is on and what was asked.
+    let other = checkout
+        .execute(json!({ "repo": "fixture", "ref": "topic" }))
+        .await
+        .unwrap();
+    assert!(other.is_error, "a different ref must be refused: {other:?}");
+    assert!(
+        other.text().contains("branch main") && other.text().contains("branch topic"),
+        "the refusal must name the held ref and the requested one: {}",
+        other.text()
+    );
+
+    // A pull request over the same held branch: refused the same way.
+    let pr = checkout
+        .execute(json!({ "repo": "fixture", "pr": 7 }))
+        .await
+        .unwrap();
+    assert!(
+        pr.is_error,
+        "a pr over a held branch must be refused: {pr:?}"
+    );
+    assert!(
+        pr.text().contains("branch main") && pr.text().contains("pull request #7"),
+        "the refusal must name the held branch and the requested pr: {}",
+        pr.text()
+    );
 }
 
 /// A checkout that would push the company past its cap is refused **before**

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -2028,6 +2028,7 @@ mod tests {
             expires_at_millis: u64::MAX,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
             scope: minted,
         };
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -705,6 +705,10 @@ working on):\n{}\n]",
         if outcome == ResolveOutcome::NotParked {
             return Ok(ResolveReceipt::AlreadyResolved);
         }
+        // Issue #796: the approval has left the parked set — drop its pending
+        // mark. On approve the grant minted just below now names the task; on
+        // deny nothing does, so its held checkout becomes sweepable.
+        self.rt.grants.clear_pending(id);
         self.rt.journal.record_resolved(id).await?;
         if let ResolveOutcome::Approved(effect) = outcome {
             self.settle_approved_effect(id, effect, by.clone(), scope)
@@ -1975,6 +1979,21 @@ impl<'a> CycleHostImpl<'a> {
                 Some(self.cycle_id.clone()),
             )
             .await?;
+        // Issue #796: a parked approval mints no grant until it resolves, so
+        // until then neither grant map names this work unit. Mark it pending on
+        // the shared grant set so an unrelated turn's `sweep_orphans` treats the
+        // checkout this parked step is holding as live rather than orphaned. The
+        // key is derived exactly as `approval_work_key` derives the grant's
+        // `origin_task` (the card, else the sanitised thread), so the pending
+        // mark and the grant it becomes name one unit; cleared when the approval
+        // is settled or expires.
+        if let Some(work) = self
+            .task_id
+            .clone()
+            .or_else(|| self.thread_id.as_deref().and_then(sanitize_work_segment))
+        {
+            self.rt.grants.mark_pending(&approval_id, work);
+        }
         // …and armed on the live counter in the same breath. A turn that parks
         // four calls is blocked on four decisions; the runtime holds its
         // continuation until the last of them lands and then runs it once.

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -867,7 +867,7 @@ working on):\n{}\n]",
             origin_parent: conversation.parent,
             // Issue #796: the task this call was parked from, carried so a
             // standing grant can reclaim the task's checkout across parks.
-            origin_task: self.approval_origin_task(id),
+            origin_task: self.approval_work_key(id),
             // Issue #457: which slice of the tool the card was actually about.
             // Read off the **parked effect's own payload** — the arguments the
             // operator was shown — rather than re-derived from anything live, so
@@ -914,7 +914,7 @@ working on):\n{}\n]",
             origin_parent: conversation.parent,
             // Issue #796: the task this call was parked from, so the
             // re-dispatched turn can reclaim its held-across-park checkout.
-            origin_task: self.approval_origin_task(id),
+            origin_task: self.approval_work_key(id),
         };
         self.rt.journal.record_granted(&grant).await?;
         self.rt.grants.grant(grant);
@@ -926,18 +926,32 @@ working on):\n{}\n]",
         Ok(())
     }
 
-    /// The task a parked approval belonged to, if it was raised from a task turn
-    /// (issue #796).
+    /// The work unit a parked approval belongs to, for stamping a grant's
+    /// `origin_task` (issue #796).
     ///
-    /// The same `approval_task` join [`consumed_grant_effect`](Self::consumed_grant_effect)
-    /// uses, lifted out so both mint paths stamp a grant's `origin_task` from one
-    /// projection. `None` for an approval raised outside a task.
-    fn approval_origin_task(&self, id: &ApprovalId) -> Option<String> {
-        self.rt
+    /// A task card names it directly. A DM/chat has no card, but its conversation
+    /// is just as much a unit of work — the agent checks out, edits, commits and
+    /// publishes across a batch of approvals raised in the same thread — so the
+    /// thread stands in, sanitised to a single safe branch segment. The checkout
+    /// retention and `repo_publish`'s `oc/<company>/<unit>` branch then key on one
+    /// value for both, and the whole task-scoped machinery covers a DM unchanged.
+    ///
+    /// `None` only when there is neither a card nor a usable thread.
+    fn approval_work_key(&self, id: &ApprovalId) -> Option<String> {
+        if let Some(task) = self
+            .rt
             .journal
             .approval_task(id)
             .flatten()
             .and_then(|task| task.task_id().map(str::to_string))
+        {
+            return Some(task);
+        }
+        self.rt
+            .journal
+            .approval_conversation(id)
+            .and_then(|c| c.thread)
+            .and_then(|thread| sanitize_work_segment(&thread))
     }
 
     /// Describes a grant the agent just redeemed, so an operator-approved tool
@@ -967,7 +981,14 @@ working on):\n{}\n]",
         Some(ExecutedEffect {
             kind: effect.kind.clone(),
             amount_usd: effect.amount_usd,
-            task_id: self.approval_origin_task(id),
+            // The card this call was on, for the retry confirmation (#351) — a
+            // real task only, never the #796 DM work key, which is not a card.
+            task_id: self
+                .rt
+                .journal
+                .approval_task(id)
+                .flatten()
+                .and_then(|task| task.task_id().map(str::to_string)),
             at_millis: now_millis(),
             irreversible: self.rt.approval_gate.is_irreversible(&effect),
         })
@@ -1444,6 +1465,35 @@ async fn recipient_is_established(rt: &CompanyRuntime, to: &str) -> bool {
         .has_inbound_from(rt.id(), &key, to)
         .await
         .unwrap_or(false) // fail closed → parks for approval
+}
+
+/// Maps a conversation thread into a single safe branch segment (issue #796).
+///
+/// The write tier's branch is `oc/<company>/<unit>`, and for a DM the unit is
+/// its thread — which, unlike a card id, can hold anything. Keep the characters
+/// `RepoManager::validate_task_segment` accepts, fold the rest to `-`, and
+/// prefix `dm-` so the result cannot lead with `-`, cannot be empty, cannot
+/// collide with a card id, and reads as "a conversation's branch" in `git log`.
+/// `None` when nothing usable survives.
+fn sanitize_work_segment(thread: &str) -> Option<String> {
+    let cleaned: String = thread
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.') {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect();
+    let cleaned = cleaned.trim_matches(['-', '.']);
+    if cleaned.is_empty() {
+        return None;
+    }
+    // Bound the body well under `validate_task_segment`'s 128-char cap; the
+    // characters are all ASCII, so a byte take is a char take.
+    let body: String = cleaned.chars().take(100).collect();
+    Some(format!("dm-{body}"))
 }
 
 /// The board task a cycle is working, read off its own trigger events
@@ -2269,6 +2319,27 @@ impl CycleHost for CycleHostImpl<'_> {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// Issue #796: a DM's thread becomes a safe, `dm-`-prefixed branch segment
+    /// `RepoManager::validate_task_segment` accepts; an empty or all-garbage
+    /// thread yields nothing, so `repo_publish` refuses rather than build a
+    /// broken ref.
+    #[test]
+    fn sanitize_work_segment_makes_a_safe_branch_segment() {
+        assert_eq!(sanitize_work_segment("coder"), Some("dm-coder".into()));
+        // Colons, slashes and spaces fold to '-'.
+        assert_eq!(
+            sanitize_work_segment("dm:coder/main x"),
+            Some("dm-dm-coder-main-x".into())
+        );
+        // Leading/trailing separators are trimmed before the prefix.
+        assert_eq!(sanitize_work_segment("--weird--"), Some("dm-weird".into()));
+        // Dots and underscores are already valid and survive.
+        assert_eq!(sanitize_work_segment("a_b.c"), Some("dm-a_b.c".into()));
+        // Nothing usable.
+        assert_eq!(sanitize_work_segment(""), None);
+        assert_eq!(sanitize_work_segment("///"), None);
+    }
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
 

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -865,6 +865,9 @@ working on):\n{}\n]",
             // within it; both come from one read so they cannot disagree.
             origin_thread: conversation.thread,
             origin_parent: conversation.parent,
+            // Issue #796: the task this call was parked from, carried so a
+            // standing grant can reclaim the task's checkout across parks.
+            origin_task: self.approval_origin_task(id),
             // Issue #457: which slice of the tool the card was actually about.
             // Read off the **parked effect's own payload** — the arguments the
             // operator was shown — rather than re-derived from anything live, so
@@ -909,6 +912,9 @@ working on):\n{}\n]",
             // the thread within it; one read, so the pair cannot disagree.
             origin_thread: conversation.thread,
             origin_parent: conversation.parent,
+            // Issue #796: the task this call was parked from, so the
+            // re-dispatched turn can reclaim its held-across-park checkout.
+            origin_task: self.approval_origin_task(id),
         };
         self.rt.journal.record_granted(&grant).await?;
         self.rt.grants.grant(grant);
@@ -918,6 +924,20 @@ working on):\n{}\n]",
             "[approval] minted a single-use grant; the agent will re-issue the call"
         );
         Ok(())
+    }
+
+    /// The task a parked approval belonged to, if it was raised from a task turn
+    /// (issue #796).
+    ///
+    /// The same `approval_task` join [`consumed_grant_effect`](Self::consumed_grant_effect)
+    /// uses, lifted out so both mint paths stamp a grant's `origin_task` from one
+    /// projection. `None` for an approval raised outside a task.
+    fn approval_origin_task(&self, id: &ApprovalId) -> Option<String> {
+        self.rt
+            .journal
+            .approval_task(id)
+            .flatten()
+            .and_then(|task| task.task_id().map(str::to_string))
     }
 
     /// Describes a grant the agent just redeemed, so an operator-approved tool
@@ -947,12 +967,7 @@ working on):\n{}\n]",
         Some(ExecutedEffect {
             kind: effect.kind.clone(),
             amount_usd: effect.amount_usd,
-            task_id: self
-                .rt
-                .journal
-                .approval_task(id)
-                .flatten()
-                .and_then(|task| task.task_id().map(str::to_string)),
+            task_id: self.approval_origin_task(id),
             at_millis: now_millis(),
             irreversible: self.rt.approval_gate.is_irreversible(&effect),
         })
@@ -3439,6 +3454,7 @@ mod test {
             at_millis: 0,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         });
         // A fresh one, to prove the sweep is selective rather than a flush.
         rt.grants.grant(GrantedCall {
@@ -3449,6 +3465,7 @@ mod test {
             at_millis: now_millis(),
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         });
 
         let expired = rt.sweep_expired_grants().await.unwrap();

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -163,6 +163,23 @@ pub struct GrantedCall {
     /// is the pre-#435 behaviour.
     #[serde(default)]
     pub origin_parent: Option<EventSeq>,
+    /// The task the parked call belonged to, when it was raised from a task turn
+    /// (issue #796) — copied off the approval's `approval_task` join when the
+    /// grant is minted.
+    ///
+    /// **Routing only, never part of the redemption match**, on exactly the same
+    /// terms as [`origin_thread`](Self::origin_thread): the operator approved a
+    /// call, not a task, and [`GrantSet::consume`] matches on `(agent, tool,
+    /// args)` alone. It rides along so the re-dispatched turn can reclaim the
+    /// task's held-across-park checkout ([`CheckoutLedger`] in
+    /// `crate::harness::repo`) and so a denied or expired grant's tree can be
+    /// swept once no live grant names the task.
+    ///
+    /// `None` for an approval raised outside a task (a plain operator chat) and
+    /// on a grant replayed from a line written before this field existed — both
+    /// mean there is no task checkout to resume, which is the pre-#796 behaviour.
+    #[serde(default)]
+    pub origin_task: Option<String>,
 }
 
 /// The hard ceiling on a standing grant's life: 7 days.
@@ -288,6 +305,16 @@ pub struct StandingGrant {
     /// answer in the channel, as before.
     #[serde(default)]
     pub origin_parent: Option<EventSeq>,
+    /// The task the parked call belonged to, when raised from a task turn
+    /// (issue #796), carried on exactly the terms
+    /// [`GrantedCall::origin_task`] documents: routing and cleanup only, never
+    /// part of the `(agent, tool, unexpired)` match. A standing grant can resume
+    /// a task's checkout across repeated parks, so it carries the same link.
+    ///
+    /// `None` for an approval raised outside a task, and on a grant replayed
+    /// from a line written before this field existed.
+    #[serde(default)]
+    pub origin_task: Option<String>,
     /// The slice of [`tool`](Self::tool) this grant is confined to, when the
     /// tool's name is not the whole of what it can do (issue #457).
     ///
@@ -483,6 +510,24 @@ impl GrantSet {
         self.inner.lock().expect("grant set poisoned").live.len()
     }
 
+    /// Whether any live grant — single-use or standing — names `task` as its
+    /// origin (issue #796).
+    ///
+    /// The harness asks this to decide whether a task's checkout held across an
+    /// approval park is still awaiting a resume (a live grant names it) or has
+    /// been orphaned by a denied or expired approval (none does), so
+    /// [`CheckoutLedger::sweep_orphans`](crate::harness::repo::CheckoutLedger::sweep_orphans)
+    /// can reclaim the disk. A spent grant is already removed from both maps, so
+    /// this reads `false` the moment the resume is under way — which is safe
+    /// because the resuming turn has reclaimed the tree onto its turn-scoped list
+    /// by then.
+    pub fn any_for_task(&self, task: &str) -> bool {
+        let state = self.inner.lock().expect("grant set poisoned");
+        let names_task = |t: &Option<String>| t.as_deref() == Some(task);
+        state.live.values().any(|g| names_task(&g.origin_task))
+            || state.standing.values().any(|g| names_task(&g.origin_task))
+    }
+
     // -----------------------------------------------------------------------
     // Standing grants (issue #374)
     // -----------------------------------------------------------------------
@@ -631,6 +676,7 @@ mod test {
             at_millis: 1_000,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         }
     }
 
@@ -656,6 +702,7 @@ mod test {
         set.grant(GrantedCall {
             origin_thread: Some("desk-finance".to_string()),
             origin_parent: Some(EventSeq::new(7)),
+            origin_task: None,
             ..call("a1", "finance", "composio_execute", args.clone())
         });
         let redeemed = set
@@ -680,6 +727,7 @@ mod test {
             set.grant(GrantedCall {
                 origin_thread: origin.0,
                 origin_parent: origin.1,
+                origin_task: None,
                 ..call("a1", "finance", "composio_execute", args.clone())
             });
             assert!(
@@ -836,6 +884,7 @@ mod test {
             expires_at_millis,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
             scope: None,
         }
     }

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -427,6 +427,21 @@ struct GrantState {
     /// redemption semantics (remove vs leave). Fusing them would put a branch on
     /// every operation of both.
     standing: HashMap<GrantId, StandingGrant>,
+    /// Work units with an approval **parked but not yet resolved** (issue #796),
+    /// keyed by the approval id so each resolution clears exactly its own entry.
+    ///
+    /// A parked approval mints no grant until the operator decides it, so between
+    /// the park and the decision neither `live` nor `standing` names its task.
+    /// Without this map [`any_for_task`](GrantSet::any_for_task) would read
+    /// `false` in that window and an unrelated turn's
+    /// [`sweep_orphans`](crate::harness::repo::CheckoutLedger::sweep_orphans)
+    /// would delete the checkout the parked step is holding for its own resume —
+    /// the very deadlock #796 exists to prevent, reopened one turn upstream.
+    /// Filled when the effect parks, emptied when it resolves, is denied, or
+    /// expires. In-memory only, like the checkouts it guards: a restart boot-
+    /// sweeps every checkout, so there is nothing left for a rehydrated mark to
+    /// protect.
+    pending: HashMap<ApprovalId, String>,
 }
 
 impl GrantSet {
@@ -510,22 +525,55 @@ impl GrantSet {
         self.inner.lock().expect("grant set poisoned").live.len()
     }
 
-    /// Whether any live grant — single-use or standing — names `task` as its
-    /// origin (issue #796).
+    /// Records that a work unit has an approval **parked and awaiting a
+    /// decision** (issue #796), so [`any_for_task`](Self::any_for_task) treats it
+    /// as live until the approval resolves.
+    ///
+    /// Keyed by the approval id, computed the same way the mint side derives a
+    /// grant's [`GrantedCall::origin_task`], so the pending mark and the grant it
+    /// eventually becomes name one unit. A task parking a second approval simply
+    /// adds a second entry naming the same task; each clears independently.
+    pub fn mark_pending(&self, approval_id: &ApprovalId, task: String) {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .pending
+            .insert(approval_id.clone(), task);
+    }
+
+    /// Drops the pending-approval mark for `approval_id` (issue #796) — whether
+    /// it was approved (a grant now names the task), denied, or expired (nothing
+    /// does, so its checkout is now sweepable). A no-op for an id that never
+    /// parked a task-scoped effect.
+    pub fn clear_pending(&self, approval_id: &ApprovalId) {
+        self.inner
+            .lock()
+            .expect("grant set poisoned")
+            .pending
+            .remove(approval_id);
+    }
+
+    /// Whether a live grant, a standing grant, **or a still-parked approval**
+    /// names `task` as its origin (issue #796).
     ///
     /// The harness asks this to decide whether a task's checkout held across an
-    /// approval park is still awaiting a resume (a live grant names it) or has
-    /// been orphaned by a denied or expired approval (none does), so
+    /// approval park is still awaiting a resume or has been orphaned by a denied
+    /// or expired approval, so
     /// [`CheckoutLedger::sweep_orphans`](crate::harness::repo::CheckoutLedger::sweep_orphans)
-    /// can reclaim the disk. A spent grant is already removed from both maps, so
-    /// this reads `false` the moment the resume is under way — which is safe
-    /// because the resuming turn has reclaimed the tree onto its turn-scoped list
-    /// by then.
+    /// can reclaim the disk. Three states keep it live: a live grant names it (an
+    /// approved step waiting to be re-issued), a standing grant names it, or an
+    /// approval it parked is **still pending** — that last case mints no grant
+    /// yet, so without `pending` the checkout would be swept in the window
+    /// between the park and the operator's decision. A spent grant is already
+    /// removed from every map, so this reads `false` the moment the resume is
+    /// under way — which is safe because the resuming turn has reclaimed the tree
+    /// onto its turn-scoped list by then.
     pub fn any_for_task(&self, task: &str) -> bool {
         let state = self.inner.lock().expect("grant set poisoned");
         let names_task = |t: &Option<String>| t.as_deref() == Some(task);
         state.live.values().any(|g| names_task(&g.origin_task))
             || state.standing.values().any(|g| names_task(&g.origin_task))
+            || state.pending.values().any(|t| t == task)
     }
 
     // -----------------------------------------------------------------------

--- a/src/runtime/journal.rs
+++ b/src/runtime/journal.rs
@@ -2812,6 +2812,7 @@ mod test {
             at_millis,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
         }
     }
 
@@ -2911,6 +2912,7 @@ mod test {
             expires_at_millis,
             origin_thread: None,
             origin_parent: None,
+            origin_task: None,
             scope: None,
         }
     }

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -5634,6 +5634,7 @@ mod test {
                 expires_at_millis: crate::ports::now_millis() + 60 * 60 * 1000,
                 origin_thread: None,
                 origin_parent: None,
+                origin_task: None,
                 scope: None,
             });
 


### PR DESCRIPTION
## Summary

Fixes the supervised-mode deadlock the write tier (#735/#736) hits in real use (issue #796): an agent can check out a repo, edit, and commit, but never publish — the working tree is deleted between every parked step, so the commit `repo_publish` needs is gone by the time it runs.

**Root cause.** Under `supervised` every step of `repo_checkout` → edit → `git_operations` commit → `repo_publish` is `Reach::Consequence` and **parks**, and each park ends the turn. The `CheckoutJanitor` deletes the checkout at *every* turn end (and again at the next turn's claim), so the tree never survives from one parked step to the next. The tool contract — "deleted at **task** end" (#245 §5, #247 §7) — was never actually honoured; the janitor was per-turn.

**Fix.** A checkout a task turn parks with is held on a task-keyed retained set the janitor does not touch, and deleted only when the task truly ends.

- `CheckoutLedger` gains `retain_for_task` / `reclaim` / `purge_task` / `sweep_orphans` (+ `has_active`) beside the existing turn-scoped list.
- The parked call's task is carried on the grant (`GrantedCall::origin_task`, `StandingGrant::origin_task`), stamped at mint from the approval's `approval_task` join.
- The approval **re-issue** stamps the resumed task on the ledger (so `repo_publish` can name its branch — which #735 could not do on this path) and **reclaims** the checkout the parked step left, so the resumed commit and publish operate on the same tree. If it parks again, the tree is held again.
- Every janitor claim **sweeps** any task whose approval was denied or expired (no live grant names it) — the deny/expire cleanup, done lazily in the harness with no runtime coupling.
- `repo_checkout` **reuses** a reclaimed tree instead of re-cloning over the agent's own commits.

Autonomous/`full` mode is unaffected — the whole chain runs in one un-parked turn there, so the retention never engages.

## Stacking

Built on **#778** (`feat/735-repo-publish`), which is not yet on `main`, so like #784 this PR's diff shows the parent's changes too until #735 merges. The net #796 change is the two commits `0c39c054` (ledger primitive + tests) and `103aed2d` (origin-task wiring + re-issue reclaim + docs). Rebase onto `main` follows #735 merging.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings` (default)
- [x] `cargo clippy --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] New ledger tests: retain→purge-survives→reclaim, `purge_task`, `sweep_orphans` (live vs orphaned), retain-twice
- [x] New brain tests: `an_approved_grant_reclaims_the_task_checkout_it_resumes`, `an_orphaned_task_checkout_is_swept_at_the_next_janitor_claim`
- [x] Touched modules regression: `runtime::grants`, `runtime::cycle`, `harness::repo`, `harness::brain` — 204 passed, 0 failed (`RUST_MIN_STACK=16777216`, as CI sets)

Closes #796.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added approval-gated repository publishing for eligible, push-capable repositories.
  * Publishes exact approved commits through a staged workflow without directly pushing.
  * Repository checkouts now persist across supervised approval pauses, allowing work to continue in the same tree.

* **Bug Fixes**
  * Improved cleanup of completed, denied, expired, and orphaned checkouts.
  * Added safeguards for read-only repositories, unsafe task identifiers, unauthorized branches, and non-fast-forward updates.
  * Preserved task context across approvals and redispatched work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->