### PR TITLE
auth: hide ecosystem sign-in where the hub will refuse the redirect target

### DIFF
--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -155,6 +155,8 @@ addressing forms work: `/api/v1/companies/{id}/…` and `/api/v1/company/…`.
 | `POST …/auth/request` | Mail a magic link. Always `{"sent": true}` |
 | `POST …/auth/verify` | Redeem a link → session cookie |
 | `POST …/auth/login` | Email + password → session cookie |
+| `GET …/auth/hub` | The ecosystem sign-in buttons this host can offer. `{"providers": []}` when it can offer none |
+| `POST …/auth/hub` | A platform token from the hub → session cookie |
 | `POST …/auth/password` | Set/replace your own password (needs a session) |
 | `GET …/auth/me` | Who this session belongs to |
 | `POST …/auth/logout` | Revoke this session |
@@ -180,6 +182,42 @@ the org chart, and every answer is a phishing target. It is also why
 — response *time* would otherwise answer what the body refuses to.
 
 Clients must not undo this. The console renders one vague message.
+
+## Ecosystem sign-in
+
+A host wired to the TinyHumans hub can also offer Google, GitHub and X. The
+browser goes to the hub's OAuth start pointed back at this console; the hub
+returns a platform token in the URL; `POST …/auth/hub` asks the hub whose it is
+and then applies **this company's own roster** — the same
+`eligibility` → `upsert_from_eligibility` → `mint_session` path a magic link
+takes. The hub says who they are; it never says whether they may in, and the
+session minted is an ordinary human session, never the hosting layer's machine
+credential.
+
+`GET …/auth/hub` answers `{"providers": []}` — not a 404 — whenever this host
+cannot complete the flow, so the console has one code path and falls through to
+the magic-link form. Two things produce an empty list:
+
+- **No hub.** A self-hosted host has no exchange, so it could not check a token
+  that came back. Three buttons that send someone through Google to be turned
+  away on return are worse than none.
+- **A redirect target the hub will refuse.** The return URL is
+  `{OPENCOMPANY_PUBLIC_URL}/?company={company_id}`, and the hub's redirect gate
+  currently accepts RFC 8252 **loopback** origins only. A local console on
+  `http://127.0.0.1:<port>` passes; every hosted `https://<slug>.<domain>`
+  origin is answered `400` before the provider handshake begins.
+
+The second is issue #512 and is a hosted-only gap: sign-in there is by magic
+link until `tinyhumansai/backend#1243` teaches that gate to accept provisioned
+tenant origins. Nothing here needs to change when it does — the origin comes
+from `OPENCOMPANY_PUBLIC_URL` — beyond deleting `hub_accepts_redirect_uri` and
+its one call site.
+
+Note the shape the gate has to accept: **not** a bare origin. The `?company=`
+rides along, and in shared-single-DB mode the id is namespaced `<tenant>--<id>`,
+so it varies per tenant and over time. Only the origin component is stable, and
+a gate matching the whole string against a registry of origins would reproduce
+this failure exactly.
 
 ## Passwords
 

--- a/src/server/hub_identity.rs
+++ b/src/server/hub_identity.rs
@@ -104,6 +104,9 @@ pub const HUB_PROVIDERS: &[HubProvider] = &[
 /// Nothing here needs to change when it does: the origin this builds on comes
 /// from [`AppConfig::host_base_url`](crate::AppConfig::host_base_url), so
 /// hosted is `OPENCOMPANY_PUBLIC_URL=https://…` and no code edit.
+///
+/// Until then, [`hub_accepts_redirect_uri`] is what keeps a console from
+/// offering a button that lands on that `400`.
 pub fn login_start_url(api_url: &str, provider: &str, redirect_uri: &str) -> String {
     format!(
         "{}/auth/{}/login?redirectUri={}",
@@ -111,6 +114,49 @@ pub fn login_start_url(api_url: &str, provider: &str, redirect_uri: &str) -> Str
         provider,
         percent_encode(redirect_uri),
     )
+}
+
+/// Whether the hub will accept `redirect_uri` as a sign-in return target.
+///
+/// A copy of somebody else's rule, held here for one reason: so a console can
+/// decline to render a button that cannot complete. That is the same judgement
+/// `hub_providers` already makes for a host with no exchange at all — the
+/// difference between a console that says "sign in with a link" and one that
+/// sends someone to Google and back into a bare `400`.
+///
+/// Mirrors the platform backend's RFC 8252 check (`isLoopbackHttpUri`, in
+/// `src/utils/deepLinkRedirect.ts`): `http://` on `127.0.0.1`, `localhost`, or
+/// `[::1]`, port and path irrelevant. Every hosted `https://<slug>.<domain>`
+/// origin fails it, which is the whole of issue #512.
+///
+/// ## Delete this when the gate moves
+///
+/// `tinyhumansai/backend#1243` teaches that gate to accept provisioned tenant
+/// origins. When it lands, this function and its single call site in
+/// `server::users::routes::hub_providers` both go, and hosted consoles start
+/// offering the buttons with no other change. Nothing else calls it, and it
+/// deliberately owns no configuration — a knob to turn it off would outlive the
+/// condition it exists for.
+///
+/// Divergence is one-directional by construction: an input this rejects and the
+/// hub would have accepted costs a hidden button, never a broken sign-in.
+pub fn hub_accepts_redirect_uri(redirect_uri: &str) -> bool {
+    let Some((scheme, rest)) = redirect_uri.split_once("://") else {
+        return false;
+    };
+    if !scheme.eq_ignore_ascii_case("http") {
+        return false;
+    }
+    // The authority is everything before the path, query, or fragment...
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
+    // ...minus any userinfo, which `new URL(…).hostname` also discards.
+    let host_port = authority.rsplit('@').next().unwrap_or_default();
+    let host = match host_port.strip_prefix('[') {
+        // An IPv6 literal keeps its own colons; a port, if any, follows `]`.
+        Some(inner) => inner.split(']').next().unwrap_or_default(),
+        None => host_port.split(':').next().unwrap_or_default(),
+    };
+    matches!(host, "127.0.0.1" | "localhost" | "::1")
 }
 
 /// Percent-encodes `value` for use as a single query-string value.
@@ -223,6 +269,80 @@ impl HubIdentityExchange for MockHubIdentityExchange {
                 email: email.clone(),
             })
             .ok_or_else(rejected)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    /// The exact string the hub's gate receives from a hosted console.
+    ///
+    /// Pinned because it is the thing `tinyhumansai/backend#1243` has to accept,
+    /// and it is **not** a bare origin — the `?company=` rides along. A gate that
+    /// compares this string against a registry of provisioned origins rejects
+    /// every real request and reproduces issue #512 exactly; only the origin
+    /// component is stable, and in shared-single-DB mode the company id is
+    /// namespaced `<tenant>--<id>` and varies per tenant and over time.
+    #[test]
+    fn a_hosted_start_url_carries_the_tenant_origin_and_its_company() {
+        let start = login_start_url(
+            "https://hub.example.com",
+            "google",
+            "https://smoke1.example.com/?company=smoke1",
+        );
+
+        assert_eq!(
+            start,
+            "https://hub.example.com/auth/google/login\
+             ?redirectUri=https%3A%2F%2Fsmoke1.example.com%2F%3Fcompany%3Dsmoke1"
+        );
+    }
+
+    #[test]
+    fn a_local_console_is_a_loopback_uri_the_hub_accepts() {
+        // Every shape RFC 8252 allows, since the bind is operator-chosen.
+        assert!(hub_accepts_redirect_uri(
+            "http://127.0.0.1:8080/?company=acme"
+        ));
+        assert!(hub_accepts_redirect_uri(
+            "http://localhost:3000/?company=acme"
+        ));
+        assert!(hub_accepts_redirect_uri("http://[::1]:8080/?company=acme"));
+        assert!(hub_accepts_redirect_uri("http://127.0.0.1/"));
+        assert!(hub_accepts_redirect_uri("HTTP://127.0.0.1:8080/"));
+    }
+
+    #[test]
+    fn a_hosted_origin_is_not_one_the_hub_accepts() {
+        // The whole of issue #512: `https` fails the check on scheme alone, so
+        // no hosted tenant can pass it whatever its hostname.
+        assert!(!hub_accepts_redirect_uri(
+            "https://smoke1.example.com/?company=smoke1"
+        ));
+        assert!(!hub_accepts_redirect_uri("https://127.0.0.1:8080/"));
+    }
+
+    #[test]
+    fn a_host_that_merely_looks_loopback_is_not_accepted() {
+        // The near misses a substring or prefix test would wave through. Each is
+        // a public hostname that anyone can point at an address they control.
+        assert!(!hub_accepts_redirect_uri("http://127.0.0.1.example.com/"));
+        assert!(!hub_accepts_redirect_uri("http://localhost.example.com/"));
+        assert!(!hub_accepts_redirect_uri("http://evil.com/127.0.0.1"));
+        assert!(!hub_accepts_redirect_uri("http://evil.com/?x=localhost"));
+        // Userinfo is the classic one: the host here is `evil.com`, and both
+        // this and `new URL(…).hostname` say so.
+        assert!(!hub_accepts_redirect_uri("http://127.0.0.1@evil.com/"));
+        // Not the loopback *address*, just inside its /8.
+        assert!(!hub_accepts_redirect_uri("http://127.0.0.2:8080/"));
+    }
+
+    #[test]
+    fn something_that_is_not_a_url_is_not_accepted() {
+        assert!(!hub_accepts_redirect_uri(""));
+        assert!(!hub_accepts_redirect_uri("127.0.0.1:8080"));
+        assert!(!hub_accepts_redirect_uri("http://"));
     }
 }
 

--- a/src/server/hub_identity.rs
+++ b/src/server/hub_identity.rs
@@ -138,8 +138,11 @@ pub fn login_start_url(api_url: &str, provider: &str, redirect_uri: &str) -> Str
 /// deliberately owns no configuration — a knob to turn it off would outlive the
 /// condition it exists for.
 ///
-/// Divergence is one-directional by construction: an input this rejects and the
-/// hub would have accepted costs a hidden button, never a broken sign-in.
+/// Divergence is one-directional by construction: this is stricter than the
+/// hub, never laxer. It refuses the IPv4 shorthands `URL` normalizes
+/// (`http://127.1/`, `http://2130706433/` are both `127.0.0.1` there), which
+/// costs a hidden button on a console configured that way — and never a click
+/// that 400s.
 pub fn hub_accepts_redirect_uri(redirect_uri: &str) -> bool {
     let Some((scheme, rest)) = redirect_uri.split_once("://") else {
         return false;
@@ -147,16 +150,51 @@ pub fn hub_accepts_redirect_uri(redirect_uri: &str) -> bool {
     if !scheme.eq_ignore_ascii_case("http") {
         return false;
     }
-    // The authority is everything before the path, query, or fragment...
+    // The authority is everything before the path, query, or fragment.
     let authority = rest.split(['/', '?', '#']).next().unwrap_or_default();
-    // ...minus any userinfo, which `new URL(…).hostname` also discards.
-    let host_port = authority.rsplit('@').next().unwrap_or_default();
-    let host = match host_port.strip_prefix('[') {
-        // An IPv6 literal keeps its own colons; a port, if any, follows `]`.
-        Some(inner) => inner.split(']').next().unwrap_or_default(),
-        None => host_port.split(':').next().unwrap_or_default(),
+    let Some(host) = authority_host(authority) else {
+        return false;
     };
-    matches!(host, "127.0.0.1" | "localhost" | "::1")
+    // `URL` lowercases a hostname, so `LOCALHOST` is a loopback host there too.
+    host.eq_ignore_ascii_case("127.0.0.1")
+        || host.eq_ignore_ascii_case("localhost")
+        || host.eq_ignore_ascii_case("::1")
+}
+
+/// The host of an authority, or `None` when it is not one `URL` would parse.
+///
+/// Being strict is the whole job. A malformed authority this waved through and
+/// the hub rejects is the one direction that costs something: the console
+/// renders a button, and the click lands on the very `400` this guard exists to
+/// keep people away from.
+fn authority_host(authority: &str) -> Option<&str> {
+    // Userinfo is discarded, as `new URL(…).hostname` discards it — the host of
+    // `http://127.0.0.1@evil.example/` is `evil.example`.
+    let host_port = match authority.rsplit_once('@') {
+        Some((_, after)) => after,
+        None => authority,
+    };
+    let (host, port) = match host_port.strip_prefix('[') {
+        // An IPv6 literal must close its bracket, and nothing but a port may
+        // follow it: `[::1` and `[::1]junk` are parse errors, not hosts.
+        Some(tail) => tail.split_once(']')?,
+        // Otherwise the first colon begins the port — which is what makes a
+        // bare `::1` fall out here as a bad port rather than a host. To be one
+        // it has to be bracketed.
+        None => match host_port.find(':') {
+            Some(at) => (&host_port[..at], &host_port[at..]),
+            None => (host_port, ""),
+        },
+    };
+    if !port.is_empty() {
+        // A colon then digits, or nothing at all. An empty port
+        // (`http://127.0.0.1:/`) means the default, which `URL` also accepts.
+        let digits = port.strip_prefix(':')?;
+        if !digits.bytes().all(|b| b.is_ascii_digit()) {
+            return None;
+        }
+    }
+    Some(host)
 }
 
 /// Percent-encodes `value` for use as a single query-string value.
@@ -311,6 +349,51 @@ mod test {
         assert!(hub_accepts_redirect_uri("http://[::1]:8080/?company=acme"));
         assert!(hub_accepts_redirect_uri("http://127.0.0.1/"));
         assert!(hub_accepts_redirect_uri("HTTP://127.0.0.1:8080/"));
+        // `URL` lowercases the host, so these are loopback at the hub too.
+        // Rejecting them would hide a button that works.
+        assert!(hub_accepts_redirect_uri(
+            "http://LOCALHOST:8080/?company=acme"
+        ));
+        assert!(hub_accepts_redirect_uri("http://LocalHost/"));
+        assert!(hub_accepts_redirect_uri("http://[::1]/"));
+        // An empty port is legal and means the default.
+        assert!(hub_accepts_redirect_uri("http://127.0.0.1:/"));
+    }
+
+    /// An authority the hub's `new URL` throws on must be refused here too.
+    ///
+    /// This is the direction that costs something. Accepting a shape the hub
+    /// rejects renders a button whose click ends on the bare `400` this guard
+    /// exists to prevent, so each of these is a live regression rather than a
+    /// tidiness rule.
+    #[test]
+    fn a_malformed_authority_is_refused_as_the_hub_refuses_it() {
+        // An unclosed IPv6 bracket.
+        assert!(!hub_accepts_redirect_uri("http://[::1/?company=acme"));
+        assert!(!hub_accepts_redirect_uri("http://[::1"));
+        // Closed, but with something other than a port trailing it.
+        assert!(!hub_accepts_redirect_uri("http://[::1]junk/?company=acme"));
+        assert!(!hub_accepts_redirect_uri("http://[::1]:80junk/"));
+        // A port that is not a number.
+        assert!(!hub_accepts_redirect_uri(
+            "http://127.0.0.1:abc/?company=acme"
+        ));
+        assert!(!hub_accepts_redirect_uri("http://127.0.0.1:80:90/"));
+        // An IPv6 address has to be bracketed to be a host at all.
+        assert!(!hub_accepts_redirect_uri("http://::1/"));
+    }
+
+    /// Where this is knowingly stricter than the hub.
+    ///
+    /// `URL` normalizes both of these to `127.0.0.1`, so the hub would take
+    /// them. Pinned deliberately: the cost is a hidden button on a console
+    /// nobody configures this way, and the alternative is reimplementing
+    /// WHATWG's IPv4 parser inside a guard that gets deleted when
+    /// `tinyhumansai/backend#1243` lands.
+    #[test]
+    fn ipv4_shorthand_is_refused_though_the_hub_would_take_it() {
+        assert!(!hub_accepts_redirect_uri("http://127.1:8080/"));
+        assert!(!hub_accepts_redirect_uri("http://2130706433/"));
     }
 
     #[test]

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -47,6 +47,16 @@ async fn state_with(
     home: &std::path::Path,
     exchange: Option<Arc<MockHubIdentityExchange>>,
 ) -> AppState {
+    state_with_public_url(home, exchange, None).await
+}
+
+/// The same host, with `public_url` set as the platform sets it on a tenant —
+/// which is the only difference between a local console and a hosted one.
+async fn state_with_public_url(
+    home: &std::path::Path,
+    exchange: Option<Arc<MockHubIdentityExchange>>,
+    public_url: Option<&str>,
+) -> AppState {
     let store = crate::store::FsCompanyStore::new(home.to_path_buf());
     let id = CompanyId::new("acme");
     store
@@ -75,6 +85,7 @@ async fn state_with(
     let mut state = AppState::new(AppConfig {
         bind: "127.0.0.1:8080".to_string(),
         api_url: "https://hub.example.com".to_string(),
+        public_url: public_url.map(str::to_string),
         ..AppConfig::default()
     })
     .with_home(home.to_path_buf());
@@ -187,6 +198,29 @@ async fn the_start_url_points_at_the_hub_and_returns_to_this_console() {
     // Encoded as one value: unescaped, the console's own `?company=` would be
     // read by the hub as one of its own query parameters.
     assert!(!start.contains("redirectUri=http://"));
+}
+
+#[tokio::test]
+async fn a_hosted_console_offers_no_providers_while_the_hub_refuses_its_origin() {
+    let home = home();
+    let state = state_with_public_url(
+        home.path(),
+        Some(Arc::new(MockHubIdentityExchange::new())),
+        Some("https://smoke1.example.com"),
+    )
+    .await;
+
+    let body = providers(&state).await;
+
+    // Issue #512: the hub's redirect gate accepts loopback origins only, so
+    // every one of these buttons answers 400 before Google is ever reached.
+    // Empty is the same "no honest button to offer" the no-exchange case takes,
+    // and it leaves the magic-link form — which does work hosted — standing
+    // alone rather than under three that cannot.
+    //
+    // Fails when `tinyhumansai/backend#1243` lands and the guard comes out,
+    // which is the point: this test is the reminder to delete it.
+    assert_eq!(body["providers"].as_array().unwrap().len(), 0);
 }
 
 #[tokio::test]

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -670,7 +670,8 @@ fn console_redirect_uri(state: &AppState, company: &CompanyId) -> String {
 ///
 /// Answers `{"providers": []}` rather than a 404 on a host with no hub, so the
 /// console has one code path: ask, render what comes back, and fall through to
-/// the magic-link form when nothing does.
+/// the magic-link form when nothing does. A host that cannot complete a
+/// sign-in — for either of the two reasons below — takes that same path.
 async fn hub_providers(
     company: PublicCompany,
     State(state): State<AppState>,
@@ -685,6 +686,22 @@ async fn hub_providers(
         });
     }
     let redirect_uri = console_redirect_uri(&state, company.runtime.id());
+    // The same judgement one step earlier in the flow. A hosted console's
+    // `https` origin is refused by the hub's redirect gate with a `400` raised
+    // before the provider handshake begins (issue #512), so the button is not
+    // merely likely to fail — it cannot succeed, on any tenant, on either hub.
+    // Showing it spends a click to reach an error page that names nothing the
+    // person can act on; the magic-link form below it works today.
+    //
+    // Temporary, and paired with one thing to delete: when
+    // `tinyhumansai/backend#1243` lands, drop this guard together with
+    // `hub_accepts_redirect_uri` and hosted consoles offer the buttons again
+    // with no other change.
+    if !crate::server::hub_identity::hub_accepts_redirect_uri(&redirect_uri) {
+        return Json(HubProvidersResult {
+            providers: Vec::new(),
+        });
+    }
     let api_url = &state.config().api_url;
     Json(HubProvidersResult {
         providers: crate::server::hub_identity::HUB_PROVIDERS


### PR DESCRIPTION
## Summary

The hosted console's Google/GitHub/X buttons cannot complete sign-in on any tenant. The console hands the hub an `https://<slug>.<domain>/?company=<id>` return target; the hub's redirect gate accepts RFC 8252 loopback origins only and answers `400` before the provider handshake starts.

There is no fix to make on this side — the console derives that origin from `OPENCOMPANY_PUBLIC_URL`, so hosted is already a pure configuration path and `hub_identity.rs`'s "nothing here needs to change when it does" holds. The fix is `tinyhumansai/backend#1243`.

What this PR does is the second half of #512's checklist: stop offering a button that cannot complete, and pin the string the gate has to accept.

## What changed

- **`hub_accepts_redirect_uri`** (`src/server/hub_identity.rs`) — a mirror of the backend's `isLoopbackHttpUri`. `hub_providers` returns `{"providers": []}` when the redirect target would be refused.

  This is not new UI. It is the judgement the route already makes one line above for a host with no exchange, whose comment reads *"the difference between a console that says 'sign in with a link' and one that sends someone through Google to be turned away on return."* An empty list is a state the console already handles by rendering the magic-link form alone — which works on a hosted tenant today.

  Deliberately no configuration knob: a switch to disable this would outlive the condition it exists for. One function, one call site, both doc-commented with backend#1243 as the removal condition, and the route test goes red when the gate lands so it cannot silently stay off.

- **Pinned the hosted start URL** — the existing test asserted only the loopback form. The hosted `https` shape is what backend#1243 must accept, and it is **not a bare origin**: the `?company=` rides along, and in shared-single-DB mode the id is namespaced `<tenant>--<id>`. A gate matching the whole string against a registry of origins would reproduce this failure exactly.

- **Docs** — `docs/spec/runtime/users.md` had no entry for the hub routes at all. Added them to the routes table plus an "Ecosystem sign-in" section covering both empty-list cases and the not-a-bare-origin trap.

## Behaviour change

| Host | Before | After |
|---|---|---|
| Local (`http://127.0.0.1:<port>`) | 3 buttons, working | unchanged |
| Self-hosted, no hub | no buttons | unchanged |
| Hosted (`OPENCOMPANY_PUBLIC_URL=https://…`) | 3 buttons → raw JSON `400` on click | magic-link form alone |

## Verified

`cargo fmt --all -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — 2311 passed, 0 failed. 6 new tests; the 10 existing hub tests are untouched and still pass.

End to end against two real hosts from the same binary and console build, differing only in `OPENCOMPANY_PUBLIC_URL`, driven in a real browser:

- local `:8091` → 3 buttons, hrefs carry the percent-encoded loopback target
- hosted `:8092` → 0 buttons, no orphaned divider or Terms line (they live in the same block)
- the RCA itself against production `api.tinyhumans.ai`: loopback target → `302` to Google; `https://smoke1.tinyhumans.ai/?company=smoke1` → `400 redirectUri must be an http loopback URI`
- the fallback actually completes: with SMTP wired on the hosted host, requested a link in the browser, read the code from the mail the host sent, followed it, and got `oc_session_agentic-marketing-agency` (httpOnly)

Note for anyone reproducing: the buttons need `--features tinyhumans` and mail needs `--features smtp`; and setting `OPENCOMPANY_PUBLIC_URL` makes `is_local_only()` false, so the host correctly refuses to echo `dev_code`.

## Not done here

Verifying a *successful* hosted OAuth round trip is genuinely blocked on backend#1243 and deliberately not stubbed. I have posted two further traps on that issue: the callback prefers `targetUri` over a non-loopback payload URI (`callbackHandler.ts:319-324`), and `buildLoginRedirectUrl` synthesizes a path that loses the `?company=`. Fixing the start gate alone is not sufficient.

Refs #512, `tinyhumansai/backend#1243`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added ecosystem sign-in documentation covering provider discovery, hub token sign-in, identity verification, and tenant-specific callbacks.
  - Added validation for sign-in redirect targets, accepting only safe local loopback addresses.
- **Bug Fixes**
  - Hosted consoles now show no sign-in providers when their redirect target cannot be supported.
  - Improved rejection of malformed, deceptive, or non-local redirect URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->