### PR TITLE
fix(workflows): bound what a fan-in hands an agent turn (#849)

### DIFF
--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -130,6 +130,51 @@ Every new field carries `#[serde(default)]`. `CompanyEvent::WorkflowRunFinished`
 is replayed at boot, so a field without one makes every pre-existing journal
 line fail to parse — silent history loss, not a compile error.
 
+## What an `agent` node receives from upstream, and its bound
+
+`translate()` binds `input = "=items"` on every `agent` node, so a node's turn
+carries the resolved output of **every** direct predecessor — that is what makes
+a fan-in (`gather N sources → rank them`) deliver all N rather than the first.
+The fold happens in
+[`src/workflows/caps/mod.rs`](../../../src/workflows/caps/mod.rs), under the
+heading `## Input from the previous step`.
+
+That fold is **bounded**
+([`src/workflows/caps/upstream.rs`](../../../src/workflows/caps/upstream.rs)).
+One agent node's turn carries at most `DEFAULT_UPSTREAM_BUDGET_CHARS` (32,000)
+characters of upstream text, and the budget is divided max-min fairly across the
+predecessors — a short source is served in full and the large ones split what is
+left, so one enormous source cannot crowd its siblings out. A model that
+advertises an input window may lower that budget for its own size; it may never
+raise it, because the advertised figure describes the model rather than the turn
+and says nothing about the system prompt, the tool schemas or the teammate's
+session history sharing the same window.
+
+Three properties are contractual:
+
+- **The bound is at the join, not at the producer.** A cap on a `tool_call`
+  node's own output would bound each fetch separately and still let three
+  bounded fetches sum to an oversized turn, and it would miss the other
+  producers — an upstream `agent` reply and a `transform` payload are unbounded
+  in exactly the same way. One rule at the join covers a single 500KB
+  `web_fetch` and a three-way fan-in alike.
+- **Truncation is never silent.** Each cut source carries a
+  `[TRUNCATED BY OPENCOMPANY — source i of n …]` marker in the turn, so the
+  agent knows it is holding a fragment, and the run carries an operator notice
+  on
+  [`WorkflowRun::notices`](../../../src/ports/workflow_runner.rs) naming how much arrived, how much
+  fitted and what to do instead.
+- **A bounded turn is not a failed run.** The upstream work is already paid for
+  by the time the fold happens, so an oversized input truncates and reports
+  rather than failing the node and discarding that work.
+
+A provider that refuses a turn on its context window anyway — the remaining
+causes are the node's own instruction, its tool schemas, or the teammate's
+accumulated session history — has its error rewritten before it reaches the run,
+because the vendor wording ("the conversation is too long … please start a new
+chat") describes a chat product: a workflow step has no conversation an operator
+owns and no chat for them to start.
+
 ## The engine-only kinds OpenCompany rejects
 
 The engine catalog carries four kinds the parser does **not** accept:

--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -141,14 +141,26 @@ heading `## Input from the previous step`.
 
 That fold is **bounded**
 ([`src/workflows/caps/upstream.rs`](../../../src/workflows/caps/upstream.rs)).
-One agent node's turn carries at most `DEFAULT_UPSTREAM_BUDGET_CHARS` (32,000)
-characters of upstream text, and the budget is divided max-min fairly across the
-predecessors — a short source is served in full and the large ones split what is
-left, so one enormous source cannot crowd its siblings out. A model that
-advertises an input window may lower that budget for its own size; it may never
-raise it, because the advertised figure describes the model rather than the turn
-and says nothing about the system prompt, the tool schemas or the teammate's
-session history sharing the same window.
+The section one agent node's turn carries is never longer than
+`DEFAULT_UPSTREAM_BUDGET_CHARS` (32,000) characters — **including every
+truncation marker and separator**, not merely the source text inside them. The
+budget is divided max-min fairly across the predecessors, so a short source is
+served in full and the large ones split what is left and cannot crowd it out. A
+model that advertises an input window may lower that budget for its own size; it
+may never raise it, because the advertised figure describes the model rather than
+the turn and says nothing about the system prompt, the tool schemas or the
+teammate's session history sharing the same window.
+
+The accounting is paid for three ways, each where it fits: separators and the
+omitted-sources line are deducted up front; each truncation marker is reserved
+out of the allowance of the source it describes; and predecessors past
+`max_rendered_sources` — the point where each one's fair share falls below a
+readable `MIN_SOURCE_SHARE_CHARS` — are aggregated into a single `[OMITTED BY
+OPENCOMPANY — N of M inputs …]` line rather than rendered as unreadable shards.
+That last cap is what makes per-source markers affordable at all: without it a
+thousand-way fan-in (a `split_out` over a large array is enough) adds a thousand
+markers, which is how the first cut of this bound could emit 243,886 characters
+under a 32,000-character budget.
 
 Three properties are contractual:
 
@@ -158,12 +170,14 @@ Three properties are contractual:
   producers — an upstream `agent` reply and a `transform` payload are unbounded
   in exactly the same way. One rule at the join covers a single 500KB
   `web_fetch` and a three-way fan-in alike.
-- **Truncation is never silent.** Each cut source carries a
-  `[TRUNCATED BY OPENCOMPANY — source i of n …]` marker in the turn, so the
+- **Truncation is never silent, and never unbudgeted.** Each cut source carries
+  a `[TRUNCATED BY OPENCOMPANY — source i of n …]` marker in the turn, so the
   agent knows it is holding a fragment, and the run carries an operator notice
   on
   [`WorkflowRun::notices`](../../../src/ports/workflow_runner.rs) naming how much arrived, how much
-  fitted and what to do instead.
+  fitted, how many inputs were dropped entirely, and what to do instead. The
+  markers are inside the budget they report on — a bound whose own reporting can
+  breach it is not a bound.
 - **A bounded turn is not a failed run.** The upstream work is already paid for
   by the time the fold happens, so an oversized input truncates and reports
   rather than failing the node and discarding that work.

--- a/src/workflows/agent_upstream_input_test.rs
+++ b/src/workflows/agent_upstream_input_test.rs
@@ -279,3 +279,184 @@ to = "b"
         "the second predecessor's output must too — a fan-in must not lose all but the first: {b_turn}"
     );
 }
+
+// ── Issue #849: and it must be *bounded* on the way in ──
+
+/// How many characters each upstream node in [`the_fan_in_turn_is_bounded`]
+/// replies with. Comfortably over
+/// [`DEFAULT_UPSTREAM_BUDGET_CHARS`](crate::workflows::caps::DEFAULT_UPSTREAM_BUDGET_CHARS)
+/// once summed, and synthetic on purpose: the reported failure is intermittent
+/// *because* it depended on how much text a live sports section happened to
+/// return that minute, so a test that fetched a real page would be the same coin
+/// flip.
+const OVERSIZED_REPLY_CHARS: usize = 60_000;
+
+/// A model endpoint whose upstream nodes reply with an oversized payload, so the
+/// downstream fan-in turn is handed far more than a turn can carry.
+///
+/// Same content-aware shape as [`spawn_endpoint`] — the answer is a function of
+/// which node is calling, never of position in a script — so sibling branches may
+/// run in any order.
+async fn spawn_oversized_endpoint() -> (String, Arc<Endpoint>) {
+    let endpoint = Arc::new(Endpoint {
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&endpoint);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let endpoint = Arc::clone(&endpoint);
+            async move {
+                let blob = serde_json::to_string(&body).unwrap_or_default();
+                endpoint.seen.lock().unwrap().push(body);
+                // Each upstream node returns a payload led by its own marker, so
+                // the downstream turn can be checked for the presence of ALL of
+                // them — a bound that silently dropped a whole source would pass
+                // a size assertion and fail here.
+                let content = ["NODE_A_PROMPT", "NODE_A2_PROMPT"]
+                    .iter()
+                    .find(|marker| blob.contains(**marker))
+                    .map(|marker| {
+                        let lead = format!("{}_OUTPUT_MARKER ", marker.trim_end_matches("_PROMPT"));
+                        format!(
+                            "{lead}{}",
+                            "x".repeat(OVERSIZED_REPLY_CHARS.saturating_sub(lead.len()))
+                        )
+                    })
+                    .unwrap_or_else(|| "B_INERT_REPLY".to_string());
+                Json(json!({
+                    "choices": [{
+                        "index": 0,
+                        "message": { "role": "assistant", "content": content }
+                    }],
+                    "usage": { "prompt_tokens": 8, "completion_tokens": 2 }
+                }))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), handle)
+}
+
+/// The issue's shape, end to end: two upstream nodes each produce far more text
+/// than a turn can carry, they fan in to one agent, and that agent's turn must
+/// be **bounded** — with every source still represented, every cut marked in the
+/// turn, and the operator told on the run.
+///
+/// The graph, the translation, the runner, the pool and the fold are all real;
+/// only the model is stubbed. Before #849 the downstream turn carried both
+/// payloads verbatim, which is what intermittently earned a provider
+/// `CONTEXT_LENGTH_EXCEEDED` — after the upstream work was already paid for.
+#[tokio::test]
+async fn a_fan_in_turn_is_bounded_and_the_run_says_so() {
+    const GRAPH: &str = r#"
+id = "fanin-big"
+name = "Fan-in (oversized)"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "a"
+kind = "agent"
+name = "A"
+summary = "NODE_A_PROMPT"
+agent = "research_a"
+[[node]]
+id = "a2"
+kind = "agent"
+name = "A2"
+summary = "NODE_A2_PROMPT"
+agent = "research_b"
+[[node]]
+id = "combine"
+kind = "merge"
+name = "Combine"
+[[node]]
+id = "b"
+kind = "agent"
+name = "B"
+summary = "NODE_B_PROMPT"
+agent = "editor"
+[[edge]]
+from = "start"
+to = "a"
+[[edge]]
+from = "start"
+to = "a2"
+[[edge]]
+from = "a"
+to = "combine"
+[[edge]]
+from = "a2"
+to = "combine"
+[[edge]]
+from = "combine"
+to = "b"
+"#;
+
+    let dir = tempfile::tempdir().unwrap();
+    let (base_url, endpoint) = spawn_oversized_endpoint().await;
+    let (deps, _journal) = deps(base_url, dir.path());
+    let record = record_with_agents(&["research_a", "research_b", "editor"]);
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(GRAPH).expect("graph parses");
+    let run = super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        json!({ "request": "rank today's stories" }),
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("the fan-in still runs to completion — a bounded turn is not a failed one");
+
+    let seen = endpoint.seen.lock().unwrap().clone();
+    let b_turn = turn_containing(&seen, "NODE_B_PROMPT");
+
+    // Bounded. The two replies alone are 120k characters; what reaches the turn
+    // must be a small multiple of the budget, not a function of what upstream
+    // produced. The generous slack covers the rest of the request body — the
+    // system prompt, the tool schemas and the JSON framing all ride in this blob
+    // — because the assertion under test is "the payload no longer scales with
+    // the sources", not an exact size.
+    let budget = crate::workflows::caps::DEFAULT_UPSTREAM_BUDGET_CHARS;
+    assert!(
+        b_turn.chars().count() < budget * 2,
+        "the fan-in turn must not carry both payloads whole: {} characters for a {budget}-character \
+         budget",
+        b_turn.chars().count()
+    );
+
+    // Every source is still represented — a bound that drops a whole source is
+    // the #782 regression wearing a different hat.
+    for marker in ["NODE_A_OUTPUT_MARKER", "NODE_A2_OUTPUT_MARKER"] {
+        assert!(
+            b_turn.contains(marker),
+            "{marker} was lost entirely rather than truncated: {}",
+            &b_turn[..b_turn.len().min(2_000)]
+        );
+    }
+
+    // Visible to the agent…
+    assert!(
+        b_turn.contains("TRUNCATED BY OPENCOMPANY"),
+        "a truncated turn must say so to the agent reading it"
+    );
+
+    // …and to the operator, on the run itself rather than in a host log.
+    assert!(
+        run.notices
+            .iter()
+            .any(|notice| notice.contains("truncated") && notice.contains("summarise each one")),
+        "the run must carry an operator notice naming the truncation and the remedy: {:?}",
+        run.notices
+    );
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -54,6 +54,9 @@ mod http;
 mod resolver;
 mod state;
 mod tools;
+/// Issue #849: how much upstream output one agent node's turn may carry, and
+/// what to say when a provider refuses the turn on its context window anyway.
+mod upstream;
 
 use std::sync::Arc;
 
@@ -78,6 +81,13 @@ pub(crate) use self::tools::{
     WORKFLOW_TOOL_CATALOG, WORKFLOW_TOOL_NAMESPACES, wired_workflow_namespaces, workflow_tool_info,
     workflow_tool_wiring,
 };
+/// Issue #849: the ceiling on what one agent node's turn carries from upstream.
+/// Re-exported so the end-to-end fan-in proof
+/// ([`agent_upstream_input_test`](crate::workflows::agent_upstream_input_test))
+/// asserts against the shipped number rather than a copy of it — which is the
+/// only caller outside this module, hence the `cfg`.
+#[cfg(test)]
+pub(crate) use self::upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
 // `WORKFLOW_TOOL_SLUGS` stays module-private to `tools` since #813: the catalogue
 // (`WORKFLOW_TOOL_CATALOG`) is what callers ground and validate against, and the
 // slug table is now only its in-module pinning cross-check.
@@ -1056,7 +1066,32 @@ impl AgentRunner for HarnessAgentRunner {
         // dropped (a `agent -> agent` pipeline's second teammate saw nothing).
         // The static `prompt` still leads (`message_from_request`); the upstream
         // input is appended under a labelled heading, then the #154 run topic.
-        let instruction = append_upstream_input(&message_from_request(&request), &request);
+        //
+        // Issue #849: bounded on the way in. Nothing used to limit what a fan-in
+        // folded here, so three `web_fetch` payloads were concatenated verbatim
+        // and the turn intermittently died on a provider context-window 400 —
+        // after the fetches were already paid for. The budget is applied before
+        // the request is composed, so the boundary is decided by us rather than
+        // discovered by the provider.
+        let budget = upstream::budget_chars(
+            self.deps
+                .provider
+                .profile()
+                .and_then(|profile| profile.max_input_tokens),
+        );
+        let (instruction, upstream_report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+        if let Some(notice) = upstream_report.notice() {
+            tracing::warn!(
+                company = %self.company,
+                workflow = %self.workflow_id,
+                run_id = %self.run_id,
+                agent = agent_ref,
+                budget,
+                "workflow agent node: upstream input exceeded this step's budget and was truncated"
+            );
+            self.notices.push(notice);
+        }
         let message = compose_turn_message(&instruction, self.run_request.as_deref());
         // Issue #881: which node this is. `translate` writes it in the
         // first-class config layer beside `agent_ref` (config cannot shadow
@@ -1132,8 +1167,17 @@ impl AgentRunner for HarnessAgentRunner {
             (outcome, parked)
         });
         let (outcome, parked) = self.board_claim.scoped(turn).await;
-        let outcome = outcome
-            .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
+        // Issue #849: a provider context-window refusal reaches the operator as
+        // the run's error text, and the vendor's own wording ("Please start a
+        // new chat") is unfollowable in a workflow — there is no chat and no
+        // button. Rewrite that one class into what is actually too big and what
+        // to do about it, keeping the provider's words at the end. Every other
+        // failure passes through exactly as before.
+        let outcome = outcome.map_err(|e| {
+            let raw = e.to_string();
+            let reported = upstream::context_overflow_advice(&raw).unwrap_or(raw);
+            EngineError::Capability(format!("harness agent '{agent_ref}': {reported}"))
+        })?;
 
         // ── Issue #881: a node whose deliverable was parked is BLOCKED ───────
         //
@@ -1267,20 +1311,37 @@ const UPSTREAM_INPUT_HEADING: &str = "## Input from the previous step";
 /// A single-agent workflow with no predecessor therefore composes exactly the
 /// message it did before #782, never a dangling empty heading. `message` shape is
 /// then decided by [`compose_turn_message`] alone, as before.
-fn append_upstream_input(instruction: &str, request: &Value) -> String {
-    let Some(section) = request.get("input").and_then(render_upstream_input) else {
-        return instruction.to_string();
+///
+/// # Bounded (issue #849)
+///
+/// `budget` is the most upstream text this turn may carry, and it is enforced
+/// here rather than discovered by the provider. The returned
+/// [`UpstreamReport`](upstream::UpstreamReport) says what the budget did — it is
+/// empty of truncations for nearly every run, and the caller raises an operator
+/// notice only when it is not.
+fn append_upstream_input(
+    instruction: &str,
+    request: &Value,
+    budget: usize,
+) -> (String, upstream::UpstreamReport) {
+    let Some((section, report)) = request
+        .get("input")
+        .and_then(|input| render_upstream_input(input, budget))
+    else {
+        return (instruction.to_string(), upstream::UpstreamReport::default());
     };
     let instruction = instruction.trim_end();
-    if instruction.is_empty() {
+    let folded = if instruction.is_empty() {
         format!("{UPSTREAM_INPUT_HEADING}\n{section}")
     } else {
         format!("{instruction}\n\n{UPSTREAM_INPUT_HEADING}\n{section}")
-    }
+    };
+    (folded, report)
 }
 
 /// Renders the upstream envelope(s) an agent node received (`request["input"]`,
-/// the resolved `=items` set) into the text the agent reads.
+/// the resolved `=items` set) into the text the agent reads, bounded to `budget`
+/// characters in total (issue #849).
 ///
 /// Each predecessor item is a stable `{ json, text, raw }` envelope (see the
 /// tinyflows `envelope` module), so the human-readable `text` (an upstream
@@ -1289,16 +1350,59 @@ fn append_upstream_input(instruction: &str, request: &Value) -> String {
 /// Multiple predecessors — a fan-in (`merge -> agent`) or several edges into one
 /// agent — are all rendered, separated by a rule, so none is lost.
 ///
+/// # Why the bound lives here and not at the `tool_call` node's own output
+///
+/// This is the **join**, and it is the only place the whole set is visible at
+/// once. A cap at a `tool_call` node's output would bound each fetch separately
+/// and still let three bounded fetches sum to an oversized turn, and it would
+/// have to spend its cap blind to how many siblings were about to arrive. It
+/// would also miss every other producer — an upstream *agent* node's reply is
+/// unbounded in exactly the same way, and a `transform` node can manufacture a
+/// large payload from a small one. Bounding at the join covers a single enormous
+/// `web_fetch` and a three-way fan-in with one rule: the same
+/// [`allocate_fairly`](upstream::allocate_fairly) call handles one source and N.
+///
 /// Returns `None` when nothing is renderable — an empty set, all-`null` items, or
 /// empty containers — which is what keeps the no-upstream path byte-identical.
-fn render_upstream_input(input: &Value) -> Option<String> {
+fn render_upstream_input(
+    input: &Value,
+    budget: usize,
+) -> Option<(String, upstream::UpstreamReport)> {
     let items: Vec<&Value> = match input {
         Value::Array(items) => items.iter().collect(),
         Value::Null => return None,
         other => vec![other],
     };
     let rendered: Vec<String> = items.into_iter().filter_map(render_upstream_item).collect();
-    (!rendered.is_empty()).then(|| rendered.join("\n\n---\n\n"))
+    if rendered.is_empty() {
+        return None;
+    }
+
+    let sizes: Vec<usize> = rendered.iter().map(|text| text.chars().count()).collect();
+    let allowances = upstream::allocate_fairly(&sizes, budget);
+    let of = rendered.len();
+    let mut sources = Vec::with_capacity(of);
+    let mut sections = Vec::with_capacity(of);
+    for (index, (text, (&produced, &kept))) in rendered
+        .iter()
+        .zip(sizes.iter().zip(allowances.iter()))
+        .enumerate()
+    {
+        sources.push(upstream::SourceBudget { produced, kept });
+        if kept >= produced {
+            sections.push(text.clone());
+            continue;
+        }
+        // Cut, and say so in the turn itself: an agent that cannot tell it is
+        // holding a fragment will present the fragment as the whole source.
+        let mut section = upstream::truncate_chars(text, kept);
+        section.push_str(&upstream::truncation_marker(index + 1, of, produced, kept));
+        sections.push(section);
+    }
+    Some((
+        sections.join("\n\n---\n\n"),
+        upstream::UpstreamReport { sources, budget },
+    ))
 }
 
 /// Renders one upstream item into the text an agent reads.
@@ -1709,6 +1813,19 @@ mod tests {
 
     // ── Issue #782: the upstream node's output reaches the next agent's turn ──
 
+    /// [`append_upstream_input`] under the shipped budget, keeping the #782
+    /// tests reading about *what reaches the turn* rather than about the #849
+    /// budget they are all far below. The truncation report those calls discard
+    /// has its own tests below.
+    fn folded(request: &Value) -> String {
+        append_upstream_input(
+            &message_from_request(request),
+            request,
+            upstream::DEFAULT_UPSTREAM_BUDGET_CHARS,
+        )
+        .0
+    }
+
     /// The headline. An `agent -> agent` pipeline's second teammate must receive
     /// the first's output. `translate` binds `input = "=items"`, the engine
     /// resolves it to the predecessor envelope, and this proves the runner folds
@@ -1722,7 +1839,7 @@ mod tests {
             "prompt": "Write the launch post.",
             "input": [{ "json": {}, "text": "The analyst found a 20% MoM jump.", "raw": {} }],
         });
-        let message = append_upstream_input(&message_from_request(&request), &request);
+        let message = folded(&request);
         // The node's own instruction still leads.
         assert!(message.starts_with("Write the launch post."), "{message}");
         // …the upstream output is present, under its heading…
@@ -1746,7 +1863,7 @@ mod tests {
                 { "json": {}, "text": "Predecessor B: sentiment is positive.", "raw": {} },
             ],
         });
-        let message = append_upstream_input(&message_from_request(&request), &request);
+        let message = folded(&request);
         assert!(
             message.contains("Predecessor A: market is up."),
             "first predecessor missing: {message}"
@@ -1766,7 +1883,7 @@ mod tests {
             "prompt": "Summarise the fetch.",
             "input": [{ "json": { "rows": 3 }, "text": null, "raw": { "rows": 3 } }],
         });
-        let message = append_upstream_input(&message_from_request(&request), &request);
+        let message = folded(&request);
         assert!(message.contains(UPSTREAM_INPUT_HEADING), "{message}");
         assert!(
             message.contains("\"rows\""),
@@ -1795,13 +1912,13 @@ mod tests {
             }
             let request = Value::Object(request);
             assert_eq!(
-                append_upstream_input(&message_from_request(&request), &request),
+                folded(&request),
                 base,
                 "input {input:?} must not alter the message or add an empty heading"
             );
             // And the whole composition (including the #154 run topic) is
             // unchanged from what `compose_turn_message` alone would produce.
-            let instruction = append_upstream_input(&message_from_request(&request), &request);
+            let instruction = folded(&request);
             assert_eq!(
                 compose_turn_message(&instruction, Some("ship dark mode")),
                 compose_turn_message(base, Some("ship dark mode")),
@@ -1819,13 +1936,207 @@ mod tests {
             "prompt": "Write the post.",
             "input": [{ "json": {}, "text": "ANALYST_SAID_THIS", "raw": {} }],
         });
-        let instruction = append_upstream_input(&message_from_request(&request), &request);
+        let instruction = folded(&request);
         let message = compose_turn_message(&instruction, Some("dark mode launch"));
         assert!(message.starts_with("Write the post."), "{message}");
         assert!(message.contains(UPSTREAM_INPUT_HEADING), "{message}");
         assert!(message.contains("ANALYST_SAID_THIS"), "{message}");
         assert!(message.contains("Request for this run:"), "{message}");
         assert!(message.contains("dark mode launch"), "{message}");
+    }
+
+    // ── Issue #849: nothing may hand an agent node an unbounded payload ──
+    //
+    // Driven by synthetic oversized payloads, never by a live page: the reported
+    // failure is intermittent *because* it depends on how much text a sports
+    // section happened to return that minute, so a test that reproduced it that
+    // way would be a coin flip too.
+
+    /// One predecessor envelope carrying `chars` characters of page-like text —
+    /// the shape a `web_fetch` `tool_call` node emits (its non-JSON output is
+    /// wrapped as `{"text": …}`, which the tinyflows envelope lifts to `text`).
+    fn source_envelope(marker: &str, chars: usize) -> Value {
+        let body = format!("{marker}{}", "x".repeat(chars.saturating_sub(marker.len())));
+        json!({ "json": { "text": body.clone() }, "text": body, "raw": { "text": body } })
+    }
+
+    /// How much slack above the budget the markers, the heading and the section
+    /// rules are allowed to add. They sit **outside** the budget deliberately —
+    /// the budget exists to bound upstream *text*, and letting our own accounting
+    /// compete for room would mean the truncation marker could itself be the
+    /// thing squeezed out (the reasoning `memory_loop`'s skipped-hit marker
+    /// arrived at first).
+    const MARKER_SLACK: usize = 2_000;
+
+    /// The reported shape: three fetched sources fan in to one ranking agent.
+    /// Every source must still be represented, the turn must be bounded, and
+    /// every cut must be visible.
+    #[test]
+    fn a_three_way_fan_in_is_bounded_and_no_source_is_lost() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let request = json!({
+            "prompt": "Rank today's stories.",
+            "input": [
+                source_envelope("SOURCE_ONE", 200_000),
+                source_envelope("SOURCE_TWO", 200_000),
+                source_envelope("SOURCE_THREE", 200_000),
+            ],
+        });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        assert!(
+            message.chars().count() <= budget + MARKER_SLACK,
+            "600k characters of upstream input must not reach a turn: {} characters",
+            message.chars().count()
+        );
+        // …and every source is still *there*, which is what separates a bound
+        // from "drop everything after the first".
+        for marker in ["SOURCE_ONE", "SOURCE_TWO", "SOURCE_THREE"] {
+            assert!(message.contains(marker), "{marker} was lost entirely");
+        }
+        // Each cut is visible to the agent.
+        assert_eq!(
+            message.matches("TRUNCATED BY OPENCOMPANY").count(),
+            3,
+            "every truncated source carries its own marker: {message}"
+        );
+        assert!(message.contains("source 3 of 3"), "{message}");
+
+        // …and to the operator.
+        assert_eq!(report.sources.len(), 3);
+        assert!(report.truncated_any());
+        let notice = report.notice().expect("the operator is told");
+        assert!(notice.contains("3 sources"), "{notice}");
+        assert!(notice.contains("3 of them were truncated"), "{notice}");
+    }
+
+    /// The "is it only a fan-in?" question, answered: it is not. A **single**
+    /// enormous `web_fetch` into one agent runs the same unbounded path, and the
+    /// bound at the join covers it with no second rule.
+    #[test]
+    fn a_single_enormous_source_is_bounded_too() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let request = json!({
+            "prompt": "Summarise this page.",
+            "input": [source_envelope("ONLY_SOURCE", 500_000)],
+        });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        assert!(
+            message.chars().count() <= budget + MARKER_SLACK,
+            "a single 500k-character page must not reach a turn whole: {} characters",
+            message.chars().count()
+        );
+        assert!(message.contains("ONLY_SOURCE"), "the source still arrives");
+        assert!(message.contains("source 1 of 1"), "{message}");
+        assert_eq!(report.sources.len(), 1);
+        assert!(report.truncated_any());
+    }
+
+    /// A large sibling must not starve a small one — the fan-in failure mode a
+    /// flat per-source cap would not fix and a running total would make
+    /// order-dependent.
+    #[test]
+    fn a_short_source_survives_whole_beside_an_enormous_one() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let short = "SHORT_SOURCE: the wire service filed three lines today.";
+        let request = json!({
+            "prompt": "Rank today's stories.",
+            "input": [
+                source_envelope("HUGE_SOURCE", 400_000),
+                json!({ "json": {}, "text": short, "raw": {} }),
+            ],
+        });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        assert!(
+            message.contains(short),
+            "the short source must arrive intact, not be crowded out: {message}"
+        );
+        assert_eq!(
+            message.matches("TRUNCATED BY OPENCOMPANY").count(),
+            1,
+            "only the enormous source is cut: {message}"
+        );
+        assert_eq!(report.sources[1].produced, report.sources[1].kept);
+        assert!(report.sources[0].kept < report.sources[0].produced);
+    }
+
+    /// The overwhelmingly common run: everything fits, so the fold is exactly
+    /// what #782 produced and the operator is told nothing new.
+    #[test]
+    fn an_ordinary_fan_in_is_untouched_and_says_nothing() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let request = json!({
+            "prompt": "Combine the research.",
+            "input": [
+                { "json": {}, "text": "Predecessor A: market is up.", "raw": {} },
+                { "json": {}, "text": "Predecessor B: sentiment is positive.", "raw": {} },
+            ],
+        });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        assert!(!message.contains("TRUNCATED"), "{message}");
+        assert!(!report.truncated_any());
+        assert_eq!(report.notice(), None);
+        assert!(
+            message.contains("Predecessor A: market is up."),
+            "{message}"
+        );
+        assert!(
+            message.contains("Predecessor B: sentiment is positive."),
+            "{message}"
+        );
+    }
+
+    /// The bound survives composition: the marker is still in the message the
+    /// teammate is actually sent, alongside the node's instruction and the #154
+    /// run topic.
+    #[test]
+    fn the_truncation_marker_survives_into_the_composed_turn() {
+        let request = json!({
+            "prompt": "Rank today's stories.",
+            "input": [source_envelope("BIG_SOURCE", 200_000)],
+        });
+        let (instruction, _) = append_upstream_input(
+            &message_from_request(&request),
+            &request,
+            upstream::DEFAULT_UPSTREAM_BUDGET_CHARS,
+        );
+        let message = compose_turn_message(&instruction, Some("today's sport"));
+        assert!(message.starts_with("Rank today's stories."), "{message}");
+        assert!(message.contains("TRUNCATED BY OPENCOMPANY"), "{message}");
+        assert!(message.contains("Request for this run:"), "{message}");
+        assert!(message.contains("today's sport"), "{message}");
+    }
+
+    /// A source rendered as JSON (a `transform` / structured `tool_call` output,
+    /// which has no prose `text`) is bounded on the same path — the bound is on
+    /// what the turn carries, not on which node kind produced it.
+    #[test]
+    fn a_structured_source_is_bounded_on_the_same_path() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let rows: Vec<Value> = (0..20_000)
+            .map(|n| json!({ "headline": format!("story {n}"), "score": n }))
+            .collect();
+        let request = json!({
+            "prompt": "Rank these.",
+            "input": [{ "json": { "rows": rows }, "text": null, "raw": {} }],
+        });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        assert!(
+            message.chars().count() <= budget + MARKER_SLACK,
+            "a structured payload is bounded too: {} characters",
+            message.chars().count()
+        );
+        assert!(message.contains("TRUNCATED BY OPENCOMPANY"), "{message}");
+        assert!(report.truncated_any());
     }
 
     #[test]

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1378,31 +1378,11 @@ fn render_upstream_input(
         return None;
     }
 
-    let sizes: Vec<usize> = rendered.iter().map(|text| text.chars().count()).collect();
-    let allowances = upstream::allocate_fairly(&sizes, budget);
-    let of = rendered.len();
-    let mut sources = Vec::with_capacity(of);
-    let mut sections = Vec::with_capacity(of);
-    for (index, (text, (&produced, &kept))) in rendered
-        .iter()
-        .zip(sizes.iter().zip(allowances.iter()))
-        .enumerate()
-    {
-        sources.push(upstream::SourceBudget { produced, kept });
-        if kept >= produced {
-            sections.push(text.clone());
-            continue;
-        }
-        // Cut, and say so in the turn itself: an agent that cannot tell it is
-        // holding a fragment will present the fragment as the whole source.
-        let mut section = upstream::truncate_chars(text, kept);
-        section.push_str(&upstream::truncation_marker(index + 1, of, produced, kept));
-        sections.push(section);
-    }
-    Some((
-        sections.join("\n\n---\n\n"),
-        upstream::UpstreamReport { sources, budget },
-    ))
+    // Composition, budgeting and the markers that account for both live together
+    // in `upstream`, so the guarantee — the section is never longer than `budget`,
+    // *including* every marker and separator — is one function's postcondition
+    // rather than a property spread across this loop and that module.
+    Some(upstream::bound_sections(&rendered, budget))
 }
 
 /// Renders one upstream item into the text an agent reads.
@@ -2112,6 +2092,35 @@ mod tests {
         assert!(message.contains("TRUNCATED BY OPENCOMPANY"), "{message}");
         assert!(message.contains("Request for this run:"), "{message}");
         assert!(message.contains("today's sport"), "{message}");
+    }
+
+    /// A thousand-way fan-in — a `split_out` over a large array is all it takes —
+    /// must not smuggle a thousand truncation markers past the budget. This is
+    /// the fold-level twin of `upstream`'s
+    /// `a_thousand_oversized_sources_stay_inside_the_budget`, driven through the
+    /// real envelope shape rather than pre-rendered strings, because that is the
+    /// path a graph actually takes.
+    #[test]
+    fn a_thousand_way_fan_in_cannot_smuggle_its_markers_past_the_budget() {
+        let budget = upstream::DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let inputs: Vec<Value> = (0..1_000)
+            .map(|n| source_envelope(&format!("SOURCE_{n}"), 5_000))
+            .collect();
+        let request = json!({ "prompt": "Rank today's stories.", "input": inputs });
+        let (message, report) =
+            append_upstream_input(&message_from_request(&request), &request, budget);
+
+        // The section itself is bounded by `budget`; the message adds only the
+        // node's own instruction and the heading, which are not upstream text.
+        assert!(
+            message.chars().count() <= budget + MARKER_SLACK,
+            "5,000,000 characters of upstream input across 1,000 sources produced a {}-character \
+             turn",
+            message.chars().count()
+        );
+        assert_eq!(report.sources.len(), 1_000, "every input is accounted for");
+        let notice = report.notice().expect("the operator is told");
+        assert!(notice.contains("1000 sources"), "{notice}");
     }
 
     /// A source rendered as JSON (a `transform` / structured `tool_call` output,

--- a/src/workflows/caps/upstream.rs
+++ b/src/workflows/caps/upstream.rs
@@ -427,16 +427,22 @@ impl UpstreamReport {
     /// not see everything, and the operator has to be able to know that without
     /// reading the host's logs.
     pub(super) fn notice(&self) -> Option<String> {
-        // An omitted source is also `truncated()` (it kept nothing), so the two
-        // counts are separated here rather than double-reported: `cut` is the
-        // sources that are in the turn as fragments, `omitted` the ones that are
-        // not in it at all.
-        let cut = self
-            .sources
+        // `cut` is the sources that are in the turn as fragments, `omitted` the
+        // ones that are not in it at all — separated rather than double-reported.
+        //
+        // Counted over the rendered prefix directly rather than by subtracting
+        // `omitted` from every `truncated()` row, because that subtraction
+        // assumed every omitted row is also truncated. One that produced nothing
+        // has `kept == produced`, so it is not truncated, and subtracting it
+        // anyway under-counted `cut` — to zero in the two-source case, which took
+        // the omission-only branch and never told the operator a rendered source
+        // had been cut at all. `bound_sections` always appends the omitted rows
+        // last, so the rendered ones are exactly the leading `sources - omitted`.
+        let rendered = self.sources.len().saturating_sub(self.omitted);
+        let cut = self.sources[..rendered]
             .iter()
             .filter(|source| source.truncated())
-            .count()
-            .saturating_sub(self.omitted);
+            .count();
         if cut == 0 && self.omitted == 0 {
             return None;
         }
@@ -666,6 +672,44 @@ mod tests {
         assert!(notice.contains("1 of them was truncated"), "{notice}");
         assert!(notice.contains("32000 characters"), "{notice}");
         assert!(notice.contains("summarise each one"), "{notice}");
+    }
+
+    /// An empty source in the omitted tail must not erase the truncation half of
+    /// the notice.
+    ///
+    /// CodeRabbit on PR #851: `cut` was derived by subtracting `omitted` from the
+    /// count of every `truncated()` row, which assumes every omitted row is also
+    /// truncated. One that produced nothing has `kept == produced`, so it is
+    /// *not* truncated, and subtracting it anyway under-counted `cut` — here to
+    /// zero, which took the omission-only branch and left the operator never told
+    /// that a rendered source had been cut.
+    #[test]
+    fn an_empty_omitted_source_does_not_hide_a_truncated_one() {
+        let report = UpstreamReport {
+            sources: vec![
+                // Rendered, and cut.
+                SourceBudget {
+                    produced: 40_000,
+                    kept: 31_900,
+                },
+                // Omitted, and produced nothing — so `truncated()` is false.
+                SourceBudget {
+                    produced: 0,
+                    kept: 0,
+                },
+            ],
+            budget: 32_000,
+            omitted: 1,
+        };
+        let notice = report.notice().expect("a cut fold speaks");
+        assert!(
+            notice.contains("1 of them were truncated"),
+            "the truncated rendered source is still reported: {notice}"
+        );
+        assert!(
+            notice.contains("a further 1 could not be shown"),
+            "the omission is still reported alongside it: {notice}"
+        );
     }
 
     // ── The bound must hold for the reporting of the bound, too ──

--- a/src/workflows/caps/upstream.rs
+++ b/src/workflows/caps/upstream.rs
@@ -60,6 +60,25 @@
 //! Two bounds on two different resources; a node's output can be well inside the
 //! storage cap and still be more than a turn will take.
 //!
+//! # Nothing this module emits grows with the number of sources
+//!
+//! Stated as a standing property because breaching it is how the bound broke the
+//! first time (see [`bound_sections`]). Every string produced here is either
+//! O(1) in the number of predecessors, or emitted a number of times that
+//! [`max_rendered_sources`] bounds:
+//!
+//! | Emitted | How many | Size |
+//! | --- | --- | --- |
+//! | [`truncation_marker`] | ≤ [`max_rendered_sources`] per fold | ≤ [`MAX_MARKER_CHARS`], pinned by test |
+//! | [`omitted_sources_marker`] | ≤ 1 per fold | ≤ [`MAX_MARKER_CHARS`], pinned by test |
+//! | the [`clamp_to_budget`] marker | ≤ 1 per fold | a fixed literal |
+//! | [`UpstreamReport::notice`] | 1 per agent node turn | fixed text + five numbers |
+//!
+//! The notice is the only one that leaves the turn (it goes to the run), and it
+//! *aggregates* — one sentence however many sources were cut. Its per-run count
+//! is bounded by the number of agent nodes in the graph, which is the same rate
+//! the other [`RunNotices`](super::RunNotices) producers already push at.
+//!
 //! Every function here is pure, so the boundary is driven in tests by a
 //! synthetic oversized payload rather than by whatever a live page returns.
 
@@ -173,6 +192,184 @@ pub(super) fn truncation_marker(index: usize, of: usize, produced: usize, kept: 
     )
 }
 
+/// The most characters [`truncation_marker`] and [`omitted_sources_marker`] can
+/// produce, whatever numbers they are handed.
+///
+/// Pinned rather than measured at run time because it is *reserved* out of a
+/// source's own allowance before the marker exists, and asserted against both
+/// markers at their numeric extremes by
+/// [`no_marker_can_exceed_its_reserved_size`](tests::no_marker_can_exceed_its_reserved_size)
+/// — so a future edit that makes a marker wordier fails a test rather than
+/// silently spending budget it was not given.
+const MAX_MARKER_CHARS: usize = 320;
+
+/// What separates one rendered source from the next.
+const SECTION_SEPARATOR: &str = "\n\n---\n\n";
+
+/// The least text a source must be able to carry for rendering it to be worth
+/// anything.
+///
+/// Below this a "source" is a sentence fragment: it cannot be read, ranked or
+/// quoted, and it still costs a separator and a truncation marker. Handing a
+/// model a thousand 32-character shards is not a smaller version of the gather —
+/// it is noise with the shape of data.
+const MIN_SOURCE_SHARE_CHARS: usize = 1_024;
+
+/// How many predecessors are worth rendering under `budget`, before each one's
+/// fair share drops below [`MIN_SOURCE_SHARE_CHARS`].
+///
+/// At least one, always: a single source is rendered (and truncated) however
+/// small the budget, because dropping the only input is never the better answer.
+pub(super) fn max_rendered_sources(budget: usize) -> usize {
+    (budget / MIN_SOURCE_SHARE_CHARS).max(1)
+}
+
+/// The characters the separators between `rendered` sections will cost.
+fn separators_chars(rendered: usize) -> usize {
+    rendered.saturating_sub(1) * SECTION_SEPARATOR.chars().count()
+}
+
+/// The single line standing in for the predecessors there was no room to render
+/// at all.
+///
+/// **One line for all of them, deliberately.** This is the half of the accounting
+/// that must not scale with the number of sources — the per-source marker below
+/// is bounded by [`max_rendered_sources`], but the sources *past* that limit are
+/// unbounded in principle (a `split_out` over a large array), so what stands in
+/// for them has to be O(1). It still names the count, so "we did not show you
+/// 970 sources" never reads to the model as "there were only 30".
+fn omitted_sources_marker(omitted: usize, total: usize) -> String {
+    format!(
+        "\n\n[OMITTED BY OPENCOMPANY — {omitted} of this step's {total} inputs are not shown at \
+         all. This step's input budget cannot carry a useful amount of each. They were NOT read. \
+         Summarise the sources in earlier steps, or feed this step fewer of them.]"
+    )
+}
+
+/// Clips a fully composed section to `budget`, marking it if it had to.
+///
+/// The **unconditional backstop**. Everything above aims to land inside the
+/// budget by construction; this makes the guarantee hold whatever the arithmetic
+/// above does, so the invariant is one assertion in one place rather than a
+/// property a reader has to re-derive from three interacting caps. It should
+/// never fire — [`the_backstop_is_never_what_enforces_the_budget`](tests::the_backstop_is_never_what_enforces_the_budget)
+/// pins that it does not on the paths we know of — and it is here for the paths
+/// we do not.
+fn clamp_to_budget(section: String, budget: usize) -> String {
+    if section.chars().count() <= budget {
+        return section;
+    }
+    const CLAMPED: &str = "\n\n[TRUNCATED BY OPENCOMPANY — this step's whole input was clipped to its character \
+         budget. The rest was NOT read.]";
+    let marker_chars = CLAMPED.chars().count();
+    // A budget too small to hold the marker gets a bare clip: a marker that
+    // itself overflowed the budget would be the bug it exists to report.
+    if budget <= marker_chars {
+        return truncate_chars(&section, budget);
+    }
+    let mut clamped = truncate_chars(&section, budget - marker_chars);
+    clamped.push_str(CLAMPED);
+    clamped
+}
+
+/// Composes the upstream section from already-rendered predecessor texts, inside
+/// `budget` — **markers, separators and all**.
+///
+/// # The guarantee
+///
+/// The returned string is never longer than `budget` characters. Not "the source
+/// text is never longer": the whole section. That distinction is issue #849's own
+/// bug reappearing inside its fix — the first cut of this code bounded source
+/// text with [`allocate_fairly`] and then appended an *unbudgeted* marker per cut
+/// source and an unbudgeted separator between each pair, so a thousand oversized
+/// sources kept 32,000 characters of text and added roughly 216,000 characters of
+/// our own accounting on top. A bound that the reporting of the bound can breach
+/// is not a bound.
+///
+/// # How the accounting is paid for
+///
+/// Three mechanisms, each where it fits:
+///
+/// * **The separators and the omitted-sources line are charged up front**,
+///   deducted from the budget before any source text is allocated. Both are known
+///   before a single character is rendered.
+/// * **Each truncation marker is charged to the source it describes**, reserved
+///   out of that source's own allowance. This is the honest place for it: the
+///   marker exists *because* that source was cut, and it stands in the space the
+///   cut text vacated.
+/// * **Sources past [`max_rendered_sources`] are aggregated into one line**
+///   rather than rendered at all. Per-source markers can only be afforded while
+///   their number is bounded, and this is what bounds it — a fan-in of a thousand
+///   is not served by a thousand shards too small to read.
+///
+/// The per-source marker survives for the sources that *are* rendered because it
+/// is doing work no aggregate can do: it sits at the exact point the text stops,
+/// which is what stops a model describing a source it has only seen the opening
+/// of. Aggregating it away would buy budget by removing the signal.
+pub(super) fn bound_sections(rendered: &[String], budget: usize) -> (String, UpstreamReport) {
+    let total = rendered.len();
+    let render_count = total.min(max_rendered_sources(budget));
+    let omitted = total - render_count;
+
+    // Charged before any text: both are known up front, and neither is optional.
+    let omitted_note = (omitted > 0).then(|| omitted_sources_marker(omitted, total));
+    let fixed = separators_chars(render_count)
+        + omitted_note
+            .as_deref()
+            .map_or(0, |note| note.chars().count());
+    let text_budget = budget.saturating_sub(fixed);
+
+    let sizes: Vec<usize> = rendered[..render_count]
+        .iter()
+        .map(|text| text.chars().count())
+        .collect();
+    let allowances = allocate_fairly(&sizes, text_budget);
+
+    let mut sections = Vec::with_capacity(render_count);
+    let mut sources = Vec::with_capacity(total);
+    for (index, (&produced, &allowance)) in sizes.iter().zip(allowances.iter()).enumerate() {
+        if allowance >= produced {
+            sections.push(rendered[index].clone());
+            sources.push(SourceBudget {
+                produced,
+                kept: produced,
+            });
+            continue;
+        }
+        // Cut, and said so in the turn itself: an agent that cannot tell it is
+        // holding a fragment will present the fragment as the whole source. The
+        // marker is reserved out of THIS source's allowance, so saying it costs
+        // the budget nothing extra.
+        let kept = allowance.saturating_sub(MAX_MARKER_CHARS);
+        let mut section = truncate_chars(&rendered[index], kept);
+        section.push_str(&truncation_marker(index + 1, total, produced, kept));
+        sections.push(section);
+        sources.push(SourceBudget { produced, kept });
+    }
+    // The sources there was no room for are still accounted for — at zero — so
+    // the operator notice counts every input the step was handed, not only the
+    // ones it managed to show.
+    for text in &rendered[render_count..] {
+        sources.push(SourceBudget {
+            produced: text.chars().count(),
+            kept: 0,
+        });
+    }
+
+    let mut section = sections.join(SECTION_SEPARATOR);
+    if let Some(note) = omitted_note {
+        section.push_str(&note);
+    }
+    (
+        clamp_to_budget(section, budget),
+        UpstreamReport {
+            sources,
+            budget,
+            omitted,
+        },
+    )
+}
+
 /// What one predecessor contributed to a turn, and how much of it survived the
 /// budget.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -198,10 +395,17 @@ impl SourceBudget {
 /// ordinary run says nothing new.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub(super) struct UpstreamReport {
-    /// Per-source accounting, positionally aligned with the rendered sources.
+    /// Per-source accounting, one row per predecessor the step was handed — in
+    /// order, and including the ones there was no room to render, which carry
+    /// `kept: 0`.
     pub(super) sources: Vec<SourceBudget>,
     /// The budget those sources were allocated out of.
     pub(super) budget: usize,
+    /// How many predecessors were not rendered at all (the tail past
+    /// [`max_rendered_sources`]). Reported separately from truncation because
+    /// they are a different fact: a truncated source is present in the turn as a
+    /// fragment, an omitted one is not present at all.
+    pub(super) omitted: usize,
 }
 
 impl UpstreamReport {
@@ -223,8 +427,17 @@ impl UpstreamReport {
     /// not see everything, and the operator has to be able to know that without
     /// reading the host's logs.
     pub(super) fn notice(&self) -> Option<String> {
-        let cut = self.sources.iter().filter(|s| s.truncated()).count();
-        if cut == 0 {
+        // An omitted source is also `truncated()` (it kept nothing), so the two
+        // counts are separated here rather than double-reported: `cut` is the
+        // sources that are in the turn as fragments, `omitted` the ones that are
+        // not in it at all.
+        let cut = self
+            .sources
+            .iter()
+            .filter(|source| source.truncated())
+            .count()
+            .saturating_sub(self.omitted);
+        if cut == 0 && self.omitted == 0 {
             return None;
         }
         let sources = self.sources.len();
@@ -232,14 +445,26 @@ impl UpstreamReport {
         let kept: usize = self.sources.iter().map(|s| s.kept).sum();
         let budget = self.budget;
         let plural = if sources == 1 { "" } else { "s" };
-        let verb = if cut == 1 { "was" } else { "were" };
+        // Both halves are stated whenever they happened, and each is only stated
+        // when it did — an operator reading "0 were truncated" learns nothing and
+        // trusts the next sentence less.
+        let what = match (cut, self.omitted) {
+            (0, omitted) => format!("{omitted} of them could not be shown to it at all"),
+            (cut, 0) => {
+                let verb = if cut == 1 { "was" } else { "were" };
+                format!("{cut} of them {verb} truncated")
+            }
+            (cut, omitted) => format!(
+                "{cut} of them were truncated and a further {omitted} could not be shown to it at \
+                 all"
+            ),
+        };
         Some(format!(
             "A step in this workflow was handed {produced} characters from {sources} \
              source{plural} — more than the {budget} characters one step may pass to a model — so \
-             {cut} of them {verb} truncated and the step ran on the {kept} characters that \
-             fitted. Its result did not see everything. To use the whole of each source, \
-             summarise each one in a step of its own before this one, or have each source return \
-             less."
+             {what}, and the step ran on the {kept} characters that fitted. Its result did not see \
+             everything. To use the whole of each source, summarise each one in a step of its own \
+             before this one, or have each source return less."
         ))
     }
 }
@@ -410,6 +635,7 @@ mod tests {
                 },
             ],
             budget: 32_000,
+            omitted: 0,
         };
         assert!(!report.truncated_any());
         assert_eq!(report.notice(), None);
@@ -431,6 +657,7 @@ mod tests {
                 },
             ],
             budget: 32_000,
+            omitted: 0,
         };
         assert!(report.truncated_any());
         let notice = report.notice().expect("a cut fold speaks");
@@ -439,6 +666,165 @@ mod tests {
         assert!(notice.contains("1 of them was truncated"), "{notice}");
         assert!(notice.contains("32000 characters"), "{notice}");
         assert!(notice.contains("summarise each one"), "{notice}");
+    }
+
+    // ── The bound must hold for the reporting of the bound, too ──
+    //
+    // CodeRabbit on PR #851: the first cut of this module bounded source text and
+    // then appended an *unbudgeted* marker per truncated source and an unbudgeted
+    // separator between each pair. A thousand oversized sources therefore kept
+    // 32,000 characters of text and added ~216,000 characters of our own
+    // accounting — 7.7× the budget, which is issue #849's own failure reappearing
+    // through its fix. These are the assertions whose absence let that through.
+
+    /// `n` synthetic oversized sources.
+    fn oversized_sources(n: usize, chars: usize) -> Vec<String> {
+        (0..n)
+            .map(|index| format!("SOURCE_{index} {}", "x".repeat(chars)))
+            .collect()
+    }
+
+    /// The headline invariant, at the scale that broke it: the **whole rendered
+    /// section** — text, markers, separators, omission line — is inside the
+    /// budget.
+    #[test]
+    fn a_thousand_oversized_sources_stay_inside_the_budget() {
+        let budget = DEFAULT_UPSTREAM_BUDGET_CHARS;
+        let (section, report) = bound_sections(&oversized_sources(1_000, 200), budget);
+        assert!(
+            section.chars().count() <= budget,
+            "the section must be bounded including its own accounting: {} characters for a \
+             {budget}-character budget",
+            section.chars().count()
+        );
+        // Every input is still accounted for, even the ones with no room.
+        assert_eq!(report.sources.len(), 1_000);
+        assert!(report.omitted > 0, "the tail is omitted, not silently kept");
+        let notice = report.notice().expect("the operator is told");
+        assert!(notice.contains("1000 sources"), "{notice}");
+        assert!(notice.contains("could not be shown"), "{notice}");
+    }
+
+    /// The same at absurd scale, and with a tiny budget — the two directions that
+    /// break a cap derived by division.
+    #[test]
+    fn the_bound_holds_at_every_scale_and_budget() {
+        for count in [1usize, 2, 31, 32, 999, 5_000] {
+            for budget in [
+                0usize,
+                1,
+                120,
+                1_023,
+                1_024,
+                5_000,
+                DEFAULT_UPSTREAM_BUDGET_CHARS,
+            ] {
+                let (section, _) = bound_sections(&oversized_sources(count, 400), budget);
+                assert!(
+                    section.chars().count() <= budget,
+                    "{count} sources under a {budget}-character budget produced {} characters",
+                    section.chars().count()
+                );
+            }
+        }
+    }
+
+    /// A source too small to be worth reading is not rendered as a shard — it is
+    /// aggregated into one line that names how many were left out, so the count
+    /// cannot scale with the number of sources.
+    #[test]
+    fn sources_past_the_useful_limit_are_aggregated_into_one_line() {
+        let budget = DEFAULT_UPSTREAM_BUDGET_CHARS;
+        assert_eq!(max_rendered_sources(budget), 31);
+        let (section, report) = bound_sections(&oversized_sources(500, 5_000), budget);
+        assert_eq!(report.omitted, 500 - 31);
+        assert_eq!(
+            section.matches("OMITTED BY OPENCOMPANY").count(),
+            1,
+            "one line for all of them, never one per source"
+        );
+        assert!(
+            section.contains("469 of this step's 500 inputs"),
+            "{}",
+            &section[section.len().saturating_sub(400)..]
+        );
+        assert!(
+            section.matches("TRUNCATED BY OPENCOMPANY").count() <= 31,
+            "per-source markers are bounded by the render limit"
+        );
+    }
+
+    /// The marker is reserved out of the source it describes, so saying "this was
+    /// cut" costs the budget nothing extra — and a source still keeps a readable
+    /// amount of text after paying for its own marker.
+    #[test]
+    fn a_truncation_marker_is_paid_for_by_its_own_source() {
+        let budget = 8_000;
+        let (section, report) = bound_sections(&oversized_sources(4, 100_000), budget);
+        assert!(section.chars().count() <= budget);
+        for source in &report.sources {
+            assert!(
+                source.kept >= MIN_SOURCE_SHARE_CHARS.saturating_sub(MAX_MARKER_CHARS) / 2,
+                "a rendered source keeps a readable amount after its marker: {source:?}"
+            );
+        }
+    }
+
+    /// Neither marker may outgrow the space reserved for it, at any numbers. A
+    /// wordier marker in a future edit fails here rather than quietly spending
+    /// budget it was not given.
+    #[test]
+    fn no_marker_can_exceed_its_reserved_size() {
+        let extremes = [
+            truncation_marker(usize::MAX, usize::MAX, usize::MAX, usize::MAX - 1),
+            truncation_marker(usize::MAX, usize::MAX, usize::MAX, 0),
+            truncation_marker(1, 1, 1, 0),
+            omitted_sources_marker(usize::MAX, usize::MAX),
+            omitted_sources_marker(1, 2),
+        ];
+        for marker in extremes {
+            assert!(
+                marker.chars().count() <= MAX_MARKER_CHARS,
+                "marker is {} characters, over the {MAX_MARKER_CHARS} reserved: {marker}",
+                marker.chars().count()
+            );
+        }
+    }
+
+    /// The backstop is a backstop. If it is what enforces the budget on an
+    /// ordinary path, the arithmetic above it is wrong and this says so — a clamp
+    /// that fires routinely would be hiding a mis-accounting rather than guarding
+    /// against one.
+    #[test]
+    fn the_backstop_is_never_what_enforces_the_budget() {
+        for count in [1usize, 3, 31, 500] {
+            for chars in [10usize, 5_000, 200_000] {
+                let (section, _) = bound_sections(
+                    &oversized_sources(count, chars),
+                    DEFAULT_UPSTREAM_BUDGET_CHARS,
+                );
+                assert!(
+                    !section.contains("whole input was clipped"),
+                    "the clamp fired for {count} sources of {chars} characters, so the budgeting \
+                     above it did not add up"
+                );
+            }
+        }
+    }
+
+    /// And the common case is still untouched: sources that fit are rendered
+    /// verbatim, joined by the same separator, with no marker and no notice.
+    #[test]
+    fn an_ordinary_fold_is_unchanged_by_any_of_this() {
+        let rendered = vec![
+            "Predecessor A: market is up.".to_string(),
+            "Predecessor B: sentiment is positive.".to_string(),
+        ];
+        let (section, report) = bound_sections(&rendered, DEFAULT_UPSTREAM_BUDGET_CHARS);
+        assert_eq!(section, rendered.join(SECTION_SEPARATOR));
+        assert!(!report.truncated_any());
+        assert_eq!(report.omitted, 0);
+        assert_eq!(report.notice(), None);
     }
 
     /// The reported failure's exact provider string is recognised, and the

--- a/src/workflows/caps/upstream.rs
+++ b/src/workflows/caps/upstream.rs
@@ -1,0 +1,501 @@
+//! What an upstream node is allowed to hand a downstream agent turn, and what
+//! to say when the provider refuses the turn anyway (issue #849).
+//!
+//! Issue #782 gave an upstream node's output a channel into the next agent's
+//! turn. Nothing bounded that channel, so a fan-in — gather N sources, rank them
+//! — concatenated every predecessor's payload into one turn verbatim. Three
+//! `web_fetch` nodes reading busy pages intermittently pushed that turn past the
+//! model's context window, and the run discovered it as a raw provider 400
+//! **after** the fetches were already paid for:
+//!
+//! ```text
+//! inference returned 400 Bad Request: {"success":false,
+//!  "error":"The conversation is too long for model 'chat-v1'. Please start a new chat.",
+//!  "errorCode":"CONTEXT_LENGTH_EXCEEDED"}
+//! ```
+//!
+//! Four of seven runs of the *same* graph over the *same* sources succeeded; the
+//! only variable was how much text the pages happened to return that minute. A
+//! workflow whose outcome is a coin flip is the defect, not the 400.
+//!
+//! # The three things this module does
+//!
+//! 1. **Bounds the payload.** [`budget_chars`] fixes how many characters of
+//!    upstream input one agent node may carry, and [`allocate_fairly`] divides
+//!    that budget across the predecessors so one enormous source cannot crowd
+//!    the others out. Whatever is cut is cut *visibly*: [`truncation_marker`]
+//!    leaves a marker in the turn itself, so the agent knows it is reasoning
+//!    over a fragment and cannot present it as the whole.
+//! 2. **Says so before spending.** The budget is applied while the turn is being
+//!    composed — before the request reaches the provider — and
+//!    [`UpstreamReport::notice`] names how much arrived, how much fitted and how
+//!    many sources were cut, on [`WorkflowRun::notices`](crate::ports::WorkflowRun::notices),
+//!    the run surface the operator reads.
+//! 3. **Translates the refusal.** [`context_overflow_advice`] rewrites a
+//!    provider context-window 400 into something actionable inside a workflow.
+//!    "Please start a new chat" is advice for a chat product; a workflow step has
+//!    no chat and the operator has no button for it.
+//!
+//! # Truncate-and-report rather than fail-the-run
+//!
+//! The issue asks to fail before spending. The spending has already happened by
+//! the time a fan-in is composed — the fetches ran first — so failing the run
+//! here would throw that paid work away and deliver the operator nothing, to
+//! avoid a turn that a bounded input makes succeed. So the boundary is enforced
+//! by bounding, and the "which inputs overflowed" report rides the marker and
+//! the notice instead of an error. The one overflow that can still reach the
+//! provider — a turn whose *own* instruction, tool schemas or accumulated
+//! session history is what is too large — is what [`context_overflow_advice`]
+//! exists for.
+//!
+//! # Why not
+//! [`bound_node_output`](crate::ports::bound_node_output)
+//!
+//! That bound already exists and does not help here: it clips the **persisted**
+//! run-output snapshot the console reads back, so its budget is a durable-storage
+//! ceiling (`RUN_OUTPUT_MAX_BYTES`) applied per string across the whole node map,
+//! after the run has settled. This one is applied while a single turn is composed,
+//! its budget is a share of a model's context, and it has to divide that budget
+//! *between* predecessors — which is the property a per-string cap cannot express.
+//! Two bounds on two different resources; a node's output can be well inside the
+//! storage cap and still be more than a turn will take.
+//!
+//! Every function here is pure, so the boundary is driven in tests by a
+//! synthetic oversized payload rather than by whatever a live page returns.
+
+/// The most upstream input, in characters, any single agent node's turn carries.
+///
+/// A ceiling rather than a target: nearly every run is far below it and folds
+/// its upstream input untouched. Roughly 8k tokens at the conservative
+/// [`CHARS_PER_TOKEN`] estimate — enough for a genuine multi-source gather (the
+/// reported failure fanned in three pages of 8.9k–14.7k characters each) while
+/// leaving the rest of the window to the step's instruction, its tool schemas
+/// and the teammate's session history.
+pub(crate) const DEFAULT_UPSTREAM_BUDGET_CHARS: usize = 32_000;
+
+/// Characters per token, used only to turn a model's advertised token window
+/// into a character budget.
+///
+/// Deliberately **low**. An underestimate makes the same text look like more
+/// tokens than it is, so the derived budget errs small; an overestimate would
+/// err large, which is the direction that reproduces the bug.
+const CHARS_PER_TOKEN: usize = 3;
+
+/// The share of a model's advertised input window upstream input may claim.
+///
+/// The window is not ours alone: the step's own instruction, the run request,
+/// every tool schema the teammate carries, and that teammate's accumulated
+/// session history are all in the same turn. An eighth leaves room for all of
+/// them.
+const UPSTREAM_WINDOW_SHARE: usize = 8;
+
+/// How many characters of upstream input a node's turn may carry, given what the
+/// configured model advertises as its input window.
+///
+/// An advertised window can only make the budget **smaller**, never larger, and
+/// that asymmetry is the whole point. The reported failure was on `chat-v1`,
+/// whose nominal window is enormous, and the turn was refused a long way inside
+/// it — because the advertised figure describes the model, not the turn, and
+/// says nothing about the system prompt, the tool schemas or the session history
+/// sharing it. Trusting it upward is exactly how a fan-in gets handed more than
+/// the provider will take. Trusting it downward is safe and worth doing: a small
+/// model gets a proportionally smaller budget rather than the flat ceiling.
+pub(super) fn budget_chars(max_input_tokens: Option<u64>) -> usize {
+    let Some(tokens) = max_input_tokens.filter(|tokens| *tokens > 0) else {
+        return DEFAULT_UPSTREAM_BUDGET_CHARS;
+    };
+    let advertised = usize::try_from(tokens)
+        .unwrap_or(usize::MAX)
+        .saturating_div(UPSTREAM_WINDOW_SHARE)
+        .saturating_mul(CHARS_PER_TOKEN);
+    DEFAULT_UPSTREAM_BUDGET_CHARS.min(advertised)
+}
+
+/// Divides `budget` across sources of the given `sizes`, returning how many
+/// characters each may keep (positionally aligned with `sizes`).
+///
+/// Max-min fair: every source is offered an equal share, a source needing less
+/// than its share takes only what it needs, and what it leaves is redistributed
+/// among the larger ones. So three 10k sources under a 32k budget are untouched,
+/// while a 300-character source beside two 200k ones keeps all 300 and the two
+/// split the rest evenly — a big source is never allowed to starve a small one,
+/// which is precisely what "concatenate until the provider complains" did.
+///
+/// Deterministic regardless of input order: ties break on position, and the
+/// allocation is computed by size order rather than arrival order.
+pub(super) fn allocate_fairly(sizes: &[usize], budget: usize) -> Vec<usize> {
+    let mut by_size: Vec<usize> = (0..sizes.len()).collect();
+    by_size.sort_by_key(|&index| (sizes[index], index));
+
+    let mut kept = vec![0usize; sizes.len()];
+    let mut remaining = budget;
+    let mut unallocated = sizes.len();
+    for index in by_size {
+        // `unallocated` is non-zero on every iteration by construction: it starts
+        // at the number of sources and is decremented exactly once per source.
+        let share = remaining / unallocated;
+        let take = sizes[index].min(share);
+        kept[index] = take;
+        remaining -= take;
+        unallocated -= 1;
+    }
+    kept
+}
+
+/// Truncates `text` to `keep` characters, on a character boundary.
+///
+/// Characters, not bytes: a byte slice through the middle of a multi-byte
+/// character panics, and a fetched page is exactly where a non-ASCII character
+/// lands on an arbitrary offset.
+pub(super) fn truncate_chars(text: &str, keep: usize) -> String {
+    text.chars().take(keep).collect()
+}
+
+/// The marker left in the turn where a source was cut.
+///
+/// **Visible on purpose.** Silent truncation is worse than the 400 it prevents:
+/// the agent would rank three sources believing it had read all of each, and
+/// state its answer with the confidence of complete information. The marker says
+/// which source, how much it produced, how much survived, and — the load-bearing
+/// sentence — that the rest was not read.
+pub(super) fn truncation_marker(index: usize, of: usize, produced: usize, kept: usize) -> String {
+    if kept == 0 {
+        return format!(
+            "\n\n[TRUNCATED BY OPENCOMPANY — source {index} of {of} produced {produced} \
+             characters and none of it fitted this step's input budget. It was NOT read.]"
+        );
+    }
+    let dropped = produced - kept;
+    format!(
+        "\n\n[TRUNCATED BY OPENCOMPANY — source {index} of {of} produced {produced} characters; \
+         the {kept} above are all that was kept and the remaining {dropped} were NOT read. Do not \
+         describe this source as if you have seen all of it.]"
+    )
+}
+
+/// What one predecessor contributed to a turn, and how much of it survived the
+/// budget.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) struct SourceBudget {
+    /// Characters the source rendered to.
+    pub(super) produced: usize,
+    /// Characters of it the turn actually carries.
+    pub(super) kept: usize,
+}
+
+impl SourceBudget {
+    /// Whether this source was cut.
+    fn truncated(&self) -> bool {
+        self.kept < self.produced
+    }
+}
+
+/// What the budget did to one turn's upstream input — one row per renderable
+/// predecessor, in the order they were rendered.
+///
+/// Produced on **every** fold, including the overwhelmingly common one where
+/// nothing was cut; [`notice`](Self::notice) is `None` in that case, so an
+/// ordinary run says nothing new.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(super) struct UpstreamReport {
+    /// Per-source accounting, positionally aligned with the rendered sources.
+    pub(super) sources: Vec<SourceBudget>,
+    /// The budget those sources were allocated out of.
+    pub(super) budget: usize,
+}
+
+impl UpstreamReport {
+    /// Whether anything was cut. The production path asks
+    /// [`notice`](Self::notice) instead (it needs the sentence, not the bool),
+    /// so this exists for the assertions that want to say what they mean.
+    #[cfg(test)]
+    pub(super) fn truncated_any(&self) -> bool {
+        self.sources.iter().any(SourceBudget::truncated)
+    }
+
+    /// The operator-facing notice for this fold, or `None` when everything
+    /// fitted.
+    ///
+    /// It lands on [`WorkflowRun::notices`](crate::ports::WorkflowRun::notices)
+    /// — the surface issue #638 added for exactly this shape of fact: something
+    /// the operator needs, that is not a failure, and that no other field on a
+    /// run can carry. The run succeeded and its output is valid; it simply did
+    /// not see everything, and the operator has to be able to know that without
+    /// reading the host's logs.
+    pub(super) fn notice(&self) -> Option<String> {
+        let cut = self.sources.iter().filter(|s| s.truncated()).count();
+        if cut == 0 {
+            return None;
+        }
+        let sources = self.sources.len();
+        let produced: usize = self.sources.iter().map(|s| s.produced).sum();
+        let kept: usize = self.sources.iter().map(|s| s.kept).sum();
+        let budget = self.budget;
+        let plural = if sources == 1 { "" } else { "s" };
+        let verb = if cut == 1 { "was" } else { "were" };
+        Some(format!(
+            "A step in this workflow was handed {produced} characters from {sources} \
+             source{plural} — more than the {budget} characters one step may pass to a model — so \
+             {cut} of them {verb} truncated and the step ran on the {kept} characters that \
+             fitted. Its result did not see everything. To use the whole of each source, \
+             summarise each one in a step of its own before this one, or have each source return \
+             less."
+        ))
+    }
+}
+
+/// Substrings that identify a provider refusal as a context-window overflow.
+///
+/// Matched case-insensitively against the whole error chain, because the wording
+/// is the provider's and varies: the reported one is a managed-backend
+/// `CONTEXT_LENGTH_EXCEEDED` with an OpenAI-style sentence, and the OpenAI /
+/// Anthropic / OpenRouter surfaces a BYOK tenant reaches all phrase it
+/// differently.
+const CONTEXT_OVERFLOW_SIGNATURES: &[&str] = &[
+    "context_length_exceeded",
+    "context length exceeded",
+    "conversation is too long",
+    "maximum context",
+    "context window",
+    "prompt is too long",
+    "too many tokens",
+];
+
+/// Rewrites a context-window refusal into something an operator can act on, or
+/// `None` when the error is anything else.
+///
+/// The message the console showed for the reported failure ended in *"The
+/// conversation is too long for model 'chat-v1'. Please start a new chat."* —
+/// two vendor sentences that are unactionable here twice over: there is no
+/// conversation an operator owns, and no chat for them to start. This names what
+/// is actually too big and what to do about each candidate, and keeps the
+/// provider's own words at the end so support can still match them.
+///
+/// It deliberately does not claim the upstream input is the cause. By the time a
+/// turn reaches the provider that input has already been bounded, so the
+/// remaining suspects are the ones listed.
+pub(super) fn context_overflow_advice(error: &str) -> Option<String> {
+    let haystack = error.to_lowercase();
+    if !CONTEXT_OVERFLOW_SIGNATURES
+        .iter()
+        .any(|signature| haystack.contains(signature))
+    {
+        return None;
+    }
+    Some(format!(
+        "the model refused this step's turn because the turn is larger than its context window. \
+         This is a workflow step, so there is no chat to restart. The input this step received \
+         from earlier steps is already bounded (any truncation is reported on this run), which \
+         leaves: the number of steps feeding this one — summarise each source in a step of its \
+         own first; this step's own instruction — shorten it; or the teammate's accumulated \
+         session history — assign this step a teammate that is not also handling chat. Provider \
+         reported: {error}"
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An advertised window may lower the budget and must never raise it — the
+    /// asymmetry the reported `chat-v1` failure is the argument for. A model
+    /// claiming a million tokens still gets the flat ceiling.
+    #[test]
+    fn an_advertised_window_only_lowers_the_budget() {
+        assert_eq!(budget_chars(None), DEFAULT_UPSTREAM_BUDGET_CHARS);
+        assert_eq!(budget_chars(Some(0)), DEFAULT_UPSTREAM_BUDGET_CHARS);
+        assert_eq!(budget_chars(Some(1_000_000)), DEFAULT_UPSTREAM_BUDGET_CHARS);
+        // 32k tokens → an eighth of it, at 3 chars/token.
+        assert_eq!(budget_chars(Some(32_000)), 12_000);
+        // A tiny window yields a tiny budget rather than the ceiling.
+        assert_eq!(budget_chars(Some(8_000)), 3_000);
+        // No overflow on an absurd advertisement.
+        assert_eq!(budget_chars(Some(u64::MAX)), DEFAULT_UPSTREAM_BUDGET_CHARS);
+    }
+
+    /// Everything fits → nothing is touched, and the budget is not spent for its
+    /// own sake.
+    #[test]
+    fn sources_that_fit_are_untouched() {
+        assert_eq!(allocate_fairly(&[10, 10, 10], 32_000), vec![10, 10, 10]);
+        assert_eq!(allocate_fairly(&[], 32_000), Vec::<usize>::new());
+    }
+
+    /// The headline allocation property: one enormous source cannot starve a
+    /// small one, and the total never exceeds the budget.
+    #[test]
+    fn a_small_source_survives_beside_enormous_ones() {
+        let kept = allocate_fairly(&[300, 200_000, 200_000], 32_000);
+        assert_eq!(kept[0], 300, "the small source is served in full");
+        assert_eq!(
+            kept[1], kept[2],
+            "the two large sources split what is left evenly"
+        );
+        assert_eq!(
+            kept.iter().sum::<usize>(),
+            32_000,
+            "the budget is not exceeded"
+        );
+    }
+
+    /// Equal-sized oversized sources split the budget equally, and the split is
+    /// independent of the order they arrive in.
+    #[test]
+    fn equal_oversized_sources_split_the_budget_and_order_does_not_matter() {
+        assert_eq!(
+            allocate_fairly(&[90_000, 90_000, 90_000], 30_000),
+            vec![10_000, 10_000, 10_000]
+        );
+        let ascending = allocate_fairly(&[10, 50_000, 90_000], 20_000);
+        let descending = allocate_fairly(&[90_000, 50_000, 10], 20_000);
+        assert_eq!(ascending[0], descending[2]);
+        assert_eq!(ascending[1], descending[1]);
+        assert_eq!(ascending[2], descending[0]);
+    }
+
+    /// A budget too small to give every source a character still terminates and
+    /// still respects the budget — the degenerate case a division-by-share must
+    /// not divide by zero on.
+    #[test]
+    fn a_budget_smaller_than_the_source_count_still_allocates() {
+        let kept = allocate_fairly(&[100, 100, 100], 2);
+        assert_eq!(kept.iter().sum::<usize>(), 2);
+        assert_eq!(allocate_fairly(&[100], 0), vec![0]);
+    }
+
+    /// Truncation is on a character boundary — a fetched page is exactly where a
+    /// multi-byte character lands on an arbitrary offset, and a byte slice there
+    /// panics.
+    #[test]
+    fn truncation_respects_character_boundaries() {
+        assert_eq!(truncate_chars("héllo wörld", 5), "héllo");
+        assert_eq!(truncate_chars("abc", 99), "abc");
+        assert_eq!(truncate_chars("abc", 0), "");
+    }
+
+    /// The marker names the source, both sizes, and that the rest was not read —
+    /// an agent that cannot tell it is holding a fragment will present the
+    /// fragment as the whole.
+    #[test]
+    fn the_marker_says_what_was_cut_and_that_it_was_not_read() {
+        let marker = truncation_marker(2, 3, 14_700, 10_000);
+        assert!(marker.contains("source 2 of 3"), "{marker}");
+        assert!(marker.contains("14700"), "{marker}");
+        assert!(marker.contains("10000"), "{marker}");
+        assert!(
+            marker.contains("4700"),
+            "the dropped count is stated: {marker}"
+        );
+        assert!(marker.contains("NOT read"), "{marker}");
+
+        // Nothing survived at all: the wording must not read as "0 characters
+        // above are all that was kept".
+        let none = truncation_marker(1, 2, 500, 0);
+        assert!(none.contains("none of it fitted"), "{none}");
+        assert!(none.contains("NOT read"), "{none}");
+    }
+
+    /// A fold where everything fitted says nothing to the operator.
+    #[test]
+    fn an_untruncated_fold_raises_no_notice() {
+        let report = UpstreamReport {
+            sources: vec![
+                SourceBudget {
+                    produced: 10,
+                    kept: 10,
+                },
+                SourceBudget {
+                    produced: 20,
+                    kept: 20,
+                },
+            ],
+            budget: 32_000,
+        };
+        assert!(!report.truncated_any());
+        assert_eq!(report.notice(), None);
+    }
+
+    /// A fold that cut something reports how much arrived, how much fitted, how
+    /// many sources were cut, and the remedy.
+    #[test]
+    fn a_truncated_fold_reports_the_sizes_and_the_remedy() {
+        let report = UpstreamReport {
+            sources: vec![
+                SourceBudget {
+                    produced: 100,
+                    kept: 100,
+                },
+                SourceBudget {
+                    produced: 40_000,
+                    kept: 31_900,
+                },
+            ],
+            budget: 32_000,
+        };
+        assert!(report.truncated_any());
+        let notice = report.notice().expect("a cut fold speaks");
+        assert!(notice.contains("40100 characters"), "{notice}");
+        assert!(notice.contains("2 sources"), "{notice}");
+        assert!(notice.contains("1 of them was truncated"), "{notice}");
+        assert!(notice.contains("32000 characters"), "{notice}");
+        assert!(notice.contains("summarise each one"), "{notice}");
+    }
+
+    /// The reported failure's exact provider string is recognised, and the
+    /// rewrite drops the advice that cannot be followed while keeping the
+    /// provider's own words.
+    #[test]
+    fn the_reported_provider_refusal_is_translated() {
+        let raw = r#"tinyagents harness run failed: model error: inference returned 400 Bad \
+             Request: {"success":false,"error":"The conversation is too long for model \
+             'chat-v1'. Please start a new chat.","errorCode":"CONTEXT_LENGTH_EXCEEDED"}"#;
+        let advice = context_overflow_advice(raw).expect("recognised as a context overflow");
+        assert!(
+            advice.contains("no chat to restart"),
+            "the unactionable vendor advice is contradicted: {advice}"
+        );
+        assert!(
+            advice.contains("summarise each source"),
+            "a remedy is named: {advice}"
+        );
+        assert!(
+            advice.contains("session history"),
+            "the remaining suspects are named: {advice}"
+        );
+        assert!(
+            advice.contains("CONTEXT_LENGTH_EXCEEDED"),
+            "the provider's own words survive for support: {advice}"
+        );
+    }
+
+    /// The other providers' wordings are recognised too — the phrasing is the
+    /// provider's, and a BYOK tenant reaches several.
+    #[test]
+    fn other_provider_wordings_are_recognised() {
+        for raw in [
+            "This model's maximum context length is 8192 tokens",
+            "prompt is too long: 210000 tokens > 200000 maximum",
+            "error code: context_length_exceeded",
+            "input exceeds the context window",
+        ] {
+            assert!(
+                context_overflow_advice(raw).is_some(),
+                "not recognised: {raw}"
+            );
+        }
+    }
+
+    /// Anything that is not a context overflow is left exactly as it was — this
+    /// must never become a catch-all that relabels unrelated failures.
+    #[test]
+    fn unrelated_errors_are_not_relabelled() {
+        for raw in [
+            "inference returned 401 Unauthorized",
+            "tool_call 'web_fetch': URL is not allowed",
+            "the conversation was cancelled",
+            "",
+        ] {
+            assert_eq!(context_overflow_advice(raw), None, "wrongly claimed: {raw}");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #849.

A workflow's `agent` node folded **every** predecessor's output into its turn verbatim. Nothing bounded that channel, so a three-source gather intermittently died on a raw provider 400 — after the fetches were already paid for:

```
inference returned 400 Bad Request: {"success":false,
 "error":"The conversation is too long for model 'chat-v1'. Please start a new chat.",
 "errorCode":"CONTEXT_LENGTH_EXCEEDED"}
```

Four of seven runs of the *same* graph over the *same* sources succeeded. The only variable was how much text the pages happened to return that minute. A workflow whose outcome is a coin flip is the defect, not the 400.

New module `src/workflows/caps/upstream.rs`, wired into the existing #782 fold in `caps/mod.rs`:

1. **The payload is bounded.** At most `DEFAULT_UPSTREAM_BUDGET_CHARS` (32,000) characters per turn — **the whole rendered section, truncation markers and separators included, not merely the source text inside them** (see the review round below) — divided **max-min fairly** across the predecessors — a short source is served in full and the large ones split what is left. A 300-character wire item beside two 200k pages keeps all 300. A flat per-source cap does not fix starvation, and a running total makes the result depend on which branch finished first.
2. **Truncation is visible to both the model and the operator.** Each cut source carries a `[TRUNCATED BY OPENCOMPANY — source 2 of 3 produced 14700 characters; the 10000 above are all that was kept and the remaining 4700 were NOT read. Do not describe this source as if you have seen all of it.]` marker **in the turn itself**, so the agent knows it is holding a fragment and cannot present it as the whole; *and* the run carries an operator notice on `WorkflowRun::notices` — the #638 channel added for exactly this shape of fact — naming how much arrived, how much fitted, how many sources were cut, and the remedy. Silent truncation would be worse than the 400 it prevents.
3. **The provider refusal is translated.** A context-window 400 is rewritten before it reaches the run: it names what is actually too big (the number of feeding steps, the step's own instruction, the teammate's accumulated session history), what to do about each, and keeps the provider's own words at the end for support.

## API Or Behavior Changes

**Behaviour, agent nodes only.** An `agent` node's turn now carries at most 32,000 characters of upstream text. Every run below that budget — the overwhelming majority — composes a **byte-identical** message to before, raises no notice and is unaffected; pinned by `an_ordinary_fan_in_is_untouched_and_says_nothing` and the pre-existing `no_upstream_output_is_byte_identical`.

A run whose input exceeds the budget now **succeeds with truncated input plus a notice**, where it previously either succeeded or failed on a provider 400 depending on page size.

Error text for a context-window refusal changes shape (the vendor sentence is replaced, the vendor string retained). Every other error passes through unchanged, pinned by `unrelated_errors_are_not_relabelled`.

No public API change. `DEFAULT_UPSTREAM_BUDGET_CHARS` is `pub(crate)` and `#[cfg(test)]`-re-exported for one assertion.

### Review round: the bound did not cover its own reporting

CodeRabbit flagged (Major) that the first cut of this change bounded source text and then appended an **unbudgeted** marker per truncated source and an unbudgeted separator between each pair, with no final limit. It holds, and rather than reason about it I measured it:

| | |
| --- | --- |
| Marker | **209 characters**, one per truncated source |
| Separator | 7 characters, one per pair |
| 1,000 oversized sources under a 32,000-character budget | **243,886 characters rendered — 7.6× the budget** |

That is issue #849's own failure reappearing through #849's fix. The three-source tests never saw it because the assertion slack (`MARKER_SLACK: 2000`) covered about **eight** markers — worth stating plainly, because the missing coverage was a *class* of test, not a single case: nothing asserted on the **final rendered section**, only on per-source slices and whole-message size at small N.

**A second instance the review did not mention, found while fixing it:** the separators are unbudgeted *even when nothing is truncated*. Ten thousand one-character sources all fit the text budget and still added 70,000 characters of separator. Same root cause, same fix — credit for the marker case is CodeRabbit's, the separator case is mine.

**The invariant is now: the rendered section never exceeds `budget`, markers and separators included.** One number, one assertion, one function's postcondition. Paid for three ways, each where it fits — this is deliberately *both* of the options the review offered plus a third, because they solve different halves:

- **Reserved** — each truncation marker is charged to the allowance of the source it describes. That is the honest place for it: the marker exists because that source was cut and stands in the space the cut text vacated.
- **Aggregated** — predecessors there is no room for at all collapse into one `[OMITTED BY OPENCOMPANY — 469 of this step's 500 inputs …]` line. This is the half that must not scale with source count, and it does not.
- **Capped, by derivation not by magic number** — `max_rendered_sources(budget) = budget / MIN_SOURCE_SHARE_CHARS` (1,024), so 31 at the default budget. **This is what makes per-source markers affordable at all**; reservation alone does not bound a thousand markers, it merely makes each cost a source its text. A thousand 32-character shards is noise with the shape of data — no model can rank them — so the honest rendering is 31 readable sources plus a line saying 469 were not shown.

Per-source markers survive for the sources that *are* rendered because aggregating them away would buy budget by deleting the signal: the marker sits at the exact point the text stops, which is what stops a model narrating a source it has only seen the opening of. One aggregate line cannot do that job. The reasoning is in the module doc, not only here.

An unconditional `clamp_to_budget` backstops the arithmetic, and `the_backstop_is_never_what_enforces_the_budget` asserts it does **not** fire on any known path — a clamp that bites routinely hides a mis-accounting rather than guarding against one.

`MAX_MARKER_CHARS` (320) is now pinned by test at both markers' numeric extremes (`usize::MAX` in every field), so a future edit that makes a marker wordier fails a test instead of silently spending budget it was not reserved. The module doc carries a standing table of everything emitted, its count and its size, since breaching that property is how this broke.

The operator notice now distinguishes truncated from omitted — *"31 of them were truncated and a further 469 could not be shown to it at all"* — because a fragment and an absence are different facts about what the step saw.

**Not fixed, flagged:** `RunNotices` itself is uncapped. That is pre-existing and shared with the #638 approval and board-write producers; this change adds one notice per agent node turn, the same rate they push at, so it introduces no new scaling factor. Capping it would change that contract and belongs in its own change.

### Three judgement calls a reviewer should weigh

**1. Truncate-and-report rather than fail-the-run — this contradicts the issue text, deliberately.**

The issue (which I wrote) asks to *fail before spending*. That framing is wrong, and reading only the issue will make this look like a missed requirement. By the time a fan-in is composed the spending has **already happened** — the fetches ran first. Failing there throws that paid work away and delivers the operator nothing, in order to avoid a turn that a bounded input makes succeed. So the boundary is enforced by *bounding*, before the request is composed, and the "which inputs overflowed" report rides the marker and the notice instead of an error. The one overflow that can still reach the provider — a turn whose own instruction, tool schemas or session history is what is too large — is what the error translation exists for.

**2. An advertised context window may LOWER the budget and never raise it.**

`chat-v1`'s nominal window is enormous and the turn was refused a long way inside it, because the advertised figure describes the model rather than the turn and says nothing about the system prompt, the tool schemas or the session history sharing it. Trusting it upward is exactly how a fan-in gets handed more than the provider will take; trusting it downward is safe and worth doing, so a small model gets a proportionally smaller budget. The reasoning is in the code at `budget_chars`, not only here.

**3. I did NOT thread a node id into `translate`, and the issue's "name the node" is met another way.**

`AgentRunner::run_agent` receives the resolved node *config* — `prompt`, `input`, `agent_ref` — never the node id, so naming the node in the error would mean adding a `node_id` key in `translate` and carrying it through config resolution. I did not, because the console **already** names it: `RunHistoryPanel` renders `This run failed at "rank": ` from the #371 node trail, so the operator reads the node name immediately before this message. The error names the agent ref, the inputs and the remedy; the node name is supplied by the surface it appears on. Say the word if you would rather have it in the string too.

For the same reason the marker says `source 2 of 3` rather than naming the producing node: the `input = "=items"` binding resolves to the item set with no provenance, and changing that binding is precisely the shape #782 pinned. Carrying provenance through the fold is a follow-on, not a drive-by.

### The bound is at the join, not at the producer

Worth stating because it is the natural review question. A cap on a `tool_call` node's own output would bound each fetch separately and still let three bounded fetches sum to an oversized turn, and it would have to spend its cap blind to how many siblings were about to arrive. It would also miss every other producer — an upstream `agent` node's reply is unbounded in exactly the same way, and a `transform` can manufacture a large payload from a small one. **A single enormous `web_fetch` into one agent runs the same unbounded path as the three-way fan-in** (`a_single_enormous_source_is_bounded_too`), and one rule at the join covers both.

This is a different resource from `ports::bound_node_output`, which clips the persisted run-output snapshot after a run settles against a durable-storage ceiling. A node's output can be well inside that cap and still be more than a turn will take. Noted in the module doc so the two are not confused.

## Tests

27 new tests. 19 pure unit tests in `upstream.rs`, 7 fold-level tests in `caps/mod.rs`, and 1 end-to-end test through the real graph → `translate` → `run_workflow` → `HarnessAgentRunner` → `HarnessPool` with only the model stubbed.

**Every payload is synthetic.** The reported failure is intermittent *because* it depended on what a live sports section returned that minute, so a test that fetched a real page would be the same coin flip.

### Revert-and-check, round two (the marker budgeting)

I neutralised each of the four new mechanisms independently — cap → `usize::MAX`, up-front charge → removed, marker reservation → removed, clamp → pass-through. **All 5 new tests failed**, none vacuous:

```
a_thousand_oversized_sources_stay_inside_the_budget .............. FAILED  243886 chars for a 32000 budget
a_thousand_way_fan_in_cannot_smuggle_its_markers_past_the_budget . FAILED  245941-character turn
the_bound_holds_at_every_scale_and_budget ........................ FAILED  133 chars under a 0 budget
sources_past_the_useful_limit_are_aggregated_into_one_line ....... FAILED
a_truncation_marker_is_paid_for_by_its_own_source ................ FAILED
```

`the_bound_holds_at_every_scale_and_budget` sweeps 6 source counts × 7 budgets including 0 and the 1,023/1,024 boundary either side of the derived cap.

### Revert-and-check, round one (the original bound)

I neutralised each behaviour in place — budget → `usize::MAX`, allocation → keep everything, marker → empty string, notice → `None`, translation → `None` — and re-ran. **13 of the 19 failed.** The end-to-end test failed with the bug in its message:

```
the fan-in turn must not carry both payloads whole: 136965 characters for a 32000-character budget
```

**The other 6 still passed with the fix reverted, by design, and are not claimed as coverage of it:** `sources_that_fit_are_untouched`, `an_untruncated_fold_raises_no_notice`, `an_ordinary_fan_in_is_untouched_and_says_nothing`, `unrelated_errors_are_not_relabelled`, `truncation_respects_character_boundaries`, and the `budget_chars(None)` arm. They are no-regression and no-overreach guards — the under-budget path must stay byte-identical, and the error translator must never relabel an unrelated failure — and a no-op trivially satisfies them. They prove the change breaks nothing, not that it does anything.

### Commands run locally

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean. Ran with `--no-deps` to mirror CI; a bare `--all-targets` fails on vendored-crate lints CI never evaluates.
- [x] `cargo build --all-targets` — clean (default features). Also `cargo check --features openhuman,tinycortex --lib`, since default features compile none of `src/workflows`.
- [x] `cargo test` — 2340 passed, 0 failed (default features). Also `cargo test --features openhuman,tinycortex --lib` — **3619 passed, 0 failed**, which is the run that actually exercises this change.

### A pre-existing local failure, flagged not fixed

`workflows::agent_upstream_input_test` stack-overflows at the default thread stack size. **This reproduces on unmodified `upstream/main`** — I checked out pristine `src/workflows/` and confirmed it before writing anything. CI sets `RUST_MIN_STACK: 16777216` on the gated lane; all 306 `workflows::` tests pass at that exact value locally. Not caused by this PR, and out of scope for it, but it will bite anyone running these tests locally without the env var.

### One unverified observation from the issue data

In the issue's table the four passes are all 19:50–19:51 and the three failures all 19:58–20:03 — **monotone in time**. The harness keeps one live session per roster agent and history survives across turns, so `analytics_analyst`'s accumulated session history is a plausible second variable alongside page size. I did not confirm this: isolating it needs many staging runs and no single run distinguishes the two causes. It is a hypothesis, not a finding — it is why the error translation names session history as a suspect, and why bounding the fold reduces the growth rate as well as the peak.

## Documentation

`docs/spec/runtime/workflow-vocabulary.md` gains a section on what an `agent` node receives from upstream and its bound: the budget, the fair division, why the bound is at the join rather than the producer, that truncation is never silent, and that a bounded turn is not a failed run. Module-level rationale lives in `src/workflows/caps/upstream.rs`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow agents now receive bounded upstream inputs with fair allocation across sources.
  * Oversized content is truncated with visible markers while preserving contributions from each predecessor.
  * Operators receive run notices when upstream content is truncated or sources are omitted.
  * Provider context-window errors now include workflow-specific guidance.

* **Documentation**
  * Added documentation describing upstream input handling, budgeting, truncation, and error guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->