### PR TITLE
feat(connections): open a remote MCP server the way a Composio provider opens (#821)

### DIFF
--- a/docs/modules/mcp.md
+++ b/docs/modules/mcp.md
@@ -148,6 +148,32 @@ Settings page built on it crashed on open (issue #414). The client casts an
 unparsed body to the declared type, so a second surface is never caught by the
 compiler — only by whoever opens the page.
 
+### Opening one server
+
+A row's name opens the server into
+[`ProviderDetail`](../../frontend/src/views/connections/ProviderDetail.tsx) — the
+same panel a Composio provider opens into (issues #404, #821), on a
+`ConnectionSubject` union rather than a second MCP-specific panel. The reason is
+the paragraph above one level up: two surfaces describing the same idea acquire
+two vocabularies and then drift.
+
+The panel is read-only. Enable, `Test`, `Tools` and `Remove` stay on the row;
+what it adds is what the row cannot say —
+
+- **Connected, and as what.** MCP has no connection object, so this is assembled
+  from two facts a single badge would collapse: `enabled` (whether any agent
+  receives the tools at all) and the last probe (whether the endpoint answered
+  when someone last asked). A server nobody has pressed `Test` on has no `health`
+  at all, and "never probed" is neither reachable nor broken. See `mcpStanding`
+  in `frontend/src/lib/connection-detail.ts`.
+- **Usage**, read from `byProvider` under the `mcp:<server>` key this module's
+  metering records (`src/metering/oauth.rs`) — never the bare slug, which is the
+  same-named Composio toolkit's row.
+- **No connection date**, stated rather than left blank. There is no connect step
+  to record one; the probe timestamp the host *does* keep sits beside it.
+- **What a disconnect reaches**: the tool belt on the next turn, and nothing at
+  the server's own end. A manifest server says it cannot be removed at all.
+
 ## Pool-staleness caveat
 
 Agents materialize their MCP registry once, when the

--- a/frontend/src/lib/connection-detail.ts
+++ b/frontend/src/lib/connection-detail.ts
@@ -1,4 +1,4 @@
-// What a provider's detail view is allowed to claim (issue #404).
+// What a connection's detail view is allowed to claim (issues #404, #821).
 //
 // The issue's rule — "do not invent a number … say so on screen rather than
 // rendering a plausible-looking zero" — is not only about usage. Two of the
@@ -10,10 +10,16 @@
 //  - **what has gone through it**: metered per *provider*, never per account,
 //    and an unmetered host is not a host where nothing happened.
 //
-// These are the two decisions, kept out of the component so they can be pinned
+// A remote MCP server (#821) adds a third, which is the one its own surface
+// gets wrong today: it has no connection object at all, so "connected" has to
+// be assembled from two facts that a single badge would collapse — whether the
+// harness hands its tools out, and what the endpoint said the last time anyone
+// asked. See [`mcpStanding`].
+//
+// These are the decisions, kept out of the component so they can be pinned
 // without a DOM.
 
-import type { ProviderCallsDto } from "@/api/types";
+import type { McpHealth, McpServer, ProviderCallsDto } from "@/api/types";
 
 /**
  * "connected 9 Aug 2026", or a statement that no date exists.
@@ -57,4 +63,118 @@ export function connectedOn(createdAt: string | undefined): string {
 export function callsForProvider(rows: readonly ProviderCallsDto[], slug: string): number {
   const want = slug.trim().toLowerCase();
   return rows.find((r) => r.provider.trim().toLowerCase() === want)?.calls ?? 0;
+}
+
+/** The namespace prefix the host records a remote MCP server's calls under. */
+export const MCP_PROVIDER_PREFIX = "mcp:";
+
+/**
+ * The `byProvider` key a remote MCP server's calls land on, or `null` when the
+ * server cannot be named (issue #821).
+ *
+ * The mirror of `mcp_provider` in `src/metering/oauth.rs`: trimmed, lowercased,
+ * and prefixed. Feed it to {@link callsForProvider} rather than teaching that
+ * function a prefix — the lookup stays one exact match on one namespaced key,
+ * which is what keeps a Composio `gmail` and an MCP server called `gmail` from
+ * reading as each other.
+ *
+ * An unnameable server returns `null`, where the host would have recorded a
+ * bare `unknown`. That row is the host's *cannot-attribute* bucket, shared with
+ * every other call whose provider was unknown — reading it as this server's
+ * total would be inventing exactly the number the panel refuses to invent. The
+ * caller reports "not attributable" instead. In practice unreachable: the host
+ * rejects a server without a name, so nothing on the list can be in this state.
+ */
+export function mcpProviderSlug(server: string): string | null {
+  const normalized = server.trim().toLowerCase();
+  if (normalized === "") return null;
+  return `${MCP_PROVIDER_PREFIX}${normalized}`;
+}
+
+/** What a remote MCP server is right now, in the two facts that decide it. */
+export interface McpStanding {
+  /**
+   * Whether the harness hands this server's tools to agents at all.
+   *
+   * Not "is it healthy": a turned-off server whose endpoint answers perfectly
+   * is still contributing nothing, and that is the fact an operator opened the
+   * panel to learn.
+   */
+  live: boolean;
+  /** Connected, and as what — the one line under the title. */
+  summary: string;
+  /** What the last probe found, or a statement that there has not been one. */
+  probe: string;
+}
+
+/**
+ * The standing of a remote MCP server (issue #821).
+ *
+ * MCP has no connection object — no account, no grant, no record of a connect.
+ * What it has is two independent facts, and the wrong answer here is to collapse
+ * them into one "connected" badge:
+ *
+ *  - **`enabled`** decides whether any agent receives the server's tools. A
+ *    disabled server is unreachable by construction however well its endpoint
+ *    answers.
+ *  - **the last probe** says whether the endpoint answered when someone last
+ *    asked, which is a different question and is often unanswered: a server
+ *    nobody has pressed Test on has no `health` at all. "Never probed" is not
+ *    "broken" and it is not "fine" — rendering it as either invents the probe
+ *    that was never run.
+ *
+ * `authConfigured` is the "as what": a stored outbound credential, or none.
+ * Never the credential, which the host does not serve.
+ */
+export function mcpStanding(server: McpServer, health: McpHealth | undefined): McpStanding {
+  const summary = !server.enabled
+    ? "turned off — no agent receives its tools"
+    : server.authConfigured
+      ? "on, calling with a stored credential"
+      : "on, calling with no credential";
+  return { live: server.enabled, summary, probe: probeLine(health) };
+}
+
+/** The probe half of [`mcpStanding`]. */
+function probeLine(health: McpHealth | undefined): string {
+  // Never pressed Test, and never probed on an add. Distinct from every status
+  // below, including `unknown` — which is a probe that ran and could not tell.
+  if (health === undefined) return "this server has not been probed from here";
+  switch (health.status) {
+    case "ok":
+      return `reachable — ${health.toolCount} tool${health.toolCount === 1 ? "" : "s"} on the last probe`;
+    case "needs_config":
+      return "the last probe was refused for want of a credential";
+    case "error":
+      return "the last probe did not reach it";
+    default:
+      return "the last probe could not tell whether it is reachable";
+  }
+}
+
+/**
+ * "last probed 13 Aug 2026, 14:22", or `null` when there is no probe to date.
+ *
+ * The counterpart of [`connectedOn`], and the reason MCP gets a timestamp at all:
+ * the host *does* record when it last asked (`checkedAtMillis`), even though it
+ * records nothing about when the server was added. Stating the one it has beside
+ * the one it does not is what keeps "connection date not recorded" from reading
+ * as "this panel knows no dates".
+ *
+ * A non-finite or non-positive value is treated as no probe rather than as the
+ * epoch — the host omits `health` entirely when it has never probed, so a zero
+ * here is a malformed wire value, and "last probed 1 Jan 1970" is the same class
+ * of plausible-looking lie as a rendered zero.
+ */
+export function probedOn(atMillis: number | undefined): string | null {
+  if (atMillis === undefined || !Number.isFinite(atMillis) || atMillis <= 0) return null;
+  const at = new Date(atMillis);
+  if (Number.isNaN(at.getTime())) return null;
+  return `last probed ${at.toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  })}`;
 }

--- a/frontend/src/views/ConnectionsView.tsx
+++ b/frontend/src/views/ConnectionsView.tsx
@@ -18,7 +18,7 @@ import { Badge } from "@/components/ui/badge";
 import { catalogWarning } from "@/lib/composio-catalog";
 import { toolkitSlug, type ComposioReach } from "@/lib/connections";
 import { buildGridProviders, disconnectRouteFor, type GridProvider } from "@/lib/provider-grid";
-import { ProviderDetail } from "@/views/connections/ProviderDetail";
+import { ProviderDetail, type ConnectionSubject } from "@/views/connections/ProviderDetail";
 import { armTourResume } from "@/tour/state";
 import { InferenceSection } from "@/views/connections/InferenceSection";
 import { McpServersSection } from "@/views/connections/McpServersSection";
@@ -458,6 +458,27 @@ export function ConnectionsView({ client, company }: Props) {
     [providers, opened],
   );
 
+  // The panel's subject, with this arm's controls attached (issue #821). A
+  // Composio provider cannot be opened without the revoke that actually
+  // releases it — `disconnectConnection` answers 200 while releasing nothing,
+  // which is the defect `disconnect()` above exists to route around — so the
+  // handlers travel inside the variant rather than as sibling props.
+  //
+  // Rebuilt every render rather than memoized: nothing downstream keys off this
+  // object's identity (the panel's usage read keys off the slug it derives),
+  // and a memo whose value carries fresh closures would have to lie about its
+  // dependencies to stay stable.
+  const detailSubject: ConnectionSubject | null =
+    openedProvider === null
+      ? null
+      : {
+          kind: "composio",
+          provider: openedProvider,
+          noCredential: status?.credentialSource === "none",
+          onConnectAnother: (p) => void connect(p),
+          onDisconnectAccount: (p, account) => void disconnectAccount(p, account),
+        };
+
   // Counted off the rendered grid, not off the raw host rows. The badge used to
   // count every row `GET …/connections` returned while the grid below drew only
   // the eleven tiles the console had metadata for — so the header could read "3
@@ -564,19 +585,17 @@ export function ConnectionsView({ client, company }: Props) {
         />
 
         {/* A connection as an object you open rather than a row with a button
-            (issue #404). Composio only: the native catalog is inert — its
-            credential is written and read by nothing (#396) — and a detail view
-            is exactly where that would look healthiest. */}
+            (issue #404). The grid's half is Composio only: the native catalog is
+            inert — its credential is written and read by nothing (#396) — and a
+            detail view is exactly where that would look healthiest. The same
+            panel opens a remote MCP server, from `McpServersSection` (#821). */}
         <ProviderDetail
           client={client}
           company={company}
-          provider={openedProvider}
+          subject={detailSubject}
           canManage={canManage && load !== "unavailable"}
-          noCredential={status?.credentialSource === "none"}
           busy={busy !== null}
           onClose={() => setOpened(null)}
-          onConnectAnother={(p) => void connect(p)}
-          onDisconnectAccount={(p, account) => void disconnectAccount(p, account)}
         />
       </div>
     </div>

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   AlertTriangle,
   Check,
   ChevronDown,
+  ChevronRight,
   Info,
   Loader2,
   LogIn,
@@ -34,6 +35,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Switch } from "@/components/ui/switch";
+import { ProviderDetail } from "@/views/connections/ProviderDetail";
 
 type McpLoad = "loading" | "ready" | "unavailable" | "error";
 type ToolsState =
@@ -90,6 +92,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
   // click can't spawn a second overlapping poll. Cleared on unmount so stale
   // callbacks don't fire against a gone component.
   const pollTimers = useRef<Record<string, number>>({});
+  // The name of the server whose detail panel is open, or `null` (issue #821).
+  // A name rather than the row itself, so an open panel re-derives from
+  // `servers` after a refresh instead of showing the row as it was when clicked.
+  const [opened, setOpened] = useState<string | null>(null);
   // Set by the unmount cleanup below. A sign-in poll that is mid-`await` when
   // this component goes away has already removed its own timer entry, so the
   // cleanup has nothing left to cancel — it checks this instead of re-arming.
@@ -353,6 +359,14 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
     }
   }
 
+  // Re-derived from the list every render rather than captured on click, so the
+  // open panel reflects the last refresh — a toggle, a completed sign-in or a
+  // removal all reach it without a second copy of the row to keep in step.
+  const openedServer = useMemo(
+    () => servers.find((s) => s.name === opened) ?? null,
+    [servers, opened],
+  );
+
   if (load === "unavailable") {
     if (chrome === "inline") return null;
     return (
@@ -427,7 +441,28 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                       className="space-y-2 py-3 first:pt-0 last:pb-0"
                     >
                       <div className="flex flex-wrap items-center gap-2">
-                        <span className="font-medium">{server.name}</span>
+                        {/* The row's handle on its own detail view (issue #821).
+                            A button on the name rather than a trailing "Open":
+                            the row's right edge is already five controls deep,
+                            and the name is what an operator points at when they
+                            want to know what a server is.
+
+                            The chevron is not decoration. Hover styling alone
+                            makes a name that opens something indistinguishable
+                            from one that does not until the pointer is already
+                            on it — which on a touch screen is never, and for
+                            anyone scanning the page is a control that does not
+                            exist. */}
+                        <button
+                          type="button"
+                          data-testid="mcp-server-open"
+                          className="inline-flex cursor-pointer items-center gap-0.5 rounded-sm font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none"
+                          onClick={() => setOpened(server.name)}
+                          aria-label={`Open ${server.name}`}
+                        >
+                          {server.name}
+                          <ChevronRight className="size-3.5 text-muted-foreground" />
+                        </button>
                         <Badge variant={server.source === "manifest" ? "secondary" : "outline"}>
                           {server.source}
                         </Badge>
@@ -631,6 +666,36 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
           </CardContent>
         </Card>
       )}
+
+      {/* A server as an object you open, in the same panel a Composio provider
+          opens into (issue #821). Rendered from here rather than from the page
+          above, because the live health an operator just pressed Test for lives
+          in this component's state — and because this section is also the whole
+          of Settings, MCP Servers, which gets the detail view for free.
+
+          `openedServer` is re-derived from `servers` every render, so a removed
+          server closes its own panel rather than leaving a page describing
+          something that is gone. */}
+      <ProviderDetail
+        client={client}
+        company={company}
+        subject={
+          openedServer === null
+            ? null
+            : {
+                kind: "mcp",
+                server: openedServer,
+                // The live Test result when there has been one this session,
+                // else the server's own persisted probe — the same precedence
+                // the row's badge uses, so the panel and the row it opened from
+                // cannot report different health.
+                health: tested[openedServer.name] ?? openedServer.health,
+              }
+        }
+        canManage={canManage}
+        busy={busy !== null}
+        onClose={() => setOpened(null)}
+      />
     </section>
   );
 }

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, Loader2, LogIn, Unplug } from "lucide-react";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { ComposioConnectedAccount } from "@/api/composio";
+import type { McpHealth, McpServer } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
@@ -13,37 +14,72 @@ import {
   SheetHeader,
   SheetTitle,
 } from "@/components/ui/sheet";
-import { callsForProvider, connectedOn } from "@/lib/connection-detail";
+import {
+  callsForProvider,
+  connectedOn,
+  mcpProviderSlug,
+  mcpStanding,
+  probedOn,
+} from "@/lib/connection-detail";
 import { toolkitSlug } from "@/lib/connections";
 import type { GridProvider } from "@/lib/provider-grid";
+
+/**
+ * What this panel has been opened on — one of the connection systems
+ * OpenCompany has, with everything that system's arm needs to act.
+ *
+ * A discriminated union rather than a bag of optional props (issue #821). The
+ * two arms have genuinely different controls, and the failure this shape rules
+ * out is a real one on this page: `disconnectConnection` answers 200 for a
+ * Composio provider while revoking nothing (see `ConnectionsView.disconnect`).
+ * Carrying each arm's handlers *inside* its own variant means an MCP subject
+ * cannot be handed a Composio revoke, and a Composio subject cannot be opened
+ * without one — neither is a rule a caller has to remember.
+ */
+export type ConnectionSubject =
+  | {
+      kind: "composio";
+      provider: GridProvider;
+      /**
+       * Nothing to authorize against — no credential of any tier resolves, so a
+       * Connect could only fail. Stated here rather than only on the page behind
+       * the panel: this is where the button is.
+       */
+      noCredential: boolean;
+      onConnectAnother: (provider: GridProvider) => void;
+      onDisconnectAccount: (provider: GridProvider, account: ComposioConnectedAccount) => void;
+    }
+  | {
+      kind: "mcp";
+      server: McpServer;
+      /**
+       * The live result of an on-demand Test, when one has been run this
+       * session; otherwise the server's own persisted `health`, which is
+       * `undefined` on a server nobody has probed. The distinction is the
+       * panel's, not a detail — see `mcpStanding`.
+       */
+      health: McpHealth | undefined;
+    };
 
 interface Props {
   client: OpenCompanyClient;
   company: string | null;
-  /** The provider to show, or `null` when nothing is open. */
-  provider: GridProvider | null;
+  /** What to show, or `null` when nothing is open. */
+  subject: ConnectionSubject | null;
   /** Whether this viewer may change what the company connects through (#403). */
   canManage: boolean;
-  /**
-   * Nothing to authorize against — no credential of any tier resolves, so a
-   * Connect could only fail. Stated here rather than only on the page behind
-   * the panel: this is where the button is.
-   */
-  noCredential: boolean;
   /** A connect or disconnect is in flight somewhere on the page. */
   busy: boolean;
   onClose: () => void;
-  onConnectAnother: (provider: GridProvider) => void;
-  onDisconnectAccount: (provider: GridProvider, account: ComposioConnectedAccount) => void;
 }
 
 /** The window the usage figure covers. Matches the Usage view's own default. */
 const USAGE_RANGE = "30d";
 
 /**
- * A provider as an object you can open (issue #404).
+ * A connection as an object you can open (issues #404, #821).
  *
- * Opens whether or not it is connected — "connected **or not**" is the issue's
+ * Opens whether or not it is connected — "connected **or not**" is #404's
  * wording, and OpenHuman's `ComposioConnectModal` is a phase machine that opens
  * on a disconnected toolkit and connects from inside. Keeping the one-click
  * connect on the tile and the panel for connected providers only would have
@@ -51,54 +87,67 @@ const USAGE_RANGE = "30d";
  * what is wired to it" — which is the question the issue exists to make
  * answerable.
  *
+ * ## Two systems, one vocabulary
+ *
+ * A Composio provider and a remote MCP server open into the same panel, because
+ * the alternative — a second MCP-specific panel — is how two surfaces come to
+ * describe the same idea with two vocabularies and then drift (issue #821, and
+ * #414 for the last time it happened to the MCP screen specifically). What
+ * differs between the arms is what each system genuinely records; what does not
+ * differ is the shape of the answer, or the rule about inventing one.
+ *
  * ## What this is honest about, and why each line is worded the way it is
  *
- * The issue's requirement is not "show more fields" — it is that every claim on
- * this panel is one the system can actually back. Three of them could not be
- * made naively:
+ * The requirement is not "show more fields" — it is that every claim on this
+ * panel is one the system can actually back. Four of them could not be made
+ * naively:
  *
- *  1. **Which account an agent uses.** OpenHuman marks the first of several as
- *     the default, and inheriting that was the plan. It is not true here:
- *     `composio_execute` posts `{tool, arguments}` and **no connection id**
- *     (`src/harness/composio.rs`, and `execute_tool` in the shared client), so
- *     nothing on this side selects an account — Composio resolves it for the
- *     entity. A "Default" chip would name a decision this product does not
- *     make. The panel says that instead.
+ *  1. **Which account an agent uses** (Composio). OpenHuman marks the first of
+ *     several as the default, and inheriting that was the plan. It is not true
+ *     here: `composio_execute` posts `{tool, arguments}` and **no connection
+ *     id** (`src/harness/composio.rs`, and `execute_tool` in the shared
+ *     client), so nothing on this side selects an account — Composio resolves it
+ *     for the entity. A "Default" chip would name a decision this product does
+ *     not make. The panel says that instead.
  *  2. **When it was connected.** Only Composio records it. The native
  *     `oauth/{provider}` store keeps `{token, account}` and journals nothing on
  *     connect, and MCP has no such concept — so for those the date is not
  *     merely missing, it is unrecoverable. An empty cell would read as
  *     "never"; the panel says "not recorded".
  *  3. **What has gone through it.** Composio meters a successful
- *     `composio_execute` per toolkit (`src/metering/oauth.rs`), so the number
- *     here is real — but it is per *provider*, not per *account*, and both
- *     accounts of a two-Gmail company land on the same total. Rendering it
+ *     `composio_execute` per toolkit and the MCP bridge meters a successful
+ *     remote call under `mcp:<server>` (`src/metering/oauth.rs`), so the number
+ *     here is real for both — but it is per *connection*, not per *account*, and
+ *     both accounts of a two-Gmail company land on the same total. Rendering it
  *     against one account would be a number that means something else.
+ *  4. **Whether an MCP server is connected.** It has no connection object, so
+ *     the answer is assembled from `enabled` and the last probe — two facts one
+ *     badge would collapse, with "never probed" the case that has no honest
+ *     single-badge rendering at all. See `mcpStanding`.
  *
- * ## Composio only
+ * ## Composio and MCP only
  *
  * The native OAuth catalog gets no detail view. Its credential is written and
  * read by nothing (#396), and a page devoted to how healthy a connection is,
  * is exactly where an inert one would look most alive. A provider that also
  * holds a native credential says so as a caveat, not as a second connection.
  */
-export function ProviderDetail({
-  client,
-  company,
-  provider,
-  canManage,
-  noCredential,
-  busy,
-  onClose,
-  onConnectAnother,
-  onDisconnectAccount,
-}: Props) {
-  const slug = provider ? toolkitSlug(provider.slug) : null;
+export function ProviderDetail({ client, company, subject, canManage, busy, onClose }: Props) {
+  // The `byProvider` key this subject's calls land on. `null` for a closed
+  // panel, and — unreachably, since the host rejects an unnamed server — for an
+  // MCP server whose name normalizes away; the MCP arm renders that case rather
+  // than reading the host's shared `unknown` bucket as this server's total.
+  const usageKey =
+    subject === null
+      ? null
+      : subject.kind === "composio"
+        ? toolkitSlug(subject.provider.slug)
+        : mcpProviderSlug(subject.server.name);
   const [calls, setCalls] = useState<number | null>(null);
   const [usageLoad, setUsageLoad] = useState<"loading" | "ready" | "unavailable">("loading");
 
   useEffect(() => {
-    if (slug === null) return;
+    if (usageKey === null) return;
     let alive = true;
     setUsageLoad("loading");
     setCalls(null);
@@ -106,7 +155,7 @@ export function ProviderDetail({
       .usage(USAGE_RANGE, company)
       .then((usage) => {
         if (!alive) return;
-        setCalls(callsForProvider(usage.byProvider, slug));
+        setCalls(callsForProvider(usage.byProvider, usageKey));
         setUsageLoad("ready");
       })
       // A host without the usage route (older build) 404s. "Not recorded here"
@@ -118,166 +167,358 @@ export function ProviderDetail({
     return () => {
       alive = false;
     };
-  }, [client, company, slug]);
+  }, [client, company, usageKey]);
 
-  const accounts = provider?.accounts ?? [];
-  const live = accounts.filter((a) => a.connected);
+  const usage = { load: usageLoad, calls, key: usageKey };
 
   return (
-    <Sheet open={provider !== null} onOpenChange={(next) => !next && onClose()}>
+    <Sheet open={subject !== null} onOpenChange={(next) => !next && onClose()}>
       <SheetContent side="right" className="w-full overflow-y-auto sm:max-w-md">
-        {provider && (
-          <>
-            <SheetHeader className="border-b">
-              <SheetTitle className="flex items-center gap-2">
-                <span className="truncate">{provider.label}</span>
-              </SheetTitle>
-              <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
-                <Badge variant="outline" className="font-normal">
-                  {/* Which of the three systems this provider is reached
-                      through — one of the questions the issue asks the view to
-                      answer, and stated rather than left to be inferred from
-                      the fact that a panel opened at all. */}
-                  Composio
-                </Badge>
-                <span>
-                  {live.length === 0
-                    ? "not connected"
-                    : live.length === 1
-                      ? "1 account connected"
-                      : `${live.length} accounts connected`}
-                </span>
-              </SheetDescription>
-            </SheetHeader>
-
-            <div className="space-y-4 px-4 pb-6">
-              <section className="space-y-2" aria-label="Connected accounts">
-                {accounts.map((account) => (
-                  <AccountRow
-                    key={account.id}
-                    account={account}
-                    canManage={canManage}
-                    busy={busy}
-                    onDisconnect={() => onDisconnectAccount(provider, account)}
-                  />
-                ))}
-                {accounts.length === 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    {/* An account and a *usable* account are different states,
-                        and a provider that has never been connected is a third.
-                        The empty case says which of them this is rather than
-                        "not connected", which would cover all three. */}
-                    No Composio account is connected for {provider.label}, so its agents have none of
-                    its tools.
-                  </p>
-                )}
-              </section>
-
-              {live.length > 1 && (
-                <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                  <AlertTriangle className="mt-px size-3 shrink-0" />
-                  <span>
-                    Holding several accounts is fine — they are the company&apos;s, and every member
-                    works through them. Which one an agent acts as is not set here:{" "}
-                    <span className="font-mono">composio_execute</span> sends no connection id, so
-                    Composio resolves it. Disconnect the one you do not want an agent to use.
-                  </span>
-                </p>
-              )}
-
-              {provider.via.includes("native") && (
-                <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
-                  <AlertTriangle className="mt-px size-3 shrink-0" />
-                  <span>
-                    This company also stores a self-hosted OAuth credential for {provider.label}. No
-                    agent reads it (issue #396), it is not what the accounts above are, and
-                    disconnecting here does not touch it.
-                  </span>
-                </p>
-              )}
-
-              {/* Hidden for a provider that is neither connected nor has been
-                  used: "0 calls in the last 30 days" is true there but says
-                  nothing, and in open mode this panel opens over a catalog of
-                  123 providers that have never been touched. A non-zero count
-                  on a disconnected provider is the opposite — it is the
-                  interesting case, so it stays. */}
-              {(provider.connected || (usageLoad === "ready" && (calls ?? 0) > 0)) && (
-                <>
-                  <Separator />
-
-                  <section className="space-y-1" aria-label="Usage">
-                    <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
-                      Usage
-                    </h4>
-                    {usageLoad === "loading" && (
-                      <p className="text-xs text-muted-foreground">Reading usage…</p>
-                    )}
-                    {usageLoad === "unavailable" && (
-                      <p className="text-xs text-muted-foreground">
-                        This host does not report usage, so what has gone through this connection is
-                        not recorded here.
-                      </p>
-                    )}
-                    {usageLoad === "ready" && (
-                      <>
-                        <p className="text-sm">
-                          <span className="font-medium">{calls}</span>{" "}
-                          {calls === 1 ? "call" : "calls"} in the last 30 days
-                        </p>
-                        <p className="text-xs text-muted-foreground">
-                          Successful tool calls through {provider.label}, counted per provider rather
-                          than per account — a call through any account above lands on this one
-                          total.
-                        </p>
-                      </>
-                    )}
-                  </section>
-                </>
-              )}
-
-              {canManage && (
-                <>
-                  <Separator />
-                  <section className="space-y-2" aria-label="Manage this connection">
-                    <Button
-                      variant="outline"
-                      className="w-full"
-                      disabled={busy || noCredential}
-                      onClick={() => onConnectAnother(provider)}
-                      data-testid="provider-detail-connect-another"
-                    >
-                      <LogIn className="size-4" />
-                      {accounts.length === 0 ? "Connect an account" : "Connect another account"}
-                    </Button>
-                    {noCredential && (
-                      <p className="text-xs text-muted-foreground">
-                        There is no credential for this company to authorize against yet, so a
-                        sign-in has nothing to present. Set the company&apos;s TinyHumans credential
-                        on the Connections page first.
-                      </p>
-                    )}
-                    {accounts.length > 0 && (
-                      <p className="text-xs text-muted-foreground">
-                        Disconnecting removes the connection at Composio, so agents lose these tools
-                        on their next turn. It does not sign the company out of {provider.label}, and
-                        it does not delete anything there.
-                      </p>
-                    )}
-                  </section>
-                </>
-              )}
-
-              {!canManage && (
-                <p className="text-xs text-muted-foreground">
-                  Only an admin can connect or disconnect an account here.
-                </p>
-              )}
-            </div>
-          </>
+        {subject?.kind === "composio" && (
+          <ComposioBody subject={subject} canManage={canManage} busy={busy} usage={usage} />
+        )}
+        {subject?.kind === "mcp" && (
+          <McpBody subject={subject} canManage={canManage} usage={usage} />
         )}
       </SheetContent>
     </Sheet>
+  );
+}
+
+/** The usage read, as both arms consume it. */
+interface Usage {
+  load: "loading" | "ready" | "unavailable";
+  calls: number | null;
+  /** The `byProvider` key, or `null` when this subject has none to look up. */
+  key: string | null;
+}
+
+/**
+ * The Usage section, shared by both arms.
+ *
+ * `perConnection` is the sentence under the figure, and it is the arm's to
+ * write: what "counted per connection rather than per account" rules out
+ * differs between a toolkit with two Gmail accounts and a server with one
+ * endpoint, and a single generic line would be vague in the Composio case and
+ * wrong in the MCP one.
+ */
+function UsageSection({ usage, perConnection }: { usage: Usage; perConnection: string }) {
+  return (
+    <section className="space-y-1" aria-label="Usage" data-testid="connection-detail-usage">
+      <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">Usage</h4>
+      {usage.key === null ? (
+        <p className="text-xs text-muted-foreground">
+          This connection has no name to count calls against, so what has gone through it is not
+          attributable here.
+        </p>
+      ) : usage.load === "loading" ? (
+        <p className="text-xs text-muted-foreground">Reading usage…</p>
+      ) : usage.load === "unavailable" ? (
+        <p className="text-xs text-muted-foreground">
+          This host does not report usage, so what has gone through this connection is not recorded
+          here.
+        </p>
+      ) : (
+        <>
+          <p className="text-sm">
+            <span className="font-medium">{usage.calls}</span>{" "}
+            {usage.calls === 1 ? "call" : "calls"} in the last 30 days
+          </p>
+          <p className="text-xs text-muted-foreground">{perConnection}</p>
+        </>
+      )}
+    </section>
+  );
+}
+
+/** A Composio provider: its accounts, and what may be done with them. */
+function ComposioBody({
+  subject,
+  canManage,
+  busy,
+  usage,
+}: {
+  subject: Extract<ConnectionSubject, { kind: "composio" }>;
+  canManage: boolean;
+  busy: boolean;
+  usage: Usage;
+}) {
+  const { provider, noCredential, onConnectAnother, onDisconnectAccount } = subject;
+  const accounts = provider.accounts ?? [];
+  const live = accounts.filter((a) => a.connected);
+
+  return (
+    <>
+      <SheetHeader className="border-b">
+        <SheetTitle className="flex items-center gap-2">
+          <span className="truncate">{provider.label}</span>
+        </SheetTitle>
+        <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
+          <Badge variant="outline" className="font-normal">
+            {/* Which of the three systems this provider is reached through —
+                one of the questions the issue asks the view to answer, and
+                stated rather than left to be inferred from the fact that a
+                panel opened at all. */}
+            Composio
+          </Badge>
+          <span>
+            {live.length === 0
+              ? "not connected"
+              : live.length === 1
+                ? "1 account connected"
+                : `${live.length} accounts connected`}
+          </span>
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="space-y-4 px-4 pb-6">
+        <section className="space-y-2" aria-label="Connected accounts">
+          {accounts.map((account) => (
+            <AccountRow
+              key={account.id}
+              account={account}
+              canManage={canManage}
+              busy={busy}
+              onDisconnect={() => onDisconnectAccount(provider, account)}
+            />
+          ))}
+          {accounts.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              {/* An account and a *usable* account are different states, and a
+                  provider that has never been connected is a third. The empty
+                  case says which of them this is rather than "not connected",
+                  which would cover all three. */}
+              No Composio account is connected for {provider.label}, so its agents have none of its
+              tools.
+            </p>
+          )}
+        </section>
+
+        {live.length > 1 && (
+          <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+            <AlertTriangle className="mt-px size-3 shrink-0" />
+            <span>
+              Holding several accounts is fine — they are the company&apos;s, and every member works
+              through them. Which one an agent acts as is not set here:{" "}
+              <span className="font-mono">composio_execute</span> sends no connection id, so Composio
+              resolves it. Disconnect the one you do not want an agent to use.
+            </span>
+          </p>
+        )}
+
+        {provider.via.includes("native") && (
+          <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+            <AlertTriangle className="mt-px size-3 shrink-0" />
+            <span>
+              This company also stores a self-hosted OAuth credential for {provider.label}. No agent
+              reads it (issue #396), it is not what the accounts above are, and disconnecting here
+              does not touch it.
+            </span>
+          </p>
+        )}
+
+        {/* Hidden for a provider that is neither connected nor has been used:
+            "0 calls in the last 30 days" is true there but says nothing, and in
+            open mode this panel opens over a catalog of 123 providers that have
+            never been touched. A non-zero count on a disconnected provider is
+            the opposite — it is the interesting case, so it stays. */}
+        {(provider.connected || (usage.load === "ready" && (usage.calls ?? 0) > 0)) && (
+          <>
+            <Separator />
+            <UsageSection
+              usage={usage}
+              perConnection={`Successful tool calls through ${provider.label}, counted per provider rather than per account — a call through any account above lands on this one total.`}
+            />
+          </>
+        )}
+
+        {canManage && (
+          <>
+            <Separator />
+            <section className="space-y-2" aria-label="Manage this connection">
+              <Button
+                variant="outline"
+                className="w-full"
+                disabled={busy || noCredential}
+                onClick={() => onConnectAnother(provider)}
+                data-testid="provider-detail-connect-another"
+              >
+                <LogIn className="size-4" />
+                {accounts.length === 0 ? "Connect an account" : "Connect another account"}
+              </Button>
+              {noCredential && (
+                <p className="text-xs text-muted-foreground">
+                  There is no credential for this company to authorize against yet, so a sign-in has
+                  nothing to present. Set the company&apos;s TinyHumans credential on the Connections
+                  page first.
+                </p>
+              )}
+              {accounts.length > 0 && (
+                <p className="text-xs text-muted-foreground">
+                  Disconnecting removes the connection at Composio, so agents lose these tools on
+                  their next turn. It does not sign the company out of {provider.label}, and it does
+                  not delete anything there.
+                </p>
+              )}
+            </section>
+          </>
+        )}
+
+        {!canManage && (
+          <p className="text-xs text-muted-foreground">
+            Only an admin can connect or disconnect an account here.
+          </p>
+        )}
+      </div>
+    </>
+  );
+}
+
+/**
+ * A remote MCP server (issue #821).
+ *
+ * Read-only, deliberately: the enable toggle, Test, Tools and Remove stay on
+ * the list behind this panel until the panel is proven. What the panel adds is
+ * the answer the list cannot give — what this server *is*, what has gone
+ * through it, and what removing it would and would not reach.
+ */
+function McpBody({
+  subject,
+  canManage,
+  usage,
+}: {
+  subject: Extract<ConnectionSubject, { kind: "mcp" }>;
+  canManage: boolean;
+  usage: Usage;
+}) {
+  const { server, health } = subject;
+  const standing = mcpStanding(server, health);
+  const probedAt = probedOn(health?.checkedAtMillis);
+
+  return (
+    <>
+      <SheetHeader className="border-b">
+        <SheetTitle className="flex items-center gap-2">
+          <span className="truncate">{server.name}</span>
+        </SheetTitle>
+        <SheetDescription className="flex flex-wrap items-center gap-1.5 text-xs">
+          <Badge variant="outline" className="font-normal">
+            MCP
+          </Badge>
+          <span data-testid="mcp-detail-standing">{standing.summary}</span>
+        </SheetDescription>
+      </SheetHeader>
+
+      <div className="space-y-4 px-4 pb-6">
+        <section className="space-y-2" aria-label="What this server is">
+          <div className="space-y-1 rounded-lg border border-border px-3 py-2">
+            <p className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+              Endpoint
+            </p>
+            {/* Wrapped, not truncated: the list truncates it to keep rows
+                even, and "what URL are my agents actually calling" is a reason
+                to open the panel rather than a detail to hide again. */}
+            <p className="font-mono text-xs break-all">{server.endpoint}</p>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {server.source === "manifest"
+              ? "Declared in this company's company.toml, so it comes back on every boot — it can be turned off here but not deleted."
+              : "Added from the console, so it lives in this company's runtime store rather than in company.toml."}
+          </p>
+          <p className="text-xs text-muted-foreground" data-testid="mcp-detail-probe">
+            {standing.probe}
+            {probedAt !== null && ` · ${probedAt}`}
+          </p>
+          {/* The host scrubs this string — it can carry no credential, no
+              response body and no query string — which is why it can be shown
+              verbatim rather than re-spelled into a category. */}
+          {health && health.status !== "ok" && health.message && (
+            <p className="text-xs text-muted-foreground">{health.message}</p>
+          )}
+          <p className="text-xs text-muted-foreground" data-testid="mcp-detail-connected-on">
+            {/* The same answer the native path gets, for the same reason: there
+                is no connect to record. Said rather than left blank, which
+                reads as "never". */}
+            {connectedOn(undefined)} — MCP has no connect step to record one.
+          </p>
+        </section>
+
+        {!standing.live && (
+          <p className="flex items-start gap-2 rounded-md bg-muted/40 p-2 text-xs text-muted-foreground">
+            <AlertTriangle className="mt-px size-3 shrink-0" />
+            <span>
+              This server is turned off, so no teammate receives its tools whatever their grants say
+              and whatever the endpoint answers. Its configuration and any stored credential survive
+              — turning it back on restores its tools on the next turn.
+            </span>
+          </p>
+        )}
+
+        {/* Reachability (issue #568) restated where the panel can afford the
+            sentence the row could not. Scoped to an enabled server for the same
+            reason as the list: a disabled server is empty by construction, so
+            flagging it would cry wolf on intent. */}
+        {standing.live && server.reachableBy !== undefined && (
+          <p
+            className={
+              server.reachableBy.length === 0
+                ? "flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 px-2 py-1 text-xs font-medium text-destructive"
+                : "text-xs text-muted-foreground"
+            }
+            data-testid="mcp-detail-reachability"
+          >
+            {server.reachableBy.length === 0 ? (
+              <>
+                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                <span>
+                  No agent can reach this server — no teammate&apos;s tool grants cover{" "}
+                  <code className="font-mono">mcp:{server.name}</code>. Whatever usage says below
+                  happened before that was true.
+                </span>
+              </>
+            ) : (
+              <span>
+                Reachable by:{" "}
+                <span className="font-medium text-foreground">{server.reachableBy.join(", ")}</span>
+              </span>
+            )}
+          </p>
+        )}
+
+        <Separator />
+
+        <UsageSection
+          usage={usage}
+          perConnection={`Successful tool calls your agents made through ${server.name}, counted under mcp:${server.name.trim().toLowerCase()} so a Composio provider of the same name cannot be read as this one.`}
+        />
+
+        <Separator />
+
+        <section className="space-y-2" aria-label="Removing this server">
+          <h4 className="text-xs font-medium tracking-wide text-muted-foreground uppercase">
+            What a disconnect reaches
+          </h4>
+          <p className="text-xs text-muted-foreground" data-testid="mcp-detail-disconnect-scope">
+            {server.source === "manifest"
+              ? "This server is declared in company.toml, so it cannot be removed from the console — turning it off drops it from every agent's tool belt on the next turn, and it returns on the next boot unless the manifest changes."
+              : "Removing it drops it from every agent's tool belt on the next turn and deletes the credential stored here for it."}{" "}
+            Nothing is revoked at the server&apos;s own end: no token it issued is invalidated and no
+            session there is closed. Revoke those where they were issued.
+          </p>
+          {canManage ? (
+            <p className="text-xs text-muted-foreground">
+              {server.source === "manifest"
+                ? "Turn it off with the switch on its row behind this panel."
+                : "Turn it off or remove it from its row behind this panel."}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Only an admin can turn a tool server off or remove one.
+            </p>
+          )}
+        </section>
+      </div>
+    </>
   );
 }
 

--- a/frontend/test/e2e/mcp.spec.ts
+++ b/frontend/test/e2e/mcp.spec.ts
@@ -77,6 +77,55 @@ test("Settings MCP lists the company's servers instead of crashing on open", asy
   expect(pageErrors, `the page threw: ${pageErrors.join(" | ")}`).toEqual([]);
 });
 
+test("a server opens into the panel a Composio provider opens into", async ({ page }) => {
+  // Issue #821. #819 gave a Composio provider a detail view and left MCP as a
+  // list — the uneven half of #404, and the wrong half to leave for a company
+  // routing its real work through MCP servers. What is asserted here is not
+  // "a sheet opened" but the four claims the sheet exists to make, because each
+  // has a plausible-looking wrong answer the list surface would have given.
+  const pageErrors: string[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error.message));
+
+  await openMcpSettings(page);
+
+  const row = page.getByTestId("mcp-server-row").filter({ hasText: "deepwiki" });
+  await expect(row).toBeVisible();
+  await row.getByTestId("mcp-server-open").click();
+
+  const panel = page.getByRole("dialog");
+  await expect(panel).toBeVisible();
+
+  // Which of the three connection systems this is, said rather than left to be
+  // inferred from the fact that a panel opened at all.
+  await expect(panel).toContainText("MCP");
+  await expect(panel).toContainText("https://mcp.deepwiki.com/mcp");
+
+  // The manifest server the harness declares has never been probed on this
+  // host: `Test` needs the `openhuman` feature and reports `not_wired` here. So
+  // this is the case with no honest single-badge rendering — not reachable, not
+  // broken — and the panel has to say which.
+  await expect(panel.getByTestId("mcp-detail-probe")).toContainText("has not been probed");
+
+  // MCP records no connect, the same answer the native path gets and for the
+  // same reason. A blank here reads as "never connected".
+  await expect(panel.getByTestId("mcp-detail-connected-on")).toContainText(
+    "connection date not recorded",
+  );
+
+  // What a disconnect reaches — and, for a manifest server, that the console
+  // cannot remove it at all.
+  const scope = panel.getByTestId("mcp-detail-disconnect-scope");
+  await expect(scope).toContainText("cannot be removed from the console");
+  await expect(scope).toContainText("Nothing is revoked at the server's own end");
+
+  // Usage, read under `mcp:deepwiki`. The harness host serves the usage route
+  // and no agent has called this server, so a real zero is the right answer —
+  // the case that must NOT be confused with the unavailable one below it.
+  await expect(panel.getByTestId("connection-detail-usage")).toContainText("in the last 30 days");
+
+  expect(pageErrors, `the page threw: ${pageErrors.join(" | ")}`).toEqual([]);
+});
+
 test("an admin adds and removes a runtime MCP server", async ({ page }) => {
   const pageErrors: string[] = [];
   page.on("pageerror", (error) => pageErrors.push(error.message));

--- a/frontend/test/unit/connection-detail.test.ts
+++ b/frontend/test/unit/connection-detail.test.ts
@@ -1,15 +1,22 @@
-// What the provider detail view is allowed to claim (issue #404).
+// What the connection detail view is allowed to claim (issues #404, #821).
 //
-// The issue names the failure mode it exists to prevent: "Do not invent a
-// number. If per-connection usage is not recorded today, say so on screen …
-// rather than rendering a plausible-looking zero." These pin the two places the
-// view could quietly do the equivalent — a missing date rendered as a blank
-// (which reads as "never"), and one connection system's total read as another's.
+// #404 names the failure mode this exists to prevent: "Do not invent a number.
+// If per-connection usage is not recorded today, say so on screen … rather than
+// rendering a plausible-looking zero." These pin the places the view could
+// quietly do the equivalent — a missing date rendered as a blank (which reads as
+// "never"), one connection system's total read as another's, and (#821) a
+// remote MCP server's two independent facts collapsed into one "connected".
 
 import { describe, expect, it } from "vitest";
 
-import type { ProviderCallsDto } from "@/api/types";
-import { callsForProvider, connectedOn } from "@/lib/connection-detail";
+import type { McpHealth, McpServer, ProviderCallsDto } from "@/api/types";
+import {
+  callsForProvider,
+  connectedOn,
+  mcpProviderSlug,
+  mcpStanding,
+  probedOn,
+} from "@/lib/connection-detail";
 
 describe("connectedOn", () => {
   it("states the date Composio recorded", () => {
@@ -61,5 +68,111 @@ describe("callsForProvider", () => {
   it("matches the host's normalization rather than its spelling", () => {
     // `by_provider` groups on a trimmed, lowercased slug (`src/metering/oauth.rs`).
     expect(callsForProvider([row("GitHub", 5)], "github")).toBe(5);
+  });
+});
+
+describe("mcpProviderSlug", () => {
+  it("mirrors the key the host records an MCP call under", () => {
+    // `mcp_provider` in `src/metering/oauth.rs`: trimmed, lowercased, prefixed.
+    expect(mcpProviderSlug("linear")).toBe("mcp:linear");
+    expect(mcpProviderSlug("  LINEAR ")).toBe("mcp:linear");
+  });
+
+  it("reads the server's own total and not the toolkit's", () => {
+    // The whole point of the prefix (#698). Composio `linear` and an MCP server
+    // called `linear` are two connections; each panel reads its own row.
+    const rows: ProviderCallsDto[] = [
+      { provider: "mcp:linear", calls: 31 },
+      { provider: "linear", calls: 4 },
+    ];
+    expect(callsForProvider(rows, mcpProviderSlug("linear")!)).toBe(31);
+    expect(callsForProvider(rows, "linear")).toBe(4);
+  });
+
+  it("refuses to attribute a server it cannot name", () => {
+    // The host would have recorded a bare `unknown` — its shared
+    // cannot-attribute bucket, holding every other unnamed call too. Reading
+    // that as this server's total is the invented number the panel exists to
+    // avoid, so there is no slug to look up and the caller says so instead.
+    expect(mcpProviderSlug("")).toBeNull();
+    expect(mcpProviderSlug("   ")).toBeNull();
+  });
+});
+
+describe("mcpStanding", () => {
+  function server(over: Partial<McpServer> = {}): McpServer {
+    return {
+      name: "linear",
+      endpoint: "https://mcp.linear.app/mcp",
+      source: "runtime",
+      enabled: true,
+      allowedTools: [],
+      disallowedTools: [],
+      timeoutSecs: 30,
+      authConfigured: true,
+      ...over,
+    };
+  }
+
+  function health(over: Partial<McpHealth> = {}): McpHealth {
+    return { status: "ok", message: "", toolCount: 3, checkedAtMillis: 1_760_000_000_000, ...over };
+  }
+
+  it("reads a turned-off server as contributing nothing, however well it probes", () => {
+    // The two facts that must not collapse into one badge: `enabled` decides
+    // whether any agent gets the tools, the probe decides whether the endpoint
+    // answered. A healthy disabled server is still handing out nothing.
+    const standing = mcpStanding(server({ enabled: false }), health());
+    expect(standing.live).toBe(false);
+    expect(standing.summary).toContain("turned off");
+    expect(standing.probe).toContain("reachable");
+  });
+
+  it("says whether there is a credential, without ever having one to say", () => {
+    expect(mcpStanding(server({ authConfigured: true }), undefined).summary).toContain(
+      "with a stored credential",
+    );
+    expect(mcpStanding(server({ authConfigured: false }), undefined).summary).toContain(
+      "with no credential",
+    );
+  });
+
+  it("keeps a probe that never ran apart from one that could not tell", () => {
+    // No `health` is a server nobody has pressed Test on. `unknown` is a probe
+    // that ran and came back inconclusive. Rendering either as the other
+    // invents a result — in one direction a probe, in the other an answer.
+    expect(mcpStanding(server(), undefined).probe).toBe("this server has not been probed from here");
+    expect(mcpStanding(server(), health({ status: "unknown" })).probe).toContain("could not tell");
+  });
+
+  it("counts the tools the last probe actually found", () => {
+    expect(mcpStanding(server(), health({ toolCount: 1 })).probe).toContain("1 tool on");
+    expect(mcpStanding(server(), health({ toolCount: 9 })).probe).toContain("9 tools on");
+  });
+
+  it("distinguishes a refused credential from an endpoint that did not answer", () => {
+    expect(mcpStanding(server(), health({ status: "needs_config" })).probe).toContain(
+      "want of a credential",
+    );
+    expect(mcpStanding(server(), health({ status: "error" })).probe).toContain("did not reach it");
+  });
+});
+
+describe("probedOn", () => {
+  it("states the probe time the host does record", () => {
+    // The counterpart of `connectedOn`: MCP records no connect, but it does
+    // record when it last asked. Locale-formatted, so assert the parts.
+    const line = probedOn(Date.UTC(2026, 7, 13, 9, 30));
+    expect(line).toContain("last probed");
+    expect(line).toContain("2026");
+  });
+
+  it("has no probe date rather than one at the epoch", () => {
+    // The host omits `health` entirely when it has never probed, so a zero here
+    // is a malformed wire value — and "last probed 1 Jan 1970" is the same
+    // class of plausible-looking lie as a rendered zero.
+    expect(probedOn(undefined)).toBeNull();
+    expect(probedOn(0)).toBeNull();
+    expect(probedOn(Number.NaN)).toBeNull();
   });
 });

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -6,23 +6,25 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import type { OpenCompanyClient } from "@/api/client";
 import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
-import type { ConnectionState, UsageDto } from "@/api/types";
+import type { ConnectionState, McpHealth, McpServer, UsageDto } from "@/api/types";
 import type { ComposioReach } from "@/lib/connections";
 import { buildGridProviders, type GridProvider } from "@/lib/provider-grid";
-import { ProviderDetail } from "@/views/connections/ProviderDetail";
+import { ProviderDetail, type ConnectionSubject } from "@/views/connections/ProviderDetail";
 
 /**
- * The provider detail view's claims (issue #404).
+ * The connection detail view's claims (issues #404, #821).
  *
  * This suite is normally for pure functions — see `vitest.config.ts`. The
  * exception is earned the same way `select-popup-width` earns it: the thing
  * under test *is* what reaches the operator's eye. The issue is not asking for
  * fields on a panel, it is asking that every sentence on the panel be one the
- * system can back, and three of them cannot be checked anywhere but here:
+ * system can back, and four of them cannot be checked anywhere but here:
  *
  *  1. no account is marked as the one agents use, because none is;
  *  2. a missing connection date says so rather than showing a blank;
- *  3. a member is not offered a disconnect the host will refuse (#403).
+ *  3. a member is not offered a disconnect the host will refuse (#403);
+ *  4. an MCP server's usage is read under `mcp:<server>` and never as the
+ *     same-named Composio toolkit's (#698, #821).
  */
 
 const OPEN: ComposioReach = {
@@ -91,18 +93,30 @@ async function render(
   client = clientWith([]),
   noCredential = false,
 ) {
+  await open(
+    {
+      kind: "composio",
+      provider,
+      noCredential,
+      onConnectAnother: () => {},
+      onDisconnectAccount: () => {},
+    },
+    canManage,
+    client,
+  );
+}
+
+/** Open the panel on any subject — the shared half of `render` and `openMcp`. */
+async function open(subject: ConnectionSubject, canManage: boolean, client = clientWith([])) {
   await act(async () => {
     root.render(
       createElement(ProviderDetail, {
         client,
         company: null,
-        provider,
+        subject,
         canManage,
-        noCredential,
         busy: false,
         onClose: () => {},
-        onConnectAnother: () => {},
-        onDisconnectAccount: () => {},
       }),
     );
   });
@@ -241,5 +255,123 @@ describe("the provider detail view", () => {
     // A detail view is where that would look healthiest, so it is stated.
     await render(gmail([account()], ["composio", "native"]), true);
     expect(text()).toContain("No agent reads it");
+  });
+});
+
+/** A server as `.../mcp/servers` returns it. */
+function mcpServer(over: Partial<McpServer> = {}): McpServer {
+  return {
+    name: "linear",
+    endpoint: "https://mcp.linear.app/mcp",
+    source: "runtime",
+    enabled: true,
+    allowedTools: [],
+    disallowedTools: [],
+    timeoutSecs: 30,
+    authConfigured: true,
+    ...over,
+  };
+}
+
+async function openMcp(
+  server: McpServer,
+  health: McpHealth | undefined = undefined,
+  canManage = true,
+  client = clientWith([]),
+) {
+  await open({ kind: "mcp", server, health }, canManage, client);
+}
+
+describe("the same panel, opened on a remote MCP server (#821)", () => {
+  it("says which of the three systems this is, and what it is calling as", async () => {
+    await openMcp(mcpServer());
+    expect(text()).toContain("MCP");
+    expect(text()).toContain("on, calling with a stored credential");
+    // What an operator opened it to see: the URL their agents actually call.
+    expect(text()).toContain("https://mcp.linear.app/mcp");
+  });
+
+  it("does not report a probe that was never run as a health verdict", async () => {
+    // The case with no honest single-badge rendering. A server nobody has
+    // pressed Test on is neither reachable nor broken, and the list's badge
+    // renders nothing at all for it — which on a detail view reads as "fine".
+    await openMcp(mcpServer(), undefined);
+    expect(text()).toContain("has not been probed from here");
+    expect(text()).not.toContain("reachable —");
+    expect(text()).not.toContain("last probed");
+  });
+
+  it("keeps 'turned off' apart from 'unreachable'", async () => {
+    // Two independent facts one badge would collapse: a disabled server whose
+    // endpoint answers perfectly still contributes nothing, and that is the
+    // fact the panel was opened to learn.
+    await openMcp(
+      mcpServer({ enabled: false }),
+      { status: "ok", message: "", toolCount: 9, checkedAtMillis: 1_760_000_000_000 },
+    );
+    expect(text()).toContain("turned off");
+    expect(text()).toContain("reachable — 9 tools on the last probe");
+    expect(text()).toContain("no teammate receives its tools");
+  });
+
+  it("reads usage under mcp:<server>, never as the same-named toolkit's", async () => {
+    // The collision `mcp:` was named to prevent (#698). A company with a
+    // Composio `linear` and an MCP server called `linear` has two connections,
+    // and one row's total is not the other's.
+    await openMcp(mcpServer({ name: "linear" }), undefined, true, clientWith([
+      { provider: "mcp:linear", calls: 31 },
+      { provider: "linear", calls: 4 },
+    ]));
+    expect(text()).toContain("31");
+    expect(text()).toContain("in the last 30 days");
+    expect(text()).toContain("mcp:linear");
+    expect(text()).not.toContain("4 calls");
+  });
+
+  it("does not report a zero when the host records no usage at all", async () => {
+    const broken = {
+      usage: async () => {
+        throw new Error("no usage route on this host");
+      },
+    } as unknown as OpenCompanyClient;
+    await openMcp(mcpServer(), undefined, true, broken);
+    expect(text()).toContain("does not report usage");
+    expect(text()).not.toContain("0 calls");
+  });
+
+  it("says a connection date is not recorded, and why there is none to record", async () => {
+    // The same answer the native path gets, for the same reason — MCP has no
+    // connect step at all. A blank here would read as "never connected".
+    await openMcp(mcpServer());
+    expect(text()).toContain("connection date not recorded");
+    expect(text()).toContain("no connect step to record one");
+  });
+
+  it("states what removing a runtime server reaches, and what it does not", async () => {
+    await openMcp(mcpServer({ source: "runtime" }));
+    expect(text()).toContain("drops it from every agent's tool belt on the next turn");
+    expect(text()).toContain("Nothing is revoked at the server's own end");
+  });
+
+  it("does not offer to remove a server the manifest owns", async () => {
+    // A manifest server can be disabled but not deleted, and it returns on the
+    // next boot — a "removing it deletes it" sentence would be false there.
+    await openMcp(mcpServer({ source: "manifest" }));
+    expect(text()).toContain("cannot be removed from the console");
+    expect(text()).toContain("returns on the next boot");
+  });
+
+  it("tells a member the controls are an admin's rather than offering them", async () => {
+    await openMcp(mcpServer(), undefined, false);
+    expect(text()).toContain("Only an admin can turn a tool server off");
+  });
+
+  it("flags an enabled server no agent's grants cover", async () => {
+    // #568, restated where the panel can afford the sentence the row could not:
+    // usage above it is history, not evidence that it is reachable now.
+    await openMcp(mcpServer({ reachableBy: [] }));
+    expect(text()).toContain("No agent can reach this server");
+    await openMcp(mcpServer({ reachableBy: ["ceo", "engineer"] }));
+    expect(text()).toContain("ceo, engineer");
   });
 });


### PR DESCRIPTION
Closes #821.

Follows #819, which is already merged — `ProviderDetail.tsx` and
`connection-detail.ts` come from it, and this branch was cut from its head. The
diff here is #821's own: three commits, eight files.

## What this does

#819 gave a Composio provider a detail view and deliberately left MCP as a list
— the uneven half of #404, and the wrong half to leave for a company routing its
real work through MCP servers. This opens a remote MCP server into the **same**
panel, on a `ConnectionSubject` union. Not a second MCP-specific panel, which is
exactly what #404 exists to prevent, and what happened to the MCP screen once
already (#414).

Read-only, as the issue's "smallest first slice" asks. Enable, `Test`, `Tools`
and `Remove` stay on the row; the panel adds what the row cannot say:

| Claim | How it is backed |
|---|---|
| Connected, and as what | `mcpStanding()` — `enabled` and the last probe kept apart |
| Usage | `byProvider` under `mcp:<server>` (`src/metering/oauth.rs`, #698/#744) |
| When it was connected | Stated as not recorded; MCP has no connect step |
| What a disconnect reaches | Tool belt next turn; nothing at the server's own end |

## Two decisions worth review

**`callsForProvider` was not taught the prefix**, though the issue suggests it
"would take the prefix". Its existing test pins the opposite, and correctly:
prefix-matching would re-create by hand the `gmail` / `mcp:gmail` collision the
namespace was chosen to prevent. `mcpProviderSlug()` builds the namespaced key
instead and the lookup stays one exact match on one key.

**The panel renders from `McpServersSection`, not `ConnectionsView`.** The live
health an operator just pressed `Test` for lives in that component's state, so
hoisting it would let the panel and the row it opened from report different
health. It also means Settings, MCP Servers gets the detail view for free.

Two smaller ones. `mcpStanding` keeps "never probed" apart from every probe
status including `unknown` — a server nobody has pressed `Test` on is neither
reachable nor broken, and it is the common case on a host without the
`openhuman` feature. And `probedOn` returns null rather than the epoch for a
zero `checkedAtMillis`, on the same grounds as the issue's rule about zeros.

The row's name got a chevron rather than hover styling alone — caught by looking
at a screenshot of the real page, where the clickable name was indistinguishable
from plain text.

## Commands run

- `npm run typecheck`, `typecheck:unit`, `typecheck:e2e`, `npm run build`
- `npm test` — 645 pass (52 files), including 22 render tests over both arms
- `npx playwright test` against a real `target/debug/opencompany` host —
  **124 pass**, 10 skipped (live-brain), including a new `mcp.spec.ts` case
  asserting the four claims above
- `scripts/ci/assert-design-tokens.sh`, `scripts/ci/assert-md-line-cap.sh`

## Not covered

The Composio arm has no e2e walk. The default-feature host serves no Composio,
so the grid renders no openable tile — its coverage is the vitest render suite,
which is where #819 put it for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
