### PR TITLE
fix(server): let a console-created desk take members (#833)

### DIFF
--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -222,10 +222,10 @@ struct SetDeskOrder {
 /// (`ops::team::add_member`): load the record, mutate `overlay_desk_members`,
 /// and save. The manifest's `[[group_chat]]` blueprint is never rewritten.
 ///
-/// Validates that the desk exists in the manifest and that `agent_id` resolves
-/// to a roster teammate (a manifest agent or a team-overlay teammate); rejects
-/// with `404`/`400` otherwise. Adding a teammate already on the desk (manifest
-/// or overlay) is a `409`.
+/// Validates that the desk exists and that `agent_id` resolves to a roster
+/// teammate (a manifest agent or a team-overlay teammate); rejects with
+/// `404`/`400` otherwise. Adding a teammate already on the desk (manifest or
+/// overlay) is a `409`.
 async fn add_desk_member(
     scope: ScopedCompany,
     Path(DeskPath { desk_id }): Path<DeskPath>,
@@ -238,9 +238,12 @@ async fn add_desk_member(
         .load(scope.id())
         .await?
         .ok_or_else(|| OpenCompanyError::CompanyNotFound(scope.id().to_string()))?;
-    // The desk must be one of the company's blueprint group chats.
-    if !record.manifest.group_chats.iter().any(|c| c.id == desk_id) {
-        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+    // The desk must exist — either a manifest blueprint group chat or an
+    // operator-created overlay desk (#140). A manifest-only check meant a desk
+    // created in the console could be reordered and deleted but never staffed
+    // (#833); `desk_exists` is the same check `effective_desk_members` uses.
+    if !record.desk_exists(&desk_id) {
+        return Err(ApiError(OpenCompanyError::NotFound(format!(
             "desk {desk_id}"
         ))));
     }
@@ -348,11 +351,13 @@ async fn remove_desk_member(
         .load(scope.id())
         .await?
         .ok_or_else(|| OpenCompanyError::CompanyNotFound(scope.id().to_string()))?;
-    // First validate that the desk exists in the manifest — otherwise a caller
-    // supplying an unknown desk_id gets a desk-scoped 404 rather than a confusing
-    // member-scoped one (Greptile feedback).
-    if !record.manifest.group_chats.iter().any(|c| c.id == desk_id) {
-        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+    // First validate that the desk exists at all — otherwise a caller supplying
+    // an unknown desk_id gets a desk-scoped 404 rather than a confusing
+    // member-scoped one (Greptile feedback). Existence spans both blueprint and
+    // operator-created overlay desks (#140); a manifest-only check here stranded
+    // console-created desks with members that could never be removed (#833).
+    if !record.desk_exists(&desk_id) {
+        return Err(ApiError(OpenCompanyError::NotFound(format!(
             "desk {desk_id}"
         ))));
     }
@@ -373,7 +378,7 @@ async fn remove_desk_member(
         .overlay_desk_members
         .retain(|m| !(m.desk_id == desk_id && m.agent_id == agent_id));
     if record.overlay_desk_members.len() == before {
-        return Err(ApiError(OpenCompanyError::CompanyNotFound(format!(
+        return Err(ApiError(OpenCompanyError::NotFound(format!(
             "desk member {agent_id}"
         ))));
     }
@@ -2711,6 +2716,153 @@ mod test {
             .await
             .unwrap();
         assert_eq!(gone.status(), StatusCode::NOT_FOUND);
+    }
+
+    /// Creates an overlay desk through the same route `create_desk` serves and
+    /// returns its derived id, so the desk under test exists only in the overlay
+    /// — nothing about it is declared in the manifest.
+    async fn seed_overlay_desk(app: &axum::Router, cookie: &str, body: &str) -> String {
+        let created = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/company/desks")
+                    .header("cookie", cookie)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::CREATED);
+        let bytes = to_bytes(created.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        value["id"].as_str().unwrap().to_string()
+    }
+
+    async fn post_desk_member(
+        app: &axum::Router,
+        cookie: &str,
+        desk: &str,
+        body: &str,
+    ) -> Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/company/desks/{desk}/members"))
+                    .header("cookie", cookie)
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    async fn delete_desk_member(
+        app: &axum::Router,
+        cookie: &str,
+        desk: &str,
+        agent: &str,
+    ) -> Response {
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/company/desks/{desk}/members/{agent}"))
+                    .header("cookie", cookie)
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    /// Reads the `error` string out of an api.md error envelope.
+    async fn error_message(response: Response) -> String {
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        value["error"].as_str().unwrap().to_string()
+    }
+
+    /// Returns the effective member list of `desk` from `list_desks`.
+    async fn desk_members(app: &axum::Router, cookie: &str, desk: &str) -> Vec<String> {
+        let desks = get_desks(app, cookie).await;
+        desks
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|d| d["id"] == desk)
+            .unwrap_or_else(|| panic!("desk {desk} present in list"))["members"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|m| m.as_str().unwrap().to_string())
+            .collect()
+    }
+
+    /// A desk that exists only in the operator overlay can be staffed and
+    /// unstaffed like a manifest desk. Both membership handlers used to test the
+    /// manifest alone, so a console-created desk could be reordered and deleted
+    /// but never gain or lose a member (#833). Every other desk test seeds its
+    /// desk from the manifest, so only an overlay-created desk exercises this.
+    #[tokio::test]
+    async fn desk_member_writes_reach_an_overlay_created_desk() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(&home, desk_manifest()).await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let desk =
+            seed_overlay_desk(&app, &cookie, r#"{"name":"Growth desk","members":["ceo"]}"#).await;
+        assert_eq!(desk, "growth_desk");
+        assert_eq!(desk_members(&app, &cookie, &desk).await, ["ceo"]);
+
+        let added = post_desk_member(&app, &cookie, &desk, r#"{"agent_id":"eng"}"#).await;
+        assert_eq!(added.status(), StatusCode::NO_CONTENT);
+        assert_eq!(desk_members(&app, &cookie, &desk).await, ["ceo", "eng"]);
+
+        let removed = delete_desk_member(&app, &cookie, &desk, "eng").await;
+        assert_eq!(removed.status(), StatusCode::NO_CONTENT);
+        assert_eq!(desk_members(&app, &cookie, &desk).await, ["ceo"]);
+    }
+
+    /// An unknown desk id is refused as a missing desk, not a missing company.
+    /// The refusal used to be raised as `CompanyNotFound("desk ghost")`, which
+    /// rendered as `company not found: desk ghost` — the wrong resource, and the
+    /// desk id stuffed into a company id slot (#833). The status stays `404`
+    /// because both variants map there.
+    #[tokio::test]
+    async fn unknown_desk_member_writes_refuse_as_a_missing_desk() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_manifest(&home, desk_manifest()).await;
+        let app = router(state);
+        let cookie = crate::server::test_support::fixed_cookie("acme");
+
+        let added = post_desk_member(&app, &cookie, "ghost", r#"{"agent_id":"eng"}"#).await;
+        assert_eq!(added.status(), StatusCode::NOT_FOUND);
+        let message = error_message(added).await;
+        assert!(
+            !message.contains("company not found"),
+            "add refusal blames the company: {message:?}"
+        );
+        assert!(message.contains("ghost"), "add refusal drops the desk id");
+
+        let removed = delete_desk_member(&app, &cookie, "ghost", "eng").await;
+        assert_eq!(removed.status(), StatusCode::NOT_FOUND);
+        let message = error_message(removed).await;
+        assert!(
+            !message.contains("company not found"),
+            "remove refusal blames the company: {message:?}"
+        );
+        assert!(
+            message.contains("ghost"),
+            "remove refusal drops the desk id"
+        );
     }
 
     /// Creating a desk persists it as an overlay and surfaces it in `list_desks`


### PR DESCRIPTION
## Summary

A desk created in the console could be reordered and deleted but never staffed. Adding a teammate to one failed with `company not found: desk design` — a message in which neither half was true.

Desks come from two places: manifest blueprint group chats, and operator-created overlay desks. `CompanyRecord::desk_exists` is the check that knows both. `add_desk_member` and `remove_desk_member` tested only the manifest half. `set_desk_order`, sitting between them, already used `desk_exists` — the fix reached that path and not the two either side of it.

The refusals were wrong twice over: `CompanyNotFound` for a missing **desk**, with the payload formatted as `desk {id}`, so a desk id landed in a company id slot. `NotFound` is the variant for a resource that is not a company. The sibling refusal in `remove_desk_member` for an unknown member had the same shape and is corrected alongside them.

Closes #833

## API Or Behavior Changes

- Adding and removing members now works on operator-created desks. Manifest desks are unaffected.
- Three refusals move from `CompanyNotFound` to `NotFound`. **Both variants already map to 404 in the same match arm**, so no status code changes. The stable envelope `code` field moves from `company_not_found` to `not_found` for these three cases only. Nothing in `frontend/src` or `docs/` branches on either string, and no document pins this error contract.
- Messages change from `company not found: desk <id>` to `not found: desk <id>`, and `company not found: desk member <id>` to `not found: desk member <id>`.

## Tests

Two new tests in `src/server/operator.rs`. Both seed a desk through the same route `create_desk` serves, so the desk under test exists only in the overlay and nothing about it is declared in the manifest:

- `desk_member_writes_reach_an_overlay_created_desk` — adds a member, asserts the desk actually holds it, then removes it.
- `unknown_desk_member_writes_refuse_as_a_missing_desk` — asserts a genuinely unknown desk id gives 404 on both routes and that neither message blames the company.

Teeth proved by reverting, not asserted:

| Production state | reach-overlay-desk | unknown-desk |
|---|---|---|
| Fixed | pass | pass |
| Both handlers reverted | fail — `404` vs `204` on the add | fail — `add refusal blames the company` |
| Only `remove` reverted | fail — `404` vs `204` on the **delete** | fail — `remove refusal blames the company` |

The third row was run deliberately. With both reverted the first test dies on the add and never reaches the remove, which would leave `remove_desk_member` unproven; restoring only `add` shows both tests still fail on the remove assertions, so each handler is independently covered.

The pre-existing suite stays green throughout, which is the point: every seeded company declares its desks in the manifest, so a manifest-only check could never be caught by it.

Gates: `cargo fmt --all -- --check` clean · `cargo clippy --locked --all-targets -- -D warnings` clean · `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` clean · `cargo test --locked` 2332 passed, 0 failed, 1 ignored.

## Documentation

None needed. The two `docs/` files describing desk surfaces do not document these routes' error contract, and the handler doc comments — which did say "in the manifest" — are corrected in this change.

## Related

Found while manually testing desk creation; reported by the operator, not by a test.

Two adjacent findings deliberately left out of scope, both reported rather than fixed here:

- `resolve_desk` (the `?desk=` chat-history selector) matches manifest group chats by id or name and falls through for anything else, so an overlay desk addressed by display name resolves to itself-as-id and history filters on the wrong key. `CompanyRecord::resolve_desk_id` already handles both sources. Different subsystem, separate fix.
- `delete_desk`'s manifest-only check is correct by design — a blueprint desk cannot be deleted, so that test is a 409 gate rather than an existence check.