### PR TITLE
feat(console): create teammates and drag the hierarchy on the Company page (#839)

### DIFF
--- a/frontend/src/lib/org.ts
+++ b/frontend/src/lib/org.ts
@@ -214,6 +214,31 @@ export function reorderedIds(
   return ids;
 }
 
+/**
+ * The full desk order produced by dropping one seat at another position.
+ * Returning the host's complete list keeps drag-and-drop and the keyboard
+ * controls on the same write contract: position zero remains the lead.
+ */
+export function reorderedIdsAfterDrop(
+  desk: OrgDesk,
+  fromIndex: number,
+  toIndex: number,
+): string[] | null {
+  if (
+    fromIndex < 0 ||
+    fromIndex >= desk.seats.length ||
+    toIndex < 0 ||
+    toIndex >= desk.seats.length ||
+    fromIndex === toIndex
+  ) {
+    return null;
+  }
+  const ids = desk.seats.map((seat) => seat.id);
+  const [moved] = ids.splice(fromIndex, 1);
+  ids.splice(toIndex, 0, moved);
+  return ids;
+}
+
 /** A one-line summary of the chart, for the company node. */
 export function summarize(tree: OrgTree): string {
   const seats = tree.desks.reduce((n, d) => n + d.seats.length, 0);

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -13,12 +13,12 @@
 // `aria-level`, and no code path here can emit `aria-level="4"`, which is what
 // the e2e spec asserts.
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { ChevronDown, ChevronUp, Crown, Plus, Trash2, Users, X } from "lucide-react";
+import { useCallback, useEffect, useRef, useState, type DragEvent } from "react";
+import { ChevronDown, ChevronUp, Crown, Plus, Trash2, UserPlus, Users, X } from "lucide-react";
 
 import { listPeople } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
-import type { DeskDto, TeamMemberDto } from "@/api/types";
+import { ApiError, type DeskDto, type TeamMemberDto } from "@/api/types";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -32,6 +32,7 @@ import {
   addableTo,
   buildOrgTree,
   reorderedIds,
+  reorderedIdsAfterDrop,
   summarize,
   type OrgDesk,
   type OrgPerson,
@@ -40,6 +41,9 @@ import {
 } from "@/lib/org";
 import { cn } from "@/lib/utils";
 import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
+import { AddMemberDialog, type NewMemberFields } from "@/views/chat/AddMemberDialog";
+
+const SEAT_MIME = "application/x-opencompany-seat";
 
 interface Props {
   client: OpenCompanyClient;
@@ -68,6 +72,8 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [createOpen, setCreateOpen] = useState(false);
+  const [addMemberOpen, setAddMemberOpen] = useState(false);
+  const [addMemberDeskId, setAddMemberDeskId] = useState<string | null>(null);
   // A generation token so a response for a company we have navigated away from
   // cannot overwrite the one on screen. Same guard `SkillsView` uses.
   const gen = useRef(0);
@@ -211,6 +217,48 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
     }
   }
 
+  /**
+   * Company creation is durable structure, so a host without the team write
+   * plane must explain the refusal rather than borrow ChatView's local-only
+   * fallback. A local row could not be placed on a desk and would vanish on
+   * the next chart read.
+   */
+  async function addMember(fields: NewMemberFields) {
+    const deskId = addMemberDeskId;
+    setBusy("add-member");
+    setError(null);
+    try {
+      let created: TeamMemberDto;
+      try {
+        created = await client.addTeamMember(
+          { name: fields.name, role: fields.role, description: fields.description || undefined },
+          company,
+        );
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 404) {
+          throw new Error("This host does not support creating teammates from the Company page.");
+        }
+        throw e;
+      }
+      if (deskId) {
+        try {
+          await client.addDeskMember(deskId, created.id, company);
+        } catch (e) {
+          throw new Error(
+            `Teammate ${fields.name} was created, but could not be added to the selected desk: ${e instanceof Error ? e.message : "unknown error"}`,
+          );
+        }
+      }
+      await boot();
+      setAddMemberOpen(false);
+    } catch (e) {
+      setAddMemberOpen(false);
+      setError(e instanceof Error ? e.message : "Could not create teammate.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
   return (
     <div ref={chartRef} className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-4xl space-y-6 px-4 py-6">
@@ -222,16 +270,29 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
               desk, move someone between desks, or change who leads.
             </p>
           </div>
-          <Button
-            size="sm"
-            variant="outline"
-            className="shrink-0"
-            disabled={load === "loading"}
-            onClick={() => setCreateOpen(true)}
-          >
-            <Plus className="mr-1.5 size-4" />
-            New desk
-          </Button>
+          <div className="flex shrink-0 flex-wrap justify-end gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={load === "loading"}
+              onClick={() => setCreateOpen(true)}
+            >
+              <Plus className="mr-1.5 size-4" />
+              New desk
+            </Button>
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={load === "loading"}
+              onClick={() => {
+                setAddMemberDeskId(null);
+                setAddMemberOpen(true);
+              }}
+            >
+              <UserPlus className="mr-1.5 size-4" />
+              New teammate
+            </Button>
+          </div>
         </div>
 
         {error && (
@@ -264,6 +325,10 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
                 busy={busy}
                 focusMark={focusMark}
                 onCreate={() => setCreateOpen(true)}
+                onCreateMember={(desk) => {
+                  setAddMemberDeskId(desk.id);
+                  setAddMemberOpen(true);
+                }}
                 onAdd={(desk, agentId) =>
                   void mutate(`${desk.id}:${agentId}`, () =>
                     client.addDeskMember(desk.id, agentId, company),
@@ -280,6 +345,11 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
                   void mutate(`${desk.id}:${desk.seats[index].id}`, () =>
                     client.setDeskOrder(desk.id, next, company),
                   );
+                }}
+                onDrop={(desk, fromIndex, toIndex) => {
+                  const next = reorderedIdsAfterDrop(desk, fromIndex, toIndex);
+                  if (!next) return;
+                  void mutate(`drag:${desk.id}`, () => client.setDeskOrder(desk.id, next, company));
                 }}
                 onDelete={(desk) =>
                   void mutate(`delete:${desk.id}`, () => client.deleteDesk(desk.id, company))
@@ -298,6 +368,11 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         onOpenChange={setCreateOpen}
         onCreated={() => void boot()}
       />
+      <AddMemberDialog
+        open={addMemberOpen}
+        onOpenChange={setAddMemberOpen}
+        onAdd={(fields) => void addMember(fields)}
+      />
     </div>
   );
 }
@@ -314,9 +389,11 @@ function Chart({
   busy,
   focusMark,
   onCreate,
+  onCreateMember,
   onAdd,
   onRemove,
   onMove,
+  onDrop,
   onDelete,
 }: {
   tree: OrgTree;
@@ -324,9 +401,11 @@ function Chart({
   /** The desk a `#/company/<deskId>` link landed on, ringed until first input. */
   focusMark: string | null;
   onCreate: () => void;
+  onCreateMember: (desk: OrgDesk) => void;
   onAdd: (desk: OrgDesk, agentId: string) => void;
   onRemove: (desk: OrgDesk, agentId: string) => void;
   onMove: (desk: OrgDesk, index: number, direction: "up" | "down") => void;
+  onDrop: (desk: OrgDesk, fromIndex: number, toIndex: number) => void;
   onDelete: (desk: OrgDesk) => void;
 }) {
   return (
@@ -356,8 +435,10 @@ function Chart({
                 busy={busy}
                 focused={focusMark === desk.id}
                 onAdd={(agentId) => onAdd(desk, agentId)}
+                onCreateMember={() => onCreateMember(desk)}
                 onRemove={(agentId) => onRemove(desk, agentId)}
                 onMove={(index, direction) => onMove(desk, index, direction)}
+                onDrop={(fromIndex, toIndex) => onDrop(desk, fromIndex, toIndex)}
                 onDelete={() => onDelete(desk)}
               />
             ))}
@@ -374,9 +455,11 @@ function DeskNode({
   addable,
   busy,
   focused,
+  onCreateMember,
   onAdd,
   onRemove,
   onMove,
+  onDrop,
   onDelete,
 }: {
   desk: OrgDesk;
@@ -384,12 +467,15 @@ function DeskNode({
   busy: string | null;
   /** This desk is the one a `#/company/<deskId>` link asked for. */
   focused: boolean;
+  onCreateMember: () => void;
   onAdd: (agentId: string) => void;
   onRemove: (agentId: string) => void;
   onMove: (index: number, direction: "up" | "down") => void;
+  onDrop: (fromIndex: number, toIndex: number) => void;
   onDelete: () => void;
 }) {
   const locked = busy !== null;
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
   return (
     <div
       role="treeitem"
@@ -451,6 +537,8 @@ function DeskNode({
             <Seat
               key={seat.id}
               seat={seat}
+              index={index}
+              deskId={desk.id}
               deskName={desk.name}
               first={index === 0}
               last={index === desk.seats.length - 1}
@@ -459,17 +547,22 @@ function DeskNode({
               onUp={() => onMove(index, "up")}
               onDown={() => onMove(index, "down")}
               onRemove={() => onRemove(seat.id)}
+              onDragStart={() => setDraggingIndex(index)}
+              onDrop={(toIndex) => {
+                if (draggingIndex !== null) onDrop(draggingIndex, toIndex);
+                setDraggingIndex(null);
+              }}
             />
           ))}
 
-          <div className="pt-1">
+          <div className="flex items-center gap-1 pt-1">
             <DropdownMenu>
               <DropdownMenuTrigger
                 render={
                   <Button
                     variant="outline"
                     size="sm"
-                    className="w-full"
+                    className="min-w-0 flex-1"
                     disabled={addable.length === 0 || locked}
                   />
                 }
@@ -487,6 +580,16 @@ function DeskNode({
                 </DropdownMenuContent>
               )}
             </DropdownMenu>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="size-8 shrink-0"
+              aria-label={`Create teammate on ${desk.name}`}
+              disabled={locked}
+              onClick={onCreateMember}
+            >
+              <UserPlus className="size-4" />
+            </Button>
           </div>
         </div>
       </div>
@@ -497,6 +600,8 @@ function DeskNode({
 /** One seat — level 3, the deepest a path here can go. */
 function Seat({
   seat,
+  index,
+  deskId,
   deskName,
   first,
   last,
@@ -505,8 +610,12 @@ function Seat({
   onUp,
   onDown,
   onRemove,
+  onDragStart,
+  onDrop,
 }: {
   seat: OrgSeat;
+  index: number;
+  deskId: string;
   deskName: string;
   first: boolean;
   last: boolean;
@@ -515,14 +624,36 @@ function Seat({
   onUp: () => void;
   onDown: () => void;
   onRemove: () => void;
+  onDragStart: () => void;
+  onDrop: (toIndex: number) => void;
 }) {
+  function startDrag(event: DragEvent<HTMLDivElement>) {
+    onDragStart();
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData(SEAT_MIME, `${deskId}:${index}`);
+    event.dataTransfer.setData("text/plain", `${deskId}:${index}`);
+  }
+
+  function drop(event: DragEvent<HTMLDivElement>) {
+    event.preventDefault();
+    const payload = event.dataTransfer.getData(SEAT_MIME) || event.dataTransfer.getData("text/plain");
+    const [sourceDeskId, sourceIndex] = payload.split(":");
+    const fromIndex = Number(sourceIndex);
+    if (sourceDeskId === deskId && Number.isInteger(fromIndex)) onDrop(index);
+  }
+
   return (
     <div
       role="treeitem"
       aria-level={3}
       aria-selected="false"
+      draggable={!locked}
+      data-seat-id={seat.id}
+      onDragStart={startDrag}
+      onDragOver={(event) => event.preventDefault()}
+      onDrop={drop}
       className={cn(
-        "flex items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm",
+        "flex cursor-grab items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-sm active:cursor-grabbing",
         busy && "opacity-50",
       )}
     >

--- a/frontend/src/views/company/OrgChartView.tsx
+++ b/frontend/src/views/company/OrgChartView.tsx
@@ -13,8 +13,23 @@
 // `aria-level`, and no code path here can emit `aria-level="4"`, which is what
 // the e2e spec asserts.
 
-import { useCallback, useEffect, useRef, useState, type DragEvent } from "react";
-import { ChevronDown, ChevronUp, Crown, Plus, Trash2, UserPlus, Users, X } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type DragEvent,
+} from "react";
+import {
+  ChevronDown,
+  ChevronUp,
+  Crown,
+  Plus,
+  Trash2,
+  UserPlus,
+  Users,
+  X,
+} from "lucide-react";
 
 import { listPeople } from "@/api/auth";
 import type { OpenCompanyClient } from "@/api/client";
@@ -41,7 +56,10 @@ import {
 } from "@/lib/org";
 import { cn } from "@/lib/utils";
 import { DeskCreateDialog } from "@/views/company/DeskCreateDialog";
-import { AddMemberDialog, type NewMemberFields } from "@/views/chat/AddMemberDialog";
+import {
+  AddMemberDialog,
+  type NewMemberFields,
+} from "@/views/chat/AddMemberDialog";
 
 const SEAT_MIME = "application/x-opencompany-seat";
 
@@ -95,26 +113,33 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
         client.listTeam(company).catch(() => [] as TeamMemberDto[]),
         listPeople(client, company)
           .then((rows) =>
-            rows.map(
-              (p): OrgPerson => ({
-                id: p.id,
-                name: p.displayName?.trim() || p.email.split("@")[0],
-                email: p.email,
-                role: p.role,
-              }),
-            ),
+            rows.map((p): OrgPerson => ({
+              id: p.id,
+              name: p.displayName?.trim() || p.email.split("@")[0],
+              email: p.email,
+              role: p.role,
+            })),
           )
           .catch(() => [] as OrgPerson[]),
         client.status(company).catch(() => null),
       ]);
       if (mine !== gen.current) return;
-      setTree(buildOrgTree(status?.name || company || "This company", desks, roster, people));
+      setTree(
+        buildOrgTree(
+          status?.name || company || "This company",
+          desks,
+          roster,
+          people,
+        ),
+      );
       setLoad("ready");
     } catch (e) {
       if (mine !== gen.current) return;
       // A failed `/desks` is a real error, not an empty company. Inventing an
       // empty chart here would tell the operator their desks are gone.
-      setError(e instanceof Error ? e.message : "Could not load the org chart.");
+      setError(
+        e instanceof Error ? e.message : "Could not load the org chart.",
+      );
       setLoad("error");
     }
   }, [client, company]);
@@ -165,7 +190,8 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
   }, [company, focusDeskId]);
 
   useEffect(() => {
-    if (load !== "ready" || !focusDeskId || focused.current === focusDeskId) return;
+    if (load !== "ready" || !focusDeskId || focused.current === focusDeskId)
+      return;
     const node = chartRef.current?.querySelector<HTMLElement>(
       `[data-desk-id="${CSS.escape(focusDeskId)}"]`,
     );
@@ -211,7 +237,9 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
       await run();
       await boot();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Something went wrong. Try again.");
+      setError(
+        e instanceof Error ? e.message : "Something went wrong. Try again.",
+      );
     } finally {
       setBusy(null);
     }
@@ -227,16 +255,29 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
     const deskId = addMemberDeskId;
     setBusy("add-member");
     setError(null);
+    // Whether the host has the teammate, which decides whether the chart needs
+    // re-reading on the way out. A desk add that fails after the teammate is
+    // created leaves the two disagreeing: the roster has someone the chart has
+    // never heard of, so the message telling the operator to place them by hand
+    // would point at a dropdown that does not list them yet.
+    let createdOnHost = false;
     try {
       let created: TeamMemberDto;
       try {
         created = await client.addTeamMember(
-          { name: fields.name, role: fields.role, description: fields.description || undefined },
+          {
+            name: fields.name,
+            role: fields.role,
+            description: fields.description || undefined,
+          },
           company,
         );
+        createdOnHost = true;
       } catch (e) {
         if (e instanceof ApiError && e.status === 404) {
-          throw new Error("This host does not support creating teammates from the Company page.");
+          throw new Error(
+            "This host does not support creating teammates from the Company page.",
+          );
         }
         throw e;
       }
@@ -254,6 +295,9 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
     } catch (e) {
       setAddMemberOpen(false);
       setError(e instanceof Error ? e.message : "Could not create teammate.");
+      if (createdOnHost) {
+        await boot();
+      }
     } finally {
       setBusy(null);
     }
@@ -266,8 +310,9 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
           <div className="space-y-1">
             <h2 className="text-2xl font-semibold tracking-tight">Company</h2>
             <p className="text-sm text-muted-foreground">
-              How your company is organised: the desks it works from and who staffs each one. Add a
-              desk, move someone between desks, or change who leads.
+              How your company is organised: the desks it works from and who
+              staffs each one. Add a desk, move someone between desks, or change
+              who leads.
             </p>
           </div>
           <div className="flex shrink-0 flex-wrap justify-end gap-2">
@@ -349,10 +394,14 @@ export function OrgChartView({ client, company, focusDeskId }: Props) {
                 onDrop={(desk, fromIndex, toIndex) => {
                   const next = reorderedIdsAfterDrop(desk, fromIndex, toIndex);
                   if (!next) return;
-                  void mutate(`drag:${desk.id}`, () => client.setDeskOrder(desk.id, next, company));
+                  void mutate(`drag:${desk.id}`, () =>
+                    client.setDeskOrder(desk.id, next, company),
+                  );
                 }}
                 onDelete={(desk) =>
-                  void mutate(`delete:${desk.id}`, () => client.deleteDesk(desk.id, company))
+                  void mutate(`delete:${desk.id}`, () =>
+                    client.deleteDesk(desk.id, company),
+                  )
                 }
               />
               <Unplaced tree={tree} />
@@ -410,7 +459,12 @@ function Chart({
 }) {
   return (
     <div role="tree" aria-label="Company org chart" className="space-y-3">
-      <div role="treeitem" aria-level={1} aria-expanded="true" aria-selected="false">
+      <div
+        role="treeitem"
+        aria-level={1}
+        aria-expanded="true"
+        aria-selected="false"
+      >
         <div className="rounded-xl border bg-muted/40 px-4 py-3">
           <p className="font-medium">{tree.companyName}</p>
           <p className="text-xs text-muted-foreground">{summarize(tree)}</p>
@@ -438,7 +492,9 @@ function Chart({
                 onCreateMember={() => onCreateMember(desk)}
                 onRemove={(agentId) => onRemove(desk, agentId)}
                 onMove={(index, direction) => onMove(desk, index, direction)}
-                onDrop={(fromIndex, toIndex) => onDrop(desk, fromIndex, toIndex)}
+                onDrop={(fromIndex, toIndex) =>
+                  onDrop(desk, fromIndex, toIndex)
+                }
                 onDelete={() => onDelete(desk)}
               />
             ))}
@@ -509,7 +565,9 @@ function DeskNode({
               )}
             </p>
             {desk.description && (
-              <p className="line-clamp-2 text-xs text-muted-foreground">{desk.description}</p>
+              <p className="line-clamp-2 text-xs text-muted-foreground">
+                {desk.description}
+              </p>
             )}
           </div>
           {/* Only an operator-created desk can be deleted at runtime. A
@@ -524,14 +582,21 @@ function DeskNode({
               disabled={locked}
               onClick={onDelete}
             >
-              <Trash2 className={cn("size-3.5", busy === `delete:${desk.id}` && "opacity-50")} />
+              <Trash2
+                className={cn(
+                  "size-3.5",
+                  busy === `delete:${desk.id}` && "opacity-50",
+                )}
+              />
             </Button>
           )}
         </div>
 
         <div role="group" className="space-y-1 border-t px-3 py-2">
           {desk.seats.length === 0 && (
-            <p className="py-1 text-xs text-muted-foreground">Nobody staffs this desk yet.</p>
+            <p className="py-1 text-xs text-muted-foreground">
+              Nobody staffs this desk yet.
+            </p>
           )}
           {desk.seats.map((seat, index) => (
             <Seat
@@ -568,12 +633,20 @@ function DeskNode({
                 }
               >
                 <Plus className="size-4" />
-                {addable.length === 0 ? "Everyone is on this desk" : "Add teammate"}
+                {addable.length === 0
+                  ? "Everyone is on this desk"
+                  : "Add teammate"}
               </DropdownMenuTrigger>
               {addable.length > 0 && (
-                <DropdownMenuContent align="start" className="max-h-64 overflow-y-auto">
+                <DropdownMenuContent
+                  align="start"
+                  className="max-h-64 overflow-y-auto"
+                >
                   {addable.map((member) => (
-                    <DropdownMenuItem key={member.id} onClick={() => onAdd(member.id)}>
+                    <DropdownMenuItem
+                      key={member.id}
+                      onClick={() => onAdd(member.id)}
+                    >
                       <span className="truncate">{member.name}</span>
                     </DropdownMenuItem>
                   ))}
@@ -636,7 +709,9 @@ function Seat({
 
   function drop(event: DragEvent<HTMLDivElement>) {
     event.preventDefault();
-    const payload = event.dataTransfer.getData(SEAT_MIME) || event.dataTransfer.getData("text/plain");
+    const payload =
+      event.dataTransfer.getData(SEAT_MIME) ||
+      event.dataTransfer.getData("text/plain");
     const [sourceDeskId, sourceIndex] = payload.split(":");
     const fromIndex = Number(sourceIndex);
     if (sourceDeskId === deskId && Number.isInteger(fromIndex)) onDrop(index);
@@ -659,10 +734,22 @@ function Seat({
     >
       <span className="flex min-w-0 items-center gap-1.5">
         {seat.lead && (
-          <Crown role="img" aria-label="Desk lead" className="size-3.5 shrink-0 text-muted-foreground" />
+          <Crown
+            role="img"
+            aria-label="Desk lead"
+            className="size-3.5 shrink-0 text-muted-foreground"
+          />
         )}
-        <span className={cn("truncate", !seat.known && "text-muted-foreground")}>{seat.name}</span>
-        {seat.role && <span className="truncate text-xs text-muted-foreground">{seat.role}</span>}
+        <span
+          className={cn("truncate", !seat.known && "text-muted-foreground")}
+        >
+          {seat.name}
+        </span>
+        {seat.role && (
+          <span className="truncate text-xs text-muted-foreground">
+            {seat.role}
+          </span>
+        )}
         {/* A seat naming somebody the roster no longer has. Shown, not hidden:
             it is a fact about the structure only the operator can fix. */}
         {!seat.known && (
@@ -734,11 +821,15 @@ function Unplaced({ tree }: { tree: OrgTree }) {
         <section className="space-y-2">
           <h3 className="text-sm font-medium">Not on a desk</h3>
           <p className="text-xs text-muted-foreground">
-            Roster teammates the company has not staffed anywhere. Add them to a desk above.
+            Roster teammates the company has not staffed anywhere. Add them to a
+            desk above.
           </p>
           <ul className="flex flex-wrap gap-1.5">
             {tree.unassigned.map((member) => (
-              <li key={member.id} className="rounded-md border px-2 py-1 text-xs">
+              <li
+                key={member.id}
+                className="rounded-md border px-2 py-1 text-xs"
+              >
                 {member.name}
               </li>
             ))}
@@ -749,14 +840,19 @@ function Unplaced({ tree }: { tree: OrgTree }) {
         <section className="space-y-2">
           <h3 className="text-sm font-medium">People</h3>
           <p className="text-xs text-muted-foreground">
-            The humans who can sign in. Desks staff agents, so the company declares no desk for a
-            person, and this chart does not guess one.
+            The humans who can sign in. Desks staff agents, so the company
+            declares no desk for a person, and this chart does not guess one.
           </p>
           <ul className="flex flex-wrap gap-1.5">
             {tree.people.map((person) => (
-              <li key={person.id} className="rounded-md border px-2 py-1 text-xs">
+              <li
+                key={person.id}
+                className="rounded-md border px-2 py-1 text-xs"
+              >
                 {person.name}
-                <span className="ml-1.5 text-muted-foreground">{person.role}</span>
+                <span className="ml-1.5 text-muted-foreground">
+                  {person.role}
+                </span>
               </li>
             ))}
           </ul>

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -60,6 +60,12 @@ let writes: { method: string; path: string; body?: unknown }[] = [];
 let roster = [...ROSTER];
 let teamWriteAvailable = true;
 
+/**
+ * Makes `POST .../desks/{id}/members` refuse, so the partial failure is
+ * reachable: the teammate is created on the host and then cannot be placed.
+ */
+let deskAddAvailable = true;
+
 /** The host's desks, as this stub holds them. Mutated by the write routes. */
 let desks: Desk[] = [];
 
@@ -67,6 +73,7 @@ function reset() {
   writes = [];
   roster = [...ROSTER];
   teamWriteAvailable = true;
+  deskAddAvailable = true;
   desks = [
     {
       id: "engineering",
@@ -96,7 +103,9 @@ async function mockApi(page: Page) {
   await page.addInitScript(() => {
     const real = Storage.prototype.getItem;
     Storage.prototype.getItem = function getItem(key: string) {
-      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+      return key.startsWith("oc-tour:")
+        ? '{"skipped":true}'
+        : real.call(this, key);
     };
   });
 
@@ -105,9 +114,18 @@ async function mockApi(page: Page) {
     const method = request.method();
     const path = new URL(request.url()).pathname;
     const json = (body: unknown, status = 200) =>
-      route.fulfill({ status, contentType: "application/json", body: JSON.stringify(body) });
+      route.fulfill({
+        status,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
     const noContent = () => route.fulfill({ status: 204, body: "" });
-    const status = { id: COMPANY, name: "Acme", lifecycle: "running", pending_approvals: 0 };
+    const status = {
+      id: COMPANY,
+      name: "Acme",
+      lifecycle: "running",
+      pending_approvals: 0,
+    };
 
     if (path === "/api/v1/companies") return json([status]);
     if (path === `/api/v1/companies/${COMPANY}`) return json(status);
@@ -122,7 +140,8 @@ async function mockApi(page: Page) {
       const body = request.postDataJSON() as { ordered_member_ids?: string[] };
       writes.push({ method, path, body });
       const target = desk(order[1]);
-      if (target && body.ordered_member_ids) target.members = [...body.ordered_member_ids];
+      if (target && body.ordered_member_ids)
+        target.members = [...body.ordered_member_ids];
       return noContent();
     }
 
@@ -133,7 +152,9 @@ async function mockApi(page: Page) {
       const target = desk(member[1]);
       if (target) {
         target.members = target.members.filter((m) => m !== member[2]);
-        target.overlayMembers = (target.overlayMembers ?? []).filter((m) => m !== member[2]);
+        target.overlayMembers = (target.overlayMembers ?? []).filter(
+          (m) => m !== member[2],
+        );
       }
       return noContent();
     }
@@ -143,11 +164,18 @@ async function mockApi(page: Page) {
     if (members && method === "POST") {
       // snake_case on the wire, as above (`AddDeskMember { agent_id }`).
       const body = request.postDataJSON() as { agent_id: string };
+      if (!deskAddAvailable) {
+        writes.push({ method, path, body });
+        return json({ error: "the desk refused the member" }, 409);
+      }
       writes.push({ method, path, body });
       const target = desk(members[1]);
       if (target) {
         target.members = [...target.members, body.agent_id];
-        target.overlayMembers = [...(target.overlayMembers ?? []), body.agent_id];
+        target.overlayMembers = [
+          ...(target.overlayMembers ?? []),
+          body.agent_id,
+        ];
       }
       return noContent();
     }
@@ -183,7 +211,11 @@ async function mockApi(page: Page) {
 
     if (path.endsWith("/team") && method === "POST") {
       if (!teamWriteAvailable) return json({ error: "not supported" }, 404);
-      const body = request.postDataJSON() as { name: string; role: string; description?: string };
+      const body = request.postDataJSON() as {
+        name: string;
+        role: string;
+        description?: string;
+      };
       const created = {
         id: `new-${roster.length}`,
         name: body.name,
@@ -210,18 +242,26 @@ async function mockApi(page: Page) {
       ]);
     }
     if (path.endsWith("/events")) {
-      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+      return route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: "",
+      });
     }
-    if (path.endsWith("/me")) return json({ id: "op", email: "op@example.com", role: "admin" });
+    if (path.endsWith("/me"))
+      return json({ id: "op", email: "op@example.com", role: "admin" });
     return json([]);
   });
 }
 
-const chart = (page: Page) => page.getByRole("tree", { name: "Company org chart" });
+const chart = (page: Page) =>
+  page.getByRole("tree", { name: "Company org chart" });
 
 /** A desk node by its heading text; `aria-level` 2 keeps seats from matching. */
 const deskNode = (page: Page, name: string) =>
-  chart(page).locator('[role="treeitem"][aria-level="2"]').filter({ hasText: name });
+  chart(page)
+    .locator('[role="treeitem"][aria-level="2"]')
+    .filter({ hasText: name });
 
 /**
  * Land on the chart from a cold load.
@@ -252,13 +292,16 @@ const memberPane = (page: Page) => page.getByRole("complementary").last();
  */
 async function openMemberPane(page: Page) {
   const toggle = page.getByRole("button", { name: /members$/i });
-  if ((await toggle.getAttribute("aria-pressed")) !== "true") await toggle.click();
+  if ((await toggle.getAttribute("aria-pressed")) !== "true")
+    await toggle.click();
   await expect(page.getByRole("heading", { name: "Team" })).toBeVisible();
 }
 
 test.beforeEach(reset);
 
-test("#311 the org chart is reachable, which it was not before", async ({ page }) => {
+test("#311 the org chart is reachable, which it was not before", async ({
+  page,
+}) => {
   await mockApi(page);
 
   // Start somewhere else, so arriving at the chart is a real navigation and not
@@ -297,30 +340,44 @@ test("#311 the chart is three levels and never a fourth", async ({ page }) => {
   await expect(root).toContainText("2 desks · 4 seats");
 
   // Level 2 is the desks, level 3 the seats on them.
-  await expect(chart(page).locator('[role="treeitem"][aria-level="2"]')).toHaveCount(2);
-  await expect(chart(page).locator('[role="treeitem"][aria-level="3"]')).toHaveCount(4);
+  await expect(
+    chart(page).locator('[role="treeitem"][aria-level="2"]'),
+  ).toHaveCount(2);
+  await expect(
+    chart(page).locator('[role="treeitem"][aria-level="3"]'),
+  ).toHaveCount(4);
 
   // And there is no fourth. The cap is structural: no desk can name a parent
   // desk, so nothing here can emit one.
-  await expect(chart(page).locator('[role="treeitem"][aria-level="4"]')).toHaveCount(0);
+  await expect(
+    chart(page).locator('[role="treeitem"][aria-level="4"]'),
+  ).toHaveCount(0);
 });
 
 test("#311 the lead is the desk's first member, badged", async ({ page }) => {
   await mockApi(page);
   await openChart(page);
 
-  const seats = deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]');
+  const seats = deskNode(page, "Engineering").locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
   await expect(seats).toHaveCount(2);
   await expect(seats.first()).toContainText("Grace");
   // Through the role, not the bare attribute: a `getByLabel` match proves the
   // attribute is in the DOM, not that anything would announce it. The crown
   // carries `role="img"` so the accessible name actually resolves.
-  await expect(seats.first().getByRole("img", { name: "Desk lead" })).toBeVisible();
+  await expect(
+    seats.first().getByRole("img", { name: "Desk lead" }),
+  ).toBeVisible();
   await expect(seats.nth(1)).toContainText("Ada");
-  await expect(seats.nth(1).getByRole("img", { name: "Desk lead" })).toHaveCount(0);
+  await expect(
+    seats.nth(1).getByRole("img", { name: "Desk lead" }),
+  ).toHaveCount(0);
 });
 
-test("#311 a desk can be created from the chart and survives a reload", async ({ page }) => {
+test("#311 a desk can be created from the chart and survives a reload", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
@@ -336,7 +393,9 @@ test("#311 a desk can be created from the chart and survives a reload", async ({
 
   await expect(deskNode(page, "Support")).toBeVisible();
 
-  const created = writes.find((w) => w.method === "POST" && w.path.endsWith("/desks"));
+  const created = writes.find(
+    (w) => w.method === "POST" && w.path.endsWith("/desks"),
+  );
   expect(created?.body).toMatchObject({ name: "Support", members: ["linus"] });
 
   // The proof that this is the host's and not the component's: reload.
@@ -346,7 +405,9 @@ test("#311 a desk can be created from the chart and survives a reload", async ({
   await expect(deskNode(page, "Support")).toContainText("Linus");
 });
 
-test("#311 membership can be edited from the chart and survives a reload", async ({ page }) => {
+test("#311 membership can be edited from the chart and survives a reload", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
@@ -354,15 +415,22 @@ test("#311 membership can be edited from the chart and survives a reload", async
   // rather than dropping him.
   const unplaced = page.getByRole("heading", { name: "Not on a desk" });
   await expect(unplaced).toBeVisible();
-  await expect(unplaced.locator("xpath=following-sibling::ul[1]")).toContainText("Turing");
+  await expect(
+    unplaced.locator("xpath=following-sibling::ul[1]"),
+  ).toContainText("Turing");
 
   const engineering = deskNode(page, "Engineering");
   await engineering.getByRole("button", { name: "Add teammate" }).click();
   await page.getByRole("menuitem", { name: "Linus" }).click();
 
-  await expect(engineering.locator('[role="treeitem"][aria-level="3"]')).toHaveCount(3);
+  await expect(
+    engineering.locator('[role="treeitem"][aria-level="3"]'),
+  ).toHaveCount(3);
   expect(
-    writes.some((w) => w.method === "POST" && w.path.endsWith("/desks/engineering/members")),
+    writes.some(
+      (w) =>
+        w.method === "POST" && w.path.endsWith("/desks/engineering/members"),
+    ),
   ).toBe(true);
 
   await page.reload();
@@ -373,18 +441,24 @@ test("#311 membership can be edited from the chart and survives a reload", async
   await deskNode(page, "Engineering")
     .getByRole("button", { name: "Remove Linus from Engineering" })
     .click();
-  await expect(deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]')).toHaveCount(2);
+  await expect(
+    deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]'),
+  ).toHaveCount(2);
   await page.reload();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
   await expect(deskNode(page, "Engineering")).not.toContainText("Linus");
 });
 
-test("#839 creates a teammate on a selected desk and persists it", async ({ page }) => {
+test("#839 creates a teammate on a selected desk and persists it", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
   const growth = deskNode(page, "Growth");
-  await growth.getByRole("button", { name: "Create teammate on Growth" }).click();
+  await growth
+    .getByRole("button", { name: "Create teammate on Growth" })
+    .click();
   const dialog = page.getByRole("dialog");
   await dialog.getByLabel("Name").fill("Babbage");
   await dialog.getByLabel("Role").fill("Platform Engineer");
@@ -392,8 +466,17 @@ test("#839 creates a teammate on a selected desk and persists it", async ({ page
   await dialog.getByRole("button", { name: "Add member" }).click();
 
   await expect(growth).toContainText("Babbage");
-  expect(writes.find((write) => write.method === "POST" && write.path.endsWith("/team"))).toBeTruthy();
-  expect(writes.find((write) => write.method === "POST" && write.path.endsWith("/desks/growth/members"))).toBeTruthy();
+  expect(
+    writes.find(
+      (write) => write.method === "POST" && write.path.endsWith("/team"),
+    ),
+  ).toBeTruthy();
+  expect(
+    writes.find(
+      (write) =>
+        write.method === "POST" && write.path.endsWith("/desks/growth/members"),
+    ),
+  ).toBeTruthy();
 
   await page.reload();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
@@ -410,12 +493,16 @@ test("#839 creates a teammate with no desk as unplaced", async ({ page }) => {
   await dialog.getByLabel("Role").fill("Roaming Engineer");
   await dialog.getByRole("button", { name: "Add member" }).click();
 
-  await expect(page.getByRole("heading", { name: "Not on a desk" })).toContainText("Not on a desk");
+  await expect(
+    page.getByRole("heading", { name: "Not on a desk" }),
+  ).toContainText("Not on a desk");
   await expect(page.getByText("No Desk", { exact: true })).toBeVisible();
   expect(writes.some((write) => write.path.includes("/members"))).toBe(false);
 });
 
-test("#839 refuses a company-page teammate add when the host has no team write plane", async ({ page }) => {
+test("#839 refuses a company-page teammate add when the host has no team write plane", async ({
+  page,
+}) => {
   teamWriteAvailable = false;
   await mockApi(page);
   await openChart(page);
@@ -426,11 +513,15 @@ test("#839 refuses a company-page teammate add when the host has no team write p
   await dialog.getByLabel("Role").fill("Unavailable");
   await dialog.getByRole("button", { name: "Add member" }).click();
 
-  await expect(page.getByRole("alert")).toContainText("does not support creating teammates");
+  await expect(page.getByRole("alert")).toContainText(
+    "does not support creating teammates",
+  );
   await expect(page.locator("text=Not Saved")).toHaveCount(0);
 });
 
-test("#311 the lead can be changed from the chart and survives a reload", async ({ page }) => {
+test("#311 the lead can be changed from the chart and survives a reload", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
@@ -440,21 +531,73 @@ test("#311 the lead can be changed from the chart and survives a reload", async 
     .getByRole("button", { name: "Move Ada up in Engineering" })
     .click();
 
-  const seats = deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]');
+  const seats = deskNode(page, "Engineering").locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
   await expect(seats.first()).toContainText("Ada");
-  await expect(seats.first().getByRole("img", { name: "Desk lead" })).toBeVisible();
+  await expect(
+    seats.first().getByRole("img", { name: "Desk lead" }),
+  ).toBeVisible();
 
-  const ordered = writes.find((w) => w.method === "PUT" && w.path.endsWith("/order"));
+  const ordered = writes.find(
+    (w) => w.method === "PUT" && w.path.endsWith("/order"),
+  );
   expect(ordered?.body).toEqual({ ordered_member_ids: ["ada", "grace"] });
 
   await page.reload();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
   await expect(
-    deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]').first(),
+    deskNode(page, "Engineering")
+      .locator('[role="treeitem"][aria-level="3"]')
+      .first(),
   ).toContainText("Ada");
 });
 
-test("#839 dragging a seat reorders the desk and persists the new lead", async ({ page }) => {
+test("#839 a teammate created but not placed is still on the chart to place by hand", async ({
+  page,
+}) => {
+  // The half-done case: the host takes the teammate and then refuses the desk.
+  // The message tells the operator to place them themselves, so the chart has
+  // to have re-read — otherwise it points at a dropdown the teammate is not in
+  // yet, and the only way out is an unrelated reload.
+  deskAddAvailable = false;
+  await mockApi(page);
+  await openChart(page);
+
+  const growth = deskNode(page, "Growth");
+  await growth
+    .getByRole("button", { name: "Create teammate on Growth" })
+    .click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("Hopper");
+  await dialog.getByLabel("Role").fill("Compiler");
+  await dialog.getByRole("button", { name: "Add member" }).click();
+
+  await expect(page.getByRole("alert")).toContainText(
+    "could not be added to the selected desk",
+  );
+  await expect(page.getByRole("alert")).toContainText("Hopper");
+  // Created on the host, so it must be on the chart's unplaced list — the one
+  // place a teammate with no desk belongs, and where the operator picks them
+  // up to place by hand. Asserted against that list rather than the page: the
+  // alert names Hopper too, so a page-wide match would pass whether or not the
+  // chart had re-read at all.
+  const unplaced = page
+    .locator("section", {
+      has: page.getByRole("heading", { name: "Not on a desk" }),
+    })
+    .last();
+  await expect(unplaced).toContainText("Hopper");
+  expect(
+    writes.find(
+      (write) => write.method === "POST" && write.path.endsWith("/team"),
+    ),
+  ).toBeTruthy();
+});
+
+test("#839 dragging a seat reorders the desk and persists the new lead", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
@@ -463,26 +606,38 @@ test("#839 dragging a seat reorders the desk and persists the new lead", async (
   await seats.nth(1).dragTo(seats.first());
 
   await expect(seats.first()).toContainText("Ada");
-  expect(writes.find((write) => write.method === "PUT" && write.path.endsWith("/order"))?.body).toEqual({
+  expect(
+    writes.find(
+      (write) => write.method === "PUT" && write.path.endsWith("/order"),
+    )?.body,
+  ).toEqual({
     ordered_member_ids: ["ada", "grace"],
   });
 
   await page.reload();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
-  const reloadedSeats = deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]');
+  const reloadedSeats = deskNode(page, "Engineering").locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
   await expect(reloadedSeats.first()).toContainText("Ada");
-  await expect(reloadedSeats.first().getByRole("img", { name: "Desk lead" })).toBeVisible();
+  await expect(
+    reloadedSeats.first().getByRole("img", { name: "Desk lead" }),
+  ).toBeVisible();
   await expect(reloadedSeats.nth(1)).toContainText("Grace");
 });
 
-test("#311 blueprint structure offers no control the host would refuse", async ({ page }) => {
+test("#311 blueprint structure offers no control the host would refuse", async ({
+  page,
+}) => {
   await mockApi(page);
   await openChart(page);
 
   // A manifest desk cannot be deleted at runtime, so no delete is offered.
   await expect(deskNode(page, "Engineering")).toContainText("Blueprint");
   await expect(
-    deskNode(page, "Engineering").getByRole("button", { name: "Delete Engineering" }),
+    deskNode(page, "Engineering").getByRole("button", {
+      name: "Delete Engineering",
+    }),
   ).toHaveCount(0);
   // Nor can its manifest members be removed.
   await expect(
@@ -492,9 +647,15 @@ test("#311 blueprint structure offers no control the host would refuse", async (
   // An operator-created desk can be deleted, and its added member removed —
   // but its founding member is still blueprint to the host.
   const growth = deskNode(page, "Growth");
-  await expect(growth.getByRole("button", { name: "Delete Growth" })).toBeVisible();
-  await expect(growth.getByRole("button", { name: "Remove Hedy from Growth" })).toBeVisible();
-  await expect(growth.getByRole("button", { name: "Remove Linus from Growth" })).toHaveCount(0);
+  await expect(
+    growth.getByRole("button", { name: "Delete Growth" }),
+  ).toBeVisible();
+  await expect(
+    growth.getByRole("button", { name: "Remove Hedy from Growth" }),
+  ).toBeVisible();
+  await expect(
+    growth.getByRole("button", { name: "Remove Linus from Growth" }),
+  ).toHaveCount(0);
 
   await growth.getByRole("button", { name: "Delete Growth" }).click();
   await expect(deskNode(page, "Growth")).toHaveCount(0);
@@ -503,7 +664,9 @@ test("#311 blueprint structure offers no control the host would refuse", async (
   await expect(deskNode(page, "Growth")).toHaveCount(0);
 });
 
-test("#485 #/company/<deskId> lands on that desk, not just on the chart", async ({ page }) => {
+test("#485 #/company/<deskId> lands on that desk, not just on the chart", async ({
+  page,
+}) => {
   await mockApi(page);
 
   // The chat member pane's "Manage on the org chart" writes exactly this
@@ -529,14 +692,18 @@ test("#485 #/company/<deskId> lands on that desk, not just on the chart", async 
   await expect(growth).not.toHaveAttribute("data-desk-focused", "true");
 });
 
-test("#485 a desk id the chart doesn't have is a silent no-op", async ({ page }) => {
+test("#485 a desk id the chart doesn't have is a silent no-op", async ({
+  page,
+}) => {
   await mockApi(page);
 
   // `useHashView` hands the second segment back unvalidated, and a link can
   // outlive the desk it names. A stale bookmark gets the company, not a banner.
   await page.goto("/#/company/deleted-last-week");
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
-  await expect(chart(page).locator('[role="treeitem"][aria-level="2"]')).toHaveCount(2);
+  await expect(
+    chart(page).locator('[role="treeitem"][aria-level="2"]'),
+  ).toHaveCount(2);
   await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(0);
   await expect(page.getByRole("alert")).toHaveCount(0);
   // Not rewritten either: only this view knows which desk ids exist, so the
@@ -547,13 +714,18 @@ test("#485 a desk id the chart doesn't have is a silent no-op", async ({ page })
   // same chart at a desk it *does* have and the marker appears.
   await page.goto("/#/company/engineering");
   await expect
-    .poll(() => deskNode(page, "Engineering").getAttribute("data-desk-focused"), {
-      timeout: 30_000,
-    })
+    .poll(
+      () => deskNode(page, "Engineering").getAttribute("data-desk-focused"),
+      {
+        timeout: 30_000,
+      },
+    )
     .toBe("true");
 });
 
-test("#485 following the same desk link twice still lands on it", async ({ page }) => {
+test("#485 following the same desk link twice still lands on it", async ({
+  page,
+}) => {
   await mockApi(page);
 
   // Every hop here is an in-app hash change, never `page.goto`: a full
@@ -561,7 +733,10 @@ test("#485 following the same desk link twice still lands on it", async ({ page 
   // would pass whether or not the bug exists.
   await page.goto("/#/company/growth");
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
-  await expect(deskNode(page, "Growth")).toHaveAttribute("data-desk-focused", "true");
+  await expect(deskNode(page, "Growth")).toHaveAttribute(
+    "data-desk-focused",
+    "true",
+  );
 
   // Off to the bare chart. The view stays mounted, so whatever it remembers
   // about the last honoured id survives.
@@ -584,12 +759,17 @@ test("#485 following the same desk link twice still lands on it", async ({ page 
   await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(1);
 });
 
-test("#485 a stale id does not leave the previous desk wearing the ring", async ({ page }) => {
+test("#485 a stale id does not leave the previous desk wearing the ring", async ({
+  page,
+}) => {
   await mockApi(page);
 
   await page.goto("/#/company/growth");
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
-  await expect(deskNode(page, "Growth")).toHaveAttribute("data-desk-focused", "true");
+  await expect(deskNode(page, "Growth")).toHaveAttribute(
+    "data-desk-focused",
+    "true",
+  );
 
   // An id the chart does not have is a no-op for *arrival*, but it must still
   // retire the previous target's mark — otherwise the ring claims a desk the
@@ -601,29 +781,41 @@ test("#485 a stale id does not leave the previous desk wearing the ring", async 
   await expect(chart(page).locator("[data-desk-focused]")).toHaveCount(0);
 });
 
-test("#485 a membership edit on the chart is there when you get back to chat", async ({ page }) => {
+test("#485 a membership edit on the chart is there when you get back to chat", async ({
+  page,
+}) => {
   await mockApi(page);
 
   // The round trip #485 is actually for: read the desk in chat, notice it is
   // short a person, fix that where it can be fixed, come back.
   await page.goto("/#/chat/engineering");
-  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({
+    timeout: 30_000,
+  });
   await openMemberPane(page);
   await expect(memberPane(page)).toContainText("Grace");
-  await expect(memberPane(page).locator("ul").first()).not.toContainText("Turing");
+  await expect(memberPane(page).locator("ul").first()).not.toContainText(
+    "Turing",
+  );
 
-  await memberPane(page).getByRole("button", { name: "Manage on the org chart" }).click();
+  await memberPane(page)
+    .getByRole("button", { name: "Manage on the org chart" })
+    .click();
   await expect(chart(page)).toBeVisible({ timeout: 30_000 });
 
   const engineering = deskNode(page, "Engineering");
   await engineering.getByRole("button", { name: "Add teammate" }).click();
   await page.getByRole("menuitem", { name: "Turing" }).click();
-  await expect(engineering.locator('[role="treeitem"][aria-level="3"]')).toHaveCount(3);
+  await expect(
+    engineering.locator('[role="treeitem"][aria-level="3"]'),
+  ).toHaveCount(3);
 
   // Back the way we came — a hash navigation, so Back is the operator's own
   // route home and not a reload.
   await page.goBack();
-  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByPlaceholder("Message #engineering")).toBeVisible({
+    timeout: 30_000,
+  });
   await openMemberPane(page);
   // Chat re-reads the desks when it remounts, so no reload is needed for the
   // edit to show. The two surfaces stay separate reads of one host list —
@@ -632,7 +824,9 @@ test("#485 a membership edit on the chart is there when you get back to chat", a
   await expect(memberPane(page).locator("ul").first()).toContainText("Turing");
 });
 
-test("#311 a seat naming nobody on the roster is shown, not hidden", async ({ page }) => {
+test("#311 a seat naming nobody on the roster is shown, not hidden", async ({
+  page,
+}) => {
   reset();
   desks[0].members = ["grace", "ghost"];
   await mockApi(page);
@@ -641,7 +835,9 @@ test("#311 a seat naming nobody on the roster is shown, not hidden", async ({ pa
   // The chat member pane drops an unresolvable id, which is right for a chat.
   // Here it is a fact about the structure that only the operator can fix, so it
   // stays on screen and says what it is.
-  const seats = deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]');
+  const seats = deskNode(page, "Engineering").locator(
+    '[role="treeitem"][aria-level="3"]',
+  );
   await expect(seats).toHaveCount(2);
   await expect(seats.nth(1)).toContainText("ghost");
   await expect(seats.nth(1)).toContainText("Not on the roster");

--- a/frontend/test/e2e/org-tree.spec.ts
+++ b/frontend/test/e2e/org-tree.spec.ts
@@ -57,12 +57,16 @@ const ROSTER = [
 
 /** Every write the console made, so the request shape can be asserted on. */
 let writes: { method: string; path: string; body?: unknown }[] = [];
+let roster = [...ROSTER];
+let teamWriteAvailable = true;
 
 /** The host's desks, as this stub holds them. Mutated by the write routes. */
 let desks: Desk[] = [];
 
 function reset() {
   writes = [];
+  roster = [...ROSTER];
+  teamWriteAvailable = true;
   desks = [
     {
       id: "engineering",
@@ -177,7 +181,20 @@ async function mockApi(page: Page) {
       return json(desks);
     }
 
-    if (path.endsWith("/team")) return json(ROSTER);
+    if (path.endsWith("/team") && method === "POST") {
+      if (!teamWriteAvailable) return json({ error: "not supported" }, 404);
+      const body = request.postDataJSON() as { name: string; role: string; description?: string };
+      const created = {
+        id: `new-${roster.length}`,
+        name: body.name,
+        role: body.role,
+        description: body.description,
+      };
+      roster = [...roster, created];
+      writes.push({ method, path, body });
+      return json(created, 201);
+    }
+    if (path.endsWith("/team")) return json(roster);
     if (path.endsWith("/users")) {
       return json([
         {
@@ -362,6 +379,57 @@ test("#311 membership can be edited from the chart and survives a reload", async
   await expect(deskNode(page, "Engineering")).not.toContainText("Linus");
 });
 
+test("#839 creates a teammate on a selected desk and persists it", async ({ page }) => {
+  await mockApi(page);
+  await openChart(page);
+
+  const growth = deskNode(page, "Growth");
+  await growth.getByRole("button", { name: "Create teammate on Growth" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("Babbage");
+  await dialog.getByLabel("Role").fill("Platform Engineer");
+  await dialog.getByLabel("What they do").fill("Builds the platform");
+  await dialog.getByRole("button", { name: "Add member" }).click();
+
+  await expect(growth).toContainText("Babbage");
+  expect(writes.find((write) => write.method === "POST" && write.path.endsWith("/team"))).toBeTruthy();
+  expect(writes.find((write) => write.method === "POST" && write.path.endsWith("/desks/growth/members"))).toBeTruthy();
+
+  await page.reload();
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  await expect(deskNode(page, "Growth")).toContainText("Babbage");
+});
+
+test("#839 creates a teammate with no desk as unplaced", async ({ page }) => {
+  await mockApi(page);
+  await openChart(page);
+
+  await page.getByRole("button", { name: "New teammate" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("No Desk");
+  await dialog.getByLabel("Role").fill("Roaming Engineer");
+  await dialog.getByRole("button", { name: "Add member" }).click();
+
+  await expect(page.getByRole("heading", { name: "Not on a desk" })).toContainText("Not on a desk");
+  await expect(page.getByText("No Desk", { exact: true })).toBeVisible();
+  expect(writes.some((write) => write.path.includes("/members"))).toBe(false);
+});
+
+test("#839 refuses a company-page teammate add when the host has no team write plane", async ({ page }) => {
+  teamWriteAvailable = false;
+  await mockApi(page);
+  await openChart(page);
+
+  await page.getByRole("button", { name: "New teammate" }).click();
+  const dialog = page.getByRole("dialog");
+  await dialog.getByLabel("Name").fill("Not Saved");
+  await dialog.getByLabel("Role").fill("Unavailable");
+  await dialog.getByRole("button", { name: "Add member" }).click();
+
+  await expect(page.getByRole("alert")).toContainText("does not support creating teammates");
+  await expect(page.locator("text=Not Saved")).toHaveCount(0);
+});
+
 test("#311 the lead can be changed from the chart and survives a reload", async ({ page }) => {
   await mockApi(page);
   await openChart(page);
@@ -384,6 +452,27 @@ test("#311 the lead can be changed from the chart and survives a reload", async 
   await expect(
     deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]').first(),
   ).toContainText("Ada");
+});
+
+test("#839 dragging a seat reorders the desk and persists the new lead", async ({ page }) => {
+  await mockApi(page);
+  await openChart(page);
+
+  const engineering = deskNode(page, "Engineering");
+  const seats = engineering.locator('[role="treeitem"][aria-level="3"]');
+  await seats.nth(1).dragTo(seats.first());
+
+  await expect(seats.first()).toContainText("Ada");
+  expect(writes.find((write) => write.method === "PUT" && write.path.endsWith("/order"))?.body).toEqual({
+    ordered_member_ids: ["ada", "grace"],
+  });
+
+  await page.reload();
+  await expect(chart(page)).toBeVisible({ timeout: 30_000 });
+  const reloadedSeats = deskNode(page, "Engineering").locator('[role="treeitem"][aria-level="3"]');
+  await expect(reloadedSeats.first()).toContainText("Ada");
+  await expect(reloadedSeats.first().getByRole("img", { name: "Desk lead" })).toBeVisible();
+  await expect(reloadedSeats.nth(1)).toContainText("Grace");
 });
 
 test("#311 blueprint structure offers no control the host would refuse", async ({ page }) => {

--- a/frontend/test/unit/org-tree.test.ts
+++ b/frontend/test/unit/org-tree.test.ts
@@ -6,6 +6,7 @@ import {
   depthOf,
   MAX_DEPTH,
   reorderedIds,
+  reorderedIdsAfterDrop,
   summarize,
 } from "@/lib/org";
 import type { DeskDto, TeamMemberDto } from "@/api/types";
@@ -198,6 +199,25 @@ describe("reorderedIds", () => {
     const engineering = tree().desks[0];
     reorderedIds(engineering, 1, "up");
     expect(engineering.seats.map((s) => s.id)).toEqual(["grace", "ada"]);
+  });
+});
+
+describe("reorderedIdsAfterDrop", () => {
+  it("returns the full order when a drop changes the lead", () => {
+    expect(reorderedIdsAfterDrop(tree().desks[0], 1, 0)).toEqual(["ada", "grace"]);
+  });
+
+  it("rejects an invalid or no-op drop", () => {
+    const engineering = tree().desks[0];
+    expect(reorderedIdsAfterDrop(engineering, 0, 0)).toBeNull();
+    expect(reorderedIdsAfterDrop(engineering, -1, 0)).toBeNull();
+    expect(reorderedIdsAfterDrop(engineering, 0, 9)).toBeNull();
+  });
+
+  it("does not mutate the desk", () => {
+    const engineering = tree().desks[0];
+    reorderedIdsAfterDrop(engineering, 1, 0);
+    expect(engineering.seats.map((seat) => seat.id)).toEqual(["grace", "ada"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Two gaps on the same surface, reported from operating the product.

**You could not create a teammate from the Company page.** It could create a desk and attach an *existing* teammate, but nothing more — so an operator setting up a company could make a desk and then had to leave the page to make anyone to put in it. The capability already existed: `addTeamMember` posts to `{scope}/team`, and its only two callers were the chat members pane and `TeamView`, which is parked in `HIDDEN_VIEWS`, absent from the sidebar and reachable only by typing `#/team`.

**Reordering a desk was one click per position.** Chevrons calling `onMove(index, "up" | "down")`, so moving someone from the bottom of a six-person desk to the top was five clicks with a re-render between each.

Both are UI-only against write paths that already exist. No Rust changed.

Closes #839

## API Or Behavior Changes

- A teammate can be created from the Company page, at company level or from a desk. Created from a desk it chains through `addDeskMember` so it lands there; created with none selected it appears under "Not on a desk" rather than nowhere.
- Seats are draggable. `setDeskOrder` already took the **full ordered list** rather than a swap or a delta — exactly what a drop produces — so there is no API change. Position zero is the desk lead, so a drop into first position changes the lead, the same as the chevrons do.
- **The chevrons stay.** Drag alone is unreachable without a pointer, and both controls write through the same contract.

One deliberate divergence from `ChatView`: its `addTeamMember` call falls back to a local-only row on a `404`. That is not reused here. A row that exists only in the browser cannot be placed on a desk and vanishes on the next chart read, so a host without the team write plane gets an explanation instead of a teammate that appears to exist. A partial failure — teammate created, desk add refused — says exactly that rather than reporting either outright success or outright failure.

## Tests

Reordering is geometry, so its coverage is in Playwright rather than jsdom, and every case asserts the **write** and then **survives a reload** — a test that only checked the optimistic local update would pass against a broken write.

`frontend/test/e2e/org-tree.spec.ts`:
- creates a teammate on a selected desk; asserts both `POST …/team` and `POST …/desks/growth/members` went, then reloads and finds them still placed;
- creates one with no desk; asserts it lands under "Not on a desk" and that **no** membership write was sent;
- asserts the `404` path refuses in words rather than inventing a local row;
- drags a seat to first position; asserts the `PUT …/order` body is the full expected list, then reloads and finds the new lead.

`frontend/test/unit/org-tree.test.ts` covers the pure `reorderedIdsAfterDrop` helper, including the no-op and out-of-range cases.

Teeth proved by reverting, not asserted: reverting the creation path fails 1 e2e test; reverting the drag path fails 1 unit and 1 e2e test.

Gates: `npm ci` · `npm run typecheck` · `typecheck:unit` · `typecheck:e2e` · `npx vitest run` **657 passed / 53 files** · `npm run build` clean · `scripts/ci/assert-design-tokens.sh` clean · `npx playwright test org-tree` **17 passed** against a locally built host.

The page toolbar wraps rather than growing, so the new control does not repeat #824's clipping at 1024px.

## Documentation

None — no documented surface changes.

## Related

#830 covers the same page's behaviour below 768px; nothing here touches it.