### PR TITLE
fix(console): let the workflows toolbar wrap instead of clipping its last control (#824)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1304,7 +1304,20 @@ export function WorkflowsView({
             </p>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        {/* Issue #824. `flex-wrap` on the ACTION ROW, not just on the header
+            above it. The header already wraps, but that wrap only breaks
+            between its two children — and this row is one child whose buttons
+            are `shrink-0`, so on its own line it stayed 1386px wide inside a
+            1289px container and overflowed into an `overflow-hidden` ancestor.
+            Nothing in that chain scrolls, so `New workflow` was not merely
+            off-screen, it could not be clicked.
+
+            The row grows every time a control is added — `Pause` (#814) took
+            the overhang from 22px to 113px, which is what finally made it
+            visible — so it needs a break point of its own rather than a wider
+            budget. `justify-end` keeps the wrapped line aligned to the right
+            edge it belongs to instead of drifting left under the title. */}
+        <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
           <Select
             // Issue #406, half one. NOT `selectedId ?? undefined`: Base UI
             // decides controlled-vs-uncontrolled ONCE, on the first render,

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -1,0 +1,119 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+/**
+ * Issue #824: the workflows toolbar laid out wider than its container and
+ * overflowed into an `overflow-hidden` ancestor, so its last control —
+ * **New workflow** — was clipped off the right edge. Nothing in that chain
+ * scrolls, so the button was not merely off-screen: it could not be clicked.
+ *
+ * This is a **layout** defect, so it is only observable in a browser. jsdom
+ * computes no geometry, and a unit test asserting the class string would pass
+ * against any width — including a row that still overflows. The measurement has
+ * to be a real one.
+ *
+ * The row grows every time a control is added. `Pause` (#814) took the overhang
+ * from 22px to 113px, which is what made it visible, but the row was already
+ * overflowing before it. So the spec asserts the **property** rather than
+ * today's button count: every control in the toolbar is inside the viewport and
+ * clickable. A tenth control that reintroduces the overflow fails here.
+ *
+ * Runs at two widths. 1280 is the common laptop width the defect was reported
+ * at; 1024 is the narrow end, where a fix that merely bought a few pixels would
+ * still fail.
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+const WORKFLOW_ID = "e2e-824-toolbar";
+
+/** The tour's overlay swallows pointer events; tolerate its absence. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+async function createWorkflow(request: APIRequestContext) {
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
+    data: {
+      id: WORKFLOW_ID,
+      name: "Toolbar reachability",
+      description: "Created by the #824 e2e spec.",
+      nodes: [
+        { id: "start", kind: "trigger", name: "Start", schedule: "0 9 * * *" },
+        { id: "done", kind: "output", name: "Report" },
+      ],
+      edges: [{ from: "start", to: "done" }],
+    },
+  });
+  expect(res.ok(), `create: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+async function removeWorkflow(request: APIRequestContext) {
+  await request.delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`).catch(() => undefined);
+}
+
+/**
+ * The toolbar's controls. A workflow must be **selected** for the full set to
+ * mount — Pause/Edit/Delete are per-workflow — which is the state the defect
+ * appears in and the reason this spec creates one.
+ */
+const CONTROLS = [
+  "Run",
+  "Test run",
+  "Browse",
+  "Copilot",
+  "History",
+  "Edit",
+  "Delete",
+  "New workflow",
+];
+
+test.describe("workflows toolbar reachability (#824)", () => {
+  test.beforeEach(async ({ request }) => {
+    await removeWorkflow(request);
+    await createWorkflow(request);
+  });
+
+  test.afterEach(async ({ request }) => {
+    await removeWorkflow(request);
+  });
+
+  for (const width of [1280, 1024]) {
+    test(`every toolbar control is inside the viewport at ${width}px`, async ({ page }) => {
+      await page.setViewportSize({ width, height: 800 });
+      await page.goto("/#/workflows");
+      await dismissTour(page);
+
+      // Wait for the toolbar to mount before measuring anything.
+      const newWorkflow = page.getByRole("button", { name: "New workflow" });
+      await expect(newWorkflow).toBeVisible();
+
+      for (const name of CONTROLS) {
+        const control = page.getByRole("button", { name, exact: false }).first();
+        await expect(control, `${name} should be mounted`).toBeVisible();
+        // The assertion that matters. `toBeVisible` is true for a button that
+        // has been pushed past the right edge — it is painted, just not
+        // anywhere reachable. `toBeInViewport` is what distinguishes the two.
+        await expect(control, `${name} should be reachable at ${width}px`).toBeInViewport();
+      }
+    });
+  }
+
+  test("New workflow can actually be clicked, not merely rendered", async ({ page }) => {
+    // The defect's real cost. Every control above could be in the viewport and
+    // this could still fail if something overlapped it, so the last word is an
+    // actual click with its actual consequence.
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await page.goto("/#/workflows");
+    await dismissTour(page);
+
+    await page.getByRole("button", { name: "New workflow" }).click();
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(page.getByText("Describe the workflow")).toBeVisible();
+  });
+});

--- a/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
+++ b/frontend/test/e2e/workflow-toolbar-reachable.spec.ts
@@ -1,4 +1,10 @@
-import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+import {
+  expect,
+  test,
+  type APIRequestContext,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 
 /**
  * Issue #824: the workflows toolbar laid out wider than its container and
@@ -24,6 +30,7 @@ import { expect, test, type APIRequestContext, type Page } from "@playwright/tes
 
 const COMPANY_SCOPE = "/api/v1/company";
 const WORKFLOW_ID = "e2e-824-toolbar";
+const WORKFLOW_NAME = "Toolbar reachability";
 
 /** The tour's overlay swallows pointer events; tolerate its absence. */
 async function dismissTour(page: Page) {
@@ -41,9 +48,11 @@ async function createWorkflow(request: APIRequestContext) {
   const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
     data: {
       id: WORKFLOW_ID,
-      name: "Toolbar reachability",
+      name: WORKFLOW_NAME,
       description: "Created by the #824 e2e spec.",
       nodes: [
+        // The `schedule` is load-bearing, not decoration: it is what makes
+        // `isScheduled` true and mounts the Pause control asserted below.
         { id: "start", kind: "trigger", name: "Start", schedule: "0 9 * * *" },
         { id: "done", kind: "output", name: "Report" },
       ],
@@ -54,23 +63,78 @@ async function createWorkflow(request: APIRequestContext) {
 }
 
 async function removeWorkflow(request: APIRequestContext) {
-  await request.delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`).catch(() => undefined);
+  await request
+    .delete(`${COMPANY_SCOPE}/workflows/${WORKFLOW_ID}`)
+    .catch(() => undefined);
 }
 
 /**
- * The toolbar's controls. A workflow must be **selected** for the full set to
- * mount — Pause/Edit/Delete are per-workflow — which is the state the defect
- * appears in and the reason this spec creates one.
+ * Selects the workflow in the picker, so the per-workflow half of the toolbar
+ * mounts and the row is at its **widest** — the state the defect appears in.
+ *
+ * The view does auto-select when the list lands, so this is belt-and-braces
+ * today. It is here anyway because the auto-select is not what this spec is
+ * about: were it ever to change, the assertions below would start failing on a
+ * toolbar that was simply never populated, which reads as a layout regression
+ * and is not one. Selecting explicitly keeps the failure honest. Matches the
+ * helper in `workflow-node-config.spec.ts`.
  */
-const CONTROLS = [
-  "Run",
-  "Test run",
-  "Browse",
-  "Copilot",
-  "History",
-  "Edit",
-  "Delete",
-  "New workflow",
+async function selectWorkflow(page: Page, name: string) {
+  const picker = page.getByRole("combobox").first();
+  await expect(picker).toBeEnabled();
+  await picker.click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(picker).toContainText(name);
+}
+
+/**
+ * The toolbar's controls, each with the locator that finds it.
+ *
+ * `Pause` is not addressed by name like the rest: its accessible name comes
+ * from an `aria-label` that flips to `Resume schedule` once the schedule is
+ * off, so a name match would silently stop matching the day the fixture starts
+ * out paused. The test id is stable across both.
+ *
+ * It also only mounts for a **scheduled** workflow (`isScheduled` — a trigger
+ * node carrying a `schedule`), which is why the fixture's trigger has one.
+ * That matters more than it looks: Pause is the control that made this defect
+ * visible, taking the overhang from 22px to 113px, so a version of this spec
+ * that skipped it would be measuring the row that fits.
+ */
+const CONTROLS: Array<{ label: string; find: (page: Page) => Locator }> = [
+  {
+    label: "Run",
+    find: (p) => p.getByRole("button", { name: "Run", exact: false }).first(),
+  },
+  {
+    label: "Test run",
+    find: (p) => p.getByRole("button", { name: "Test run" }).first(),
+  },
+  {
+    label: "Browse",
+    find: (p) => p.getByRole("button", { name: "Browse" }).first(),
+  },
+  {
+    label: "Copilot",
+    find: (p) => p.getByRole("button", { name: "Copilot" }).first(),
+  },
+  {
+    label: "History",
+    find: (p) => p.getByRole("button", { name: "History" }).first(),
+  },
+  { label: "Pause", find: (p) => p.getByTestId("workflow-toggle-enabled") },
+  {
+    label: "Edit",
+    find: (p) => p.getByRole("button", { name: "Edit" }).first(),
+  },
+  {
+    label: "Delete",
+    find: (p) => p.getByRole("button", { name: "Delete" }).first(),
+  },
+  {
+    label: "New workflow",
+    find: (p) => p.getByRole("button", { name: "New workflow" }),
+  },
 ];
 
 test.describe("workflows toolbar reachability (#824)", () => {
@@ -84,35 +148,57 @@ test.describe("workflows toolbar reachability (#824)", () => {
   });
 
   for (const width of [1280, 1024]) {
-    test(`every toolbar control is inside the viewport at ${width}px`, async ({ page }) => {
+    test(`every toolbar control is inside the viewport at ${width}px`, async ({
+      page,
+    }) => {
       await page.setViewportSize({ width, height: 800 });
       await page.goto("/#/workflows");
       await dismissTour(page);
 
       // Wait for the toolbar to mount before measuring anything.
-      const newWorkflow = page.getByRole("button", { name: "New workflow" });
-      await expect(newWorkflow).toBeVisible();
+      await expect(
+        page.getByRole("button", { name: "New workflow" }),
+      ).toBeVisible();
+      await selectWorkflow(page, WORKFLOW_NAME);
 
-      for (const name of CONTROLS) {
-        const control = page.getByRole("button", { name, exact: false }).first();
-        await expect(control, `${name} should be mounted`).toBeVisible();
+      for (const { label, find } of CONTROLS) {
+        const control = find(page);
+        await expect(control, `${label} should be mounted`).toBeVisible();
         // The assertion that matters. `toBeVisible` is true for a button that
         // has been pushed past the right edge — it is painted, just not
         // anywhere reachable. `toBeInViewport` is what distinguishes the two.
-        await expect(control, `${name} should be reachable at ${width}px`).toBeInViewport();
+        await expect(
+          control,
+          `${label} should be reachable at ${width}px`,
+        ).toBeInViewport();
       }
     });
   }
 
-  test("New workflow can actually be clicked, not merely rendered", async ({ page }) => {
+  test("New workflow can actually be clicked, not merely rendered", async ({
+    page,
+  }) => {
     // The defect's real cost. Every control above could be in the viewport and
     // this could still fail if something overlapped it, so the last word is an
     // actual click with its actual consequence.
     await page.setViewportSize({ width: 1280, height: 800 });
     await page.goto("/#/workflows");
     await dismissTour(page);
+    // Selected, because that is the crowded row. Clicking against the short
+    // one would prove nothing: the short row never clipped anything.
+    await selectWorkflow(page, WORKFLOW_NAME);
 
-    await page.getByRole("button", { name: "New workflow" }).click();
+    const newWorkflow = page.getByRole("button", { name: "New workflow" });
+    // Measured before the click, and the reason is not belt-and-braces: a
+    // Playwright click scrolls its target into view first, and it manages that
+    // even inside the `overflow-hidden` ancestor a person cannot scroll. So
+    // `click()` alone SUCCEEDS against the clipped layout — verified by
+    // reverting the fix, where this test passed and the two above failed. The
+    // click is what proves the button works; this line is what proves a person
+    // could reach it.
+    await expect(newWorkflow).toBeInViewport();
+
+    await newWorkflow.click();
     await expect(page.getByRole("dialog")).toBeVisible();
     await expect(page.getByText("Describe the workflow")).toBeVisible();
   });


### PR DESCRIPTION
## Summary

The workflows toolbar laid out wider than its container and overflowed into an
`overflow-hidden` ancestor, so **New workflow** was clipped off the right edge.
Nothing in that chain scrolls, so it was not merely off-screen — it could not be
clicked.

Measured on staging (`staging-be9ff799`, 1337px viewport):

```
button "New workflow"        left 1321  right 1450     ← 113px past the edge
div .flex.items-center.gap-2   nowrap   1386px wide
div .flex.flex-wrap…           wrap     content 1402 > 1289
div .flex.flex-1.flex-col      overflow-x HIDDEN       ← clips here
document                       not scrollable
```

## API Or Behavior Changes

One line, `WorkflowsView.tsx:1307`:

```diff
-<div className="flex items-center gap-2">
+<div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
```

**Why the header's existing `flex-wrap` did not already cover this.** The header
row wraps, and its left group already carries `min-w-0` — but that wrap only
breaks *between* the header's two children. The action row is one child whose
buttons are `shrink-0`, so once on its own line it was still 1386px inside a
1289px container with no internal break point.

**Not caused by `Pause` (#814), though it made it visible.** Remove that button
and its gap and the row still ends at `1359` — 22px past the edge. #814 took the
overhang from 22px to 113px. The row grows with every control added and had no
way to absorb one, which is why the fix is a break point rather than a wider
budget.

`justify-end` keeps a wrapped line against the right edge it belongs to instead
of drifting left under the title. At full width nothing moves — the row still
lays out on one line.

A horizontal scrollbar was considered and rejected: a toolbar that hides its own
actions behind a scroll is the same defect with an extra step.

## Tests

`frontend/test/e2e/workflow-toolbar-reachable.spec.ts` — Playwright, because this
is a **layout** defect. jsdom computes no geometry, so a unit test asserting the
class string would pass against a row that still overflows; the measurement has
to be real.

Three cases:

- every toolbar control is `toBeInViewport()` at **1280px** and at **1024px**.
  `toBeVisible()` deliberately is not the assertion — it is true for a button
  pushed past the right edge, which is exactly the bug;
- **New workflow** is clicked for real and the dialog asserted, since a control
  can be in the viewport and still be unclickable if something overlaps it;
- the spec asserts the *property* (every control reachable), not today's button
  count, so a tenth control that reintroduces the overflow fails here.

A workflow is created over HTTP in `beforeEach` because Pause/Edit/Delete only
mount with a selection — the state the defect appears in.

Verified live before writing any code by injecting the candidate rule on
staging: **New workflow** moved to a second line, right edge `193`, reachable.

Commands run locally, all green:

- [x] `npm run typecheck`
- [x] `npm run typecheck:e2e`
- [x] `npx vitest run` — 598 passed, 50 files
- [x] `npm run build`
- [x] `scripts/ci/assert-design-tokens.sh`

The new spec is not run locally (it needs the host `playwright.config.ts` brings
up); it runs in the `Console E2E` job.

## Documentation

The change carries a comment explaining why the wrap belongs on the action row
rather than the header, and that the row grows with each added control — the
reasoning that would otherwise be re-litigated the next time someone reads
`flex-wrap` on a parent and assumes it is redundant.

## Related

Closes #824

- #814 — added `Pause`, which widened the overhang from 22px to 113px
- The Tasks board shows the same symptom (`Done` off-screen) but its container is
  `overflow-x-auto`, so every column is reachable by scrolling. Scrollable and
  inconvenient, not clipped and unusable — left alone deliberately.
