### PR TITLE
fix(workspace): claim a folder atomically so a publish race cannot poison the path (#759)

### DIFF
--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -139,6 +139,9 @@ pub trait WorkspaceStore: Send + Sync {
     async fn write(&self, company: &CompanyId, id: &str, content: &str,
                    author: WorkspaceOrigin) -> Result<WorkspaceNode>;
     async fn create(&self, /* parent, name, kind, content */) -> Result<WorkspaceNode>;
+    async fn adopt_or_create_folder(&self, company: &CompanyId, parent: Option<&str>,
+                                    name: &str, origin: WorkspaceOrigin)
+        -> Result<FolderClaim>;                  // Created | Adopted  (#759)
     async fn rename_move(&self, /* id, new_name, new_parent */) -> Result<WorkspaceNode>;
     async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool>;
     async fn is_empty(&self, company: &CompanyId) -> Result<bool>;
@@ -190,6 +193,40 @@ and writes blob-first/document-second, deleting in the mirror order, so a crash
 strands only a blob nothing references; `MongoStore::from_database` sweeps those
 at boot. Tenancy in the shared bucket is a filter on `metadata.company_id` **and**
 `metadata.node_id` for every read, delete and sweep.
+
+**Folder claims (#759).** `adopt_or_create_folder` is the only way the publish
+walk and the `Agents/` scaffold create a folder. It is a store primitive rather
+than a read plus a `create` because the read is honest about one instant and the
+create acts on it later: two publishes needing `Agents/<agent>/<task>/` both saw
+it free, and sqlite and mongodb both created — leaving two folders under one
+name. That state does not decay. Path resolution answers a duplicated name with
+`Conflict`, so a race lasting microseconds refuses every later publish beneath
+that path, for every agent, permanently.
+
+Afterwards exactly one folder answers to `(parent, name)` among the nodes this
+primitive governs, and the returned node is it. A `parent` of `None` is the
+workspace root, so the roots are claimed by the same call as everything below
+them. Adoption **preserves the original authorship stamp**: `origin` is used only
+when this call is the one that creates. A file holding the name, or a
+pre-existing ambiguity, is a `Conflict` — fail-closed, exactly as before.
+
+`FolderClaim::{Created, Adopted}` exists for one consumer: `WorkspaceAnnouncer`
+emits its node-created frame **only** on `Created`. A frame for a folder that was
+already standing would tell an open console something appeared when nothing did,
+on the adoption path nearly every publish takes.
+
+It is deliberately not `swap_files`' compare-and-swap. That stages a payload and
+makes the loser *fail*, which is right for a file — its bytes are a content claim
+with one legitimate winner. A folder is a payload-free container claim: two
+publishers wanting one folder want the same thing, so the loser must adopt and
+carry on. That also dissolves loser cleanup, since a loser never owns a folder.
+
+Backends decide it where each of them can: `FsOps` under the workspace-index lock
+it already holds for every write (single-process per data dir by contract),
+sqlite inside a `TransactionBehavior::Immediate` transaction (two stores can open
+one file), and MongoDB with a second partial unique index — see `storage.md`. The
+agent's own `workspace_create` tool is **not** routed through this: adopting there
+would silently merge two intentionally separate hand-made folders.
 
 **Search (#607).** Workspace search is a **company-layer helper**
 (`company::workspace_search`) over the port's existing `tree` + `read`, not a

--- a/docs/spec/runtime/storage.md
+++ b/docs/spec/runtime/storage.md
@@ -110,6 +110,30 @@ and `owners`; and the WS3 console-surface collections `tasks`, `workspace`,
 `facts`, `usage`, `skills`, and `inboxes`. The `usage` collection is trimmed to the 90-day retention window
 on each `record` (see [`UsageMeter`](ports-console.md#usagemeter)).
 
+**Path-uniqueness indexes on `workspace_nodes`.** This backend has neither a
+per-company lock nor a transaction it can require of its deployment, so "one node
+per path" cannot be a read followed by a write; it is the database's own
+invariant. Two **partial unique** indexes carry it: `(company_id,
+file_path_key)` for files (issue #697) and `(company_id, folder_path_key)` for
+the folders `adopt_or_create_folder` claims (issue #759). Both keys encode
+`{parent_id}\0{name}` — NUL, because no node name may contain one — and both are
+separate fields on purpose, so a folder and a note may still share a name exactly
+as they always could. This is a race fix, not a new tree rule.
+
+*Partial* is what makes them safe to add to a live tenant: a plain unique index
+is built over every existing document, so a company that already lost one of
+these races would fail index creation, and that failure happens during
+`ensure_indexes` — taking the tenant's startup down. Restricted to documents that
+*have* the field, each index covers everything written from now on and ignores
+history it cannot repair; legacy duplicates keep being refused one layer up.
+
+Only the primitives stamp the keys. Plain `create` does not stamp
+`folder_path_key`, so console-made folders are unguarded (and unaffected). A
+folder that `rename_move` touches **drops** its key: the claim exists to decide
+contention on the publish walk, and a key that travelled with a hand-moved folder
+would keep guarding the path it left — refusing that path forever, which is the
+outage the primitive exists to prevent.
+
 ### Multi-tenant isolation (two layers)
 
 1. **Database per tenant (recommended).** The hosting layer (the
@@ -188,6 +212,12 @@ monotonic event sequence, export totality) it exercises each WS3 store —
 `assert_skill_state_store`, `assert_inbox_store`, `assert_usage_meter` — plus a
 dedicated `assert_usage_retention` that verifies samples older than the 90-day
 window are evicted on write. A new backend passes only when all of these hold.
+
+`assert_workspace_folder_claims` (issue #759) additionally drives eight
+concurrent callers at one `(parent, name)`: all must succeed, all must come away
+holding the same folder, and exactly one may report having created it. That case
+is the point of the function — a naive read-then-create passes every sequential
+assertion beside it and fails only there, which is the defect's exact shape.
 
 ## Testing
 

--- a/src/company/artifact_mirror.rs
+++ b/src/company/artifact_mirror.rs
@@ -79,7 +79,7 @@ use crate::ports::now_millis;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
 
-use super::workspace_scaffold::{create_folder, ensure_agent_folder};
+use super::workspace_scaffold::ensure_agent_folder;
 
 /// One publish, as [`materialize`] needs it.
 ///
@@ -661,6 +661,25 @@ fn split_source(source: &str) -> Result<Vec<&str>> {
 }
 
 /// Adopt-or-create the folder `name` under `parent`, keeping `nodes` current.
+///
+/// # The snapshot answers, the store decides (issue #759)
+///
+/// The `nodes` snapshot is a fast path and nothing more: a hit means the folder
+/// was already there when the tree was read, and a folder does not stop
+/// existing. A *miss* is only a statement about that instant, and the create
+/// used to act on it later — so two publishes needing `Agents/<agent>/<task>/`
+/// both saw it free and both created, leaving two folders under one name.
+///
+/// That state does not decay. The `many` arm below answers a duplicated name
+/// with `Conflict`, so a race lasting microseconds refuses every later publish
+/// beneath that path, for every agent, permanently. The write therefore always
+/// goes through [`WorkspaceStore::adopt_or_create_folder`], which decides the
+/// contention where it can actually be decided — under the store's own lock,
+/// transaction or unique index.
+///
+/// The node pushed back into the snapshot is the one the **store** returned, so
+/// a publisher that adopted somebody else's folder walks on with the winner's
+/// id rather than one it invented.
 async fn resolve_folder(
     workspace: &dyn WorkspaceStore,
     company: &CompanyId,
@@ -677,26 +696,12 @@ async fn resolve_folder(
              beneath it"
         ))),
         [] => {
-            let id = create_folder(
-                workspace,
-                company,
-                name,
-                Some(parent.to_string()),
-                origin(agent_id),
-            )
-            .await?;
-            nodes.push(WorkspaceNode {
-                id: id.clone(),
-                name: name.to_string(),
-                kind: NodeKind::Folder,
-                parent_id: Some(parent.to_string()),
-                updated_at_millis: now_millis(),
-                created_by: origin(agent_id),
-                updated_by: origin(agent_id),
-                mime: None,
-                size: None,
-                sha256: None,
-            });
+            let node = workspace
+                .adopt_or_create_folder(company, Some(parent), name, origin(agent_id))
+                .await?
+                .into_node();
+            let id = node.id.clone();
+            nodes.push(node);
             Ok(id)
         }
         many => Err(OpenCompanyError::Conflict(format!(
@@ -795,6 +800,19 @@ mod test {
                 return WorkspaceStore::create(&*self.0, company, node, content).await;
             }
             Err(OpenCompanyError::InvalidRequest("over quota".to_string()))
+        }
+        /// Folders are claimed for real, for the same reason `create` lets them
+        /// through: the scaffold walks `Agents/<id>/<task>/` on the way in, and
+        /// refusing that would fail the publish before it ever reaches the file
+        /// this double exists to refuse.
+        async fn adopt_or_create_folder(
+            &self,
+            company: &CompanyId,
+            parent: Option<&str>,
+            name: &str,
+            origin: WorkspaceOrigin,
+        ) -> Result<crate::ports::workspace::FolderClaim> {
+            WorkspaceStore::adopt_or_create_folder(&*self.0, company, parent, name, origin).await
         }
         async fn create_binary(
             &self,
@@ -1162,6 +1180,15 @@ mod test {
         ) -> Result<WorkspaceNode> {
             WorkspaceStore::rename_move(&*self.0, company, id, name, parent).await
         }
+        async fn adopt_or_create_folder(
+            &self,
+            company: &CompanyId,
+            parent: Option<&str>,
+            name: &str,
+            origin: WorkspaceOrigin,
+        ) -> Result<crate::ports::workspace::FolderClaim> {
+            WorkspaceStore::adopt_or_create_folder(&*self.0, company, parent, name, origin).await
+        }
         async fn swap_files(
             &self,
             company: &CompanyId,
@@ -1331,6 +1358,333 @@ mod test {
             1,
             "and revising it must not fork the path either: {after:?}"
         );
+    }
+
+    /// A real store that holds the first `arrivals` `tree()` reads at a
+    /// two-party barrier, so two publishers provably act on the *same* snapshot.
+    ///
+    /// # Why the tree read and not the folder write
+    ///
+    /// This is the race's own precondition: both publishers read "that folder is
+    /// not there", and before issue #759 both then created. Pausing where the
+    /// snapshot is taken forces exactly that interleaving without replacing any
+    /// of the code under test — the folder claim, whichever backend decides it,
+    /// runs for real afterwards.
+    ///
+    /// It is also the only pause point that exists **on both sides of the fix**,
+    /// which is what lets these two tests be run against the base commit to
+    /// watch them fail. A barrier inside the new primitive could only ever
+    /// observe the fixed code.
+    ///
+    /// `arrivals` is a budget rather than a switch: after that many `tree()`
+    /// calls the barrier is bypassed, so a publisher that fails early (which is
+    /// exactly what the *unfixed* code does) cannot strand its partner waiting
+    /// for a rendezvous that will never come.
+    struct PausedTreeRead {
+        inner: Arc<FsOps>,
+        barrier: Arc<tokio::sync::Barrier>,
+        arrivals: std::sync::atomic::AtomicUsize,
+    }
+
+    impl PausedTreeRead {
+        fn new(inner: Arc<FsOps>, arrivals: usize) -> Self {
+            Self {
+                inner,
+                barrier: Arc::new(tokio::sync::Barrier::new(2)),
+                arrivals: std::sync::atomic::AtomicUsize::new(arrivals),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl WorkspaceStore for PausedTreeRead {
+        async fn tree(&self, company: &CompanyId) -> Result<Vec<WorkspaceNode>> {
+            let budget = self
+                .arrivals
+                .fetch_update(
+                    std::sync::atomic::Ordering::SeqCst,
+                    std::sync::atomic::Ordering::SeqCst,
+                    |left| left.checked_sub(1),
+                )
+                .is_ok();
+            if budget {
+                self.barrier.wait().await;
+            }
+            WorkspaceStore::tree(&*self.inner, company).await
+        }
+        async fn read(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, String)>> {
+            WorkspaceStore::read(&*self.inner, company, id).await
+        }
+        async fn write(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            content: &str,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write(&*self.inner, company, id, content, author).await
+        }
+        async fn create(
+            &self,
+            company: &CompanyId,
+            node: &WorkspaceNode,
+            content: Option<&str>,
+        ) -> Result<()> {
+            WorkspaceStore::create(&*self.inner, company, node, content).await
+        }
+        async fn adopt_or_create_folder(
+            &self,
+            company: &CompanyId,
+            parent: Option<&str>,
+            name: &str,
+            origin: WorkspaceOrigin,
+        ) -> Result<crate::ports::workspace::FolderClaim> {
+            WorkspaceStore::adopt_or_create_folder(&*self.inner, company, parent, name, origin)
+                .await
+        }
+        async fn create_binary(
+            &self,
+            company: &CompanyId,
+            node: &WorkspaceNode,
+            bytes: &[u8],
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::create_binary(&*self.inner, company, node, bytes).await
+        }
+        async fn write_binary(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            bytes: &[u8],
+            mime: Option<&str>,
+            author: WorkspaceOrigin,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::write_binary(&*self.inner, company, id, bytes, mime, author).await
+        }
+        async fn read_bytes(
+            &self,
+            company: &CompanyId,
+            id: &str,
+        ) -> Result<Option<(WorkspaceNode, crate::ports::workspace::BlobStream)>> {
+            WorkspaceStore::read_bytes(&*self.inner, company, id).await
+        }
+        async fn rename_move(
+            &self,
+            company: &CompanyId,
+            id: &str,
+            name: Option<&str>,
+            parent: Option<Option<&str>>,
+        ) -> Result<WorkspaceNode> {
+            WorkspaceStore::rename_move(&*self.inner, company, id, name, parent).await
+        }
+        async fn swap_files(
+            &self,
+            company: &CompanyId,
+            expected_id: Option<&str>,
+            replacement_id: &str,
+            name: &str,
+        ) -> Result<Option<WorkspaceNode>> {
+            WorkspaceStore::swap_files(&*self.inner, company, expected_id, replacement_id, name)
+                .await
+        }
+        async fn delete(&self, company: &CompanyId, id: &str) -> Result<bool> {
+            WorkspaceStore::delete(&*self.inner, company, id).await
+        }
+        async fn is_empty(&self, company: &CompanyId) -> Result<bool> {
+            WorkspaceStore::is_empty(&*self.inner, company).await
+        }
+    }
+
+    /// Every node under `parent` carrying `name`, by id.
+    fn named_children(nodes: &[WorkspaceNode], parent: &str, name: &str) -> Vec<String> {
+        nodes
+            .iter()
+            .filter(|n| n.parent_id.as_deref() == Some(parent) && n.name == name)
+            .map(|n| n.id.clone())
+            .collect()
+    }
+
+    /// Issue #759, the folder half of the publish walk: two publishers needing
+    /// the same **task folder** that does not exist yet.
+    ///
+    /// The filenames differ on purpose. Issue #697 already made two publishers
+    /// contending for one *file* path resolve to a single winner, so a test
+    /// using one filename would be satisfied by that fix alone and would say
+    /// nothing about the folder above it. Different names means both files must
+    /// land — and they can only both land if the folder they land in is one
+    /// folder.
+    ///
+    /// The last assertion is the one that speaks to severity. A duplicated
+    /// folder is not a transient: `resolve_folder`'s ambiguity arm answers
+    /// `Conflict` for every later publish beneath that path, for every agent,
+    /// permanently. Proving a third publish still works is proving the momentary
+    /// race did not become a standing outage.
+    #[tokio::test]
+    async fn two_publishes_needing_one_task_folder_share_it_rather_than_duplicating_it() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+
+        // Seed only the agent folder, by publishing something for a different
+        // task. The task folder under test must still be absent — that is the
+        // create arm this test exists for.
+        materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-seed",
+                ..target("seed.md", "# Seed")
+            },
+        )
+        .await
+        .expect("seeding `Agents/cmo/`");
+        let agent_folder = ws
+            .tree(&co)
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|n| n.name == "cmo")
+            .expect("the agent folder exists")
+            .id;
+        assert!(
+            named_children(&ws.tree(&co).await.unwrap(), &agent_folder, "t-9").is_empty(),
+            "the race is about a task folder that does not exist yet"
+        );
+
+        // Four arrivals: each publisher reads the tree twice on this path — once
+        // in the member-folder minter, once in `materialize` itself — and the
+        // second rendezvous is the one that puts both of them on a snapshot with
+        // no `t-9` in it.
+        let racing = PausedTreeRead::new(ops.clone(), 4);
+        let left = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                task_id: "t-9",
+                ..target("left.md", "# From the left")
+            },
+        );
+        let right = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                task_id: "t-9",
+                ..target("right.md", "# From the right")
+            },
+        );
+        let (left, right) = tokio::join!(left, right);
+        let left = left.expect("the left publish must succeed");
+        let right = right.expect("the right publish must succeed");
+
+        let nodes = ws.tree(&co).await.unwrap();
+        let task_folders = named_children(&nodes, &agent_folder, "t-9");
+        assert_eq!(
+            task_folders.len(),
+            1,
+            "one task folder, or every later publish beneath it is refused forever: {nodes:?}"
+        );
+        let task_folder = &task_folders[0];
+
+        for (id, name) in [(&left.node_id, "left.md"), (&right.node_id, "right.md")] {
+            let node = nodes
+                .iter()
+                .find(|n| &n.id == id)
+                .unwrap_or_else(|| panic!("the published node for {name} is in the tree"));
+            assert_eq!(node.name, name);
+            assert_eq!(
+                node.parent_id.as_deref(),
+                Some(task_folder.as_str()),
+                "both deliverables must land in the one task folder"
+            );
+        }
+
+        // …and the path stays publishable, which a duplicate would have ended.
+        materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-9",
+                ..target("later.md", "# A later publish")
+            },
+        )
+        .await
+        .expect("the shared task folder must still accept a publish");
+        let after = ws.tree(&co).await.unwrap();
+        assert_eq!(
+            named_children(&after, &agent_folder, "t-9").len(),
+            1,
+            "and it must still be one folder: {after:?}"
+        );
+    }
+
+    /// The same race one level up, on the folders the *scaffold* mints:
+    /// `Agents/` and `Agents/<agent-id>/`.
+    ///
+    /// Nothing is seeded, so both publishers read an empty tree and both need
+    /// the root and the agent's own folder. Different task ids keep the task
+    /// folders apart, so the only thing they can contend for is the pair
+    /// `ensure_member_folder` claims — which is what pins that conversion
+    /// independently of `resolve_folder`'s.
+    ///
+    /// Two arrivals rather than four: the rendezvous that matters is the member
+    /// minter's tree read, and budgeting only that one leaves a publisher that
+    /// fails there (the unfixed behaviour) unable to strand its partner.
+    #[tokio::test]
+    async fn two_publishers_minting_one_agent_folder_share_it_rather_than_duplicating_it() {
+        let (_dir, ops, co) = stores();
+        let ws: &dyn WorkspaceStore = ops.as_ref();
+        assert!(ws.is_empty(&co).await.unwrap(), "nothing is seeded");
+
+        let racing = PausedTreeRead::new(ops.clone(), 2);
+        let left = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                task_id: "t-left",
+                ..target("left.md", "# From the left")
+            },
+        );
+        let right = materialize(
+            &racing,
+            &co,
+            PublishTarget {
+                task_id: "t-right",
+                ..target("right.md", "# From the right")
+            },
+        );
+        let (left, right) = tokio::join!(left, right);
+        left.expect("the left publish must succeed");
+        right.expect("the right publish must succeed");
+
+        let nodes = ws.tree(&co).await.unwrap();
+        let roots: Vec<&WorkspaceNode> = nodes
+            .iter()
+            .filter(|n| n.parent_id.is_none() && n.name == AGENTS_ROOT)
+            .collect();
+        assert_eq!(
+            roots.len(),
+            1,
+            "one `{AGENTS_ROOT}` root — two would make every agent folder ambiguous: {nodes:?}"
+        );
+        assert_eq!(
+            named_children(&nodes, &roots[0].id, "cmo").len(),
+            1,
+            "one folder for the agent, or the agent can never publish again: {nodes:?}"
+        );
+
+        // The whole subtree stays usable afterwards.
+        materialize(
+            ws,
+            &co,
+            PublishTarget {
+                task_id: "t-later",
+                ..target("later.md", "# A later publish")
+            },
+        )
+        .await
+        .expect("the agent's folder must still accept a publish");
     }
 
     /// Issue #662. A shape-changing publish whose replacement **fails** must
@@ -1619,15 +1973,9 @@ mod test {
             .0
             .parent_id
             .unwrap();
-        create_folder(
-            ws,
-            &co,
-            "launch.md",
-            Some(parent),
-            WorkspaceOrigin::Operator,
-        )
-        .await
-        .unwrap();
+        ws.adopt_or_create_folder(&co, Some(&parent), "launch.md", WorkspaceOrigin::Operator)
+            .await
+            .expect("claim the folder standing in the note's place");
 
         let refused = materialize(ws, &co, target("launch.md", "body"))
             .await

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -150,8 +150,14 @@ pub async fn ensure_workspace_scaffold(
                 "[workspace] {why}; not provisioning the `{root}` root"
             ),
             Found::Free => {
-                if let Err(e) =
-                    create_folder(store, company, root, None, WorkspaceOrigin::Seed).await
+                // Through the store primitive, so a boot racing a publish (or
+                // two tenant replicas booting together) adopts rather than
+                // duplicating the root — see `ensure_member_folder`. The
+                // warn-and-continue reporting is unchanged: a convenience folder
+                // must not take down a boot.
+                if let Err(e) = store
+                    .adopt_or_create_folder(company, None, root, WorkspaceOrigin::Seed)
+                    .await
                 {
                     tracing::warn!(
                         company = %company,
@@ -231,6 +237,22 @@ pub async fn ensure_desk_folder(
 
 /// The shared body of [`ensure_agent_folder`] and [`ensure_desk_folder`]:
 /// resolve `root`, then resolve `id` beneath it, creating what is missing.
+///
+/// # The tree read is a fast path; the store decides (issue #759)
+///
+/// [`find`] answering `Free` describes the instant the tree was read, and the
+/// create used to act on it afterwards. Two agents first producing something at
+/// once therefore both saw `Agents/` free — or both saw `Agents/<id>/` free —
+/// and both created, leaving two folders under one name. Nothing repairs that:
+/// [`find`] answers a duplicated name with `Collision` from then on, so a race
+/// lasting microseconds refuses that agent's folder forever.
+///
+/// Both creates now go through [`WorkspaceStore::adopt_or_create_folder`], which
+/// resolves the contention inside the store. That also makes the stale snapshot
+/// harmless: a caller whose read predates another's create adopts the folder
+/// that exists rather than minting a rival, and — because the root claim returns
+/// the *winner's* id — the member folder beneath it is claimed under the same
+/// parent either way.
 async fn ensure_member_folder(
     store: &dyn WorkspaceStore,
     company: &CompanyId,
@@ -253,13 +275,23 @@ async fn ensure_member_folder(
 
     let root_id = match find(&nodes, None, root) {
         Found::Folder(id) => id,
-        Found::Free => create_folder(store, company, root, None, WorkspaceOrigin::Seed).await?,
+        Found::Free => {
+            store
+                .adopt_or_create_folder(company, None, root, WorkspaceOrigin::Seed)
+                .await?
+                .into_node()
+                .id
+        }
         Found::Collision(why) => return Err(OpenCompanyError::Conflict(why)),
     };
 
     match find(&nodes, Some(&root_id), id) {
         Found::Folder(existing) => Ok(existing),
-        Found::Free => create_folder(store, company, id, Some(root_id), origin).await,
+        Found::Free => Ok(store
+            .adopt_or_create_folder(company, Some(&root_id), id, origin)
+            .await?
+            .into_node()
+            .id),
         Found::Collision(why) => Err(OpenCompanyError::Conflict(why)),
     }
 }
@@ -304,34 +336,6 @@ pub(crate) fn find(nodes: &[WorkspaceNode], parent: Option<&str>, name: &str) ->
             count = many.len()
         )),
     }
-}
-
-/// Create one folder and hand back its id.
-///
-/// `pub(crate)` so [`artifact_mirror`](crate::company::artifact_mirror) mints
-/// the folders beneath `Agents/<id>/` the same way this module mints the ones
-/// above them — one creation shape, one set of origin-stamping rules.
-pub(crate) async fn create_folder(
-    store: &dyn WorkspaceStore,
-    company: &CompanyId,
-    name: &str,
-    parent_id: Option<String>,
-    origin: WorkspaceOrigin,
-) -> Result<String> {
-    let node = WorkspaceNode {
-        id: crate::ports::generate_id(),
-        name: name.to_string(),
-        kind: NodeKind::Folder,
-        parent_id,
-        updated_at_millis: crate::ports::now_millis(),
-        created_by: origin.clone(),
-        updated_by: origin,
-        mime: None,
-        size: None,
-        sha256: None,
-    };
-    store.create(company, &node, None).await?;
-    Ok(node.id)
 }
 
 /// Whether `name` is usable as a single workspace path segment.

--- a/src/company/workspace_search/test.rs
+++ b/src/company/workspace_search/test.rs
@@ -580,6 +580,15 @@ impl WorkspaceStore for FixedTree {
     ) -> crate::Result<()> {
         unreachable!("search never creates")
     }
+    async fn adopt_or_create_folder(
+        &self,
+        _company: &CompanyId,
+        _parent: Option<&str>,
+        _name: &str,
+        _origin: WorkspaceOrigin,
+    ) -> crate::Result<crate::ports::workspace::FolderClaim> {
+        unreachable!("search never claims a folder")
+    }
     async fn create_binary(
         &self,
         _company: &CompanyId,

--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -243,10 +243,29 @@ mod tests {
 
     use super::*;
     use crate::company::workspace_scaffold::{
-        DESKS_ROOT, create_folder, ensure_agent_folder, ensure_workspace_scaffold,
+        DESKS_ROOT, ensure_agent_folder, ensure_workspace_scaffold,
     };
     use crate::ports::workspace::WorkspaceOrigin;
     use crate::store::FsOps;
+
+    /// Claim one folder and hand back its id.
+    ///
+    /// The store primitive (issue #759), spelled for a test that only wants a
+    /// folder to exist. It replaced the scaffold's old `create_folder` helper,
+    /// which was a plain read-then-create and is gone.
+    async fn claim_folder(
+        ws: &dyn WorkspaceStore,
+        company: &CompanyId,
+        name: &str,
+        parent: Option<&str>,
+        origin: WorkspaceOrigin,
+    ) -> String {
+        ws.adopt_or_create_folder(company, parent, name, origin)
+            .await
+            .expect("claim a folder")
+            .into_node()
+            .id
+    }
 
     async fn store() -> (tempfile::TempDir, Arc<dyn WorkspaceStore>) {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -332,15 +351,14 @@ mod tests {
             .find(|node| node.name == "cmo")
             .unwrap()
             .id;
-        create_folder(
+        claim_folder(
             ws.as_ref(),
             &company,
             "task-1",
-            Some(cmo),
+            Some(&cmo),
             WorkspaceOrigin::Seed,
         )
-        .await
-        .unwrap();
+        .await;
 
         let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
             .await
@@ -454,45 +472,41 @@ mod tests {
         ensure_workspace_scaffold(ws.as_ref(), &company)
             .await
             .unwrap();
-        create_folder(
+        claim_folder(
             ws.as_ref(),
             &company,
             "Archive",
             None,
             WorkspaceOrigin::Operator,
         )
-        .await
-        .unwrap();
-        let desks = create_folder(
+        .await;
+        let desks = claim_folder(
             ws.as_ref(),
             &company,
             DESKS_ROOT,
             None,
             WorkspaceOrigin::Seed,
         )
-        .await
-        .unwrap();
-        create_folder(
+        .await;
+        claim_folder(
             ws.as_ref(),
             &company,
             "creative_studio",
-            Some(desks),
+            Some(&desks),
             WorkspaceOrigin::Seed,
         )
-        .await
-        .unwrap();
+        .await;
         let ceo = ensure_agent_folder(ws.as_ref(), &company, "ceo")
             .await
             .unwrap();
-        create_folder(
+        claim_folder(
             ws.as_ref(),
             &company,
             "drafts",
-            Some(ceo),
+            Some(&ceo),
             WorkspaceOrigin::Seed,
         )
-        .await
-        .unwrap();
+        .await;
 
         let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
             .await
@@ -519,15 +533,14 @@ mod tests {
     async fn a_company_with_no_agents_root_is_a_no_op() {
         let (_dir, ws) = store().await;
         let company = CompanyId::new("fresh");
-        create_folder(
+        claim_folder(
             ws.as_ref(),
             &company,
             "Notes",
             None,
             WorkspaceOrigin::Operator,
         )
-        .await
-        .unwrap();
+        .await;
 
         let removed = sweep_empty_agent_folders(ws.as_ref(), &company, false)
             .await

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2974,6 +2974,15 @@ mod tests {
         ) -> crate::Result<()> {
             unreachable!("the listing never creates")
         }
+        async fn adopt_or_create_folder(
+            &self,
+            _company: &CompanyId,
+            _parent: Option<&str>,
+            _name: &str,
+            _origin: WorkspaceOrigin,
+        ) -> crate::Result<crate::ports::workspace::FolderClaim> {
+            unreachable!("the listing never claims a folder")
+        }
         async fn rename_move(
             &self,
             _company: &CompanyId,

--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -133,6 +133,121 @@ pub enum WorkspaceOrigin {
     },
 }
 
+/// What [`WorkspaceStore::adopt_or_create_folder`] did to satisfy a caller's
+/// claim on `(parent, name)` (issue #759).
+///
+/// The caller almost always wants the node and not the verb — a publish walking
+/// `Agents/<agent>/<task>/` does the same thing either way. The distinction is
+/// carried anyway because exactly one consumer must be able to tell: the
+/// workspace announcer emits a node-created frame, and a frame for a folder that
+/// was already standing would tell an open console that something appeared when
+/// nothing did. Returning a bare id would make that undecidable at the only
+/// layer that has to decide it.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FolderClaim {
+    /// The name was free and this call minted the folder.
+    Created(WorkspaceNode),
+    /// A folder was already there and is handed back untouched — authorship
+    /// stamp, timestamp and all. See [`WorkspaceStore::adopt_or_create_folder`]
+    /// for why adoption rather than refusal is the right answer for a folder.
+    Adopted(WorkspaceNode),
+}
+
+impl FolderClaim {
+    /// The folder that now answers to `(parent, name)`, however it got there.
+    pub fn node(&self) -> &WorkspaceNode {
+        match self {
+            Self::Created(node) | Self::Adopted(node) => node,
+        }
+    }
+
+    /// The folder's id — the thing nearly every caller actually wants.
+    pub fn id(&self) -> &str {
+        &self.node().id
+    }
+
+    /// Consumes the claim for the node inside it.
+    pub fn into_node(self) -> WorkspaceNode {
+        match self {
+            Self::Created(node) | Self::Adopted(node) => node,
+        }
+    }
+
+    /// Whether this call is the one that minted the folder.
+    pub fn was_created(&self) -> bool {
+        matches!(self, Self::Created(_))
+    }
+}
+
+/// The folder node a store is about to insert for a claim.
+///
+/// Shared so all three backends mint the same shape — a fresh ULID, both origin
+/// fields stamped with the caller's `origin`, and no blob metadata — rather than
+/// three chances to stamp `created_by` differently.
+pub fn new_folder(name: &str, parent_id: Option<&str>, origin: WorkspaceOrigin) -> WorkspaceNode {
+    WorkspaceNode {
+        id: crate::ports::generate_id(),
+        name: name.to_string(),
+        kind: NodeKind::Folder,
+        parent_id: parent_id.map(str::to_string),
+        updated_at_millis: crate::ports::now_millis(),
+        created_by: origin.clone(),
+        updated_by: origin,
+        mime: None,
+        size: None,
+        sha256: None,
+    }
+}
+
+/// The folder already answering to `(parent, name)`, or `None` when the name is
+/// free — refusing anything a claim must not resolve.
+///
+/// The read half of [`WorkspaceStore::adopt_or_create_folder`], shared so the
+/// fail-closed rule has one implementation and all three backends refuse with
+/// the same sentence. The conformance suite asserts on those sentences, which is
+/// only worth anything if they cannot drift.
+///
+/// A *file* holding the name, or several nodes holding it, is a
+/// [`Conflict`](crate::error::OpenCompanyError::Conflict): the first because a
+/// folder and a note at one path is the ambiguity the tool layer already
+/// refuses, and the second because a tree that lost this race *before* the guard
+/// existed must stay refused rather than have a third node added to it.
+pub fn existing_folder_claim<'a>(
+    nodes: impl Iterator<Item = &'a WorkspaceNode>,
+    parent: Option<&str>,
+    name: &str,
+) -> Result<Option<WorkspaceNode>> {
+    use crate::error::OpenCompanyError;
+    let matches: Vec<&WorkspaceNode> = nodes
+        .filter(|node| node.parent_id.as_deref() == parent && node.name == name)
+        .collect();
+    match matches.as_slice() {
+        [one] if one.kind == NodeKind::Folder => Ok(Some((*one).clone())),
+        [_] => Err(OpenCompanyError::Conflict(folder_claim_file_refusal(name))),
+        [] => Ok(None),
+        many => Err(OpenCompanyError::Conflict(folder_claim_ambiguous_refusal(
+            name,
+            many.len(),
+        ))),
+    }
+}
+
+/// The refusal every backend gives when a *file* already carries the name a
+/// folder claim asked for.
+pub fn folder_claim_file_refusal(name: &str) -> String {
+    format!(
+        "`{name}` already exists as a note, not a folder, so a folder cannot be claimed at that \
+         path"
+    )
+}
+
+/// The refusal every backend gives when the name a folder claim asked for is
+/// already carried by more than one node — a tree that lost this race before the
+/// guard existed.
+pub fn folder_claim_ambiguous_refusal(name: &str, count: usize) -> String {
+    format!("{count} nodes under this folder are named `{name}`, so the path is ambiguous")
+}
+
 /// One node in the workspace tree. `id` is a stable ULID; `parent_id` is `None`
 /// at the workspace root.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -355,6 +470,54 @@ pub trait WorkspaceStore: Send + Sync {
         node: &WorkspaceNode,
         content: Option<&str>,
     ) -> Result<()>;
+    /// Claims the folder `name` under `parent`, minting it or adopting the one
+    /// already there — atomically, against every other caller of this method
+    /// (issue #759).
+    ///
+    /// **The contract**: when this returns `Ok`, exactly one folder answers to
+    /// `(parent, name)` among the nodes this primitive governs, and the returned
+    /// node is it. `parent` of `None` is the workspace root, which is why it is
+    /// an `Option` rather than a `&str` — the `Agents/` and `Desks/` roots are
+    /// claimed by the same call as everything beneath them.
+    ///
+    /// Adoption **preserves the original authorship stamp**: `origin` is used
+    /// only when this call is the one that creates the folder. A second
+    /// publisher does not get to rewrite whose folder it is.
+    ///
+    /// Fail-closed on anything that is not a single folder: a *file* holding the
+    /// name is a [`Conflict`](crate::error::OpenCompanyError::Conflict), and so
+    /// is a name already carried by several nodes — a tree that lost this race
+    /// before the guard existed stays refused rather than gaining a third node.
+    /// Both refusals come from [`existing_folder_claim`], so they read the same
+    /// on every backend.
+    ///
+    /// # Why adoption, and not [`swap_files`](Self::swap_files)'s compare-and-swap
+    ///
+    /// `swap_files` stages a payload and makes the loser **fail**, which is
+    /// right for a file: its bytes are a content claim with one legitimate
+    /// winner. A folder is a payload-free **container** claim — two publishers
+    /// that both want `Agents/cmo/task-42/` want the same thing, so the loser
+    /// must adopt and carry on rather than report a publish failure the operator
+    /// can do nothing about. Forcing folders through that CAS would need a
+    /// re-read-and-adopt retry loop wrapped around it, and `swap_files` rejects
+    /// non-file replacements outright for fs-rename and GridFS reasons that do
+    /// not apply here.
+    ///
+    /// It also dissolves loser cleanup: a loser never owns a folder, so nothing
+    /// was ever written beneath one that gets discarded.
+    ///
+    /// # No default implementation, deliberately
+    ///
+    /// A read-then-create default would compile everywhere and silently
+    /// reintroduce the exact race this exists to close on any backend that
+    /// forgot to override it. Required, so the compiler names every implementor.
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: WorkspaceOrigin,
+    ) -> Result<FolderClaim>;
     /// Creates a **binary** file node holding `bytes`.
     ///
     /// The binary twin of [`create`](Self::create), with the same freshness and

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -175,6 +175,32 @@ impl WorkspaceStore for WorkspaceAnnouncer {
         Ok(())
     }
 
+    /// Claims through, and announces `opened` **only when the folder was
+    /// actually minted** (issue #759).
+    ///
+    /// An adoption changed nothing: the folder was already standing, already in
+    /// the tree the console last read, already announced when whoever created it
+    /// created it. Announcing it again would tell an open Workspace tab that
+    /// something appeared, on a publish that only walked past it — and the
+    /// publish walk adopts on nearly every publish a company ever makes, so the
+    /// noise would be the common case rather than an edge one.
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: crate::ports::workspace::WorkspaceOrigin,
+    ) -> Result<crate::ports::workspace::FolderClaim> {
+        let claim = self
+            .inner
+            .adopt_or_create_folder(company, parent, name, origin)
+            .await?;
+        if let crate::ports::workspace::FolderClaim::Created(node) = &claim {
+            self.announce(company, &node.id, CHANGE_OPENED).await;
+        }
+        Ok(claim)
+    }
+
     /// A binary node appearing in the tree is the same event as a note
     /// appearing: something the operator did not type is now there to look at.
     /// An uploaded image or a published chart therefore reaches an open

--- a/src/runtime/workspace_events.rs
+++ b/src/runtime/workspace_events.rs
@@ -442,6 +442,41 @@ mod test {
         );
     }
 
+    /// Issue #759: a folder claim announces `opened` when it **mints** the
+    /// folder and says nothing when it adopts one.
+    ///
+    /// Both halves are load-bearing. Without the first, a published deliverable
+    /// would appear in a tab that never learned its folder existed. Without the
+    /// second, every publish into an established folder — which is nearly every
+    /// publish a company ever makes — would put an `opened` frame on the feed
+    /// for a node that has been sitting there for weeks.
+    #[tokio::test]
+    async fn a_folder_claim_announces_only_when_it_mints_the_folder() {
+        let (_dir, store, log, co) = wired();
+
+        let claim = store
+            .adopt_or_create_folder(&co, None, "Agents", WorkspaceOrigin::Seed)
+            .await
+            .unwrap();
+        assert!(claim.was_created());
+        assert_eq!(
+            changes(&log),
+            vec![(claim.node().id.clone(), "opened".to_string())]
+        );
+        log.appended.lock().unwrap().clear();
+
+        let adopted = store
+            .adopt_or_create_folder(&co, None, "Agents", WorkspaceOrigin::Seed)
+            .await
+            .unwrap();
+        assert!(!adopted.was_created());
+        assert_eq!(adopted.node().id, claim.node().id);
+        assert!(
+            changes(&log).is_empty(),
+            "adopting a folder that was already standing changed nothing"
+        );
+    }
+
     /// An overwrite announces an update — the frame an agent's `workspace_write`
     /// and the console's `PUT` both need, and the one the Workspace tab had no
     /// way to learn about at all.

--- a/src/runtime/workspace_quota.rs
+++ b/src/runtime/workspace_quota.rs
@@ -319,6 +319,22 @@ impl WorkspaceStore for QuotaEnforcedWorkspace {
         self.inner.create(company, node, content).await
     }
 
+    /// Unmetered, like every other folder write: quota counts binary payloads,
+    /// and a folder carries none. Delegated rather than defaulted because the
+    /// port has no default — a wrapper that silently read-then-created would
+    /// reintroduce the race (issue #759) from inside the decorator stack.
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: WorkspaceOrigin,
+    ) -> Result<crate::ports::workspace::FolderClaim> {
+        self.inner
+            .adopt_or_create_folder(company, parent, name, origin)
+            .await
+    }
+
     async fn create_binary(
         &self,
         company: &CompanyId,

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2967,6 +2967,239 @@ pub async fn assert_workspace_binary_store(ws: Arc<dyn WorkspaceStore>) {
     );
 }
 
+/// Every backend decides a folder claim the same way — including under
+/// contention (issue #759).
+///
+/// The contention case at the end is the one that matters. A naive
+/// read-then-create passes every sequential assertion above it and fails only
+/// there, which is precisely the shape of the defect: each backend's answer was
+/// correct about the instant it looked and wrong by the time it wrote. It is
+/// also what proves the MongoDB partial unique index is actually deciding, since
+/// nothing else on that backend can.
+pub async fn assert_workspace_folder_claims(ws: Arc<dyn WorkspaceStore>) {
+    use crate::ports::workspace::{
+        FolderClaim, folder_claim_ambiguous_refusal, folder_claim_file_refusal,
+    };
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+    let cmo = WorkspaceOrigin::Agent {
+        id: "cmo".to_string(),
+    };
+    let cto = WorkspaceOrigin::Agent {
+        id: "cto".to_string(),
+    };
+
+    // -- Created when the name is free ------------------------------------
+    let claim = ws
+        .adopt_or_create_folder(&alpha, None, "Agents", cmo.clone())
+        .await
+        .expect("a free root name is claimable");
+    assert!(claim.was_created(), "nothing was there to adopt");
+    let root = claim.node().clone();
+    assert_eq!(root.name, "Agents");
+    assert_eq!(root.kind, NodeKind::Folder);
+    assert_eq!(root.parent_id, None);
+    assert_eq!(
+        root.created_by, cmo,
+        "the creating caller's origin is stamped"
+    );
+    assert_eq!(root.updated_by, cmo);
+    assert!(
+        ws.tree(&alpha)
+            .await
+            .unwrap()
+            .iter()
+            .any(|n| n.id == root.id),
+        "a created folder is in the tree"
+    );
+
+    // -- Adopted, idempotently, keeping the original authorship -----------
+    let again = ws
+        .adopt_or_create_folder(&alpha, None, "Agents", cto.clone())
+        .await
+        .expect("an existing folder is adopted, not refused");
+    assert!(!again.was_created(), "the folder was already there");
+    assert_eq!(again.node().id, root.id, "adoption returns the same folder");
+    assert_eq!(
+        again.node().created_by,
+        cmo,
+        "adoption must not rewrite whose folder it is"
+    );
+    assert_eq!(
+        ws.tree(&alpha)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|n| n.parent_id.is_none() && n.name == "Agents")
+            .count(),
+        1,
+        "and it must not have minted a rival"
+    );
+
+    // -- Nested under a parent, and only under that parent -----------------
+    let nested = ws
+        .adopt_or_create_folder(&alpha, Some(&root.id), "cmo", cmo.clone())
+        .await
+        .expect("a folder under a folder");
+    assert!(nested.was_created());
+    assert_eq!(nested.node().parent_id.as_deref(), Some(root.id.as_str()));
+    // The same name at the root is a different path and must be free there.
+    let sibling_at_root = ws
+        .adopt_or_create_folder(&alpha, None, "cmo", cmo.clone())
+        .await
+        .expect("the root is a different parent");
+    assert!(sibling_at_root.was_created());
+    assert_ne!(sibling_at_root.node().id, nested.node().id);
+
+    // -- A file holding the name is refused, identically on every backend --
+    let note = WorkspaceNode {
+        id: "claim-note".to_string(),
+        name: "notes.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: None,
+        updated_at_millis: now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
+        mime: None,
+        size: None,
+        sha256: None,
+    };
+    ws.create(&alpha, &note, Some("body")).await.unwrap();
+    let refused = ws
+        .adopt_or_create_folder(&alpha, None, "notes.md", cmo.clone())
+        .await
+        .expect_err("a note cannot be adopted as a folder");
+    assert!(
+        refused
+            .to_string()
+            .ends_with(&folder_claim_file_refusal("notes.md")),
+        "the refusal must be the shared one, or it drifts between backends: {refused}"
+    );
+
+    // -- A missing or non-folder parent is refused ------------------------
+    assert!(
+        ws.adopt_or_create_folder(&alpha, Some("no-such-parent"), "x", cmo.clone())
+            .await
+            .is_err(),
+        "a claim under a parent that does not exist is refused"
+    );
+    assert!(
+        ws.adopt_or_create_folder(&alpha, Some("claim-note"), "x", cmo.clone())
+            .await
+            .is_err(),
+        "a claim under a *file* is refused"
+    );
+
+    // -- Pre-existing ambiguity stays fail-closed -------------------------
+    //
+    // Written through `create` rather than through the primitive, because the
+    // primitive is exactly what makes this state unreachable from now on. It is
+    // still reachable from *history*: a tenant that lost this race before the
+    // guard existed carries it, and the answer must be a refusal rather than a
+    // third node piled on top. Ids are supplied, so no backend has to accept a
+    // name it would refuse — only a `create` that skips the sibling check, which
+    // sqlite and mongodb both do.
+    for id in ["dup-a", "dup-b"] {
+        let dup = WorkspaceNode {
+            id: id.to_string(),
+            name: "Legacy".to_string(),
+            kind: NodeKind::Folder,
+            parent_id: Some(root.id.clone()),
+            ..note.clone()
+        };
+        // `fs` refuses the second by design (issue #666); it has never been able
+        // to represent this state, so it simply has nothing to fail closed on.
+        if ws.create(&alpha, &dup, None).await.is_err() {
+            break;
+        }
+    }
+    let legacy: Vec<WorkspaceNode> = ws
+        .tree(&alpha)
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|n| n.name == "Legacy")
+        .collect();
+    if legacy.len() > 1 {
+        let refused = ws
+            .adopt_or_create_folder(&alpha, Some(&root.id), "Legacy", cmo.clone())
+            .await
+            .expect_err("an ambiguous path must stay refused");
+        assert!(
+            refused
+                .to_string()
+                .ends_with(&folder_claim_ambiguous_refusal("Legacy", legacy.len())),
+            "the ambiguity refusal must be the shared one: {refused}"
+        );
+    }
+
+    // -- Companies do not see each other's claims -------------------------
+    let elsewhere = ws
+        .adopt_or_create_folder(&beta, None, "Agents", cmo.clone())
+        .await
+        .expect("another company's identical path is free");
+    assert!(
+        elsewhere.was_created(),
+        "company beta must not adopt company alpha's folder"
+    );
+    assert_ne!(elsewhere.node().id, root.id);
+
+    // -- Eight-way contention on one path ---------------------------------
+    //
+    // The assertion the sequential cases cannot make. All eight callers must
+    // succeed, all eight must be holding the SAME folder, and exactly one may
+    // report having created it — that last count is what a duplicated folder
+    // would break even where the ids happened to agree.
+    let contested = Arc::new(root.id.clone());
+    let mut racers = Vec::new();
+    for i in 0..8 {
+        let ws = ws.clone();
+        let alpha = alpha.clone();
+        let parent = contested.clone();
+        let origin = WorkspaceOrigin::Agent {
+            id: format!("racer-{i}"),
+        };
+        racers.push(tokio::spawn(async move {
+            ws.adopt_or_create_folder(&alpha, Some(&parent), "task-42", origin)
+                .await
+        }));
+    }
+    let mut ids = Vec::new();
+    let mut created = 0usize;
+    for racer in racers {
+        let claim = racer
+            .await
+            .expect("the claim task must not panic")
+            .expect("every caller must come away with the folder, winner or not");
+        if matches!(claim, FolderClaim::Created(_)) {
+            created += 1;
+        }
+        ids.push(claim.into_node().id);
+    }
+    assert_eq!(created, 1, "exactly one caller may mint the folder");
+    assert!(
+        ids.windows(2).all(|pair| pair[0] == pair[1]),
+        "every caller must hold the same folder: {ids:?}"
+    );
+    let tree = ws.tree(&alpha).await.unwrap();
+    assert_eq!(
+        tree.iter()
+            .filter(|n| n.parent_id.as_deref() == Some(root.id.as_str()) && n.name == "task-42")
+            .count(),
+        1,
+        "one folder under one name, or every later publish beneath it is refused: {tree:?}"
+    );
+
+    // …and it stays claimable afterwards, which is the no-permanent-outage half.
+    let after = ws
+        .adopt_or_create_folder(&alpha, Some(&root.id), "task-42", cmo)
+        .await
+        .expect("the contested path must still resolve");
+    assert!(!after.was_created());
+    assert_eq!(&after.node().id, &ids[0]);
+}
+
 /// A folder node for the binary suite.
 fn folder_node(id: &str, name: &str) -> WorkspaceNode {
     WorkspaceNode {

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1251,6 +1251,69 @@ impl WorkspaceStore for FsOps {
         self.save_index(company, &index).await
     }
 
+    /// The whole claim — look, then adopt or insert — under the one lock every
+    /// other write to this index already takes (issue #759).
+    ///
+    /// That lock is what makes it atomic here, and it is enough: the `fs`
+    /// backend is single-process per data directory by documented contract (see
+    /// `docs/spec/runtime/storage.md`), so there is no second writer for it to
+    /// miss. The other two backends have to reach for a transaction and an index
+    /// respectively because their deployments have one.
+    ///
+    /// Before this, the same claim was a `tree()` read in the caller followed by
+    /// a plain [`create`](WorkspaceStore::create). The read was honest about the
+    /// instant it happened and the create acted on it later; on this backend
+    /// `reject_path_collision` then refused the loser, so a concurrent publish
+    /// failed spuriously instead of adopting the folder it wanted.
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: WorkspaceOrigin,
+    ) -> Result<crate::ports::workspace::FolderClaim> {
+        use crate::ports::workspace::{FolderClaim, existing_folder_claim, new_folder};
+        reject_unsafe_name(name)?;
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.workspace_index_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut index = self.load_index(company).await?;
+        if let Some(parent) = parent {
+            match index.get(parent) {
+                Some(p) if p.kind == NodeKind::Folder => {}
+                Some(_) => {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "parent is not a folder".to_string(),
+                    ));
+                }
+                None => {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "parent folder does not exist".to_string(),
+                    ));
+                }
+            }
+        }
+        if let Some(existing) = existing_folder_claim(index.values(), parent, name)? {
+            return Ok(FolderClaim::Adopted(existing));
+        }
+        let node = new_folder(name, parent, origin);
+        // Still checked, and it is not the sibling check above repeated: this
+        // backend renders a node's *path* from the chain of names above it, so a
+        // legacy tree carrying duplicate-named ancestors can put two different
+        // `(parent, name)` pairs on one directory. Refusing keeps the claim
+        // fail-closed in exactly the case the sibling check cannot see.
+        reject_path_collision(&index, &node.id, &node.name, parent)?;
+        index.insert(node.id.clone(), node.clone());
+        let physical = self.physical_path(company, &index, &node.id)?;
+        tokio::fs::create_dir_all(&physical)
+            .await
+            .map_err(|e| io_err(&physical, e))?;
+        self.save_index(company, &index).await?;
+        Ok(FolderClaim::Created(node))
+    }
+
     /// Writes the payload to its real path, then indexes it.
     ///
     /// **File first, index second — the same order the text path already uses.**

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -2225,6 +2225,13 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_workspace_folder_claims() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_workspace_folder_claims(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
     async fn workspace_files_land_on_disk_under_folders() {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -166,15 +166,38 @@ fn unique_partial(keys: Document, present: &str) -> IndexModel {
 /// respectively, and MongoDB has neither across two documents, so the insert
 /// either violates the index or it does not.
 ///
-/// Files only. Folders deliberately carry no key, so the index never indexes
-/// them and a folder may still share a name with a file exactly as before —
-/// this is a race fix, not a new tree rule.
+/// Files only. Folders carry [`folder_path_key`] in a separate field instead
+/// (issue #759), so the two guards never make a folder and a file contend for
+/// one name. The key encoding is shared — see [`path_key`].
+fn file_path_key(parent_id: Option<&str>, name: &str) -> String {
+    path_key(parent_id, name)
+}
+
+/// The uniqueness key for a **folder's** path inside one company (issue #759).
+///
+/// The same `{parent}\0{name}` string as [`file_path_key`], stored in a
+/// **different field** (`folder_path_key`) behind its own partial unique index.
+/// Two fields rather than one shared key on purpose: a folder and a file are
+/// still allowed to share a name, exactly as they were before either guard
+/// existed. This is a race fix, not a new tree rule, and one key would quietly
+/// make it the latter.
+///
+/// Stamped only by [`adopt_or_create_folder`], never by plain `create` — so the
+/// console's own folder creation is unaffected and a legacy tenant carrying
+/// duplicates keeps booting (the index is partial; see [`unique_partial`]).
+///
+/// [`adopt_or_create_folder`]: crate::ports::workspace::WorkspaceStore::adopt_or_create_folder
+fn folder_path_key(parent_id: Option<&str>, name: &str) -> String {
+    path_key(parent_id, name)
+}
+
+/// The shared `{parent}\0{name}` encoding behind both path keys.
 ///
 /// NUL is the separator because [`reject_unsafe_name`](crate::store::fs_ops)
-/// keeps it out of every node name, so no name can forge a different pair's
-/// key. The root is the empty string; a node parented at the root and one
-/// parented under a folder therefore never collide.
-fn file_path_key(parent_id: Option<&str>, name: &str) -> String {
+/// keeps it out of every node name, so no name can forge a different pair's key.
+/// The root is the empty string; a node parented at the root and one parented
+/// under a folder therefore never collide.
+fn path_key(parent_id: Option<&str>, name: &str) -> String {
     format!("{}\u{0}{}", parent_id.unwrap_or(""), name)
 }
 
@@ -243,7 +266,7 @@ impl MongoStore {
         // address may have several login codes over time.
         let nonunique = |keys: Document| IndexModel::builder().keys(keys).build();
         // See `unique_partial`.
-        let plans: [(&str, IndexModel); 31] = [
+        let plans: [(&str, IndexModel); 32] = [
             ("companies", unique(doc! {"company_id": 1})),
             ("ledger", unique(doc! {"company_id": 1, "idx": 1})),
             ("events", unique(doc! {"company_id": 1, "seq": 1})),
@@ -266,6 +289,17 @@ impl MongoStore {
             (
                 "workspace_nodes",
                 unique_partial(doc! {"company_id": 1, "file_path_key": 1}, "file_path_key"),
+            ),
+            // One folder per path, for the folders the publish walk claims
+            // (issue #759). A separate field from the file key on purpose; see
+            // `folder_path_key`. Partial for the same boot-safety reason: a
+            // tenant that already lost this race must keep starting.
+            (
+                "workspace_nodes",
+                unique_partial(
+                    doc! {"company_id": 1, "folder_path_key": 1},
+                    "folder_path_key",
+                ),
             ),
             ("users", unique(doc! {"company_id": 1, "user_id": 1})),
             // Enforces one account per address per company, and backs the login
@@ -2758,6 +2792,86 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         Ok(())
     }
 
+    /// Find-then-insert, with the **partial unique index deciding the race**
+    /// and a re-read adopting the winner when it loses (issue #759).
+    ///
+    /// This is the only backend that cannot serialize a read-then-insert: there
+    /// is no per-company lock and no transaction it can require of its
+    /// deployment, so a find that says "free" is a statement about an instant
+    /// and the insert acts on it later. The answer is the one issue #697 already
+    /// established for files — let the database hold the line — applied to a
+    /// second field.
+    ///
+    /// The re-read is what makes the loser *adopt* rather than fail. That is the
+    /// whole difference from `swap_files`: two publishers wanting one folder want
+    /// the same thing, so the one the index refuses must come back, find the
+    /// winner's folder and use it.
+    ///
+    /// The retry is bounded. Each pass either adopts, inserts, or loses to a
+    /// duplicate key — and a duplicate key means a competing folder now exists,
+    /// which the next find must see. More than a couple of passes therefore
+    /// means something is deleting folders as fast as they are created, and
+    /// looping forever on that would hang a publish rather than fail it.
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: crate::ports::workspace::WorkspaceOrigin,
+    ) -> Result<crate::ports::workspace::FolderClaim> {
+        use crate::ports::workspace::{FolderClaim, NodeKind, existing_folder_claim, new_folder};
+        /// Enough to absorb a burst of concurrent claimers; see the doc above
+        /// for why an unbounded loop would be worse than a refusal.
+        const ATTEMPTS: usize = 8;
+
+        for _ in 0..ATTEMPTS {
+            let nodes = self.workspace_nodes(company).await?;
+            if let Some(parent) = parent {
+                match nodes.get(parent) {
+                    Some(p) if p.kind == NodeKind::Folder => {}
+                    Some(_) => {
+                        return Err(OpenCompanyError::InvalidRequest(
+                            "parent is not a folder".to_string(),
+                        ));
+                    }
+                    None => {
+                        return Err(OpenCompanyError::InvalidRequest(
+                            "parent folder does not exist".to_string(),
+                        ));
+                    }
+                }
+            }
+            if let Some(existing) = existing_folder_claim(nodes.values(), parent, name)? {
+                return Ok(FolderClaim::Adopted(existing));
+            }
+            let node = new_folder(name, parent, origin.clone());
+            let mut document = doc! {
+                "company_id": company.as_ref(),
+                "node_id": &node.id,
+                "node_json": serde_json::to_string(&node)?,
+                "content": "",
+                "updated_ms": node.updated_at_millis as i64,
+            };
+            document.insert("folder_path_key", folder_path_key(parent, name));
+            match self
+                .collection("workspace_nodes")
+                .insert_one(document)
+                .await
+            {
+                Ok(_) => return Ok(FolderClaim::Created(node)),
+                // Somebody else claimed the path between the find and the
+                // insert. Nothing was written — this backend's create is one
+                // document — so the next pass simply adopts their folder.
+                Err(err) if is_duplicate_key(&err) => continue,
+                Err(err) => return Err(mongo_err(err)),
+            }
+        }
+        Err(OpenCompanyError::Conflict(format!(
+            "the folder `{name}` could not be claimed after {ATTEMPTS} attempts; something is \
+             creating and removing it concurrently"
+        )))
+    }
+
     /// GridFS — the only backend where the payload cannot ride in the record.
     ///
     /// A BSON document caps at 16 MB, and the artifacts this issue exists for
@@ -2977,15 +3091,28 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
             "node_json": serde_json::to_string(&node)?,
             "updated_ms": node.updated_at_millis as i64,
         };
-        let mut update = match node_path_key(&node) {
+        let mut unset = Document::new();
+        match node_path_key(&node) {
             Some(key) => {
                 set.insert("file_path_key", key);
-                doc! {"$set": set}
             }
-            None => doc! {"$set": set},
-        };
-        if node_path_key(&node).is_none() {
-            update.insert("$unset", doc! {"file_path_key": ""});
+            None => {
+                unset.insert("file_path_key", "");
+            }
+        }
+        // A moved folder **drops** its claim rather than carrying it (issue
+        // #759). The claim exists to decide a race between two publishers on the
+        // publish walk; an operator who moved the folder by hand has taken it
+        // out of that walk's reach, and a key that travelled with it would keep
+        // guarding the path it left — refusing that path to every later publish
+        // forever, which is the very outage this primitive exists to prevent.
+        // Demoting to unguarded is what every console-made folder already is.
+        if node.kind == NodeKind::Folder {
+            unset.insert("folder_path_key", "");
+        }
+        let mut update = doc! {"$set": set};
+        if !unset.is_empty() {
+            update.insert("$unset", unset);
         }
         self.collection("workspace_nodes")
             .update_one(doc! {"company_id": company.as_ref(), "node_id": id}, update)

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3453,6 +3453,112 @@ mod test {
         );
     }
 
+    /// Issue #759's index, asserted the same way and for the same reason.
+    ///
+    /// The folder guard is a second `unique_partial`, and a partial filter that
+    /// named the wrong field would be the identical silent failure: an index
+    /// built over an empty set, rejecting nothing, while every sequential test
+    /// still passed. Asserting the constructed `IndexModel` catches that with no
+    /// server, so it cannot pass vacuously.
+    ///
+    /// It also pins the field **name**: the folder key must be its own field,
+    /// not `file_path_key`. Sharing one field would make a folder and a file
+    /// contend for a single name — a new tree rule this change explicitly does
+    /// not introduce.
+    #[test]
+    fn the_folder_claim_index_is_partial_unique_on_its_own_field() {
+        let model = unique_partial(
+            doc! {"company_id": 1, "folder_path_key": 1},
+            "folder_path_key",
+        );
+        let filter = model
+            .options
+            .as_ref()
+            .and_then(|options| options.partial_filter_expression.as_ref())
+            .expect("the index is partial");
+
+        assert!(
+            filter.contains_key("folder_path_key"),
+            "the filter must name the field it guards: {filter:?}"
+        );
+        assert!(
+            !filter.contains_key("file_path_key"),
+            "the folder guard must not key on the file field, or a folder and a note would \
+             contend for one name: {filter:?}"
+        );
+        assert_eq!(
+            filter
+                .get_document("folder_path_key")
+                .expect("the condition"),
+            &doc! {"$exists": true},
+        );
+        assert!(
+            model
+                .options
+                .as_ref()
+                .and_then(|options| options.unique)
+                .unwrap_or(false),
+            "a partial filter without uniqueness would guard nothing at all"
+        );
+        // The two keys share an encoding, which is what lets one `path_key`
+        // serve both — pinned so a future edit cannot make them silently differ.
+        assert_eq!(
+            folder_path_key(Some("p"), "task-42"),
+            file_path_key(Some("p"), "task-42")
+        );
+    }
+
+    /// Issue #759, the subtle half: a folder that is **moved** drops its claim.
+    ///
+    /// `rename_move` has to `$unset` `folder_path_key`, and a missing unset is
+    /// invisible until somebody needs the vacated path again. The moved
+    /// document would keep guarding the path it left, so the next publish that
+    /// wanted `Agents/cmo/task-42/` would be refused by an index entry
+    /// describing a folder that is no longer there — the permanent outage this
+    /// primitive exists to prevent, reintroduced by the fix itself.
+    ///
+    /// Asserted by reclaiming the old path and checking a *new* folder was
+    /// minted there, rather than by reading the document: the claim is only
+    /// worth what the next claimer observes.
+    #[tokio::test]
+    async fn a_moved_folder_releases_its_claim_on_the_path_it_left() {
+        use crate::ports::workspace::WorkspaceStore;
+        let Some(s) = store().await else { return };
+        let company = CompanyId::new("mover");
+        let origin = crate::ports::workspace::WorkspaceOrigin::Seed;
+
+        let parent = s
+            .adopt_or_create_folder(&company, None, "Agents", origin.clone())
+            .await
+            .expect("the root")
+            .into_node()
+            .id;
+        let moved = s
+            .adopt_or_create_folder(&company, Some(&parent), "task-42", origin.clone())
+            .await
+            .expect("the folder")
+            .into_node()
+            .id;
+
+        // The operator renames it out of the way.
+        s.rename_move(&company, &moved, Some("task-42-archived"), None)
+            .await
+            .expect("rename to the workspace root");
+
+        // The vacated path must be claimable again, by a genuinely new folder.
+        let reclaimed = s
+            .adopt_or_create_folder(&company, Some(&parent), "task-42", origin)
+            .await
+            .expect("the path the moved folder left must be free");
+        assert!(
+            reclaimed.was_created(),
+            "a stale claim would have made this adopt a folder that is not there"
+        );
+        assert_ne!(reclaimed.node().id, moved);
+
+        drop_db(&s).await;
+    }
+
     /// **Issue #392 through the port**: the host-durable append asks the server
     /// for `j:true`, and the process-durable one does not.
     ///
@@ -4044,6 +4150,16 @@ mod test {
     async fn conformance_workspace_binary_store() {
         let Some(s) = store().await else { return };
         conformance::assert_workspace_binary_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    /// Issue #759. The only lane where the folder-claim primitive's contention
+    /// case runs against the partial unique index that actually decides it —
+    /// this backend has neither a lock nor a transaction to fall back on.
+    #[tokio::test]
+    async fn conformance_workspace_folder_claims() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_folder_claims(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3392,6 +3392,13 @@ mod test {
         conformance::assert_workspace_binary_store(store()).await;
     }
 
+    /// Issue #759: the folder-claim primitive, including the eight-way
+    /// contention case an immediate transaction is what decides here.
+    #[tokio::test]
+    async fn conformance_workspace_folder_claims() {
+        conformance::assert_workspace_folder_claims(store()).await;
+    }
+
     /// Issue #700's emptiness predicate, against the backend that can actually
     /// hold the shape it has to survive.
     ///

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -2686,6 +2686,67 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         Ok(())
     }
 
+    /// Read-siblings then adopt-or-`INSERT`, inside an **immediate**
+    /// transaction (issue #759).
+    ///
+    /// The same device this backend's [`swap_files`] already uses, and for the
+    /// same reason: two `SqliteStore` instances can point at one database file,
+    /// so the write reservation has to be taken *before* the read or both
+    /// callers see the name free and both insert. Nothing else here would stop
+    /// them — plain [`create`] checks only that the node **id** is fresh and has
+    /// never had a sibling-name guard at all.
+    ///
+    /// [`swap_files`]: crate::ports::workspace::WorkspaceStore::swap_files
+    /// [`create`]: crate::ports::workspace::WorkspaceStore::create
+    async fn adopt_or_create_folder(
+        &self,
+        company: &CompanyId,
+        parent: Option<&str>,
+        name: &str,
+        origin: crate::ports::workspace::WorkspaceOrigin,
+    ) -> Result<crate::ports::workspace::FolderClaim> {
+        use crate::ports::workspace::{FolderClaim, NodeKind, existing_folder_claim, new_folder};
+        let mut conn = self.conn();
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let nodes = self.workspace_nodes(&tx, company)?;
+        if let Some(parent) = parent {
+            match nodes.get(parent) {
+                Some(p) if p.kind == NodeKind::Folder => {}
+                Some(_) => {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "parent is not a folder".to_string(),
+                    ));
+                }
+                None => {
+                    return Err(OpenCompanyError::InvalidRequest(
+                        "parent folder does not exist".to_string(),
+                    ));
+                }
+            }
+        }
+        // Adoption commits nothing: the transaction is dropped, which rolls back
+        // a reservation that never wrote.
+        if let Some(existing) = existing_folder_claim(nodes.values(), parent, name)? {
+            return Ok(FolderClaim::Adopted(existing));
+        }
+        let node = new_folder(name, parent, origin);
+        tx.execute(
+            "INSERT INTO workspace_nodes (company_id, id, node_json, content, updated_ms) \
+             VALUES (?1, ?2, ?3, '', ?4)",
+            params![
+                company.as_ref(),
+                node.id,
+                serde_json::to_string(&node)?,
+                node.updated_at_millis as i64
+            ],
+        )
+        .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
+        Ok(FolderClaim::Created(node))
+    }
+
     /// One `INSERT` carrying the node and its payload together.
     ///
     /// **sqlite cannot orphan a blob**, and that is a property of this statement


### PR DESCRIPTION
## Summary

Race-fix half of #759. `resolve_folder` and `ensure_member_folder` are read-then-create:
`children_named` / `find` answering "free" describes a snapshot, and the `create_folder`
acts on it later. Both sit on the publish walk, so two concurrent publishes needing
`Agents/<agent>/<task>/` can both create it.

What each backend did before this change:

- **sqlite** — `create` guards duplicate node *id* only, no sibling-name check → two folders,
  one name.
- **mongodb** — #697's partial unique `file_path_key` index deliberately keys files only
  ("Folders deliberately carry no key") → two folders, one name.
- **fs** — `reject_path_collision` refuses the loser under the index lock, so no duplicate,
  but the loser's publish **fails spuriously** instead of adopting. Lesser, same line.

The duplicate is not a cosmetic wart. `resolve_folder`'s `many =>` arm then answers
`Conflict("… the path is ambiguous")` for **every** future publish beneath that path, for
**every** agent, permanently. A momentary race becomes a standing outage.

#697 closed the file arm of exactly this walk; its own race test annotates the folder walk
as "racy in its own right… a separate defect". This is that defect.

**The primitive adopts rather than failing, and that is the design point.** #697's
`swap_files` stages a payload and makes the loser fail — right for a file, whose bytes are a
content claim with one legitimate winner. A folder is a payload-free **container** claim:
two publishers wanting `Agents/cmo/task-42/` want the same thing, so the loser takes the
winner's node and continues. That also dissolves loser-cleanup by construction — the loser
never owns a folder, so nothing can have been written beneath a discarded one.

`WorkspaceStore::adopt_or_create_folder(company, parent: Option<&str>, name, origin) ->
FolderClaim::{Created, Adopted}`. **Required, with no default implementation** — a
read-then-create default would silently reintroduce the race on any backend that forgot to
override it, so the compiler is made to find every impl.

- **fs** — whole body under the existing workspace-index `path_lock`. Still calls
  `reject_path_collision` on the create branch; that is not a redundant repeat of the sibling
  check, because this backend renders paths from the *chain* of names, so duplicate-named
  ancestors can put two different `(parent, name)` pairs on one directory.
- **sqlite** — `TransactionBehavior::Immediate` around read-siblings → adopt-or-INSERT, the
  pattern its own `swap_files` already uses. Adoption commits nothing; the reservation rolls
  back.
- **mongodb** — the one backend that cannot serialize read-then-insert, so it reuses #697's
  own device: a second partial unique index on a **separate** `folder_path_key` field
  (`path_key` format shared with `file_path_key`), stamped only on folders this primitive
  mints. Partial, so legacy tenants already carrying duplicates still boot — #697's exact
  argument. find → insert → on duplicate-key, re-find and adopt, bounded at 8 attempts.
  `rename_move` always `$unset`s the folder key, so an operator-moved folder demotes to
  unguarded (the status of every console folder) rather than leaving a stale key that would
  make the vacated path permanently unclaimable.

Converted: `resolve_folder`'s create arm, both `ensure_member_folder` arms, and the boot
scaffold arm. `create_folder` had no callers left and is deleted. The announcer emits
`opened` on `Created` only — an adoption is not a new folder. Quota delegates; folders carry
no payload.

**Deliberately out of scope**: the agent's `workspace_create` tool shares the shape but not
the semantics — two agents hand-making `Notes/Q3/` may mean different things, so adopting is
the wrong default there, and its blast radius is one retryable tool call rather than a
poisoned publish funnel. It needs a decision on leaf semantics before code (likely this
primitive for interior segments, a decided refusal for the leaf). Follow-up issue drafted.

**Merge order**: this lands first; the recovery half (#808, `feat/759-duplicate-folder-repair`)
rebases after. The expected `src/company/mod.rs` overlap turned out not to exist —
`create_folder` was `pub(crate)` and never re-exported, so this branch never opened that file.

## API Or Behavior Changes

- **`WorkspaceStore` gains a required method.** Any out-of-tree implementor must add it;
  that is intentional, per the no-default argument above.
- **New MongoDB index** — partial unique on `(company_id, folder_path_key)`. Partial, so
  existing tenants with duplicates still boot. `plans` array 31 → 32.
- **A folder rename now `$unset`s `folder_path_key`** on mongodb, demoting the moved folder
  to unguarded.
- `create_folder` removed (was `pub(crate)`, no callers).
- No route, response shape, or console behaviour changes.

## Tests

Counts read rather than exit codes — a filter that selects nothing exits 0.

`cargo test --locked` **2303 passed** · sqlite lane **36** (was 35) · **mongo lane 35,
base measured at 32** against a live `mongo:7` with `OPENCOMPANY_TEST_MONGODB_REQUIRED=1`
(without that flag the lane skips silently) · `openhuman,tinycortex --tests` **3514** ·
scoped suites export 10 / mongodb-selection 12 / tool-belt 26 / media-toolbelt 18 ·
`assert-integration-targets-run.sh` and `assert-feature-lanes.sh` green.
fmt clean; clippy default, `openhuman,tinycortex`, and `openhuman,mcp,telegram` all clean
(`--no-deps` where CI does); `check --all-features --all-targets` clean.

Every new gate was observed RED first, by mutation — not asserted:

| Gate | Failure when the fix is removed |
|---|---|
| mirror agent-folder race, at base `d0f908bb` | `Conflict("workspace already contains \`Agents\` in that folder")` |
| mirror task-folder race, at base `d0f908bb` | `Conflict("workspace already contains \`t-9\` in that folder")` |
| mongo 8-way contention, `folder_path_key` insert removed | `Conflict("3 nodes under this folder are named \`task-42\`, so the path is ambiguous")` |
| mongo rename, `$unset` removed | `Conflict("the folder \`task-42\` could not be claimed after 8 attempts…")` — the vacated path became permanently unclaimable |

The base proof was run by reverting `src/` to `d0f908bb` and injecting the two race tests
with the new trait-method override stripped. The barrier double pauses on `tree()` — the
race's own precondition — precisely so the test exists on both sides of the fix.

The 8-way contention case is the one that matters for mongodb: a naive read-then-insert
passes every sequential test and fails only under real contention.

Conformance covers all three backends: created-when-free, adopted-idempotent-same-id,
file-name refusal, authorship preserved on adopt, and the contention case. The three
backends share refusal strings so they refuse identically.

**One pre-existing failure, verified not from this branch.**
`harness::brain::tests::a_cancelled_delegated_card_records_no_artifact` stack-overflows
locally under `--features openhuman,tinycortex`. Reproduced identically with `src/` reverted
to `d0f908bb`; `RUST_MIN_STACK=16777216` makes the whole lane pass. Local stack-size
artifact, not a code defect on this branch.

## Documentation

`docs/spec/runtime/ports-console.md#workspacestore` (the primitive and its contract) and
the MongoDB index in the storage spec.

Deviation worth noting: the prose went to `ports-console.md`, not `ports.md`. `ports.md` is
a hub table that links there, and the `WorkspaceStore` trait sketch already lives in
`ports-console.md` — putting it in `ports.md` would have duplicated the trait.

Part of #759


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate workspace folders when multiple operations create the same folder concurrently.
  * Existing matching folders are now safely adopted while preserving their ownership.
  * Added consistent handling for conflicting files, invalid parents, and ambiguous duplicate folders.

* **Workspace Events**
  * Folder creation events are emitted only when a folder is newly created, not when an existing folder is adopted.

* **Reliability**
  * Added consistent behavior across filesystem, SQLite, and MongoDB storage.
  * Expanded coverage for concurrent folder creation and workspace claim scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->