### PR TITLE
fix(workflows): refuse granted-but-unwired tools in the dry run and the copilot (#840)

### DIFF
--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -129,7 +129,10 @@ pub(crate) use workflow_create::{
 // builder that is its only caller. Issue #753 adds `workflow_callable_tool_slugs`
 // on the same footing — the create-time copilot's tool grounding.
 #[cfg(feature = "openhuman")]
-pub(crate) use workflow_create::{courtesy_validate_draft, workflow_callable_tool_slugs};
+pub(crate) use workflow_create::{
+    courtesy_validate_draft, workflow_callable_tool_slugs, workflow_effective_tool_slugs,
+    workflow_granted_but_unwired_tool_slugs,
+};
 pub use workspace_seed::{NodeKind, SeedNode, extract_wikilinks, walk_workspace};
 
 use crate::{Result, VERSION};

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -317,7 +317,7 @@ pub struct CompanyRuntime {
     #[cfg(feature = "openhuman")]
     pub(crate) builder: Option<Arc<crate::harness::workflow_build::WorkflowBuilder>>,
     #[cfg(feature = "openhuman")]
-    pub(crate) workflow_wired_namespaces: Option<std::collections::BTreeSet<&'static str>>,
+    pub(crate) workflow_harness_deps: Option<crate::harness::HarnessDeps>,
     /// MCP installs and live connections for this runtime. The wrapper owns a
     /// company-home-scoped OpenHuman config while the live registry remains
     /// shared in-process with harness agents.
@@ -390,7 +390,7 @@ impl CompanyRuntime {
             #[cfg(feature = "openhuman")]
             builder: None,
             #[cfg(feature = "openhuman")]
-            workflow_wired_namespaces: None,
+            workflow_harness_deps: None,
             #[cfg(feature = "mcp")]
             mcp: None,
         }
@@ -482,16 +482,27 @@ impl CompanyRuntime {
     }
 
     #[cfg(feature = "openhuman")]
-    pub fn wired_workflow_namespaces(&self) -> Option<&std::collections::BTreeSet<&'static str>> {
-        self.workflow_wired_namespaces.as_ref()
+    pub async fn wired_workflow_namespaces(
+        &self,
+        company: &crate::ports::CompanyRecord,
+    ) -> Option<std::collections::BTreeSet<&'static str>> {
+        let deps = self.workflow_harness_deps.as_ref()?;
+        let mut resolved = deps.clone();
+        if let Some(plan) = &resolved.plan {
+            resolved.capabilities = crate::harness::capability_budget::resolve_filter(
+                plan,
+                resolved.meter.as_deref(),
+                &company.id,
+                crate::ports::now_millis(),
+            )
+            .await;
+        }
+        Some(crate::workflows::caps::wired_workflow_namespaces(&resolved))
     }
 
     #[cfg(feature = "openhuman")]
-    pub fn set_wired_workflow_namespaces(
-        &mut self,
-        namespaces: std::collections::BTreeSet<&'static str>,
-    ) {
-        self.workflow_wired_namespaces = Some(namespaces);
+    pub fn set_workflow_harness_deps(&mut self, deps: crate::harness::HarnessDeps) {
+        self.workflow_harness_deps = Some(deps);
     }
 
     /// Attaches the embedded MCP runtime used by REST and harness agents.

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -316,6 +316,8 @@ pub struct CompanyRuntime {
     /// and the boot reaper settles any run left mid-build.
     #[cfg(feature = "openhuman")]
     pub(crate) builder: Option<Arc<crate::harness::workflow_build::WorkflowBuilder>>,
+    #[cfg(feature = "openhuman")]
+    pub(crate) workflow_wired_namespaces: Option<std::collections::BTreeSet<&'static str>>,
     /// MCP installs and live connections for this runtime. The wrapper owns a
     /// company-home-scoped OpenHuman config while the live registry remains
     /// shared in-process with harness agents.
@@ -387,6 +389,8 @@ impl CompanyRuntime {
             planner: None,
             #[cfg(feature = "openhuman")]
             builder: None,
+            #[cfg(feature = "openhuman")]
+            workflow_wired_namespaces: None,
             #[cfg(feature = "mcp")]
             mcp: None,
         }
@@ -475,6 +479,19 @@ impl CompanyRuntime {
     #[cfg(feature = "openhuman")]
     pub fn builder(&self) -> Option<&Arc<crate::harness::workflow_build::WorkflowBuilder>> {
         self.builder.as_ref()
+    }
+
+    #[cfg(feature = "openhuman")]
+    pub fn wired_workflow_namespaces(&self) -> Option<&std::collections::BTreeSet<&'static str>> {
+        self.workflow_wired_namespaces.as_ref()
+    }
+
+    #[cfg(feature = "openhuman")]
+    pub fn set_wired_workflow_namespaces(
+        &mut self,
+        namespaces: std::collections::BTreeSet<&'static str>,
+    ) {
+        self.workflow_wired_namespaces = Some(namespaces);
     }
 
     /// Attaches the embedded MCP runtime used by REST and harness agents.

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2086,6 +2086,178 @@ impl std::fmt::Debug for CompanyRuntime {
 mod tests {
     use super::{emergency_from_load, task_enters_in_progress, task_enters_planning};
 
+    #[cfg(feature = "openhuman")]
+    use std::sync::{Arc, Mutex};
+
+    #[cfg(feature = "openhuman")]
+    use async_trait::async_trait;
+
+    #[cfg(feature = "openhuman")]
+    #[derive(Default)]
+    struct RecordingMeter {
+        queried_companies: Mutex<Vec<crate::ports::types::CompanyId>>,
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[async_trait]
+    impl crate::ports::UsageMeter for RecordingMeter {
+        async fn record(
+            &self,
+            _company: &crate::ports::types::CompanyId,
+            _sample: &crate::ports::UsageSample,
+        ) -> crate::Result<()> {
+            Ok(())
+        }
+
+        async fn query(
+            &self,
+            company: &crate::ports::types::CompanyId,
+            _since_millis: u64,
+        ) -> crate::Result<Vec<crate::ports::UsageSample>> {
+            self.queried_companies.lock().unwrap().push(company.clone());
+            Ok(Vec::new())
+        }
+    }
+
+    #[cfg(feature = "openhuman")]
+    async fn runtime_and_record() -> (
+        super::CompanyRuntime,
+        crate::ports::CompanyRecord,
+        tempfile::TempDir,
+    ) {
+        let home = tempfile::tempdir().expect("tempdir");
+        let manifest: crate::company::CompanyManifest = toml::from_str(
+            r#"
+            [company]
+            name = "Acme"
+
+            [[agent]]
+            id = "ceo"
+            role = "Chief"
+
+            [policy]
+            mode = "supervised"
+            "#,
+        )
+        .expect("manifest");
+        let runtime = crate::runtime::RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(crate::ports::types::CompanyId::new("acme"))
+            .build()
+            .await
+            .expect("runtime");
+        let record = runtime
+            .store()
+            .load(runtime.id())
+            .await
+            .expect("load")
+            .expect("record");
+        (runtime, record, home)
+    }
+
+    #[cfg(feature = "openhuman")]
+    fn wiring_deps(
+        runtime: &super::CompanyRuntime,
+        meter: Option<Arc<dyn crate::ports::UsageMeter>>,
+        capabilities: crate::harness::toolbelt::CapabilityFilter,
+        plan: Option<crate::harness::capability_budget::CapabilityPlan>,
+    ) -> crate::harness::HarnessDeps {
+        crate::harness::HarnessDeps {
+            provider: Arc::new(crate::harness::provider::MockProvider::default()),
+            provider_slug: "mock".to_string(),
+            context: runtime.context.clone(),
+            store: runtime.store.clone(),
+            meter,
+            workspace_root: std::env::temp_dir(),
+            audit_root: std::env::temp_dir(),
+            model_override: None,
+            tasks: None,
+            artifacts: None,
+            skills: None,
+            skills_source_dir: None,
+            skills_registry: Arc::from([]),
+            mcp_servers: Vec::new(),
+            default_mcp_servers: Vec::new(),
+            facts: None,
+            events: None,
+            delegations: crate::harness::orchestrator::DelegationQueue::default(),
+            workflow_runner: crate::harness::orchestrator::WorkflowRunnerHandle::default(),
+            mcp_failures: crate::harness::mcp_probe::McpFailureQueue::default(),
+            pending_publishes: crate::harness::publish::PendingPublishQueue::default(),
+            workflow_refs: crate::harness::workflow_refs::WorkflowRefQueue::default(),
+            run_outputs: crate::harness::orchestrator::RunOutputCache::default(),
+            run_output_store: None,
+            workflow_revisions: None,
+            approval_requests: crate::harness::policy::ApprovalRequestQueue::default(),
+            secrets: None,
+            web_allowed_domains: Vec::new(),
+            capabilities,
+            workflow_source_dir: None,
+            plan,
+            media: None,
+            composio: None,
+            search: None,
+            steer: crate::company::steer::InflightRegistry::default(),
+            run_supervisor: crate::runtime::RunSupervisor::default(),
+            delivery: None,
+            workspace: None,
+            repos: None,
+            repo_bindings: Vec::new(),
+            checkouts: crate::harness::repo::CheckoutLedger::default(),
+        }
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn workflow_wiring_is_absent_without_harness_deps() {
+        let (runtime, record, _home) = runtime_and_record().await;
+        assert_eq!(runtime.wired_workflow_namespaces(&record).await, None);
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn workflow_wiring_keeps_the_static_capability_filter_without_a_plan() {
+        let (mut runtime, record, _home) = runtime_and_record().await;
+        runtime.set_workflow_harness_deps(wiring_deps(
+            &runtime,
+            None,
+            crate::harness::toolbelt::CapabilityFilter::DenyNamespaces(
+                ["web"].into_iter().collect(),
+            ),
+            None,
+        ));
+        let namespaces = runtime
+            .wired_workflow_namespaces(&record)
+            .await
+            .expect("wiring");
+        assert!(!namespaces.contains("web"));
+        assert!(namespaces.contains("shell"));
+    }
+
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn workflow_wiring_resolves_the_plan_against_its_company_meter() {
+        let (mut runtime, record, _home) = runtime_and_record().await;
+        let meter = Arc::new(RecordingMeter::default());
+        runtime.set_workflow_harness_deps(wiring_deps(
+            &runtime,
+            Some(meter.clone()),
+            crate::harness::toolbelt::CapabilityFilter::AllowAll,
+            Some(crate::harness::capability_budget::CapabilityPlan {
+                period: crate::harness::capability_budget::BudgetPeriod::Daily,
+                budgets: [("shell".to_string(), u64::MAX)].into_iter().collect(),
+                total_budget: None,
+            }),
+        ));
+        let namespaces = runtime
+            .wired_workflow_namespaces(&record)
+            .await
+            .expect("wiring");
+        assert!(namespaces.contains("shell"));
+        assert!(!namespaces.contains("web"));
+        assert!(!namespaces.contains("code"));
+        assert_eq!(*meter.queried_companies.lock().unwrap(), vec![record.id]);
+    }
+
     /// Issue #86: the kill switch's boot decision, including the direction it
     /// fails in.
     ///

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -864,8 +864,10 @@ fn validate_tool_call_node(node: &RawNode, record: &CompanyRecord) -> Result<()>
     Ok(())
 }
 
-/// The wired `tool_call` slugs this company can actually reach from a workflow,
-/// for grounding the create-time copilot (issue #753).
+/// The granted `tool_call` slugs this company may author and pass create-time
+/// validation (issue #753). Deployment wiring is intentionally not checked:
+/// author-now-wire-later remains legal, while prompt grounding uses the
+/// effective sibling below.
 ///
 /// It is the exact companion of [`validate_tool_call_node`]'s grant half: a slug
 /// survives here iff that gate would accept it — its namespace covered by
@@ -894,6 +896,50 @@ pub(crate) fn workflow_callable_tool_slugs(record: &CompanyRecord) -> Vec<String
             } else {
                 crate::harness::build::grants_cover(grants, info.namespace)
             }
+        })
+        .map(|info| info.slug.to_string())
+        .collect()
+}
+
+/// The tools the create-time copilot may ground on: catalogue, company grant,
+/// and deployment wiring all agree. Create validation intentionally remains
+/// permissive for a granted-but-unwired tool so an operator may author now and
+/// wire the provider later; this narrower set is prompt grounding only.
+#[cfg(feature = "openhuman")]
+pub(crate) fn workflow_effective_tool_slugs(
+    record: &CompanyRecord,
+    wired: Option<&std::collections::BTreeSet<&'static str>>,
+) -> Vec<String> {
+    let grants = &record.manifest.tools.allow;
+    crate::workflows::caps::WORKFLOW_TOOL_CATALOG
+        .iter()
+        .filter(|info| {
+            let granted = if info.namespace == "search" {
+                crate::company::grants_search_explicit(grants)
+            } else {
+                crate::harness::build::grants_cover(grants, info.namespace)
+            };
+            granted && wired.is_none_or(|namespaces| namespaces.contains(info.namespace))
+        })
+        .map(|info| info.slug.to_string())
+        .collect()
+}
+
+#[cfg(feature = "openhuman")]
+pub(crate) fn workflow_granted_but_unwired_tool_slugs(
+    record: &CompanyRecord,
+    wired: Option<&std::collections::BTreeSet<&'static str>>,
+) -> Vec<String> {
+    let grants = &record.manifest.tools.allow;
+    crate::workflows::caps::WORKFLOW_TOOL_CATALOG
+        .iter()
+        .filter(|info| {
+            let granted = if info.namespace == "search" {
+                crate::company::grants_search_explicit(grants)
+            } else {
+                crate::harness::build::grants_cover(grants, info.namespace)
+            };
+            granted && !wired.is_none_or(|namespaces| namespaces.contains(info.namespace))
         })
         .map(|info| info.slug.to_string())
         .collect()

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -1227,11 +1227,12 @@ fn description_system_prompt() -> String {
 
 /// Renders the company evidence plus the operator's description as the single
 /// user message for a create-time copilot draft (issue #753). The description is
-/// laid out as data (not instructions), and the granted tool slugs are named so
+/// laid out as data (not instructions), and the effective tool slugs are named so
 /// a `tool_call` node the model authors is one courtesy validation will accept.
 fn description_evidence_prompt(
     e: &CompanyEvidence,
-    granted_slugs: &[String],
+    effective_slugs: &[String],
+    granted_but_unwired_slugs: &[String],
     description: &str,
 ) -> String {
     let mut out = String::new();
@@ -1255,10 +1256,10 @@ fn description_evidence_prompt(
         "\n## Tools (a `tool_call` node's `config.slug` must be one of these, exactly; put the \
          tool's arguments under `config.args`)\n",
     );
-    if granted_slugs.is_empty() {
+    if effective_slugs.is_empty() {
         out.push_str("- (no tools granted — do not use a tool_call node)\n");
     }
-    for slug in granted_slugs {
+    for slug in effective_slugs {
         // Ground each slug in its honest capability and required args (issue
         // #813) so the model does not reach for a tool that cannot do what the
         // step needs (a `read_workspace_state` that cannot read a file), or emit
@@ -1273,6 +1274,17 @@ fn description_evidence_prompt(
             }
             None => out.push_str(&format!("- `{slug}`\n")),
         }
+    }
+    out.push_str(
+        "\nAdvisory: granted but not wired on this deployment — do not author these; if the task \
+         needs one, say so.\n",
+    );
+    if granted_but_unwired_slugs.is_empty() {
+        out.push_str("- (none)\n");
+    } else {
+        out.push_str("- ");
+        out.push_str(&granted_but_unwired_slugs.join(", "));
+        out.push('\n');
     }
 
     out.push_str("\n## Workflows that already exist (do not clash with these names)\n");
@@ -1647,14 +1659,22 @@ pub(crate) async fn draft_workflow_from_description(
     };
     let description = cap(description, MAX_DESCRIPTION_CHARS);
     let company = gather_company_evidence(runtime).await?;
-    let granted_slugs = crate::company::workflow_callable_tool_slugs(&company.record);
+    let wired = runtime.wired_workflow_namespaces();
+    let effective_slugs = crate::company::workflow_effective_tool_slugs(&company.record, wired);
+    let granted_but_unwired_slugs =
+        crate::company::workflow_granted_but_unwired_tool_slugs(&company.record, wired);
 
     // A synchronous request mints no attempt row, but its spend is still metered
     // against a fresh id — see the doc. BOTH attempts share this id.
     let run_id = generate_id();
 
     let system = description_system_prompt();
-    let base_user = description_evidence_prompt(&company, &granted_slugs, &description);
+    let base_user = description_evidence_prompt(
+        &company,
+        &effective_slugs,
+        &granted_but_unwired_slugs,
+        &description,
+    );
 
     // The user message for the current attempt: the grounding prompt first, then
     // — on the second attempt — the corrective prompt built from attempt one's

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -1257,7 +1257,7 @@ fn description_evidence_prompt(
          tool's arguments under `config.args`)\n",
     );
     if effective_slugs.is_empty() {
-        out.push_str("- (no tools granted — do not use a tool_call node)\n");
+        out.push_str("- (no callable tools are wired — do not use a tool_call node)\n");
     }
     for slug in effective_slugs {
         // Ground each slug in its honest capability and required args (issue
@@ -1659,10 +1659,11 @@ pub(crate) async fn draft_workflow_from_description(
     };
     let description = cap(description, MAX_DESCRIPTION_CHARS);
     let company = gather_company_evidence(runtime).await?;
-    let wired = runtime.wired_workflow_namespaces();
-    let effective_slugs = crate::company::workflow_effective_tool_slugs(&company.record, wired);
+    let wired = runtime.wired_workflow_namespaces(&company.record).await;
+    let effective_slugs =
+        crate::company::workflow_effective_tool_slugs(&company.record, wired.as_ref());
     let granted_but_unwired_slugs =
-        crate::company::workflow_granted_but_unwired_tool_slugs(&company.record, wired);
+        crate::company::workflow_granted_but_unwired_tool_slugs(&company.record, wired.as_ref());
 
     // A synchronous request mints no attempt row, but its spend is still metered
     // against a fresh id — see the doc. BOTH attempts share this id.

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -22,6 +22,7 @@ use super::*;
 use crate::company::CompanyManifest;
 use crate::ports::runs::{NewRun, RunStatus};
 use crate::ports::types::CompanyId;
+use crate::ports::{UsageMeter, UsageSample};
 
 // ---------------------------------------------------------------------------
 // A scripted model
@@ -142,6 +143,23 @@ allow = ["docs", "web"]
 
 fn manifest() -> CompanyManifest {
     toml::from_str(MANIFEST).expect("the fixture manifest parses")
+}
+
+struct EmptyUsageMeter;
+
+#[async_trait]
+impl UsageMeter for EmptyUsageMeter {
+    async fn record(&self, _company: &CompanyId, _sample: &UsageSample) -> crate::Result<()> {
+        Ok(())
+    }
+
+    async fn query(
+        &self,
+        _company: &CompanyId,
+        _since_millis: u64,
+    ) -> crate::Result<Vec<UsageSample>> {
+        Ok(Vec::new())
+    }
 }
 
 /// A valid answer: a two-node scheduled graph whose agent is on the roster.
@@ -904,11 +922,26 @@ async fn the_description_prompt_excludes_capability_filtered_tools() {
     let company = gather_company_evidence(&runtime).await.unwrap();
     let mut record = company.record.clone();
     record.manifest.tools.allow.push("search".to_string());
-    // This is the resolved result a capability plan supplies to the live
-    // wiring resolver: a plan that filters `web` must remove every web slug
-    // from prompt grounding, even when the company grants the namespace.
-    let capability_filter =
-        crate::harness::toolbelt::CapabilityFilter::DenyNamespaces(["web"].into_iter().collect());
+    // The live resolver reads a plan whose namespace key set is the callable
+    // tier. Omitting `web` must remove every web slug from prompt grounding,
+    // even when the company grants the namespace.
+    let capability_filter = crate::harness::capability_budget::resolve_filter(
+        &crate::harness::capability_budget::CapabilityPlan {
+            period: crate::harness::capability_budget::BudgetPeriod::Daily,
+            budgets: [
+                ("shell".to_string(), u64::MAX),
+                ("code".to_string(), u64::MAX),
+                ("search".to_string(), u64::MAX),
+            ]
+            .into_iter()
+            .collect(),
+            total_budget: None,
+        },
+        Some(&EmptyUsageMeter),
+        &record.id,
+        crate::ports::now_millis(),
+    )
+    .await;
     let wired: std::collections::BTreeSet<&'static str> =
         crate::workflows::caps::WORKFLOW_TOOL_NAMESPACES
             .into_iter()

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -853,7 +853,7 @@ async fn the_description_prompt_renders_the_company_state_verbatim() {
     let slugs = crate::company::workflow_callable_tool_slugs(&company.record);
 
     let description = "email the weekly digest every Monday morning";
-    let prompt = description_evidence_prompt(&company, &slugs, description);
+    let prompt = description_evidence_prompt(&company, &slugs, &[], description);
     assert!(
         prompt.contains(description),
         "the description appears verbatim"
@@ -898,6 +898,27 @@ async fn the_description_prompt_renders_the_company_state_verbatim() {
     );
 }
 
+#[tokio::test]
+async fn the_description_prompt_excludes_granted_but_unwired_tools() {
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(DESC_GRAPH)).await;
+    let company = gather_company_evidence(&runtime).await.unwrap();
+    let mut record = company.record.clone();
+    record.manifest.tools.allow.push("search".to_string());
+    let wired: std::collections::BTreeSet<&'static str> =
+        ["shell", "code", "web"].into_iter().collect();
+    let effective = crate::company::workflow_effective_tool_slugs(&record, Some(&wired));
+    let unwired = crate::company::workflow_granted_but_unwired_tool_slugs(&record, Some(&wired));
+    assert!(!effective.iter().any(|slug| slug == "web_search"));
+    assert_eq!(unwired, vec!["web_search".to_string()]);
+
+    let evidence = CompanyEvidence { record, ..company };
+    let prompt = description_evidence_prompt(&evidence, &effective, &unwired, "search the web");
+    assert!(!prompt.contains("web_search —"));
+    assert!(prompt.contains("granted but not wired"));
+    assert!(prompt.contains("web_search"));
+    assert!(prompt.contains("if the task needs one, say so"));
+}
+
 /// A company with no teammates and no granted tools renders the guiding lines
 /// that keep the model from authoring an `agent` or `tool_call` node it cannot
 /// ground.
@@ -912,7 +933,7 @@ async fn the_description_prompt_names_an_empty_roster_and_toolset() {
         existing_ids: HashSet::new(),
         ..base
     };
-    let prompt = description_evidence_prompt(&empty, &[], "do the thing");
+    let prompt = description_evidence_prompt(&empty, &[], &[], "do the thing");
     assert!(prompt.contains("no teammates"), "{prompt}");
     assert!(prompt.contains("no tools granted"), "{prompt}");
     assert!(prompt.contains("(none yet)"), "{prompt}");

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -899,23 +899,38 @@ async fn the_description_prompt_renders_the_company_state_verbatim() {
 }
 
 #[tokio::test]
-async fn the_description_prompt_excludes_granted_but_unwired_tools() {
+async fn the_description_prompt_excludes_capability_filtered_tools() {
     let (_home, runtime) = runtime_with(ScriptedModel::replying(DESC_GRAPH)).await;
     let company = gather_company_evidence(&runtime).await.unwrap();
     let mut record = company.record.clone();
     record.manifest.tools.allow.push("search".to_string());
+    // This is the resolved result a capability plan supplies to the live
+    // wiring resolver: a plan that filters `web` must remove every web slug
+    // from prompt grounding, even when the company grants the namespace.
+    let capability_filter =
+        crate::harness::toolbelt::CapabilityFilter::DenyNamespaces(["web"].into_iter().collect());
     let wired: std::collections::BTreeSet<&'static str> =
-        ["shell", "code", "web"].into_iter().collect();
+        crate::workflows::caps::WORKFLOW_TOOL_NAMESPACES
+            .into_iter()
+            .filter(|namespace| {
+                !matches!(
+                    &capability_filter,
+                    crate::harness::toolbelt::CapabilityFilter::DenyNamespaces(denied)
+                        if denied.contains(namespace)
+                )
+            })
+            .collect();
     let effective = crate::company::workflow_effective_tool_slugs(&record, Some(&wired));
     let unwired = crate::company::workflow_granted_but_unwired_tool_slugs(&record, Some(&wired));
-    assert!(!effective.iter().any(|slug| slug == "web_search"));
-    assert_eq!(unwired, vec!["web_search".to_string()]);
+    assert!(!effective.iter().any(|slug| slug == "web_fetch"));
+    assert!(effective.iter().any(|slug| slug == "web_search"));
+    assert!(unwired.iter().any(|slug| slug == "web_fetch"));
 
     let evidence = CompanyEvidence { record, ..company };
     let prompt = description_evidence_prompt(&evidence, &effective, &unwired, "search the web");
-    assert!(!prompt.contains("web_search —"));
+    assert!(!prompt.contains("web_fetch —"));
     assert!(prompt.contains("granted but not wired"));
-    assert!(prompt.contains("web_search"));
+    assert!(prompt.contains("web_fetch"));
     assert!(prompt.contains("if the task needs one, say so"));
 }
 
@@ -935,7 +950,7 @@ async fn the_description_prompt_names_an_empty_roster_and_toolset() {
     };
     let prompt = description_evidence_prompt(&empty, &[], &[], "do the thing");
     assert!(prompt.contains("no teammates"), "{prompt}");
-    assert!(prompt.contains("no tools granted"), "{prompt}");
+    assert!(prompt.contains("no callable tools are wired"), "{prompt}");
     assert!(prompt.contains("(none yet)"), "{prompt}");
 }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1570,9 +1570,7 @@ impl RuntimeBuilder {
         #[cfg(feature = "openhuman")]
         let mut builder: Option<Arc<crate::harness::workflow_build::WorkflowBuilder>> = None;
         #[cfg(feature = "openhuman")]
-        let mut workflow_wired_namespaces: Option<
-            std::collections::BTreeSet<&'static str>,
-        > = None;
+        let mut workflow_harness_deps: Option<crate::harness::HarnessDeps> = None;
 
         // Load the persisted record BEFORE constructing the brain so the brain's
         // in-memory record carries the operator overlays (team, desk memberships,
@@ -2183,8 +2181,7 @@ impl RuntimeBuilder {
                                 // brain's `CheckoutJanitor`.
                                 checkouts: crate::harness::repo::CheckoutLedger::default(),
                             };
-                            workflow_wired_namespaces =
-                                Some(crate::workflows::caps::wired_workflow_namespaces(&deps));
+                            workflow_harness_deps = Some(deps.clone());
                             let record = CompanyRecord {
                                 id: id.clone(),
                                 manifest: self.manifest.clone(),
@@ -2487,8 +2484,8 @@ impl RuntimeBuilder {
             runtime.set_builder(builder);
         }
         #[cfg(feature = "openhuman")]
-        if let Some(namespaces) = workflow_wired_namespaces {
-            runtime.set_wired_workflow_namespaces(namespaces);
+        if let Some(deps) = workflow_harness_deps {
+            runtime.set_workflow_harness_deps(deps);
         }
 
         // Boot lifecycle step 3: going-public. Best-effort and non-blocking —

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1569,6 +1569,10 @@ impl RuntimeBuilder {
         // way via `CompanyRuntime::set_builder` below.
         #[cfg(feature = "openhuman")]
         let mut builder: Option<Arc<crate::harness::workflow_build::WorkflowBuilder>> = None;
+        #[cfg(feature = "openhuman")]
+        let mut workflow_wired_namespaces: Option<
+            std::collections::BTreeSet<&'static str>,
+        > = None;
 
         // Load the persisted record BEFORE constructing the brain so the brain's
         // in-memory record carries the operator overlays (team, desk memberships,
@@ -2179,6 +2183,8 @@ impl RuntimeBuilder {
                                 // brain's `CheckoutJanitor`.
                                 checkouts: crate::harness::repo::CheckoutLedger::default(),
                             };
+                            workflow_wired_namespaces =
+                                Some(crate::workflows::caps::wired_workflow_namespaces(&deps));
                             let record = CompanyRecord {
                                 id: id.clone(),
                                 manifest: self.manifest.clone(),
@@ -2479,6 +2485,10 @@ impl RuntimeBuilder {
         #[cfg(feature = "openhuman")]
         if let Some(builder) = builder {
             runtime.set_builder(builder);
+        }
+        #[cfg(feature = "openhuman")]
+        if let Some(namespaces) = workflow_wired_namespaces {
+            runtime.set_wired_workflow_namespaces(namespaces);
         }
 
         // Boot lifecycle step 3: going-public. Best-effort and non-blocking —

--- a/src/workflows/caps/dry_run.rs
+++ b/src/workflows/caps/dry_run.rs
@@ -40,6 +40,8 @@ use serde_json::{Value, json};
 use tinyflows::caps::{AgentRunner, HttpClient, ToolInvoker};
 use tinyflows::error::{EngineError, Result as TfResult};
 
+use super::tools::{WorkflowToolWiring, refusal_for};
+
 /// A marker key set on every dry-stub output, so a downstream node (or a test)
 /// can tell a stubbed item from a real one.
 pub(super) const DRY_RUN_MARKER: &str = "dry_run";
@@ -88,12 +90,13 @@ pub(super) struct DryRunTools {
     /// The company's `[tools].allow` grant globs — the same gate the live
     /// invoker applies, reused verbatim.
     grants: Vec<String>,
+    wiring: WorkflowToolWiring,
 }
 
 impl DryRunTools {
     /// Builds a dry invoker gated by the company's `[tools].allow`.
-    pub(super) fn new(grants: Vec<String>) -> Self {
-        Self { grants }
+    pub(super) fn new(grants: Vec<String>, wiring: WorkflowToolWiring) -> Self {
+        Self { grants, wiring }
     }
 }
 
@@ -117,21 +120,8 @@ impl ToolInvoker for DryRunTools {
         // (`WorkflowToolInvoker::invoke`): a dry run must refuse an ungranted
         // tool exactly as a real one does, because that refusal is part of the
         // routing a test run exists to prove. The check is pure — no effect.
-        let Some(namespace) = crate::harness::toolbelt::namespace_of(slug) else {
-            return Err(EngineError::Capability(format!(
-                "tool_call '{slug}' is not a wired workflow tool"
-            )));
-        };
-        let granted = if namespace == "search" {
-            crate::company::grants_search_explicit(&self.grants)
-        } else {
-            crate::harness::build::grants_cover(&self.grants, namespace)
-        };
-        if !granted {
-            return Err(EngineError::Capability(format!(
-                "tool_call '{slug}' (namespace '{namespace}') is not granted by this company's \
-                 [tools].allow"
-            )));
+        if let Some(message) = refusal_for(slug, &self.grants, &self.wiring) {
+            return Err(EngineError::Capability(message));
         }
         tracing::debug!(slug, "workflow dry run: stubbing tool_call (not executed)");
         Ok(json!({
@@ -181,7 +171,13 @@ mod tests {
     #[tokio::test]
     async fn dry_tools_keep_the_grant_gate_but_do_not_execute() {
         // No `code` grant → a `code`-namespace slug is refused, exactly as live.
-        let ungranted = DryRunTools::new(vec!["web.*".to_string()]);
+        let ungranted = DryRunTools::new(
+            vec!["web.*".to_string()],
+            WorkflowToolWiring {
+                wired_namespaces: ["web"].into_iter().collect(),
+                ..WorkflowToolWiring::default()
+            },
+        );
         let denied = ungranted.invoke("csv_export", json!({}), None).await;
         assert!(
             matches!(denied, Err(EngineError::Capability(ref m)) if m.contains("not granted")),
@@ -194,13 +190,42 @@ mod tests {
             "{unwired:?}"
         );
         // A granted slug returns the canned echo — no execution.
-        let granted = DryRunTools::new(vec!["code.*".to_string()]);
+        let granted = DryRunTools::new(
+            vec!["code.*".to_string()],
+            WorkflowToolWiring {
+                wired_namespaces: ["code"].into_iter().collect(),
+                ..WorkflowToolWiring::default()
+            },
+        );
         let echoed = granted
             .invoke("csv_export", json!({ "filename": "x.csv" }), None)
             .await
             .expect("granted dry tool echoes");
         assert_eq!(echoed[DRY_RUN_MARKER], json!(true));
         assert_eq!(echoed["slug"], "csv_export");
+    }
+
+    #[tokio::test]
+    async fn dry_tools_refuse_granted_search_without_a_backend() {
+        let dry = DryRunTools::new(
+            vec!["search".to_string()],
+            WorkflowToolWiring {
+                missing: [(
+                    "search",
+                    super::super::tools::MissingReason::SearchBackendNotConfigured,
+                )]
+                .into_iter()
+                .collect(),
+                ..WorkflowToolWiring::default()
+            },
+        );
+        let refused = dry.invoke("web_search", json!({}), None).await;
+        assert!(
+            matches!(refused, Err(EngineError::Capability(ref message))
+                if message.contains("no managed search backend")
+                    && message.contains("ask the platform operator")),
+            "{refused:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -74,7 +74,10 @@ use self::http::GuardedHttpClient;
 use self::resolver::StoreWorkflowResolver;
 use self::state::{CompanyStateStore, NoopState};
 use self::tools::WorkflowToolInvoker;
-pub(crate) use self::tools::{WORKFLOW_TOOL_CATALOG, WORKFLOW_TOOL_NAMESPACES, workflow_tool_info};
+pub(crate) use self::tools::{
+    WORKFLOW_TOOL_CATALOG, WORKFLOW_TOOL_NAMESPACES, wired_workflow_namespaces, workflow_tool_info,
+    workflow_tool_wiring,
+};
 // `WORKFLOW_TOOL_SLUGS` stays module-private to `tools` since #813: the catalogue
 // (`WORKFLOW_TOOL_CATALOG`) is what callers ground and validate against, and the
 // slug table is now only its in-module pinning cross-check.
@@ -171,6 +174,7 @@ pub async fn build_capabilities(
     // operator's, which is the disagreement `effective_policy` exists to prevent.
     let mode = PolicyMode::parse(&record.effective_policy().mode);
     let grants = record.manifest.tools.allow.clone();
+    let wiring = workflow_tool_wiring(&deps);
 
     // sub_workflow-by-id resolves children from the union of the company's seed
     // `workflows/` directory and the record's runtime-authored bodies — so a
@@ -207,7 +211,7 @@ pub async fn build_capabilities(
             "workflow: building DRY capability bundle — no real effects will run"
         );
         (
-            Arc::new(dry_run::DryRunTools::new(grants)),
+            Arc::new(dry_run::DryRunTools::new(grants, wiring.clone())),
             Arc::new(dry_run::DryRunHttp),
             Arc::new(NoopState),
             Some(Arc::new(dry_run::DryRunAgent)),
@@ -269,6 +273,7 @@ pub async fn build_capabilities(
             &deps.capabilities,
             deps.search.as_ref(),
             search_metering,
+            wiring,
         );
         let http = GuardedHttpClient::new(exec_security, web_allowed_domains);
 

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -623,6 +623,7 @@ mod tests {
             &CapabilityFilter::AllowAll,
             None,
             test_metering(),
+            WorkflowToolWiring::default(),
         );
 
         let recorded = json!({ "status": 201, "id": "abc" });

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -27,7 +27,7 @@
 //! coverage, so `*` never buys a managed search call and the invoke-time gate
 //! matches construction.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -57,6 +57,82 @@ use crate::harness::toolbelt::{self, CapabilityFilter};
 /// slug whose namespace falls outside this set, so a save can't green-light a
 /// slug the run would always fail to look up — keep the two in lockstep.
 pub(crate) const WORKFLOW_TOOL_NAMESPACES: [&str; 4] = ["shell", "code", "web", "search"];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MissingReason {
+    SearchBackendNotConfigured,
+    CapabilityTierFiltered,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct WorkflowToolWiring {
+    pub(crate) wired_namespaces: BTreeSet<&'static str>,
+    pub(crate) missing: BTreeMap<&'static str, MissingReason>,
+}
+
+fn capability_filtered(filter: &CapabilityFilter, namespace: &'static str) -> bool {
+    match filter {
+        CapabilityFilter::AllowAll => false,
+        CapabilityFilter::DenyNamespaces(denied) => denied.contains(namespace),
+    }
+}
+
+pub(crate) fn workflow_tool_wiring(deps: &crate::harness::HarnessDeps) -> WorkflowToolWiring {
+    let mut wiring = WorkflowToolWiring::default();
+    for namespace in WORKFLOW_TOOL_NAMESPACES {
+        let missing = if namespace == "search" && deps.search.is_none() {
+            Some(MissingReason::SearchBackendNotConfigured)
+        } else if capability_filtered(&deps.capabilities, namespace) {
+            Some(MissingReason::CapabilityTierFiltered)
+        } else {
+            None
+        };
+        if let Some(reason) = missing {
+            wiring.missing.insert(namespace, reason);
+        } else {
+            wiring.wired_namespaces.insert(namespace);
+        }
+    }
+    wiring
+}
+
+pub(crate) fn wired_workflow_namespaces(
+    deps: &crate::harness::HarnessDeps,
+) -> BTreeSet<&'static str> {
+    workflow_tool_wiring(deps).wired_namespaces
+}
+
+pub(crate) fn refusal_for(
+    slug: &str,
+    grants: &[String],
+    wiring: &WorkflowToolWiring,
+) -> Option<String> {
+    let Some(namespace) = toolbelt::namespace_of(slug) else {
+        return Some(format!("tool_call '{slug}' is not a wired workflow tool"));
+    };
+    let granted = if namespace == "search" {
+        crate::company::grants_search_explicit(grants)
+    } else {
+        crate::harness::build::grants_cover(grants, namespace)
+    };
+    if !granted {
+        return Some(format!(
+            "tool_call '{slug}' (namespace '{namespace}') is not granted by this company's [tools].allow"
+        ));
+    }
+    match wiring.missing.get(namespace) {
+        Some(MissingReason::SearchBackendNotConfigured) => Some(format!(
+            "tool_call '{slug}' is granted, but no managed search backend is configured on this deployment; ask the platform operator to configure search or remove the node"
+        )),
+        Some(MissingReason::CapabilityTierFiltered) => Some(format!(
+            "tool_call '{slug}' is granted, but the deployment's capability tier filtered it; ask the platform operator to raise the capability tier or remove the node"
+        )),
+        None if !wiring.wired_namespaces.contains(namespace) => Some(format!(
+            "tool_call '{slug}' is not available in company workflows"
+        )),
+        None => None,
+    }
+}
 
 /// The wired workflow-tool slugs, paired with the grant namespace each maps to —
 /// the reverse of [`toolbelt::namespace_of`], restricted to the families
@@ -213,6 +289,7 @@ pub struct WorkflowToolInvoker {
     tools: HashMap<String, Arc<dyn Tool>>,
     /// The company's `[tools].allow` grant globs — the fail-closed gate.
     grants: Vec<String>,
+    wiring: WorkflowToolWiring,
 }
 
 impl WorkflowToolInvoker {
@@ -238,11 +315,14 @@ impl WorkflowToolInvoker {
         filter: &CapabilityFilter,
         search: Option<&SearchBackend>,
         search_metering: SearchMetering,
+        wiring: WorkflowToolWiring,
     ) -> Self {
         // Mirror `build_agent`: do not initialize a tool family (or its audit
         // state) unless the company's grants can invoke that namespace.
         let mut tools: Vec<Box<dyn Tool>> = Vec::new();
-        if crate::harness::build::grants_cover(&grants, "shell") {
+        if crate::harness::build::grants_cover(&grants, "shell")
+            && wiring.wired_namespaces.contains("shell")
+        {
             tools.extend(toolbelt::shell_tools(
                 security.clone(),
                 toolbelt::native_runtime(),
@@ -250,10 +330,14 @@ impl WorkflowToolInvoker {
                 workspace,
             ));
         }
-        if crate::harness::build::grants_cover(&grants, "code") {
+        if crate::harness::build::grants_cover(&grants, "code")
+            && wiring.wired_namespaces.contains("code")
+        {
             tools.extend(toolbelt::code_tools(security.clone(), workspace));
         }
-        if crate::harness::build::grants_cover(&grants, "web") {
+        if crate::harness::build::grants_cover(&grants, "web")
+            && wiring.wired_namespaces.contains("web")
+        {
             tools.extend(toolbelt::web_tools(
                 security,
                 web_allowed_domains,
@@ -266,7 +350,9 @@ impl WorkflowToolInvoker {
         // managed request) AND a managed search backend on the deps. Granted-but-
         // uncredentialed wires nothing and warns, so `web_search` degrades
         // gracefully when no managed credential is configured (fail-closed).
-        if crate::company::grants_search_explicit(&grants) {
+        if crate::company::grants_search_explicit(&grants)
+            && wiring.wired_namespaces.contains("search")
+        {
             match search {
                 Some(backend) => {
                     tools.extend(crate::harness::search::search_tools(
@@ -293,7 +379,11 @@ impl WorkflowToolInvoker {
             .map(|tool| (tool.name().to_string(), Arc::<dyn Tool>::from(tool)))
             .collect();
 
-        Self { tools, grants }
+        Self {
+            tools,
+            grants,
+            wiring,
+        }
     }
 }
 
@@ -320,27 +410,13 @@ impl ToolInvoker for WorkflowToolInvoker {
             return Ok(result);
         }
         // FAIL-CLOSED grant check FIRST, before any lookup or execution.
-        let Some(namespace) = toolbelt::namespace_of(slug) else {
-            return Err(EngineError::Capability(format!(
-                "tool_call '{slug}' is not a wired workflow tool"
-            )));
-        };
+        if let Some(message) = refusal_for(slug, &self.grants, &self.wiring) {
+            return Err(EngineError::Capability(message));
+        }
         // The priced `search` namespace needs an EXPLICIT `search` grant — the
         // catch-all `*` must never confer a managed search call — so this gate
         // matches the construction gate in `new` (and `build::build_agent`).
         // Every other namespace uses the ordinary grant-glob intersection.
-        let granted = if namespace == "search" {
-            crate::company::grants_search_explicit(&self.grants)
-        } else {
-            crate::harness::build::grants_cover(&self.grants, namespace)
-        };
-        if !granted {
-            return Err(EngineError::Capability(format!(
-                "tool_call '{slug}' (namespace '{namespace}') is not granted by this company's \
-                 [tools].allow"
-            )));
-        }
-
         let tool = self.tools.get(slug).ok_or_else(|| {
             EngineError::Capability(format!(
                 "tool_call '{slug}' is not available in company workflows"
@@ -476,6 +552,7 @@ mod tests {
         let invoker = WorkflowToolInvoker {
             tools: HashMap::new(),
             grants: vec!["web.*".to_string()],
+            wiring: WorkflowToolWiring::default(),
         };
         let denied = tokio_test_block_on(invoker.invoke("csv_export", json!({}), None));
         assert!(
@@ -498,6 +575,7 @@ mod tests {
         let wildcard = WorkflowToolInvoker {
             tools: HashMap::new(),
             grants: vec!["*".to_string()],
+            wiring: WorkflowToolWiring::default(),
         };
         let denied = tokio_test_block_on(wildcard.invoke("web_search", json!({}), None));
         assert!(
@@ -509,6 +587,7 @@ mod tests {
         let granted = WorkflowToolInvoker {
             tools: HashMap::new(),
             grants: vec!["search".to_string()],
+            wiring: WorkflowToolWiring::default(),
         };
         let looked_up = tokio_test_block_on(granted.invoke("web_search", json!({}), None));
         assert!(
@@ -569,6 +648,31 @@ mod tests {
     }
 
     #[test]
+    fn granted_search_refusals_name_provider_and_capability_failures() {
+        let provider = WorkflowToolWiring {
+            missing: [("search", MissingReason::SearchBackendNotConfigured)]
+                .into_iter()
+                .collect(),
+            ..WorkflowToolWiring::default()
+        };
+        let provider_message = refusal_for("web_search", &["search".to_string()], &provider)
+            .expect("missing provider refuses");
+        assert!(provider_message.contains("no managed search backend"));
+        assert!(provider_message.contains("ask the platform operator"));
+
+        let tier = WorkflowToolWiring {
+            missing: [("search", MissingReason::CapabilityTierFiltered)]
+                .into_iter()
+                .collect(),
+            ..WorkflowToolWiring::default()
+        };
+        let tier_message = refusal_for("web_search", &["search".to_string()], &tier)
+            .expect("tier filtering refuses");
+        assert!(tier_message.contains("capability tier filtered"));
+        assert!(tier_message.contains("raise the capability tier"));
+    }
+
+    #[test]
     fn construction_only_initializes_granted_tool_families() {
         let dir = tempfile::tempdir().unwrap();
         // A SEPARATE root from the workspace: the audit sink is host-owned and
@@ -589,6 +693,7 @@ mod tests {
             &CapabilityFilter::AllowAll,
             None,
             test_metering(),
+            WorkflowToolWiring::default(),
         );
         assert!(none.tools.is_empty());
 
@@ -601,6 +706,7 @@ mod tests {
             &CapabilityFilter::AllowAll,
             None,
             test_metering(),
+            WorkflowToolWiring::default(),
         );
         assert!(code.tools.contains_key("apply_patch"));
         assert!(code.tools.contains_key("csv_export"));
@@ -632,6 +738,10 @@ mod tests {
             &CapabilityFilter::AllowAll,
             Some(&backend),
             test_metering(),
+            WorkflowToolWiring {
+                wired_namespaces: WORKFLOW_TOOL_NAMESPACES.into_iter().collect(),
+                missing: BTreeMap::new(),
+            },
         );
         assert!(wired.tools.contains_key("web_search"));
 
@@ -645,6 +755,10 @@ mod tests {
             &CapabilityFilter::AllowAll,
             Some(&backend),
             test_metering(),
+            WorkflowToolWiring {
+                wired_namespaces: WORKFLOW_TOOL_NAMESPACES.into_iter().collect(),
+                missing: BTreeMap::new(),
+            },
         );
         assert!(!wildcard.tools.contains_key("web_search"));
 
@@ -658,8 +772,47 @@ mod tests {
             &CapabilityFilter::AllowAll,
             None,
             test_metering(),
+            WorkflowToolWiring {
+                wired_namespaces: WORKFLOW_TOOL_NAMESPACES.into_iter().collect(),
+                missing: BTreeMap::new(),
+            },
         );
         assert!(!uncredentialed.tools.contains_key("web_search"));
+    }
+
+    #[test]
+    fn wiring_namespaces_match_constructed_tool_namespaces() {
+        let dir = tempfile::tempdir().unwrap();
+        let audit = tempfile::tempdir().unwrap();
+        let security = Arc::new(toolbelt::exec_security(
+            dir.path(),
+            crate::harness::policy::PolicyMode::Supervised,
+        ));
+        let wiring = WorkflowToolWiring {
+            wired_namespaces: WORKFLOW_TOOL_NAMESPACES.into_iter().collect(),
+            missing: BTreeMap::new(),
+        };
+        let invoker = WorkflowToolInvoker::new(
+            security,
+            dir.path(),
+            audit.path(),
+            Vec::new(),
+            vec!["*".to_string(), "search".to_string()],
+            &CapabilityFilter::AllowAll,
+            Some(&SearchBackend::new(
+                "https://api.example.test".to_string(),
+                crate::company::credentials::Credential::from_value("managed"),
+                5,
+            )),
+            test_metering(),
+            wiring.clone(),
+        );
+        let constructed: BTreeSet<&str> = invoker
+            .tools
+            .keys()
+            .filter_map(|slug| toolbelt::namespace_of(slug))
+            .collect();
+        assert_eq!(constructed, wiring.wired_namespaces);
     }
 
     /// A throwaway [`SearchMetering`] for the construction tests — the tool is

--- a/src/workflows/caps/tools.rs
+++ b/src/workflows/caps/tools.rs
@@ -706,7 +706,10 @@ mod tests {
             &CapabilityFilter::AllowAll,
             None,
             test_metering(),
-            WorkflowToolWiring::default(),
+            WorkflowToolWiring {
+                wired_namespaces: ["code"].into_iter().collect(),
+                ..WorkflowToolWiring::default()
+            },
         );
         assert!(code.tools.contains_key("apply_patch"));
         assert!(code.tools.contains_key("csv_export"));


### PR DESCRIPTION
## Summary

A company's `[tools].allow` says what a workflow is *permitted* to reach. It does not say
what this deployment can actually *wire*: `search` needs a managed backend, and any
namespace can be removed by the deployment's capability tier. The gap between granted and
wired is where this bug lives.

Before this change the two sides disagreed:

- **The live invoker** knew about wiring and refused correctly at run time.
- **The dry run** carried its own copy of the refusal logic that checked grants only, so a
  granted-but-unwired tool — `web_search` on a deployment with no search backend —
  **passed the dry run and then failed the real run**. The dry run exists to tell an author
  that in advance, so this was the one answer it must never get wrong.
- **The create-time copilot** grounded its prompt on the granted catalogue, so it would
  happily propose a `web_search` node on a deployment that cannot run one.

This PR makes the *effective* set — granted ∩ wired — the single thing every surface reads.

- `WorkflowToolWiring` becomes the shared model of what this deployment wires, with a
  `MissingReason` per namespace (`SearchBackendNotConfigured` / `CapabilityTierFiltered`).
- `refusal_for` is the one refusal path, and the dry run now calls it instead of
  reimplementing it. Distinct refusals per cause, so an author is told *which* thing to ask
  the platform operator for rather than a flat "not available".
- Workflow creation intersects the catalogue with the effective set, while keeping create
  validation permissive where it already was.
- The copilot grounds its prompt on the effective set and emits a granted-but-unwired
  advisory, so a tool the deployment cannot run is neither silently proposed nor silently
  dropped.

Sharing one refusal path is the point. Two copies of a rule that must agree is what produced
the defect, and a test that pins them together is what keeps it fixed —
`wiring_namespaces_match_constructed_tool_namespaces` fails if the wiring model and the
tools actually constructed drift apart.

## API Or Behavior Changes

No route, schema, or wire-format change. No frontend change.

Behaviour that changes, all in the direction of refusing earlier and saying why:

- A dry run of a granted-but-unwired `tool_call` now **fails** where it previously
  succeeded. This is the fix: the run was always going to fail, and the dry run's job is to
  say so first.
- Refusal messages now name the cause and the remedy — a missing managed search backend and
  a capability-tier filter read differently, and both point at the platform operator.
- The create-time copilot no longer proposes tools this deployment cannot wire, and reports
  granted-but-unwired ones as an advisory.

## Tests

Counts read rather than exit codes — a filter that selects nothing exits 0.

- `cargo test --locked` — **2335 passed, 0 failed**
- `RUST_MIN_STACK=33554432 cargo test --locked --features openhuman,tinycortex --tests` —
  **3590 passed, 0 failed**, every integration target non-zero
- Focused: `--features openhuman,tinycortex --lib workflows::caps` — **55 passed, 0 failed**
- `cargo fmt --all -- --check` clean; `cargo clippy --locked --all-targets -- -D warnings`
  clean; `cargo clippy --locked --no-deps --features openhuman,mcp,telegram --all-targets
  -- -D warnings` clean
- `scripts/ci/assert-feature-lanes.sh` and `scripts/ci/assert-integration-targets-run.sh`
  both green

**Teeth, proved by mutation rather than asserted.** Making `refusal_for` return `None` for
every granted tool — i.e. pretending everything granted is wired — turns the suite red:

```
---- workflows::caps::dry_run::tests::dry_tools_refuse_granted_search_without_a_backend stdout ----
thread '…' panicked at src/workflows/caps/dry_run.rs:210:9

---- workflows::caps::tools::tests::granted_search_refusals_name_provider_and_capability_failures stdout ----
thread '…' panicked at src/workflows/caps/tools.rs:597:14

test result: FAILED. 53 passed; 2 failed
```

The first is the reported defect exactly: without the wiring check, a granted-but-unwired
`web_search` dry-runs clean. The mutation was reverted and the suite re-run green (55/0).

**Note on where these tests run.** Everything added here is behind `openhuman`, so
`Check (--all-features)` compiles it and would execute none of it. The gated
`Rust (openhuman, tinycortex)` lane runs `--tests`, which includes the lib's unit tests, so
these are executed in CI — verified by running that exact invocation, and by
`assert-feature-lanes.sh` reporting 0 features owed a lane.

## Documentation

Module docs on `src/workflows/caps/tools.rs` describe the wiring model and why the refusal
path is shared. No public API, route, or launcher behaviour changed.

Part of #840


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workflow tools now reflect both granted permissions and actual deployment wiring.
  * Workflow creation distinguishes available tools from granted tools that are not yet connected.
  * Tool availability accounts for configured backends and capability restrictions.
  * Runtime configuration now determines which workflow tool namespaces are available.

* **Bug Fixes**
  * Improved handling of unavailable, ungranted, or unsupported tool requests.
  * Search requests are clearly refused when no managed search backend is configured.
  * Workflow guidance identifies tools that are granted but unavailable for use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->