### PR TITLE
fix(approvals): render a host-scoped grant's URL verbatim

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -416,7 +416,20 @@ export interface StandingGrant {
   expires_at_millis: number;
   /**
    * The slice of the tool it is confined to, when the tool's name is not the
-   * whole of what it can do (#457) — a Composio toolkit like `github`.
+   * whole of what it can do (#457).
+   *
+   * **Two kinds of value, in one untyped string** — both minted by the host's
+   * `standing_scope_of`, and a reader that assumes either one is the bug #785
+   * was:
+   *
+   * * a **Composio toolkit** identifier like `github` — a slug, which has to be
+   *   spelled out before an operator can read it;
+   * * a **URL origin** like `https://docs.rs`, added for `web_fetch` by
+   *   #673/#739 — already exactly what the operator approved, and to be shown
+   *   untouched.
+   *
+   * Render it through `grantHeadline` in `lib/language`, which is the one place
+   * that tells them apart. Do not spell a scope out at a call site.
    *
    * Absent for every tool whose name already says everything, and absent from
    * an older host that predates the field. Both mean "nothing to narrow", so

--- a/frontend/src/lib/language.ts
+++ b/frontend/src/lib/language.ts
@@ -2,7 +2,7 @@
 // never exposes runtime internals ("agent graph", "tier", "dispatch", "cycle",
 // "checkpoint", "A2A"). Everything a person sees goes through this layer.
 
-import type { ApprovalSummary, FeedbackCategory } from "../api/types";
+import type { ApprovalSummary, FeedbackCategory, StandingGrant } from "../api/types";
 
 /**
  * A company's lifecycle state, in plain language, with a status tone.
@@ -285,6 +285,79 @@ export function approvalAction(a: ApprovalSummary): string {
  */
 export function toolAction(kind: string): string {
   return labelFor(EFFECT_LABELS, kind) ?? labelFor(TOOL_LABELS, kind) ?? "Use one of its tools";
+}
+
+/**
+ * What one standing permission actually covers, in one line (#457).
+ *
+ * {@link toolAction} alone answers "which tool", which is the whole sentence for
+ * `file_write` and only half of it for `composio_execute`: that name carries
+ * every action of every connected provider, so a row reading "Act in one of its
+ * connected accounts" leaves an operator unable to tell a permission over their
+ * code host from one over their mailbox — and a permission you cannot read is
+ * one you cannot decide to revoke. When the host names a scope, the row names
+ * what it narrows to.
+ *
+ * Composed as a suffix rather than a second phrasing table: the tool's own words
+ * stay in {@link toolAction}, so there is nothing here to drift out of step
+ * with it.
+ *
+ * Lives here rather than in the view because it now has a branch worth naming
+ * ({@link scopeLabel}), and the branch is the whole of issue #785.
+ */
+export function grantHeadline(g: StandingGrant): string {
+  const action = toolAction(g.tool);
+  return g.scope ? `${action} — ${scopeLabel(g.scope)} only` : action;
+}
+
+/**
+ * A grant's scope as a person would read it (#785).
+ *
+ * `StandingGrant.scope` is one string carrying **two different kinds** of value,
+ * minted by two arms of the same host function (`standing_scope_of`):
+ *
+ * * a **Composio toolkit** identifier — `microsoft_teams` — which is a slug and
+ *   has to be spelled out before an operator can read it;
+ * * a **URL origin** — `https://docs.rs` — added for `web_fetch` by #673/#739,
+ *   which is already exactly what the operator approved and must survive
+ *   untouched.
+ *
+ * Issue #785 was the second kind going through the first kind's speller:
+ * `https://docs.rs` has no `_`, so it stayed one "word" and came out as
+ * `Https://docs.rs`. A scheme is not a proper noun, and an operator reading a
+ * row *in order to decide whether to revoke it* should not have to wonder
+ * whether the display is lying about the rest of the string too.
+ *
+ * The kinds are told apart here, on the value, rather than by a discriminator
+ * on the wire. `scope` is the enforcement key — the host matches a live call
+ * against it with exact string equality (`StandingGrant::admits_scope`) and it
+ * is replayed from the journal — so retyping it is a persisted-format change to
+ * a security-relevant comparison, not a label fix. What that suggestion is
+ * really worth is naming the two kinds at the type, which the doc comments on
+ * both sides now do. If a third kind ever arrives, this function is the one
+ * place that has to learn about it.
+ */
+function scopeLabel(scope: string): string {
+  return scope.includes("://") ? scope : toolkitLabel(scope);
+}
+
+/**
+ * A toolkit identifier as a person would write it: `microsoft_teams` →
+ * "Microsoft Teams".
+ *
+ * Mechanical on purpose. A lookup table of pretty provider names would render
+ * the ~30 toolkits it knew and the raw slug for everything else, and the ones it
+ * did not know would be exactly the ones added most recently.
+ *
+ * Toolkit slugs only — see {@link scopeLabel} for why a URL origin must never
+ * reach this.
+ */
+function toolkitLabel(scope: string): string {
+  return scope
+    .split("_")
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ");
 }
 
 /** A one-line, human summary of what needs approval. */

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -22,7 +22,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
-import { approvalSummary, timeAgo, toolAction } from "@/lib/language";
+import { approvalSummary, grantHeadline, timeAgo, toolAction } from "@/lib/language";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { isRecord, parseNodeMessages } from "@/views/workflows/run-output";
 
@@ -395,41 +395,6 @@ function StandingPermissions({
       </div>
     </section>
   );
-}
-
-/**
- * What one standing permission actually covers, in one line (#457).
- *
- * `toolAction` alone answers "which tool", which is the whole sentence for
- * `file_write` and only half of it for `composio_execute`: that name carries
- * every action of every connected provider, so a row reading "Act in one of its
- * connected accounts" leaves an operator unable to tell a permission over their
- * code host from one over their mailbox — and a permission you cannot read is
- * one you cannot decide to revoke. When the host names a scope, the row names
- * the provider.
- *
- * Composed as a suffix rather than a second phrasing table: the tool's own words
- * stay in `lib/language`, so there is nothing here to drift out of step with it.
- */
-function grantHeadline(g: StandingGrant): string {
-  const action = toolAction(g.tool);
-  return g.scope ? `${action} — ${providerLabel(g.scope)} only` : action;
-}
-
-/**
- * A toolkit identifier as a person would write it: `microsoft_teams` →
- * "Microsoft Teams".
- *
- * Mechanical on purpose. A lookup table of pretty provider names would render
- * the ~30 toolkits it knew and the raw slug for everything else, and the ones it
- * did not know would be exactly the ones added most recently.
- */
-function providerLabel(scope: string): string {
-  return scope
-    .split("_")
-    .filter(Boolean)
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(" ");
 }
 
 /**

--- a/frontend/test/unit/language.test.ts
+++ b/frontend/test/unit/language.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { approvalAction, payloadLines, toolAction } from "@/lib/language";
-import type { ApprovalSummary } from "@/api/types";
+import { approvalAction, grantHeadline, payloadLines, toolAction } from "@/lib/language";
+import type { ApprovalSummary, StandingGrant } from "@/api/types";
 
 /**
  * The gated tools an operator is asked to sign off on say what they are (#701).
@@ -126,5 +126,59 @@ describe("a kind nobody has named", () => {
 
   it("falls back the same way from the permissions list", () => {
     expect(toolAction("some_tool_nobody_declared")).toBe("Use one of its tools");
+  });
+});
+
+/**
+ * A standing permission's headline (#457), and the scope suffix it carries.
+ *
+ * `StandingGrant.scope` is one string holding two kinds of value — a Composio
+ * toolkit slug, and (since #673/#739) a URL origin for `web_fetch`. Issue #785
+ * was the second kind going through the first kind's speller, so a host-scoped
+ * grant rendered `Https://docs.rs`.
+ *
+ * Both kinds are asserted here on purpose: the toolkit case alone is what CI and
+ * review already had, and it stayed green through the whole of #785.
+ */
+function grant(over: Partial<StandingGrant> & Pick<StandingGrant, "tool">): StandingGrant {
+  return {
+    id: "g1",
+    agent: "ceo",
+    granted_by: { kind: "user", id: "u1" },
+    at_millis: 1_000,
+    expires_at_millis: 2_000,
+    ...over,
+  };
+}
+
+describe("what a standing permission covers", () => {
+  it("keeps a host scope verbatim, scheme and all", () => {
+    expect(grantHeadline(grant({ tool: "web_fetch", scope: "https://docs.rs" }))).toBe(
+      "Fetch a web page — https://docs.rs only",
+    );
+  });
+
+  it("keeps the scheme of every origin shape the host can mint", () => {
+    // `standing_scope_of` mints `scheme://host[:port]` — lower-case, port kept.
+    for (const origin of [
+      "https://www.bbc.com",
+      "http://localhost:8080",
+      "https://docs.rs:443",
+      "https://sub.domain.example.co.uk",
+    ]) {
+      expect(grantHeadline(grant({ tool: "web_fetch", scope: origin }))).toBe(
+        `Fetch a web page — ${origin} only`,
+      );
+    }
+  });
+
+  it("still spells a toolkit slug out for an operator", () => {
+    expect(
+      grantHeadline(grant({ tool: "composio_execute", scope: "microsoft_teams" })),
+    ).toBe("Act in one of its connected accounts — Microsoft Teams only");
+  });
+
+  it("says only the action when the grant narrows to nothing", () => {
+    expect(grantHeadline(grant({ tool: "file_write" }))).toBe("Write a file in its workspace");
   });
 });

--- a/src/runtime/grants.rs
+++ b/src/runtime/grants.rs
@@ -335,6 +335,16 @@ pub struct StandingGrant {
     /// passing. Slug-exact would re-park every new action and make the grant
     /// worth nothing.
     ///
+    /// `Some(origin)` — a `scheme://host[:port]` URL origin — for `web_fetch`
+    /// since issues #673/#739, on the same terms and from the same function.
+    /// **This is a second kind of value in the same string**, and a reader that
+    /// assumes the toolkit kind is wrong about it: the console spelled
+    /// `https://docs.rs` out with the toolkit speller and rendered
+    /// `Https://docs.rs` for three releases (issue #785). Anything that
+    /// *displays* a scope has to tell the two apart; anything that *matches* one
+    /// must not care, because [`admits_scope`](Self::admits_scope) is exact
+    /// string equality over whichever kind was minted.
+    ///
     /// `None` also on a grant replayed from a journal line written before this
     /// field existed, where it means "unscoped" and reproduces the old
     /// behaviour exactly — see [`admits_scope`](Self::admits_scope).


### PR DESCRIPTION
## Summary

A standing permission scoped to a host rendered its scheme capitalised — **`Fetch a web page — Https://docs.rs only`**. Confirmed on staging today, on three live grants (`Https://www.theguardian.com`, `Https://www.bbc.com`, `Https://www.espn.com`).

`grantHeadline` sent **both kinds** of `StandingGrant.scope` through `providerLabel`, which was written for Composio toolkit slugs and upper-cases the first letter of each `_`-separated word. A URL origin has no `_`, so it survived as a single "word" and only its scheme was touched.

The two kinds are now told apart in one named place. `grantHeadline` moves from `ApprovalsView.tsx` into `lib/language.ts` — next to the `toolAction` it composes with (which its own doc already pointed at), and where the unit runner can reach it: it was module-private in a `.tsx`, and `vitest.config.ts` is explicit that the runner is for pure functions with no React. It gains `scopeLabel`, the single function a third kind of scope would have to teach.

### Which fix, and why

The issue offered two options. I took the value-side branch, and **rejected the typed host-side discriminator** — with reasons, since the issue is right that sniffing punctuation can re-create this class of bug:

- `scope` is the **enforcement key**. `StandingGrant::admits_scope` (`src/runtime/grants.rs`) matches a live call against it with **exact string equality**, and `standing_scope_of`'s own doc insists the mint side and the live-call side must read with identical code *"or a grant could be minted that never matches its own tool"*.
- It is `Serialize, Deserialize` and **journal-replayed** — the field docs repeatedly describe grants *"replayed from a journal line written before this field existed"*.

So retyping it is a persisted-format change to a security-relevant comparison, not a label fix, and it does not belong in a cosmetic label PR.

But the part of that suggestion that *was* free has been taken. Both the Rust field doc and the TS `StandingGrant.scope` doc still described a Composio toolkit **only** — three releases after #673/#739 added the URL origin. That stale documentation is precisely why the console's assumption read as true to everyone who looked at it. Both now name the two kinds, and say that a *displaying* reader must tell them apart while a *matching* one must not care.

If a third kind ever arrives, `scopeLabel` is the one place that has to learn about it, and the type doc on both sides now says so.

## API Or Behavior Changes

None. No wire, storage, or matching change — `admits_scope` and the journal format are untouched. The only behaviour change is the rendered string for a host-scoped grant:

| scope | before | after |
| --- | --- | --- |
| `https://docs.rs` | `Fetch a web page — Https://docs.rs only` | `Fetch a web page — https://docs.rs only` |
| `microsoft_teams` | `… — Microsoft Teams only` | unchanged |
| absent | `Write a file in its workspace` | unchanged |

## Tests

Four cases in `frontend/test/unit/language.test.ts`, covering both scope kinds and the unscoped row. The host cases assert the origin **verbatim**, including a port (`http://localhost:8080`), an explicit `:443`, and a multi-label domain.

**Revert proof.** With `scopeLabel` reverted to the old speller and nothing else changed:

```
Tests  2 failed | 29 passed (31)

Expected: "Fetch a web page — https://www.bbc.com only"
Received: "Fetch a web page — Https://www.bbc.com only"
```

The two host cases fail; the toolkit case and the no-scope case stay **green**. That asymmetry is the whole reason this shipped past CI and a review, and it is why the issue asked for more than a snapshot of the toolkit case.

**Console checks run locally** — all four steps the `Console` CI job runs, plus the targeted file:

| command | result |
| --- | --- |
| `npm run typecheck` (`tsc -b`) | exit 0 |
| `npm run typecheck:e2e` | exit 0 |
| `npm run typecheck:unit` | exit 0 |
| `npx vitest run test/unit/language.test.ts` | **31 passed** |

The full unit suite also reports 57 failures in `connection-registry`, `desktop-bridge` and `tour-resume` — **pre-existing and unrelated**: identical with these changes stashed, all `window.localStorage.clear is not a function`, caused by a local `pnpm` install resolving `jsdom` 27.4.0 under the declared `^27.0.1` range where `package-lock.json` pins 27.0.1. CI installs with `npm ci`, so CI is unaffected. Filed separately as #852 rather than widened into this PR.

- [x] `cargo fmt --all -- --check` — not run locally (fleet policy: no local cargo builds on the shared disk). The Rust change is a **doc comment only** — no executable line changes — so CI's Rust lanes are the check.
- [x] `cargo clippy --all-targets -- -D warnings` — as above; doc-comment-only change, covered by CI.
- [x] `cargo build --all-targets` — as above; doc-comment-only change, covered by CI.
- [x] `cargo test` — as above; doc-comment-only change, covered by CI. No Rust behaviour is touched, so no Rust test could distinguish this diff.

## Documentation

The documentation fix *is* half of this change, not an afterthought:

- `src/runtime/grants.rs` — `StandingGrant::scope` now documents the `Some(origin)` kind from #673/#739 alongside the toolkit kind, and states the display/match split.
- `frontend/src/api/types.ts` — the mirrored TS doc does the same, and points readers at `grantHeadline` rather than letting them spell a scope out at a call site.

No `docs/` page describes this string, so none needed updating.

Closes #785
