### PR TITLE
fix(workflows): give delivery a destination that reaches a human (#835)

### DIFF
--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1605,7 +1605,13 @@ impl RuntimeBuilder {
         // threads. Resolve both manifest and operator-created candidates
         // through CompanyRecord so this wiring cannot drift from the desk
         // existence rules used by the server and the harness.
-        let desk_record = existing.clone().unwrap_or_else(|| CompanyRecord {
+        // Built fresh rather than cloned from `existing`: the persisted record
+        // carries the manifest of a PREVIOUS boot, so cloning it would wire
+        // desk channels from a stale `[[group_chat]]` list — a desk added to
+        // `company.toml` would never become a delivery destination, and one
+        // removed there would linger as one. The overlay halves are already
+        // lifted out of `existing` above, so this loses nothing.
+        let desk_record = CompanyRecord {
             id: id.clone(),
             manifest: self.manifest.clone(),
             ledger: Vec::new(),
@@ -1619,7 +1625,7 @@ impl RuntimeBuilder {
             overlay_policy: None,
             disabled_workflows: Vec::new(),
             template_provenance: None,
-        });
+        };
         let mut desk_ids = Vec::new();
         let candidates = desk_record
             .manifest
@@ -4503,6 +4509,76 @@ mod test {
             .collect();
         assert!(ids.contains(&"engineering"));
         assert!(ids.contains(&"research"));
+    }
+
+    /// A desk added to `company.toml` since the last boot is wired on this one.
+    ///
+    /// The persisted record carries the manifest of a PREVIOUS boot, so reusing
+    /// it for desk resolution silently wires yesterday's `[[group_chat]]` list:
+    /// a desk the operator has just added would never become a delivery
+    /// destination, and the only symptom would be a workflow refusing a
+    /// destination the manifest plainly declares. The overlay halves still come
+    /// from the persisted record, which the `research` assertion pins.
+    #[tokio::test]
+    async fn a_desk_added_to_the_manifest_since_the_last_boot_is_wired() {
+        use crate::ports::CompanyStore;
+        use crate::store::FsCompanyStore;
+
+        let dir = tempfile::tempdir().unwrap();
+        let common = r#"
+            [company]
+            name = "Acme"
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            [[group_chat]]
+            id = "engineering"
+            name = "Engineering"
+            members = ["ceo"]
+        "#;
+        let persisted = parse(common);
+        let booting = parse(&format!(
+            "{common}\n[[group_chat]]\nid = \"growth\"\nname = \"Growth\"\nmembers = [\"ceo\"]\n"
+        ));
+        let id = CompanyId::new("acme");
+        FsCompanyStore::new(dir.path())
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: persisted,
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: vec![crate::ports::types::OverlayDesk {
+                    id: "research".to_string(),
+                    name: "Research".to_string(),
+                    description: None,
+                    members: vec!["ceo".to_string()],
+                }],
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+
+        let runtime = RuntimeBuilder::new(dir.path(), booting)
+            .with_id(id)
+            .build()
+            .await
+            .unwrap();
+
+        let ids: Vec<_> = runtime
+            .channels
+            .iter()
+            .map(|channel| channel.channel_id())
+            .collect();
+        assert!(ids.contains(&"growth"), "{ids:?}");
+        assert!(ids.contains(&"engineering"), "{ids:?}");
+        assert!(ids.contains(&"research"), "{ids:?}");
     }
 
     #[cfg(feature = "tinyplace")]

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -51,7 +51,7 @@ use crate::ports::ScheduleFireStore;
 // Separate line (#596) for the same reason.
 use crate::ports::WorkflowRunOutputStore;
 use crate::runtime::board_events::BoardAnnouncer;
-use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
+use crate::runtime::channel::{DeskChannel, OPERATOR_CHANNEL, OperatorChannel};
 use crate::runtime::handover::RuntimeHandover;
 use crate::runtime::journal::RuntimeJournal;
 use crate::runtime::tools::{StubToolProvider, grant_matches};
@@ -1140,7 +1140,7 @@ impl RuntimeBuilder {
 
         // Channels: always the operator surface, plus any `openhuman` channel
         // the manifest enables when the daemon is reachable.
-        let channels = match self.channels {
+        let mut channels = match self.channels {
             Some(channels) => channels,
             None => {
                 let mut channels: Vec<Arc<dyn ChannelAdapter>> =
@@ -1600,6 +1600,53 @@ impl RuntimeBuilder {
             .as_ref()
             .map(|r| r.overlay_desks.clone())
             .unwrap_or_default();
+
+        // Desks are delivery destinations as well as inbound conversation
+        // threads. Resolve both manifest and operator-created candidates
+        // through CompanyRecord so this wiring cannot drift from the desk
+        // existence rules used by the server and the harness.
+        let desk_record = existing.clone().unwrap_or_else(|| CompanyRecord {
+            id: id.clone(),
+            manifest: self.manifest.clone(),
+            ledger: Vec::new(),
+            lifecycle: lifecycle.clone(),
+            overlay_agents: overlay_agents.clone(),
+            overlay_desk_members: overlay_desk_members.clone(),
+            overlay_desk_order: overlay_desk_order.clone(),
+            overlay_desks: overlay_desks.clone(),
+            overlay_workflows: Vec::new(),
+            overlay_budgets: Vec::new(),
+            overlay_policy: None,
+            disabled_workflows: Vec::new(),
+            template_provenance: None,
+        });
+        let mut desk_ids = Vec::new();
+        let candidates = desk_record
+            .manifest
+            .group_chats
+            .iter()
+            .map(|desk| desk.id.as_str())
+            .chain(
+                desk_record
+                    .overlay_desks
+                    .iter()
+                    .map(|desk| desk.id.as_str()),
+            );
+        for candidate in candidates {
+            if let Some(desk_id) = desk_record.resolve_desk_id(candidate)
+                && desk_record.desk_exists(&desk_id)
+                && !desk_ids.contains(&desk_id)
+            {
+                desk_ids.push(desk_id);
+            }
+        }
+        for desk_id in desk_ids {
+            channels.push(Arc::new(DeskChannel::new(
+                id.clone(),
+                desk_id,
+                events.clone(),
+            )));
+        }
         // Issue #168: the runtime-authored workflow graph bodies. A rebuild that
         // dropped these would delete every workflow the console created on a
         // hosted tenant — they have no on-disk copy to fall back to.
@@ -2076,7 +2123,16 @@ impl RuntimeBuilder {
                                     // before their first sign-in mints a user
                                     // record. `None` off the hosted serve path.
                                     bootstrap_admin: self.bootstrap_admin.clone(),
-                                    channels: channels.clone(),
+                                    // The operator adapter is an interactive
+                                    // response surface, not a workflow delivery
+                                    // destination: its buffer has no durable
+                                    // reader. Desk and provider adapters are the
+                                    // accepted workflow write paths.
+                                    channels: channels
+                                        .iter()
+                                        .filter(|channel| channel.channel_id() != OPERATOR_CHANNEL)
+                                        .cloned()
+                                        .collect(),
                                     // Issue #227: the same gate and journal the
                                     // runtime gets below — one approvals queue,
                                     // so a report parked by a workflow lands in
@@ -4392,6 +4448,61 @@ mod test {
         assert!(!granted.ok);
         // Only the boot-time `health()` probe touched the transport.
         assert_eq!(rpc.call_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn wires_manifest_and_overlay_desks_as_delivery_channels() {
+        let dir = tempfile::tempdir().unwrap();
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Acme"
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+            [[group_chat]]
+            id = "engineering"
+            name = "Engineering"
+            members = ["ceo"]
+            "#,
+        );
+        let id = CompanyId::new("acme");
+        FsCompanyStore::new(dir.path())
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: vec![crate::ports::types::OverlayDesk {
+                    id: "research".to_string(),
+                    name: "Research".to_string(),
+                    description: None,
+                    members: vec!["ceo".to_string()],
+                }],
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(dir.path(), manifest)
+            .with_id(id)
+            .build()
+            .await
+            .unwrap();
+
+        let ids: Vec<_> = runtime
+            .channels
+            .iter()
+            .map(|channel| channel.channel_id())
+            .collect();
+        assert!(ids.contains(&"engineering"));
+        assert!(ids.contains(&"research"));
     }
 
     #[cfg(feature = "tinyplace")]

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -126,6 +126,55 @@ impl std::fmt::Debug for OperatorChannel {
     }
 }
 
+/// A durable-looking channel that records what it was sent, for tests whose
+/// subject is the runner's delivery bookkeeping rather than any one adapter.
+///
+/// Those tests used [`OperatorChannel`] as their spy, which stopped working
+/// when workflow delivery began refusing `operator` outright: the count they
+/// assert is "how many times did the report reach the channel", and a refusal
+/// answers a different question. This carries an ordinary channel id so it
+/// clears the refusal, and keeps the buffer so the counting still works.
+#[cfg(test)]
+#[derive(Clone, Default)]
+pub(crate) struct RecordingChannel {
+    id: String,
+    sent: Arc<StdMutex<Vec<OutboundMessage>>>,
+}
+
+#[cfg(test)]
+impl RecordingChannel {
+    pub(crate) fn new(id: &str) -> Self {
+        Self {
+            id: id.to_string(),
+            sent: Arc::default(),
+        }
+    }
+
+    pub(crate) fn sent(&self) -> Vec<OutboundMessage> {
+        self.sent.lock().expect("recording buffer poisoned").clone()
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl ChannelAdapter for RecordingChannel {
+    fn channel_id(&self) -> &str {
+        &self.id
+    }
+
+    fn inbound(&self) -> BoxStream<'static, InboundMessage> {
+        Box::pin(stream::empty())
+    }
+
+    async fn send(&self, msg: OutboundMessage) -> Result<()> {
+        self.sent
+            .lock()
+            .expect("recording buffer poisoned")
+            .push(msg);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -134,7 +134,12 @@ impl std::fmt::Debug for OperatorChannel {
 /// assert is "how many times did the report reach the channel", and a refusal
 /// answers a different question. This carries an ordinary channel id so it
 /// clears the refusal, and keeps the buffer so the counting still works.
+// Every consumer of this lives behind `openhuman`/`tinycortex`, so a
+// default-feature build compiles it and constructs it nowhere. That is a
+// feature-configuration fact, not dead code: the runner and delivery suites
+// that use it are simply not selected in that lane (issue #770).
 #[cfg(test)]
+#[allow(dead_code)]
 #[derive(Clone, Default)]
 pub(crate) struct RecordingChannel {
     id: String,
@@ -142,6 +147,7 @@ pub(crate) struct RecordingChannel {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 impl RecordingChannel {
     pub(crate) fn new(id: &str) -> Self {
         Self {
@@ -196,5 +202,60 @@ mod test {
             .unwrap();
         assert_eq!(channel.sent().len(), 1);
         assert_eq!(channel.sent()[0].text, "hello");
+    }
+
+    /// An [`EventLog`] whose `append` always errors, so the desk channel's own
+    /// failure path is reachable.
+    struct FailingEventLog;
+
+    #[async_trait]
+    impl EventLog for FailingEventLog {
+        async fn append(&self, _company: &CompanyId, _event: CompanyEvent) -> Result<EventSeq> {
+            Err(crate::OpenCompanyError::Config(
+                "event journal is unwritable".into(),
+            ))
+        }
+
+        async fn read_from(
+            &self,
+            _company: &CompanyId,
+            _seq: EventSeq,
+            _limit: usize,
+        ) -> Result<Vec<crate::ports::types::StoredEvent>> {
+            Ok(Vec::new())
+        }
+
+        fn subscribe(
+            &self,
+            _company: &CompanyId,
+        ) -> BoxStream<'static, crate::ports::types::StoredEvent> {
+            Box::pin(stream::empty())
+        }
+    }
+
+    /// A desk send is a durable write, so a journal that refuses it is a failed
+    /// delivery — not a silent one. `send` propagates rather than logging and
+    /// answering `Ok`, and this pins that: swallowing the error would leave
+    /// delivery reporting `Sent` for a report that reached nobody, which is the
+    /// exact defect the desk channel exists to end (issue #835).
+    #[tokio::test]
+    async fn a_desk_send_fails_when_the_journal_refuses_it() {
+        let channel = DeskChannel::new(
+            CompanyId::new("acme"),
+            "engineering".to_string(),
+            Arc::new(FailingEventLog),
+        );
+        assert_eq!(channel.channel_id(), "engineering");
+        let result = channel
+            .send(OutboundMessage {
+                message_id: None,
+                task_id: None,
+                channel: "engineering".into(),
+                text: "the weekly digest".into(),
+                steps: Vec::new(),
+                reply_to: None,
+            })
+            .await;
+        assert!(result.is_err(), "an unwritable journal must fail the send");
     }
 }

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -13,10 +13,73 @@ use futures::stream::{self, BoxStream};
 
 use crate::Result;
 use crate::ports::channel::ChannelAdapter;
-use crate::ports::types::{InboundMessage, OutboundMessage};
+use crate::ports::events::EventLog;
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, InboundMessage, OutboundMessage};
 
 /// The channel id of the always-present operator surface.
 pub const OPERATOR_CHANNEL: &str = "operator";
+
+/// A desk-backed [`ChannelAdapter`]. Sending appends an agent reply to the
+/// company's durable event log, which is the existing read path for desk chat
+/// history. The adapter is deliberately one-per-desk so channel lookup and
+/// chat-thread ownership use the same canonical desk id.
+#[derive(Clone)]
+pub struct DeskChannel {
+    company: CompanyId,
+    desk_id: String,
+    events: Arc<dyn EventLog>,
+}
+
+impl DeskChannel {
+    /// Creates a channel for an already-resolved desk id.
+    pub fn new(company: CompanyId, desk_id: String, events: Arc<dyn EventLog>) -> Self {
+        Self {
+            company,
+            desk_id,
+            events,
+        }
+    }
+}
+
+#[async_trait]
+impl ChannelAdapter for DeskChannel {
+    fn channel_id(&self) -> &str {
+        &self.desk_id
+    }
+
+    fn inbound(&self) -> BoxStream<'static, InboundMessage> {
+        Box::pin(stream::empty())
+    }
+
+    async fn send(&self, msg: OutboundMessage) -> Result<()> {
+        self.events
+            .append(
+                &self.company,
+                CompanyEvent::AgentReply {
+                    chat_id: self.desk_id.clone(),
+                    agent_id: "workflow".to_string(),
+                    text: msg.text,
+                    steps: msg.steps,
+                    task_id: msg.task_id,
+                    parent: msg
+                        .reply_to
+                        .and_then(|reply| reply.chat_id.parse::<u64>().ok())
+                        .map(EventSeq::new),
+                },
+            )
+            .await?;
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for DeskChannel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DeskChannel")
+            .field("company", &self.company)
+            .field("desk_id", &self.desk_id)
+            .finish()
+    }
+}
 
 /// The built-in operator [`ChannelAdapter`], buffering sent messages in memory.
 #[derive(Clone, Default)]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -115,7 +115,7 @@ pub mod workspace_quota;
 pub use advance::{SYSTEM_ATTRIBUTION, advance_settled_card, append_result};
 pub use board_events::{BoardAnnouncer, CHANGE_OPENED, CHANGE_REMOVED, CHANGE_UPDATED};
 pub use builder::{RuntimeBuilder, company_id_from_name};
-pub use channel::{OPERATOR_CHANNEL, OperatorChannel};
+pub use channel::{DeskChannel, OPERATOR_CHANNEL, OperatorChannel};
 pub use cron::{CivilTime, CronExpr};
 pub use cycle::CycleRunner;
 pub use handover::RuntimeHandover;

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -32,8 +32,8 @@
 //!   [`UserStore`](crate::ports::UserStore) (active `Admin` users). The graph
 //!   names no address, so an author cannot point it at an outsider. Constrained
 //!   by construction; no grant needed. With no admin address (or no mailbox) it
-//!   falls back to the always-present `operator` channel rather than becoming a
-//!   silent no-op.
+//!   reports a failed delivery when neither a mailbox nor a durable channel is
+//!   available; the interactive operator buffer is not a workflow destination.
 //! * **`email`** — the graph names an arbitrary address, so it is the dangerous
 //!   one and carries **two independent gates**, both fail-closed:
 //!   1. the company's `[tools].allow` must cover the `email` namespace (the same
@@ -175,8 +175,8 @@ const TRUNCATION_MARKER: &str = "\n\n… (report truncated)";
 #[derive(Clone)]
 pub struct WorkflowDeliveryDeps {
     /// The company's own outbound-mail handle (sender + its SMTP credentials).
-    /// `None` when the company has no mailbox: `owner` then falls back to the
-    /// operator channel, and `email` is reported `skipped`.
+    /// `None` when the company has no mailbox: `owner` then reports a failed
+    /// delivery, and `email` is reported `skipped`.
     pub mail: Option<CompanyMail>,
     /// The company's inboxes — both the established-thread check and the
     /// outbound audit record go through this port.
@@ -200,7 +200,8 @@ pub struct WorkflowDeliveryDeps {
     /// The `Debug` impl prints its presence only, never the address, the same
     /// stance the mail handle takes.
     pub bootstrap_admin: Option<String>,
-    /// Every wired channel adapter, including the always-present `operator`.
+    /// Wired delivery adapters. The interactive `operator` adapter may be
+    /// present for cycle responses but is rejected for workflow delivery.
     pub channels: Vec<Arc<dyn ChannelAdapter>>,
     /// What a cold `email` recipient is parked on (issue #227). `None` fails
     /// closed to the pre-#227 behaviour: the report is `skipped`, never a
@@ -588,9 +589,10 @@ async fn deliver_one(
                         });
                     }
                 }
-                // No mailbox, or no admin has an address: fall back to the
-                // always-present operator channel so the owner still hears about
-                // it. Never a silent no-op.
+                // No mailbox, or no admin has an address: try the operator
+                // adapter only to produce the explicit failure row. Its buffer
+                // is not a workflow delivery surface, so this cannot report a
+                // successful discard.
                 _ => {
                     let (why, why_reason) = if delivery.mail.is_none() {
                         (
@@ -1195,6 +1197,29 @@ async fn post_to_channel(
     subject: &str,
     text: &str,
 ) -> Result<(), (DeliveryReason, String)> {
+    // The built-in operator adapter is an in-memory response spy, not a
+    // durable delivery surface. Interactive chat journals its own replies
+    // after the cycle; workflow delivery has no such reader, so naming
+    // `operator` must fail rather than report a successful discard.
+    if channel_id == crate::runtime::channel::OPERATOR_CHANNEL {
+        let wired: Vec<&str> = delivery
+            .channels
+            .iter()
+            .filter(|channel| channel.channel_id() != crate::runtime::channel::OPERATOR_CHANNEL)
+            .map(|channel| channel.channel_id())
+            .collect();
+        return Err((
+            DeliveryReason::ChannelNotWired,
+            format!(
+                "`{channel_id}` is not a workflow delivery channel — this runtime has: {}",
+                if wired.is_empty() {
+                    "no durable channels".to_string()
+                } else {
+                    wired.join(", ")
+                }
+            ),
+        ));
+    }
     let Some(adapter) = delivery
         .channels
         .iter()
@@ -1324,7 +1349,7 @@ mod tests {
     use crate::policy::ManifestApprovalGate;
     use crate::ports::UserRecord;
     use crate::ports::types::CompanyId;
-    use crate::runtime::channel::{OPERATOR_CHANNEL, OperatorChannel};
+    use crate::runtime::channel::{DeskChannel, OPERATOR_CHANNEL, OperatorChannel};
     use crate::server::ops::mailer::{MailSender, RecordingMailSender};
     use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
     use crate::store::{FsInboxStore, FsOps};
@@ -1835,8 +1860,8 @@ admins = [{list}]
         assert_eq!(h.mail.sent()[0].1.to, "ada@acme.test");
     }
 
-    /// With no mailbox wired, `owner` falls back to the always-present operator
-    /// channel rather than becoming a silent no-op.
+    /// With no mailbox wired, `owner` cannot use the operator's in-memory
+    /// response surface as workflow delivery and reports the failure loudly.
     #[tokio::test]
     async fn owner_falls_back_to_the_operator_channel_without_mail() {
         let dir = tempfile::tempdir().unwrap();
@@ -1854,16 +1879,15 @@ admins = [{list}]
         .await;
 
         assert_eq!(reports.len(), 1, "{reports:?}");
-        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
         assert_eq!(reports[0].target.as_deref(), Some(OPERATOR_CHANNEL));
         assert!(reports[0].detail.contains("no mailbox"), "{reports:?}");
-        let sent = h.channel.sent();
-        assert_eq!(sent.len(), 1);
-        assert!(sent[0].text.contains("Q3 is up 12%."), "{}", sent[0].text);
+        assert_eq!(reports[0].reason, DeliveryReason::OwnerFallbackFailed);
+        assert!(h.channel.sent().is_empty());
     }
 
-    /// A company with a mailbox but no admin address also falls back — the owner
-    /// still hears about it.
+    /// A company with a mailbox but no admin address also fails rather than
+    /// claiming that the operator buffer delivered the report.
     #[tokio::test]
     async fn owner_falls_back_when_no_admin_has_an_address() {
         let dir = tempfile::tempdir().unwrap();
@@ -1880,10 +1904,10 @@ admins = [{list}]
         .await;
 
         assert_eq!(reports.len(), 1, "{reports:?}");
-        assert_eq!(reports[0].status, DeliveryStatus::Sent);
+        assert_eq!(reports[0].status, DeliveryStatus::Failed);
         assert!(reports[0].detail.contains("no active admin"), "{reports:?}");
         assert!(h.mail.sent().is_empty(), "nothing should have been emailed");
-        assert_eq!(h.channel.sent().len(), 1);
+        assert!(h.channel.sent().is_empty());
     }
 
     /// Both fallbacks unavailable: no mail, no operator channel. Still a row —
@@ -2021,11 +2045,8 @@ admins = [{list}]
         .await;
 
         assert_eq!(reports.len(), 1, "{reports:?}");
-        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
-        assert_eq!(
-            reports[0].reason,
-            DeliveryReason::OwnerFellBackNoAdminAddress
-        );
+        assert_eq!(reports[0].status, DeliveryStatus::Failed, "{reports:?}");
+        assert_eq!(reports[0].reason, DeliveryReason::OwnerFallbackFailed);
         assert!(
             reports[0].detail.contains("standing admin invite"),
             "the fallback wording must name standing invites now: {reports:?}"
@@ -2034,7 +2055,10 @@ admins = [{list}]
             h.mail.sent().is_empty(),
             "a suspended admin must not be mailed, invite or not"
         );
-        assert_eq!(h.channel.sent().len(), 1, "the report went to the operator");
+        assert!(
+            h.channel.sent().is_empty(),
+            "the operator buffer is not delivery"
+        );
     }
 
     /// **Dedupe.** An address named both as an active admin and as the bootstrap
@@ -2737,12 +2761,17 @@ mode = "full"
     #[tokio::test]
     async fn channel_posts_to_the_wired_adapter() {
         let dir = tempfile::tempdir().unwrap();
-        let h = Harness::new(dir.path(), true, true);
+        let mut h = Harness::new(dir.path(), true, true);
+        h.deps.channels = vec![Arc::new(DeskChannel::new(
+            h.company.clone(),
+            "engineering".to_string(),
+            h.events.clone(),
+        ))];
 
         let reports = deliver_outputs(
             Some(&h.deps),
             &record(&[]),
-            &graph("channel", Some(OPERATOR_CHANNEL)),
+            &graph("channel", Some("engineering")),
             "run-1",
             &reached_output(),
             &[],
@@ -2751,10 +2780,16 @@ mode = "full"
 
         assert_eq!(reports.len(), 1, "{reports:?}");
         assert_eq!(reports[0].status, DeliveryStatus::Sent);
-        let sent = h.channel.sent();
-        assert_eq!(sent.len(), 1);
-        assert_eq!(sent[0].channel, OPERATOR_CHANNEL);
-        assert!(sent[0].text.contains("Q3 is up 12%."));
+        let events = h
+            .events
+            .read_from(&h.company, crate::ports::types::EventSeq::new(0), 20)
+            .await
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            CompanyEvent::AgentReply { chat_id, text, .. }
+                if chat_id == "engineering" && text.contains("Q3 is up 12%.")
+        )));
     }
 
     /// A channel the deployment never wired cannot be conjured by a graph. The
@@ -3084,12 +3119,17 @@ to = "done"
     #[tokio::test]
     async fn a_sent_delivery_journals_one_record() {
         let dir = tempfile::tempdir().unwrap();
-        let h = Harness::new(dir.path(), false, true);
+        let mut h = Harness::new(dir.path(), false, true);
+        h.deps.channels = vec![Arc::new(DeskChannel::new(
+            h.company.clone(),
+            "engineering".to_string(),
+            h.events.clone(),
+        ))];
 
         let reports = deliver_outputs(
             Some(&h.deps),
             &record(&[]),
-            &graph("channel", Some("operator")),
+            &graph("channel", Some("engineering")),
             "run-1",
             &reached_output(),
             &[],
@@ -3117,7 +3157,17 @@ to = "done"
         assert_eq!(run_id, "run-1");
         assert_eq!(node, "done");
         assert_eq!(kind, "channel");
-        assert_eq!(target.as_deref(), Some("operator"));
+        assert_eq!(target.as_deref(), Some("engineering"));
+        let events = h
+            .events
+            .read_from(&h.company, crate::ports::types::EventSeq::new(0), 20)
+            .await
+            .unwrap();
+        assert!(events.iter().any(|event| matches!(
+            &event.event,
+            CompanyEvent::AgentReply { chat_id, text, .. }
+                if chat_id == "engineering" && text.contains("Q3 is up 12%.")
+        )));
     }
 
     /// A `Pending` park journals a record too: the card is durable and approving
@@ -3225,13 +3275,8 @@ to = "done"
         .await;
 
         assert_eq!(reports.len(), 1, "{reports:?}");
-        assert_eq!(
-            reports[0].status,
-            DeliveryStatus::Sent,
-            "an unwritable journal must not fail a send that succeeded: {reports:?}"
-        );
-        // And the report really did reach the transport.
-        assert_eq!(h.channel.sent().len(), 1);
+        assert_eq!(reports[0].status, DeliveryStatus::Failed, "{reports:?}");
+        assert!(h.channel.sent().is_empty());
     }
 
     /// Issue #542: the dry router runs the routing half only. A reached output

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1466,6 +1466,12 @@ allow = [{allow}]
         deps: WorkflowDeliveryDeps,
         mail: RecordingMailSender,
         channel: OperatorChannel,
+        /// A durable-looking channel, present only when
+        /// [`with_recording_channel`](Harness::with_recording_channel) wired
+        /// one. Needed by any case whose subject is what happens AFTER a send
+        /// succeeds: `operator` is refused before the send, so it can no longer
+        /// stand in for a channel that works.
+        recording: Option<crate::runtime::channel::RecordingChannel>,
         inbox: Arc<FsInboxStore>,
         users: Arc<FsOps>,
         company: CompanyId,
@@ -1511,6 +1517,7 @@ allow = [{allow}]
                 },
                 mail,
                 channel,
+                recording: None,
                 inbox,
                 users,
                 company: CompanyId::new("acme"),
@@ -1671,6 +1678,26 @@ admins = [{list}]
         fn with_failing_events(mut self) -> Self {
             self.deps.events = Arc::new(FailingEventLog);
             self
+        }
+
+        /// Wires a channel that accepts a send, under an ordinary channel id.
+        ///
+        /// The operator channel used to serve this purpose, but delivery now
+        /// refuses it outright, which lands the caller in the refusal branch
+        /// before the behaviour under test is reached. Anything that asserts
+        /// what follows a successful send needs this instead.
+        fn with_recording_channel(mut self, id: &str) -> Self {
+            let channel = crate::runtime::channel::RecordingChannel::new(id);
+            self.deps.channels.push(Arc::new(channel.clone()));
+            self.recording = Some(channel);
+            self
+        }
+
+        /// The channel [`with_recording_channel`](Harness::with_recording_channel) wired.
+        fn recording(&self) -> &crate::runtime::channel::RecordingChannel {
+            self.recording
+                .as_ref()
+                .expect("with_recording_channel was not called")
         }
     }
 
@@ -3262,12 +3289,17 @@ to = "done"
     #[tokio::test]
     async fn a_journal_failure_does_not_fail_a_delivery() {
         let dir = tempfile::tempdir().unwrap();
-        let h = Harness::new(dir.path(), false, true).with_failing_events();
+        // A channel that accepts the send, so the journal write is what this
+        // case actually reaches. Pointed at `operator` it would fail on the
+        // refusal instead and pass for the wrong reason.
+        let h = Harness::new(dir.path(), false, true)
+            .with_recording_channel("engineering")
+            .with_failing_events();
 
         let reports = deliver_outputs(
             Some(&h.deps),
             &record(&[]),
-            &graph("channel", Some("operator")),
+            &graph("channel", Some("engineering")),
             "run-1",
             &reached_output(),
             &[],
@@ -3275,8 +3307,12 @@ to = "done"
         .await;
 
         assert_eq!(reports.len(), 1, "{reports:?}");
-        assert_eq!(reports[0].status, DeliveryStatus::Failed, "{reports:?}");
-        assert!(h.channel.sent().is_empty());
+        assert_eq!(reports[0].status, DeliveryStatus::Sent, "{reports:?}");
+        assert_eq!(
+            h.recording().sent().len(),
+            1,
+            "the report reached the channel despite the journal"
+        );
     }
 
     /// Issue #542: the dry router runs the routing half only. A reached output

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1432,7 +1432,7 @@ to = "done"
 
     /// A graph whose terminal `output` node routes its report to the operator
     /// channel. `trigger → output` only, so it needs no roster.
-    const REPORT_TO_OPERATOR: &str = r#"
+    const REPORT_TO_DESK: &str = r#"
 id = "report"
 name = "Report"
 [[node]]
@@ -1445,7 +1445,7 @@ kind = "output"
 name = "Owner summary"
 [node.destination]
 kind = "channel"
-target = "operator"
+target = "engineering"
 [[edge]]
 from = "start"
 to = "done"
@@ -1458,10 +1458,10 @@ to = "done"
     /// same function, which is why delivery lives here.
     #[tokio::test]
     async fn a_run_delivers_its_output_report_through_the_runner() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let mut deps = deps(dir.path());
         deps.delivery = Some(crate::workflows::WorkflowDeliveryDeps {
             mail: None,
@@ -1474,7 +1474,7 @@ to = "done"
             events: Arc::new(crate::store::FsEventLog::new(dir.path())),
         });
 
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
         let run = run_workflow(
             Arc::new(HarnessPool::new()),
             deps,
@@ -1509,7 +1509,7 @@ to = "done"
     #[tokio::test]
     async fn an_unwired_runtime_still_runs_but_says_the_report_was_not_sent() {
         let dir = tempfile::tempdir().unwrap();
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
         let run = run_workflow(
             Arc::new(HarnessPool::new()),
             deps(dir.path()),
@@ -3140,7 +3140,7 @@ to = "gate"
     fn deps_delivering_to_channel(
         dir: &std::path::Path,
         events: Arc<dyn crate::ports::EventLog>,
-        channel: crate::runtime::channel::OperatorChannel,
+        channel: crate::runtime::channel::RecordingChannel,
         consult_journal: bool,
     ) -> HarnessDeps {
         let mut deps = deps(dir);
@@ -3173,14 +3173,14 @@ to = "gate"
     /// assertion fails, which is what makes the guard provably load-bearing.
     #[tokio::test]
     async fn a_crashed_runs_delivery_is_not_repeated_on_an_independent_re_run() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
         let events: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path()));
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let rec = record();
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
 
         // Run 1 delivers, then "crashes": run_workflow returns, but nothing
         // journals a WorkflowRunFinished for it.
@@ -3244,14 +3244,14 @@ to = "gate"
     /// re-delivery the whole issue is about happens.
     #[tokio::test]
     async fn without_the_durable_consult_a_crashed_runs_report_is_re_delivered() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
         let events: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path()));
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let rec = record();
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
 
         let deps1 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
         let ctx1 = WorkflowRunContext::new(false);
@@ -3300,14 +3300,14 @@ to = "gate"
     /// day, because a clean finish clears the durable ledger.
     #[tokio::test]
     async fn a_clean_finish_lets_the_next_run_deliver_again() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
         let events: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path()));
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let rec = record();
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
 
         // Run 1 delivers…
         let deps1 = deps_delivering_to_channel(dir.path(), events.clone(), channel.clone(), true);
@@ -4229,10 +4229,10 @@ to = "done"
     /// for the run.
     #[tokio::test]
     async fn t4_dry_run_delivers_nothing_and_journals_nothing() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let events: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path()));
         let mut deps = deps(dir.path());
@@ -4247,7 +4247,7 @@ to = "done"
             events: events.clone(),
         });
 
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
         let run = run_workflow(
             Arc::new(HarnessPool::new()),
             deps,
@@ -4289,10 +4289,10 @@ to = "done"
     /// behaviours.
     #[tokio::test]
     async fn t5_the_same_graph_run_for_real_dispatches_and_journals() {
-        use crate::runtime::channel::OperatorChannel;
+        use crate::runtime::channel::RecordingChannel;
 
         let dir = tempfile::tempdir().unwrap();
-        let channel = OperatorChannel::new();
+        let channel = RecordingChannel::new("engineering");
         let events: Arc<dyn crate::ports::EventLog> =
             Arc::new(crate::store::FsEventLog::new(dir.path()));
         let mut deps = deps(dir.path());
@@ -4307,7 +4307,7 @@ to = "done"
             events: events.clone(),
         });
 
-        let file = parse_workflow(REPORT_TO_OPERATOR).expect("parses");
+        let file = parse_workflow(REPORT_TO_DESK).expect("parses");
         let run = run_workflow(
             Arc::new(HarnessPool::new()),
             deps,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1430,7 +1430,7 @@ to = "done"
 
     // --- Output destinations, end to end (issue #170) ------------------------
 
-    /// A graph whose terminal `output` node routes its report to the operator
+    /// A graph whose terminal `output` node routes its report to a desk
     /// channel. `trigger → output` only, so it needs no roster.
     const REPORT_TO_DESK: &str = r#"
 id = "report"


### PR DESCRIPTION
## Summary

A workflow report had nowhere to go. `OperatorChannel` holds an in-memory `Vec`, its `inbound` is `stream::empty()`, and every reader of `sent()` in the tree is a test — so a report delivered there was discarded, and `send` returning `Ok(())` meant delivery recorded `DeliveryStatus::Sent` for it.

Nobody chose that path. `operator` is not a selectable destination; the `owner` kind falls back to it whenever the company has no mailbox, which is every provisioned tenant by default. Observed on a staging tenant:

```
sent · send → owner  operator
no mailbox is configured for this company, so the report went to the operator channel
```

The console has no operator channel to open, so that message names a place with no existence in the product and marks the delivery successful.

Two changes:

- **`post_to_channel` refuses `operator`.** Both routes to it — an explicit `channel` destination and the `owner` fallback — now end in a `Failed` row naming the durable channels that do exist. The fallback still calls through the same gate, so one place decides what "operator is not a delivery surface" means; its success arm is consequently unreachable and left in place deliberately, so a future change to the gate cannot quietly reintroduce a `Sent` for a discard without that arm being revisited.
- **Desks become the destination.** `DeskChannel` appends the report to the company event log as the desk's own chat message — the surface the console already reads — so a delivered report is something a person can open. Manifest group chats and operator-created overlay desks are both wired, via `resolve_desk_id` / `desk_exists` rather than a manifest-only check (the defect fixed in #834).

Closes #835

## API Or Behavior Changes

- Naming `operator` as a workflow delivery destination now fails with `ChannelNotWired` instead of succeeding. Message: ``  `operator` is not a workflow delivery channel — this runtime has: <durable channels> ``.
- An `owner` delivery on a company with no mailbox (or no admin address) now reports `Failed` / `OwnerFallbackFailed` instead of `Sent`. **This will make previously-green runs show a failed delivery row.** That is the point: those runs were never delivering anything.
- Every desk is now a valid `channel` destination, addressed by desk id.

Interactive chat is untouched — it journals its own replies after the cycle and does not go through this path.

## Tests

New coverage asserts the *outcome*, not the call: desk delivery is verified by reading the appended event back out of the company event log, and the fallback tests assert `channel.sent()` is empty, so a regression that reinstates the discard fails rather than passing on a spy.

- `wires_manifest_and_overlay_desks_as_delivery_channels` — both desk sources become adapters.
- Delivery tests covering the explicit-`operator` refusal and the `owner` fallback, asserting `Failed` + `OwnerFallbackFailed` and an untouched operator buffer.

Teeth proved by reverting, not asserted: reverting the operator refusal fails **4** tests; reverting the desk wiring fails **1**.

Gates: `cargo fmt --all -- --check` clean · `cargo clippy --locked --all-targets -- -D warnings` clean · `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` clean · `cargo test --locked` 2331 passed, 0 failed, 1 ignored. Frontend untouched.

## Documentation

None. The delivery module's own docs describe destinations in terms of wired adapters, which stays accurate.

## Related

Part 3 of #835 — authoring-time destination validation — is **excluded** here: `feat/813-channel-picker-validation` already covers it.

That branch's picker currently offers `operator`. With this change it would be offering a destination that always fails, so its integration needs to either filter `operator` out for workflow destinations or read the runtime's destination semantics directly. Flagging rather than fixing across branches.

#836 is the adjacent authoring bug: the copilot can propose a `kind: channel` destination with no target, which the save rejects with a bare `Unprocessable Entity`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added durable desk channels that deliver agent replies to company event logs.
  - Manifest and overlay desks now receive configured channels automatically.

- **Bug Fixes**
  - Workflow delivery no longer sends messages to the temporary operator channel.
  - Owner fallback now reports an explicit delivery failure when no durable destination is available.
  - Improved delivery behavior across direct, ledger, dry-run, and live workflow executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->