### PR TITLE
fix(console): repair localStorage under jsdom on Node 25+ (the jsdom range was not the cause)

### DIFF
--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
+      '@fontsource-variable/geist-mono':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.2)
@@ -502,6 +505,9 @@ packages:
 
   '@floating-ui/utils@0.2.12':
     resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
+  '@fontsource-variable/geist-mono@5.3.0':
+    resolution: {integrity: sha512-vBbuwDEo9AkrqADMXOrlAR3DFcJi4/JxeuU43FoiQERnNwsfXNnvxvReZG02cQKmyk4DZkZdBZX3oTDvy2zBAw==}
 
   '@fontsource-variable/geist@5.2.9':
     resolution: {integrity: sha512-TP+QSBG3wxKGPE33CbMy/L0Nu3qvJ6Fy81Yc4LnQ95xH+i+cfEp8fyU8/kfV14YwszxIFPhnoMTbjL71waVpyQ==}
@@ -3400,6 +3406,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
 
   '@floating-ui/utils@0.2.12': {}
+
+  '@fontsource-variable/geist-mono@5.3.0': {}
 
   '@fontsource-variable/geist@5.2.9': {}
 

--- a/frontend/test/unit/setup/web-storage.ts
+++ b/frontend/test/unit/setup/web-storage.ts
@@ -1,0 +1,77 @@
+/**
+ * Give the jsdom suites jsdom's `localStorage`, on every Node this repo can be
+ * checked out on (issue #852).
+ *
+ * # The failure this exists to prevent
+ *
+ * Three suites — `connection-registry`, `desktop-bridge`, `tour-resume` — open
+ * with `window.localStorage.clear()`. On Node 25 all 57 of their tests fail on
+ * that line with:
+ *
+ *     TypeError: window.localStorage.clear is not a function
+ *
+ * On Node 22, the version CI pins and `frontend/Dockerfile` ships, they pass.
+ * The jsdom version is not the variable: 27.0.1 and 27.4.0 both pass on Node 22
+ * and both fail on Node 25.
+ *
+ * # Why
+ *
+ * Node 25 exposes WebStorage as an unflagged global, so `localStorage` is now a
+ * property of `globalThis` before any test environment is built. Vitest's
+ * `populateGlobal` copies the jsdom window onto the global, but skips any key
+ * the global already owns unless that key is on its own hard-coded list — and
+ * `localStorage`/`sessionStorage` are not on it:
+ *
+ *     if (k in global) return keysArray.includes(k)
+ *
+ * So on Node 22 (`'localStorage' in globalThis === false`) the key is copied and
+ * `window.localStorage` is jsdom's `Storage`. On Node 25 the key is dropped and
+ * `window.localStorage` resolves to Node's own built-in — which, with no
+ * `--localstorage-file` given, is an empty object with no `clear`, no `getItem`
+ * and no `setItem`. Hence the error, and hence its shape: not a Storage that
+ * behaves differently, a non-Storage.
+ *
+ * # What this does
+ *
+ * Re-points the two storage globals at the jsdom window's real ones. Vitest
+ * hands us the `JSDOM` instance as `globalThis.jsdom`, so this reaches the
+ * genuine `Storage` objects rather than substituting a hand-written stand-in:
+ * the suites keep testing against the same implementation they always did, on
+ * Node 22 and Node 25 alike. `window === globalThis` under this environment, so
+ * defining the property here is what fixes `window.localStorage` in the tests.
+ *
+ * On Node 22 this is a no-op — the globals are already jsdom's and the identity
+ * check short-circuits. Under `environment: "node"`, which is this suite's
+ * default and most of its files, there is no `globalThis.jsdom` and nothing
+ * happens at all; a node-environment test still sees whatever its Node version
+ * gives it.
+ *
+ * This is a workaround for a Vitest/Node interaction, not for a jsdom one.
+ * When Vitest adds `localStorage` to the keys it carries over from the window,
+ * this file can go.
+ */
+
+type StorageName = "localStorage" | "sessionStorage";
+
+const dom = (globalThis as { jsdom?: { window: Record<StorageName, Storage> } }).jsdom;
+
+if (dom?.window) {
+  for (const name of ["localStorage", "sessionStorage"] as const) {
+    const fromJsdom = dom.window[name];
+
+    // Identity, not feature-detection. `globalThis[name]` on Node 25 is an
+    // object, and truthy, and would survive a `typeof` check; the only thing
+    // that distinguishes it from the one the tests need is that it is not the
+    // window's.
+    if (fromJsdom && globalThis[name] !== fromJsdom) {
+      Object.defineProperty(globalThis, name, {
+        value: fromJsdom,
+        // Writable and configurable because Vitest's teardown deletes and
+        // restores globals between files, and a locked property would make it
+        // throw rather than tear down.
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+}

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -50,5 +50,11 @@ export default defineConfig({
     // imports `@playwright/test` and needs a browser — can never be collected
     // by this runner.
     include: ["test/unit/**/*.test.ts"],
+    // Runs before every file, in whichever environment that file asked for.
+    // It is a no-op except under jsdom on Node 25+, where it repairs the two
+    // storage globals Vitest declines to carry over from the window — without
+    // it, 57 tests in three files fail on `localStorage.clear` (issue #852).
+    // Not collected as a test: `include` above only matches `*.test.ts`.
+    setupFiles: ["./test/unit/setup/web-storage.ts"],
   },
 });


### PR DESCRIPTION
## Summary

Closes #852.

**The issue's diagnosis was wrong, and this PR overturns it rather than implementing it.** #852
attributed 57 failing tests to `jsdom`'s caret range admitting 27.4.0, and proposed pinning
`"jsdom": "~27.0.1"`. jsdom is not the variable. Node is.

|                                    | jsdom 27.0.1 (what the lockfile pins) | jsdom 27.4.0 (max the range admits) |
| ---------------------------------- | ------------------------------------- | ----------------------------------- |
| **Node 22.14** — CI + `Dockerfile` | ✅ 57 pass                            | ✅ 57 pass                          |
| **Node 25.3**                      | ❌ 57 fail                            | ❌ 57 fail                          |

Both jsdom versions pass on Node 22. Both fail on Node 25. The proposed pin would have been the
worst outcome available: a closed issue and a live bug, with the next person on Node 25 hitting the
identical failure while believing the fix was already applied.

### What actually breaks

Node 25 exposes WebStorage as an unflagged global, so `localStorage` is already a property of
`globalThis` before any test environment is constructed — on Node 22 it is not:

```
node 22:  'localStorage' in globalThis === false
node 25:  'localStorage' in globalThis === true
```

Vitest's `populateGlobal` copies the jsdom window onto the global, but skips any key the global
already owns unless that key is on its own hard-coded list — and `localStorage`/`sessionStorage`
are not on it:

```js
if (k in global) return keysArray.includes(k)   // vitest/dist/chunks/index.CmSc2RE5.js:250
```

So on Node 22 the key is copied and `window.localStorage` is jsdom's `Storage`. On Node 25 the key
is dropped and `window.localStorage` resolves to Node's own built-in, which with no
`--localstorage-file` given is an empty object:

```
window.localStorage        -> {}          (prototype: Object.prototype)
window.localStorage.clear  -> undefined
```

That explains the error's shape, which the original diagnosis could not: it is not a `Storage` that
behaves differently across versions, it is a non-`Storage`.

### The fix

`frontend/test/unit/setup/web-storage.ts`, wired in as `setupFiles`. It re-points the two storage
globals at the jsdom window's real ones, which Vitest hands over as `globalThis.jsdom` — so the
suites keep testing against jsdom's own `Storage` rather than a hand-written stand-in. It is a
no-op on Node 22 (identity check short-circuits) and under `environment: "node"`, this suite's
default, where there is no `globalThis.jsdom` at all.

This is a workaround for a Vitest/Node interaction, not a jsdom one. When Vitest carries
`localStorage` over from the window, the file can be deleted.

### The three open questions from #852, answered

**1. No pin, and no other dependency needs one.** I ran a full fresh resolution of *every* declared
range — `rm -rf node_modules package-lock.json && npm install`, which resolves jsdom 27.4.0,
`@base-ui/react` 1.7.0, `lucide-react` 1.31.0, `recharts` 3.10.1, `shadcn` 4.18.0,
`@playwright/test` 1.62.1 — and the suite is green on both Node 22 and Node 25 with all three
typechecks passing. That satisfies this issue's own acceptance criterion without pinning anything.

For the record, since #852 asked for a sweep: **11 of 34 direct dependencies** currently resolve to
something newer than the lockfile pins. That is not a defect to be filed 11 more times — it is what
a caret range *is*. The lockfile is the mechanism that makes it safe, and it is doing its job.

**2. `pnpm-lock.yaml` — fixed, and deleting it would have been the wrong call.** #852 floated
removing it as a resolver "the project does not actually maintain". It is not vestigial:
`src-tauri/tauri.conf.json` runs `pnpm dev` and `pnpm build`, so pnpm is what the desktop build
resolves with — precisely the resolver that never reads `package-lock.json`. Regenerating it was 8
lines, purely additive (the missing `@fontsource-variable/geist-mono` entry), and
`pnpm install --frozen-lockfile` now passes.

To be precise about what this does and does not buy: CI's `Desktop` job runs `npm ci` and
`npm run build` directly, so it never reads `pnpm-lock.yaml` either. The pnpm path is the *local*
desktop one — `npm run tauri:dev` / `tauri:build` shell out to `pnpm` via `beforeDevCommand` /
`beforeBuildCommand`. So this PR makes the file correct, but nothing in CI keeps it correct. That
is an argument for validating it or dropping it, not for leaving it as-is; I have kept it because
deleting it would leave the local desktop build resolving ranges with no lockfile at all, which is
strictly worse than a stale one. Folded into the follow-up issue.

One detail worth recording: `pnpm-lock.yaml` has pinned **jsdom 27.4.0** all along. The desktop
build path has been resolving the supposedly broken version without complaint for as long as the
file has existed — independent confirmation that 27.4.0 is fine.

**3. A CI lane that installs from the range rather than the lockfile — I recommend no.** Such a
lane goes red when an upstream publishes a bad minor, which destroys the property the `Console`
job's own comment exists to defend: that a green run is attributable to the diff. A lane that
reddens for reasons outside your change is a lane people learn to ignore, and an ignored gate is
worse than no gate. If that coverage is wanted it belongs on a schedule, decoupled from PRs, where
its redness is informative rather than obstructive.

More to the point: **a range-installing lane would not have caught this bug.** It would run on
Node 22 and stay green. What would have caught it is a Node version matrix. I have not added one
here — that is a CI design decision wider than this fix, and it deserves its own issue rather than
being smuggled into a test-setup PR.

**4. Nothing in the repo constrains a contributor's Node version.** CI pins 22 via `setup-node` and
`frontend/Dockerfile` builds `FROM node:22-slim`, but a contributor gets whatever they happen to
have installed — which is the entire reason this looked like a dependency bug. An `engines.node`
field or a `.nvmrc` would have prevented it outright. Deliberately not added here for the same
scope reason as above; filing separately.

## API Or Behavior Changes

None. Test-environment setup only — no `src/` file is touched, and no shipped behavior changes.
The console's own use of `localStorage` in a real browser was never affected.

## Tests

All commands run from `frontend/`, on both Node 22.14.0 (CI's version) and Node 25.3.0.

```
npm ci && npx vitest run                 # 53 files / 658 tests pass, both Node versions
npm run typecheck                        # pass
npm run typecheck:e2e                    # pass
npm run typecheck:unit                   # pass  (covers the new file — tsconfig.unit.json includes test/unit)
pnpm install --frozen-lockfile           # pass (failed on main)
```

Fresh resolution of the declared ranges, not the lockfile — the acceptance criterion in #852:

```
rm -rf node_modules package-lock.json && npm install   # resolves jsdom 27.4.0 + 10 other newer deps
npx vitest run                                          # 53/53 pass on Node 22 AND Node 25
npm run typecheck && npm run typecheck:e2e && npm run typecheck:unit   # all pass
```

**Revert-and-check.** With the fix removed and nothing else changed, on Node 25:

```
❯ test/unit/connection-registry.test.ts (29 tests | 29 failed)
❯ test/unit/desktop-bridge.test.ts      (17 tests | 17 failed)
❯ test/unit/tour-resume.test.ts         (11 tests | 11 failed)
 Test Files  3 failed | 50 passed (53)
   → window.localStorage.clear is not a function
```

With it applied: `Test Files 53 passed (53)`. The 4-cell matrix at the top of this PR was produced
by running the suite once per cell, not inferred.

`package-lock.json` is untouched by this PR — the fresh-resolution runs above were reproductions,
and the committed lockfile was restored and re-verified with `npm ci` afterwards.

- [x] N/A — `cargo fmt --all -- --check` — no Rust changed; this PR touches `frontend/` only.
- [x] N/A — `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- [x] N/A — `cargo build --all-targets` — no Rust changed.
- [x] N/A — `cargo test` — no Rust changed; the affected suite is the Vitest console suite, run above.

## Documentation

No doc change needed. The reasoning lives where someone hitting this will actually be standing: a
file-level comment in `frontend/test/unit/setup/web-storage.ts` giving the Node-22-vs-25 matrix, the
`populateGlobal` line responsible, and the condition under which the file should be deleted. The
`setupFiles` entry in `vitest.config.ts` carries a short pointer to it, matching that file's
existing house style of explaining each option.
