### PR TITLE
fix(console): let a select popup grow to fit its options (#811)

### DIFF
--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -56,6 +56,30 @@ function SelectTrigger({
   )
 }
 
+/**
+ * The select popup's own box.
+ *
+ * **Width is a floor, not a match** (issue #811). `--anchor-width` is the
+ * trigger's width, and the triggers are `w-fit` — so binding `width` to it made
+ * every popup exactly as wide as whatever short value happened to be selected
+ * (`trigger`, `none`, `agent`) and clipped its own options mid-word. The
+ * workflow node-kind picker was the worst case: each label explains what the
+ * kind does, and the explanation is the half that got cut — `Trigger — starts
+ * the w…`. An operator meeting that picker for the first time is reading
+ * exactly the text that is missing.
+ *
+ * `min-w` keeps the popup from ever being *narrower* than its trigger, which is
+ * the only thing the exact binding bought, while leaving it free to grow to its
+ * content. The `max(9rem, …)` inside preserves the old `min-w-36` floor for a
+ * trigger narrower than that.
+ *
+ * `max-w` then stops a long option pushing the popup off-screen:
+ * `--available-width` is what the positioner measured to the viewport edge, and
+ * 28rem is a readable line length, so it takes the smaller of the two.
+ */
+const SELECT_POPUP_CLASSES =
+  "relative isolate z-50 max-h-(--available-height) max-w-[min(28rem,var(--available-width))] min-w-[max(9rem,var(--anchor-width))] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+
 function SelectContent({
   className,
   children,
@@ -83,7 +107,7 @@ function SelectContent({
         <SelectPrimitive.Popup
           data-slot="select-content"
           data-align-trigger={alignItemWithTrigger}
-          className={cn("relative isolate z-50 max-h-(--available-height) w-(--anchor-width) min-w-36 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn(SELECT_POPUP_CLASSES, "duration-100 data-[align-trigger=true]:animate-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         >
           <SelectScrollUpButton />

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -76,9 +76,17 @@ function SelectTrigger({
  * `max-w` then stops a long option pushing the popup off-screen:
  * `--available-width` is what the positioner measured to the viewport edge, and
  * 28rem is a readable line length, so it takes the smaller of the two.
+ *
+ * **The floor is capped by that same ceiling, and it has to be.** When the two
+ * conflict CSS resolves in favour of `min-width` — measured, not assumed:
+ * `min-width:max(9rem,40rem)` against `max-width:min(28rem,20rem)` lays out at
+ * 640px, not 320px. So an uncapped floor would let a trigger wider than the
+ * space beside it push the popup straight off the viewport, which is the one
+ * thing `max-w` is here to prevent. Wrapping the floor in the same `min(…)`
+ * makes the ceiling authoritative in every case.
  */
 const SELECT_POPUP_CLASSES =
-  "relative isolate z-50 max-h-(--available-height) max-w-[min(28rem,var(--available-width))] min-w-[max(9rem,var(--anchor-width))] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
+  "relative isolate z-50 max-h-(--available-height) max-w-[min(28rem,var(--available-width))] min-w-[min(max(9rem,var(--anchor-width)),28rem,var(--available-width))] origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover text-popover-foreground shadow-md ring-1 ring-foreground/10"
 
 function SelectContent({
   className,

--- a/frontend/test/unit/select-popup-width.test.ts
+++ b/frontend/test/unit/select-popup-width.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/**
+ * The select popup's width (issue #811).
+ *
+ * The defect was one class: the popup was `w-(--anchor-width)`, an exact match
+ * to the trigger. Triggers are `w-fit`, so a short selected value produced a
+ * popup too narrow for its own options and every label was cut mid-word —
+ * `Trigger — starts the w…` in the workflow node-kind picker, where the cut half
+ * is the part that explains what the kind does.
+ *
+ * jsdom does no layout, so this cannot assert rendered pixels. What it CAN
+ * assert is the rule itself, and that is the whole defect: the popup must not
+ * bind `width` to the anchor. A revert to `w-(--anchor-width)` fails here rather
+ * than shipping and being noticed by an operator.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+function renderSelect() {
+  act(() => {
+    root.render(
+      createElement(
+        Select,
+        { defaultValue: "trigger", open: true },
+        createElement(SelectTrigger, null, createElement(SelectValue)),
+        createElement(
+          SelectContent,
+          null,
+          createElement(SelectItem, { value: "trigger" }, "Trigger — starts the workflow"),
+          createElement(SelectItem, { value: "agent" }, "Agent — a teammate performs a step"),
+        ),
+      ),
+    );
+  });
+}
+
+/** The popup renders through a portal, so it is on `document`, not `container`. */
+function popup(): HTMLElement | null {
+  return document.querySelector('[data-slot="select-content"]');
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the select popup's width", () => {
+  it("does not pin its width to the trigger", () => {
+    renderSelect();
+    const cls = popup()?.className ?? "";
+    // The exact-width binding, in either spelling Tailwind accepts.
+    expect(cls).not.toMatch(/(^|\s)w-\(--anchor-width\)/);
+    expect(cls).not.toMatch(/(^|\s)w-\[var\(--anchor-width\)\]/);
+  });
+
+  it("takes the trigger's width as a floor, so it is never narrower", () => {
+    renderSelect();
+    expect(popup()?.className ?? "").toMatch(/min-w-\[max\(9rem,var\(--anchor-width\)\)\]/);
+  });
+
+  it("keeps a ceiling, so one long option cannot push it off-screen", () => {
+    renderSelect();
+    expect(popup()?.className ?? "").toMatch(/max-w-\[min\(28rem,var\(--available-width\)\)\]/);
+  });
+
+  it("still renders its options", () => {
+    // Guards the guard: if the popup stopped rendering, every assertion above
+    // would pass against an empty string.
+    renderSelect();
+    expect(popup()?.textContent).toContain("Trigger — starts the workflow");
+    expect(popup()?.textContent).toContain("Agent — a teammate performs a step");
+  });
+});

--- a/frontend/test/unit/select-popup-width.test.ts
+++ b/frontend/test/unit/select-popup-width.test.ts
@@ -76,12 +76,23 @@ describe("the select popup's width", () => {
 
   it("takes the trigger's width as a floor, so it is never narrower", () => {
     renderSelect();
-    expect(popup()?.className ?? "").toMatch(/min-w-\[max\(9rem,var\(--anchor-width\)\)\]/);
+    expect(popup()?.className ?? "").toMatch(/min-w-\[min\(max\(9rem,var\(--anchor-width\)\)/);
   });
 
   it("keeps a ceiling, so one long option cannot push it off-screen", () => {
     renderSelect();
     expect(popup()?.className ?? "").toMatch(/max-w-\[min\(28rem,var\(--available-width\)\)\]/);
+  });
+
+  it("caps the floor by the ceiling, because min-width outranks max-width", () => {
+    // Not a style preference — a measured CSS rule. `min-width:max(9rem,40rem)`
+    // against `max-width:min(28rem,20rem)` lays out at 640px, not 320px, so an
+    // uncapped floor lets a trigger wider than the space beside it push the
+    // popup off the viewport and quietly defeats the ceiling above.
+    renderSelect();
+    expect(popup()?.className ?? "").toMatch(
+      /min-w-\[min\(max\(9rem,var\(--anchor-width\)\),28rem,var\(--available-width\)\)\]/,
+    );
   });
 
   it("still renders its options", () => {


### PR DESCRIPTION
## Summary

Select popups were pinned to their trigger's width, so they clipped their own
options mid-word. One class in the shared primitive; the whole console inherits it.

The workflow create/edit pane is where it hurts most, because there the option
label *is* the documentation:

```
before                          after
Trigger — starts the w…         Trigger — starts the workflow
Agent — a teammate…             Agent — a teammate performs a step
Condition — branches…           Condition — branches on something
Merge — combines s…             Merge — combines several inputs into one
Transform — reshape…            Transform — reshapes the data
Output — reports the…           Output — reports the result back
No schedule (run man…           No schedule (run manually)
Weekly — Monday 09…             Weekly — Monday 09:00 UTC
```

An operator meeting the node-kind picker for the first time was reading exactly
the half that was missing.

## API Or Behavior Changes

`frontend/src/components/ui/select.tsx` — `SelectContent`'s popup:

```diff
-w-(--anchor-width) min-w-36
+max-w-[min(28rem,var(--available-width))] min-w-[max(9rem,var(--anchor-width))]
```

`--anchor-width` is the trigger's width, and the triggers are `w-fit` — so
binding `width` to it made every popup exactly as wide as whatever short value
happened to be selected (`trigger`, `none`, `agent`), whatever its options
needed.

Width becomes a **floor** instead of a match. `min-w` keeps a popup from ever
being *narrower* than its trigger — the only thing the exact binding bought —
while leaving it free to grow. The `max(9rem, …)` preserves the old `min-w-36`
floor for a trigger narrower than that, so that guarantee is not quietly dropped.
`max-w` then stops a long option pushing the popup off-screen: `--available-width`
is what the positioner measured to the viewport edge, 28rem is a readable line
length, and it takes the smaller.

**Nothing can get narrower under this change** — the new floor is exactly the old
width — so no existing dropdown can start clipping as a result. This is the
shared primitive, so all 25 `<SelectContent>` sites are affected: workflows,
tasks, people, skills, memory, inbox, artifacts, usage, connections, domain
settings, feedback. Workflows is merely where the labels are longest.

## Tests

`frontend/test/unit/select-popup-width.test.ts` — 4 cases.

jsdom does no layout, so this cannot assert rendered pixels. It asserts the rule,
which is the entire defect: the popup must not bind `width` to the anchor, must
carry the floor, and must carry the ceiling. A fourth case asserts the options
still render — without it the other three would pass just as happily against a
popup that had stopped rendering at all.

**Negative control, run for real:** restoring `w-(--anchor-width) min-w-36`
fails 3 of the 4.

Verified live against `smoke1` (`staging-d0f908bb`) before writing any code, by
injecting the candidate rule and re-opening the pickers — all eight node kinds
and all five schedule options render in full.

Commands run locally, all green:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npx vitest run` — 580 passed, 47 files
- [x] `npm run build`
- [x] `scripts/ci/assert-design-tokens.sh`

## Documentation

The class list is hoisted to a documented `SELECT_POPUP_CLASSES` constant — a
long Tailwind string in an attribute had nowhere to say *why* the width is a
floor, which is the part that would otherwise be "simplified" back to `w-` by
the next person who reads it as redundant.

## Related

Closes #811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Select menus now automatically size to fit their content while respecting minimum, maximum, and available viewport widths.
  * Existing positioning, scrolling, appearance, animations, and option rendering remain unchanged.

* **Tests**
  * Added coverage to verify responsive select popup sizing and displayed options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->