### PR TITLE
feat(workflows): ground the create-time copilot — output-node delivery, teammate resolution, tool capability (#813)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -579,6 +579,12 @@ export interface WorkflowDraftFromDescription {
   workflow?: WorkflowGraph;
   /** Why the work is better done once. Present when not `automatable`. */
   reason?: string;
+  /**
+   * Host corrections the operator should see (issue #813) — e.g. the copilot
+   * matched a teammate named by role to their roster id. Present (and non-empty)
+   * only when the draft was corrected; older hosts omit the field entirely.
+   */
+  notes?: string[];
 }
 
 /**

--- a/frontend/src/lib/workflow-draft.ts
+++ b/frontend/src/lib/workflow-draft.ts
@@ -1,0 +1,45 @@
+import type { WorkflowDraftFromDescription } from "@/api/workflows";
+
+/**
+ * The create-time copilot's draft, reduced to the three banner slots the
+ * New-workflow dialog renders (issue #813).
+ *
+ * A pure reducer so the branch logic — a drafted graph shows a summary and any
+ * host corrections; a one-off shows a reason — is unit-testable without standing
+ * up the dialog. The dialog itself only wires these strings into `<Alert>`s.
+ */
+export interface DraftBanners {
+  /** The summary line to show above the hydrated form; `null` for a one-off. */
+  summary: string | null;
+  /**
+   * Host corrections the operator should see (issue #813) — e.g. "Assigned the
+   * … step to teammate `qa_engineer`". Empty when the draft needed none, or when
+   * the work was a one-off. Blank entries are dropped.
+   */
+  notes: string[];
+  /** The "better done once" reason; `null` when a graph was drafted. */
+  reason: string | null;
+}
+
+/**
+ * Maps a copilot draft response onto its banner slots. A drafted graph
+ * (`automatable` with a `workflow`) yields a summary plus any correction notes;
+ * anything else yields the not-automatable reason, with a sensible default when
+ * the host sent none.
+ */
+export function draftBanners(drafted: WorkflowDraftFromDescription): DraftBanners {
+  if (drafted.automatable && drafted.workflow) {
+    return {
+      summary: drafted.summary
+        ? `Drafted: ${drafted.summary} — review below, then Create.`
+        : "Drafted — review below, then Create.",
+      notes: (drafted.notes ?? []).filter((note) => note.trim().length > 0),
+      reason: null,
+    };
+  }
+  return {
+    summary: null,
+    notes: [],
+    reason: drafted.reason ?? "This is better done once than built into a workflow.",
+  };
+}

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -42,6 +42,7 @@ import {
   configFromDraft,
   hasConfigForm,
 } from "@/lib/workflow-node-config";
+import { draftBanners } from "@/lib/workflow-draft";
 import type { OpenCompanyClient } from "@/api/client";
 import { ApiError } from "@/api/types";
 import { CronPreviewLine } from "@/views/CronPreviewLine";
@@ -414,6 +415,10 @@ export function WorkflowCreateDialog({
   const [draftError, setDraftError] = useState<string | null>(null);
   const [draftSummary, setDraftSummary] = useState<string | null>(null);
   const [draftReason, setDraftReason] = useState<string | null>(null);
+  // Host corrections the copilot made to the draft (issue #813) — e.g. a
+  // name/role→id rewrite — shown under the summary so the author sees WHY the
+  // hydrated graph differs from a literal reading of their request.
+  const [draftNotes, setDraftNotes] = useState<string[]>([]);
   const [cognition, setCognition] = useState<CognitionPath | null>(null);
   const formId = useId();
 
@@ -451,6 +456,7 @@ export function WorkflowCreateDialog({
     setDraftError(null);
     setDraftSummary(null);
     setDraftReason(null);
+    setDraftNotes([]);
     let live = true;
     (async () => {
       try {
@@ -789,8 +795,10 @@ export function WorkflowCreateDialog({
     setDraftError(null);
     setDraftSummary(null);
     setDraftReason(null);
+    setDraftNotes([]);
     try {
       const drafted = await draftWorkflowFromDescription(client, company, description);
+      const banners = draftBanners(drafted);
       if (drafted.automatable && drafted.workflow) {
         const graph = drafted.workflow;
         // Hydrate via the same helpers edit mode uses, so a drafted graph and a
@@ -804,16 +812,13 @@ export function WorkflowCreateDialog({
         // errors — they belonged to whatever was on screen before.
         setError(null);
         setFieldErrors({});
-        setDraftSummary(
-          drafted.summary
-            ? `Drafted: ${drafted.summary} — review below, then Create.`
-            : "Drafted — review below, then Create.",
-        );
+        setDraftSummary(banners.summary);
+        // Any host corrections (issue #813) — e.g. a role→id rewrite — so the
+        // author sees WHY the drafted graph differs from a literal reading.
+        setDraftNotes(banners.notes);
       } else {
         // Not automatable: the form is left untouched, with the model's reason.
-        setDraftReason(
-          drafted.reason ?? "This is better done once than built into a workflow.",
-        );
+        setDraftReason(banners.reason);
       }
     } catch (e) {
       // A capability gap (404/409) or a network failure — surface it inline; the
@@ -973,6 +978,17 @@ export function WorkflowCreateDialog({
             {draftSummary && (
               <Alert>
                 <AlertDescription>{draftSummary}</AlertDescription>
+              </Alert>
+            )}
+            {draftNotes.length > 0 && (
+              <Alert data-testid="workflow-copilot-notes">
+                <AlertDescription>
+                  <ul className="list-disc space-y-1 pl-4">
+                    {draftNotes.map((note, i) => (
+                      <li key={i}>{note}</li>
+                    ))}
+                  </ul>
+                </AlertDescription>
               </Alert>
             )}
             {draftReason && (

--- a/frontend/test/unit/workflow-draft.test.ts
+++ b/frontend/test/unit/workflow-draft.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowDraftFromDescription, WorkflowGraph } from "@/api/workflows";
+import { draftBanners } from "@/lib/workflow-draft";
+
+/**
+ * The create-time copilot's banner reducer (issue #813).
+ *
+ * The dialog only wires these three slots into `<Alert>`s, so the branch logic —
+ * a drafted graph shows a summary and any host corrections; a one-off shows a
+ * reason — is proved here rather than through a render.
+ */
+
+/** A minimal graph, enough to make a draft "automatable with a workflow". */
+const GRAPH: WorkflowGraph = {
+  id: "weekly-digest",
+  name: "Weekly digest",
+  nodes: [],
+  edges: [],
+};
+
+function drafted(over: Partial<WorkflowDraftFromDescription>): WorkflowDraftFromDescription {
+  return { automatable: true, ...over };
+}
+
+describe("draftBanners", () => {
+  it("builds a summary line and passes host notes through for a drafted graph", () => {
+    const banners = draftBanners(
+      drafted({
+        workflow: GRAPH,
+        summary: "email the weekly digest",
+        notes: ["Assigned the “Write” step to teammate `qa_engineer`."],
+      }),
+    );
+    expect(banners.summary).toBe(
+      "Drafted: email the weekly digest — review below, then Create.",
+    );
+    expect(banners.notes).toEqual([
+      "Assigned the “Write” step to teammate `qa_engineer`.",
+    ]);
+    expect(banners.reason).toBeNull();
+  });
+
+  it("falls back to a bare summary line and no notes when the host sent none", () => {
+    const banners = draftBanners(drafted({ workflow: GRAPH }));
+    expect(banners.summary).toBe("Drafted — review below, then Create.");
+    expect(banners.notes).toEqual([]);
+    expect(banners.reason).toBeNull();
+  });
+
+  it("drops blank notes rather than rendering empty bullets", () => {
+    const banners = draftBanners(
+      drafted({ workflow: GRAPH, summary: "x", notes: ["  ", "kept"] }),
+    );
+    expect(banners.notes).toEqual(["kept"]);
+  });
+
+  it("surfaces the reason for a not-automatable answer, with a default", () => {
+    const withReason = draftBanners({ automatable: false, reason: "this only runs once" });
+    expect(withReason.summary).toBeNull();
+    expect(withReason.notes).toEqual([]);
+    expect(withReason.reason).toBe("this only runs once");
+
+    const noReason = draftBanners({ automatable: false });
+    expect(noReason.reason).toBe("This is better done once than built into a workflow.");
+  });
+});

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -813,6 +813,45 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
                 node.id
             )));
         }
+        // (d) Required args present (issue #813). The engine reads a `tool_call`'s
+        // arguments from `config.args` (tinyflows
+        // `nodes/integration/tool_call.rs`), so a known slug whose required args
+        // are absent THERE runs and does nothing useful — the legal-but-empty
+        // `read_workspace_state` (which cannot read a file anyway) was the case
+        // that motivated this. Reject the missing args at author time, naming them
+        // and what the tool is, so the console/copilot fixes it now instead of
+        // shipping a dud node. Same philosophy as the #661 `required_config`
+        // arm, one level down (the args sub-table, not the config root). Because
+        // this is the SHARED create/update gate, a hand-author hears it at save
+        // and the create-time copilot hears it via courtesy validation → one
+        // corrective retry. A tool with no required args (`read_workspace_state`)
+        // is unaffected here — its uselessness is handled by copilot grounding.
+        if let Some(info) = crate::workflows::caps::workflow_tool_info(slug) {
+            let args = node
+                .config
+                .as_ref()
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get("args"))
+                .and_then(toml::Value::as_table);
+            let missing: Vec<&str> = info
+                .required_args
+                .iter()
+                .copied()
+                .filter(|arg| !tool_arg_present(args, arg))
+                .collect();
+            if !missing.is_empty() {
+                return Err(OpenCompanyError::InvalidRequest(format!(
+                    "node `{}` calls tool `{slug}` but its `config.args` is missing {} — {}.",
+                    node.id,
+                    missing
+                        .iter()
+                        .map(|arg| format!("`{arg}`"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                    info.capability
+                )));
+            }
+        }
     }
     #[cfg(not(feature = "openhuman"))]
     {
@@ -834,7 +873,7 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
 /// `search` grant (a `*` wildcard never confers it). So the tools the copilot
 /// shows the model are precisely the ones a proposed `tool_call` node will clear
 /// at courtesy validation, and the two cannot drift: both read
-/// [`WORKFLOW_TOOL_SLUGS`](crate::workflows::caps) (itself pinned to
+/// [`WORKFLOW_TOOL_CATALOG`](crate::workflows::caps) (itself pinned to
 /// `namespace_of`) and both apply the same grant rule.
 ///
 /// Gated with the copilot it serves — the only caller is
@@ -844,17 +883,35 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
 #[cfg(feature = "openhuman")]
 pub(crate) fn workflow_callable_tool_slugs(record: &CompanyRecord) -> Vec<String> {
     let grants = &record.manifest.tools.allow;
-    crate::workflows::caps::WORKFLOW_TOOL_SLUGS
+    // Reads the rich [`WORKFLOW_TOOL_CATALOG`](crate::workflows::caps) since #813
+    // (the same grant rule, just the catalogue as the source), so the slugs the
+    // copilot grounds on and the ones it can validate come from one table.
+    crate::workflows::caps::WORKFLOW_TOOL_CATALOG
         .iter()
-        .filter(|(_slug, namespace)| {
-            if *namespace == "search" {
+        .filter(|info| {
+            if info.namespace == "search" {
                 crate::company::grants_search_explicit(grants)
             } else {
-                crate::harness::build::grants_cover(grants, namespace)
+                crate::harness::build::grants_cover(grants, info.namespace)
             }
         })
-        .map(|(slug, _namespace)| (*slug).to_string())
+        .map(|info| info.slug.to_string())
         .collect()
+}
+
+/// Whether a required `config.args` key is present and carries a usable value
+/// (issue #813): a non-blank string — a `=`-expression that binds at run time
+/// counts — or any non-null non-string value (a number, a non-empty array or
+/// table). A blank string or an absent key is treated as missing.
+#[cfg(feature = "openhuman")]
+fn tool_arg_present(args: Option<&toml::Table>, key: &str) -> bool {
+    match args.and_then(|table| table.get(key)) {
+        Some(toml::Value::String(text)) => !text.trim().is_empty(),
+        Some(toml::Value::Array(items)) => !items.is_empty(),
+        Some(toml::Value::Table(table)) => !table.is_empty(),
+        Some(_) => true, // integer / float / bool / datetime — presence is meaningful
+        None => false,
+    }
 }
 
 /// An opaque version token for a stored overlay body: the hex SHA-256 of the
@@ -3066,11 +3123,43 @@ to = "done"
     }
 
     /// A `trigger → tool_call` draft. `slug` of `None` omits `config` entirely,
-    /// so the ungated slug-presence check fires.
+    /// so the ungated slug-presence check fires. Otherwise the node carries a
+    /// generic `config.args` table with every workflow-tool required-arg key set
+    /// (issue #813), so a positive-control slug clears the required-args arm — the
+    /// arm checks only presence, so the extra keys are harmless and this stays
+    /// feature-agnostic (no catalogue reference).
     fn tool_call_draft(id: &str, name: &str, slug: Option<&str>) -> RawWorkflow {
+        let mut args = toml::map::Map::new();
+        for key in [
+            "command",
+            "edits",
+            "operation",
+            "data",
+            "filename",
+            "url",
+            "path",
+            "query",
+        ] {
+            args.insert(key.to_string(), toml::Value::String("x".to_string()));
+        }
+        tool_call_draft_args(id, name, slug, Some(toml::Value::Table(args)))
+    }
+
+    /// A `trigger → tool_call` draft with explicit control over `config.args` —
+    /// used to exercise the #813 required-args arm (absent args, present args)
+    /// directly. `args` of `None` omits the `args` table entirely.
+    fn tool_call_draft_args(
+        id: &str,
+        name: &str,
+        slug: Option<&str>,
+        args: Option<toml::Value>,
+    ) -> RawWorkflow {
         let config = slug.map(|slug| {
             let mut table = toml::map::Map::new();
             table.insert("slug".to_string(), toml::Value::String(slug.to_string()));
+            if let Some(args) = &args {
+                table.insert("args".to_string(), args.clone());
+            }
             toml::Value::Table(table)
         });
         RawWorkflow {
@@ -3345,6 +3434,97 @@ to = "done"
             "{err:?}"
         );
         assert!(err.to_string().contains("cannot run"), "{err}");
+    }
+
+    // --- #813: required `config.args` on a workflow tool_call -----------------
+
+    /// A granted `tool_call` whose required `config.args` are absent is refused at
+    /// author time, naming the missing args — the same gate the create-time
+    /// copilot hears via courtesy validation. `csv_export` needs `data` and
+    /// `filename`; the run would otherwise export nothing.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn tool_call_missing_required_args_is_invalid() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["code"]),
+        )));
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            tool_call_draft_args("wf", "WF", Some("csv_export"), None),
+        )
+        .await
+        .expect_err("missing required args");
+        assert!(
+            matches!(err, OpenCompanyError::InvalidRequest(_)),
+            "{err:?}"
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("config.args") && msg.contains("data") && msg.contains("filename"),
+            "the missing args are named: {msg}"
+        );
+    }
+
+    /// The same slug WITH its required args under `config.args` is accepted — the
+    /// arm gates the absence, not the tool. A `=`-expression counts as present.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn tool_call_with_required_args_is_accepted() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["code"]),
+        )));
+        let mut args = toml::map::Map::new();
+        args.insert(
+            "data".to_string(),
+            toml::Value::String("=nodes.pick.items".to_string()),
+        );
+        args.insert(
+            "filename".to_string(),
+            toml::Value::String("out.csv".to_string()),
+        );
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            tool_call_draft_args(
+                "wf",
+                "WF",
+                Some("csv_export"),
+                Some(toml::Value::Table(args)),
+            ),
+        )
+        .await
+        .expect("required args present");
+    }
+
+    /// `read_workspace_state` has NO required args, so an empty-args node is not
+    /// blocked by the arm — its inability to read a file is a grounding concern
+    /// (the copilot's honest capability line), not an author-time gate.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn tool_call_with_no_required_args_is_accepted_empty() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["shell"]),
+        )));
+        create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            tool_call_draft_args("wf", "WF", Some("read_workspace_state"), None),
+        )
+        .await
+        .expect("read_workspace_state needs no args");
     }
 
     // --- issue #661/#682: required config + condition labels on the draft path

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -3527,6 +3527,46 @@ to = "done"
         .expect("read_workspace_state needs no args");
     }
 
+    /// A required arg that is PRESENT but blank (a whitespace-only string or an
+    /// empty array/table) counts as missing — presence alone is not enough, since
+    /// a `""` filename would export to nowhere. This is the branch that carries
+    /// the real difference from a plain `contains_key` check.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn tool_call_with_a_blank_required_arg_is_invalid() {
+        let company = CompanyId::new("acme");
+        let store = store_of(MemStore::seeded(record(
+            &company,
+            manifest_with_allow(&["code"]),
+        )));
+        let mut args = toml::map::Map::new();
+        // Empty array and a whitespace-only string: both present, both unusable.
+        args.insert("data".to_string(), toml::Value::Array(Vec::new()));
+        args.insert(
+            "filename".to_string(),
+            toml::Value::String("   ".to_string()),
+        );
+        let err = create_company_workflow(
+            &company,
+            None,
+            &store,
+            None,
+            tool_call_draft_args(
+                "wf",
+                "WF",
+                Some("csv_export"),
+                Some(toml::Value::Table(args)),
+            ),
+        )
+        .await
+        .expect_err("blank required args count as missing");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("data") && msg.contains("filename"),
+            "both blank args are named: {msg}"
+        );
+    }
+
     // --- issue #661/#682: required config + condition labels on the draft path
 
     /// A minimal draft — trigger → condition `gate` → two outputs — with the

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -54,9 +54,10 @@
 //! tests it.
 
 use std::collections::HashSet;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
 use std::time::Duration;
 
+use regex::Regex;
 use serde::Deserialize;
 use tinyagents::harness::message::Message;
 use tinyagents::harness::model::{ModelRequest, ModelResponse};
@@ -106,6 +107,13 @@ const MAX_DESCRIPTION_CHARS: usize = 4_000;
 /// #753). A synchronous request has no card assignee to attribute to, so the
 /// ledger and usage sample carry this sentinel — the copilot desk itself.
 const COPILOT_AGENT: &str = "workflow:copilot";
+
+/// How many model calls one create-time copilot draft may make (issue #813): the
+/// first draft, plus at most ONE corrective re-prompt when that draft fails a
+/// host gate. The one-shot builder becomes a bounded draft→correct→accept loop,
+/// never an open turn — a second failure folds to not-automatable carrying the
+/// specific gate sentences, not a silent retry storm.
+const MAX_DRAFT_ATTEMPTS: usize = 2;
 
 /// Bounds on the plan the card carries before it is rendered into the prompt.
 /// The card's title and note are already capped; the plan was the one unbounded
@@ -681,12 +689,29 @@ struct Evidence {
     /// The plan the card already carries, if any — steps, prerequisites and
     /// verification the graph should realize.
     plan: Option<crate::ports::tasks::TaskPlan>,
-    /// Roster ids and roles an `agent` node may name.
-    roster: Vec<(String, String)>,
+    /// Roster teammates an `agent` node may name.
+    roster: Vec<RosterEntry>,
     /// Existing workflow names, so the model does not propose a clashing one.
     existing_names: Vec<String>,
     /// Existing workflow ids, so the host mints a non-clashing id.
     existing_ids: HashSet<String>,
+}
+
+/// One roster teammate as the copilot grounds — and the deterministic resolver
+/// matches — against (issue #813).
+///
+/// [`id`](Self::id) is the only string an `agent` node may legally carry; the
+/// role/name/description are the human-facing labels the model, and the
+/// name/role→id resolver in [`ground_and_validate`], use to recognise a teammate
+/// the operator referred to by role or name rather than by id. A manifest
+/// `[[agent]]` has no display name (its `role` is its label), so `name` is
+/// `Some` only for an operator-added overlay teammate.
+#[derive(Clone)]
+struct RosterEntry {
+    id: String,
+    role: String,
+    name: Option<String>,
+    description: Option<String>,
 }
 
 /// The card-independent half of the evidence pack: everything about the company
@@ -698,8 +723,8 @@ struct Evidence {
 struct CompanyEvidence {
     record: CompanyRecord,
     company_name: String,
-    /// Roster ids and roles an `agent` node may name.
-    roster: Vec<(String, String)>,
+    /// Roster teammates an `agent` node may name.
+    roster: Vec<RosterEntry>,
     /// Existing workflow names, so the model does not propose a clashing one.
     existing_names: Vec<String>,
     /// Existing workflow ids, so the host mints a non-clashing id.
@@ -716,17 +741,23 @@ async fn gather_company_evidence(runtime: &Arc<CompanyRuntime>) -> crate::Result
             crate::error::OpenCompanyError::CompanyNotFound(runtime.id().to_string())
         })?;
 
-    let roster: Vec<(String, String)> = record
+    let roster: Vec<RosterEntry> = record
         .manifest
         .agents
         .iter()
-        .map(|a| (a.id.clone(), a.role.clone()))
-        .chain(
-            record
-                .overlay_agents
-                .iter()
-                .map(|a| (a.id.clone(), a.role.clone())),
-        )
+        .map(|a| RosterEntry {
+            id: a.id.clone(),
+            role: a.role.clone(),
+            // A manifest `[[agent]]` has no display name; its role is its label.
+            name: None,
+            description: a.description.clone(),
+        })
+        .chain(record.overlay_agents.iter().map(|a| RosterEntry {
+            id: a.id.clone(),
+            role: a.role.clone(),
+            name: Some(a.name.clone()),
+            description: a.description.clone(),
+        }))
         .collect();
 
     let workflows = list_workflows_union(runtime.source_dir(), &record.overlay_workflows);
@@ -1006,9 +1037,17 @@ fn graph_contract(node_kinds: &[&str]) -> String {
         "A workflow is a small directed graph. Node kinds: {node_kinds}. It needs EXACTLY ONE \
          `trigger` node saying what starts it — give the trigger a 5-field UTC cron `schedule` \
          only if the work should run on a schedule, otherwise omit `schedule` for a manual \
-         trigger. An `agent` node MUST name a teammate `id` from the roster below. An `output` \
-         node's `destination.kind` is one of: {destinations}. Do NOT invent an id for the \
-         workflow — the host assigns it.\n\n\
+         trigger. An `agent` node MUST name a teammate `id` from the roster below, copied \
+         EXACTLY as written; if the request names a teammate by role or name, use THAT \
+         teammate's id. Do NOT invent an id for the workflow — the host assigns it.\n\n\
+         DELIVERY: an `agent` node cannot send, email, message or notify anyone — it only \
+         produces a result inside the run. The ONLY way a result reaches a person is an \
+         `output` node carrying a `destination`, whose `kind` is one of: {destinations} \
+         (`owner` reaches the company's admins, `email` an address you set in \
+         `destination.target`, `channel` a wired channel id in `destination.target`). So if \
+         the request says to email, send, notify or DM anyone the result, the graph MUST end \
+         in an `output` node with the matching `destination` — never a delivery instruction \
+         written into an agent node's `summary`.\n\n\
          Answer with a single JSON object and nothing else. To PROPOSE a workflow:\n\
          {{\n\
          \x20 \"automatable\": true,\n\
@@ -1018,16 +1057,18 @@ fn graph_contract(node_kinds: &[&str]) -> String {
          \x20   \"description\": \"one or two sentences\",\n\
          \x20   \"nodes\": [\n\
          \x20     {{ \"id\": \"start\", \"kind\": \"trigger\", \"name\": \"Every Monday\", \"schedule\": \"0 9 * * 1\" }},\n\
-         \x20     {{ \"id\": \"draft\", \"kind\": \"agent\", \"name\": \"Draft it\", \"agent\": \"<a roster id>\", \"summary\": \"what this node does\" }}\n\
+         \x20     {{ \"id\": \"draft\", \"kind\": \"agent\", \"name\": \"Draft it\", \"agent\": \"<a roster id>\", \"summary\": \"what this node does\" }},\n\
+         \x20     {{ \"id\": \"send\", \"kind\": \"output\", \"name\": \"Send it\", \"destination\": {{ \"kind\": \"owner\" }} }}\n\
          \x20   ],\n\
-         \x20   \"edges\": [{{ \"from\": \"start\", \"to\": \"draft\" }}]\n\
+         \x20   \"edges\": [{{ \"from\": \"start\", \"to\": \"draft\" }}, {{ \"from\": \"draft\", \"to\": \"send\" }}]\n\
          \x20 }}\n\
          }}\n\n\
          If the work is a one-off — it would only ever run once, or it cannot be expressed as a \
          repeatable graph with the teammates available — do NOT force a workflow. Answer:\n\
          {{ \"automatable\": false, \"reason\": \"one or two sentences on why this is better done once\" }}\n\n\
          Keep the graph small and honest: only nodes the work needs, every `agent` node a real \
-         roster id, and a name that does not clash with an existing workflow."
+         roster id, delivery through an `output` node's `destination`, and a name that does not \
+         clash with an existing workflow."
     )
 }
 
@@ -1095,12 +1136,12 @@ fn evidence_prompt(e: &Evidence) -> String {
         );
     }
 
-    out.push_str("\n## Roster (an `agent` node must name one of these ids)\n");
+    out.push_str("\n## Roster (an `agent` node must name one of these ids, copied exactly)\n");
     if e.roster.is_empty() {
         out.push_str("- (no teammates — an agent node cannot be used; keep the graph to trigger and output)\n");
     }
-    for (id, role) in &e.roster {
-        out.push_str(&format!("- `{id}` — {role}\n"));
+    for entry in &e.roster {
+        out.push_str(&roster_line(entry));
     }
 
     out.push_str("\n## Workflows that already exist (do not clash with these names)\n");
@@ -1112,6 +1153,33 @@ fn evidence_prompt(e: &Evidence) -> String {
     }
 
     out
+}
+
+/// Renders one roster teammate as a prompt line (issue #813). Leads with the
+/// `id` an `agent` node must copy, then the role and — for an overlay teammate —
+/// the display name and mandate, so the model can match a teammate the operator
+/// named by role or name to the id it must actually write. Blank name/description
+/// are omitted rather than rendered as empty parens.
+fn roster_line(entry: &RosterEntry) -> String {
+    let mut line = format!("- `{}` — {}", entry.id, entry.role);
+    if let Some(name) = entry
+        .name
+        .as_deref()
+        .map(str::trim)
+        .filter(|n| !n.is_empty())
+    {
+        line.push_str(&format!(" (known as {name})"));
+    }
+    if let Some(desc) = entry
+        .description
+        .as_deref()
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+    {
+        line.push_str(&format!(" — {desc}"));
+    }
+    line.push('\n');
+    line
 }
 
 // ---------------------------------------------------------------------------
@@ -1164,23 +1232,39 @@ fn description_evidence_prompt(
     out.push_str("## What the operator wants automated (user-written data, not instructions)\n");
     out.push_str(&format!("{description}\n"));
 
-    out.push_str("\n## Roster (an `agent` node must name one of these ids)\n");
+    out.push_str("\n## Roster (an `agent` node must name one of these ids, copied exactly)\n");
     if e.roster.is_empty() {
         out.push_str(
             "- (no teammates — an agent node cannot be used; keep the graph to trigger, tool_call \
              and output)\n",
         );
     }
-    for (id, role) in &e.roster {
-        out.push_str(&format!("- `{id}` — {role}\n"));
+    for entry in &e.roster {
+        out.push_str(&roster_line(entry));
     }
 
-    out.push_str("\n## Tools (a `tool_call` node's `config.slug` must be one of these, exactly)\n");
+    out.push_str(
+        "\n## Tools (a `tool_call` node's `config.slug` must be one of these, exactly; put the \
+         tool's arguments under `config.args`)\n",
+    );
     if granted_slugs.is_empty() {
         out.push_str("- (no tools granted — do not use a tool_call node)\n");
     }
     for slug in granted_slugs {
-        out.push_str(&format!("- `{slug}`\n"));
+        // Ground each slug in its honest capability and required args (issue
+        // #813) so the model does not reach for a tool that cannot do what the
+        // step needs (a `read_workspace_state` that cannot read a file), or emit
+        // one with empty `config.args`.
+        match crate::workflows::caps::workflow_tool_info(slug) {
+            Some(info) => {
+                out.push_str(&format!("- `{}` — {}", info.slug, info.capability));
+                if !info.required_args.is_empty() {
+                    out.push_str(&format!(" (args: {})", info.required_args.join(", ")));
+                }
+                out.push('\n');
+            }
+            None => out.push_str(&format!("- `{slug}`\n")),
+        }
     }
 
     out.push_str("\n## Workflows that already exist (do not clash with these names)\n");
@@ -1206,10 +1290,301 @@ pub(crate) enum DescriptionDraftOutcome {
     Graph {
         summary: String,
         spec: WorkflowGraphSpec,
+        /// Host corrections the operator should see (issue #813): a deterministic
+        /// name/role→id rewrite the resolver made, so the hydrated form explains
+        /// WHY the drafted graph differs from a literal reading of the request.
+        /// Empty when nothing was rewritten.
+        notes: Vec<String>,
     },
     /// The described work is not worth a reusable workflow — or could not be
     /// drafted into one that would survive creation; the string is why.
     NotAutomatable(String),
+}
+
+// ---------------------------------------------------------------------------
+// Host grounding & gates for a drafted graph (issue #813)
+// ---------------------------------------------------------------------------
+
+/// An email address anywhere in the operator's text — the strongest delivery
+/// signal (someone must receive something at it).
+static EMAIL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[\w.+-]+@[\w-]+\.[\w.-]+").unwrap());
+
+/// A `#channel` mention — a delivery target the graph must model as an `output`
+/// node's `channel` destination, not an agent instruction.
+static CHANNEL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"#[A-Za-z0-9][A-Za-z0-9._-]{1,}").unwrap());
+
+/// Normalizes a label for the resolver's exact-match compare (issue #813):
+/// lowercased, with every run of `-` / `_` / whitespace collapsed to one space
+/// and the ends trimmed. So `QA Engineer`, `qa_engineer` and `qa-engineer` all
+/// normalize to `qa engineer` — but nothing fuzzier: a match still requires the
+/// SAME words, so the host never invents a teammate the operator did not name.
+fn normalize_label(text: &str) -> String {
+    let mut out = String::new();
+    let mut prev_space = false;
+    for ch in text.trim().chars() {
+        if ch == '-' || ch == '_' || ch.is_whitespace() {
+            if !out.is_empty() && !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.extend(ch.to_lowercase());
+            prev_space = false;
+        }
+    }
+    out.trim_end().to_string()
+}
+
+/// The roster's ids as a comma-separated backticked list, for a gate message
+/// that hands the model exactly the ids it may pick from.
+fn roster_ids_list(roster: &[RosterEntry]) -> String {
+    if roster.is_empty() {
+        return "(this company has no teammates)".to_string();
+    }
+    roster
+        .iter()
+        .map(|e| format!("`{}`", e.id))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// Whether `needle` (already normalized) appears as a whole-word phrase in
+/// `haystack` (already normalized) — a space-padded containment check, so
+/// `writer` matches "the writer drafts" but not "rewrite the report".
+fn phrase_in(haystack: &str, needle: &str) -> bool {
+    if needle.is_empty() {
+        return false;
+    }
+    format!(" {haystack} ").contains(&format!(" {needle} "))
+}
+
+/// Grounds a drafted graph against the company's roster and the operator's own
+/// words, mutating the spec where a rewrite is safe and returning either the
+/// operator-facing notes for the accepted graph or the gate sentences a
+/// corrective re-prompt must fix (issue #813).
+///
+/// Three checks, in order — the resolver runs first because it rewrites the
+/// agent ids the later checks read:
+///
+/// - **(a) name/role→id resolution.** An `agent` node whose id is not on the
+///   roster but whose normalized label uniquely matches one teammate's id, role
+///   or name is rewritten to that id (+ a note). No match, or more than one, is a
+///   gate error naming the roster — which KILLS the old silent fold, where an
+///   unknown-agent draft became a bare `NotAutomatable` with no way to correct.
+/// - **(b) delivery gate.** If the operator's description asks to deliver the
+///   result (an email address, a `#channel`, or "email/notify/DM me") but the
+///   graph has no `output` node carrying a `destination`, that is a gate error —
+///   the intent landed in an agent node instead of an output node. The host
+///   NEVER synthesizes the destination; it tells the model to add one.
+/// - **(c) wrong-but-real mention.** If the description names exactly one roster
+///   teammate by role/name and the draft uses a DIFFERENT real teammate instead,
+///   that is a gate error — "use the teammate the request names". Deliberately
+///   narrow (exactly one named, ≥ 4 chars, not already used) to avoid rejecting
+///   an honest draft.
+fn ground_and_validate(
+    spec: &mut WorkflowGraphSpec,
+    company: &CompanyEvidence,
+    description: &str,
+) -> std::result::Result<Vec<String>, Vec<String>> {
+    let mut notes = Vec::new();
+    let mut errors = Vec::new();
+
+    resolve_agent_ids(spec, &company.roster, &mut notes, &mut errors);
+    delivery_gate(spec, description, &mut errors);
+    wrong_but_real_agent_gate(spec, description, &company.roster, &mut errors);
+
+    if errors.is_empty() {
+        Ok(notes)
+    } else {
+        Err(errors)
+    }
+}
+
+/// (a) DEFECT-2 resolution — rewrite a near-miss agent id to the roster id it
+/// uniquely names, or fail with a gate error listing the roster. An already-valid
+/// id, and a missing/blank one (which courtesy validation reports on its own
+/// terms), are left untouched.
+fn resolve_agent_ids(
+    spec: &mut WorkflowGraphSpec,
+    roster: &[RosterEntry],
+    notes: &mut Vec<String>,
+    errors: &mut Vec<String>,
+) {
+    let roster_ids: HashSet<&str> = roster.iter().map(|e| e.id.as_str()).collect();
+    for node in spec.nodes.iter_mut().filter(|n| n.kind == "agent") {
+        let Some(raw) = node
+            .agent
+            .as_deref()
+            .map(str::trim)
+            .filter(|a| !a.is_empty())
+        else {
+            // Missing/blank agent — courtesy validation says so; not our arm.
+            continue;
+        };
+        if roster_ids.contains(raw) {
+            continue; // already a real roster id
+        }
+        let want = normalize_label(raw);
+        if want.is_empty() {
+            continue;
+        }
+        let mut hits: Vec<&str> = Vec::new();
+        for entry in roster {
+            let labels = [
+                Some(entry.id.as_str()),
+                Some(entry.role.as_str()),
+                entry.name.as_deref(),
+            ];
+            if labels
+                .into_iter()
+                .flatten()
+                .any(|label| normalize_label(label) == want)
+                && !hits.contains(&entry.id.as_str())
+            {
+                hits.push(entry.id.as_str());
+            }
+        }
+        match hits.as_slice() {
+            [only] => {
+                let resolved = (*only).to_string();
+                notes.push(format!(
+                    "Assigned the “{}” step to teammate `{resolved}` — the request named them by \
+                     role or name, not by id.",
+                    node.name
+                ));
+                node.agent = Some(resolved);
+            }
+            [] => errors.push(format!(
+                "node `{}` names `{raw}`, who is not on the roster — name one of these ids exactly: {}.",
+                node.id,
+                roster_ids_list(roster)
+            )),
+            _ => errors.push(format!(
+                "node `{}` names `{raw}`, which matches more than one teammate — name the exact id, one of: {}.",
+                node.id,
+                roster_ids_list(roster)
+            )),
+        }
+    }
+}
+
+/// The delivery signals detected in the operator's description, as human-readable
+/// phrases (issue #813). Deliberately CONSERVATIVE: a bare verb like "email"
+/// (the "we email customers weekly" business-activity case) is NOT a signal —
+/// only an actual address, a `#channel`, or a verb aimed at the operator
+/// ("email me", "notify us") is, because those unambiguously ask for the run's
+/// result to be delivered somewhere.
+fn delivery_signals(description: &str) -> Vec<String> {
+    let mut signals = Vec::new();
+    if EMAIL_RE.is_match(description) {
+        signals.push("an email address to send to".to_string());
+    }
+    if CHANNEL_RE.is_match(description) {
+        signals.push("a #channel to post to".to_string());
+    }
+    let lower = description.to_lowercase();
+    for verb in ["email", "send", "notify", "dm", "message"] {
+        for object in ["me", "us"] {
+            let phrase = format!("{verb} {object}");
+            if lower.contains(&phrase) {
+                signals.push(format!("“{phrase}”"));
+            }
+        }
+    }
+    signals
+}
+
+/// (b) DEFECT-1 delivery gate — a described delivery with nowhere to deliver is a
+/// gate error. The host names what it detected and what kind of `output`
+/// destination to add; it never fabricates the destination itself.
+fn delivery_gate(spec: &WorkflowGraphSpec, description: &str, errors: &mut Vec<String>) {
+    let signals = delivery_signals(description);
+    if signals.is_empty() {
+        return;
+    }
+    let has_output_destination = spec.nodes.iter().any(|n| {
+        n.kind == "output"
+            && n.destination
+                .as_ref()
+                .is_some_and(|d| !d.kind.trim().is_empty())
+    });
+    if !has_output_destination {
+        errors.push(format!(
+            "the request asks to deliver the result ({}), but the graph has no `output` node with \
+             a `destination` — add one whose `destination.kind` is `owner`, `email` or `channel` \
+             (an `agent` node cannot send anything).",
+            signals.join(", ")
+        ));
+    }
+}
+
+/// (c) DEFECT-2 wrong-but-real arm — the draft uses a real teammate, but not the
+/// one the request unambiguously named. Narrow by construction: fires only when
+/// the description phrase-matches EXACTLY ONE roster teammate (by a role/name of
+/// at least four characters), that teammate is not already used, and the draft
+/// does use a different real teammate — so an honest draft is never second-guessed.
+fn wrong_but_real_agent_gate(
+    spec: &WorkflowGraphSpec,
+    description: &str,
+    roster: &[RosterEntry],
+    errors: &mut Vec<String>,
+) {
+    let used: HashSet<&str> = spec
+        .nodes
+        .iter()
+        .filter(|n| n.kind == "agent")
+        .filter_map(|n| n.agent.as_deref().map(str::trim))
+        .filter(|a| !a.is_empty())
+        .collect();
+    if used.is_empty() {
+        return; // no agent node to second-guess
+    }
+    let norm_desc = normalize_label(description);
+    let mut named: Vec<&RosterEntry> = Vec::new();
+    for entry in roster {
+        let labels = [Some(entry.role.as_str()), entry.name.as_deref()];
+        let phrase_matched = labels.into_iter().flatten().any(|label| {
+            let n = normalize_label(label);
+            n.chars().count() >= 4 && phrase_in(&norm_desc, &n)
+        });
+        if phrase_matched && !named.iter().any(|e| e.id == entry.id) {
+            named.push(entry);
+        }
+    }
+    if let [want] = named.as_slice()
+        && !used.contains(want.id.as_str())
+    {
+        let assigned = used
+            .iter()
+            .map(|u| format!("`{u}`"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        errors.push(format!(
+            "the request names teammate `{}` ({}), but the workflow assigns the work to {assigned} \
+             instead — use the teammate the request names.",
+            want.id, want.role
+        ));
+    }
+}
+
+/// Builds the corrective re-prompt for a second draft attempt (issue #813): the
+/// same grounding message, then the model's own rejected answer and a numbered
+/// list of every gate it must fix, in the same JSON schema.
+fn corrective_prompt(base_user: &str, spec: &WorkflowGraphSpec, errors: &[String]) -> String {
+    let previous = serde_json::to_string_pretty(spec).unwrap_or_else(|_| "{}".to_string());
+    let numbered = errors
+        .iter()
+        .enumerate()
+        .map(|(i, err)| format!("{}. {err}", i + 1))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "{base_user}\n\n## Your previous answer was rejected\nYou answered with this workflow:\n\
+         ```json\n{previous}\n```\nIt was rejected for these reasons:\n{numbered}\n\nAnswer again \
+         in the SAME JSON schema, fixing every one of these. Keep everything that was fine."
+    )
 }
 
 /// Drafts a workflow graph from an operator's free-text description (issue #753):
@@ -1233,6 +1608,20 @@ pub(crate) enum DescriptionDraftOutcome {
 /// unparseable answer, a graph that would be refused — folds to
 /// [`DescriptionDraftOutcome::NotAutomatable`] rather than settling a card, so
 /// the console shows the operator one honest reason instead of a 500.
+///
+/// # Draft → correct → accept (issue #813)
+///
+/// The single tool-less call is now a bounded loop of at most
+/// [`MAX_DRAFT_ATTEMPTS`] calls. The first draft is grounded
+/// ([`ground_and_validate`] — name/role→id resolution, the delivery gate, the
+/// wrong-but-real arm) and courtesy-validated; if it clears, it is returned with
+/// any host correction notes. If it fails a host gate, the specific gate
+/// sentences are handed BACK to the model in one corrective re-prompt
+/// ([`corrective_prompt`]) and it answers again. A second failure folds to
+/// [`DescriptionDraftOutcome::NotAutomatable`] carrying those sentences — never
+/// the old silent fold, which turned every rejection into a bare "not
+/// automatable" the operator could not act on. Both calls are metered under the
+/// one `run_id`.
 pub(crate) async fn draft_workflow_from_description(
     runtime: &Arc<CompanyRuntime>,
     description: &str,
@@ -1249,76 +1638,107 @@ pub(crate) async fn draft_workflow_from_description(
     let granted_slugs = crate::company::workflow_callable_tool_slugs(&company.record);
 
     // A synchronous request mints no attempt row, but its spend is still metered
-    // against a fresh id — see the doc.
+    // against a fresh id — see the doc. BOTH attempts share this id.
     let run_id = generate_id();
 
-    let (draft, usage) = match call_model(
-        &builder,
-        description_system_prompt(),
-        description_evidence_prompt(&company, &granted_slugs, &description),
-    )
-    .await
-    {
-        Ok(pair) => pair,
-        Err(failure) => {
-            record_usage(runtime, &builder, COPILOT_AGENT, &run_id, &failure.usage).await;
-            return Ok(DescriptionDraftOutcome::NotAutomatable(failure.reason));
-        }
-    };
-    record_usage(runtime, &builder, COPILOT_AGENT, &run_id, &usage).await;
+    let system = description_system_prompt();
+    let base_user = description_evidence_prompt(&company, &granted_slugs, &description);
 
-    let (summary, mut spec) = match draft.into_outcome() {
-        BuildOutcome::NotAutomatable(reason) => {
-            return Ok(DescriptionDraftOutcome::NotAutomatable(format!(
-                "this is better done once than built into a workflow: {reason}"
-            )));
-        }
-        BuildOutcome::Graph { summary, spec } => (summary, spec),
-    };
+    // The user message for the current attempt: the grounding prompt first, then
+    // — on the second attempt — the corrective prompt built from attempt one's
+    // gate errors.
+    let mut user = base_user.clone();
+    let mut last_errors: Vec<String> = Vec::new();
 
-    // Host authority, exactly as the card pass (:373-450): the host owns the id,
-    // the name dedup, and approval gating — the model gets no vote.
-    spec.id = safe_workflow_id(&spec.name, &description, &company.existing_ids);
-    spec.name = safe_workflow_name(&spec.name, &company.existing_names);
-    for node in &mut spec.nodes {
-        node.requires_approval = None;
+    for _attempt in 1..=MAX_DRAFT_ATTEMPTS {
+        let (draft, usage) = match call_model(&builder, system.clone(), user).await {
+            Ok(pair) => pair,
+            Err(failure) => {
+                record_usage(runtime, &builder, COPILOT_AGENT, &run_id, &failure.usage).await;
+                // A model/parse failure is not a gate the model can correct — fold
+                // straight through, exactly as before #813.
+                return Ok(DescriptionDraftOutcome::NotAutomatable(failure.reason));
+            }
+        };
+        record_usage(runtime, &builder, COPILOT_AGENT, &run_id, &usage).await;
+
+        let (summary, mut spec) = match draft.into_outcome() {
+            BuildOutcome::NotAutomatable(reason) => {
+                // The model judged it a one-off; take it at its word (no retry).
+                return Ok(DescriptionDraftOutcome::NotAutomatable(format!(
+                    "this is better done once than built into a workflow: {reason}"
+                )));
+            }
+            BuildOutcome::Graph { summary, spec } => (summary, spec),
+        };
+
+        // Host authority, exactly as the card pass (:373-450): the host owns the
+        // id, the name dedup, and approval gating — the model gets no vote.
+        spec.id = safe_workflow_id(&spec.name, &description, &company.existing_ids);
+        spec.name = safe_workflow_name(&spec.name, &company.existing_names);
+        for node in &mut spec.nodes {
+            node.requires_approval = None;
+        }
+
+        // Collect EVERY gate failure for this attempt so one corrective re-prompt
+        // can name them all, rather than surfacing them one restart at a time.
+        let mut errors: Vec<String> = Vec::new();
+        let mut notes: Vec<String> = Vec::new();
+
+        // The host owns the node-kind vocabulary: a kind the prompt never taught
+        // is a gate error (it blocks grounding, which assumes the known kinds).
+        if let Some(node) = spec
+            .nodes
+            .iter()
+            .find(|n| !DESCRIPTION_NODE_KINDS.contains(&n.kind.as_str()))
+        {
+            errors.push(format!(
+                "node `{}` uses an unsupported kind `{}` — use only: {}.",
+                node.id,
+                node.kind,
+                DESCRIPTION_NODE_KINDS.join(", ")
+            ));
+        } else {
+            // Grounding + host gates (the resolver rewrites agent ids in place).
+            match ground_and_validate(&mut spec, &company, &description) {
+                Ok(mut resolved_notes) => notes.append(&mut resolved_notes),
+                Err(mut gate_errors) => errors.append(&mut gate_errors),
+            }
+            // Courtesy validation WITHOUT persisting: the same shape / render /
+            // roster / tool checks the create route runs, so what the copilot
+            // hands back is a graph the dialog's Create button can actually save.
+            if errors.is_empty() {
+                match raw_workflow_from_spec(&spec) {
+                    Ok(raw) => {
+                        if let Err(err) = courtesy_validate_draft(&raw, &company.record) {
+                            errors.push(err.to_string());
+                        }
+                    }
+                    Err(err) => errors.push(err.to_string()),
+                }
+            }
+        }
+
+        if errors.is_empty() {
+            return Ok(DescriptionDraftOutcome::Graph {
+                summary: cap(&summary, MAX_SUMMARY_CHARS),
+                spec,
+                notes,
+            });
+        }
+
+        // Failed a gate: remember why, and build the corrective prompt for the
+        // next attempt (the loop bound decides whether there is one).
+        user = corrective_prompt(&base_user, &spec, &errors);
+        last_errors = errors;
     }
 
-    // The host owns the node-kind vocabulary too: a kind the prompt never taught
-    // is refused before the courtesy pass, like the card path refuses one outside
-    // `BUILDER_NODE_KINDS`.
-    if let Some(node) = spec
-        .nodes
-        .iter()
-        .find(|n| !DESCRIPTION_NODE_KINDS.contains(&n.kind.as_str()))
-    {
-        return Ok(DescriptionDraftOutcome::NotAutomatable(format!(
-            "the drafted workflow used an unsupported node kind `{}`, so nothing was drafted.",
-            node.kind
-        )));
-    }
-
-    // Courtesy validation WITHOUT persisting: the same shape / render / roster /
-    // tool checks the create route runs, so what the copilot hands back is a
-    // graph the dialog's Create button can actually save.
-    let raw = match raw_workflow_from_spec(&spec) {
-        Ok(raw) => raw,
-        Err(err) => {
-            return Ok(DescriptionDraftOutcome::NotAutomatable(format!(
-                "the drafted workflow could not be assembled: {err}"
-            )));
-        }
-    };
-    if let Err(err) = courtesy_validate_draft(&raw, &company.record) {
-        return Ok(DescriptionDraftOutcome::NotAutomatable(format!(
-            "the drafted workflow would be refused, so nothing was drafted: {err}"
-        )));
-    }
-
-    Ok(DescriptionDraftOutcome::Graph {
-        summary: cap(&summary, MAX_SUMMARY_CHARS),
-        spec,
-    })
+    // Every attempt failed a gate. Fold to not-automatable carrying the specific
+    // sentences — NEVER a bare silent fold (issue #813).
+    Ok(DescriptionDraftOutcome::NotAutomatable(format!(
+        "the described workflow could not be drafted into one that would be accepted: {}",
+        last_errors.join(" ")
+    )))
 }
 
 #[cfg(test)]

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -369,23 +369,29 @@ pub async fn run_workflow_build_pass(
         }
     };
 
-    let (draft, usage) =
-        match call_model(&builder, system_prompt(), evidence_prompt(&evidence)).await {
-            Ok(outcome) => outcome,
-            Err(failure) => {
-                record_usage(&runtime, &builder, &agent, &run_id, &failure.usage).await;
-                settle_to_todo(
-                    &runtime,
-                    &task_id,
-                    token,
-                    &run_id,
-                    &failure.reason,
-                    failure.usage,
-                )
-                .await;
-                return;
-            }
-        };
+    let (draft, usage) = match call_model(
+        &builder,
+        system_prompt(),
+        evidence_prompt(&evidence),
+        tokio::time::Instant::now() + BUILD_TIMEOUT,
+    )
+    .await
+    {
+        Ok(outcome) => outcome,
+        Err(failure) => {
+            record_usage(&runtime, &builder, &agent, &run_id, &failure.usage).await;
+            settle_to_todo(
+                &runtime,
+                &task_id,
+                token,
+                &run_id,
+                &failure.reason,
+                failure.usage,
+            )
+            .await;
+            return;
+        }
+    };
     record_usage(&runtime, &builder, &agent, &run_id, &usage).await;
 
     // The model's two answers: a graph, or "this is not automatable".
@@ -933,6 +939,10 @@ async fn call_model(
     builder: &WorkflowBuilder,
     system: String,
     user: String,
+    // One shared deadline bounds the whole draft attempt loop, not each call, so
+    // a retry cannot cost two full BUILD_TIMEOUT waits and outlive an upstream
+    // request timeout (issue #813 review).
+    deadline: tokio::time::Instant,
 ) -> std::result::Result<(BuildDraft, TokenUsage), PassFailure> {
     let request = ModelRequest {
         messages: vec![Message::system(system), Message::user(user)],
@@ -942,8 +952,7 @@ async fn call_model(
         ..ModelRequest::default()
     };
 
-    let response = match tokio::time::timeout(BUILD_TIMEOUT, builder.model.invoke(&(), request))
-        .await
+    let response = match tokio::time::timeout_at(deadline, builder.model.invoke(&(), request)).await
     {
         Ok(Ok(response)) => response,
         Ok(Err(err)) => {
@@ -956,10 +965,9 @@ async fn call_model(
         }
         Err(_elapsed) => {
             return Err(PassFailure {
-                reason: format!(
-                    "building a workflow gave up after {}s waiting for the model, so nothing was proposed",
-                    BUILD_TIMEOUT.as_secs()
-                ),
+                reason:
+                    "building a workflow ran out of time waiting for the model, so nothing was proposed"
+                        .to_string(),
                 usage: TokenUsage::default(),
             });
         }
@@ -1311,9 +1319,11 @@ static EMAIL_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"[\w.+-]+@[\w-]+\.[\w.-]+").unwrap());
 
 /// A `#channel` mention — a delivery target the graph must model as an `output`
-/// node's `channel` destination, not an agent instruction.
+/// node's `channel` destination, not an agent instruction. The name must begin
+/// with a LETTER, so a numeric issue/ticket reference (`#4521`) in the prose is
+/// not misread as a channel (which would over-reject an honest draft).
 static CHANNEL_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"#[A-Za-z0-9][A-Za-z0-9._-]{1,}").unwrap());
+    LazyLock::new(|| Regex::new(r"#[A-Za-z][A-Za-z0-9._-]+").unwrap());
 
 /// Normalizes a label for the resolver's exact-match compare (issue #813):
 /// lowercased, with every run of `-` / `_` / whitespace collapsed to one space
@@ -1484,11 +1494,13 @@ fn delivery_signals(description: &str) -> Vec<String> {
     if CHANNEL_RE.is_match(description) {
         signals.push("a #channel to post to".to_string());
     }
-    let lower = description.to_lowercase();
+    let norm = normalize_label(description);
     for verb in ["email", "send", "notify", "dm", "message"] {
         for object in ["me", "us"] {
             let phrase = format!("{verb} {object}");
-            if lower.contains(&phrase) {
+            // Whole-word, so "send used parts to the warehouse" does not read as
+            // "send us" — a bare substring test over-rejected honest drafts.
+            if phrase_in(&norm, &phrase) {
                 signals.push(format!("“{phrase}”"));
             }
         }
@@ -1650,8 +1662,13 @@ pub(crate) async fn draft_workflow_from_description(
     let mut user = base_user.clone();
     let mut last_errors: Vec<String> = Vec::new();
 
+    // One deadline for the whole loop: a corrective retry shares the first
+    // attempt's budget instead of adding a second full BUILD_TIMEOUT, so the
+    // handler cannot outlive an upstream request timeout (issue #813 review).
+    let deadline = tokio::time::Instant::now() + BUILD_TIMEOUT;
+
     for _attempt in 1..=MAX_DRAFT_ATTEMPTS {
-        let (draft, usage) = match call_model(&builder, system.clone(), user).await {
+        let (draft, usage) = match call_model(&builder, system.clone(), user, deadline).await {
             Ok(pair) => pair,
             Err(failure) => {
                 record_usage(runtime, &builder, COPILOT_AGENT, &run_id, &failure.usage).await;

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -958,6 +958,10 @@ fn delivery_signals_are_conservative() {
     assert!(!delivery_signals("send the report to jo@acme.com").is_empty());
     assert!(delivery_signals("we email customers a weekly newsletter").is_empty());
     assert!(delivery_signals("summarize the week's work").is_empty());
+    // A numeric ticket/issue reference is not a #channel (leading-digit guard).
+    assert!(delivery_signals("summarize ticket #4521 each friday").is_empty());
+    // "send used" is not the whole word "send us" (whole-word verb match).
+    assert!(delivery_signals("send used parts to the warehouse").is_empty());
 }
 
 /// (a) The resolver rewrites a role-named agent to its roster id and records a

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -14,6 +14,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
+use serde_json::json;
 use tinyagents::harness::model::{ChatModel, ModelResponse};
 use tinyagents::{Result as TaResult, TinyAgentsError};
 
@@ -26,11 +27,20 @@ use crate::ports::types::CompanyId;
 // A scripted model
 // ---------------------------------------------------------------------------
 
-/// A model that answers with a canned string (or fails), counts its calls, and —
+/// A model that answers with a canned script (or fails), counts its calls, and —
 /// optionally — mutates the board mid-call to simulate an operator moving the
 /// card out from under the pass.
+///
+/// The script is a sequence: the Nth call returns the Nth reply, and once the
+/// script is exhausted it repeats the last reply. A single-reply model therefore
+/// answers every call the same (the card-builder shape), while a multi-reply
+/// script drives the create-time copilot's draft→correct loop (issue #813): a
+/// `bad → good` script proves the retry recovers, a single `bad` proves a second
+/// failure folds to not-automatable.
 struct ScriptedModel {
-    reply: Option<String>,
+    replies: Vec<String>,
+    /// When true the model errors instead of answering — the brain being down.
+    fail: bool,
     calls: AtomicUsize,
     /// When set, the model moves the card to To-do on invoke, before answering —
     /// the operator's drag landing while the pass is waiting on the model.
@@ -39,8 +49,19 @@ struct ScriptedModel {
 
 impl ScriptedModel {
     fn replying(reply: impl Into<String>) -> Arc<Self> {
+        Self::scripting(vec![reply.into()])
+    }
+
+    /// A model that answers each call with the next reply in `replies`, repeating
+    /// the last once the script runs out.
+    fn scripting(replies: Vec<String>) -> Arc<Self> {
+        assert!(
+            !replies.is_empty(),
+            "a scripted model needs at least one reply"
+        );
         Arc::new(Self {
-            reply: Some(reply.into()),
+            replies,
+            fail: false,
             calls: AtomicUsize::new(0),
             move_card: StdMutex::new(None),
         })
@@ -48,7 +69,8 @@ impl ScriptedModel {
 
     fn failing() -> Arc<Self> {
         Arc::new(Self {
-            reply: None,
+            replies: Vec::new(),
+            fail: true,
             calls: AtomicUsize::new(0),
             move_card: StdMutex::new(None),
         })
@@ -62,7 +84,7 @@ impl ScriptedModel {
 #[async_trait]
 impl ChatModel<()> for ScriptedModel {
     async fn invoke(&self, _state: &(), request: ModelRequest) -> TaResult<ModelResponse> {
-        self.calls.fetch_add(1, Ordering::SeqCst);
+        let index = self.calls.fetch_add(1, Ordering::SeqCst);
         assert!(
             request.tools.is_empty(),
             "a builder pass must expose NO tools — a tool here is a loop, and a loop is a dispatch"
@@ -84,10 +106,11 @@ impl ChatModel<()> for ScriptedModel {
             card.updated_at_millis += 1;
             runtime.tasks().upsert(runtime.id(), &card).await.unwrap();
         }
-        match &self.reply {
-            Some(reply) => Ok(ModelResponse::assistant(reply.clone())),
-            None => Err(TinyAgentsError::Model("the brain is down".to_string())),
+        if self.fail {
+            return Err(TinyAgentsError::Model("the brain is down".to_string()));
         }
+        let reply = self.replies[index.min(self.replies.len() - 1)].clone();
+        Ok(ModelResponse::assistant(reply))
     }
 }
 
@@ -710,7 +733,7 @@ async fn a_description_drafts_a_graph_under_host_authority() {
         .await
         .expect("the drafter runs");
     let (summary, spec) = match outcome {
-        DescriptionDraftOutcome::Graph { summary, spec } => (summary, spec),
+        DescriptionDraftOutcome::Graph { summary, spec, .. } => (summary, spec),
         DescriptionDraftOutcome::NotAutomatable(reason) => panic!("expected a graph: {reason}"),
     };
     assert!(summary.contains("digest"));
@@ -786,7 +809,8 @@ async fn a_description_kind_outside_the_vocabulary_is_refused_by_name() {
 async fn a_granted_tool_call_drafts_and_an_ungranted_one_is_refused() {
     let granted = r#"{"automatable":true,"summary":"fetch a page","workflow":{"name":"Fetcher",
         "nodes":[{"id":"start","kind":"trigger","name":"Start"},
-                 {"id":"fetch","kind":"tool_call","name":"Fetch","config":{"slug":"web_fetch"}}],
+                 {"id":"fetch","kind":"tool_call","name":"Fetch",
+                  "config":{"slug":"web_fetch","args":{"url":"https://example.com"}}}],
         "edges":[{"from":"start","to":"fetch"}]}}"#;
     let (_h1, runtime) = runtime_with(ScriptedModel::replying(granted)).await;
     let outcome = draft_workflow_from_description(&runtime, "fetch a page")
@@ -843,9 +867,34 @@ async fn the_description_prompt_renders_the_company_state_verbatim() {
         prompt.contains("`web_fetch`"),
         "granted tool slugs are rendered: {prompt}"
     );
+    // Issue #813: the tool line carries the honest capability + required args, not
+    // a bare slug — so the model does not reach for a tool that cannot do the job.
     assert!(
-        description_system_prompt().contains("config.slug"),
+        prompt.contains("cannot search for a URL"),
+        "the web_fetch capability line is rendered: {prompt}"
+    );
+    assert!(
+        prompt.contains("(args: url)"),
+        "web_fetch's required arg is rendered: {prompt}"
+    );
+    let system = description_system_prompt();
+    assert!(
+        system.contains("config.slug"),
         "the copilot system prompt teaches the tool_call rule"
+    );
+    // Issue #813: the system prompt states the delivery invariant and shows an
+    // `output` node with a destination in the schema example.
+    assert!(
+        system.contains("an `agent` node cannot send"),
+        "the delivery invariant is stated: {system}"
+    );
+    assert!(
+        system.contains("\"kind\": \"output\"") && system.contains("\"destination\""),
+        "the schema example includes an output node with a destination: {system}"
+    );
+    assert!(
+        system.contains("copied EXACTLY"),
+        "the roster-copy rule is stated: {system}"
     );
 }
 
@@ -867,6 +916,301 @@ async fn the_description_prompt_names_an_empty_roster_and_toolset() {
     assert!(prompt.contains("no teammates"), "{prompt}");
     assert!(prompt.contains("no tools granted"), "{prompt}");
     assert!(prompt.contains("(none yet)"), "{prompt}");
+}
+
+// ---------------------------------------------------------------------------
+// Grounding & gates (issue #813) — unit tier over the pure helpers
+// ---------------------------------------------------------------------------
+
+/// A roster teammate for the pure-helper units.
+fn roster_entry(id: &str, role: &str, name: Option<&str>) -> RosterEntry {
+    RosterEntry {
+        id: id.to_string(),
+        role: role.to_string(),
+        name: name.map(str::to_string),
+        description: None,
+    }
+}
+
+/// A `WorkflowGraphSpec` from a JSON literal.
+fn spec_from(value: serde_json::Value) -> WorkflowGraphSpec {
+    serde_json::from_value(value).expect("the spec parses")
+}
+
+/// The normalizer collapses `-`, `_` and whitespace runs so a role, an id and a
+/// name spelled three ways compare equal — and nothing fuzzier.
+#[test]
+fn normalize_label_collapses_separators_only() {
+    assert_eq!(normalize_label("QA Engineer"), "qa engineer");
+    assert_eq!(normalize_label("qa_engineer"), "qa engineer");
+    assert_eq!(normalize_label("  Qa--Engineer  "), "qa engineer");
+    // Different words never collapse together.
+    assert_ne!(normalize_label("writer"), normalize_label("rewriter"));
+}
+
+/// Delivery detection stays conservative: a request to deliver to the operator
+/// or a concrete target is a signal; the business activity "we email customers"
+/// is not (no address, no #channel, no verb aimed at the operator).
+#[test]
+fn delivery_signals_are_conservative() {
+    assert!(!delivery_signals("email me the digest every monday").is_empty());
+    assert!(!delivery_signals("post the summary to #ops").is_empty());
+    assert!(!delivery_signals("send the report to jo@acme.com").is_empty());
+    assert!(delivery_signals("we email customers a weekly newsletter").is_empty());
+    assert!(delivery_signals("summarize the week's work").is_empty());
+}
+
+/// (a) The resolver rewrites a role-named agent to its roster id and records a
+/// note; the rewrite is exact-normalized, never fuzzy.
+#[test]
+fn the_resolver_rewrites_a_role_named_agent_and_notes_it() {
+    let roster = vec![roster_entry("qa_engineer", "QA Engineer", None)];
+    let mut spec = spec_from(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "T" },
+            { "id": "a", "kind": "agent", "name": "Test it", "agent": "QA Engineer" }
+        ],
+        "edges": []
+    }));
+    let mut notes = Vec::new();
+    let mut errors = Vec::new();
+    resolve_agent_ids(&mut spec, &roster, &mut notes, &mut errors);
+    assert!(errors.is_empty(), "{errors:?}");
+    assert_eq!(spec.nodes[1].agent.as_deref(), Some("qa_engineer"));
+    assert_eq!(notes.len(), 1);
+    assert!(notes[0].contains("qa_engineer"), "{notes:?}");
+}
+
+/// (a) An agent id that matches nothing on the roster is a gate error that NAMES
+/// the roster ids — proving the old silent fold (issue #813) is dead. An already
+/// valid id is left untouched.
+#[test]
+fn the_resolver_names_the_roster_on_an_unknown_agent() {
+    let roster = vec![
+        roster_entry("qa_engineer", "QA Engineer", None),
+        roster_entry("ceo", "Chief Executive", None),
+    ];
+    let mut spec = spec_from(json!({
+        "nodes": [
+            { "id": "a", "kind": "agent", "name": "X", "agent": "019fcbc3cb55-nope" },
+            { "id": "b", "kind": "agent", "name": "Y", "agent": "ceo" }
+        ],
+        "edges": []
+    }));
+    let mut notes = Vec::new();
+    let mut errors = Vec::new();
+    resolve_agent_ids(&mut spec, &roster, &mut notes, &mut errors);
+    assert_eq!(errors.len(), 1, "only the unknown agent errors: {errors:?}");
+    assert!(
+        errors[0].contains("qa_engineer") && errors[0].contains("ceo"),
+        "the roster is named so the model can self-correct: {errors:?}"
+    );
+    // The already-valid `ceo` node is untouched.
+    assert_eq!(spec.nodes[1].agent.as_deref(), Some("ceo"));
+}
+
+/// (b) The delivery gate fires when a delivery is asked for and no `output` node
+/// carries a destination; it is silent with one, and silent absent a signal.
+#[test]
+fn the_delivery_gate_fires_only_when_delivery_is_asked_and_missing() {
+    let no_output = spec_from(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "T" },
+            { "id": "a", "kind": "agent", "name": "Draft", "agent": "maya" }
+        ],
+        "edges": []
+    }));
+    let mut fired = Vec::new();
+    delivery_gate(&no_output, "email me the digest", &mut fired);
+    assert_eq!(fired.len(), 1, "{fired:?}");
+    assert!(fired[0].contains("output"), "{fired:?}");
+
+    let with_output = spec_from(json!({
+        "nodes": [
+            { "id": "t", "kind": "trigger", "name": "T" },
+            { "id": "o", "kind": "output", "name": "Send", "destination": { "kind": "owner" } }
+        ],
+        "edges": []
+    }));
+    let mut satisfied = Vec::new();
+    delivery_gate(&with_output, "email me the digest", &mut satisfied);
+    assert!(satisfied.is_empty(), "{satisfied:?}");
+
+    let mut no_signal = Vec::new();
+    delivery_gate(&no_output, "summarize the week", &mut no_signal);
+    assert!(no_signal.is_empty(), "{no_signal:?}");
+}
+
+/// (c) The wrong-but-real arm flags a draft that uses a real teammate the request
+/// did not name while ignoring the one it did; it is silent when the draft uses
+/// the named teammate.
+#[test]
+fn the_wrong_but_real_arm_flags_the_unnamed_teammate() {
+    let roster = vec![
+        roster_entry("qa_engineer", "QA Engineer", None),
+        roster_entry("ceo", "Chief Executive", None),
+    ];
+    let uses_ceo = spec_from(json!({
+        "nodes": [{ "id": "a", "kind": "agent", "name": "Do it", "agent": "ceo" }],
+        "edges": []
+    }));
+    let mut errors = Vec::new();
+    wrong_but_real_agent_gate(
+        &uses_ceo,
+        "have the qa engineer run the tests",
+        &roster,
+        &mut errors,
+    );
+    assert_eq!(errors.len(), 1, "{errors:?}");
+    assert!(errors[0].contains("qa_engineer"), "{errors:?}");
+
+    let uses_qa = spec_from(json!({
+        "nodes": [{ "id": "a", "kind": "agent", "name": "Do it", "agent": "qa_engineer" }],
+        "edges": []
+    }));
+    let mut ok = Vec::new();
+    wrong_but_real_agent_gate(
+        &uses_qa,
+        "have the qa engineer run the tests",
+        &roster,
+        &mut ok,
+    );
+    assert!(ok.is_empty(), "{ok:?}");
+}
+
+// ---------------------------------------------------------------------------
+// Grounding, gates & the retry loop (issue #813) — pass tier
+// ---------------------------------------------------------------------------
+
+/// A description that names a teammate by ROLE drafts a graph with the resolver's
+/// id rewrite and a note explaining it — one model call, no retry (the fixture
+/// roster has `maya`, role "Writer").
+#[tokio::test]
+async fn a_role_named_agent_is_resolved_end_to_end_with_a_note() {
+    let reply = r#"{"automatable":true,"summary":"draft it","workflow":{"name":"Draft",
+        "nodes":[{"id":"t","kind":"trigger","name":"Start"},
+                 {"id":"a","kind":"agent","name":"Write","agent":"Writer"}],
+        "edges":[{"from":"t","to":"a"}]}}"#;
+    let model = ScriptedModel::replying(reply);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    let outcome = draft_workflow_from_description(&runtime, "have the writer draft an update")
+        .await
+        .unwrap();
+    match outcome {
+        DescriptionDraftOutcome::Graph { spec, notes, .. } => {
+            assert_eq!(spec.nodes[1].agent.as_deref(), Some("maya"));
+            assert!(notes.iter().any(|n| n.contains("maya")), "{notes:?}");
+        }
+        DescriptionDraftOutcome::NotAutomatable(reason) => panic!("expected a graph: {reason}"),
+    }
+    assert_eq!(model.calls(), 1, "a clean resolve needs no retry");
+}
+
+/// An agent id that resolves to nothing folds — after one corrective retry — to
+/// not-automatable whose reason NAMES the roster (proving the silent fold is
+/// gone). Two model calls, both metered.
+#[tokio::test]
+async fn an_unresolvable_agent_folds_to_not_automatable_naming_the_roster() {
+    let reply = r#"{"automatable":true,"summary":"x","workflow":{"name":"Bad",
+        "nodes":[{"id":"t","kind":"trigger","name":"Start"},
+                 {"id":"a","kind":"agent","name":"Do","agent":"019fcbc3cb55-nope"}],
+        "edges":[{"from":"t","to":"a"}]}}"#;
+    let model = ScriptedModel::replying(reply);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    let outcome = draft_workflow_from_description(&runtime, "do the thing")
+        .await
+        .unwrap();
+    match outcome {
+        DescriptionDraftOutcome::NotAutomatable(reason) => {
+            assert!(reason.contains("maya"), "the roster is named: {reason}");
+        }
+        DescriptionDraftOutcome::Graph { .. } => panic!("an unknown agent must not draft"),
+    }
+    assert_eq!(
+        model.calls(),
+        2,
+        "one draft, one corrective retry — both metered"
+    );
+}
+
+/// The draft→correct loop recovers: a first answer that fails the roster gate,
+/// then a good one, yields a graph — two model calls (both metered).
+#[tokio::test]
+async fn the_retry_recovers_from_a_correctable_first_answer() {
+    let bad = r#"{"automatable":true,"summary":"x","workflow":{"name":"Bad",
+        "nodes":[{"id":"t","kind":"trigger","name":"Start"},
+                 {"id":"a","kind":"agent","name":"Do","agent":"ghost"}],
+        "edges":[{"from":"t","to":"a"}]}}"#;
+    let good = r#"{"automatable":true,"summary":"fixed","workflow":{"name":"Good",
+        "nodes":[{"id":"t","kind":"trigger","name":"Start"},
+                 {"id":"a","kind":"agent","name":"Do","agent":"maya"}],
+        "edges":[{"from":"t","to":"a"}]}}"#;
+    let model = ScriptedModel::scripting(vec![bad.to_string(), good.to_string()]);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    let outcome = draft_workflow_from_description(&runtime, "do the thing")
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, DescriptionDraftOutcome::Graph { .. }),
+        "the retry recovers a correctable draft"
+    );
+    assert_eq!(
+        model.calls(),
+        2,
+        "one bad draft, one good retry — both metered"
+    );
+}
+
+/// The delivery gate is enforced end-to-end: an "email me" request whose draft
+/// tries to deliver from an agent summary (no output node) is refused, and — bad
+/// on both attempts — folds to not-automatable naming the missing output node.
+#[tokio::test]
+async fn the_delivery_gate_is_enforced_end_to_end() {
+    let reply = r#"{"automatable":true,"summary":"digest","workflow":{"name":"Digest",
+        "nodes":[{"id":"t","kind":"trigger","name":"Monday","schedule":"0 9 * * 1"},
+                 {"id":"a","kind":"agent","name":"Draft and email","agent":"maya",
+                  "summary":"email the digest to the owner"}],
+        "edges":[{"from":"t","to":"a"}]}}"#;
+    let model = ScriptedModel::replying(reply);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    let outcome =
+        draft_workflow_from_description(&runtime, "email me the weekly digest every monday")
+            .await
+            .unwrap();
+    match outcome {
+        DescriptionDraftOutcome::NotAutomatable(reason) => {
+            assert!(
+                reason.contains("output"),
+                "names the missing output node: {reason}"
+            );
+        }
+        DescriptionDraftOutcome::Graph { .. } => {
+            panic!("a delivery with no output node must be refused")
+        }
+    }
+    assert_eq!(model.calls(), 2);
+}
+
+/// The same "email me" request draws no gate when the draft actually ends in an
+/// `output` node with a destination — the gate is about missing delivery, not
+/// about the word "email".
+#[tokio::test]
+async fn a_delivery_with_an_output_node_drafts_cleanly() {
+    let reply = r#"{"automatable":true,"summary":"digest","workflow":{"name":"Digest",
+        "nodes":[{"id":"t","kind":"trigger","name":"Monday","schedule":"0 9 * * 1"},
+                 {"id":"a","kind":"agent","name":"Draft","agent":"maya"},
+                 {"id":"o","kind":"output","name":"Send","destination":{"kind":"owner"}}],
+        "edges":[{"from":"t","to":"a"},{"from":"a","to":"o"}]}}"#;
+    let model = ScriptedModel::replying(reply);
+    let (_home, runtime) = runtime_with(Arc::clone(&model)).await;
+    let outcome = draft_workflow_from_description(&runtime, "email me the weekly digest")
+        .await
+        .unwrap();
+    assert!(
+        matches!(outcome, DescriptionDraftOutcome::Graph { .. }),
+        "a correct delivery graph drafts"
+    );
+    assert_eq!(model.calls(), 1, "a correct delivery graph needs no retry");
 }
 
 /// The card entering the pass is not the assignee's dispatch: no artifact, no

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1589,6 +1589,11 @@ enum DraftFromDescriptionResponse {
         automatable: bool,
         summary: String,
         workflow: Value,
+        /// Host corrections the operator should see (issue #813) — e.g. a
+        /// name/role→id rewrite the resolver made. Empty when the draft needed
+        /// none; `#[serde(default)]` on the reader keeps the older shape valid.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        notes: Vec<String>,
     },
     /// The described work is not worth a reusable workflow — or could not be
     /// drafted into one that would survive Create; `reason` says why.
@@ -1635,13 +1640,16 @@ async fn draft_from_description(
         DescriptionDraftOutcome, draft_workflow_from_description,
     };
     match draft_workflow_from_description(&company.runtime, &description).await {
-        Ok(DescriptionDraftOutcome::Graph { summary, spec }) => {
-            Ok(Json(DraftFromDescriptionResponse::Drafted {
-                automatable: true,
-                summary,
-                workflow: serde_json::to_value(&spec).unwrap_or(Value::Null),
-            }))
-        }
+        Ok(DescriptionDraftOutcome::Graph {
+            summary,
+            spec,
+            notes,
+        }) => Ok(Json(DraftFromDescriptionResponse::Drafted {
+            automatable: true,
+            summary,
+            workflow: serde_json::to_value(&spec).unwrap_or(Value::Null),
+            notes,
+        })),
         Ok(DescriptionDraftOutcome::NotAutomatable(reason)) => {
             Ok(Json(DraftFromDescriptionResponse::NotAutomatable {
                 automatable: false,

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -74,7 +74,10 @@ use self::http::GuardedHttpClient;
 use self::resolver::StoreWorkflowResolver;
 use self::state::{CompanyStateStore, NoopState};
 use self::tools::WorkflowToolInvoker;
-pub(crate) use self::tools::{WORKFLOW_TOOL_NAMESPACES, WORKFLOW_TOOL_SLUGS};
+pub(crate) use self::tools::{WORKFLOW_TOOL_CATALOG, WORKFLOW_TOOL_NAMESPACES, workflow_tool_info};
+// `WORKFLOW_TOOL_SLUGS` stays module-private to `tools` since #813: the catalogue
+// (`WORKFLOW_TOOL_CATALOG`) is what callers ground and validate against, and the
+// slug table is now only its in-module pinning cross-check.
 
 /// The four effectful capability slots [`build_capabilities`] chooses by mode:
 /// `tool_call`, `http_request`, `state`, and the optional `agent` runner. The

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -76,6 +76,13 @@ pub(crate) const WORKFLOW_TOOL_NAMESPACES: [&str; 4] = ["shell", "code", "web", 
 /// `media` / `composio` / `repo` slugs are deliberately absent — they map to a
 /// namespace but are agent-turn families the workflow invoker never wires (the
 /// same reason they are excluded from [`WORKFLOW_TOOL_NAMESPACES`]).
+/// Since #813 this table is a **test-only** pin: [`WORKFLOW_TOOL_CATALOG`] is the
+/// one source callers ground and validate against, and
+/// [`the_catalog_agrees_with_the_slug_table_and_namespace_of`] asserts the
+/// catalogue names exactly these slugs — so a tool added to the belt (and its
+/// `namespace_of` arm) without a catalogue row still fails a test rather than
+/// silently narrowing what the copilot can propose.
+#[cfg(test)]
 pub(crate) const WORKFLOW_TOOL_SLUGS: &[(&str, &str)] = &[
     ("shell", "shell"),
     ("read_workspace_state", "shell"),
@@ -88,6 +95,115 @@ pub(crate) const WORKFLOW_TOOL_SLUGS: &[(&str, &str)] = &[
     ("image_info", "web"),
     ("web_search", "search"),
 ];
+
+/// One row of the create-time copilot's tool catalogue (issue #813): a wired
+/// `tool_call` slug, the grant namespace it maps to, an **honest** one-line
+/// capability, and the args a proposed node must carry.
+///
+/// The capability line states what the tool can AND plainly cannot do, so the
+/// model is grounded in the real shape of the tool rather than its name alone —
+/// the `read_workspace_state` "overview only, cannot read a file" gap is the case
+/// that motivated this. `required_args` names the keys the engine reads from a
+/// node's `config.args` (tinyflows resolves a `tool_call`'s arguments from
+/// `config.args`, not from the node config root — see
+/// `vendor/openhuman/vendor/tinyflows/src/nodes/integration/tool_call.rs`), so a
+/// slug that runs but does nothing useful with empty args is caught at author
+/// time by [`validate_tool_call_node`](crate::company::workflow_create).
+pub(crate) struct WorkflowToolInfo {
+    /// The runtime tool name (== a `tool_call` node's `config.slug`).
+    pub(crate) slug: &'static str,
+    /// The grant namespace [`toolbelt::namespace_of`] maps `slug` to.
+    pub(crate) namespace: &'static str,
+    /// One honest sentence: what the tool does, and what it cannot.
+    pub(crate) capability: &'static str,
+    /// The `config.args` keys a proposed node must set for the tool to do
+    /// anything — empty when the tool has no required arg.
+    pub(crate) required_args: &'static [&'static str],
+}
+
+/// The wired workflow tools, each with the honest capability line and required
+/// args the create-time copilot grounds the model in (issue #813).
+///
+/// A **strict** companion of [`WORKFLOW_TOOL_SLUGS`]: it names the exact same
+/// slugs (asserted both directions by
+/// [`the_catalog_agrees_with_the_slug_table_and_namespace_of`]) and each row's
+/// namespace is what [`toolbelt::namespace_of`] returns, so the catalogue cannot
+/// drift from what the invoker actually wires or from what a proposed `tool_call`
+/// clears at courtesy validation. The capability lines and `required_args` are
+/// pinned to the vendored tool schemas: `required_args` is each tool's schema
+/// `required` list, and the "cannot" halves state a real limit of the tool
+/// (`read_workspace_state` reads no file; `web_fetch` searches for nothing).
+pub(crate) const WORKFLOW_TOOL_CATALOG: &[WorkflowToolInfo] = &[
+    WorkflowToolInfo {
+        slug: "shell",
+        namespace: "shell",
+        capability: "runs a shell command in the company workspace (create/edit/run files); the \
+                     workspace starts empty each run",
+        required_args: &["command"],
+    },
+    WorkflowToolInfo {
+        slug: "read_workspace_state",
+        namespace: "shell",
+        capability: "an overview ONLY — git status, recent commits and the top-level file tree; it \
+                     CANNOT read a file's contents or run a command",
+        required_args: &[],
+    },
+    WorkflowToolInfo {
+        slug: "apply_patch",
+        namespace: "code",
+        capability: "applies exact-string edits to files already in the workspace",
+        required_args: &["edits"],
+    },
+    WorkflowToolInfo {
+        slug: "git_operations",
+        namespace: "code",
+        capability: "structured git actions (status/diff/log/branch/commit/add/checkout/stash) in \
+                     the workspace",
+        required_args: &["operation"],
+    },
+    WorkflowToolInfo {
+        slug: "csv_export",
+        namespace: "code",
+        capability: "writes a JSON array of objects to a CSV file in the workspace",
+        required_args: &["data", "filename"],
+    },
+    WorkflowToolInfo {
+        slug: "web_fetch",
+        namespace: "web",
+        capability: "GETs a URL you already have and returns its page text (truncated); it cannot \
+                     search for a URL",
+        required_args: &["url"],
+    },
+    WorkflowToolInfo {
+        slug: "http_request",
+        namespace: "web",
+        capability: "makes an HTTP request (GET/POST/…) to an allowlisted API URL you already have",
+        required_args: &["url"],
+    },
+    WorkflowToolInfo {
+        slug: "curl",
+        namespace: "web",
+        capability: "downloads a file from an http(s) URL into the workspace",
+        required_args: &["url"],
+    },
+    WorkflowToolInfo {
+        slug: "image_info",
+        namespace: "web",
+        capability: "reads image metadata (format, dimensions, size) from a workspace file",
+        required_args: &["path"],
+    },
+    WorkflowToolInfo {
+        slug: "web_search",
+        namespace: "search",
+        capability: "runs a metered web search for a query and returns result links and snippets",
+        required_args: &["query"],
+    },
+];
+
+/// The catalogue row for `slug`, if it is a wired workflow tool (issue #813).
+pub(crate) fn workflow_tool_info(slug: &str) -> Option<&'static WorkflowToolInfo> {
+    WORKFLOW_TOOL_CATALOG.iter().find(|info| info.slug == slug)
+}
 
 /// A [`ToolInvoker`] over the Cell A toolbelt (plus the metered `search` family),
 /// scoped to a per-company workflow workspace and gated by the company's
@@ -267,6 +383,50 @@ mod tests {
             assert!(
                 WORKFLOW_TOOL_NAMESPACES.contains(namespace),
                 "slug `{slug}`'s namespace `{namespace}` is not a wired workflow namespace"
+            );
+        }
+    }
+
+    /// [`WORKFLOW_TOOL_CATALOG`] is a strict companion of
+    /// [`WORKFLOW_TOOL_SLUGS`], not a second source of truth: it names the exact
+    /// same slugs (both directions), every row's namespace is what
+    /// [`toolbelt::namespace_of`] returns and is a wired workflow namespace, and
+    /// no capability line or required-arg name is blank. A tool added to (or
+    /// dropped from) the slug table without a matching catalogue edit fails here
+    /// rather than silently narrowing — or mis-describing — what the create-time
+    /// copilot (issue #813) grounds the model in.
+    #[test]
+    fn the_catalog_agrees_with_the_slug_table_and_namespace_of() {
+        use std::collections::HashSet;
+        let catalog: HashSet<&str> = WORKFLOW_TOOL_CATALOG.iter().map(|info| info.slug).collect();
+        let table: HashSet<&str> = WORKFLOW_TOOL_SLUGS.iter().map(|(slug, _)| *slug).collect();
+        assert_eq!(
+            catalog, table,
+            "the tool catalogue and the slug table must name the same slugs"
+        );
+        for info in WORKFLOW_TOOL_CATALOG {
+            assert_eq!(
+                toolbelt::namespace_of(info.slug),
+                Some(info.namespace),
+                "catalogue slug `{}` is listed under `{}` but namespace_of disagrees",
+                info.slug,
+                info.namespace
+            );
+            assert!(
+                WORKFLOW_TOOL_NAMESPACES.contains(&info.namespace),
+                "catalogue slug `{}`'s namespace `{}` is not a wired workflow namespace",
+                info.slug,
+                info.namespace
+            );
+            assert!(
+                !info.capability.trim().is_empty(),
+                "catalogue slug `{}` has an empty capability line",
+                info.slug
+            );
+            assert!(
+                info.required_args.iter().all(|arg| !arg.trim().is_empty()),
+                "catalogue slug `{}` has an empty required-arg name",
+                info.slug
             );
         }
     }


### PR DESCRIPTION
## Summary

The copilot-grounding half of EPIC #813 (defects 1–3). Authoring end-to-end on staging took four runs and three edits to deliver one report — every failure was an authoring-surface problem, not an engine one. The create-time copilot is a one-shot LLM call steered by prose whose only enforcement folds a wrong draft to a silent `NotAutomatable`. Mirroring OpenHuman's reference host (host-side hard gates with model-consumable errors + rich grounding; **no** fuzzy resolver, **no** semantic tool matcher), with a hybrid **one-shot + at most one corrective re-prompt**.

- **Defect 1 — delivery expressed as an agent instruction, not an `output` node.** Only `output` nodes deliver; agents structurally can't send. `graph_contract` now states the invariant + shows an output-node example, and a **delivery gate** rejects a draft whose description asks to deliver (an address, a `#channel`, or "email/notify/DM me") but has no `output` node with a `destination`. The host never fabricates the destination — it tells the model to add one. Detector is conservative: a bare "we email customers weekly" produces no signal.
- **Defect 2 — a real-but-wrong teammate, and silent folds.** A deterministic **resolver** rewrites an `agent` id that isn't on the roster but uniquely matches one teammate's id/role/name (normalized), with an operator-facing note; no match or an ambiguous one becomes a gate error **naming the roster** — killing the old silent `NotAutomatable`. A "wrong-but-real" arm catches a draft that used a different real teammate than the one the request names.
- **Defect 3 — a legal tool that can't do the job, with empty args.** New `WORKFLOW_TOOL_CATALOG` gives each slug an honest capability line (`read_workspace_state` = "overview only … cannot read a file's contents") + `required_args`, presented to the model so it can pick a *capable* tool; `validate_tool_call_node` gains a **required-args-present** arm (args live under `config.args`).
- Correction **notes** flow to the console so the author sees why a draft was changed.

`Part of #813` — the first-run UX half (defects 5/7/8) is PR #814.

## API Or Behavior Changes

- **Author-time:** a `tool_call` node missing a required arg (per the catalogue) is now rejected at create/update (400) — for hand-authors too, since it lives in the shared gate. Saved graphs are not re-validated on load, so no load regression.
- **Copilot:** a rejected draft now triggers one corrective re-prompt (≤2 metered model calls under one run_id) and, on a second failure, a `NotAutomatable` naming the specific gate sentences instead of a bare fold. New `notes` field on the draft response.
- `WORKFLOW_TOOL_CATALOG` supersedes `WORKFLOW_TOOL_SLUGS` (internal; slug table kept as a `#[cfg(test)]` pin). No route/schema change.

## Tests

- [x] `cargo fmt --all -- --check` — pass
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — pass
- [x] `cargo check --all-targets` / `cargo check --all-features` — pass
- [x] Gated lib suite `--features openhuman,tinycortex` — 3533 passed / 0 failed (needs `RUST_MIN_STACK=16777216`; the default-stack `--tests` aborts on the unrelated pre-existing `harness::brain` stack-overflow). Independently re-verified the touched modules (workflow_build / workflow_create / caps): 176 passed / 0 failed.
- [x] Frontend: `npm run typecheck` · `npx vitest run` (580 passed, incl. new `workflow-draft.test.ts`) · `npm run build` — pass
- New Rust tests (gated lane) cover: normalize, conservative delivery signals, resolver rewrite+note, unknown→roster-naming error (silent-fold death), delivery gate pos/neg/silent, wrong-but-real, retry recovers, required-args missing/present; catalogue↔`namespace_of` coupling. Each gate observed RED against pre-change behaviour before restoring.

## Documentation

No doc file change — the grounding is code-internal and the new rules surface as author-facing error/notice text. Tool capability lines live in `WORKFLOW_TOOL_CATALOG`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow drafts can now include review summaries and correction notes from the drafting assistant.
  - Draft creation displays actionable notes when adjustments were made.
  - Draft generation can retry corrections automatically when workflow requirements are not met.

- **Bug Fixes**
  - Improved validation for required tool arguments, agent selection, delivery steps, and output configuration.
  - Enhanced workflow drafting guidance for available tools and roster information.

- **Tests**
  - Added coverage for draft notes, validation failures, corrective retries, and successful workflow delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->