### PR TITLE
feat(connections): open a provider and manage it, the way OpenHuman does (#404)

### DIFF
--- a/docs/modules/server/README.md
+++ b/docs/modules/server/README.md
@@ -365,9 +365,37 @@ Two consequences worth knowing:
   probe is a network call with no injection point, and the removed gate lived on
   the far side of it, which is how it survived unasserted.
 
-No host route releases a Composio connection — `…/connections/{provider}/disconnect`
-blanks this host's own secret — so the console offers Disconnect only for a row
-whose `via` includes `native`.
+### Releasing a connection: two routes, not interchangeable (issue #404)
+
+There are two disconnects and they act on different things:
+
+- `POST …/connections/{provider}/disconnect` blanks this host's own
+  `oauth/{provider}` secret and best-effort revokes it upstream. It has never
+  touched Composio.
+- `DELETE …/composio/connections/{connection_id}` revokes **one connected
+  account** at Composio. Addressed by connection id, because a company can hold
+  two accounts for one toolkit and exactly one of them is being released.
+
+Until the second route existed the console sent every Disconnect to the first,
+so a Composio-connected provider answered `200`, reported success, and was still
+connected on the next refresh. The console now routes by what the provider is
+actually connected through (`disconnectRouteFor` in
+`frontend/src/lib/provider-grid.ts`), preferring the Composio account when a
+provider is connected through both — the native secret is inert until #396
+lands, so blanking it would release nothing an agent can feel.
+
+`GET …/composio/connections` carries the accounts a revoke is addressed to:
+`accounts[]` per toolkit, each with Composio's verbatim `status`, its
+`createdAt` when Composio published one, and the account label when the provider
+did. `toolkit` and `connected` keep their previous meaning, so the callers that
+read only those two are untouched.
+
+**Which account an agent acts as is not decided here.** `composio_execute` posts
+`{tool, arguments}` and no connection id (`src/harness/composio.rs`), so
+Composio resolves it for the entity — nothing in this codebase selects, orders
+or defaults an account, and the console's provider detail view says so rather
+than marking one as the default. Changing that means sending a connection id on
+execute, which is a harness change, not a console one.
 
 ## tiny.place A2A inbound + discovery (`tinyplace` feature)
 

--- a/frontend/src/api/composio.ts
+++ b/frontend/src/api/composio.ts
@@ -133,12 +133,60 @@ export interface ComposioAuthorize {
   connectUrl: string;
 }
 
+/**
+ * One connected account inside a {@link ComposioConnection} (issue #404).
+ *
+ * A non-secret projection of the host's `ConnectedAccountDto` — the id is
+ * Composio's connection id, which is safe to hold here because it is the path
+ * segment `DELETE …/composio/connections/{id}` takes and carries no credential.
+ */
+export interface ComposioConnectedAccount {
+  /** Composio's connection id — what a disconnect is addressed to. */
+  id: string;
+  /**
+   * Composio's raw status string (`ACTIVE`, `INITIATED`, `EXPIRED`, …),
+   * forwarded verbatim so the console can tell "never set up" from "set up and
+   * since expired" rather than flattening both to "not connected".
+   */
+  status: string;
+  /** Whether this individual account is usable. */
+  connected: boolean;
+  /**
+   * When Composio recorded the connection. Absent when Composio did not say —
+   * and absent for every other connection system, none of which records one.
+   * Rendered as "not recorded" rather than as a blank that reads like "never".
+   */
+  createdAt?: string;
+  /**
+   * The account label the provider published (`ops@acme.test`). Omitted rather
+   * than guessed: an account the provider did not name has no honest label, and
+   * inventing one from the toolkit is how two Gmail accounts become
+   * indistinguishable at exactly the moment the operator has to pick one.
+   */
+  account?: string;
+}
+
 /** One toolkit's connected state, as returned by `GET …/composio/connections`. */
 export interface ComposioConnection {
   /** Toolkit slug, e.g. `gmail`. */
   toolkit: string;
   /** Whether the company has at least one active connection for this toolkit. */
   connected: boolean;
+  /**
+   * Every connection this company holds for the toolkit, oldest id first
+   * (issue #404).
+   *
+   * Usually one. Composio permits several accounts per toolkit and a company
+   * that connected Gmail twice needs to see which is which before revoking one
+   * — `connected: boolean` alone cannot back a disconnect, because it names
+   * nothing to disconnect.
+   *
+   * Optional on the wire rather than required: the field was added additively
+   * to a route this console already called, and a host predating it answers
+   * without one. Callers treat a missing list as "this host cannot open a
+   * provider", not as "no accounts".
+   */
+  accounts?: ComposioConnectedAccount[];
 }
 
 /** The company's Composio status. */
@@ -190,4 +238,32 @@ export function listComposioConnections(
   company: string | null,
 ): Promise<ComposioConnection[]> {
   return client.get<ComposioConnection[]>(`${client.scopeFor(company)}/composio/connections`);
+}
+
+/** What the host says it revoked, in its own words. */
+export interface ComposioDisconnect {
+  note: string;
+}
+
+/**
+ * Revoke one connected account (issue #404).
+ *
+ * Addressed by Composio's connection id, not by toolkit: a company with two
+ * Gmail accounts has two ids and exactly one of them is being released.
+ *
+ * This is **not** interchangeable with `client.disconnectConnection`, which
+ * posts to `…/connections/{provider}/disconnect` and blanks the host's own
+ * `oauth/{provider}` secret. That route has never touched Composio, so calling
+ * it for a Composio-connected provider reports success and leaves the account
+ * connected on the next refresh. 404 when the id is not this company's; 409
+ * when Composio is not in the build.
+ */
+export function disconnectComposioConnection(
+  client: OpenCompanyClient,
+  company: string | null,
+  connectionId: string,
+): Promise<ComposioDisconnect> {
+  return client.del<ComposioDisconnect>(
+    `${client.scopeFor(company)}/composio/connections/${encodeURIComponent(connectionId)}`,
+  );
 }

--- a/frontend/src/lib/connection-detail.ts
+++ b/frontend/src/lib/connection-detail.ts
@@ -1,0 +1,60 @@
+// What a provider's detail view is allowed to claim (issue #404).
+//
+// The issue's rule — "do not invent a number … say so on screen rather than
+// rendering a plausible-looking zero" — is not only about usage. Two of the
+// three facts the view states are unavailable for most connections, and each
+// has a wrong answer that looks right:
+//
+//  - **when it was connected**: only Composio records it, so a blank cell reads
+//    as "never" for the two systems that never had one to record;
+//  - **what has gone through it**: metered per *provider*, never per account,
+//    and an unmetered host is not a host where nothing happened.
+//
+// These are the two decisions, kept out of the component so they can be pinned
+// without a DOM.
+
+import type { ProviderCallsDto } from "@/api/types";
+
+/**
+ * "connected 9 Aug 2026", or a statement that no date exists.
+ *
+ * Composio is the only one of the three connection systems that records one.
+ * The native `oauth/{provider}` store keeps `{token, account}` and journals
+ * nothing on connect; MCP has no such concept. So for those the date is not a
+ * gap waiting on a timestamp column — it is a fact about the store, and saying
+ * it plainly beats a blank the operator reads as "never".
+ */
+export function connectedOn(createdAt: string | undefined): string {
+  if (createdAt === undefined || createdAt.trim() === "") {
+    return "connection date not recorded";
+  }
+  const at = new Date(createdAt);
+  // Composio's own field, forwarded verbatim by the host — which is exactly why
+  // it is parsed defensively here. An unparseable string is not evidence of a
+  // date, and `Invalid Date` on screen is worse than admitting there isn't one.
+  if (Number.isNaN(at.getTime())) return "connection date not recorded";
+  return `connected ${at.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  })}`;
+}
+
+/**
+ * Successful calls counted against one Composio toolkit over the usage window.
+ *
+ * Matched on the bare slug. A remote MCP server's calls are recorded under
+ * `mcp:<server>` (issue #698) precisely so the two namespaces cannot merge: a
+ * company with a Composio `gmail` and an MCP server its operator also called
+ * `gmail` would otherwise read one total as the other's. Prefix-matching here
+ * would re-create by hand the collision that naming was chosen to prevent.
+ *
+ * Zero is a real answer, not a missing one — `composio_execute` meters every
+ * successful call (`src/metering/oauth.rs`), so a provider with no row has had
+ * no successful call in the window. The *unmetered* case is a failed usage read,
+ * which the caller reports separately rather than flattening to zero here.
+ */
+export function callsForProvider(rows: readonly ProviderCallsDto[], slug: string): number {
+  const want = slug.trim().toLowerCase();
+  return rows.find((r) => r.provider.trim().toLowerCase() === want)?.calls ?? 0;
+}

--- a/frontend/src/lib/provider-grid.ts
+++ b/frontend/src/lib/provider-grid.ts
@@ -40,7 +40,7 @@
 // `well_known` table can run an OAuth handshake for, and the brand colours for
 // tiles the backend catalog does not cover.
 
-import type { ComposioToolkitEntry } from "@/api/composio";
+import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
 import type { ConnectionState } from "@/api/types";
 import {
   buildProviderRows,
@@ -83,16 +83,56 @@ export interface GridProvider extends ProviderRow {
   /** The connected account label, when the host knows one. Never a credential. */
   account?: string;
   /**
-   * Whether a local Disconnect can actually do anything.
+   * The Composio accounts this company holds for the toolkit (issue #404).
    *
-   * `DELETE …/connections/{provider}` blanks the host's own `oauth/{provider}`
-   * secret and best-effort revokes it upstream. It does **not** touch a Composio
-   * connection, and there is no host route that does. So a tile connected only
-   * through Composio must not offer a Disconnect: it would blank a secret that
-   * was never there, report success, and leave the tile connected on the next
-   * refresh — the same "the page says two things" failure in a different place.
+   * Empty for a provider connected only natively, for a provider connected
+   * through nothing, and on a host that predates the `accounts` field — the
+   * three cases share one rendering, which is that there is no connection
+   * object to open.
+   *
+   * Several entries is an ordinary state, not a misconfiguration: the
+   * connections are the company owner's to grant, and an owner can hold two
+   * Gmail accounts. #316 settled one account per *login*, which is a different
+   * surface (`src/server/users/`) from which Gmail an agent acts through.
+   */
+  accounts: ComposioConnectedAccount[];
+  /**
+   * Whether this tile has something a disconnect can address.
+   *
+   * Two different routes sit behind this one flag, and they are not
+   * interchangeable — see {@link disconnectRouteFor}. `POST
+   * …/connections/{provider}/disconnect` blanks the host's own
+   * `oauth/{provider}` secret; `DELETE …/composio/connections/{id}` revokes one
+   * account at Composio. Sending a Composio-connected provider to the native
+   * route blanks a secret it never had, reports success, and leaves the tile
+   * connected on the next refresh.
+   *
+   * Until #696 the second route did not exist, so this was `via.includes(
+   * "native")` and a Composio tile deliberately offered no Disconnect at all.
    */
   canDisconnect: boolean;
+}
+
+/**
+ * Which route releases this tile, or `null` when nothing here can be released.
+ *
+ * `composio` carries the ids because the host addresses a revoke by connection
+ * id — a toolkit with two accounts has two, and exactly one of them is the
+ * operator's target. The caller decides how to spend that: one account revokes
+ * directly, several is a question only the detail view can ask.
+ */
+export function disconnectRouteFor(
+  row: GridProvider,
+): { kind: "native" } | { kind: "composio"; accounts: ComposioConnectedAccount[] } | null {
+  if (!row.connected) return null;
+  const live = row.accounts.filter((a) => a.connected);
+  // Composio first: a tile connected through both is connected through Composio
+  // *for the agents*, which is the connection an operator means. The native
+  // secret is inert until #396 lands, so blanking it silently would leave the
+  // provider working and the tile still connected.
+  if (live.length > 0) return { kind: "composio", accounts: live };
+  if (row.via.includes("native")) return { kind: "native" };
+  return null;
 }
 
 /** The local tile for a Composio slug, when the console has metadata for one. */
@@ -158,6 +198,14 @@ function statesFor(
  * `GET …/connections`, the sole authority on connected. `reach` and
  * `platformManaged` feed `connectRoute`.
  *
+ * `composioAccounts` is `GET …/composio/connections`, keyed by normalized
+ * toolkit slug — the connection *objects* behind the booleans `states` already
+ * reconciles (issue #404). It stays a separate argument rather than being
+ * folded into `states`: `GET …/connections` is still the sole authority on
+ * whether a provider is connected, and a second source answering that question
+ * is precisely the shape of the bug #582 removed. This one answers a different
+ * question — *which accounts*, so a revoke has something to address.
+ *
  * The tail is the point of the union: `CONNECTION_PROVIDERS` tiles whose toolkit
  * the catalog did not offer are appended anyway. A host with Composio switched
  * off returns an empty catalog, and without this the page would render nothing
@@ -169,6 +217,7 @@ export function buildGridProviders(
   states: Readonly<Record<string, ConnectionState>>,
   reach: ComposioReach | null,
   platformManaged: boolean,
+  composioAccounts: Readonly<Record<string, ComposioConnectedAccount[]>> = {},
 ): GridProvider[] {
   const offered = new Set(catalog.map((entry) => toolkitSlug(entry.slug)));
   const nativeOnly: ComposioToolkitEntry[] = CONNECTION_PROVIDERS.filter(
@@ -199,7 +248,12 @@ export function buildGridProviders(
     // Union across every row that speaks about this tile: the host reconciles
     // within a row, and the alias split means there can be two.
     const via = [...new Set(matched.flatMap((s) => s.via ?? []))];
-    return {
+    // Looked up under both spellings for the same reason `statesFor` is: the
+    // tile's Composio slug and the id the host knows it by diverge for every
+    // hyphenated provider, and `x` / `twitter` outright.
+    const accounts =
+      composioAccounts[toolkitSlug(row.slug)] ?? composioAccounts[toolkitSlug(providerId)] ?? [];
+    const grid: GridProvider = {
       ...row,
       providerId,
       route: connectRoute({ toolkit: row.slug }, effective, reach),
@@ -207,8 +261,16 @@ export function buildGridProviders(
       // Only unknown if nothing already answered yes: a provider we know is
       // connected needs no second opinion.
       unverified: !row.connected && matched.some((s) => s.unverified === true),
-      account: matched.find((s) => s.account)?.account,
-      canDisconnect: row.connected && via.includes("native"),
+      // Prefer the host's reconciled label, then a Composio account's own. A
+      // tile with two accounts shows neither here — one of two labels on a
+      // tile reads as "this is the account", which is the question the detail
+      // view exists to answer properly.
+      account:
+        matched.find((s) => s.account)?.account ??
+        (accounts.length === 1 ? accounts[0].account : undefined),
+      accounts,
+      canDisconnect: false,
     };
+    return { ...grid, canDisconnect: disconnectRouteFor(grid) !== null };
   });
 }

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -572,6 +572,7 @@ export function ConnectionsView({ client, company }: Props) {
           company={company}
           provider={openedProvider}
           canManage={canManage && load !== "unavailable"}
+          noCredential={status?.credentialSource === "none"}
           busy={busy !== null}
           onClose={() => setOpened(null)}
           onConnectAnother={(p) => void connect(p)}

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -5,17 +5,20 @@ import { toast } from "sonner";
 import { me as fetchMe } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
 import {
+  disconnectComposioConnection,
   getComposioStatus,
   listComposioConnections,
   startComposioAuthorize,
+  type ComposioConnectedAccount,
   type ComposioStatus,
 } from "@/api/composio";
 import type { ConnectionState } from "@/api/types";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { catalogWarning } from "@/lib/composio-catalog";
-import { type ComposioReach } from "@/lib/connections";
-import { buildGridProviders, type GridProvider } from "@/lib/provider-grid";
+import { toolkitSlug, type ComposioReach } from "@/lib/connections";
+import { buildGridProviders, disconnectRouteFor, type GridProvider } from "@/lib/provider-grid";
+import { ProviderDetail } from "@/views/connections/ProviderDetail";
 import { armTourResume } from "@/tour/state";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { McpServersSection } from "@/views/connections/McpServersSection";
@@ -48,6 +51,15 @@ export function ConnectionsView({ client, company }: Props) {
   const scope = useLocalScope();
   const [load, setLoad] = useState<Load>("loading");
   const [states, setStates] = useState<Record<string, ConnectionState>>({});
+  // The Composio connection objects behind those booleans, keyed by normalized
+  // toolkit slug (issue #404). `states` still decides *whether* a provider is
+  // connected — this decides *what* is connected, which is what a revoke has to
+  // be addressed to and what the detail view opens.
+  const [accounts, setAccounts] = useState<Record<string, ComposioConnectedAccount[]>>({});
+  // The slug of the provider whose detail view is open, or `null`. A slug rather
+  // than the row itself, so the open panel re-derives from `providers` after a
+  // refresh instead of showing a snapshot of the state before the revoke.
+  const [opened, setOpened] = useState<string | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   // Bumped when the company credential changes, to remount the sections whose
   // reported tier is downstream of it (issue #586).
@@ -88,14 +100,34 @@ export function ConnectionsView({ client, company }: Props) {
   const pollTimers = useRef<Record<string, number>>({});
 
   const refresh = useCallback(async () => {
-    try {
-      const list = await client.listConnections(company);
-      setStates(Object.fromEntries(list.map((c) => [c.provider, c])));
-      setLoad("ready");
-    } catch {
+    // Both reads, together: the page's status and the accounts behind it are one
+    // answer to the operator, and refreshing them apart is how a tile ends up
+    // connected with nothing to open, or openable after the last account was
+    // revoked. Independently faulted, though — the accounts read is a strict
+    // addition, and a host that cannot answer it must not cost the page its
+    // status.
+    const [list, rows] = await Promise.all([
+      client.listConnections(company).then(
+        (l) => ({ ok: true as const, l }),
+        () => ({ ok: false as const, l: [] as ConnectionState[] }),
+      ),
+      // 409 on a build without Composio, 404 on a host predating #696. Neither
+      // is an error for this page: it means there are no connection objects to
+      // open, which the empty map already says.
+      listComposioConnections(client, company).catch(() => []),
+    ]);
+    setAccounts(
+      Object.fromEntries(
+        rows.filter((r) => r.accounts?.length).map((r) => [toolkitSlug(r.toolkit), r.accounts!]),
+      ),
+    );
+    if (!list.ok) {
       // No connections surface on this host yet — show the catalog read-only.
       setLoad("unavailable");
+      return;
     }
+    setStates(Object.fromEntries(list.l.map((c) => [c.provider, c])));
+    setLoad("ready");
   }, [client, company]);
 
   useEffect(() => {
@@ -191,6 +223,14 @@ export function ConnectionsView({ client, company }: Props) {
    * `busy` is cleared by the poll rather than by the caller — the connect is not
    * finished when the tab opens, and clearing early would offer a second Connect
    * for a sign-in already in flight.
+   *
+   * What the poll waits for is a **new account id**, not `connected` (issue
+   * #404). Adding a second account to a toolkit that is already connected leaves
+   * `connected` true throughout, so the old predicate was satisfied by the state
+   * the operator started from: the first tick — two seconds in, with the
+   * Composio tab still open — would have announced a sign-in that had not
+   * happened. Comparing ids answers both cases with one rule, since the first
+   * connect starts from an empty set.
    */
   async function connectComposio(p: { providerId: string; label: string }, toolkit: string) {
     // A sign-in for this toolkit is already polling (it can have been started
@@ -216,6 +256,12 @@ export function ConnectionsView({ client, company }: Props) {
     // opens the same URL the same way and likewise does not check.
     window.open(connectUrl, "_blank", "noopener,noreferrer");
     toast.message(`Complete ${p.label} sign-in in the new tab.`);
+    // What was already there before the tab opened. Read from the page's own
+    // state rather than re-fetched: it is the same list the operator is looking
+    // at, and a fresh read here could race the sign-in they have already
+    // completed in another tab.
+    const before = new Set((accounts[toolkitSlug(toolkit)] ?? []).map((a) => a.id));
+    const wasConnected = providers.some((row) => row.slug === toolkitSlug(toolkit) && row.connected);
     const deadline = Date.now() + 120_000;
     const poll = async () => {
       delete pollTimers.current[toolkit];
@@ -226,7 +272,12 @@ export function ConnectionsView({ client, company }: Props) {
       }
       try {
         const rows = await listComposioConnections(client, company);
-        if (rows.some((r) => r.toolkit.toLowerCase() === toolkit.toLowerCase() && r.connected)) {
+        const row = rows.find((r) => r.toolkit.toLowerCase() === toolkit.toLowerCase());
+        // An id we had not seen settles it. Falling back to `connected` covers a
+        // host predating the `accounts` field, where the first connect is the
+        // only one this poll can observe at all.
+        const arrived = row?.accounts?.some((a) => a.connected && !before.has(a.id)) === true;
+        if (arrived || (row?.accounts === undefined && row?.connected === true && !wasConnected)) {
           setBusy((b) => (b === p.providerId ? null : b));
           toast.success(`Connected ${p.label}.`);
           // Re-read the host's reconciled view so the tile flips to connected.
@@ -285,15 +336,34 @@ export function ConnectionsView({ client, company }: Props) {
   }
 
   /**
-   * Release a connection this host actually holds.
+   * Revoke one Composio account (issue #404).
    *
-   * Only offered for a tile whose `via` includes `native` (see
-   * `GridProvider.canDisconnect`): this route blanks the host's own
-   * `oauth/{provider}` secret, and no host route can release a Composio
-   * connection. Offering it on a Composio-only tile would report success and
-   * leave the tile connected on the next refresh.
+   * The only route that releases a Composio connection. `disconnectConnection`
+   * — which this page used to call for *every* tile — posts to
+   * `…/connections/{provider}/disconnect` and blanks the host's own
+   * `oauth/{provider}` secret, which a Composio-connected provider never had:
+   * it answered 200, the toast said "Disconnected Gmail", and Gmail was still
+   * connected on the next refresh.
    */
-  async function disconnect(p: GridProvider) {
+  async function disconnectAccount(p: GridProvider, account: ComposioConnectedAccount) {
+    if (busy) return;
+    setBusy(p.providerId);
+    try {
+      const { note } = await disconnectComposioConnection(client, company, account.id);
+      // The host's own words rather than ours: it is the side that knows what a
+      // revoke reached, and restating it here is a second place to drift from
+      // what actually happened.
+      toast.success(`${account.account ?? p.label}: ${note}`);
+      await refresh();
+    } catch {
+      toast.error(`Couldn't disconnect ${account.account ?? p.label}.`);
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /** Blank the host's own `oauth/{provider}` secret — the self-hosted route. */
+  async function disconnectNative(p: GridProvider) {
     if (busy) return;
     setBusy(p.providerId);
     try {
@@ -305,6 +375,30 @@ export function ConnectionsView({ client, company }: Props) {
     } finally {
       setBusy(null);
     }
+  }
+
+  /**
+   * The tile's Disconnect: release what this provider is actually connected
+   * through, or open it when that is a question rather than an action.
+   *
+   * A toolkit with two accounts has two ids and the tile names neither, so
+   * there is nothing here to pick. Guessing — first, newest, all — would revoke
+   * an account the operator did not name from a control that never showed them
+   * the list. Opening the detail view is the honest answer to an ambiguous
+   * click.
+   */
+  async function disconnect(p: GridProvider) {
+    const route = disconnectRouteFor(p);
+    if (route === null) return;
+    if (route.kind === "native") {
+      await disconnectNative(p);
+      return;
+    }
+    if (route.accounts.length > 1) {
+      setOpened(p.slug);
+      return;
+    }
+    await disconnectAccount(p, route.accounts[0]);
   }
 
   // `attested` is a property of the *instance*, not of one provider: it means
@@ -347,8 +441,18 @@ export function ConnectionsView({ client, company }: Props) {
         states,
         reach,
         platformManaged,
+        accounts,
       ),
-    [status?.effectiveCatalog, extraToolkits, states, reach, platformManaged],
+    [status?.effectiveCatalog, extraToolkits, states, reach, platformManaged, accounts],
+  );
+
+  // Re-derived from the grid every render, so the open panel reflects the last
+  // refresh rather than the row as it was when it was clicked. A provider that
+  // vanishes from the catalog under an open panel closes it, which is the only
+  // honest thing left to show.
+  const openedProvider = useMemo(
+    () => providers.find((p) => p.slug === opened) ?? null,
+    [providers, opened],
   );
 
   // Counted off the rendered grid, not off the raw host rows. The badge used to
@@ -452,7 +556,23 @@ export function ConnectionsView({ client, company }: Props) {
           loading={load === "loading" || !reachSettled}
           onConnect={(p) => void connect(p)}
           onDisconnect={(p) => void disconnect(p)}
+          onOpen={(p) => setOpened(p.slug)}
           onConnectSlug={(slug) => void connectSlug(slug)}
+        />
+
+        {/* A connection as an object you open rather than a row with a button
+            (issue #404). Composio only: the native catalog is inert — its
+            credential is written and read by nothing (#396) — and a detail view
+            is exactly where that would look healthiest. */}
+        <ProviderDetail
+          client={client}
+          company={company}
+          provider={openedProvider}
+          canManage={canManage && load !== "unavailable"}
+          busy={busy !== null}
+          onClose={() => setOpened(null)}
+          onConnectAnother={(p) => void connect(p)}
+          onDisconnectAccount={(p, account) => void disconnectAccount(p, account)}
         />
       </div>
     </div>

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -378,27 +378,30 @@ export function ConnectionsView({ client, company }: Props) {
   }
 
   /**
-   * The tile's Disconnect: release what this provider is actually connected
-   * through, or open it when that is a question rather than an action.
+   * The tile's Disconnect — the native route, and only ever the native route.
    *
-   * A toolkit with two accounts has two ids and the tile names neither, so
-   * there is nothing here to pick. Guessing — first, newest, all — would revoke
-   * an account the operator did not name from a control that never showed them
-   * the list. Opening the detail view is the honest answer to an ambiguous
-   * click.
+   * Routed rather than assumed. A tile backed by Composio opens instead of
+   * offering this (see `ProviderTile`), so in practice nothing reaches the other
+   * arm; the check is here because the alternative is the defect this whole
+   * change is about. Sending a Composio provider to
+   * `…/connections/{provider}/disconnect` blanks a secret it never had and
+   * answers 200, and that failure is invisible at the call site — it looks like
+   * a working disconnect until the next refresh. A rule that cannot be
+   * mis-called beats a comment asking callers not to.
+   *
+   * Falling back to opening the panel rather than throwing: a toolkit's accounts
+   * are revoked one at a time, by id, and the panel is where they are named.
+   * Picking one here — first, newest, all — would revoke an account the operator
+   * never saw.
    */
   async function disconnect(p: GridProvider) {
     const route = disconnectRouteFor(p);
     if (route === null) return;
-    if (route.kind === "native") {
-      await disconnectNative(p);
-      return;
-    }
-    if (route.accounts.length > 1) {
+    if (route.kind === "composio") {
       setOpened(p.slug);
       return;
     }
-    await disconnectAccount(p, route.accounts[0]);
+    await disconnectNative(p);
   }
 
   // `attested` is a property of the *instance*, not of one provider: it means

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -24,6 +24,12 @@ interface Props {
   provider: GridProvider | null;
   /** Whether this viewer may change what the company connects through (#403). */
   canManage: boolean;
+  /**
+   * Nothing to authorize against — no credential of any tier resolves, so a
+   * Connect could only fail. Stated here rather than only on the page behind
+   * the panel: this is where the button is.
+   */
+  noCredential: boolean;
   /** A connect or disconnect is in flight somewhere on the page. */
   busy: boolean;
   onClose: () => void;
@@ -35,7 +41,15 @@ interface Props {
 const USAGE_RANGE = "30d";
 
 /**
- * A connected provider as an object you can open (issue #404).
+ * A provider as an object you can open (issue #404).
+ *
+ * Opens whether or not it is connected — "connected **or not**" is the issue's
+ * wording, and OpenHuman's `ComposioConnectModal` is a phase machine that opens
+ * on a disconnected toolkit and connects from inside. Keeping the one-click
+ * connect on the tile and the panel for connected providers only would have
+ * been a nicer first click and a worse answer to "what is this provider, and
+ * what is wired to it" — which is the question the issue exists to make
+ * answerable.
  *
  * ## What this is honest about, and why each line is worded the way it is
  *
@@ -73,6 +87,7 @@ export function ProviderDetail({
   company,
   provider,
   canManage,
+  noCredential,
   busy,
   onClose,
   onConnectAnother,
@@ -119,16 +134,15 @@ export function ProviderDetail({
               </SheetTitle>
               <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
                 <Badge variant="outline" className="font-normal">
-                  {/* Which of the three systems backs this connection. The
-                      panel exists for providers Composio holds; the badge is
-                      still stated rather than assumed, because "through which
-                      system" is one of the questions the issue asks it to
-                      answer. */}
+                  {/* Which of the three systems this provider is reached
+                      through — one of the questions the issue asks the view to
+                      answer, and stated rather than left to be inferred from
+                      the fact that a panel opened at all. */}
                   Composio
                 </Badge>
                 <span>
                   {live.length === 0
-                    ? "no active account"
+                    ? "not connected"
                     : live.length === 1
                       ? "1 account connected"
                       : `${live.length} accounts connected`}
@@ -149,7 +163,12 @@ export function ProviderDetail({
                 ))}
                 {accounts.length === 0 && (
                   <p className="text-xs text-muted-foreground">
-                    No Composio account is connected for {provider.label}.
+                    {/* An account and a *usable* account are different states,
+                        and a provider that has never been connected is a third.
+                        The empty case says which of them this is rather than
+                        "not connected", which would cover all three. */}
+                    No Composio account is connected for {provider.label}, so its agents have none of
+                    its tools.
                   </p>
                 )}
               </section>
@@ -177,34 +196,45 @@ export function ProviderDetail({
                 </p>
               )}
 
-              <Separator />
+              {/* Hidden for a provider that is neither connected nor has been
+                  used: "0 calls in the last 30 days" is true there but says
+                  nothing, and in open mode this panel opens over a catalog of
+                  123 providers that have never been touched. A non-zero count
+                  on a disconnected provider is the opposite — it is the
+                  interesting case, so it stays. */}
+              {(provider.connected || (usageLoad === "ready" && (calls ?? 0) > 0)) && (
+                <>
+                  <Separator />
 
-              <section className="space-y-1" aria-label="Usage">
-                <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                  Usage
-                </h4>
-                {usageLoad === "loading" && (
-                  <p className="text-xs text-muted-foreground">Reading usage…</p>
-                )}
-                {usageLoad === "unavailable" && (
-                  <p className="text-xs text-muted-foreground">
-                    This host does not report usage, so what has gone through this connection is not
-                    recorded here.
-                  </p>
-                )}
-                {usageLoad === "ready" && (
-                  <>
-                    <p className="text-sm">
-                      <span className="font-medium">{calls}</span>{" "}
-                      {calls === 1 ? "call" : "calls"} in the last 30 days
-                    </p>
-                    <p className="text-xs text-muted-foreground">
-                      Successful tool calls through {provider.label}, counted per provider rather
-                      than per account — a call through any account above lands on this one total.
-                    </p>
-                  </>
-                )}
-              </section>
+                  <section className="space-y-1" aria-label="Usage">
+                    <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                      Usage
+                    </h4>
+                    {usageLoad === "loading" && (
+                      <p className="text-xs text-muted-foreground">Reading usage…</p>
+                    )}
+                    {usageLoad === "unavailable" && (
+                      <p className="text-xs text-muted-foreground">
+                        This host does not report usage, so what has gone through this connection is
+                        not recorded here.
+                      </p>
+                    )}
+                    {usageLoad === "ready" && (
+                      <>
+                        <p className="text-sm">
+                          <span className="font-medium">{calls}</span>{" "}
+                          {calls === 1 ? "call" : "calls"} in the last 30 days
+                        </p>
+                        <p className="text-xs text-muted-foreground">
+                          Successful tool calls through {provider.label}, counted per provider rather
+                          than per account — a call through any account above lands on this one
+                          total.
+                        </p>
+                      </>
+                    )}
+                  </section>
+                </>
+              )}
 
               {canManage && (
                 <>
@@ -213,23 +243,32 @@ export function ProviderDetail({
                     <Button
                       variant="outline"
                       className="w-full"
-                      disabled={busy}
+                      disabled={busy || noCredential}
                       onClick={() => onConnectAnother(provider)}
                       data-testid="provider-detail-connect-another"
                     >
                       <LogIn className="size-4" />
                       {accounts.length === 0 ? "Connect an account" : "Connect another account"}
                     </Button>
-                    <p className="text-xs text-muted-foreground">
-                      Disconnecting removes the connection at Composio, so agents lose these tools on
-                      their next turn. It does not sign the company out of {provider.label}, and it
-                      does not delete anything there.
-                    </p>
+                    {noCredential && (
+                      <p className="text-xs text-muted-foreground">
+                        There is no credential for this company to authorize against yet, so a
+                        sign-in has nothing to present. Set the company&apos;s TinyHumans credential
+                        on the Connections page first.
+                      </p>
+                    )}
+                    {accounts.length > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        Disconnecting removes the connection at Composio, so agents lose these tools
+                        on their next turn. It does not sign the company out of {provider.label}, and
+                        it does not delete anything there.
+                      </p>
+                    )}
                   </section>
                 </>
               )}
 
-              {!canManage && accounts.length > 0 && (
+              {!canManage && (
                 <p className="text-xs text-muted-foreground">
                   Only an admin can connect or disconnect an account here.
                 </p>

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from "react";
+import { AlertTriangle, Loader2, LogIn, Unplug } from "lucide-react";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ComposioConnectedAccount } from "@/api/composio";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { callsForProvider, connectedOn } from "@/lib/connection-detail";
+import { toolkitSlug } from "@/lib/connections";
+import type { GridProvider } from "@/lib/provider-grid";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+  /** The provider to show, or `null` when nothing is open. */
+  provider: GridProvider | null;
+  /** Whether this viewer may change what the company connects through (#403). */
+  canManage: boolean;
+  /** A connect or disconnect is in flight somewhere on the page. */
+  busy: boolean;
+  onClose: () => void;
+  onConnectAnother: (provider: GridProvider) => void;
+  onDisconnectAccount: (provider: GridProvider, account: ComposioConnectedAccount) => void;
+}
+
+/** The window the usage figure covers. Matches the Usage view's own default. */
+const USAGE_RANGE = "30d";
+
+/**
+ * A connected provider as an object you can open (issue #404).
+ *
+ * ## What this is honest about, and why each line is worded the way it is
+ *
+ * The issue's requirement is not "show more fields" — it is that every claim on
+ * this panel is one the system can actually back. Three of them could not be
+ * made naively:
+ *
+ *  1. **Which account an agent uses.** OpenHuman marks the first of several as
+ *     the default, and inheriting that was the plan. It is not true here:
+ *     `composio_execute` posts `{tool, arguments}` and **no connection id**
+ *     (`src/harness/composio.rs`, and `execute_tool` in the shared client), so
+ *     nothing on this side selects an account — Composio resolves it for the
+ *     entity. A "Default" chip would name a decision this product does not
+ *     make. The panel says that instead.
+ *  2. **When it was connected.** Only Composio records it. The native
+ *     `oauth/{provider}` store keeps `{token, account}` and journals nothing on
+ *     connect, and MCP has no such concept — so for those the date is not
+ *     merely missing, it is unrecoverable. An empty cell would read as
+ *     "never"; the panel says "not recorded".
+ *  3. **What has gone through it.** Composio meters a successful
+ *     `composio_execute` per toolkit (`src/metering/oauth.rs`), so the number
+ *     here is real — but it is per *provider*, not per *account*, and both
+ *     accounts of a two-Gmail company land on the same total. Rendering it
+ *     against one account would be a number that means something else.
+ *
+ * ## Composio only
+ *
+ * The native OAuth catalog gets no detail view. Its credential is written and
+ * read by nothing (#396), and a page devoted to how healthy a connection is,
+ * is exactly where an inert one would look most alive. A provider that also
+ * holds a native credential says so as a caveat, not as a second connection.
+ */
+export function ProviderDetail({
+  client,
+  company,
+  provider,
+  canManage,
+  busy,
+  onClose,
+  onConnectAnother,
+  onDisconnectAccount,
+}: Props) {
+  const slug = provider ? toolkitSlug(provider.slug) : null;
+  const [calls, setCalls] = useState<number | null>(null);
+  const [usageLoad, setUsageLoad] = useState<"loading" | "ready" | "unavailable">("loading");
+
+  useEffect(() => {
+    if (slug === null) return;
+    let alive = true;
+    setUsageLoad("loading");
+    setCalls(null);
+    client
+      .usage(USAGE_RANGE, company)
+      .then((usage) => {
+        if (!alive) return;
+        setCalls(callsForProvider(usage.byProvider, slug));
+        setUsageLoad("ready");
+      })
+      // A host without the usage route (older build) 404s. "Not recorded here"
+      // is the honest render — not a zero, which claims the calls were counted
+      // and there were none.
+      .catch(() => {
+        if (alive) setUsageLoad("unavailable");
+      });
+    return () => {
+      alive = false;
+    };
+  }, [client, company, slug]);
+
+  const accounts = provider?.accounts ?? [];
+  const live = accounts.filter((a) => a.connected);
+
+  return (
+    <Sheet open={provider !== null} onOpenChange={(next) => !next && onClose()}>
+      <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
+        {provider && (
+          <>
+            <SheetHeader className="border-b">
+              <SheetTitle className="flex items-center gap-2">
+                <span className="truncate">{provider.label}</span>
+              </SheetTitle>
+              <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
+                <Badge variant="outline" className="font-normal">
+                  {/* Which of the three systems backs this connection. The
+                      panel exists for providers Composio holds; the badge is
+                      still stated rather than assumed, because "through which
+                      system" is one of the questions the issue asks it to
+                      answer. */}
+                  Composio
+                </Badge>
+                <span>
+                  {live.length === 0
+                    ? "no active account"
+                    : live.length === 1
+                      ? "1 account connected"
+                      : `${live.length} accounts connected`}
+                </span>
+              </SheetDescription>
+            </SheetHeader>
+
+            <div className="space-y-4 px-4 pb-6">
+              <section className="space-y-2" aria-label="Connected accounts">
+                {accounts.map((account) => (
+                  <AccountRow
+                    key={account.id}
+                    account={account}
+                    canManage={canManage}
+                    busy={busy}
+                    onDisconnect={() => onDisconnectAccount(provider, account)}
+                  />
+                ))}
+                {accounts.length === 0 && (
+                  <p className="text-xs text-muted-foreground">
+                    No Composio account is connected for {provider.label}.
+                  </p>
+                )}
+              </section>
+
+              {live.length > 1 && (
+                <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                  <AlertTriangle className="mt-px size-3 shrink-0" />
+                  <span>
+                    Holding several accounts is fine — they are the company&apos;s, and every member
+                    works through them. Which one an agent acts as is not set here:{" "}
+                    <span className="font-mono">composio_execute</span> sends no connection id, so
+                    Composio resolves it. Disconnect the one you do not want an agent to use.
+                  </span>
+                </p>
+              )}
+
+              {provider.via.includes("native") && (
+                <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+                  <AlertTriangle className="mt-px size-3 shrink-0" />
+                  <span>
+                    This company also stores a self-hosted OAuth credential for {provider.label}. No
+                    agent reads it (issue #396), it is not what the accounts above are, and
+                    disconnecting here does not touch it.
+                  </span>
+                </p>
+              )}
+
+              <Separator />
+
+              <section className="space-y-1" aria-label="Usage">
+                <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+                  Usage
+                </h4>
+                {usageLoad === "loading" && (
+                  <p className="text-xs text-muted-foreground">Reading usage…</p>
+                )}
+                {usageLoad === "unavailable" && (
+                  <p className="text-xs text-muted-foreground">
+                    This host does not report usage, so what has gone through this connection is not
+                    recorded here.
+                  </p>
+                )}
+                {usageLoad === "ready" && (
+                  <>
+                    <p className="text-sm">
+                      <span className="font-medium">{calls}</span>{" "}
+                      {calls === 1 ? "call" : "calls"} in the last 30 days
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      Successful tool calls through {provider.label}, counted per provider rather
+                      than per account — a call through any account above lands on this one total.
+                    </p>
+                  </>
+                )}
+              </section>
+
+              {canManage && (
+                <>
+                  <Separator />
+                  <section className="space-y-2" aria-label="Manage this connection">
+                    <Button
+                      variant="outline"
+                      className="w-full"
+                      disabled={busy}
+                      onClick={() => onConnectAnother(provider)}
+                      data-testid="provider-detail-connect-another"
+                    >
+                      <LogIn className="size-4" />
+                      {accounts.length === 0 ? "Connect an account" : "Connect another account"}
+                    </Button>
+                    <p className="text-xs text-muted-foreground">
+                      Disconnecting removes the connection at Composio, so agents lose these tools on
+                      their next turn. It does not sign the company out of {provider.label}, and it
+                      does not delete anything there.
+                    </p>
+                  </section>
+                </>
+              )}
+
+              {!canManage && accounts.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Only an admin can connect or disconnect an account here.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+/** One connected account: what it is, since when, and how to release it. */
+function AccountRow({
+  account,
+  canManage,
+  busy,
+  onDisconnect,
+}: {
+  account: ComposioConnectedAccount;
+  canManage: boolean;
+  busy: boolean;
+  onDisconnect: () => void;
+}) {
+  return (
+    <div
+      className="flex items-start justify-between gap-2 rounded-lg border border-border px-3 py-2"
+      data-testid={`provider-account-${account.id}`}
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="truncate text-sm font-medium">
+          {/* Composio publishes no label for some providers, and guessing one
+              from the toolkit makes two accounts indistinguishable at the one
+              moment an operator has to tell them apart. */}
+          {account.account ?? "Account name not published"}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          <Badge variant="outline" className="mr-1.5 font-mono font-normal">
+            {/* Composio's own status string, not a re-spelling of it: "set up
+                and since expired" and "never finished setting up" are
+                different sentences and both flatten to "not connected". */}
+            {account.status}
+          </Badge>
+          {connectedOn(account.createdAt)}
+        </p>
+      </div>
+      {canManage && (
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={busy}
+          onClick={onDisconnect}
+          aria-label={`Disconnect ${account.account ?? account.id}`}
+        >
+          {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Unplug className="size-3.5" />}
+          Disconnect
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -290,12 +290,16 @@ function SectionHeading({ count }: { count: number | null }) {
  * it. An 8.5rem tile has no room for a label AND a button, and a tile that looks
  * clickable but is not would be worse than either.
  *
- * A tile connected through Composio opens its detail view instead (issue #404):
- * there is an object behind it — accounts, statuses, dates, a per-account
- * revoke — and a single icon button cannot stand for it. That is also why the
- * inline Disconnect is gone from those tiles rather than kept alongside: a
- * toolkit can hold two accounts, and a control that names neither has nothing
- * to revoke.
+ * A tile Composio can reach opens its detail view instead (issue #404),
+ * connected or not: there is an object behind it — accounts, statuses, dates, a
+ * per-account revoke, and for a disconnected one what it is and how to connect
+ * it — and a single icon button cannot stand for that. It costs the connect
+ * flow a click, which is the trade OpenHuman already makes and this issue asks
+ * us to inherit rather than re-derive.
+ *
+ * It is also why the inline Disconnect is gone from those tiles rather than
+ * kept alongside: a toolkit can hold two accounts, and a control that names
+ * neither has nothing to revoke.
  *
  * The natively-connected tile keeps the old shape — a small Disconnect control
  * in the glyph slot, so the destructive action is never the whole surface an
@@ -330,7 +334,14 @@ function ProviderTile({
   // Openable for everyone who can see the page, not only an admin (issue #403
   // gates the writes inside, not the reading): "which account is Gmail wired
   // to, and since when" is exactly what a member opens this page to learn.
-  const openable = row.connected && row.accounts.length > 0;
+  //
+  // Connected or not — the issue's own wording, and what OpenHuman does. The
+  // one exclusion is a provider Composio reports as connected while the host
+  // answered without `accounts` (it predates #696): the panel would open on a
+  // connection it cannot name, describe, date or release, which is a worse
+  // answer than the tile's badge.
+  const openable =
+    row.route.kind === "composio" && (!row.connected || row.accounts.length > 0);
   const state = row.connected
     ? row.accounts.length > 1
       ? `${row.accounts.length} accounts connected`
@@ -388,6 +399,11 @@ function ProviderTile({
     <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
   ) : connectable ? (
     <LogIn className="size-3.5 shrink-0 text-muted-foreground" />
+  ) : openable ? (
+    // Openable but not connectable: a member, who can read the panel and act on
+    // nothing in it. A sign-in glyph would promise them the one thing #403
+    // takes away.
+    <ChevronRight className="size-3.5 shrink-0 text-muted-foreground" />
   ) : null;
 
   const body = (
@@ -411,7 +427,9 @@ function ProviderTile({
   );
 
   const title = openable
-    ? `Open ${row.label} — accounts, status, and disconnect.`
+    ? row.connected
+      ? `Open ${row.label} — accounts, status, and disconnect.`
+      : `Open ${row.label} — what it is, and how to connect it.`
     : row.connected && !row.canDisconnect
       ? `${row.label} is connected through Composio; manage or revoke it there.`
       : row.description || undefined;
@@ -434,7 +452,8 @@ function ProviderTile({
           data-testid={`open-provider-${row.slug}`}
           className={cn(
             shell,
-            "transition-colors hover:border-foreground/20 hover:bg-status-done/10",
+            "transition-colors hover:border-foreground/20",
+            row.connected ? "hover:bg-status-done/10" : "hover:bg-accent",
             "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
           )}
         >

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Check, Loader2, LogIn, Search, Unplug } from "lucide-react";
+import { AlertTriangle, Check, ChevronRight, Loader2, LogIn, Search, Unplug } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
@@ -41,6 +41,8 @@ interface Props {
   loading: boolean;
   onConnect: (provider: GridProvider) => void;
   onDisconnect: (provider: GridProvider) => void;
+  /** Open a connected provider's detail view (issue #404). */
+  onOpen: (provider: GridProvider) => void;
   onConnectSlug: (slug: string) => void;
 }
 
@@ -77,6 +79,7 @@ export function ProvidersSection({
   loading,
   onConnect,
   onDisconnect,
+  onOpen,
   onConnectSlug,
 }: Props) {
   const [query, setQuery] = useState("");
@@ -212,6 +215,7 @@ export function ProvidersSection({
                 noCredential={noCredential}
                 onConnect={() => onConnect(row)}
                 onDisconnect={() => onDisconnect(row)}
+                onOpen={() => onOpen(row)}
               />
             ))}
           </ul>
@@ -286,9 +290,18 @@ function SectionHeading({ count }: { count: number | null }) {
  * it. An 8.5rem tile has no room for a label AND a button, and a tile that looks
  * clickable but is not would be worse than either.
  *
- * Connected tiles are the exception: the click target moves to a small
- * Disconnect control in the glyph slot, so the destructive action is never the
- * whole surface an operator brushes past while scanning.
+ * A tile connected through Composio opens its detail view instead (issue #404):
+ * there is an object behind it — accounts, statuses, dates, a per-account
+ * revoke — and a single icon button cannot stand for it. That is also why the
+ * inline Disconnect is gone from those tiles rather than kept alongside: a
+ * toolkit can hold two accounts, and a control that names neither has nothing
+ * to revoke.
+ *
+ * The natively-connected tile keeps the old shape — a small Disconnect control
+ * in the glyph slot, so the destructive action is never the whole surface an
+ * operator brushes past while scanning. It gets no detail view: the native
+ * catalog's credential is read by nothing (#396), and a detail view is the one
+ * place that inertness would look most like health.
  */
 function ProviderTile({
   row,
@@ -298,6 +311,7 @@ function ProviderTile({
   noCredential,
   onConnect,
   onDisconnect,
+  onOpen,
 }: {
   row: GridProvider;
   canManage: boolean;
@@ -306,16 +320,23 @@ function ProviderTile({
   noCredential: boolean;
   onConnect: () => void;
   onDisconnect: () => void;
+  onOpen: () => void;
 }) {
   // `managed` and `unavailable` render no action at all — that is the whole
   // point of routing the tile (issue #599): a button that could only 400 is
   // never drawn.
   const connectable =
     canManage && !row.connected && (row.route.kind === "composio" || row.route.kind === "native");
+  // Openable for everyone who can see the page, not only an admin (issue #403
+  // gates the writes inside, not the reading): "which account is Gmail wired
+  // to, and since when" is exactly what a member opens this page to learn.
+  const openable = row.connected && row.accounts.length > 0;
   const state = row.connected
-    ? row.via.length > 0
-      ? `connected via ${row.via.join(" + ")}`
-      : "connected"
+    ? row.accounts.length > 1
+      ? `${row.accounts.length} accounts connected`
+      : row.via.length > 0
+        ? `connected via ${row.via.join(" + ")}`
+        : "connected"
     : busy
       ? "signing in"
       : row.unverified
@@ -332,7 +353,11 @@ function ProviderTile({
   );
 
   const glyph = row.connected ? (
-    canManage && row.canDisconnect ? (
+    openable ? (
+      // Non-interactive: the whole tile is the control that opens it, and a
+      // button inside that button is not a thing the DOM allows.
+      <ChevronRight className="size-3.5 shrink-0 text-status-done-text" aria-hidden="true" />
+    ) : canManage && row.canDisconnect ? (
       <button
         type="button"
         disabled={anyBusy}
@@ -351,9 +376,10 @@ function ProviderTile({
     ) : (
       <Check
         className="size-3.5 shrink-0 text-status-done-text"
-        // Composio holds this connection and no host route can release it —
-        // `DELETE …/connections/{provider}` only blanks a local secret this
-        // provider never had. Saying where it lives beats a button that
+        // Connected, with nothing this console can address: either the viewer
+        // cannot manage it, or the host answered the connection list without
+        // `accounts` (it predates #696), so there is no id to revoke and no
+        // object to open. Saying where the connection lives beats a button that
         // reports success and changes nothing.
         aria-hidden="true"
       />
@@ -384,8 +410,9 @@ function ProviderTile({
     </>
   );
 
-  const title =
-    row.connected && !row.canDisconnect
+  const title = openable
+    ? `Open ${row.label} — accounts, status, and disconnect.`
+    : row.connected && !row.canDisconnect
       ? `${row.label} is connected through Composio; manage or revoke it there.`
       : row.description || undefined;
 
@@ -394,7 +421,26 @@ function ProviderTile({
     // other surface in this issue reconciles on — so a spec that names a tile
     // names the same thing the backend does.
     <li className="min-w-0" data-testid={`provider-${row.slug}`}>
-      {connectable ? (
+      {openable ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          title={title}
+          aria-label={`Open ${row.label}. ${state}.`}
+          // Deliberately NOT prefixed `provider-`: `connections-one-list.spec.ts`
+          // counts `[data-testid^='provider-']` nodes to prove a provider
+          // renders exactly one tile, and a nested node sharing that prefix
+          // would make this control look like a second tile.
+          data-testid={`open-provider-${row.slug}`}
+          className={cn(
+            shell,
+            "transition-colors hover:border-foreground/20 hover:bg-status-done/10",
+            "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+          )}
+        >
+          {body}
+        </button>
+      ) : connectable ? (
         <button
           type="button"
           disabled={anyBusy || (row.route.kind === "composio" && noCredential)}

--- a/frontend/test/unit/connection-detail.test.ts
+++ b/frontend/test/unit/connection-detail.test.ts
@@ -1,0 +1,65 @@
+// What the provider detail view is allowed to claim (issue #404).
+//
+// The issue names the failure mode it exists to prevent: "Do not invent a
+// number. If per-connection usage is not recorded today, say so on screen …
+// rather than rendering a plausible-looking zero." These pin the two places the
+// view could quietly do the equivalent — a missing date rendered as a blank
+// (which reads as "never"), and one connection system's total read as another's.
+
+import { describe, expect, it } from "vitest";
+
+import type { ProviderCallsDto } from "@/api/types";
+import { callsForProvider, connectedOn } from "@/lib/connection-detail";
+
+describe("connectedOn", () => {
+  it("states the date Composio recorded", () => {
+    // Formatted in the viewer's locale, so assert the parts rather than a
+    // rendering — a CI runner and a dev box do not agree on the order.
+    const line = connectedOn("2026-08-09T15:30:00Z");
+    expect(line).toContain("connected");
+    expect(line).toContain("2026");
+  });
+
+  it("says the date is not recorded rather than leaving a blank", () => {
+    // The native store keeps `{token, account}` and journals nothing on
+    // connect; MCP has no such concept. A blank in this slot reads as "never
+    // connected", which is a different — and false — sentence.
+    expect(connectedOn(undefined)).toBe("connection date not recorded");
+    expect(connectedOn("")).toBe("connection date not recorded");
+  });
+
+  it("does not render a host's unparseable string as a date", () => {
+    // Forwarded verbatim from Composio, so this is a wire value, not ours.
+    // `Invalid Date` on screen is worse than admitting there is no date.
+    expect(connectedOn("whenever")).toBe("connection date not recorded");
+  });
+});
+
+describe("callsForProvider", () => {
+  function row(provider: string, calls: number): ProviderCallsDto {
+    return { provider, calls };
+  }
+
+  it("counts the toolkit's own successful calls", () => {
+    expect(callsForProvider([row("gmail", 12), row("slack", 3)], "gmail")).toBe(12);
+  });
+
+  it("reads zero for a provider with no calls in the window", () => {
+    // A real zero, not a missing one: `composio_execute` meters every
+    // successful call, so a provider with no row has had none.
+    expect(callsForProvider([row("slack", 3)], "gmail")).toBe(0);
+  });
+
+  it("never reads an MCP server's calls as the Composio toolkit's", () => {
+    // `mcp:` exists precisely so these two cannot merge (issue #698): a company
+    // with a Composio `gmail` and an MCP server its operator also called
+    // `gmail` has two connections, and one row's total is not the other's.
+    expect(callsForProvider([row("mcp:gmail", 40), row("gmail", 2)], "gmail")).toBe(2);
+    expect(callsForProvider([row("mcp:gmail", 40)], "gmail")).toBe(0);
+  });
+
+  it("matches the host's normalization rather than its spelling", () => {
+    // `by_provider` groups on a trimmed, lowercased slug (`src/metering/oauth.rs`).
+    expect(callsForProvider([row("GitHub", 5)], "github")).toBe(5);
+  });
+});

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
+import type { ConnectionState, UsageDto } from "@/api/types";
+import type { ComposioReach } from "@/lib/connections";
+import { buildGridProviders, type GridProvider } from "@/lib/provider-grid";
+import { ProviderDetail } from "@/views/connections/ProviderDetail";
+
+/**
+ * The provider detail view's claims (issue #404).
+ *
+ * This suite is normally for pure functions — see `vitest.config.ts`. The
+ * exception is earned the same way `select-popup-width` earns it: the thing
+ * under test *is* what reaches the operator's eye. The issue is not asking for
+ * fields on a panel, it is asking that every sentence on the panel be one the
+ * system can back, and three of them cannot be checked anywhere but here:
+ *
+ *  1. no account is marked as the one agents use, because none is;
+ *  2. a missing connection date says so rather than showing a blank;
+ *  3. a member is not offered a disconnect the host will refuse (#403).
+ */
+
+const OPEN: ComposioReach = {
+  inBuild: true,
+  granted: true,
+  hasCredential: true,
+  openMode: true,
+  effectiveToolkits: [],
+};
+
+const EMPTY_USAGE: UsageDto = {
+  totals: {
+    inputTokens: 0,
+    outputTokens: 0,
+    tokens: 0,
+    costUsd: 0,
+    oauthCalls: 0,
+    connections: 0,
+    searchCalls: 0,
+  },
+  series: [],
+  byAgent: [],
+  byProvider: [],
+};
+
+function entry(slug: string, name: string): ComposioToolkitEntry {
+  return { slug, name, description: "", logo: null, categories: [] };
+}
+
+function account(over: Partial<ComposioConnectedAccount> = {}): ComposioConnectedAccount {
+  return { id: "conn-1", status: "ACTIVE", connected: true, ...over };
+}
+
+/** A real grid row, built the way the page builds it. */
+function gmail(accounts: ComposioConnectedAccount[], via: ConnectionState["via"] = ["composio"]) {
+  const rows = buildGridProviders(
+    [entry("gmail", "Gmail")],
+    [],
+    { gmail: { provider: "gmail", connected: true, via } },
+    OPEN,
+    false,
+    { gmail: accounts },
+  );
+  return rows.find((p) => p.slug === "gmail")!;
+}
+
+/** A host that answers the usage route with `byProvider` rows. */
+function clientWith(byProvider: UsageDto["byProvider"]): OpenCompanyClient {
+  return {
+    usage: async () => ({ ...EMPTY_USAGE, byProvider }),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function render(provider: GridProvider, canManage: boolean, client = clientWith([])) {
+  await act(async () => {
+    root.render(
+      createElement(ProviderDetail, {
+        client,
+        company: null,
+        provider,
+        canManage,
+        busy: false,
+        onClose: () => {},
+        onConnectAnother: () => {},
+        onDisconnectAccount: () => {},
+      }),
+    );
+  });
+}
+
+/** The panel renders through a portal, so it is on `document`, not `container`. */
+function text(): string {
+  return document.body.textContent ?? "";
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("the provider detail view", () => {
+  it("lists every account with the status Composio reported", async () => {
+    await render(
+      gmail([
+        account({ id: "conn-gmail-1", account: "ops@acme.test" }),
+        account({ id: "conn-gmail-2", account: "billing@acme.test", status: "EXPIRED", connected: false }),
+      ]),
+      true,
+    );
+    expect(text()).toContain("ops@acme.test");
+    expect(text()).toContain("billing@acme.test");
+    // Verbatim, not re-spelled: "set up and since expired" and "never finished
+    // setting up" are different sentences that both flatten to "not connected".
+    expect(text()).toContain("EXPIRED");
+  });
+
+  it("marks no account as the one agents use, because nothing chooses one", async () => {
+    // OpenHuman marks the first of several as the default and inheriting that
+    // was the plan. It is not true here: `composio_execute` posts
+    // `{tool, arguments}` and no connection id, so Composio resolves which
+    // account acts. A "Default" chip would name a decision this product does
+    // not make — the exact shape of invention the issue rules out.
+    await render(
+      gmail([
+        account({ id: "conn-gmail-1", account: "ops@acme.test" }),
+        account({ id: "conn-gmail-2", account: "billing@acme.test" }),
+      ]),
+      true,
+    );
+    expect(text()).not.toContain("Default");
+    expect(text()).toContain("composio_execute");
+  });
+
+  it("says a connection date is not recorded rather than leaving it blank", async () => {
+    await render(gmail([account({ account: "ops@acme.test" })]), true);
+    expect(text()).toContain("connection date not recorded");
+  });
+
+  it("states usage is counted per provider, not per account", async () => {
+    await render(
+      gmail([
+        account({ id: "conn-gmail-1", account: "ops@acme.test" }),
+        account({ id: "conn-gmail-2", account: "billing@acme.test" }),
+      ]),
+      true,
+      clientWith([{ provider: "gmail", calls: 12 }]),
+    );
+    expect(text()).toContain("12");
+    expect(text()).toContain("per provider rather than per account");
+  });
+
+  it("does not report a zero when the host records no usage at all", async () => {
+    // A failed usage read is not a company that made no calls. Rendering "0"
+    // here is precisely the plausible-looking zero the issue forbids.
+    const broken = {
+      usage: async () => {
+        throw new Error("no usage route on this host");
+      },
+    } as unknown as OpenCompanyClient;
+    await render(gmail([account()]), true, broken);
+    expect(text()).toContain("does not report usage");
+    expect(text()).not.toContain("0 calls");
+  });
+
+  it("says what a disconnect will and will not revoke", async () => {
+    await render(gmail([account({ account: "ops@acme.test" })]), true);
+    expect(text()).toContain("removes the connection at Composio");
+    expect(text()).toContain("does not sign the company out");
+  });
+
+  it("offers a member no control the host would refuse", async () => {
+    // Issue #403. Courtesy, not enforcement — the host answers 403 whatever
+    // this renders — but a Disconnect that can only fail is a poor thing to
+    // put in front of someone reading the page to find out what is wired.
+    await render(gmail([account({ account: "ops@acme.test" })]), false);
+    expect(text()).toContain("ops@acme.test");
+    expect(text()).not.toContain("Disconnect");
+    expect(text()).not.toContain("Connect another account");
+    expect(text()).toContain("Only an admin can connect or disconnect");
+  });
+
+  it("names the inert native credential as a caveat, not as a second connection", async () => {
+    // #396: the native `oauth/{provider}` entry is written and read by nothing.
+    // A detail view is where that would look healthiest, so it is stated.
+    await render(gmail([account()], ["composio", "native"]), true);
+    expect(text()).toContain("No agent reads it");
+  });
+});

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -69,6 +69,12 @@ function gmail(accounts: ComposioConnectedAccount[], via: ConnectionState["via"]
   return rows.find((p) => p.slug === "gmail")!;
 }
 
+/** The same provider, connected to nothing. */
+function unconnectedGmail() {
+  const rows = buildGridProviders([entry("gmail", "Gmail")], [], {}, OPEN, false);
+  return rows.find((p) => p.slug === "gmail")!;
+}
+
 /** A host that answers the usage route with `byProvider` rows. */
 function clientWith(byProvider: UsageDto["byProvider"]): OpenCompanyClient {
   return {
@@ -79,7 +85,12 @@ function clientWith(byProvider: UsageDto["byProvider"]): OpenCompanyClient {
 let container: HTMLDivElement;
 let root: Root;
 
-async function render(provider: GridProvider, canManage: boolean, client = clientWith([])) {
+async function render(
+  provider: GridProvider,
+  canManage: boolean,
+  client = clientWith([]),
+  noCredential = false,
+) {
   await act(async () => {
     root.render(
       createElement(ProviderDetail, {
@@ -87,6 +98,7 @@ async function render(provider: GridProvider, canManage: boolean, client = clien
         company: null,
         provider,
         canManage,
+        noCredential,
         busy: false,
         onClose: () => {},
         onConnectAnother: () => {},
@@ -192,6 +204,36 @@ describe("the provider detail view", () => {
     expect(text()).not.toContain("Disconnect");
     expect(text()).not.toContain("Connect another account");
     expect(text()).toContain("Only an admin can connect or disconnect");
+  });
+
+  it("opens on a provider that is not connected, and offers the connect", async () => {
+    // "connected **or not**" is the issue's wording, and OpenHuman's modal is a
+    // phase machine that opens on a disconnected toolkit and connects from
+    // inside. Keeping the panel for connected providers only was the earlier
+    // cut here; it answered "what is wired" and not "what is this".
+    await render(unconnectedGmail(), true);
+    expect(text()).toContain("not connected");
+    expect(text()).toContain("Connect an account");
+    expect(text()).toContain("agents have none of its tools");
+  });
+
+  it("shows no usage figure for a provider that was never connected or used", async () => {
+    // A true zero that says nothing, over a catalog of 123 untouched providers.
+    await render(unconnectedGmail(), true);
+    expect(text()).not.toContain("in the last 30 days");
+  });
+
+  it("keeps the usage figure on a disconnected provider that was used", async () => {
+    // The interesting case: the calls happened, then the account went away.
+    await render(unconnectedGmail(), true, clientWith([{ provider: "gmail", calls: 7 }]));
+    expect(text()).toContain("7");
+    expect(text()).toContain("in the last 30 days");
+  });
+
+  it("says why a connect cannot be started when no credential resolves", async () => {
+    // Stated where the button is, not only on the page behind the panel.
+    await render(unconnectedGmail(), true, clientWith([]), true);
+    expect(text()).toContain("no credential for this company to authorize against");
   });
 
   it("names the inert native credential as a caveat, not as a second connection", async () => {

--- a/frontend/test/unit/provider-grid.test.ts
+++ b/frontend/test/unit/provider-grid.test.ts
@@ -9,9 +9,9 @@
 
 import { describe, expect, it } from "vitest";
 
-import type { ComposioToolkitEntry } from "@/api/composio";
+import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
 import type { ConnectionState } from "@/api/types";
-import { buildGridProviders } from "@/lib/provider-grid";
+import { buildGridProviders, disconnectRouteFor } from "@/lib/provider-grid";
 import { CONNECTION_PROVIDERS, type ComposioReach } from "@/lib/connections";
 
 /** A host where Composio is live and everything is reachable (open mode). */
@@ -213,5 +213,137 @@ describe("buildGridProviders", () => {
       kind: "composio",
       toolkit: "slack",
     });
+  });
+});
+
+// The connection as an object rather than a boolean (issue #404).
+//
+// The bug these pin is one wire: every Disconnect on this page went to
+// `POST …/connections/{provider}/disconnect`, which blanks the host's own
+// `oauth/{provider}` secret. A Composio-connected provider never had one, so the
+// call answered 200, the toast said "Disconnected Gmail", and Gmail was still
+// connected on the next refresh. `DELETE …/composio/connections/{id}` (PR #696)
+// is the route that releases it, and it is addressed by account id.
+describe("disconnect routing", () => {
+  function account(over: Partial<ComposioConnectedAccount> = {}): ComposioConnectedAccount {
+    return { id: "conn-1", status: "ACTIVE", connected: true, ...over };
+  }
+
+  it("routes a Composio-connected provider to its account, not to the native blank", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+      { gmail: [account({ id: "conn-gmail-1", account: "ops@acme.test" })] },
+    );
+    const tile = bySlug(providers, "gmail");
+    expect(tile.canDisconnect).toBe(true);
+    expect(disconnectRouteFor(tile)).toEqual({
+      kind: "composio",
+      accounts: [account({ id: "conn-gmail-1", account: "ops@acme.test" })],
+    });
+  });
+
+  it("keeps the native route for a provider only the host itself holds", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["native"] }),
+      OPEN,
+      false,
+    );
+    expect(disconnectRouteFor(bySlug(providers, "gmail"))).toEqual({ kind: "native" });
+  });
+
+  it("prefers the Composio account when a provider is connected through both", () => {
+    // The native secret is inert until #396 lands, so blanking it would leave
+    // the provider working, the agents' tools intact, and the tile connected —
+    // a disconnect that reports success and releases nothing.
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["native", "composio"] }),
+      OPEN,
+      false,
+      { gmail: [account()] },
+    );
+    expect(disconnectRouteFor(bySlug(providers, "gmail"))?.kind).toBe("composio");
+  });
+
+  it("offers nothing for a provider connected through Composio on a host predating #696", () => {
+    // No `accounts` on the wire means no id, so there is nothing a revoke can
+    // be addressed to. Drawing a Disconnect anyway is the exact defect above.
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+    );
+    const tile = bySlug(providers, "gmail");
+    expect(tile.accounts).toEqual([]);
+    expect(tile.canDisconnect).toBe(false);
+    expect(disconnectRouteFor(tile)).toBeNull();
+  });
+
+  it("ignores an account Composio no longer reports as connected", () => {
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+      { gmail: [account({ status: "EXPIRED", connected: false })] },
+    );
+    const tile = bySlug(providers, "gmail");
+    // Still listed — the detail view shows it, and "set up and since expired"
+    // is a state an operator has to be able to see and clear.
+    expect(tile.accounts).toHaveLength(1);
+    expect(disconnectRouteFor(tile)).toBeNull();
+  });
+
+  it("has nothing to release for a provider that is not connected", () => {
+    const providers = buildGridProviders([entry("gmail")], [], {}, OPEN, false);
+    expect(disconnectRouteFor(bySlug(providers, "gmail"))).toBeNull();
+  });
+
+  it("finds the accounts of a provider whose host id differs from its slug", () => {
+    // `google-calendar` (host) vs `googlecalendar` (Composio). Keying the
+    // account map by one spelling and looking it up by the other is how a
+    // connected provider ends up with no object to open.
+    const providers = buildGridProviders(
+      [entry("googlecalendar")],
+      [],
+      states({ provider: "google-calendar", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+      { googlecalendar: [account({ id: "conn-cal-1" })] },
+    );
+    expect(bySlug(providers, "googlecalendar").accounts).toHaveLength(1);
+  });
+
+  it("shows no account label on a tile holding two of them", () => {
+    // One of two labels on a tile reads as "this is the account it acts as",
+    // which is precisely the claim nothing here can back: `composio_execute`
+    // sends no connection id, so which one Composio resolves is not ours to
+    // report. The count is true; a name would not be.
+    const providers = buildGridProviders(
+      [entry("gmail")],
+      [],
+      states({ provider: "gmail", connected: true, via: ["composio"] }),
+      OPEN,
+      false,
+      {
+        gmail: [
+          account({ id: "conn-gmail-1", account: "ops@acme.test" }),
+          account({ id: "conn-gmail-2", account: "billing@acme.test" }),
+        ],
+      },
+    );
+    const tile = bySlug(providers, "gmail");
+    expect(tile.account).toBeUndefined();
+    expect(tile.accounts).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary

The console half of #404. #696 made a Composio connection an object on the wire; this is the surface that opens one.

A connected provider was a row with a button. It is now a thing you open: which accounts are connected, under which status, since when, what has gone through it, a per-account disconnect, and "connect another account". Ported from `vendor/openhuman`'s `ComposioConnectModal` — its information architecture and its wording — diverging in the three places OpenCompany's reality forces, each named below.

**It also fixes a disconnect that released nothing.** Every Disconnect on this page went to `POST …/connections/{provider}/disconnect`, which blanks the host's own `oauth/{provider}` secret. A Composio-connected provider never had one, so the call answered `200`, the toast said "Disconnected Gmail", and Gmail was connected again on the next refresh. `DELETE …/composio/connections/{id}` is the route that releases it, and `disconnectRouteFor` is the one rule that decides which route a tile takes — Composio when the toolkit holds a live account, native when only the host's own secret backs it, nothing at all on a host predating #696, where there is no id a revoke could name.

Composio wins when a provider is connected through both: the native secret is read by no agent (#396), so blanking it releases nothing an agent can feel while the tile stays connected.

**Second fix, found while building "connect another account":** the post-authorize poll waited for `connected`, which is already true when adding a second account to a connected toolkit. The first tick — two seconds in, with the Composio tab still open — announced a sign-in that had not happened. It now waits for an account id it had not seen before, which answers the first connect and the second with one rule.

### Three things the port would have inherited untruthfully

**1. No account is marked as the default.** OpenHuman marks the first of several, and inheriting that was the plan named on the issue. It is not true here: `composio_execute` posts `{tool, arguments}` and **no connection id** (`src/harness/composio.rs:1155`; `execute_tool` in the shared client builds the body), so Composio resolves which account acts and nothing in this codebase selects, orders or defaults one. `list_connections_detailed`'s `(toolkit, id)` sort never reaches the execute path — it orders a read. A "Default" chip would name a decision this product does not make, so the panel says so instead. @oxoxDev — this answers the question you left open on the issue, and it is narrower than a preference: making a default real means sending a connection id on execute, which is a harness change, not a console one, and worth its own issue if we want it.

**2. The connection date.** Only Composio records one. The native store keeps `{token, account}` and journals nothing on connect; MCP has no such concept. So the panel says "connection date not recorded" rather than leaving a blank that reads as "never" — and no timestamp column is added to the native store, per the issue thread.

**3. Usage.** Real for Composio, which meters a successful `composio_execute` per toolkit (#698 / #744), so the number is not invented. But it is counted **per provider, not per account**, and the panel states that: a call through either of two Gmail accounts lands on the same total. A host that cannot answer the usage route says so rather than rendering a zero, because a failed read is not a company that made no calls.

### Scope

A Composio-reachable tile opens whether or not it is connected — "connected **or not**" is the issue's wording, and OpenHuman's modal opens on a disconnected toolkit and connects from inside. Connect therefore moves into the panel and the tile costs one extra click, which is the trade being inherited rather than re-derived. The one provider that does not open is one Composio reports as connected on a host answering without `accounts` (predating #696): the panel would open on a connection it cannot name, date or release.

Composio only. The native catalog gets no detail view — its credential is written and read by nothing (#396), and a page about how healthy a connection is, is where an inert one would look most alive. A provider that also holds a native credential says so as a caveat, not as a second connection. Connect and disconnect are hidden from a member who cannot use them (#403).

**Left for follow-ups, deliberately.** A remote MCP server still cannot be opened — `McpServersSection.tsx` is its own 717-line surface and folding it in means two ports in one PR; the panel names MCP as a system without opening one. And the native catalog stays listed on the page, per the thread's "doesn't have to happen in this slice".

A tile holding two accounts shows neither label: one of two names reads as "this is the account it acts as", which is the claim nothing here can back.

## API Or Behavior Changes

No host change — this consumes routes #696 already shipped.

Console behavior:
- A connected Composio tile opens a detail panel instead of offering an inline Disconnect. Natively-connected tiles keep the inline control and get no panel.
- Disconnect now reaches Composio. It previously reported success and changed nothing there.
- The post-authorize poll's success condition changed from `connected` to "an account id that was not there before".
- `buildGridProviders` takes a sixth, optional `composioAccounts` argument; `GridProvider` gains `accounts`. `canDisconnect` keeps its name and changes meaning — it now covers the Composio route too.

## Tests

Console-only change; the Rust suite is untouched. Commands run locally, all green:

- [x] `npm run typecheck` (`tsc -b`)
- [x] `npm run typecheck:e2e`
- [x] `npm run typecheck:unit`
- [x] `npm test` — 625 pass, 27 new
- [x] `npm run build`
- [x] `./scripts/ci/assert-design-tokens.sh`
- [x] `./scripts/ci/assert-md-line-cap.sh`

New coverage:
- `test/unit/provider-grid.test.ts` — the routing rule, including the case that produced the bug (Composio-connected must not take the native route), both-connected preference, the pre-#696 host, an expired account, and the two-account tile showing no label.
- `test/unit/connection-detail.test.ts` — the absent date, an unparseable date, and that an MCP server's `mcp:<server>` row can never be read as the Composio toolkit's total (the collision #698's prefix exists to prevent).
- `test/unit/provider-detail-render.test.ts` — jsdom, rendering the real panel through a real grid row: no "Default" anywhere, the not-recorded date, the per-provider usage caveat, no zero on an unmetered host, the disconnect-scope wording, that a member is offered no control the host would refuse, and the disconnected-provider states (opens, offers the connect, hides a usage figure that would say nothing, explains a missing credential where the button is).

**Not verified:** the panel driven against a live host. It renders for a connected Composio provider, which needs a real connected account — no path to one locally. The render tests exercise the actual component rather than a stand-in, which is the closest this can get without that.

## Documentation

`docs/modules/server/README.md` — its connections section still said "No host route releases a Composio connection", which #696 made false. Replaced with the two routes, what each acts on, why they are not interchangeable, and the fact that no account is selected at execute time.
