### PR TITLE
fix(workflows): resolve agent workflow tools against the workflow registry, and let "Build me the workflow" reach the builder

### DIFF
--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -55,6 +55,7 @@ import {
   dmChannelId,
   findChannel,
   firstChannel,
+  offersDeliverableChoice,
   resolveDmChannelId,
   toggleReaction,
   type DecidedApproval,
@@ -855,10 +856,11 @@ export function ChatView({
               placeholder={`Message ${channelTitle(channel)}`}
               disabled={sending}
               onSend={(text, deliverable) => void send(text, deliverable)}
-              // Only the company-channel composer offers "do it once" vs "build
-              // me the workflow" (issue #580): a channel line can open a board
-              // card, so the once-vs-workflow choice belongs at that prompt box.
-              deliverableChoice={active.kind === "channel"}
+              // Channel *and* DM composers offer "do it once" vs "build me the
+              // workflow" (issues #580, #845) — see `offersDeliverableChoice`,
+              // which owns the rule. Only the thread and copilot composers below
+              // go without.
+              deliverableChoice={offersDeliverableChoice(active.kind)}
             />
           </div>
 

--- a/frontend/src/views/chat/MessageComposer.tsx
+++ b/frontend/src/views/chat/MessageComposer.tsx
@@ -24,10 +24,16 @@ interface Props {
   /**
    * Show the once-vs-workflow control (issue #580), opt-in per composer.
    *
-   * Only the company-channel composer asks for it — a channel line can open a
-   * board card, so "do it once" versus "build me the workflow" belongs there.
+   * The channel and DM composers ask for it — either can open a board card, so
+   * "do it once" versus "build me the workflow" belongs at both prompt boxes.
    * The thread and copilot composers never carry it, so their `onSend` stays a
    * plain `(text)` and their wire shape is unchanged.
+   *
+   * DMs were omitted when #580 landed (issue #845). Nothing downstream was
+   * scoped to channels — the chat route reads `deliverable` off the payload
+   * whatever thread it came from — so a DM asking for a workflow was sent as a
+   * `once` card, dispatched to a desk agent holding no authoring tool, and came
+   * back as a refusal. The control was the only part missing.
    */
   deliverableChoice?: boolean;
 }

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -242,6 +242,35 @@ export function channelTitle(channel: Channel): string {
   return channel.kind === "dm" ? channel.name : `#${channel.name}`;
 }
 
+/**
+ * Whether this chat target's composer offers "Do it once" / "Build me the
+ * workflow" (issues #580, #845).
+ *
+ * True for every real chat target — a channel line and a DM can each open a
+ * board card, and the card is what routes a `workflow` request to the builder
+ * pass. It is deliberately a total function over [`ChannelKind`] rather than an
+ * inline `kind === "channel"`, so adding a kind is a decision someone makes here
+ * instead of a control that silently fails to appear.
+ *
+ * Not every composer asks: the thread and copilot composers pass nothing and
+ * keep their plain `(text)` `onSend`. A thread reply continues a message that
+ * already made this choice, and a copilot line is about one graph rather than a
+ * request to the company.
+ *
+ * #580 shipped the control on channels only. Nothing downstream was ever scoped
+ * to channels — the chat route reads `deliverable` off the payload whatever
+ * thread it came from — so the asymmetry lived entirely in the caller, and a DM
+ * asking for a workflow had no way to say so. It went as a `once` card, was
+ * dispatched to a desk agent holding no authoring tool, and came back a refusal.
+ */
+export function offersDeliverableChoice(kind: ChannelKind): boolean {
+  switch (kind) {
+    case "channel":
+    case "dm":
+      return true;
+  }
+}
+
 /* ---- senders ---- */
 
 export type SenderKind = "you" | "company" | "agent" | "system";

--- a/frontend/test/unit/chat-deliverable-choice.test.ts
+++ b/frontend/test/unit/chat-deliverable-choice.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChannelKind } from "@/views/chat/model";
+import { offersDeliverableChoice } from "@/views/chat/model";
+
+/**
+ * Issue #845: which composers offer "Do it once" / "Build me the workflow".
+ *
+ * #580 shipped the control on channel composers only. Nothing downstream was
+ * ever scoped to channels — `client.chat` carries `deliverable` off the payload
+ * whatever thread it came from, and the chat route reads it the same way — so
+ * the asymmetry lived entirely in the caller. A DM asking for a workflow had no
+ * way to say so: it went as a `once` card, was dispatched to a desk agent
+ * holding no workflow-authoring tool, and came back as a refusal. Reported
+ * verbatim on staging as "The only workflow tools I have are read-only".
+ */
+describe("offersDeliverableChoice", () => {
+  it("offers the choice on a DM — the gap this closes", () => {
+    expect(offersDeliverableChoice("dm")).toBe(true);
+  });
+
+  it("still offers it on a channel, unchanged from #580", () => {
+    expect(offersDeliverableChoice("channel")).toBe(true);
+  });
+
+  /**
+   * The rule is total over `ChannelKind` rather than an inline
+   * `kind === "channel"`, so a new kind is a decision someone makes in the
+   * function instead of a control that silently fails to appear. This pins that
+   * every kind the type admits has an answer.
+   */
+  it("answers for every channel kind", () => {
+    const kinds: ChannelKind[] = ["channel", "dm"];
+    for (const kind of kinds) {
+      expect(typeof offersDeliverableChoice(kind)).toBe("boolean");
+    }
+  });
+});

--- a/src/brain/echo.rs
+++ b/src/brain/echo.rs
@@ -187,6 +187,7 @@ mod test {
                     text: "hi".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &host,
             )

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -112,6 +112,7 @@ fn operator_request() -> CycleRequest {
             text: "hi".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),
@@ -537,6 +538,7 @@ async fn e2e_operator_message_drives_tool_call_and_gated_send_dm() {
             text: "how are we doing".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -589,6 +591,7 @@ async fn e2e_supervised_effect_parks_and_acks_not_ok() {
             text: "file it".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -655,6 +658,7 @@ async fn e2e_reported_usage_lands_on_the_usage_meter() {
         text: "how are we doing".into(),
         by: None,
         chat: None,
+        deliverable: None,
     }])
     .await
     .unwrap();
@@ -741,6 +745,7 @@ async fn e2e_hosted_catalog_advertises_delegation_tools() {
         text: "hi".into(),
         by: None,
         chat: None,
+        deliverable: None,
     }])
     .await
     .unwrap();
@@ -788,6 +793,7 @@ async fn e2e_spawn_task_tool_call_opens_a_board_card() {
         text: "open a task to ship invoicing".into(),
         by: None,
         chat: None,
+        deliverable: None,
     }])
     .await
     .unwrap();
@@ -842,6 +848,7 @@ async fn e2e_delegate_to_desk_tool_call_writes_a_handoff_card() {
         text: "have engineering build invoicing".into(),
         by: None,
         chat: None,
+        deliverable: None,
     }])
     .await
     .unwrap();
@@ -894,6 +901,7 @@ async fn e2e_a_cycle_without_usage_frames_meters_nothing() {
         text: "hello".into(),
         by: None,
         chat: None,
+        deliverable: None,
     }])
     .await
     .unwrap();

--- a/src/brain/sidecar/test.rs
+++ b/src/brain/sidecar/test.rs
@@ -111,6 +111,7 @@ fn operator_request() -> CycleRequest {
             text: "hi".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),
@@ -513,6 +514,7 @@ async fn e2e_inference_then_gated_send_dm_drives_a_channel_response() {
             text: "how are we doing".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -568,6 +570,7 @@ async fn e2e_supervised_effect_parks_through_the_real_gate() {
             text: "file it".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2486,6 +2486,7 @@ mod tests {
                     by: None,
                     chat: Some("desk-finance".into()),
                     parent: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -2499,6 +2500,7 @@ mod tests {
                     by: None,
                     chat: Some("desk-ops".into()),
                     parent: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -2557,6 +2559,7 @@ mod tests {
                     by: None,
                     chat: Some("desk-finance".into()),
                     parent: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -2650,6 +2653,7 @@ mod tests {
                             by: None,
                             chat: chat.map(str::to_string),
                             parent: None,
+                            deliverable: None,
                         },
                     )
                     .await
@@ -2680,6 +2684,7 @@ mod tests {
                     by: None,
                     chat: Some("desk-ops".into()),
                     parent: None,
+                    deliverable: None,
                 },
             )
             .await

--- a/src/company/task_intent.rs
+++ b/src/company/task_intent.rs
@@ -600,7 +600,12 @@ fn starts_with_word(lower: &str, phrase: &str) -> bool {
 
 /// Build a task title: strip a leading request frame, drop trailing
 /// punctuation, upper-case the first letter, and bound the length.
-fn to_title(original: &str) -> String {
+///
+/// `pub(crate)` since issue #845: the chat route opens a card for an explicit
+/// `workflow` deliverable even when the triage declined to name one, and it
+/// titles that card through *this* function rather than a second derivation, so
+/// a bypassed card is titled byte-for-byte as a `Track` card would have been.
+pub(crate) fn to_title(original: &str) -> String {
     let mut s = original.trim();
     // Strip stacked leading filler ("ok now …") and request-framing prefixes
     // ("please can you …") for a clean imperative title.

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2934,6 +2934,7 @@ description = "Runs Acme."
                     text: "status?".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -5501,6 +5502,7 @@ members = ["eng1", "eng2"]
                     text: "we should announce this".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -5559,6 +5561,7 @@ members = ["eng1", "eng2"]
                     text: "two things".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -5603,6 +5606,7 @@ members = ["eng1", "eng2"]
                     text: "status?".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -7732,6 +7736,7 @@ members = ["eng1", "eng2"]
                     text: "why is the site down?".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -7797,6 +7802,7 @@ members = ["eng1", "eng2"]
                     text: "handle it".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )
@@ -7836,6 +7842,7 @@ members = ["eng1", "eng2"]
                     text: "status?".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }]),
                 &NoopHost,
             )

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -5282,7 +5282,7 @@ budget_usd_daily = 0.0
             // are gated on both — with a manager and nothing bound the belt
             // would be missing `repo_checkout` / `repo_pr` and this check would
             // pass while never having looked at them, which is the exact way
-            // `describe_workflow` stayed invisible here while parking in
+            // `describe_skill` stayed invisible here while parking in
             // production.
             // Issue #752 added a fourth gate: a backend that keeps the
             // credential off this container's disk. Declared here for the same
@@ -5313,10 +5313,11 @@ budget_usd_daily = 0.0
             // `mcp_list_tools` and `mcp_call_tool` on the belt — the three
             // tools issue #443 is about. Without one the coverage check would
             // pass while never having looked at them.
-            // A skills source dir is what puts `list_workflows`,
-            // `describe_workflow` and `read_workflow_resource` on the belt.
-            // Leaving it `None` is how those three stayed invisible to this
-            // check while `describe_workflow` parked in production.
+            // A skills source dir is what puts `list_skills`, `describe_skill`
+            // and `read_skill_resource` on the belt (named for skills since
+            // issue #845; upstream calls them `*_workflow*`). Leaving it `None`
+            // is how those three stayed invisible to this check while
+            // `describe_workflow` parked in production.
             let company_src = dir.path().join("company-src");
             std::fs::create_dir_all(company_src.join("skills").join("brief")).expect("skill dir");
             std::fs::write(
@@ -5408,7 +5409,7 @@ budget_usd_daily = 0.0
             "shell",
             "workspace_write",
             "file_read",
-            "describe_workflow",
+            "describe_skill",
             "repo_checkout",
             #[cfg(feature = "mcp")]
             "mcp_list_servers",

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -1180,6 +1180,7 @@ fn chat(text: &str) -> CycleRequest {
             by: None,
             chat: None,
             parent: None,
+            deliverable: None,
         }],
         event_seqs: Vec::new(),
         compressed_history: Vec::new(),

--- a/src/harness/skills.rs
+++ b/src/harness/skills.rs
@@ -49,6 +49,10 @@ use crate::company::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md}
 use crate::error::OpenCompanyError;
 use crate::ports::skills_state::{SkillSource, SkillState};
 
+mod naming;
+
+pub use naming::{DESCRIBE_SKILL_TOOL, LIST_SKILLS_TOOL, READ_SKILL_RESOURCE_TOOL};
+
 /// One agent's effective, enabled skill set, materialized on disk so OpenHuman's
 /// skill read tools can scan it.
 pub struct EffectiveSkills {
@@ -200,6 +204,14 @@ impl EffectiveSkills {
     /// Each tool consumes only `config.workspace_dir` (verified upstream), so a
     /// throwaway [`Config`] with just that field set is enough — the global
     /// `Config::load_or_init()` and its registry are never booted.
+    ///
+    /// Wrapped by [`naming::skill_read_tools`] so they are named, described,
+    /// parameterized and answered in terms of **skills** (issue #845). Upstream
+    /// calls a skill a "workflow", which is a different thing entirely in a host
+    /// that has a workflow registry of its own — unrenamed, `list_workflows`
+    /// answered a question about the company's workflows with the contents of
+    /// `Settings → Skills`. See [`naming`] for why the rename is not only the
+    /// tool name.
     pub fn read_tools(&self) -> Vec<Box<dyn Tool>> {
         // `Config` has private fields, so build from `Default` and set the one
         // field the read tools read rather than a struct literal.
@@ -208,11 +220,11 @@ impl EffectiveSkills {
             ..Default::default()
         };
         let config = Arc::new(config);
-        vec![
+        naming::skill_read_tools(
             Box::new(WorkflowListTool::new(config.clone())),
             Box::new(WorkflowDescribeTool::new(config.clone())),
             Box::new(WorkflowReadResourceTool::new(config)),
-        ]
+        )
     }
 
     /// A plain-text catalogue of the effective skills for the persona prompt.
@@ -235,10 +247,15 @@ impl EffectiveSkills {
                 doc.name, doc.slug, doc.description
             ));
         }
-        out.push_str(
-            "Use `list_workflows` to enumerate them, `describe_workflow` to inspect one, \
-             and `read_workflow_resource` to read a skill's bundled files.\n",
-        );
+        // Named after skills, like the tools themselves (issue #845). This
+        // sentence is what hands an agent the three names, so it is also what
+        // taught every agent to call a skill a workflow.
+        out.push_str(&format!(
+            "Use `{LIST_SKILLS_TOOL}` to enumerate them, `{DESCRIBE_SKILL_TOOL}` to inspect \
+             one, and `{READ_SKILL_RESOURCE_TOOL}` to read a skill's bundled files. A skill is \
+             not one of the company's saved workflows — those are stored graphs, listed on the \
+             Workflows page, and none of these three tools can see them.\n",
+        ));
         out
     }
 
@@ -650,12 +667,14 @@ mod tests {
 
         let tools = eff.read_tools();
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        // Named after skills, not upstream's "workflow" (issue #845) — the
+        // naming boundary itself is covered in `naming::test`.
         assert_eq!(
             names,
             vec![
-                "list_workflows",
-                "describe_workflow",
-                "read_workflow_resource"
+                LIST_SKILLS_TOOL,
+                DESCRIBE_SKILL_TOOL,
+                READ_SKILL_RESOURCE_TOOL
             ]
         );
         // The tools point at the materialized scratch dir.
@@ -706,7 +725,7 @@ mod tests {
         let tools = eff.read_tools();
         let list = tools
             .iter()
-            .find(|t| t.name() == "list_workflows")
+            .find(|t| t.name() == LIST_SKILLS_TOOL)
             .expect("list tool");
         let listed = list
             .execute(json!({}))
@@ -720,12 +739,12 @@ mod tests {
 
         let describe = tools
             .iter()
-            .find(|t| t.name() == "describe_workflow")
+            .find(|t| t.name() == DESCRIBE_SKILL_TOOL)
             .expect("describe tool");
 
         // The registry skill's inline body is readable — content, not just name.
         let desc = describe
-            .execute(json!({ "workflow_id": "web-research" }))
+            .execute(json!({ "skill_id": "web-research" }))
             .await
             .expect("describe registry skill")
             .output_for_llm(false);
@@ -734,7 +753,7 @@ mod tests {
 
         // The empty-body custom skill still describes cleanly (frontmatter → def).
         let desc_empty = describe
-            .execute(json!({ "workflow_id": "quick-note" }))
+            .execute(json!({ "skill_id": "quick-note" }))
             .await
             .expect("describe empty-body skill")
             .output_for_llm(false);
@@ -742,7 +761,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn list_workflows_tool_sees_the_materialized_skill() {
+    async fn list_skills_tool_sees_the_materialized_skill() {
         use serde_json::json;
 
         let src = tempfile::tempdir().unwrap();
@@ -754,7 +773,7 @@ mod tests {
         let tools = eff.read_tools();
         let list = tools
             .iter()
-            .find(|t| t.name() == "list_workflows")
+            .find(|t| t.name() == LIST_SKILLS_TOOL)
             .expect("list tool");
         let result = list.execute(json!({})).await.expect("execute");
         let text = result.output_for_llm(false);

--- a/src/harness/skills/naming.rs
+++ b/src/harness/skills/naming.rs
@@ -1,0 +1,420 @@
+//! Skill read tools, named after skills (issue #845).
+//!
+//! # The collision
+//!
+//! Upstream OpenHuman calls a *skill* a "workflow". Its three skill read tools
+//! are literally named `list_workflows`, `describe_workflow` and
+//! `read_workflow_resource`, they take a `workflow_id`, and they answer with a
+//! JSON payload keyed `workflows`.
+//!
+//! OpenCompany has its own, entirely unrelated **workflow registry** — the saved
+//! graphs under `companies/<name>/workflows/`, rendered by the console's
+//! Workflows page, enumerated by [`list_workflows_union`](crate::company::list_workflows_union),
+//! and executed by the orchestrator's
+//! [`run_workflow`](crate::harness::orchestrator::RUN_WORKFLOW_TOOL).
+//!
+//! Wiring upstream's tools in unrenamed put both concepts on one belt under one
+//! word, and the agent-facing half of that word pointed at the wrong registry:
+//!
+//! * `list_workflows` enumerated the four installed **skills**, so an agent
+//!   asked what workflows the company had answered with the contents of
+//!   `Settings → Skills` — a set with *zero* overlap with the Workflows page.
+//! * `run_workflow` runs a **workflow**. So an agent that listed its
+//!   "workflows", picked one and ran it was crossing registries mid-turn, and an
+//!   agent asked to run a real workflow (`Campaign pipeline`) reported that it
+//!   did not exist — having looked in the skill tree.
+//!
+//! Nothing errored. The shared word is the whole of why it stayed silent.
+//!
+//! # What this module does
+//!
+//! [`skill_read_tools`] wraps each upstream tool in a [`SkillTool`] that renames
+//! it and everything the agent can see through it:
+//!
+//! | Upstream | Here |
+//! | --- | --- |
+//! | `list_workflows` | [`LIST_SKILLS_TOOL`] |
+//! | `describe_workflow` | [`DESCRIBE_SKILL_TOOL`] |
+//! | `read_workflow_resource` | [`READ_SKILL_RESOURCE_TOOL`] |
+//!
+//! The rename is not cosmetic and is not only the tool name. An agent reads four
+//! surfaces, and leaving any of them saying "workflow" leaves the bug:
+//!
+//! 1. **the name** — what it calls;
+//! 2. **the description** — written here rather than delegated, because
+//!    upstream's tells the model to go and `run_workflow` what it just listed,
+//!    which is the cross-registry step itself;
+//! 3. **the argument** — `workflow_id` is exposed as `skill_id` and mapped back
+//!    before the inner tool runs, so the schema an agent copies from never says
+//!    "workflow";
+//! 4. **the result** — the payload keys `workflows` / `workflow_id` are renamed
+//!    on the way out, and upstream's error prose is rewritten. Without this the
+//!    agent still reads `{"count":4,"workflows":[…]}` and still reports "4
+//!    installed workflows", which is the sentence in the issue.
+//!
+//! Renaming happens **at this boundary**, not in `vendor/openhuman`: "workflow"
+//! is upstream's own settled word for a skill, and its console, docs and other
+//! hosts use it consistently. It is only wrong inside OpenCompany, because only
+//! OpenCompany also has workflows.
+//!
+//! # This grants nothing
+//!
+//! All three tools stay exactly as read-only as they were — same inner tools,
+//! same workspace scoping, same permission level, arguments only re-keyed. No
+//! agent gains any reach over the workflow registry here; an agent that could
+//! not author, edit or run a company workflow before still cannot. What changes
+//! is that it now says so instead of answering from the wrong list. The
+//! `list_skills` description states the separation outright so a model that
+//! finds no workflow tools does not fall back to the skill list as a substitute.
+//!
+//! ## Keep the names in the consequence catalogue
+//!
+//! [`crate::policy::consequence`]'s `DECLARED` table names all three. It must
+//! follow a rename: an unlisted tool falls through to `undeclared`, whose
+//! read-only prefix list has `list` and `read` but **not** `describe` — so
+//! `describe_skill` would park and interrupt an operator for a local read, which
+//! is precisely the regression that module's own comment records
+//! `describe_workflow` having caused before the table existed.
+
+use async_trait::async_trait;
+use serde_json::Value;
+
+use oh::tools::traits::{PermissionLevel, Tool, ToolCallOptions, ToolResult};
+use openhuman_core::openhuman as oh;
+
+/// Tool name: enumerate the skills installed for this agent.
+pub const LIST_SKILLS_TOOL: &str = "list_skills";
+/// Tool name: describe one installed skill and the inputs it declares.
+pub const DESCRIBE_SKILL_TOOL: &str = "describe_skill";
+/// Tool name: read one file bundled inside an installed skill.
+pub const READ_SKILL_RESOURCE_TOOL: &str = "read_skill_resource";
+
+/// The argument key upstream's tools read a skill's directory name from.
+const UPSTREAM_ID_ARG: &str = "workflow_id";
+/// The argument key this module exposes in its place.
+const SKILL_ID_ARG: &str = "skill_id";
+
+/// Top-level result keys renamed on the way out, upstream → here.
+///
+/// Top-level only, and by exact key: a skill's own `description`, and the
+/// `content` of a file read through `read_skill_resource`, are the user's text
+/// and are never rewritten. A skill that documents a workflow keeps saying so.
+const RESULT_KEY_RENAMES: &[(&str, &str)] =
+    &[("workflows", "skills"), (UPSTREAM_ID_ARG, "skill_id")];
+
+/// Upstream tool names rewritten in agent-facing prose, so an error naming the
+/// tool names the one the agent actually called.
+const PROSE_TOOL_RENAMES: &[(&str, &str)] = &[
+    ("list_workflows", LIST_SKILLS_TOOL),
+    ("describe_workflow", DESCRIBE_SKILL_TOOL),
+    ("read_workflow_resource", READ_SKILL_RESOURCE_TOOL),
+    (UPSTREAM_ID_ARG, SKILL_ID_ARG),
+];
+
+/// Bare words rewritten in agent-facing prose, after [`PROSE_TOOL_RENAMES`].
+///
+/// Plural first only for readability — [`replace_whole_words`] cannot match
+/// `workflow` inside `workflows` anyway, since `s` is a token character.
+const PROSE_WORD_RENAMES: &[(&str, &str)] = &[
+    ("workflows", "skills"),
+    ("workflow", "skill"),
+    ("Workflows", "Skills"),
+    ("Workflow", "Skill"),
+];
+
+/// The three skill read tools, renamed for a host that also has workflows.
+///
+/// `inner` is upstream's tool, already scoped to the agent's materialized skill
+/// tree — this only renames what the agent sees.
+pub(super) fn skill_read_tools(
+    list: Box<dyn Tool>,
+    describe: Box<dyn Tool>,
+    read_resource: Box<dyn Tool>,
+) -> Vec<Box<dyn Tool>> {
+    vec![
+        Box::new(SkillTool {
+            inner: list,
+            name: LIST_SKILLS_TOOL,
+            description: "List the skills installed for this agent — packaged, reusable procedures \
+                 (a goal plus the steps to reach it). Returns each skill's name, dir, \
+                 description, tags, tool hints, scope, and any warnings. Use `describe_skill` \
+                 to inspect one before following it. Skills are NOT this company's saved \
+                 workflows: a workflow is a stored graph on the Workflows page, and it is not \
+                 listed here — never answer a question about the company's workflows from this \
+                 tool.",
+            renames_id_arg: false,
+        }),
+        Box::new(SkillTool {
+            inner: describe,
+            name: DESCRIBE_SKILL_TOOL,
+            description: "Describe one installed skill by `skill_id` (its directory name, as returned \
+                 by `list_skills`): the skill's definition (id, display name, when to use it) \
+                 and the inputs it declares (name, description, required, type). Read a skill \
+                 before following it. This describes a skill, never one of the company's saved \
+                 workflows.",
+            renames_id_arg: true,
+        }),
+        Box::new(SkillTool {
+            inner: read_resource,
+            name: READ_SKILL_RESOURCE_TOOL,
+            description: "Read a file bundled inside an installed skill (`skill_id` + `relative_path` \
+                 under that skill's directory, e.g. `scripts/run.sh` or `references/spec.md`). \
+                 Path-hardened and size-capped. Use to read a skill's helper scripts or \
+                 reference docs.",
+            renames_id_arg: true,
+        }),
+    ]
+}
+
+/// One upstream skill read tool, presented under its skill name.
+///
+/// Every method either overrides with a skill-named value or forwards to
+/// `inner`, so the wrapper cannot silently drop a behaviour the inner tool
+/// declares (its concurrency safety, its permission level, its timeout policy).
+/// The `spec` / `display_label` defaults derive from [`Self::name`] and
+/// [`Self::description`], so they follow the rename without an override.
+struct SkillTool {
+    inner: Box<dyn Tool>,
+    name: &'static str,
+    description: &'static str,
+    /// Whether this tool takes upstream's `workflow_id`. False for the
+    /// argument-less list tool.
+    renames_id_arg: bool,
+}
+
+impl SkillTool {
+    /// Rewrites `skill_id` back to the `workflow_id` the inner tool reads.
+    ///
+    /// Only ever *adds* the upstream key from ours; a call that already used
+    /// `workflow_id` (a model working from a stale schema) is left alone rather
+    /// than refused, so the rename cannot break a turn mid-conversation.
+    fn to_inner_args(&self, mut args: Value) -> Value {
+        if !self.renames_id_arg {
+            return args;
+        }
+        let Some(map) = args.as_object_mut() else {
+            return args;
+        };
+        if let Some(id) = map.remove(SKILL_ID_ARG) {
+            map.entry(UPSTREAM_ID_ARG).or_insert(id);
+        }
+        args
+    }
+
+    /// Rewrites one execution's outcome: result payloads and error prose.
+    fn rewrite_outcome(&self, out: anyhow::Result<ToolResult>) -> anyhow::Result<ToolResult> {
+        match out {
+            Ok(result) => Ok(rewrite_result(result)),
+            // The inner tools return their "not found" / bad-argument cases as
+            // `Err`, and that string reaches the agent too.
+            Err(err) => Err(anyhow::anyhow!(rewrite_prose(&err.to_string()))),
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for SkillTool {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn description(&self) -> &str {
+        self.description
+    }
+
+    fn parameters_schema(&self) -> Value {
+        rename_schema_id_arg(self.inner.parameters_schema(), self.renames_id_arg)
+    }
+
+    async fn execute(&self, args: Value) -> anyhow::Result<ToolResult> {
+        self.rewrite_outcome(self.inner.execute(self.to_inner_args(args)).await)
+    }
+
+    async fn execute_with_options(
+        &self,
+        args: Value,
+        options: ToolCallOptions,
+    ) -> anyhow::Result<ToolResult> {
+        self.rewrite_outcome(
+            self.inner
+                .execute_with_options(self.to_inner_args(args), options)
+                .await,
+        )
+    }
+
+    async fn execute_with_context(
+        &self,
+        args: Value,
+        options: ToolCallOptions,
+        context: Option<&tinyagents::harness::tool::ToolExecutionContext>,
+    ) -> anyhow::Result<ToolResult> {
+        self.rewrite_outcome(
+            self.inner
+                .execute_with_context(self.to_inner_args(args), options, context)
+                .await,
+        )
+    }
+
+    fn supports_markdown(&self) -> bool {
+        self.inner.supports_markdown()
+    }
+
+    fn permission_level(&self) -> PermissionLevel {
+        self.inner.permission_level()
+    }
+
+    fn permission_level_with_args(&self, args: &Value) -> PermissionLevel {
+        self.inner
+            .permission_level_with_args(&self.to_inner_args(args.clone()))
+    }
+
+    fn scope(&self) -> oh::tools::traits::ToolScope {
+        self.inner.scope()
+    }
+
+    fn category(&self) -> oh::tools::traits::ToolCategory {
+        self.inner.category()
+    }
+
+    fn is_concurrency_safe(&self, args: &Value) -> bool {
+        self.inner
+            .is_concurrency_safe(&self.to_inner_args(args.clone()))
+    }
+
+    fn external_effect(&self) -> bool {
+        self.inner.external_effect()
+    }
+
+    fn external_effect_with_args(&self, args: &Value) -> bool {
+        self.inner
+            .external_effect_with_args(&self.to_inner_args(args.clone()))
+    }
+
+    fn max_result_size_chars(&self) -> Option<usize> {
+        self.inner.max_result_size_chars()
+    }
+
+    fn timeout_policy(&self, args: &Value) -> oh::tools::traits::ToolTimeout {
+        self.inner.timeout_policy(&self.to_inner_args(args.clone()))
+    }
+}
+
+/// Re-keys `workflow_id` to `skill_id` in a parameter schema.
+///
+/// Structural — the `properties` key and the `required` entry — rather than a
+/// string replace over the serialized schema, so a *description* inside the
+/// schema that legitimately says "workflow" is not mangled. The description text
+/// upstream attaches to the id property is replaced wholesale, since it reads
+/// "Workflow id (directory name)."
+fn rename_schema_id_arg(mut schema: Value, renames: bool) -> Value {
+    if !renames {
+        return schema;
+    }
+    let Some(map) = schema.as_object_mut() else {
+        return schema;
+    };
+    if let Some(props) = map.get_mut("properties").and_then(Value::as_object_mut)
+        && let Some(mut prop) = props.remove(UPSTREAM_ID_ARG)
+    {
+        if let Some(prop_map) = prop.as_object_mut() {
+            prop_map.insert(
+                "description".to_string(),
+                Value::String("Skill id (its directory name).".to_string()),
+            );
+        }
+        props.insert(SKILL_ID_ARG.to_string(), prop);
+    }
+    if let Some(required) = map.get_mut("required").and_then(Value::as_array_mut) {
+        for entry in required.iter_mut() {
+            if entry.as_str() == Some(UPSTREAM_ID_ARG) {
+                *entry = Value::String(SKILL_ID_ARG.to_string());
+            }
+        }
+    }
+    schema
+}
+
+/// Rewrites every agent-visible block of one result.
+///
+/// A `Json` block is re-keyed structurally. A `Text` block is re-keyed the same
+/// way when it parses as a JSON object — which is how all three tools return
+/// success — and prose-scrubbed when it does not, which is how they return the
+/// allowlist refusal.
+fn rewrite_result(mut result: ToolResult) -> ToolResult {
+    use oh::skills::types::ToolContent;
+    for block in &mut result.content {
+        match block {
+            ToolContent::Json { data } => rename_top_level_keys(data),
+            ToolContent::Text { text } => match serde_json::from_str::<Value>(text) {
+                Ok(mut parsed) if parsed.is_object() => {
+                    rename_top_level_keys(&mut parsed);
+                    if let Ok(re) = serde_json::to_string(&parsed) {
+                        *text = re;
+                    }
+                }
+                _ => *text = rewrite_prose(text),
+            },
+        }
+    }
+    if let Some(md) = result.markdown_formatted.as_mut() {
+        *md = rewrite_prose(md);
+    }
+    result
+}
+
+/// Applies [`RESULT_KEY_RENAMES`] to a JSON object's own keys.
+///
+/// Top level only, deliberately: below it lies skill-authored content, and a
+/// rename there would edit what a person wrote.
+fn rename_top_level_keys(value: &mut Value) {
+    let Some(map) = value.as_object_mut() else {
+        return;
+    };
+    for (from, to) in RESULT_KEY_RENAMES {
+        if let Some(v) = map.remove(*from) {
+            map.entry(*to).or_insert(v);
+        }
+    }
+}
+
+/// Rewrites upstream's tool names and its bare "workflow"s in agent-facing prose.
+fn rewrite_prose(text: &str) -> String {
+    let mut out = text.to_string();
+    for (from, to) in PROSE_TOOL_RENAMES.iter().chain(PROSE_WORD_RENAMES) {
+        out = replace_whole_words(&out, from, to);
+    }
+    out
+}
+
+/// Replaces `needle` only where it stands as a whole token.
+///
+/// A token character is alphanumeric, `_` or `-`, so a skill whose own slug is
+/// `content-workflow` survives an error message about it intact — `\b` would
+/// not, since it treats `-` as a boundary. Run before the bare-word passes, the
+/// same rule is what keeps `describe_workflow` from being half-rewritten into
+/// `describe_skill` twice over: the `workflow` inside it is not a whole token.
+fn replace_whole_words(haystack: &str, needle: &str, replacement: &str) -> String {
+    let is_token_char = |c: char| c.is_alphanumeric() || c == '_' || c == '-';
+    let mut out = String::with_capacity(haystack.len());
+    let mut rest = haystack;
+    while let Some(at) = rest.find(needle) {
+        let before_ok = rest[..at]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_token_char(c));
+        let after = &rest[at + needle.len()..];
+        let after_ok = after.chars().next().is_none_or(|c| !is_token_char(c));
+        if before_ok && after_ok {
+            out.push_str(&rest[..at]);
+            out.push_str(replacement);
+        } else {
+            out.push_str(&rest[..at + needle.len()]);
+        }
+        rest = after;
+    }
+    out.push_str(rest);
+    out
+}
+
+#[cfg(test)]
+mod test;

--- a/src/harness/skills/naming/test.rs
+++ b/src/harness/skills/naming/test.rs
@@ -1,0 +1,297 @@
+//! Tests for the skill read tools' naming boundary (issue #845).
+//!
+//! Every test here fails against the pre-fix wiring — the tools were handed to
+//! agents exactly as upstream names them, so each assertion below is one of the
+//! four surfaces that said "workflow".
+
+use serde_json::json;
+
+use super::*;
+use crate::harness::skills::EffectiveSkills;
+
+/// Materializes a one-skill effective set and returns its read tools.
+fn tools_for(slug: &str, name: &str) -> (tempfile::TempDir, Vec<Box<dyn Tool>>) {
+    let src = tempfile::tempdir().unwrap();
+    let ws = tempfile::tempdir().unwrap();
+    let dir = src.path().join("skills").join(slug);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("SKILL.md"),
+        format!("---\nname: {name}\ndescription: Does {slug} things\n---\n\n# {name}\n\nBODY.\n"),
+    )
+    .unwrap();
+    let eff =
+        EffectiveSkills::materialize(ws.path().to_path_buf(), Some(src.path()), &[], &[]).unwrap();
+    // `ws` is dropped by the caller holding the returned handle; `src` is only
+    // read during materialize, so only `ws` has to outlive the tools.
+    let tools = eff.read_tools();
+    (ws, tools)
+}
+
+fn find<'a>(tools: &'a [Box<dyn Tool>], name: &str) -> &'a dyn Tool {
+    tools
+        .iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("no tool named {name}"))
+        .as_ref()
+}
+
+/// Surface 1: the names. This is the whole of what an agent sees on its belt.
+#[test]
+fn read_tools_are_named_after_skills() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert_eq!(
+        names,
+        vec![
+            LIST_SKILLS_TOOL,
+            DESCRIBE_SKILL_TOOL,
+            READ_SKILL_RESOURCE_TOOL
+        ]
+    );
+    // The bug in one assertion: no tool on a desk agent's belt may claim to
+    // enumerate workflows, because none of them can see the workflow registry.
+    for name in names {
+        assert!(
+            !name.contains("workflow"),
+            "{name} still claims to be about workflows"
+        );
+    }
+}
+
+/// Surface 2: the descriptions. Upstream's `list_workflows` description ends
+/// "…to inspect (`describe_workflow`) or run (`run_workflow`)" — an instruction
+/// to take something out of the skill tree and run it as a workflow, which is
+/// the cross-registry step itself.
+#[test]
+fn descriptions_never_send_an_agent_to_a_workflow_tool() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    for tool in &tools {
+        let d = tool.description();
+        assert!(
+            !d.contains("run_workflow") && !d.contains("describe_workflow"),
+            "{}: description points at a workflow tool: {d}",
+            tool.name()
+        );
+    }
+    // And the list tool says outright that this is not the workflow registry,
+    // so a model that finds no workflow tools does not substitute this list.
+    let listed = find(&tools, LIST_SKILLS_TOOL).description();
+    assert!(listed.contains("not"), "{listed}");
+    assert!(listed.contains("workflows"), "{listed}");
+}
+
+/// Surface 3: the argument. A model copies argument names out of the schema, so
+/// a schema saying `workflow_id` teaches it that a skill id is a workflow id.
+#[test]
+fn schemas_take_skill_id_not_workflow_id() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+
+    for name in [DESCRIBE_SKILL_TOOL, READ_SKILL_RESOURCE_TOOL] {
+        let schema = find(&tools, name).parameters_schema();
+        let props = schema["properties"].as_object().expect("properties");
+        assert!(props.contains_key(SKILL_ID_ARG), "{name}: {schema}");
+        assert!(!props.contains_key(UPSTREAM_ID_ARG), "{name}: {schema}");
+        let required: Vec<&str> = schema["required"]
+            .as_array()
+            .expect("required")
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(required.contains(&SKILL_ID_ARG), "{name}: {schema}");
+        assert!(!required.contains(&UPSTREAM_ID_ARG), "{name}: {schema}");
+        // The id property's own description carried "Workflow id" too.
+        assert!(
+            !props[SKILL_ID_ARG]["description"]
+                .as_str()
+                .unwrap_or_default()
+                .to_lowercase()
+                .contains("workflow"),
+            "{name}: {schema}"
+        );
+    }
+
+    // The list tool takes no arguments, so its schema is passed through as-is.
+    let list = find(&tools, LIST_SKILLS_TOOL).parameters_schema();
+    assert_eq!(list["type"], "object");
+}
+
+/// Surface 4: the payload. This is the one the issue quotes — an agent reading
+/// `{"count":4,"workflows":[…]}` reports "there are exactly 4 installed
+/// workflows" no matter what the tool it called was named.
+#[tokio::test]
+async fn list_payload_is_keyed_skills_not_workflows() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let out = find(&tools, LIST_SKILLS_TOOL)
+        .execute(json!({}))
+        .await
+        .expect("list")
+        .output_for_llm(false);
+
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("json payload");
+    assert!(parsed.get("skills").is_some(), "{out}");
+    assert!(parsed.get("workflows").is_none(), "{out}");
+    // Still the same content — the rename must not cost the enumeration.
+    assert!(out.contains("web-research"), "{out}");
+}
+
+/// The renamed argument reaches the inner tool, so `describe_skill` still works.
+#[tokio::test]
+async fn describe_accepts_skill_id_and_still_reads_the_skill() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let out = find(&tools, DESCRIBE_SKILL_TOOL)
+        .execute(json!({ SKILL_ID_ARG: "web-research" }))
+        .await
+        .expect("describe")
+        .output_for_llm(false);
+    assert!(out.contains("Web Research"), "{out}");
+}
+
+/// A model working from a stale schema keeps working. The rename is a naming
+/// fix; it must not strand a conversation that already saw the old parameter.
+#[tokio::test]
+async fn legacy_workflow_id_argument_still_resolves() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let out = find(&tools, DESCRIBE_SKILL_TOOL)
+        .execute(json!({ UPSTREAM_ID_ARG: "web-research" }))
+        .await
+        .expect("describe via the upstream key")
+        .output_for_llm(false);
+    assert!(out.contains("Web Research"), "{out}");
+}
+
+/// `read_skill_resource`'s payload echoes the id back under its own key.
+#[tokio::test]
+async fn read_resource_echoes_skill_id_not_workflow_id() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let out = find(&tools, READ_SKILL_RESOURCE_TOOL)
+        .execute(json!({ SKILL_ID_ARG: "web-research", "relative_path": "SKILL.md" }))
+        .await
+        .expect("read resource")
+        .output_for_llm(false);
+    let parsed: serde_json::Value = serde_json::from_str(&out).expect("json payload");
+    assert!(parsed.get("skill_id").is_some(), "{out}");
+    assert!(parsed.get("workflow_id").is_none(), "{out}");
+    // The file's own body is content, not a key, and is never rewritten.
+    assert!(out.contains("BODY."), "{out}");
+}
+
+/// Upstream returns "not found" as an `Err` whose string reaches the agent, and
+/// that string names `describe_workflow` and a "workflow".
+#[tokio::test]
+async fn missing_skill_error_is_phrased_in_skills() {
+    let (_ws, tools) = tools_for("web-research", "Web Research");
+    let err = find(&tools, DESCRIBE_SKILL_TOOL)
+        .execute(json!({ SKILL_ID_ARG: "nope" }))
+        .await
+        .expect_err("a missing skill must error")
+        .to_string();
+    assert!(!err.contains("workflow"), "{err}");
+    assert!(err.contains("skill"), "{err}");
+}
+
+/// The catalogue sentence in the persona is what hands an agent the three
+/// names, so it is also what taught every agent the wrong word.
+#[test]
+fn persona_catalogue_names_the_skill_tools() {
+    let src = tempfile::tempdir().unwrap();
+    let ws = tempfile::tempdir().unwrap();
+    let dir = src.path().join("skills").join("seo-audit");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("SKILL.md"),
+        "---\nname: SEO Audit\ndescription: Audit a site\n---\n\n# SEO\n",
+    )
+    .unwrap();
+    let eff =
+        EffectiveSkills::materialize(ws.path().to_path_buf(), Some(src.path()), &[], &[]).unwrap();
+
+    let catalogue = eff.catalogue();
+    assert!(catalogue.contains(LIST_SKILLS_TOOL), "{catalogue}");
+    assert!(catalogue.contains(DESCRIBE_SKILL_TOOL), "{catalogue}");
+    assert!(catalogue.contains(READ_SKILL_RESOURCE_TOOL), "{catalogue}");
+    assert!(!catalogue.contains("list_workflows"), "{catalogue}");
+    assert!(!catalogue.contains("describe_workflow"), "{catalogue}");
+    assert!(!catalogue.contains("read_workflow_resource"), "{catalogue}");
+}
+
+/// The rename must carry the consequence catalogue with it.
+///
+/// `undeclared`'s read-only prefixes are `read`/`list`/`get`/… and **not**
+/// `describe`, so an undeclared `describe_skill` is `Reach::Consequence` — it
+/// parks, and interrupts an operator to approve a local file read. That is the
+/// exact regression `consequence.rs`'s own comment records `describe_workflow`
+/// having caused before the table existed; this pins that the rename did not
+/// reintroduce it.
+#[test]
+fn skill_read_tools_are_declared_reads() {
+    use crate::policy::consequence::{Reach, consequence_of};
+    for tool in [
+        LIST_SKILLS_TOOL,
+        DESCRIBE_SKILL_TOOL,
+        READ_SKILL_RESOURCE_TOOL,
+    ] {
+        assert_eq!(
+            consequence_of(tool, &json!({})).reach,
+            Reach::Nothing,
+            "{tool} is not a declared read — it will park"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The prose scrub's one sharp edge
+// ---------------------------------------------------------------------------
+
+/// A skill's *own* slug may contain "workflow" — `content-workflow` is one of
+/// the workflow names on the staging company's own Workflows page. Rewriting it
+/// inside an error message would report a skill id that does not exist.
+#[test]
+fn whole_word_replace_leaves_hyphenated_ids_alone() {
+    assert_eq!(
+        replace_whole_words("skill `content-workflow` not found", "workflow", "skill"),
+        "skill `content-workflow` not found"
+    );
+    assert_eq!(
+        replace_whole_words("describe_workflow failed", "workflow", "skill"),
+        "describe_workflow failed"
+    );
+    assert_eq!(
+        replace_whole_words("workflow `x` not found", "workflow", "skill"),
+        "skill `x` not found"
+    );
+    // A bare match at either end of the string.
+    assert_eq!(
+        replace_whole_words("workflow", "workflow", "skill"),
+        "skill"
+    );
+    assert_eq!(
+        replace_whole_words("the workflow", "workflow", "skill"),
+        "the skill"
+    );
+}
+
+/// Tool names are rewritten before bare words, so an error naming a tool names
+/// the tool the agent actually called rather than a half-rewritten hybrid.
+#[test]
+fn prose_rewrites_tool_names_whole() {
+    let out = rewrite_prose("describe_workflow: workflow `x` is not available");
+    assert_eq!(out, "describe_skill: skill `x` is not available");
+    assert!(!out.contains("describe_skill_"), "{out}");
+}
+
+/// Only the top level is re-keyed. A skill that documents workflows keeps its
+/// own words — the payload rewrite is about the envelope, never the content.
+#[test]
+fn nested_content_is_never_rewritten() {
+    let mut payload = json!({
+        "workflows": [
+            { "name": "Workflow Builder", "description": "Explains the workflow registry" }
+        ]
+    });
+    rename_top_level_keys(&mut payload);
+    assert!(payload.get("skills").is_some(), "{payload}");
+    let entry = &payload["skills"][0];
+    assert_eq!(entry["name"], "Workflow Builder");
+    assert_eq!(entry["description"], "Explains the workflow registry");
+}

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -530,19 +530,29 @@ const DECLARED: &[Declared] = &[
         Reach::Consequence,
     ),
     d("media_list_models", EffectGroup::Other, Reach::Nothing),
-    // ---- Skills / workflow catalogue ---------------------------------------
+    // ---- Skills catalogue --------------------------------------------------
     // The three OpenHuman skill *read* tools, scoped to this agent's own
     // materialized skill tree under its workspace. All local, all reads.
     //
     // `describe_workflow` PARKED before this table existed, for the same
     // reason `file_read` did and with nobody reporting either: the read-only
     // rule matched a name *prefix* and "describe" is not one of the words. The
-    // persona hands an agent all three in one sentence — "use `list_workflows`
-    // to enumerate them, `describe_workflow` to inspect one" — so two ran and
+    // persona hands an agent all three in one sentence — "use `list_skills`
+    // to enumerate them, `describe_skill` to inspect one" — so two ran and
     // the middle one interrupted an operator.
-    d("list_workflows", EffectGroup::Other, Reach::Nothing),
-    d("describe_workflow", EffectGroup::Other, Reach::Nothing),
-    d("read_workflow_resource", EffectGroup::Other, Reach::Nothing),
+    //
+    // Issue #845 renamed all three off upstream's "workflow" wording, which is
+    // a *skill* upstream and a saved graph here. `describe_skill` inherits
+    // exactly the hazard above — "describe" is still not a read-only prefix —
+    // so these three rows are what keep the rename from re-parking it.
+    //
+    // Spelled as literals, not as `harness::skills::naming`'s constants: this
+    // table is compiled in every build and that module is behind `openhuman`.
+    // `skill_read_tools_are_declared_reads` (in that module, where the constants
+    // are) is what pins the two spellings together.
+    d("list_skills", EffectGroup::Other, Reach::Nothing),
+    d("describe_skill", EffectGroup::Other, Reach::Nothing),
+    d("read_skill_resource", EffectGroup::Other, Reach::Nothing),
     // ---- MCP ---------------------------------------------------------------
     // The agent persona *instructs* every agent to call `mcp_list_servers` (and
     // `mcp_list_tools` for a specific server) rather than answer a capability

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -1108,6 +1108,11 @@ fn composio_action_is_read(_slug: &str) -> bool {
 /// over-prompt. The coverage test is what stops a *registered* tool reaching
 /// this path at all.
 fn undeclared(name: &str) -> Consequence {
+    // `describe` is deliberately absent. This fallback is a courtesy for an
+    // unregistered read, not a second classifier to trust with an unreviewed
+    // capability: adding it would let an undeclared tool claim it only reads.
+    // Declare a known `describe_*` tool instead, as `describe_skill` does for
+    // issue #845, so its reach is an explicit policy decision.
     const READ_ONLY_PREFIXES: &[&str] = &[
         "read",
         "list",

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -458,6 +458,7 @@ mod test {
                 by: None,
                 chat: None,
                 parent: None,
+                deliverable: None,
             },
             CompanyEvent::AgentReply {
                 chat_id: "desk".into(),

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -253,6 +253,26 @@ pub enum CompanyEvent {
         /// terms above, so no stored record migrates.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         parent: Option<EventSeq>,
+        /// The composer's once-vs-workflow choice for this message (issue #845),
+        /// as the operator set it — [`TaskDeliverable::Workflow`] when they
+        /// picked "Build me the workflow".
+        ///
+        /// Carried on the event because the cycle is the only place that holds
+        /// both this fact and the turn about to answer, and without it the turn
+        /// answered blind. A `workflow` message opens a card that the **builder
+        /// pass** owns ([`crate::harness::workflow_build`]) — the chat cycle
+        /// still runs, in parallel, and the desk agent answering it has no
+        /// authoring tool and correctly says so. So the operator was told "I
+        /// can't build the workflow" *while a proposal for it was being built*.
+        /// [`CompanyRuntime::inject_workflow_builder_awareness`](crate::company::runtime::CompanyRuntime)
+        /// reads this to tell the turn who owns the authoring.
+        ///
+        /// `None` means the caller expressed no choice — every message journaled
+        /// before this field existed, and every non-chat producer. Additive on
+        /// exactly the `by` / `chat` / `parent` terms above, so no stored record
+        /// migrates.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        deliverable: Option<crate::ports::tasks::TaskDeliverable>,
     },
     /// An inbound webhook fired.
     WebhookReceived {
@@ -3751,6 +3771,7 @@ mod test {
             text: "a follow-up".into(),
             by: None,
             chat: Some("studio".into()),
+            deliverable: None,
         };
         let json = serde_json::to_string(&threaded).unwrap();
         assert!(json.contains(r#""parent":41"#), "{json}");
@@ -3824,6 +3845,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }
         );
     }
@@ -3838,6 +3860,7 @@ mod test {
             text: "hi".into(),
             by: None,
             chat: None,
+            deliverable: None,
         };
         assert_eq!(
             serde_json::to_string(&event).unwrap(),
@@ -3855,6 +3878,7 @@ mod test {
                 id: "u1".into(),
             }),
             chat: None,
+            deliverable: None,
         };
         let json = serde_json::to_value(&event).unwrap();
         assert_eq!(json["by"]["kind"], "user");
@@ -3881,6 +3905,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
             CompanyEvent::WebhookReceived {
                 channel: "email".into(),

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4888,6 +4888,7 @@ mod test {
             text: text.to_string(),
             by: None,
             chat: Some("eng".to_string()),
+            deliverable: None,
         };
 
         // Baseline: the blueprint lead answers. Asserted rather than assumed, so
@@ -5031,6 +5032,7 @@ mod test {
                 text: "hello design".to_string(),
                 by: None,
                 chat: Some("design".to_string()),
+                deliverable: None,
             }])
             .await
             .expect("cycle");
@@ -5144,6 +5146,7 @@ mod test {
                 text: "who leads?".to_string(),
                 by: None,
                 chat: Some("eng".to_string()),
+                deliverable: None,
             }])
             .await
             .expect("cycle");

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -32,7 +32,7 @@ use crate::feedback::tool::SEND_EMAIL_TOOL;
 use crate::policy::gate::ResolveOutcome;
 use crate::ports::brain::{CycleHost, UsageMetering};
 use crate::ports::runs::{RunOutcome, RunStatus};
-use crate::ports::tasks::{COLUMN_TODO, TaskRecord};
+use crate::ports::tasks::{COLUMN_TODO, TaskDeliverable, TaskRecord};
 use crate::ports::types::{
     Actor, ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult,
     CycleRequest, Effect, EffectDisposition, EffectGroup, EventSeq, LedgerEntry, OutboundMessage,
@@ -106,6 +106,36 @@ pub(crate) const RUN_CYCLE_FAILED_ERROR: &str = "the dispatch cycle failed";
 /// builds its input from this constant so a wording change fails the test rather
 /// than silently un-splitting the message.
 pub(crate) const OPEN_WORK_ANNOTATION: &str = "\n\n[Open work already handed to you";
+
+/// Where the builder-pass briefing begins on a `workflow`-deliverable operator
+/// message (issue #845, written by
+/// [`inject_workflow_builder_awareness`](CycleRunner::inject_workflow_builder_awareness)).
+///
+/// The second machine-appended part of an operator message, on exactly
+/// [`OPEN_WORK_ANNOTATION`]'s terms: in-memory only, never journaled, and
+/// stripped by [`operator_words`](crate::runtime::delegation::operator_words)
+/// before anything reasons about what the operator asked for.
+///
+/// # What it is for
+///
+/// A message sent with "Build me the workflow" opens a card the **builder pass**
+/// owns ([`crate::harness::workflow_build`]): the card does not dispatch to its
+/// assignee, and authoring the graph *is* its In-Progress work. The chat cycle
+/// still runs on the same message, in parallel — and the desk agent answering it
+/// holds no workflow-authoring tool, correctly refuses to pretend otherwise, and
+/// says so.
+///
+/// Both halves were behaving correctly and the operator was told the opposite of
+/// what was happening: on staging, "I can't build the workflow … `weekly-aeo-audit`
+/// does not exist and I cannot make it exist" was delivered while a proposal for
+/// exactly that workflow was landing In Review. This annotation is what tells the
+/// turn who owns the authoring, so it answers the substance instead of denying a
+/// capability that is being exercised on its own message.
+///
+/// It grants nothing. `create_workflow` stays orchestrator-only, the builder
+/// still only *proposes*, and a person still applies the proposal — this only
+/// stops the turn from contradicting that.
+pub(crate) const BUILDER_ANNOTATION: &str = "\n\n[This request is already being built";
 
 /// What settling an approval's verdict produced — the outcome of the fast half
 /// of a resolve, before any model is called (issue #383).
@@ -309,6 +339,12 @@ impl<'a> CycleRunner<'a> {
         if let Some(record) = &record {
             self.inject_handed_task_awareness(record, &mut events).await;
         }
+        // Issue #845: and when the operator asked for a workflow rather than a
+        // one-off, tell the turn that the builder pass owns authoring it — so it
+        // answers the substance instead of denying a capability that is being
+        // exercised on this very message. Same terms as the injection above:
+        // brain-agnostic, in-memory only, never journaled.
+        Self::inject_workflow_builder_awareness(&mut events);
 
         // Issue #390: `cycle_id` is now minted by `run` before the serial lock,
         // so the journal's bracket can cover the wait on that lock. Nothing
@@ -644,6 +680,39 @@ impl<'a> CycleRunner<'a> {
                 "{OPEN_WORK_ANNOTATION} (answer truthfully if asked what you are \
 working on):\n{}\n]",
                 lines.join("\n")
+            ));
+        }
+    }
+
+    /// Folds the builder-pass briefing into any `workflow`-deliverable operator
+    /// message (issue #845). See [`BUILDER_ANNOTATION`] for why.
+    ///
+    /// Deliberately not `async` and touching no store: unlike the handed-work
+    /// briefing, everything this needs is already on the event. Mutates only the
+    /// in-memory events handed to the brain, never the durable event log.
+    ///
+    /// Applies to every `workflow` message, addressed or not. The refusal this
+    /// prevents came from a desk agent in a channel, but an unaddressed message
+    /// reaches the orchestrator — which *does* hold `create_workflow` — and
+    /// telling it that a builder pass already owns this card is what stops it
+    /// authoring a second graph beside the proposal.
+    fn inject_workflow_builder_awareness(events: &mut [CompanyEvent]) {
+        for event in events.iter_mut() {
+            let CompanyEvent::OperatorMessage {
+                text,
+                deliverable: Some(TaskDeliverable::Workflow),
+                ..
+            } = event
+            else {
+                continue;
+            };
+            text.push_str(&format!(
+                "{BUILDER_ANNOTATION}: the operator asked for a reusable workflow, not a \
+one-off, so a card for it has been opened and the workflow builder owns authoring the graph. \
+Do NOT try to create, save or schedule a workflow yourself, and do not report that you cannot \
+— the build is already under way and its proposal goes to the operator for review. Answer the \
+substance of what they asked, and say that the workflow itself is being drafted for their \
+approval.]"
             ));
         }
     }
@@ -2433,6 +2502,134 @@ impl CycleHost for CycleHostImpl<'_> {
 mod test {
     use super::*;
 
+    /// Issue #845: a `workflow` message reaches the brain carrying the builder
+    /// briefing, and nothing else does.
+    ///
+    /// This is the fix for the mode actually observed on staging: the builder
+    /// pass had already produced a proposal for `weekly-aeo-audit` while the
+    /// desk agent answering the same message was telling the operator that it
+    /// "cannot make it exist". The turn was right about its own toolset and
+    /// wrong about the company, because nothing told it.
+    #[test]
+    fn only_a_workflow_message_gets_the_builder_briefing() {
+        let msg = |deliverable| CompanyEvent::OperatorMessage {
+            text: "set up a weekly AEO audit".to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable,
+        };
+        let text_of = |event: &CompanyEvent| match event {
+            CompanyEvent::OperatorMessage { text, .. } => text.clone(),
+            _ => unreachable!("fixture is an operator message"),
+        };
+
+        let mut events = vec![
+            msg(Some(TaskDeliverable::Workflow)),
+            msg(Some(TaskDeliverable::Once)),
+            msg(None),
+            // A non-operator event must be left entirely alone.
+            CompanyEvent::ScheduleFired {
+                cron: "0 6 * * 5".to_string(),
+                prompt: "run the audit".to_string(),
+            },
+        ];
+        CycleRunner::inject_workflow_builder_awareness(&mut events);
+
+        let briefed = text_of(&events[0]);
+        assert!(briefed.contains(BUILDER_ANNOTATION), "{briefed}");
+        assert!(
+            briefed.starts_with("set up a weekly AEO audit"),
+            "the operator's own words come first, untouched: {briefed}"
+        );
+        // The whole point: the turn is told not to deny the capability.
+        assert!(
+            briefed.contains("do not report that you cannot"),
+            "{briefed}"
+        );
+
+        for (i, label) in [(1, "once"), (2, "no choice")] {
+            let text = text_of(&events[i]);
+            assert_eq!(
+                text, "set up a weekly AEO audit",
+                "a `{label}` message must reach the brain exactly as typed"
+            );
+        }
+        assert!(matches!(events[3], CompanyEvent::ScheduleFired { .. }));
+    }
+
+    /// Issue #845, the wiring: the briefing actually reaches the brain.
+    ///
+    /// [`only_a_workflow_message_gets_the_builder_briefing`] pins what the
+    /// injection *does* by calling it; this pins that `run_cycle` calls it. The
+    /// two are separate failures — a correct injection nothing invokes leaves
+    /// the bug exactly where it was — and only this one covers the wiring, so
+    /// deleting the call site has to fail a test.
+    ///
+    /// `EffectBrain` echoes the text it was handed, so the reply is a faithful
+    /// window onto what the brain actually saw.
+    #[tokio::test]
+    async fn the_builder_briefing_reaches_the_brain_through_run_cycle() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let effect = Effect {
+            kind: "noop".into(),
+            group: EffectGroup::Other,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::Value::Null,
+            agent: None,
+            run_id: None,
+        };
+        let rt = Arc::new(
+            RuntimeBuilder::new(home.clone(), manifest("full"))
+                .with_brain(Arc::new(EffectBrain { effect }))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let ask = |deliverable| CompanyEvent::OperatorMessage {
+            text: "set up a weekly AEO audit".into(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable,
+        };
+
+        let workflow = rt
+            .run_cycle(vec![ask(Some(TaskDeliverable::Workflow))])
+            .await
+            .unwrap();
+        let seen = workflow
+            .responses
+            .iter()
+            .map(|r| r.text.clone())
+            .collect::<String>();
+        assert!(
+            seen.contains(BUILDER_ANNOTATION),
+            "the brain must be told the builder owns this: {seen}"
+        );
+
+        // …and a one-off is handed through byte-for-byte, so the annotation is
+        // not simply always on.
+        let once = rt
+            .run_cycle(vec![ask(Some(TaskDeliverable::Once))])
+            .await
+            .unwrap();
+        let seen_once = once
+            .responses
+            .iter()
+            .map(|r| r.text.clone())
+            .collect::<String>();
+        assert!(!seen_once.contains(BUILDER_ANNOTATION), "{seen_once}");
+        assert!(
+            seen_once.contains("set up a weekly AEO audit"),
+            "{seen_once}"
+        );
+    }
+
     /// Issue #796: a DM's thread becomes a safe, `dm-`-prefixed branch segment
     /// `RepoManager::validate_task_segment` accepts; an empty or all-garbage
     /// thread yields nothing, so `repo_publish` refuses rather than build a
@@ -2677,6 +2874,7 @@ mod test {
             text: "hand it off".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -3102,6 +3300,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3132,7 +3331,8 @@ mod test {
                 parent: None,
                 text: "hi".into(),
                 by: None,
-                chat: None
+                chat: None,
+                deliverable: None,
             }
         );
 
@@ -3210,6 +3410,7 @@ mod test {
                 text: "file it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3270,6 +3471,7 @@ mod test {
                 text: "do it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3334,6 +3536,7 @@ mod test {
                 text: "do it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3599,6 +3802,7 @@ mod test {
                 text: "do it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3769,6 +3973,7 @@ mod test {
                 text: "file it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3848,6 +4053,7 @@ mod test {
                 text: "send that email".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -3904,6 +4110,7 @@ mod test {
                     text: "file it".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }])
                 .await
                 .unwrap();
@@ -3964,6 +4171,7 @@ mod test {
                 text: "file it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -4034,6 +4242,7 @@ mod test {
                 text: "file it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -4122,6 +4331,7 @@ mod test {
             text: "how are we doing".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -4405,6 +4615,7 @@ mod test {
                 text: "hello".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }]),
             "operator-message"
         );
@@ -4430,13 +4641,15 @@ mod test {
                 parent: None,
                 text: "a".into(),
                 by: None,
-                chat: None
+                chat: None,
+                deliverable: None,
             }]),
             two.run_cycle(vec![CompanyEvent::OperatorMessage {
                 parent: None,
                 text: "b".into(),
                 by: None,
-                chat: None
+                chat: None,
+                deliverable: None,
             }]),
         );
         assert_eq!(ra.unwrap().responses.len(), 1);
@@ -4487,6 +4700,7 @@ mod test {
             text: "send it".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -5228,6 +5442,7 @@ mod test {
             text: "hi".into(),
             by: None,
             chat: None,
+            deliverable: None,
         };
 
         // A dispatch names the card outright.
@@ -5433,12 +5648,14 @@ mod test {
             text: "pay the invoice".into(),
             by: None,
             chat: Some(chat.to_string()),
+            deliverable: None,
         };
         let unaddressed = || CompanyEvent::OperatorMessage {
             parent: None,
             text: "hi".into(),
             by: None,
             chat: None,
+            deliverable: None,
         };
         let resolved = |id: &str| CompanyEvent::ApprovalResolved {
             approval_id: ApprovalId::new(id),
@@ -5645,6 +5862,7 @@ mod test {
             text: "pay the invoice".into(),
             by: None,
             chat: Some(chat.to_string()),
+            deliverable: None,
         };
         let resolved = |id: &str| CompanyEvent::ApprovalResolved {
             approval_id: ApprovalId::new(id),
@@ -6100,6 +6318,7 @@ mod test {
             text: "what are you working on?".into(),
             by: None,
             chat: Some("Engineering".into()),
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -6111,6 +6330,7 @@ mod test {
             text: "status?".into(),
             by: None,
             chat: None,
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -6170,6 +6390,7 @@ mod test {
             text: "what's up?".into(),
             by: None,
             chat: Some("eng".into()),
+            deliverable: None,
         }])
         .await
         .unwrap();
@@ -6248,6 +6469,7 @@ mod test {
                 text: "do it".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();
@@ -6445,6 +6667,7 @@ mod test {
                     text: "do it".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 }])
                 .await
                 .unwrap();

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -35,7 +35,7 @@ use crate::ports::tasks::{COLUMN_PLANNING, COLUMN_TODO, TaskOutputAction, TaskOu
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
-use crate::runtime::cycle::OPEN_WORK_ANNOTATION;
+use crate::runtime::cycle::{BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION};
 
 /// One agent turn, abstracted so delegation orchestration never touches the
 /// harness-specific [`HarnessDeps`](crate::harness::HarnessDeps).
@@ -2387,10 +2387,24 @@ fn work_words(text: &str) -> Vec<String> {
 /// is evidence of substance — and opened a card. Which then lengthened the
 /// briefing on the next message. Each card made the next one likelier.
 ///
-/// Splits on the shared constant rather than a transcribed copy of it, so the
+/// Splits on the shared constants rather than transcribed copies of them, so the
 /// two sides cannot drift.
+///
+/// Issue #845 added a second appended block, [`BUILDER_ANNOTATION`], on exactly
+/// the same terms — so this cuts at whichever marker comes first. Missing it
+/// would be the "thanks!" bug again in a new costume: the builder briefing is
+/// several lines of imperative prose, and `looks_like_work` scores length and
+/// work verbs, so every `workflow` message would read as substantial no matter
+/// what the operator actually typed.
 pub(crate) fn operator_words(message: &str) -> &str {
-    match message.find(OPEN_WORK_ANNOTATION) {
+    let cut = [
+        message.find(OPEN_WORK_ANNOTATION),
+        message.find(BUILDER_ANNOTATION),
+    ]
+    .into_iter()
+    .flatten()
+    .min();
+    match cut {
         Some(at) => &message[..at],
         None => message,
     }
@@ -2589,6 +2603,44 @@ investor update for the quarter\n]"
         );
         // An un-annotated message (the orchestrator's own thread) is untouched.
         assert_eq!(operator_words("draft the memo"), "draft the memo");
+    }
+
+    /// Issue #845: the builder briefing is not the operator's request either.
+    ///
+    /// The same trap as the open-work briefing above, and worse-shaped: this
+    /// block is several lines of imperative prose containing "workflow",
+    /// "create", "build" and "draft", so an unstripped `workflow` message would
+    /// score as substantial work whatever the operator typed. Built from the
+    /// shared constant, so rewording the briefing fails this test.
+    #[test]
+    fn the_cycles_builder_briefing_is_not_the_operators_request() {
+        let briefed = format!(
+            "thanks!{BUILDER_ANNOTATION}: the operator asked for a reusable workflow, not a \
+one-off, so a card for it has been opened and the workflow builder owns authoring the graph.]"
+        );
+        assert_eq!(operator_words(&briefed), "thanks!");
+        assert!(
+            !is_trackable_work(operator_words(&briefed)),
+            "small talk stays small talk however much context is folded onto it"
+        );
+        assert!(
+            is_trackable_work(&briefed),
+            "the unstripped briefing really does read as work — which is why the \
+             strip has to happen"
+        );
+    }
+
+    /// Both briefings can land on one message — a desk-addressed `workflow`
+    /// request gets the open-work list *and* the builder note. The operator's
+    /// words end at whichever marker comes first, so the cut is a `min`, not a
+    /// chain of `find`s that would leave the earlier block in place.
+    #[test]
+    fn operator_words_cuts_at_the_first_of_both_briefings() {
+        let both = format!("ship the audit{OPEN_WORK_ANNOTATION} …]{BUILDER_ANNOTATION} …]");
+        assert_eq!(operator_words(&both), "ship the audit");
+        // …and in the other order, since nothing pins which is appended first.
+        let reversed = format!("ship the audit{BUILDER_ANNOTATION} …]{OPEN_WORK_ANNOTATION} …]");
+        assert_eq!(operator_words(&reversed), "ship the audit");
     }
 
     /// A title never breaks a character in half (the byte-slice trap) and never

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -529,6 +529,7 @@ mod test {
             text: "hi".to_string(),
             by: None,
             chat: chat.map(str::to_string),
+            deliverable: None,
         }
     }
 
@@ -615,6 +616,7 @@ mod test {
                 id: "u1".to_string(),
             }),
             chat: Some(MAIN_THREAD_ID.to_string()),
+            deliverable: None,
         };
         assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
         assert!(!owns("strategy", "Strategy desk", &event));
@@ -629,6 +631,7 @@ mod test {
             text: "hi".to_string(),
             by: None,
             chat: Some(MAIN_THREAD_ID.to_string()),
+            deliverable: None,
         };
         // The console queries the main thread with desk = ("main", "main").
         assert!(owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
@@ -645,6 +648,7 @@ mod test {
             text: "hi".to_string(),
             by: None,
             chat: Some("strategy".to_string()),
+            deliverable: None,
         };
         assert!(owns("strategy", "Strategy desk", &event));
         assert!(!owns(MAIN_THREAD_ID, MAIN_THREAD_ID, &event));
@@ -763,6 +767,7 @@ mod test {
                     text: "a follow-up".to_string(),
                     by: None,
                     chat: Some("studio".to_string()),
+                    deliverable: None,
                 },
             ),
             &Viewer::Operator,
@@ -801,6 +806,7 @@ mod test {
             text: "hi".to_string(),
             by: None,
             chat: None,
+            deliverable: None,
         };
         assert!(owns(GENERAL_DESK, GENERAL_DESK, &event));
         assert!(!owns("strategy", "Strategy desk", &event));

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1200,6 +1200,23 @@ async fn run_chat(
     // the harness stops the turn from acting; this stops the route from acting
     // on its behalf, and it holds in every build because it is here rather than
     // behind the `openhuman` feature.
+    //
+    // Issue #845: an explicit `workflow` deliverable opens a card whatever the
+    // triage said. The operator reached for a control **named** "Build me the
+    // workflow" and pressed it — that is a positive statement of intent about
+    // this message, and it is better evidence than a lexical classifier's guess.
+    // Where the two disagreed, the classifier won and the choice was dropped on
+    // the floor: no card, so no builder pass, so nothing built, and no error
+    // either — the operator got a conversational reply to a request they had
+    // asked to be turned into a workflow.
+    //
+    // Deliberately narrow. It does not change what the card *is* (the title
+    // still comes from the triage, or from the message when the triage declined
+    // to name one), it does not touch `Track`'s existing behaviour, and it stays
+    // inside the `!confined` guard — a copilot thread still opens nothing,
+    // because a message *about* a graph is not a request to build one.
+    let workflow_requested =
+        !confined && message.deliverable == Some(crate::ports::tasks::TaskDeliverable::Workflow);
     if let Some(title) = (!confined)
         .then(|| crate::company::task_intent::triage_message(&message.text))
         .and_then(|triage| match triage {
@@ -1207,6 +1224,10 @@ async fn run_chat(
             crate::company::task_intent::MessageTriage::Answer
             | crate::company::task_intent::MessageTriage::Chatter => None,
         })
+        .or_else(|| {
+            workflow_requested.then(|| crate::company::task_intent::to_title(message.text.trim()))
+        })
+        .filter(|title| !title.trim().is_empty())
     {
         // Keep the full message as the note only when the title was shortened
         // from it, so a one-line ask doesn't duplicate itself.
@@ -1280,6 +1301,12 @@ async fn run_chat(
             // …and the message being replied to, so the thread is a fact about
             // the transcript rather than about one browser (issue #364).
             parent,
+            // Issue #845: and the once-vs-workflow choice, so the turn that
+            // answers this message knows whether the builder pass owns the
+            // authoring. Without it the turn ran blind and denied a capability
+            // that was being exercised on the very same message — see the field
+            // docs on `CompanyEvent::OperatorMessage`.
+            deliverable: message.deliverable,
         }])
         .await?;
     Ok((report, feedback_note))
@@ -2336,6 +2363,85 @@ mod test {
         assert_eq!(r.status(), StatusCode::OK);
         let tasks = runtime.tasks().list(&id).await.unwrap();
         assert_eq!(tasks.len(), 1, "a greeting must not open a card");
+    }
+
+    /// Issue #845: an explicit "Build me the workflow" opens a card even when
+    /// the triage would have opened nothing.
+    ///
+    /// The composer's toggle was consulted *only* on the card-opening branch,
+    /// and that branch is gated on the triage. So a `workflow` request the
+    /// classifier read as a question or as chatter dropped the choice on the
+    /// floor: no card, therefore no builder pass, therefore nothing built — and
+    /// no error either, because a conversational reply came back as though the
+    /// message had been handled.
+    ///
+    /// Both halves are pinned here: the same text opens nothing as a `once`
+    /// message and opens a `workflow` card when the operator asked for one.
+    #[tokio::test]
+    async fn an_explicit_workflow_request_opens_a_card_the_triage_declined() {
+        use crate::ports::tasks::TaskDeliverable;
+
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        // A question by construction — `is_question` fires on the wh-opener, so
+        // the triage answers `Answer` and the card branch declines.
+        let text = "what would a weekly AEO audit of the blog even look like?";
+        assert!(
+            matches!(
+                crate::company::task_intent::triage_message(text),
+                crate::company::task_intent::MessageTriage::Answer
+            ),
+            "fixture must be one the triage declines to card, or this proves nothing"
+        );
+
+        let chat = |deliverable: Option<&str>| {
+            let body = match deliverable {
+                Some(d) => format!(
+                    r#"{{"text":{},"deliverable":"{d}"}}"#,
+                    serde_json::json!(text)
+                ),
+                None => format!(r#"{{"text":{}}}"#, serde_json::json!(text)),
+            };
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/company/chat")
+                .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                .header("content-type", "application/json")
+                .body(Body::from(body))
+                .unwrap()
+        };
+
+        // `once` (and no choice at all): unchanged — the triage still decides.
+        let r = app.clone().oneshot(chat(None)).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let r = app.clone().oneshot(chat(Some("once"))).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        assert!(
+            runtime.tasks().list(&id).await.unwrap().is_empty(),
+            "a `once` question must still open nothing"
+        );
+
+        // `workflow`: the operator's explicit choice outranks the classifier.
+        let r = app.oneshot(chat(Some("workflow"))).await.unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1, "the workflow choice must open its card");
+        assert_eq!(
+            tasks[0].deliverable,
+            TaskDeliverable::Workflow,
+            "and it must be the deliverable that routes it to the builder pass"
+        );
+        // Titled through `to_title`, exactly as a `Track` card would have been.
+        assert_eq!(
+            tasks[0].title,
+            crate::company::task_intent::to_title(text),
+            "a bypassed card must be titled byte-for-byte as a tracked one"
+        );
     }
 
     /// Issue #576: **who** asked decides whether the card self-promotes.
@@ -5526,6 +5632,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
             CompanyEvent::WebhookReceived {
                 channel: "email".into(),

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -199,6 +199,7 @@ pub async fn assert_isolation_by_company(
                 text: "a".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -348,6 +349,7 @@ pub async fn assert_append_only_event_and_ledger(
                 text: "e0".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -360,6 +362,7 @@ pub async fn assert_append_only_event_and_ledger(
                 text: "e1".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -378,6 +381,7 @@ pub async fn assert_append_only_event_and_ledger(
                 text: "e2".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -412,6 +416,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
                     text: format!("a{expected}"),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -428,6 +433,7 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
                 text: "b0".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -621,6 +627,7 @@ pub async fn assert_export_totality(
             text: format!("event {i}"),
             by: None,
             chat: None,
+            deliverable: None,
         };
         events.append(&id, ev.clone()).await.unwrap();
         appended.push(ev);

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -769,6 +769,7 @@ mod test {
                 text: "kick off".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .expect("cycle");
@@ -1705,6 +1706,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }])
             .await
             .unwrap();

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1813,6 +1813,7 @@ mod test {
                         text: format!("event {i}"),
                         by: None,
                         chat: None,
+                        deliverable: None,
                     },
                 )
                 .await
@@ -2114,6 +2115,7 @@ mod test {
                     text: "a".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -2126,6 +2128,7 @@ mod test {
                     text: "b".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -2155,6 +2158,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -2166,7 +2170,8 @@ mod test {
                 parent: None,
                 text: "hi".into(),
                 by: None,
-                chat: None
+                chat: None,
+                deliverable: None,
             }
         );
     }

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3532,6 +3532,7 @@ mod test {
                     text: "hi".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -3584,6 +3585,7 @@ mod test {
                 text: "hi".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             },
         )
         .await
@@ -3595,7 +3597,8 @@ mod test {
                 parent: None,
                 text: "hi".into(),
                 by: None,
-                chat: None
+                chat: None,
+                deliverable: None,
             }
         );
     }
@@ -3682,6 +3685,7 @@ mod test {
                     text: "persist".into(),
                     by: None,
                     chat: None,
+                    deliverable: None,
                 },
             )
             .await
@@ -3698,6 +3702,7 @@ mod test {
                 text: "persist".into(),
                 by: None,
                 chat: None,
+                deliverable: None,
             }
         );
     }


### PR DESCRIPTION
## Summary

Fixes tinyhumansai/opencompany#845 — two defects on the workflow surface. Three commits, each droppable on its own.

### 1. `list_workflows` returned *skills* — `fix(skills)`

Upstream OpenHuman **calls a skill a "workflow"**. Its three skill read tools are named `list_workflows` / `describe_workflow` / `read_workflow_resource`, take a `workflow_id`, and answer with a payload keyed `workflows`. OpenCompany also has workflows — the saved graphs the Workflows page renders and `run_workflow` runs — and `EffectiveSkills::read_tools()` wired upstream's tools in unrenamed, putting both concepts on one belt under one word.

So an agent asked what workflows the company had answered with the four installed *skills* — a set with **zero** overlap with the Workflows page — and an agent asked to run `Campaign pipeline` reported it did not exist. Nothing errored; the shared word is the whole of why it stayed silent. Upstream's own `list_workflows` description ends *"…to inspect (`describe_workflow`) or run (`run_workflow`)"*, i.e. it instructs the model to take a skill out of the skill tree and run it as a workflow.

Fixed by wrapping the three tools at the OpenCompany boundary (`src/harness/skills/naming.rs`), **not** in `vendor/` — "workflow" is upstream's settled word for a skill and is correct everywhere except a host that also has workflows.

The rename covers all four agent-visible surfaces, because leaving any one leaves the bug: the **name**; the **description** (written here rather than delegated); the **argument** (`skill_id`, mapped back before the inner tool runs — a legacy `workflow_id` still resolves, so a model on a stale schema is not stranded); and the **result payload**.

> **The payload rename is the part that actually fixes the reported symptom.** Renaming only the tool leaves the agent reading `{"count":4,"workflows":[…]}` and still reporting "there are exactly 4 installed workflows" — the sentence quoted in the issue. Only top-level keys are re-keyed, so a skill's own description and a bundled file's content are never touched.

**This grants nothing.** Same inner tools, same workspace scoping, same permission level, arguments only re-keyed. An agent that could not reach the workflow registry still cannot — it now says so instead of answering from the wrong list.

> **`policy::consequence` is a fix, not a tidy-up.** The `DECLARED` rows had to follow the rename. An unlisted tool falls through to `undeclared`, whose read-only prefixes include `list` and `read` but **not** `describe` — so an undeclared `describe_skill` would be `Reach::Consequence`: it parks, and interrupts an operator to approve a *local file read*. That is the exact regression `consequence.rs`'s own comment records `describe_workflow` causing before that table existed. `skill_read_tools_are_declared_reads` pins it, and fails if the rows are reverted.

### 2. "Build me the workflow" — `fix(chat)` + `feat(console)`

**The capability exists and works.** The builder pass (#580) does not dispatch a `workflow`-deliverable card to its assignee, because authoring the graph *is* its In-Progress work; it lands a `TaskWorkflowProposal` In Review for a person to apply. On staging it had already produced a proposal for `weekly-aeo-audit` while a desk agent was answering the same message with *"I can't build the workflow … it does not exist and I cannot make it exist."* Both halves behaved correctly and the operator was told the opposite of what was happening.

Three distinct failure modes, three fixes:

**(a) The chat cycle runs on that message in parallel, and was never told.** `CompanyEvent::OperatorMessage` carried no deliverable, so the turn answered blind — and the desk agent answering it holds no authoring tool, correctly refused to pretend otherwise, and said so. Thread the choice onto the event and fold a briefing into the message the brain sees, on exactly `OPEN_WORK_ANNOTATION`'s terms: in-memory only, never journaled, stripped by `operator_words` before anything reasons about what the operator asked for. Missing that strip would be the "thanks!" bug in a new costume — the briefing is several lines of imperative prose containing "workflow", "create" and "build", and `looks_like_work` scores length and work verbs.

**(b) The choice was consulted only on the card-opening branch, which is gated on the triage.** A `workflow` request the classifier read as a question or as chatter dropped the choice silently: no card → no builder pass → nothing built, and no error either. Now the card opens whatever the triage said. The operator reached for a control *named* "Build me the workflow" and pressed it; that is better evidence about this message than a lexical classifier's guess. Titled through `to_title`, so a bypassed card is titled byte-for-byte as a tracked one, and it stays inside the `!confined` guard — a copilot thread still opens nothing.

**(c) DMs had no toggle at all** (`deliverableChoice={active.kind === "channel"}`). Nothing downstream was ever scoped to channels, so the asymmetry lived entirely in that one caller: a DM asking for a workflow went as a `once` card, was dispatched to a desk agent with no authoring tool, and came back a refusal — the DM case in the issue. The rule now lives in `offersDeliverableChoice`, total over `ChannelKind`, so a new kind is a decision someone makes rather than a control that silently fails to appear.

### Security: `CallPath::AuthoredWorkflowNode`'s premise survives

Raised on #776 and worth checking for explicitly, since a reviewer who remembers that concern will look for it.

**None of this grants an agent workflow-authoring power.** `create_workflow` and the #661 admin tools stay **orchestrator-only**; nothing here touches `orchestrator_tools`. The builder pass only ever *proposes* — it courtesy-validates a graph and stamps it on a card, and `create_company_workflow` runs solely from `POST …/workflow-proposal/apply`, which a **person** calls. So a human still authors every workflow node, and the premise that makes `AuthoredWorkflowNode` a silent path is intact. The expensive path — giving agents authoring tools, which *would* invalidate it — is the one this change makes unnecessary.

## API Or Behavior Changes

- **Agent-facing tool rename** (behaviour change, intended): `list_workflows`→`list_skills`, `describe_workflow`→`describe_skill`, `read_workflow_resource`→`read_skill_resource`; arg `workflow_id`→`skill_id`; result keys `workflows`→`skills`, `workflow_id`→`skill_id`. A legacy `workflow_id` argument is still accepted, so an in-flight conversation is not stranded.
- **`CompanyEvent::OperatorMessage` gains `deliverable`**, additive on exactly the `by`/`chat`/`parent` terms: `#[serde(default, skip_serializing_if = "Option::is_none")]`, so every stored event loads and an unset one serializes byte-for-byte as before. No migration.
- A `workflow`-deliverable chat message now (i) always opens a card and (ii) reaches the brain with a briefing appended in memory. `once` and unset messages are byte-for-byte unchanged — pinned by tests on both sides.
- DM composers now show the once-vs-workflow control.
- No HTTP route, GraphQL or storage schema changes.

## Tests

Run from the repo root. The gated lane is the one that matters here — default features skip the whole `harness` module.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI does, `--no-deps`, **both lanes**: default, and `--features openhuman,tinycortex`. Clean.
- [x] `cargo build --all-targets` — ran with `--features openhuman,tinycortex`.
- [x] `cargo test` — ran as `cargo test --features openhuman,tinycortex --tests`: **3642 + 10 + 1 + 11 + 2 passed, 0 failed**. Default lane also green (2360 + 10 + 1). Also `scripts/ci/assert-feature-lanes.sh` (0 owed a lane).
- [x] Frontend, mirroring the console job: `npm ci`, `npm run typecheck`, `npm run typecheck:unit`, `npm test`. New test passes.

**Revert checks.** Fleet standard is to prove each new test fails with its fix reverted.

- Part 1 (skills naming): reverted all three sites independently — **10 of 13 fail**. The 3 that do not are unit tests of helper functions that do not exist pre-fix (`replace_whole_words`, `rewrite_prose`, `rename_top_level_keys`); they cannot fail on a revert and are not claimed as regression coverage.
- Part 2: **all 4 fail** with their fixes reverted, checked one at a time — the triage bypass, the `operator_words` strip, and the injection. `the_builder_briefing_reaches_the_brain_through_run_cycle` covers the **wiring** specifically and fails when only the call site is deleted, which the injection's own unit test cannot catch.

**Known pre-existing failures, reproduced on a clean `origin/main` with none of my changes applied:**

- `harness::brain::tests::a_cancelled_delegated_card_records_no_artifact` — debug-build stack overflow. Passes under `RUST_MIN_STACK=16777216`, which is what the runs above used.
- `frontend`: 57 failures in `tour-resume`, `desktop-bridge`, `connection-registry` — `TypeError: window.localStorage.clear is not a function` (jsdom environment). Verified identical on stashed-clean main.
- `frontend/pnpm-lock.yaml` is out of sync with `package.json` (`@fontsource-variable/geist-mono` is declared but absent from the lock), so `pnpm install --frozen-lockfile` fails on main today. **Not touched here** — CI installs with `npm ci` against `package-lock.json`, which is fine. Flagging it rather than bundling an unrelated lockfile regen.

## Documentation

Module-level docs carry the reasoning, which is where this belongs — the failure was one of naming and wiring, not of a documented contract:

- `src/harness/skills/naming.rs` — a full module header on the collision, why the rename happens at this boundary and not in `vendor/`, why it covers four surfaces, and the `consequence.rs` hazard.
- `BUILDER_ANNOTATION` in `src/runtime/cycle.rs` — what the briefing is for and the staging evidence, alongside `OPEN_WORK_ANNOTATION`, which it parallels.
- The `deliverable` field on `CompanyEvent::OperatorMessage`, and `offersDeliverableChoice` in `frontend/src/views/chat/model.ts`.

No `docs/` page described either behaviour, so none needed updating.
