### PR TITLE
feat(workflows): wired-channel picker + on-screen author-time validation (#813 defects 4+6)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -416,6 +416,29 @@ export function listWorkflowToolSlugs(
     .then((r) => r.slugs);
 }
 
+/** The `GET …/workflows/wired-channels` answer (issue #813). */
+interface WiredChannelsResponse {
+  channels: string[];
+}
+
+/**
+ * The chat channels this running company can deliver to — the real targets an
+ * output node's `channel` destination may name (issue #813). `operator` is
+ * always present; the rest are the enabled OpenHuman-provider manifest channels.
+ * The console reads this to offer a picker instead of a free-text box that only
+ * fails at delivery with `ChannelNotWired`. A host predating the route 404s; the
+ * caller degrades to an empty list (the picker then falls back to free text)
+ * rather than blocking authoring.
+ */
+export function listWiredChannels(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<string[]> {
+  return client
+    .get<WiredChannelsResponse>(`${client.scopeFor(company)}/workflows/wired-channels`)
+    .then((r) => r.channels);
+}
+
 /**
  * Runs a workflow.
  *

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -180,7 +180,7 @@ function scheduleProblem(schedule: string): string | null {
  * same thing. `destination_messages_match_the_console` in
  * `src/company/workflow_file.rs` fails if either side is reworded alone.
  */
-function destinationTargetProblem(
+export function destinationTargetProblem(
   kind: DraftNode["destinationKind"],
   target: string,
   wiredChannels: string[],
@@ -1166,7 +1166,12 @@ export function WorkflowCreateDialog({
         {error && (
           // Wrapper carries the ref/focus target so it works regardless of
           // whether `Alert` forwards a ref (#813 defect 6).
-          <div ref={errorRef} tabIndex={-1} className="outline-none">
+          <div
+            ref={errorRef}
+            tabIndex={-1}
+            data-testid="create-error"
+            className="outline-none"
+          >
             <Alert variant="destructive">
               <AlertDescription>{error}</AlertDescription>
             </Alert>

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -13,7 +13,7 @@
 // rather than two because an edit is the same form with the same rules — a
 // second one would drift the moment either side grew a field.
 
-import { useEffect, useId, useState } from "react";
+import { useEffect, useId, useRef, useState } from "react";
 import { History, Plus, RotateCcw, Sparkles, Trash2 } from "lucide-react";
 
 import {
@@ -22,6 +22,7 @@ import {
   destinationLabel,
   createWorkflow,
   draftWorkflowFromDescription,
+  listWiredChannels,
   listWorkflowRevisions,
   listWorkflows,
   restoreWorkflowRevision,
@@ -182,6 +183,7 @@ function scheduleProblem(schedule: string): string | null {
 function destinationTargetProblem(
   kind: DraftNode["destinationKind"],
   target: string,
+  wiredChannels: string[],
 ): string | null {
   const value = target.trim();
   if (kind === "email" && !value.includes("@")) {
@@ -189,6 +191,18 @@ function destinationTargetProblem(
   }
   if (kind === "channel" && !value) {
     return "A channel destination needs a channel id — name the channel to post the report to.";
+  }
+  // #813: when the host told us which channels are wired, a target that is not
+  // one of them would only fail at delivery (`ChannelNotWired`) — catch it at
+  // author time instead. Skipped when the list is empty (host offered none), so
+  // a degraded free-text box is never wrongly rejected.
+  if (
+    kind === "channel" &&
+    value &&
+    wiredChannels.length > 0 &&
+    !wiredChannels.includes(value)
+  ) {
+    return `\`${value}\` is not a wired channel — this deployment has: ${wiredChannels.join(", ")}.`;
   }
   return null;
 }
@@ -383,12 +397,19 @@ export function WorkflowCreateDialog({
   const [nodes, setNodes] = useState<DraftNode[]>(starterNodes());
   const [edges, setEdges] = useState<DraftEdge[]>([]);
   const [roster, setRoster] = useState<TeamMemberDto[]>([]);
+  /** The chat channels this company can actually deliver to (#813): the picker
+   * options for an output node's `channel` destination. Degrades to a free-text
+   * box when the host offers no list, so authoring is never blocked. */
+  const [wiredChannels, setWiredChannels] = useState<string[]>([]);
   /** The company's workflows, for the `sub_workflow` config picker (#541). The
    * graph's own id is dropped at render time — a sub-workflow can't call
    * itself. Degrades to a free-text id field when the host offers no list. */
   const [workflows, setWorkflows] = useState<WorkflowSummary[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  /** The submit-time error banner, so a failed submit can scroll it into view
+   * and focus it rather than leave the message off-screen (#813 defect 6). */
+  const errorRef = useRef<HTMLDivElement>(null);
   /** Per-field problems raised on blur (issue #261), keyed by
    * {@link errorKey}. Separate from `error`, the submit-time banner: this one
    * is inline, scoped to the control that caused it, and never blocks Save on
@@ -478,6 +499,17 @@ export function WorkflowCreateDialog({
         if (live) setWorkflows(list);
       } catch {
         if (live) setWorkflows([]);
+      }
+    })();
+    // Issue #813: the wired-channel picker's options. Same degrade-on-failure
+    // shape — a host that can't list channels leaves the channel target a
+    // free-text box rather than blocking authoring.
+    (async () => {
+      try {
+        const channels = await listWiredChannels(client, company);
+        if (live) setWiredChannels(channels);
+      } catch {
+        if (live) setWiredChannels([]);
       }
     })();
     return () => {
@@ -589,7 +621,7 @@ export function WorkflowCreateDialog({
     if (field === "schedule") {
       problem = scheduleProblem(value);
     } else if (field === "destinationTarget") {
-      problem = destinationTargetProblem(node.destinationKind, value);
+      problem = destinationTargetProblem(node.destinationKind, value, wiredChannels);
     } else if (field.startsWith("config:")) {
       const key = field.slice("config:".length);
       const spec = configFieldSpecs(node.kind).find((s) => s.key === key);
@@ -660,6 +692,7 @@ export function WorkflowCreateDialog({
       const destinationProblem = destinationTargetProblem(
         n.destinationKind,
         n.destinationTarget,
+        wiredChannels,
       );
       if (destinationProblem) return `Node \`${nodeLabel(n)}\`: ${destinationProblem}`;
       // Kind-specific config (issue #541): required keys, malformed JSON, the
@@ -834,6 +867,14 @@ export function WorkflowCreateDialog({
     const problem = validate();
     if (problem) {
       setError(problem);
+      // Issue #813: the banner sits inline in a scrollable dialog and the Create
+      // button is below it, so on a long graph the message can land off-screen —
+      // the button then looks dead. Bring it into view and focus it (announced,
+      // deterministic — no timer) the frame after it renders.
+      requestAnimationFrame(() => {
+        errorRef.current?.scrollIntoView({ block: "center", behavior: "smooth" });
+        errorRef.current?.focus();
+      });
       return;
     }
     setSubmitting(true);
@@ -1064,6 +1105,7 @@ export function WorkflowCreateDialog({
                 client={client}
                 company={company}
                 roster={roster}
+                wiredChannels={wiredChannels}
                 workflows={workflows}
                 createMode={!editing}
                 errors={{
@@ -1122,9 +1164,13 @@ export function WorkflowCreateDialog({
         </div>
 
         {error && (
-          <Alert variant="destructive">
-            <AlertDescription>{error}</AlertDescription>
-          </Alert>
+          // Wrapper carries the ref/focus target so it works regardless of
+          // whether `Alert` forwards a ref (#813 defect 6).
+          <div ref={errorRef} tabIndex={-1} className="outline-none">
+            <Alert variant="destructive">
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          </div>
         )}
 
         {/* Issue #274: the edit-history panel. Edit mode only — a workflow being
@@ -1232,6 +1278,7 @@ function NodeRow({
   client,
   company,
   roster,
+  wiredChannels,
   workflows,
   createMode,
   errors,
@@ -1247,6 +1294,9 @@ function NodeRow({
   client: OpenCompanyClient;
   company: string | null;
   roster: TeamMemberDto[];
+  /** The company's wired chat channels (#813): the output-node channel-destination
+   * picker's options. Empty → the channel target degrades to a free-text box. */
+  wiredChannels: string[];
   /** The company's workflows, for a `sub_workflow` node's picker (issue #541). */
   workflows: WorkflowSummary[];
   /** True while creating a new workflow (not editing an existing one), so the
@@ -1377,7 +1427,33 @@ function NodeRow({
                 ))}
               </SelectContent>
             </Select>
-            {(node.destinationKind === "email" || node.destinationKind === "channel") && (
+            {node.destinationKind === "channel" && wiredChannels.length > 0 && (
+              <>
+                {/* #813: pick from the channels actually wired for this company,
+                    instead of a free-text box that only fails at delivery time. */}
+                <Select
+                  value={node.destinationTarget || ""}
+                  onValueChange={(v) => {
+                    onChange({ destinationTarget: v ?? "" });
+                    onValidateField("destinationTarget", v ?? "");
+                  }}
+                >
+                  <SelectTrigger className="h-8" aria-label="Channel id">
+                    <SelectValue placeholder="pick a wired channel" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {wiredChannels.map((channelId) => (
+                      <SelectItem key={channelId} value={channelId}>
+                        {channelId}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <FieldError id={targetErrorId} message={errors.destinationTarget} />
+              </>
+            )}
+            {(node.destinationKind === "email" ||
+              (node.destinationKind === "channel" && wiredChannels.length === 0)) && (
               <>
                 <Input
                   value={node.destinationTarget}

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -313,3 +313,36 @@ test("the collapsed destination shows a label, never the raw __none__ sentinel (
   await expect(destination).toContainText("Nowhere (run result only)");
   await expect(destination).not.toContainText("__none__");
 });
+
+test("the channel destination is a picker of wired channels, not free text (#813)", async ({
+  page,
+}) => {
+  // #813 defect 4: typing a channel id that isn't wired only failed at delivery.
+  // The target is now a picker whose options are the company's wired channels
+  // (`operator` is always wired), so an unwired id can't be entered at all.
+  const dialog = await openCreateDialog(page);
+  await dialog.getByRole("button", { name: "Add node" }).click();
+  const kind = dialog.getByLabel("Node kind").nth(1);
+  await kind.click();
+  await page.getByRole("option", { name: /^Output(?! parser)/ }).click();
+  await dialog.getByLabel("Send report to").click();
+  await page.getByRole("option", { name: /^Channel/ }).click();
+
+  // The channel target is a combobox offering the wired `operator` channel.
+  await dialog.getByLabel("Channel id").click();
+  await expect(page.getByRole("option", { name: "operator" })).toBeVisible();
+});
+
+test("submitting with an empty id surfaces the validation message on-screen (#813)", async ({
+  page,
+}) => {
+  // #813 defect 6: the banner sat below the fold, so Create looked dead. On a
+  // failed submit it must be brought into view (and focused).
+  const dialog = await openCreateDialog(page);
+  await dialog.getByLabel("Id", { exact: true }).fill("");
+  await dialog.getByRole("button", { name: "Create workflow" }).click();
+
+  const banner = dialog.getByText("Give the workflow an id.");
+  await expect(banner).toBeVisible();
+  await expect(banner).toBeInViewport();
+});

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -345,4 +345,10 @@ test("submitting with an empty id surfaces the validation message on-screen (#81
   const banner = dialog.getByText("Give the workflow an id.");
   await expect(banner).toBeVisible();
   await expect(banner).toBeInViewport();
+
+  // ...and the banner takes focus, so a keyboard/screen-reader user is landed on
+  // the reason Create did nothing rather than left at the pressed button.
+  const bannerBox = dialog.getByTestId("create-error");
+  await expect(bannerBox).toBeFocused();
+  await expect(bannerBox).toContainText("Give the workflow an id.");
 });

--- a/frontend/test/unit/workflow-destination-target.test.ts
+++ b/frontend/test/unit/workflow-destination-target.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { destinationTargetProblem } from "@/views/WorkflowCreateDialog";
+
+// #813 defect 4: a channel destination pointing at a channel this deployment
+// never wired only failed at delivery (`ChannelNotWired`). The picker keeps a
+// create-mode author on the wired list, but the branch is still reachable — an
+// edit dialog can carry a persisted target for a channel since unwired, and a
+// free-text value can be entered during the async `listWiredChannels` load
+// before the list arrives. These pin the author-time refusal on that path.
+describe("destinationTargetProblem — unwired channel", () => {
+  const wired = ["operator", "email"];
+
+  it("rejects a channel that is not in the wired set, naming what is", () => {
+    const problem = destinationTargetProblem("channel", "ghost", wired);
+    expect(problem).toBe(
+      "`ghost` is not a wired channel — this deployment has: operator, email.",
+    );
+  });
+
+  it("accepts a channel that is wired", () => {
+    expect(destinationTargetProblem("channel", "operator", wired)).toBeNull();
+    expect(destinationTargetProblem("channel", "email", wired)).toBeNull();
+  });
+
+  it("does not reject free text when the host offered no wired list", () => {
+    // Degraded/loading state: an empty list means "we don't know", so a
+    // free-text box must not be wrongly refused.
+    expect(destinationTargetProblem("channel", "anything", [])).toBeNull();
+  });
+});

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -559,6 +559,19 @@ impl CompanyRuntime {
         &self.store
     }
 
+    /// The ids of the chat channels actually wired for this running company —
+    /// exactly what an `output` node's `channel` destination may target
+    /// (issue #813). `operator` is always present; the rest are the enabled
+    /// OpenHuman-provider manifest channels. The console reads this to offer a
+    /// picker of real targets instead of a free-text box that only fails at
+    /// delivery time with `ChannelNotWired`.
+    pub fn wired_channel_ids(&self) -> Vec<String> {
+        self.channels
+            .iter()
+            .map(|channel| channel.channel_id().to_string())
+            .collect()
+    }
+
     /// The workflow ids declared in this company's manifest
     /// (`[workflows].enabled`), read from the persisted record. Empty when the
     /// record hasn't been saved yet.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4329,6 +4329,13 @@ mod test {
         assert_eq!(runtime.channels.len(), 2);
         assert!(runtime.channels.iter().any(|c| c.channel_id() == "email"));
 
+        // The #813 accessor the console's channel picker reads names BOTH: the
+        // always-wired `operator` and the openhuman-backed provider channel, so
+        // a workflow author can target either.
+        let wired = runtime.wired_channel_ids();
+        assert!(wired.contains(&"operator".to_string()));
+        assert!(wired.contains(&"email".to_string()));
+
         // A granted call routes through the OpenHuman transport.
         let result = runtime
             .tools

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4358,6 +4358,9 @@ mod test {
         // No openhuman channel is added when the daemon is unreachable.
         assert_eq!(runtime.channels.len(), 1);
         assert_eq!(runtime.channels[0].channel_id(), "operator");
+        // The #813 accessor the console's channel picker reads: `operator` is
+        // always wired, so a workflow always has at least one real target.
+        assert_eq!(runtime.wired_channel_ids(), vec!["operator".to_string()]);
 
         // Tools degrade to the grant-enforcing built-in: ungranted rejected,
         // granted returns a well-formed not-implemented result — and the RPC

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -132,6 +132,15 @@ pub fn router() -> Router<AppState> {
         // registered here with the others and BEFORE the dynamic
         // `/workflows/{wid}` below — `tool-slugs` is a syntactically valid `wid`.
         .merge(scoped("/workflows/tool-slugs", get(workflow_tool_slugs)))
+        // Issue #813: the chat channels actually wired for this running company,
+        // so the output-node destination editor can offer a picker of real
+        // targets instead of a free-text box that only fails at delivery time
+        // with `ChannelNotWired`. A static prefix registered here BEFORE the
+        // dynamic `/workflows/{wid}` — `wired-channels` is a valid `wid`.
+        .merge(scoped(
+            "/workflows/wired-channels",
+            get(workflow_wired_channels),
+        ))
         // Issue #383: stop a run that is still walking its graph. Registered
         // here, with the other static `/workflows/...` prefixes and BEFORE the
         // dynamic `/workflows/{wid}` below, for the reason the comment above
@@ -1728,6 +1737,26 @@ async fn workflow_tool_slugs(
 ) -> Result<Json<WorkflowToolSlugsResponse>, Response> {
     let _ = &company;
     Ok(Json(WorkflowToolSlugsResponse { slugs: Vec::new() }))
+}
+
+/// The `GET …/workflows/wired-channels` answer (issue #813): the chat channel
+/// ids this running company can deliver to, so the output-node destination
+/// editor offers a picker of real targets. `operator` is always present. Not
+/// feature-gated — the wired-channel set exists on every build.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct WiredChannelsResponse {
+    /// The channel ids an `output` node's `channel` destination may target;
+    /// anything else fails at delivery with `ChannelNotWired`.
+    channels: Vec<String>,
+}
+
+/// `GET …/workflows/wired-channels` (both scope forms). Reads the running
+/// company's wired channels directly — infallible, no record load needed.
+async fn workflow_wired_channels(company: ScopedCompany) -> Json<WiredChannelsResponse> {
+    Json(WiredChannelsResponse {
+        channels: company.runtime.wired_channel_ids(),
+    })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The last two defects of EPIC #813 (4 + 6) — the remaining authoring-surface gaps. With this, all eight defects are addressed (1/2/3 in #816, 5/7/8 in #814, 4/6 here).

- **Defect 4 — channel destination was free text, unvalidated until run time.** Only `operator` is actually wired, but the editor offered a bare text box; typing `engineering` failed only at delivery (`ChannelNotWired`). Now:
  - `CompanyRuntime::wired_channel_ids()` exposes the running company's wired channels; `GET …/workflows/wired-channels` serves them (mirrors the #783 `tool-slugs` route, not feature-gated — `operator` is always wired).
  - The output-node channel destination is a **picker** of those channels (graceful **free-text fallback** if the host lists none), and a non-wired id is flagged at **author time** instead of only at delivery.
- **Defect 6 — the validation message rendered below the fold.** Creating with an empty id set the real message ("Give the workflow an id.") but it sat below the scroll line, so Create looked dead. A failed submit now scrolls the banner into view and focuses it (deterministic, no timer).

Closes #813 — this completes the epic.

## API Or Behavior Changes

- New read route `GET …/workflows/wired-channels` → `{ "channels": ["operator", …] }`. No auth/scope change (same `ScopedCompany` extractor as the sibling workflow reads).
- No change to delivery: the delivery-time `ChannelNotWired` check remains the backstop; this only moves the failure earlier, to author time.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo check --features openhuman,tinycortex --all-targets`
- [x] Gated tests (`RUST_MIN_STACK=16777216`): `runtime::builder` accessor (`operator` always wired) + `server::ops::workflows`
- [x] Frontend: `npm run typecheck` · `npx vitest run` (598) · `npm run build`
- [x] Console E2E (live host): channel destination is a picker offering `operator`; empty-id submit scrolls the validation banner into view. Observed RED against pre-change (free-text box / below-fold banner) first.

## Documentation

The new route is documented by its handler doc comment alongside `tool-slugs`; no separate module doc owns the workflow HTTP surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow creation now offers configured chat channels through a destination picker.
  - Added support for retrieving available wired channels, including the built-in operator channel.
  - Free-text destination entry remains available when no channels are configured.

- **Bug Fixes**
  - Submission validation errors now scroll into view and receive focus for improved visibility.

- **Tests**
  - Added coverage for channel selection and visible validation feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->