### PR TITLE
fix(sidecar): script the cycle the runtime opens, and run the lane that would have caught it (#800)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -374,14 +374,18 @@ jobs:
       # one level up. The count is what separates "everything passed" from
       # "nothing ran", exactly as the MongoDB job argues below.
       #
-      # NO `sidecar` LANE HERE, and its absence is deliberate. That feature gates
-      # fourteen tests that had never run; twelve pass and the two offline
-      # end-to-end cases its own documentation advertises FAIL (the inference
-      # callback fires zero times). Issue #800 has the diagnosis. The lane lands
-      # with the fix rather than red, because a lane allowed to be red is the
-      # state #428 was filed about — and until then
-      # `scripts/ci/feature-lanes.txt` records the debt as `owed`, so it is
-      # countable instead of silent.
+      # `sidecar` was OWED a lane rather than merely missing one, and this is
+      # where the debt is paid. The feature gates fourteen tests that had never
+      # run; twelve passed and the two offline end-to-end cases the feature's own
+      # documentation advertises FAILED (the inference callback fired zero
+      # times). Issue #800 has the diagnosis. It lands here rather than red
+      # because a lane permitted to be red is the state #428 was filed about.
+      #
+      # It rides this job for the reason the two above do: `sidecar = []` in
+      # Cargo.toml — no dependency, nothing to fetch, nothing to build that this
+      # job does not already have. Putting it in the gated job instead would add
+      # a feature compile to the ~26-minute lane that is already the repository's
+      # critical path (#793), to buy nothing.
       #
       # `export`: the bundle round-trip. Only `pack_tar`/`unpack_tar` are gated,
       # so nine of the ten tests this selects already run at default features —
@@ -405,6 +409,16 @@ jobs:
       # service container; until then, say so rather than imply otherwise.
       - name: Test the mail surface
         run: scripts/ci/run-scoped-suite.sh "mail (imap)" imap,smtp server::ops::imap
+
+      # `sidecar`: the whole of `src/brain/sidecar/`, which the feature gates at
+      # the `mod` declaration — the idiom that hid these fourteen tests from
+      # every lane and from a casual grep alike. Through the wrapper like its
+      # neighbours, and here the non-zero count is not ceremony: the filter is a
+      # module path, the module is gated, and a `#[cfg]` moved one line would
+      # make this select nothing and still exit 0 — which is the failure mode
+      # that produced #800 in the first place, one level up.
+      - name: Test the sidecar brain
+        run: scripts/ci/run-scoped-suite.sh "sidecar brain" sidecar brain::sidecar
 
       # Issue #428. The `Console E2E` job drives a REAL host, so it needs a
       # binary. Building one over there would mean a second submodule checkout

--- a/scripts/ci/feature-lanes.txt
+++ b/scripts/ci/feature-lanes.txt
@@ -63,6 +63,7 @@ media          | partial      | openhuman,mcp,telegram,media    | harness::build
 composio       | partial      | openhuman,tinycortex,composio   | harness::composio::isolation_tests harness::composio::ops_helper_tests
 export         | partial      | export                          | store::export
 imap           | partial      | imap,smtp                       | server::ops::imap
+sidecar        | partial      | sidecar                         | brain::sidecar
 
 # --- Owed a lane: gated tests exist, and they are currently RED -------------
 #
@@ -73,8 +74,16 @@ imap           | partial      | imap,smtp                       | server::ops::i
 #
 # No lane is added for these on purpose: a lane permitted to be red is the state
 # #428 was filed about, at more expense. The lane lands with the fix.
-
-sidecar        | owed         | -                               | 14 gated tests, 12 green — the two offline end-to-end cases the feature advertises fail (the inference callback fires zero times). Tracked in #800; the lane lands with the fix.
+#
+# CURRENTLY EMPTY, and the section stays rather than leaving with its last row.
+# `sidecar` was the only entry: fourteen gated tests, twelve green, and the two
+# offline end-to-end cases the feature advertises failing. #800 fixed those and
+# the lane landed with the fix, so the row moved up to `partial`.
+#
+# The debt was paid in the shape this section promises — fix first, then lane —
+# and keeping the heading keeps that route open for the next one. A status that
+# has to be re-invented under deadline gets skipped, and the alternative to an
+# `owed` row is not a lane; it is silence.
 
 # --- Compile-only, by design ------------------------------------------------
 #

--- a/src/brain/sidecar/mock.rs
+++ b/src/brain/sidecar/mock.rs
@@ -41,6 +41,14 @@ struct Recorded {
     acks: Vec<EffectResult>,
     tool_answers: Vec<ToolResultFrame>,
     inference_answers: Vec<RecordedInference>,
+    /// Cycle ids the brain asked for that nothing had scripted.
+    ///
+    /// An unscripted cycle yields a bare `CycleComplete`, which is a *silent*
+    /// empty cycle: every downstream assertion then reads "expected 1, saw 0"
+    /// and points at the effect rather than at the miss. Recording it turns
+    /// "the fixture and the runtime disagree about the cycle id" into something
+    /// a test can assert (issue #800).
+    unmatched_cycles: Vec<String>,
 }
 
 /// An in-memory [`SidecarTransport`] that scripts cycle frames and records calls.
@@ -48,6 +56,12 @@ struct Recorded {
 pub struct MockSidecarTransport {
     /// Scripted frames keyed by cycle id.
     plans: Mutex<HashMap<String, Vec<SidecarFrame>>>,
+    /// Frames for the **next** cycle the brain opens, when no exact id is
+    /// scripted. Consumed on use — see [`Self::script_any_cycle`].
+    fallback_plan: Mutex<Option<Vec<SidecarFrame>>>,
+    /// Whether a fallback was ever scripted, so a later empty cycle reads as
+    /// expected rather than as a missed plan.
+    fallback_scripted: Mutex<bool>,
     /// An error to return from every `post_events`.
     post_events_error: Mutex<Option<OrchErrorCode>>,
     /// Recorded calls.
@@ -69,6 +83,33 @@ impl MockSidecarTransport {
             frames.push(SidecarFrame::CycleComplete);
         }
         self.plans.lock().unwrap().insert(cycle_id.into(), frames);
+    }
+
+    /// Scripts frames for **whichever** cycle the brain opens.
+    ///
+    /// Prefer this in end-to-end tests. Keying a plan to a hand-computed cycle
+    /// id couples the test to the event sequence the runtime happens to assign
+    /// — which is how the two `e2e_*` tests here silently stopped exercising
+    /// anything: they scripted `seq 0` while the runtime posts the event log's
+    /// real seq, so the brain drained an empty cycle and every assertion failed
+    /// against a plausible-looking zero (issue #800). The id's own format is
+    /// covered by `wire::cycle_id`'s tests; a cycle-drain test should not
+    /// re-derive it.
+    /// **One-shot.** The plan is consumed by the first unscripted cycle, and
+    /// every later cycle drains empty. A turn does not always open exactly one
+    /// cycle — resolving a parked approval opens another — and a replaying plan
+    /// would re-emit its effect there, re-parking what the test just resolved.
+    pub fn script_any_cycle(&self, mut frames: Vec<SidecarFrame>) {
+        if !matches!(frames.last(), Some(SidecarFrame::CycleComplete)) {
+            frames.push(SidecarFrame::CycleComplete);
+        }
+        *self.fallback_plan.lock().unwrap() = Some(frames);
+        *self.fallback_scripted.lock().unwrap() = true;
+    }
+
+    /// Cycle ids the brain opened that nothing had scripted.
+    pub fn unmatched_cycles(&self) -> Vec<String> {
+        self.recorded.lock().unwrap().unmatched_cycles.clone()
     }
 
     /// Makes every subsequent `post_events` fail with `code`.
@@ -122,13 +163,30 @@ impl SidecarTransport for MockSidecarTransport {
     }
 
     fn cycle_frames(&self, cycle_id: &str) -> BoxStream<'static, Result<SidecarFrame>> {
-        let frames = self
-            .plans
-            .lock()
-            .unwrap()
-            .get(cycle_id)
-            .cloned()
-            .unwrap_or_else(|| vec![SidecarFrame::CycleComplete]);
+        let exact = self.plans.lock().unwrap().get(cycle_id).cloned();
+        let frames = match exact {
+            Some(frames) => frames,
+            None => match self.fallback_plan.lock().unwrap().take() {
+                Some(frames) => frames,
+                // A consumed fallback means later cycles are *expected* empty,
+                // so they are not recorded as misses.
+                None if *self.fallback_scripted.lock().unwrap() => {
+                    vec![SidecarFrame::CycleComplete]
+                }
+                None => {
+                    // Nothing scripted for this cycle, exactly or otherwise.
+                    // Still an empty cycle, so existing tests that script no
+                    // plan keep their behaviour — but recorded, so a test can
+                    // tell an empty cycle apart from a missed one (#800).
+                    self.recorded
+                        .lock()
+                        .unwrap()
+                        .unmatched_cycles
+                        .push(cycle_id.to_string());
+                    vec![SidecarFrame::CycleComplete]
+                }
+            },
+        };
         stream::iter(frames.into_iter().map(Ok)).boxed()
     }
 

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -465,10 +465,6 @@ fn manifest(policy_mode: &str) -> CompanyManifest {
     toml::from_str(&toml_src).expect("valid manifest")
 }
 
-fn runtime_cid() -> String {
-    wire::cycle_id("opencompany:acme", "acme", 0)
-}
-
 fn sidecar_brain_for(
     transport: Arc<MockSidecarTransport>,
     inference: Arc<MockInferenceClient>,
@@ -491,13 +487,14 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
     let home_dir = tmp_home();
     let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockSidecarTransport::new());
-    transport.script_cycle(
-        runtime_cid(),
-        vec![
-            inference_frame(0, "how are we doing?"),
-            effect_frame("send_dm", 0, json!({ "to": "operator", "body": "on it" })),
-        ],
-    );
+    // Scripted for whichever cycle the runtime opens, not a hand-computed id.
+    // Pinning the id here coupled this test to the event seq the runtime
+    // assigns; when that moved, the brain drained an empty cycle and every
+    // assertion below failed against a plausible zero (issue #800).
+    transport.script_any_cycle(vec![
+        inference_frame(0, "how are we doing?"),
+        effect_frame("send_dm", 0, json!({ "to": "operator", "body": "on it" })),
+    ]);
     let inference = Arc::new(
         MockInferenceClient::new()
             .with_text("plan ready")
@@ -519,6 +516,15 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
         }])
         .await
         .unwrap();
+
+    // The runtime's cycle was actually found. Asserted before the effect
+    // assertions because an unmatched cycle makes every one of them fail with
+    // a zero that looks like a broken effect rather than a missed plan.
+    assert!(
+        transport.unmatched_cycles().is_empty(),
+        "the brain opened a cycle nothing scripted: {:?}",
+        transport.unmatched_cycles()
+    );
 
     // The inference callback fired through the real runtime.
     assert_eq!(inference.requests().len(), 1);
@@ -544,10 +550,8 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
     let home_dir = tmp_home();
     let home = home_dir.path().to_path_buf();
     let transport = Arc::new(MockSidecarTransport::new());
-    transport.script_cycle(
-        runtime_cid(),
-        vec![effect_frame("filing.submit", 0, Value::Null)],
-    );
+    // Whichever cycle the runtime opens — see the sibling test (issue #800).
+    transport.script_any_cycle(vec![effect_frame("filing.submit", 0, Value::Null)]);
     let inference = Arc::new(MockInferenceClient::new());
 
     let rt = Arc::new(
@@ -567,6 +571,12 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
         }])
         .await
         .unwrap();
+
+    assert!(
+        transport.unmatched_cycles().is_empty(),
+        "the brain opened a cycle nothing scripted: {:?}",
+        transport.unmatched_cycles()
+    );
 
     // The Sign-group effect parked under supervised policy: an approval is
     // queued and no channel response emitted.
@@ -592,4 +602,44 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
     .await
     .unwrap();
     assert!(rt.pending_approvals().is_empty());
+}
+
+/// The trap that hid #800 for as long as the sidecar lane went unrun.
+///
+/// An unscripted cycle drains empty, which is a legitimate case — but it is
+/// indistinguishable from a fixture whose cycle id disagrees with the
+/// runtime's. Every downstream assertion then fails as "expected 1, saw 0" and
+/// points at the effect rather than at the miss. The mock records the id so a
+/// test can tell the two apart, and this pins that it does.
+#[tokio::test]
+async fn an_unscripted_cycle_is_recorded_as_a_miss() {
+    let transport = MockSidecarTransport::new();
+
+    // Nothing scripted at all: the miss is recorded.
+    let mut frames = transport.cycle_frames("cyc:nobody:scripted:this:7");
+    while frames.next().await.is_some() {}
+    assert_eq!(
+        transport.unmatched_cycles(),
+        vec!["cyc:nobody:scripted:this:7"]
+    );
+
+    // A scripted fallback answers the next cycle, and is NOT a miss.
+    let transport = MockSidecarTransport::new();
+    transport.script_any_cycle(vec![effect_frame("noop", 0, Value::Null)]);
+    let mut frames = transport.cycle_frames("cyc:whatever:the:runtime:1");
+    while frames.next().await.is_some() {}
+    assert!(transport.unmatched_cycles().is_empty());
+
+    // It is one-shot: the cycle after it drains empty, and is still not a miss,
+    // because a plan *was* scripted — a replay would re-emit the effect into a
+    // later cycle (the approval-resolution one), which is its own defect.
+    let mut frames = transport.cycle_frames("cyc:whatever:the:runtime:2");
+    let mut count = 0usize;
+    while let Some(frame) = frames.next().await {
+        if !matches!(frame.unwrap(), SidecarFrame::CycleComplete) {
+            count += 1;
+        }
+    }
+    assert_eq!(count, 0, "the fallback replayed into a later cycle");
+    assert!(transport.unmatched_cycles().is_empty());
 }


### PR DESCRIPTION
## Summary

The sidecar brain's two `e2e_*` tests failed, and the reason was not in the code under test.

Both scripted their frame plan against `cycle_id(counterpart, session, seq)` with **`seq 0`**. The runtime posts the event log's real sequence, which is **1**. Probed on a live run:

```
posted    counterpart=opencompany:acme  session=acme  seq=1
scripted  cyc:opencompany:acme:acme:0
```

The ids never matched, so `MockSidecarTransport::cycle_frames` fell through to a bare `CycleComplete`. The brain drained an empty cycle and every assertion failed as `expected 1, saw 0` — a shape that reads like a broken effect rather than like a plan nobody delivered. That is why the issue's first reading was "the inference callback never fires": it fires fine, it was never asked.

Neither test had ever run in CI. The whole of `src/brain/sidecar/` is behind the `sidecar` feature and no lane enabled it, so nothing caught the drift when the sequence moved.

## API Or Behavior Changes

Test-fixture and CI only. No production behaviour changes — `src/brain/sidecar/mod.rs` is untouched.

**`MockSidecarTransport` gains `script_any_cycle`.** It scripts whichever cycle the runtime opens, instead of a hand-computed id. A cycle-drain test should not re-derive the id's arithmetic; `wire::cycle_id` already has its own test for the format, and re-deriving it is what coupled these tests to a number that later moved.

**It is one-shot, and that is load-bearing.** A turn does not always open exactly one cycle — resolving a parked approval opens another. My first version replayed the plan for every cycle, and the supervised test then re-parked the approval it had just resolved. The tests caught that before I did.

**An unscripted cycle is now recorded.** `unmatched_cycles()` exposes ids the brain opened that nothing had scripted. Previously an empty cycle and a missed plan were indistinguishable, which is the whole reason this looked like an effect bug. A cycle that drains empty *after* a fallback was scripted is not recorded — that is expected, not a miss.

Both `e2e_*` tests now assert **no cycle was missed** before asserting on effects, so a future id drift fails as a miss rather than as a plausible zero.

**A `sidecar` CI lane.** Without it the fix above is itself unrun and the next drift lands identically — #475's pathology, which is exactly how two failing tests stayed invisible.

Rebasing onto current `main` (which gained #770's classification work after this branch was cut) turned that into three related changes rather than one:

**It runs through `scripts/ci/run-scoped-suite.sh`, not a bare `cargo test`.** The filter is a module path and the module is gated at its `mod` declaration, so a `#[cfg]` moved one line would make this lane select nothing and still exit 0. That is the same failure as #800 one level up, and the wrapper's non-zero-count assertion is the thing that distinguishes "everything passed" from "nothing ran".

**It lives in the fast `Rust` job, not `Rust (openhuman, tinycortex)`.** `sidecar = []` in `Cargo.toml` — no dependency, nothing to fetch. The first version of this branch put it in the gated job next to `runner`; that would have added a feature compile to the ~26-minute lane that is already the repository's critical path (#793) to buy nothing.

**`scripts/ci/feature-lanes.txt` moves `sidecar` from `owed` to `partial`.** `main` currently states the opposite of this PR in two places — the table records the debt as `owed`, and `ci.yml` says "NO `sidecar` LANE HERE, and its absence is deliberate". Both were correct when written and are false the moment this merges. `assert-feature-lanes.sh` would not have caught the drift: an `owed` row only has to name an issue and have gated tests, both of which stay true after the lane exists. So the table would have gone quietly stale — which is the exact failure the table was built to end.

That leaves the `owed` section empty. It stays, with a note saying why: the debt was paid in the shape the section promises (fix first, then lane), and a status that has to be re-invented under deadline is a status that gets skipped.

## Tests

`cargo test --locked --features sidecar --lib brain::sidecar` — **15 passed** (14 existing, from 12 pass / 2 fail before).

New: `an_unscripted_cycle_is_recorded_as_a_miss` pins the diagnostic itself — an unscripted cycle records its id, a scripted fallback does not, and the fallback does not replay into the following cycle.

**Negative controls, run for real:**

| Break | Caught by |
|---|---|
| fallback replays instead of one-shot | 2 tests fail (incl. the supervised e2e re-parking) |
| misses no longer recorded | 1 test fails |
| lane filter selects nothing (`brain::sidecar_moved`) | `run-scoped-suite.sh` exits 1: "ran nothing" |
| table names a feature set no lane enables | `assert-feature-lanes.sh` exits 1: "Feature has no lane" |

Commands run locally, all green:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --features sidecar --all-targets -- -D warnings`
- [x] `cargo check --all-features`
- [x] `scripts/ci/run-scoped-suite.sh "sidecar brain" sidecar brain::sidecar` — 15 passed
- [x] `scripts/ci/assert-feature-lanes.sh` — 27 features, 17 with a lane, 0 owed
- [x] `cargo test --locked --features sidecar,tiny --lib brain::sidecar` — 15 passed (the issue noted it is not a feature-combination problem; confirmed)
- [x] `cargo test --lib brain::` — 62 passed
- [x] `.github/workflows/ci.yml` parses

## Documentation

`script_any_cycle` documents why an id is not hand-computed and why it is one-shot; the `unmatched_cycles` field documents what a silent empty cycle costs. The CI step says why the lane exists.

## Related

Closes #800

- #770 — the feature-gated-test audit this was found during, now merged. It classified `sidecar` as `owed` and deliberately added no lane; this PR pays that debt and updates both places that said so.
- #793 — the merge-queue evaluation. Why this lane is kept off the ~26-minute critical path rather than parked beside `runner`.
- #475 — a target that builds, links and runs nothing still exits 0
- #801 — the other finding from the same audit (`composio` tests dialling the network), untouched here

