### PR TITLE
fix(console): give the mobile sidebar a way back (#830)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -33,6 +33,7 @@ import {
   SidebarMenuItem,
   SidebarProvider,
   SidebarRail,
+  SidebarTrigger,
 } from "@/components/ui/sidebar";
 import { FeedbackDialog } from "@/components/feedback-dialog";
 import {
@@ -1017,6 +1018,15 @@ export function AppShell({
 
   return (
     <SidebarProvider className="h-svh overflow-hidden">
+      {/* Mobile turns the sidebar into a sheet, so its own collapse control is
+          not mounted while it is closed. Keep the way back fixed to the
+          viewport and below the page controls rather than competing with a
+          view's toolbar. Desktop keeps the labelled collapse row in the
+          sidebar itself. */}
+      <SidebarTrigger
+        aria-label="Toggle sidebar"
+        className="fixed bottom-4 left-4 z-50 md:hidden"
+      />
       <AutoCollapse view={view} />
       <Sidebar collapsible="icon">
         <SidebarHeader>

--- a/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
+++ b/frontend/test/e2e/sidebar-toggle-reachable.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from "@playwright/test";
+
+/** The tour can cover the fixed trigger while it is showing. */
+async function dismissTour(page: import("@playwright/test").Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+    await skip.click();
+  } catch {
+    // The signed-in browser profile may already have completed the tour.
+  }
+}
+
+test.describe("sidebar toggle reachability", () => {
+  test("the mobile sheet has an in-viewport way back", async ({ page }) => {
+    await page.setViewportSize({ width: 700, height: 800 });
+    await page.goto("/#/overview");
+    await dismissTour(page);
+
+    const trigger = page.getByRole("button", { name: "Toggle sidebar" });
+    await expect(trigger).toBeInViewport();
+    await trigger.click();
+    await expect(page.getByText("Workflows", { exact: true })).toBeVisible();
+  });
+
+  test("the inline sidebar keeps its labelled collapse control", async ({ page }) => {
+    await page.setViewportSize({ width: 1024, height: 800 });
+    await page.goto("/#/overview");
+    await dismissTour(page);
+
+    await expect(page.getByRole("button", { name: "Collapse" })).toBeInViewport();
+  });
+});


### PR DESCRIPTION
## Summary

Below 768px (`MOBILE_BREAKPOINT`) the sidebar stops rendering inline and becomes an off-canvas sheet, opened from `openMobile` state. That state has exactly two entry points: the `SidebarTrigger` component, and the `Cmd/Ctrl+B` shortcut wired in `components/ui/sidebar.tsx`.

`SidebarTrigger` was rendered nowhere:

```
$ grep -rn "SidebarTrigger" frontend/src/ | grep -v "ui/sidebar.tsx"
(no matches)
```

`app-shell.tsx` mounted `<Sidebar collapsible="icon">` with no trigger beside it, so in a half-width window — Chrome split view, a narrow display — the operator lost all navigation with no on-screen way back. Not a degraded layout: a dead end, escapable only by a keyboard shortcut nothing advertises, or by widening the window.

This mounts the trigger, fixed to the viewport and `md:hidden` so desktop is untouched.

Closes #830 — **partially**; see Related.

## API Or Behavior Changes

- A sidebar toggle now appears below 768px, bottom-left, above page content.
- No change at or above 768px: the sidebar stays inline and keeps its labelled collapse row.

Placement is deliberate. Putting the control in a view's header would make every view find room for it, and the workflows toolbar at 1024px has none to give — that row was clipping its last control until #826. Fixed positioning keeps the fix in one place and out of every toolbar's way.

## Tests

`frontend/test/e2e/sidebar-toggle-reachable.spec.ts`, in Playwright rather than jsdom because this is geometry: jsdom computes none, and a unit test asserting the class string would pass against a trigger painted off screen.

- At 700px: the trigger is `toBeInViewport()`, and clicking it opens the sheet — asserted by a nav item becoming visible, so the test fails if the control is present but inert.
- At 1024px: the inline sidebar still has its labelled collapse control, so the mobile fix cannot quietly replace the desktop affordance.

Teeth proved by reverting, not asserted: making the trigger `hidden` fails the 700px test on `toBeInViewport()` while the 1024px test still passes — the two are independently meaningful.

Gates: `npm ci` · `npm run typecheck` · `npm run typecheck:e2e` · `npx vitest run` **648 passed / 53 files** · `npm run build` clean · the new spec **2 passed** against a locally built host.

## Documentation

None — no documented surface changes.

## Related

#830 has a second part that is **not** addressed here: a report that the workflow canvas cannot be panned to its right side at half width. That was filed as a user report plus a code reading, was never reproduced at a measured width, and nothing here touches it. It should be reproduced and, if it turns out to be a distinct root cause, split into its own issue rather than folded into this branch. The issue says so.