### PR TITLE
feat(workflows): first-run authoring UX — on-ramp, paused disclosure, destination label (#813)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -102,6 +102,24 @@ export const DESTINATION_KINDS: { value: WorkflowDestination["kind"]; label: str
   { value: "channel", label: "Channel — a wired chat channel" },
 ];
 
+/**
+ * The collapsed-form label for a stored destination value.
+ *
+ * The output node's destination `Select` stores `node.destinationKind` — or the
+ * `"__none__"` sentinel when unset, because a `Select` item cannot carry an
+ * empty string. base-ui renders the raw stored value in the collapsed control
+ * unless it is given explicit text, so without this the trigger showed a bare
+ * `__none__` while the open list showed a friendly label. Maps the sentinel and
+ * every {@link DESTINATION_KINDS} value to its prosumer label; an unrecognized
+ * value falls back to itself. Issue #813.
+ */
+export function destinationLabel(value: string): string {
+  if (value === "__none__" || value === "") {
+    return "Nowhere (run result only)";
+  }
+  return DESTINATION_KINDS.find((kind) => kind.value === value)?.label ?? value;
+}
+
 /** A directed edge between two node ids, with an optional branch label. */
 export interface WorkflowEdge {
   from: string;

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -19,6 +19,7 @@ import { History, Plus, RotateCcw, Sparkles, Trash2 } from "lucide-react";
 import {
   CREATABLE_NODE_KINDS,
   DESTINATION_KINDS,
+  destinationLabel,
   createWorkflow,
   draftWorkflowFromDescription,
   listWorkflowRevisions,
@@ -1048,6 +1049,7 @@ export function WorkflowCreateDialog({
                 company={company}
                 roster={roster}
                 workflows={workflows}
+                createMode={!editing}
                 errors={{
                   schedule: fieldErrors[errorKey(n.key, "schedule")],
                   destinationTarget: fieldErrors[errorKey(n.key, "destinationTarget")],
@@ -1215,6 +1217,7 @@ function NodeRow({
   company,
   roster,
   workflows,
+  createMode,
   errors,
   configErrors,
   onValidateField,
@@ -1230,6 +1233,9 @@ function NodeRow({
   roster: TeamMemberDto[];
   /** The company's workflows, for a `sub_workflow` node's picker (issue #541). */
   workflows: WorkflowSummary[];
+  /** True while creating a new workflow (not editing an existing one), so the
+   * trigger row can disclose that a scheduled workflow is created paused (#813). */
+  createMode: boolean;
   /** Blur-time problems for this row's validated fields, if any. */
   errors: Partial<Record<ValidatedField, string>>;
   /** Blur-time problems for this row's config fields, keyed by engine key. */
@@ -1308,6 +1314,7 @@ function NodeRow({
           <ScheduleField
             client={client}
             company={company}
+            createMode={createMode}
             schedule={node.schedule}
             error={errors.schedule}
             onChange={(schedule) => onChange({ schedule })}
@@ -1336,7 +1343,12 @@ function NodeRow({
               }
             >
               <SelectTrigger className="h-8" aria-label="Send report to">
-                <SelectValue />
+                {/* base-ui renders the raw stored value in the collapsed
+                    control unless given text, which surfaced the bare
+                    `__none__` sentinel; map every value to its label. #813 */}
+                <SelectValue>
+                  {destinationLabel(node.destinationKind || NO_DESTINATION)}
+                </SelectValue>
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value={NO_DESTINATION}>
@@ -1412,6 +1424,7 @@ function NodeRow({
 function ScheduleField({
   client,
   company,
+  createMode,
   schedule,
   error,
   onChange,
@@ -1419,6 +1432,8 @@ function ScheduleField({
 }: {
   client: OpenCompanyClient;
   company: string | null;
+  /** True on a new workflow, to disclose the created-paused default (#813). */
+  createMode: boolean;
   schedule: string;
   /** The blur-time cron problem for this field, when there is one. */
   error?: string;
@@ -1488,6 +1503,17 @@ function ScheduleField({
           schedule={schedule}
           suppressError={Boolean(error)}
         />
+      )}
+      {/* A scheduled workflow is disarmed on create (#276 disarm rule,
+          src/company/workflow_create.rs); nothing else in the dialog says so,
+          so an author who sets a cron here would think it is armed. Disclose it
+          at author time — create mode only, and only once a real schedule is
+          set. #813 */}
+      {createMode && looksLikeCron(schedule) && (
+        <p className="text-3xs text-muted-foreground">
+          Heads up: a scheduled workflow is created paused. Resume it from the
+          list to arm the schedule.
+        </p>
       )}
     </div>
   );

--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1676,6 +1676,28 @@ export function WorkflowsView({
         ) : !selectedId ? (
           <div className="flex h-full flex-col items-center justify-center gap-3 px-4 text-center text-sm text-muted-foreground">
             <p>This company has no saved workflows yet.</p>
+            {/* Issue #813: a first-time author has no on-ramp otherwise. One
+                compact prose block — what a workflow is, a worked example
+                (mirroring the copilot placeholder), and the create-time copilot
+                as the easiest path. Deliberately no template gallery. */}
+            <div className="max-w-md space-y-2 text-2xs leading-relaxed">
+              <p>
+                A workflow runs a sequence of steps on a schedule or on demand: a{" "}
+                <span className="font-medium text-foreground">trigger</span> starts it,{" "}
+                <span className="font-medium text-foreground">agents</span> and{" "}
+                <span className="font-medium text-foreground">tools</span> do the work,
+                and an <span className="font-medium text-foreground">output</span> step
+                reports the result somewhere.
+              </p>
+              <p className="italic">
+                e.g. “Every Monday morning, have the writer draft the weekly digest
+                and email it to the team.”
+              </p>
+              <p>
+                Describe it in plain words when you create one — the copilot drafts
+                the graph for you to review and edit.
+              </p>
+            </div>
             {/* Issue #341: opens the same dialog as the toolbar button, and
                 therefore must NOT carry the same name. "Create a workflow"
                 rather than "Create the first workflow" because this state is

--- a/frontend/test/e2e/workflow-create-affordance.spec.ts
+++ b/frontend/test/e2e/workflow-create-affordance.spec.ts
@@ -93,3 +93,35 @@ test("the empty state's call to action is reachable and distinctly named", async
   const dialog = page.getByRole("dialog");
   await expect(dialog.getByText("New workflow", { exact: true })).toBeVisible();
 });
+
+test("the empty state gives a first-time author an on-ramp, not just a button (#813)", async ({
+  page,
+}) => {
+  // Same stubbed-empty list as above — the on-ramp only renders on the empty
+  // branch, and it is rendered output (prose), so it is pinned in the browser.
+  await page.route(
+    (url) => isWorkflowList(url),
+    async (route: Route) => {
+      if (route.request().method() !== "GET") return route.fallback();
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: "[]",
+      });
+    },
+  );
+
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+
+  // What a workflow is, in one line — the trigger → work → output shape.
+  await expect(
+    page.getByText(/A workflow runs a sequence of steps/),
+  ).toBeVisible();
+  // A concrete worked example (mirrors the copilot placeholder).
+  await expect(
+    page.getByText(/have the writer draft the weekly digest/),
+  ).toBeVisible();
+  // And it still points at the copilot as the easiest path.
+  await expect(page.getByText(/the copilot drafts/)).toBeVisible();
+});

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -273,3 +273,43 @@ test("a valid workflow still saves", async ({ page }) => {
   await dialog.getByRole("button", { name: "Create workflow" }).click();
   await expect(dialog).toBeHidden({ timeout: 30_000 });
 });
+
+test("a new scheduled workflow discloses that it starts paused (#813)", async ({
+  page,
+}) => {
+  // #813 defect 7: the #276 disarm rule creates a scheduled workflow paused,
+  // but the dialog showed a live "next run" preview and said nothing about it,
+  // so an author reasonably believed the cron was armed. This is rendered
+  // output gated on create-mode-and-a-real-schedule, so it is pinned here.
+  const dialog = await openCreateDialog(page);
+  const paused = dialog.getByText(/scheduled workflow is created paused/i);
+
+  // No schedule set yet — there is nothing to disclose.
+  await expect(paused).toHaveCount(0);
+
+  // Pick a preset schedule on the trigger row.
+  await dialog.getByLabel("Schedule").click();
+  await page.getByRole("option", { name: /^Daily/ }).click();
+
+  // Now the notice appears at author time, next to the schedule they just set.
+  await expect(paused).toBeVisible();
+});
+
+test("the collapsed destination shows a label, never the raw __none__ sentinel (#813)", async ({
+  page,
+}) => {
+  // #813 defect 8: base-ui renders the stored value in the collapsed control,
+  // which surfaced the bare "__none__" sentinel. The friendly label only
+  // exists once rendered, so this is a browser fact.
+  const dialog = await openCreateDialog(page);
+  await dialog.getByRole("button", { name: "Add node" }).click();
+  const kind = dialog.getByLabel("Node kind").nth(1);
+  await kind.click();
+  await page.getByRole("option", { name: /^Output(?! parser)/ }).click();
+
+  // No destination chosen yet: the control stores the "__none__" sentinel, and
+  // must still read as a human label collapsed.
+  const destination = dialog.getByLabel("Send report to");
+  await expect(destination).toContainText("Nowhere (run result only)");
+  await expect(destination).not.toContainText("__none__");
+});

--- a/frontend/test/unit/workflow-destination-label.test.ts
+++ b/frontend/test/unit/workflow-destination-label.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+import { DESTINATION_KINDS, destinationLabel } from "@/api/workflows";
+
+// #813 defect 8: the collapsed destination Select rendered the raw `__none__`
+// sentinel because base-ui prints the stored value when given no text. These pin
+// the value→label mapping the collapsed control now uses.
+describe("destinationLabel", () => {
+  it("maps the __none__ sentinel to a human label, never the raw value", () => {
+    expect(destinationLabel("__none__")).toBe("Nowhere (run result only)");
+    expect(destinationLabel("__none__")).not.toContain("__none__");
+  });
+
+  it("treats an empty stored value as no destination", () => {
+    expect(destinationLabel("")).toBe("Nowhere (run result only)");
+  });
+
+  it("maps every destination kind to its picker label", () => {
+    for (const kind of DESTINATION_KINDS) {
+      expect(destinationLabel(kind.value)).toBe(kind.label);
+    }
+  });
+
+  it("falls back to the raw value for an unrecognized kind", () => {
+    expect(destinationLabel("webhook")).toBe("webhook");
+  });
+});


### PR DESCRIPTION
## Summary

First-run authoring UX for the Workflows tab — the presentation half of EPIC #813 (defects 5, 7, 8). Frontend-only; no engine or API change.

- **Defect 5 — no on-ramp for a first-time author.** The empty Workflows board was one sentence and a button. Adds a compact static block: what a workflow is (trigger → agents/tools → output), a worked example mirroring the copilot placeholder, and the copilot as the easiest path. No template gallery; the `workflow-create-empty` testid is preserved.
- **Defect 7 — a scheduled workflow is created paused but looked armed.** The #276 disarm rule (server, unchanged) creates a scheduled workflow paused, but the dialog showed a live "next run" preview and said nothing. Adds an author-time notice next to the schedule — create mode only, and only once a real schedule is set — that it starts paused and must be Resumed to arm.
- **Defect 8 — the destination picker showed the raw `__none__` sentinel.** base-ui renders the stored value in the collapsed control unless given text, so the trigger read `__none__`. Adds a pure `destinationLabel()` that maps the sentinel and every destination kind to its label, rendered in the collapsed `SelectValue`.

`Part of #813` — the epic stays open; the copilot-grounding half (defects 1–3) ships as a separate PR.

## API Or Behavior Changes

None. Pure frontend presentation. No route, schema, or server behavior changes — the #276 create-paused disarm default is untouched (it is now merely disclosed at author time).

## Tests

Frontend gate (run locally, all green):

- [x] `npm run typecheck` — clean
- [x] `npx vitest run` — 580 passed (incl. new `workflow-destination-label.test.ts`, 4 tests, pins the sentinel/kind mapping)
- [x] `npm run build` — clean
- [x] `npx playwright test workflow-create-affordance workflow-dialog-feedback` — 12 passed, incl. 3 new #813 browser tests (empty-state on-ramp; paused notice present-with-schedule / absent-without; collapsed destination shows a label, never `__none__`)

Rust gates N/A — no Rust source changed (frontend-only):

- [x] N/A `cargo fmt` / `cargo clippy` / `cargo build` / `cargo test` — no `.rs` files in this PR.

## Documentation

None needed — presentation-only change; no public API, route, or architecture change to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer labels for workflow output destinations, including a friendly “Nowhere” label when no destination is selected.
  * Added guidance and examples to the empty workflows screen.
  * Added a notice explaining that scheduled workflows are created paused and must be resumed separately.

* **Tests**
  * Added coverage for destination labels, empty-state guidance, and workflow creation dialog behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->