### PR TITLE
feat(chat): escalate to the model only when the rules abstain (#678)

### DIFF
--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -6,8 +6,19 @@
 // Four of the suite's specs need an agent that actually executes, which needs
 // a host built with `--features openhuman,tinycortex,mcp` **and** something for
 // that harness to think with. This is that something: an OpenAI-compatible
-// chat-completions endpoint with no model behind it, whose answers are a pure
-// function of the prompt. `wiring.spec.ts`'s header has described it since the
+// chat-completions endpoint with no model behind it, whose answers are very
+// nearly a function of the prompt.
+//
+// **Very nearly, not purely** — worth knowing before you add a caller.
+// `servedDirectives` is per-process, so a `__MOCK_TOOL_CALL__` fires for the
+// FIRST request that carries it and never again. Any second call that sees the
+// same operator message therefore changes what the first one gets. Issue #678
+// hit exactly that: a triage escalation is handed the operator's raw message,
+// so it carried the directive, burned it, and left the agent's own turn with a
+// plain text reply — the tool call was logged once, for the classification.
+// `isTriageRequest` is why that no longer happens.
+//
+// `wiring.spec.ts`'s header has described it since the
 // day it was written ("a mocked inference backend that echoes a `__MOCK_LLM__`
 // marker"); until now nobody had committed one, so the specs it describes were
 // skipped rather than run.
@@ -342,9 +353,43 @@ function alreadyServed(messages, index) {
  * @param {any} body the parsed request
  * @returns {any} an OpenAI-shaped chat completion
  */
+/**
+ * Whether this request is a triage escalation rather than an agent turn
+ * (issue #678).
+ *
+ * Keyed on the opening sentence of the system prompt that
+ * `src/harness/triage.rs` owns. Coupling a fixture to prose is ordinarily a
+ * smell; the alternative here is worse, because the only other thing telling
+ * the two apart is "carries no tools", and an agent whose belt happens to be
+ * empty would be misread as a classification.
+ *
+ * @param {any[]} messages
+ * @returns {boolean}
+ */
+function isTriageRequest(messages) {
+  const first = messages[0];
+  return typeof textOf(first) === "string" && textOf(first).includes("You classify one message");
+}
+
 function chatCompletion(body) {
   const messages = Array.isArray(body?.messages) ? body.messages : [];
   const model = typeof body?.model === "string" ? body.model : "mock-brain";
+
+  // A triage escalation is a classification, not a turn (issue #678). It is
+  // handed the operator's RAW message, so it carries any `__MOCK_TOOL_CALL__`
+  // the message carried — and `servedDirectives` is per-process, so serving it
+  // here would burn the directive and leave the real turn with a plain text
+  // reply. Observed exactly that way: the tool call was logged once, for the
+  // classification, and the agent's own turn never made it.
+  //
+  // Answered `chatter` rather than refused, so the suite stays on the ungated
+  // path it was written for: only an `answer` verdict narrows the delegation
+  // claim.
+  if (isTriageRequest(messages)) {
+    process.stderr.write("[mock brain] triage classification (no directive consumed)\n");
+    return completion(model, { role: "assistant", content: "chatter" }, "stop");
+  }
+
   const directive = findDirective(messages);
 
   if (

--- a/frontend/test/unit/mock-brain.test.ts
+++ b/frontend/test/unit/mock-brain.test.ts
@@ -121,6 +121,38 @@ describe("the mock inference backend", () => {
     });
   });
 
+  it("classifies without burning the directive the same message carries", async () => {
+    // Issue #678. A triage escalation is handed the operator's RAW message, so
+    // it carries whatever directive that message carried — and `servedDirectives`
+    // is per-process, so serving it here would leave the agent's own turn with a
+    // plain text reply and no tool call. That is not hypothetical: it took the
+    // live-brain MCP spec red, with the tool call logged once, for the
+    // classification.
+    const directive = `__MOCK_TOOL_CALL__ ${JSON.stringify({
+      name: "mcp_call_tool",
+      arguments: { server: "simple", tool: "echo", arguments: { text: "burned?" } },
+    })}`;
+
+    const classification = await chat([
+      { role: "system", content: "You classify one message an operator sent to their company's chat." },
+      { role: "user", content: directive },
+    ]);
+    expect(
+      classification.choices[0].message.tool_calls,
+      "a classification must never be answered with a tool call",
+    ).toBeUndefined();
+    expect(classification.choices[0].message.content).toBe("chatter");
+
+    // The turn that follows must still get its tool call — the whole point.
+    const turn = await chat([
+      { role: "system", content: "You are the CEO of Acme." },
+      { role: "user", content: directive },
+    ]);
+    const call = turn.choices[0].message.tool_calls?.[0];
+    expect(call, "the directive must survive the classification").toBeDefined();
+    expect(call.function.name).toBe("mcp_call_tool");
+  });
+
   it("serves a directive once, then answers with the tool's own output", async () => {
     // The transcript the harness resends after the tool ran. The directive is
     // still in it; firing again would open a second card per message forever.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -120,6 +120,12 @@ impl Drop for CheckoutJanitor {
 pub struct HarnessBrain {
     pool: Arc<HarnessPool>,
     deps: HarnessDeps,
+    /// The LLM triage escalation, built on first use (issue #678).
+    ///
+    /// Lazy because it needs the company id, and a brain outlives any one
+    /// record read; `OnceLock` because it is immutable once built and the cost
+    /// is a clone of two `Arc`s, not a model call.
+    triage: std::sync::OnceLock<crate::harness::triage::MeteredTriage>,
     /// The company's record, **re-read from the store at the top of every
     /// cycle** (issue #707).
     ///
@@ -175,6 +181,7 @@ impl HarnessBrain {
             record: std::sync::RwLock::new(Arc::new(record)),
             responder,
             runs: None,
+            triage: std::sync::OnceLock::new(),
         }
     }
 
@@ -2369,6 +2376,17 @@ impl HarnessBrain {
         )
         .with_approvals(&self.deps.approval_requests)
         .with_workflow_refs(&self.deps.workflow_refs)
+        .with_triage(self.triage_escalation(&record.id))
+    }
+
+    /// The company's triage escalation, built once (issue #678).
+    fn triage_escalation(
+        &self,
+        company: &crate::ports::types::CompanyId,
+    ) -> &crate::harness::triage::MeteredTriage {
+        self.triage.get_or_init(|| {
+            crate::harness::triage::MeteredTriage::from_deps(&self.deps, company.clone())
+        })
     }
 }
 
@@ -7442,6 +7460,54 @@ members = ["eng1", "eng2"]
     /// the last user message so a test can read the turn's reply. Sharing the
     /// queue handle with [`HarnessDeps::delegations`] is what lets the brain
     /// drain it after the turn.
+    /// Whether this request is a triage escalation rather than an agent turn
+    /// (issue #678).
+    ///
+    /// Keyed on the system prompt's opening sentence, which
+    /// `harness::triage::system_prompt` owns. Coupling a fixture to prose is
+    /// ordinarily a smell; here the alternative is worse, because the only
+    /// other thing distinguishing the two is "carries no tools", and a turn
+    /// whose agent happens to have an empty belt would be misread as a
+    /// classification. Pinned by `a_triage_request_is_recognised_as_one`.
+    fn is_triage_request(request: &ModelRequest) -> bool {
+        request
+            .messages
+            .first()
+            .map(|m| m.text().contains("You classify one message"))
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn a_triage_request_is_recognised_as_one() {
+        let triage = ModelRequest {
+            messages: vec![
+                tinyagents::harness::message::Message::system(
+                    crate::harness::triage::system_prompt_for_test(),
+                ),
+                tinyagents::harness::message::Message::user("hello".to_string()),
+            ],
+            ..ModelRequest::default()
+        };
+        assert!(
+            is_triage_request(&triage),
+            "the fixture must recognise the real prompt, or it silently starts \
+             eating scripted turns again"
+        );
+        let turn = ModelRequest {
+            messages: vec![
+                tinyagents::harness::message::Message::system(
+                    "You are the CEO of Acme.".to_string(),
+                ),
+                tinyagents::harness::message::Message::user("ship it".to_string()),
+            ],
+            ..ModelRequest::default()
+        };
+        assert!(
+            !is_triage_request(&turn),
+            "an agent turn is not a classification"
+        );
+    }
+
     struct DelegatingProvider {
         queue: orchestrator::DelegationQueue,
         pushes: StdMutex<VecDeque<Vec<Delegation>>>,
@@ -7491,6 +7557,21 @@ members = ["eng1", "eng2"]
             _state: &(),
             request: ModelRequest,
         ) -> tinyagents::Result<ModelResponse> {
+            // Issue #678: a triage escalation is a classification, not a turn.
+            // It rides the same `HarnessModel` handle the roster runs on, so
+            // without this it would consume a scripted push and shift every
+            // turn's script by one — the delegation the test wrote for turn 1
+            // would be staged by a call that is not turn 1.
+            //
+            // Answering `chatter` rather than declining keeps these fixtures on
+            // the ungated path they were written for: only an `answer` verdict
+            // narrows the claim, so `chatter` leaves the gate exactly where the
+            // abstention left it. A test that wants the narrowing drives it
+            // through `DelegationRunner::with_triage` directly, where the
+            // verdict is scripted.
+            if is_triage_request(&request) {
+                return Ok(ModelResponse::assistant("chatter".to_string()));
+            }
             let invoke = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst) + 1;
             if self.faults.fail_from.is_some_and(|from| invoke >= from) {
                 return Err(tinyagents::TinyAgentsError::Model(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -115,6 +115,7 @@ pub mod steer;
 pub mod steps;
 pub mod tool_dispatcher;
 pub mod toolbelt;
+pub mod triage;
 /// Issue #661 (M7): `read_workflow` / `update_workflow` / `delete_workflow` —
 /// the agent's way to fix or retire a workflow instead of only ever creating
 /// another one beside it. Kept out of `orchestrator.rs` (already the largest

--- a/src/harness/triage.rs
+++ b/src/harness/triage.rs
@@ -1,0 +1,378 @@
+//! The LLM triage escalation — a second opinion on the operator messages the
+//! lexical classifier could not name (issue #678).
+//!
+//! # Escalation, not a pre-classifier
+//!
+//! Issue #267 sketches an LLM classifier fronting operator chat, and #678 asks
+//! for it. Read literally that is a full-price, serial round-trip **before every
+//! reply**, which is a poor trade: [`triage_message`] already names the classes
+//! a lexical detector can name, conservatively, and it is free.
+//!
+//! What it cannot do is tell you when it is guessing — every residual falls into
+//! [`MessageTriage::Chatter`] by construction. That is what
+//! [`triage_message_detailed`] fixed: a `Chatter` the classifier *decided*
+//! (empty, a greeting) is now distinguishable from one it *fell back to*.
+//!
+//! So this runs only on an abstention. Messages the cheap layer already named
+//! cost nothing and wait for nothing, and the model is asked only about the
+//! residue — the difference between paying per hard message and paying per
+//! message.
+//!
+//! # It decides, it does not act
+//!
+//! Lifted from OpenHuman's `trigger_triage`, whose framing this keeps verbatim:
+//! *"You do not act. You decide. Another component will carry out your
+//! decision."* The request carries **no tools at all**, so there is no loop and
+//! nothing it can reach.
+//!
+//! Its verdict is also deliberately narrower than the classifier's:
+//!
+//! * [`TriageVerdict::Answer`] narrows the delegation claim, exactly as a
+//!   lexical `Answer` does — the model may reply and may hand off, and its pure
+//!   board writes are refused in its own turn.
+//! * Everything else leaves the gate exactly where the abstention left it.
+//!
+//! **It never mints a card.** A verdict does not become
+//! [`MessageTriage::Track`], because the title a card is opened under is pinned
+//! byte-for-byte between the REST handler and `chat_handler_card` (issue #463) —
+//! a model-authored title would desynchronise them and orphan the card. That
+//! also keeps the issue's own tie-breaker intact: a missed card costs one
+//! follow-up message, a spurious card pollutes the board permanently.
+//!
+//! # Failure is silence, not an error
+//!
+//! Unreachable, slow, or unparseable all return [`TriageVerdict::Unavailable`],
+//! and the caller keeps the answer Layer A already gave. The operator is waiting
+//! on a reply; a classifier that cannot classify must cost nothing but its
+//! timeout.
+//!
+//! [`triage_message`]: crate::company::task_intent::triage_message
+//! [`triage_message_detailed`]: crate::company::task_intent::triage_message_detailed
+//! [`MessageTriage::Chatter`]: crate::company::task_intent::MessageTriage::Chatter
+//! [`MessageTriage::Track`]: crate::company::task_intent::MessageTriage::Track
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tinyagents::harness::message::Message;
+use tinyagents::harness::model::{ModelRequest, ModelResponse};
+
+use crate::harness::HarnessDeps;
+use crate::harness::build::model_for_tier;
+use crate::harness::provider::HarnessModel;
+use crate::ports::types::TokenUsage;
+
+/// How long an escalation may wait on the model before it is abandoned.
+///
+/// Far tighter than the planning pass's two minutes, because the cost of
+/// overrunning is different in kind: a planning card sits in a column, while an
+/// operator sits watching a chat thread with no reply. Two seconds is a
+/// classification budget, not a generation one — past it the deterministic
+/// answer is simply better than a late one.
+const TRIAGE_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Output-token ceiling. The answer is one word; this is headroom for a model
+/// that insists on punctuation, not room to explain itself.
+const MAX_OUTPUT_TOKENS: u32 = 8;
+
+/// Near-deterministic. Classification wants the same answer for the same
+/// message, and #678 names `0.2` as `trigger_triage`'s own setting — kept rather
+/// than rounded to zero so a genuinely borderline message is not forced.
+const TEMPERATURE: f64 = 0.2;
+
+/// What an escalation decided.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TriageVerdict {
+    /// A question or read request. Narrows the delegation claim.
+    Answer,
+    /// Work, or something else the gate should not touch. Named separately from
+    /// [`Self::Chatter`] so the log says which the model chose, but they act
+    /// identically here — see the module docs on why work never mints a card.
+    Work,
+    /// Neither.
+    Chatter,
+    /// No answer: unreachable, too slow, or unreadable. The caller keeps the
+    /// deterministic classification.
+    Unavailable,
+}
+
+impl TriageVerdict {
+    /// Whether this verdict narrows the delegation claim to answering-only.
+    pub fn is_answer(&self) -> bool {
+        matches!(self, Self::Answer)
+    }
+
+    /// Reads a model's reply as a verdict, or [`Self::Unavailable`].
+    ///
+    /// A **closed vocabulary**, matched on the first recognised word rather than
+    /// parsed. The model is asked for one word and usually gives one; anything
+    /// else — a sentence, an apology, an empty string, a word not on the list —
+    /// is not a classification and must not be guessed at. `Unavailable` is
+    /// always the safe reading, because it means "keep what Layer A said".
+    fn parse(text: &str) -> Self {
+        for word in text
+            .to_ascii_lowercase()
+            .split(|c: char| !c.is_alphabetic())
+        {
+            match word {
+                "answer" | "question" | "read" => return Self::Answer,
+                "work" | "track" | "task" => return Self::Work,
+                "chatter" | "neither" | "none" => return Self::Chatter,
+                _ => continue,
+            }
+        }
+        Self::Unavailable
+    }
+}
+
+/// The system prompt. Framing from OpenHuman's `trigger_triage`, narrowed to
+/// this one decision and to a one-word answer.
+fn system_prompt() -> String {
+    "You classify one message an operator sent to their company's chat.\n\
+     \n\
+     You do not act. You decide. Another component will carry out your decision.\n\
+     \n\
+     Answer with exactly one word, lowercase, and nothing else:\n\
+     \n\
+     - `answer` — a question, or a request to be told something about the \
+     company's state. It should be replied to, not turned into work.\n\
+     - `work` — a request to do something that should become a tracked task.\n\
+     - `chatter` — neither: small talk, an acknowledgement, a remark.\n\
+     \n\
+     If you cannot tell, answer `chatter`. Being unsure is not a reason to \
+     invent work."
+        .to_string()
+}
+
+/// The system prompt, for the fixture that has to recognise a classification
+/// request without consuming a scripted turn (issue #678).
+#[cfg(test)]
+pub fn system_prompt_for_test() -> String {
+    system_prompt()
+}
+
+/// A model that classifies the messages the lexical layer abstained on.
+///
+/// Holds no runtime handle, mirroring
+/// [`TaskPlanner`](crate::harness::planning::TaskPlanner): the caller already
+/// has the handles metering needs, and an evaluator that owned the runtime back
+/// would be a cycle that never frees.
+pub struct TriageEvaluator {
+    model: Arc<dyn HarnessModel>,
+    model_name: String,
+}
+
+impl TriageEvaluator {
+    /// Builds an evaluator over an explicit model.
+    pub fn new(model: Arc<dyn HarnessModel>, model_name: impl Into<String>) -> Self {
+        Self {
+            model,
+            model_name: model_name.into(),
+        }
+    }
+
+    /// Builds the company's evaluator from the harness deps.
+    ///
+    /// # Why not a cheap tier
+    ///
+    /// #678 asks for "fast-model routing" — a second, cheaper tier so
+    /// classification never pays orchestrator prices. That is the right
+    /// instinct and the wrong mechanism, for a reason
+    /// [`TaskPlanner::from_deps`](crate::harness::planning::TaskPlanner::from_deps)
+    /// already documents: an abstract tier a tenant's `[inference].models` table
+    /// does not map is **passed to their provider verbatim**
+    /// (`request_plan` falls back to the tier string as the model id). Inventing
+    /// a `fast-v1` and addressing it here would send an unknown model name to
+    /// every BYOK tenant that had not opted in, and triage would fail on exactly
+    /// the setups that otherwise work.
+    ///
+    /// So this takes the roster's own default — `model_override`, else the
+    /// tier-less default. Cheapness comes from the *shape* of the call rather
+    /// than from a tier: no tools, one short system prompt, one message, and
+    /// [`MAX_OUTPUT_TOKENS`] of output. The orchestrator's turn runs
+    /// `agentic-v1` with the full belt; this is already a fraction of it.
+    ///
+    /// A declarable cheap tier is worth having, but it needs the mapping to be
+    /// *checked* rather than assumed — a follow-up, not a default.
+    pub fn from_deps(deps: &HarnessDeps) -> Self {
+        let model_name = deps
+            .model_override
+            .clone()
+            .unwrap_or_else(|| model_for_tier(None));
+        Self::new(deps.provider.clone(), model_name)
+    }
+
+    /// The provider slug this evaluator's usage is metered under, read live so a
+    /// BYOK switch re-attributes the next escalation.
+    pub fn provider_slug(&self) -> String {
+        self.model.telemetry_provider_id()
+    }
+
+    /// Classifies one operator message, with what the call cost.
+    ///
+    /// Never returns an error: every failure is [`TriageVerdict::Unavailable`]
+    /// and the caller keeps the deterministic answer. The [`TokenUsage`] is
+    /// still returned on a *parse* failure, because those tokens were really
+    /// spent and must still be metered.
+    pub async fn classify(&self, message: &str) -> (TriageVerdict, TokenUsage) {
+        let request = ModelRequest {
+            messages: vec![
+                Message::system(system_prompt()),
+                Message::user(message.to_string()),
+            ],
+            model: Some(self.model_name.clone()),
+            temperature: Some(TEMPERATURE),
+            max_tokens: Some(MAX_OUTPUT_TOKENS),
+            ..ModelRequest::default()
+        };
+        let response = match tokio::time::timeout(TRIAGE_TIMEOUT, self.model.invoke(&(), request))
+            .await
+        {
+            Ok(Ok(response)) => response,
+            Ok(Err(err)) => {
+                tracing::debug!(
+                    error = %err,
+                    "[triage] the model could not be reached; keeping the deterministic answer"
+                );
+                return (TriageVerdict::Unavailable, TokenUsage::default());
+            }
+            Err(_elapsed) => {
+                tracing::debug!(
+                    timeout_s = TRIAGE_TIMEOUT.as_secs(),
+                    "[triage] the model did not answer in time; keeping the deterministic answer"
+                );
+                return (TriageVerdict::Unavailable, TokenUsage::default());
+            }
+        };
+        let usage = usage_from(&response);
+        (TriageVerdict::parse(&response.text()), usage)
+    }
+}
+
+/// One classification of an abstained-on message, metering included.
+///
+/// A trait rather than the concrete [`TriageEvaluator`] so the delegation seam
+/// depends on the *decision* and not on a model, a company id, a store and a
+/// meter. That keeps the escalation testable from a scripted verdict, and keeps
+/// the accounting handles out of a file that has no other business with them.
+#[async_trait::async_trait]
+pub trait TriageEscalation: Send + Sync {
+    /// Classifies `message`, recording whatever the call cost.
+    async fn classify(&self, message: &str) -> TriageVerdict;
+}
+
+/// The production escalation: a [`TriageEvaluator`] whose spend lands on the
+/// company's usage and ledger before the verdict is returned.
+pub struct MeteredTriage {
+    evaluator: TriageEvaluator,
+    company: crate::ports::types::CompanyId,
+    store: Arc<dyn crate::ports::CompanyStore>,
+    meter: Option<Arc<dyn crate::ports::usage::UsageMeter>>,
+}
+
+impl MeteredTriage {
+    /// Wires an escalation for `company` from the harness deps.
+    pub fn from_deps(deps: &HarnessDeps, company: crate::ports::types::CompanyId) -> Self {
+        Self {
+            evaluator: TriageEvaluator::from_deps(deps),
+            company,
+            store: deps.store.clone(),
+            meter: deps.meter.clone(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TriageEscalation for MeteredTriage {
+    async fn classify(&self, message: &str) -> TriageVerdict {
+        let (verdict, usage) = self.evaluator.classify(message).await;
+        // Metered even when the verdict is `Unavailable`: an unparseable reply
+        // still burned tokens, and a classification we could not read is
+        // precisely the spend an operator would want to see.
+        if let Some(meter) = self.meter.as_ref() {
+            crate::metering::record_triage_usage(
+                &usage,
+                &self.evaluator.provider_slug(),
+                &self.company,
+                self.store.as_ref(),
+                meter.as_ref(),
+            )
+            .await;
+        }
+        verdict
+    }
+}
+
+/// Token spend for one escalation, including the cost the managed provider
+/// reports on the wire. Mirrors the planning pass's reader.
+fn usage_from(response: &ModelResponse) -> TokenUsage {
+    let tokens = response.usage.unwrap_or_default();
+    let cost_usd = response
+        .raw
+        .as_ref()
+        .and_then(|raw| raw.pointer("/openhuman_usage_meta/charged_amount_usd"))
+        .and_then(serde_json::Value::as_f64)
+        .filter(|c| c.is_finite() && *c > 0.0)
+        .unwrap_or(0.0);
+    TokenUsage {
+        input: tokens.input_tokens,
+        output: tokens.output_tokens,
+        cached_input: tokens.cache_read_tokens,
+        cost_usd,
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn the_three_verdicts_read_off_a_one_word_reply() {
+        assert_eq!(TriageVerdict::parse("answer"), TriageVerdict::Answer);
+        assert_eq!(TriageVerdict::parse("work"), TriageVerdict::Work);
+        assert_eq!(TriageVerdict::parse("chatter"), TriageVerdict::Chatter);
+    }
+
+    /// Models add punctuation, capitals and the occasional preamble. None of
+    /// that is a failure to classify.
+    #[test]
+    fn a_verdict_survives_the_shapes_a_model_actually_replies_in() {
+        for (reply, want) in [
+            ("Answer.", TriageVerdict::Answer),
+            ("`work`", TriageVerdict::Work),
+            ("  chatter\n", TriageVerdict::Chatter),
+            ("The answer is: answer", TriageVerdict::Answer),
+        ] {
+            assert_eq!(TriageVerdict::parse(reply), want, "{reply:?}");
+        }
+    }
+
+    /// The closed vocabulary. Anything unrecognised is not a classification, and
+    /// guessing at it would spend the gate on noise.
+    #[test]
+    fn an_unreadable_reply_is_unavailable_rather_than_guessed() {
+        for reply in [
+            "",
+            "   ",
+            "I'm sorry, I can't help with that.",
+            "42",
+            "unknown",
+        ] {
+            assert_eq!(
+                TriageVerdict::parse(reply),
+                TriageVerdict::Unavailable,
+                "{reply:?} is not a verdict"
+            );
+        }
+    }
+
+    /// Only `Answer` touches the gate. `Work` is named for the log and acts like
+    /// `Chatter` here — a verdict never mints a card (see the module docs).
+    #[test]
+    fn only_answer_narrows_the_claim() {
+        assert!(TriageVerdict::Answer.is_answer());
+        assert!(!TriageVerdict::Work.is_answer());
+        assert!(!TriageVerdict::Chatter.is_answer());
+        assert!(!TriageVerdict::Unavailable.is_answer());
+    }
+}

--- a/src/metering/capability.rs
+++ b/src/metering/capability.rs
@@ -258,10 +258,20 @@ pub fn plan_named(name: &str) -> Option<CapabilityPlan> {
 /// filed under a different kind because it belongs to the company rather than
 /// to a teammate. Excluding it would leave a company able to plan indefinitely
 /// after crossing the tier ceiling that is supposed to have stopped it.
+///
+/// [`SampleKind::TriageCall`] is counted for the identical reason (issue #678),
+/// and the leak it closes is larger: triage escalations are driven by *chat
+/// volume*, so a company left able to classify indefinitely past its ceiling
+/// would keep paying per operator message with nothing to stop it.
 pub fn tokens_in(samples: &[UsageSample]) -> u64 {
     samples
         .iter()
-        .filter(|s| matches!(s.kind, SampleKind::Inference | SampleKind::PlanningCall))
+        .filter(|s| {
+            matches!(
+                s.kind,
+                SampleKind::Inference | SampleKind::PlanningCall | SampleKind::TriageCall
+            )
+        })
         .map(|s| s.input_tokens.saturating_add(s.output_tokens))
         .fold(0u64, |acc, t| acc.saturating_add(t))
 }

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -53,6 +53,7 @@ pub mod oauth;
 /// attribution rule. See [`planning`].
 pub mod planning;
 pub mod search;
+pub mod triage;
 mod types;
 mod usage;
 /// Issue #580: the workflow-builder pass's usage sample and its
@@ -74,6 +75,7 @@ pub use planning::{planning_sample, record_planning_usage};
 pub use search::{
     FALLBACK_SEARCH_COST_USD, MANAGED_SEARCH_PROVIDER, record_search_call, search_call_sample,
 };
+pub use triage::{record_triage_usage, triage_sample};
 pub use types::{
     AgentTokens, CategorySpend, Direction, Finances, ProviderCalls, Transaction, Usage, UsagePoint,
     UsageRange, UsageTotals,

--- a/src/metering/triage.rs
+++ b/src/metering/triage.rs
@@ -1,0 +1,148 @@
+//! Emitting [`SampleKind::TriageCall`] usage samples — what a triage
+//! escalation costs, and who it is charged to (issue #678).
+//!
+//! # Why this is not a teammate's inference
+//!
+//! A triage escalation is the tool-less model call an operator message makes
+//! when the lexical classifier in [`task_intent`](crate::company::task_intent)
+//! abstained. It happens **before** any teammate is chosen — deciding whether
+//! the orchestrator may write to the board at all is upstream of who answers —
+//! so there is no agent to attribute it to. Like a planning pass, it is charged
+//! to the whole-company bucket ([`UNATTRIBUTED_AGENT`]) with no `run_id`.
+//!
+//! It is deliberately not folded into
+//! [`SampleKind::PlanningCall`](crate::ports::usage::SampleKind) either. The two
+//! are driven by different things — planning by cards entering `planning`,
+//! triage by raw chat volume — so sharing a kind would make the planning line
+//! item move whenever chat got busier, and neither number could be tuned
+//! against the other.
+//!
+//! # Both writes are logged and swallowed
+//!
+//! Same rule as the planning path: the classification has already been made and
+//! the operator's turn is already running by the time this is called. A ledger
+//! or meter hiccup must cost the accounting row and never the reply. The tokens
+//! were genuinely spent either way, which is why the failure is logged rather
+//! than silently dropped.
+
+use crate::ports::types::{CompanyId, TokenUsage};
+use crate::ports::usage::{SampleKind, UsageMeter, UsageSample};
+use crate::ports::{CompanyStore, now_millis};
+
+use super::inference::{UNATTRIBUTED_AGENT, inference_ledger_entry};
+
+/// Builds the [`SampleKind::TriageCall`] sample for one completed escalation, or
+/// `None` when it moved no tokens and cost nothing.
+///
+/// The `None` case is the offline/mock path, exactly as in
+/// [`planning_sample`](super::planning_sample): a provider reporting no usage
+/// yields a zero [`TokenUsage`], and a row for it would claim a call happened
+/// that is indistinguishable from a real free one.
+///
+/// `agent` is not a parameter — attribution to [`UNATTRIBUTED_AGENT`] is the
+/// rule this module holds, so no caller can bill a classification to a desk.
+pub fn triage_sample(usage: &TokenUsage, provider: &str) -> Option<UsageSample> {
+    if usage.is_zero() {
+        return None;
+    }
+    Some(UsageSample {
+        at_millis: now_millis(),
+        agent: UNATTRIBUTED_AGENT.to_string(),
+        provider: super::oauth::normalize_provider(provider),
+        input_tokens: usage.input,
+        output_tokens: usage.output,
+        cached_input_tokens: usage.cached_input,
+        cost_usd: usage.cost_usd,
+        kind: SampleKind::TriageCall,
+        run_id: None,
+    })
+}
+
+/// Records one completed triage escalation: the Finances ledger entry (when it
+/// cost USD) and the usage sample (when it moved tokens or money).
+///
+/// The ledger entry goes through the same [`inference_ledger_entry`] the cycle's
+/// inference spend uses, under the same `inference.spend` kind — triage spend is
+/// inference spend as far as the money is concerned, and only the *usage*
+/// breakdown cares about the distinction.
+pub async fn record_triage_usage(
+    usage: &TokenUsage,
+    provider: &str,
+    company: &CompanyId,
+    store: &dyn CompanyStore,
+    meter: &dyn UsageMeter,
+) {
+    if usage.is_zero() {
+        return;
+    }
+    tracing::debug!(
+        company = %company,
+        provider = %provider,
+        input = usage.input,
+        output = usage.output,
+        cached_input = usage.cached_input,
+        cost_usd = usage.cost_usd,
+        "[usage] recording a triage escalation"
+    );
+    if let Some(entry) = inference_ledger_entry(usage, UNATTRIBUTED_AGENT)
+        && let Err(err) = store.append_ledger(company, entry).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to append the triage spend entry; the classification still stands"
+        );
+    }
+    if let Some(sample) = triage_sample(usage, provider)
+        && let Err(err) = meter.record(company, &sample).await
+    {
+        tracing::warn!(
+            company = %company,
+            error = %err,
+            "[usage] failed to record the triage usage sample; the classification still stands"
+        );
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    fn usage() -> TokenUsage {
+        TokenUsage {
+            input: 120,
+            output: 3,
+            cached_input: 0,
+            cost_usd: 0.0004,
+        }
+    }
+
+    #[test]
+    fn a_completed_escalation_is_charged_to_the_company_not_a_teammate() {
+        let sample = triage_sample(&usage(), "managed").expect("a sample for real spend");
+        assert_eq!(sample.kind, SampleKind::TriageCall);
+        assert_eq!(
+            sample.agent, UNATTRIBUTED_AGENT,
+            "triage runs before a teammate is chosen, so no teammate may be billed"
+        );
+        assert!(
+            sample.run_id.is_none(),
+            "an escalation belongs to no attempt"
+        );
+    }
+
+    /// The offline path. A mock provider reports nothing, and a zero row would be
+    /// indistinguishable from a real call that happened to be free.
+    #[test]
+    fn an_escalation_that_moved_nothing_writes_no_row() {
+        assert!(triage_sample(&TokenUsage::default(), "managed").is_none());
+    }
+
+    /// Distinct from planning, on purpose: the two are driven by different
+    /// things and tuned separately.
+    #[test]
+    fn triage_is_not_filed_as_planning() {
+        let sample = triage_sample(&usage(), "managed").expect("a sample");
+        assert_ne!(sample.kind, SampleKind::PlanningCall);
+    }
+}

--- a/src/ports/usage.rs
+++ b/src/ports/usage.rs
@@ -69,6 +69,21 @@ pub enum SampleKind {
     /// company plan indefinitely after its tier budget was exhausted, which is
     /// exactly the leak the tier exists to close.
     PlanningCall,
+    /// One completed triage escalation — the tool-less model call an operator
+    /// message makes when the lexical classifier abstained (issue #678).
+    ///
+    /// Its own kind for the same reason [`Self::PlanningCall`] is: it belongs to
+    /// no teammate, so it is charged to the whole-company bucket with no
+    /// `run_id`, and an operator asking "what is triage costing us?" should not
+    /// have to read that answer out of a teammate's column. Distinct from
+    /// `PlanningCall` too — conflating them would make the planning line item
+    /// move whenever chat volume moved, and the two are tuned independently.
+    ///
+    /// Counts toward the capability-tier token budget, exactly as a planning
+    /// pass does — see [`tokens_in`](crate::metering::tokens_in). It is
+    /// company-driven model spend, and excluding it would let chat keep paying
+    /// for classification after the tier budget was exhausted.
+    TriageCall,
 }
 
 /// One metered usage event.

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -425,6 +425,11 @@ pub(crate) struct DelegationRunner<'a> {
     /// that read it fall back to exactly the behaviour they had (no origin stamp,
     /// the orchestrator's voice on a note).
     workflow_run: Option<WorkflowRunRef>,
+    /// A second opinion for the messages the lexical classifier abstained on
+    /// (issue #678). `None` — every pre-#678 constructor, and any company whose
+    /// build wires no evaluator — keeps the deterministic answer, which is the
+    /// behaviour this had before.
+    triage: Option<&'a dyn crate::harness::triage::TriageEscalation>,
     /// Workflows the turn authored in-flight with the inline `create_workflow`
     /// tool (issues #112, #339), read so an operator turn can settle the card it
     /// adopted instead of leaving it in To-do (issue #678).
@@ -461,6 +466,7 @@ impl<'a> DelegationRunner<'a> {
             approvals: None,
             workflow_run: None,
             workflow_refs: None,
+            triage: None,
         }
     }
 
@@ -506,6 +512,7 @@ impl<'a> DelegationRunner<'a> {
             approvals: None,
             workflow_run: Some(run),
             workflow_refs: None,
+            triage: None,
         }
     }
 
@@ -534,6 +541,19 @@ impl<'a> DelegationRunner<'a> {
     /// the only drain lives on the dispatched-card path.
     pub(crate) fn with_workflow_refs(mut self, workflow_refs: &'a WorkflowRefQueue) -> Self {
         self.workflow_refs = Some(workflow_refs);
+        self
+    }
+
+    /// Wires the LLM escalation used when the lexical triage abstains
+    /// (issue #678).
+    ///
+    /// Without it an abstention keeps `Chatter`'s no-gate behaviour, which is
+    /// what every turn did before this existed.
+    pub(crate) fn with_triage(
+        mut self,
+        triage: &'a dyn crate::harness::triage::TriageEscalation,
+    ) -> Self {
+        self.triage = Some(triage);
         self
     }
 
@@ -710,7 +730,8 @@ impl<'a> DelegationRunner<'a> {
         // the orchestrator handed off produced the REST card AND the delegation
         // card. One message, one card — so every card-opening path below reads
         // this same answer.
-        let triage = crate::company::task_intent::triage_message(operator_words(message));
+        let triaged = crate::company::task_intent::triage_message_detailed(operator_words(message));
+        let triage = triaged.triage.clone();
         // Issue #267, Layer B: on a question, the model may not WRITE to the
         // board — but it keeps every means of answering, including the one that
         // runs somebody else's turn.
@@ -755,7 +776,33 @@ impl<'a> DelegationRunner<'a> {
         // board-write path to gate there; when #176 copies this drain site
         // through the canonical `delegation_tools` seam, the conditional claim
         // comes with it. Layer A above fronts both brains in the meantime.
-        let answering = triage.is_answer();
+        // Issue #678: the lexical layer answers most messages and abstains on
+        // the rest. Only the residue is worth a model call — escalating every
+        // message would tax each reply with a serial round-trip to improve a
+        // minority of classifications, which is the trade this deliberately
+        // does not make.
+        //
+        // An escalation can only ever *narrow* the claim, never widen what the
+        // turn may do, and it never mints a card: the title a card opens under
+        // is pinned byte-for-byte between the REST handler and
+        // `chat_handler_card` (issue #463), so a model-authored one would
+        // orphan it. `Work` and `Chatter` therefore both leave the gate where
+        // the abstention left it, and only `Answer` moves it.
+        let mut answering = triage.is_answer();
+        if !answering
+            && triaged.abstained()
+            && let Some(escalation) = self.triage
+        {
+            let verdict = escalation.classify(operator_words(message)).await;
+            if verdict.is_answer() {
+                tracing::debug!(
+                    company = %self.company,
+                    "[triage] the lexical layer abstained and the model read this as a question; \
+                     narrowing the claim to answering-only"
+                );
+                answering = true;
+            }
+        }
         // Claim the delegation queue for this turn and its drain (issue #453).
         //
         // The acquire-clear subsumes the bare `clear()` this used to open with —
@@ -3458,6 +3505,148 @@ members = ["designer"]
             "the chat handler's card is the card; this path opens none"
         );
         assert!(turn.spawned_task.is_none());
+    }
+
+    // ── Issue #678: the escalation, and where it may not reach ──────────────
+
+    /// A scripted escalation. Records what it was asked so a test can prove the
+    /// model was *not* consulted on messages the cheap layer already named.
+    struct ScriptedTriage {
+        verdict: crate::harness::triage::TriageVerdict,
+        asked: Mutex<Vec<String>>,
+    }
+
+    impl ScriptedTriage {
+        fn new(verdict: crate::harness::triage::TriageVerdict) -> Self {
+            Self {
+                verdict,
+                asked: Mutex::new(Vec::new()),
+            }
+        }
+
+        fn asked(&self) -> Vec<String> {
+            self.asked.lock().expect("asked").clone()
+        }
+    }
+
+    #[async_trait]
+    impl crate::harness::triage::TriageEscalation for ScriptedTriage {
+        async fn classify(&self, message: &str) -> crate::harness::triage::TriageVerdict {
+            self.asked.lock().expect("asked").push(message.to_string());
+            self.verdict
+        }
+    }
+
+    /// The whole point: the model is asked only about the residue. A message the
+    /// lexical layer classified costs nothing and waits for nothing.
+    #[tokio::test]
+    async fn a_message_the_cheap_layer_named_is_never_escalated() {
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Answer);
+        for named in [
+            "what is on the board?",
+            "draft the launch plan for next quarter",
+            "hi",
+        ] {
+            assert!(
+                !crate::company::task_intent::triage_message_detailed(named).abstained(),
+                "fixture must be a message a rule decides: {named:?}"
+            );
+            let turns = ScriptedTurns::new(&fx, vec![Turn::reply("ok")]);
+            fx.runner(&turns)
+                .with_triage(&escalation)
+                .handle_operator_message("chief", named, Some("general"))
+                .await
+                .expect("operator message handled");
+        }
+        assert!(
+            escalation.asked().is_empty(),
+            "escalating a message the cheap layer already named is the cost this \
+             design exists to avoid: {:?}",
+            escalation.asked()
+        );
+    }
+
+    /// An abstention IS escalated, and a verdict of `answer` narrows the claim —
+    /// the same narrowing a lexical `Answer` produces, reached by a second
+    /// opinion instead of a rule.
+    #[tokio::test]
+    async fn an_abstention_the_model_reads_as_a_question_narrows_the_claim() {
+        let residue = "the deck looks good to me";
+        assert!(
+            crate::company::task_intent::triage_message_detailed(residue).abstained(),
+            "fixture must be a message no rule decides"
+        );
+        let fx = Fixture::new();
+        let escalation = ScriptedTriage::new(crate::harness::triage::TriageVerdict::Answer);
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
+        fx.runner(&turns)
+            .with_triage(&escalation)
+            .handle_operator_message("chief", residue, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            escalation.asked(),
+            vec![residue.to_string()],
+            "the residue is exactly what the model should have been asked"
+        );
+        assert_eq!(
+            turns.claim_at_turn(0),
+            orchestrator::DrainClaim::Answering,
+            "an `answer` verdict narrows the claim, so the model's pure board \
+             writes are refused in its own turn"
+        );
+    }
+
+    /// `Work` and `Chatter` leave the gate exactly where the abstention left it.
+    /// A verdict may narrow the claim; it may never widen what a turn can do,
+    /// and it never mints a card — the #463 title contract forbids a
+    /// model-authored one.
+    #[tokio::test]
+    async fn a_non_answer_verdict_changes_nothing() {
+        let residue = "the deck looks good to me";
+        for verdict in [
+            crate::harness::triage::TriageVerdict::Work,
+            crate::harness::triage::TriageVerdict::Chatter,
+            crate::harness::triage::TriageVerdict::Unavailable,
+        ] {
+            let fx = Fixture::new();
+            let escalation = ScriptedTriage::new(verdict);
+            let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
+            fx.runner(&turns)
+                .with_triage(&escalation)
+                .handle_operator_message("chief", residue, Some("general"))
+                .await
+                .expect("operator message handled");
+            assert_eq!(
+                turns.claim_at_turn(0),
+                orchestrator::DrainClaim::Full,
+                "{verdict:?} must leave the ungated claim the abstention had"
+            );
+            assert!(
+                fx.cards().await.is_empty(),
+                "{verdict:?} must not mint a card"
+            );
+        }
+    }
+
+    /// No evaluator wired is the pre-#678 world, and it has to stay reachable:
+    /// a build without one must behave exactly as it did.
+    #[tokio::test]
+    async fn without_an_evaluator_an_abstention_keeps_the_deterministic_answer() {
+        let residue = "the deck looks good to me";
+        let fx = Fixture::new();
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("noted")]);
+        fx.runner(&turns)
+            .handle_operator_message("chief", residue, Some("general"))
+            .await
+            .expect("operator message handled");
+        assert_eq!(
+            turns.claim_at_turn(0),
+            orchestrator::DrainClaim::Full,
+            "an abstention with nobody to ask stays ungated"
+        );
     }
 
     // ── Issue #678: a workflow authored in-turn settles its card ────────────


### PR DESCRIPTION
## Summary

**PR-C of three for #678**, after #805 (the settle) and #809 (the abstention seam). This is the LLM triage layer itself.

Read literally, #678 asks to "port `trigger_triage` for operator chat" — an LLM
classifier fronting chat, which means a full-price **serial round-trip before
every reply**. This deliberately does not do that.

The deterministic layer already names the classes a lexical detector can name,
conservatively, and it is free. What it could not do was tell you when it was
guessing — every residual fell into `Chatter` by construction. #809 fixed that.
So the model is asked **only about the residue**: a message the cheap layer
named costs nothing and waits for nothing. The difference is paying per *hard*
message rather than per message.

## The "fast-model routing" in the issue is not what shipped, on purpose

#678 calls a cheap tier "the prerequisite for 1, not a nice-to-have". It is the
right instinct and the wrong mechanism, for a reason already documented on
`TaskPlanner::from_deps`:

```rust
// src/harness/provider.rs — request_plan
let model = decl.models.get(abstract_model).cloned()
    .unwrap_or_else(|| abstract_model.to_string());
```

**An unmapped tier is sent to the provider verbatim as the model id.** There is
no client-side fallback. Inventing a `fast-v1` and addressing it here would send
an unknown model name to every BYOK tenant that had not opted in, so triage
would fail on exactly the setups that otherwise work — the trap `TaskPlanner`
refuses in the same words: *"Planning quality is worth less than planning
working."*

So the evaluator takes the roster's own default. Cheapness comes from the
**shape** of the call instead: no tools at all, one short system prompt, one
message, `max_tokens: 8`, behind a 2s deadline — against an orchestrator turn
running `agentic-v1` with the full tool belt.

A *declarable* cheap tier is worth having. It needs the mapping to be **checked**
rather than assumed, which is a follow-up rather than a default.

## API Or Behavior Changes

**An operator message the lexical layer abstains on now costs one extra model
call.** That is the feature, and it is a real spend change: it is bounded to
abstentions, metered as its own kind, and counted against the tier budget.

What cannot change:

- **An escalation only ever narrows.** `Answer` produces the same
  answering-only claim a lexical `Answer` already does. `Work`, `Chatter` and
  `Unavailable` leave the gate exactly where the abstention left it. Nothing it
  returns can widen what a turn may do.
- **It never mints a card.** A verdict does not become `Track`, because the
  title a card opens under is pinned byte-for-byte between the REST handler and
  `chat_handler_card` (#463) — a model-authored title would desynchronise them
  and orphan the card. It also keeps #267's tie-breaker: a missed card costs one
  follow-up message, a spurious card pollutes the board permanently.
- **Failure is silence.** Unreachable, too slow, or unparseable all yield
  `Unavailable` and the deterministic answer stands. A closed vocabulary, so an
  unrecognised reply is never guessed at.
- **No evaluator wired is the pre-#678 world**, and a test pins that it stays
  reachable.

### New `SampleKind::TriageCall`

Its own kind, for the reason `PlanningCall` is its own kind: an escalation
happens *before* a teammate is chosen, so it belongs to none — charged to the
company bucket with no `run_id`.

Not folded into `PlanningCall` either: the two are driven by different things
(cards entering `planning` vs raw chat volume), so a shared kind would make the
planning line item move whenever chat got busier.

It **counts toward the capability-tier token budget** alongside `Inference` and
`PlanningCall` (`metering/capability.rs`). Omitting it would let chat keep paying
for classification after the tier ceiling that is supposed to have stopped it —
and that leak is the worse of the two, because chat volume drives it.

## Tests

12 new tests. In `harness/triage.rs` (4): the one-word vocabulary, the shapes a
model actually replies in (`"Answer."`, `` "`work`" ``, `"The answer is: answer"`),
that an unreadable reply is `Unavailable` rather than guessed, and that only
`Answer` touches the gate. In `metering/triage.rs` (3): company attribution, no
row for a call that moved nothing, and that it is not filed as planning. In
`runtime/delegation.rs` (4) plus one fixture test — driven by a scripted
`TriageEscalation`, so no live model is needed.

**Teeth proven.** Removing the abstention guard so every message escalates:

```
a_message_the_cheap_layer_named_is_never_escalated ... FAILED
  escalating a message the cheap layer already named is the cost this design
  exists to avoid: ["draft the launch plan for next quarter", "hi"]
```

(`"what is on the board?"` is absent because a lexical `Answer` short-circuits
before the escalation.)

### One fixture change worth review

The scripted `DelegatingProvider` serves responses from a queue. Production
providers are stateless per request, but this one is not — so a classification
would consume the delegation the test wrote for turn one, and two `brain` tests
failed exactly that way while this was being built. It now recognises a
classification request and answers `chatter` without consuming a scripted turn.

The predicate keys on the system prompt's opening sentence. That is a coupling
to prose, taken deliberately: the only other thing distinguishing the two is
"carries no tools", and an agent whose belt happens to be empty would be misread
as a classification. Pinned by `a_triage_request_is_recognised_as_one`, so a
wording drift fails a test instead of silently eating scripted turns again.

Commands run locally:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --no-deps --features openhuman,mcp,telegram --all-targets -- -D warnings`
- [x] `cargo test` — 2336 passed, 0 failed
- [x] `cargo test --features openhuman,mcp,telegram` — 3586 passed, 0 failed (post-rebase)
- [x] `scripts/ci/assert-feature-lanes.sh`, `scripts/ci/assert-integration-targets-run.sh`

**Coverage caveat.** The `harness/` and `runtime/delegation.rs` tests are behind
`#[cfg(feature = "openhuman")]`, and no CI lane runs gated `--lib` tests — see
**#807**. The `metering/` and `ports/` tests are covered by the default `Rust`
lane. The gated suite also needs `RUST_MIN_STACK` to get past #807's two
pre-existing overflows, which are unrelated to this change.

## What is left on #678

- **Item 3, a routed `automate` class — recommend dropping.** It collides with
  #580's decision D2a, *"Nothing here infers the choice from the text"*. Setting
  `deliverable = Workflow` from message text would overturn a recent, deliberate
  decision; that is a product call, not a bolt-on.
- **Item 4, hosted-path gating — recommend moving to #723.** It is written
  against #176, which is closed, and `src/brain/medulla/http.rs` still has its
  Socket.IO methods as `TODO` no-ops, so there is no model board-write path to
  gate.
- A declarable cheap tier, with the mapping checked (above).

## Documentation

The reasoning lives in the module docs: `harness/triage.rs` on why this is an
escalation rather than a pre-classifier and why not a tier, `metering/triage.rs`
on attribution, and the `SampleKind::TriageCall` doc on the budget.

## Related

Part of #678. Siblings: #805, #809. Coverage gap: #807.
