### PR TITLE
feat(ports): durable notification store with per-user read state

### DIFF
--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -29,9 +29,9 @@ use crate::ports::types::{
 };
 use crate::ports::{
     AgentEconomy, ApprovalGate, ArtifactStore, Brain, ChannelAdapter, CompanyStore, ContextStore,
-    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, ReadStateStore, RunStore,
-    SecretStore, SessionStore, SkillStateStore, TaskRecord, TaskStore, ToolProvider, UsageMeter,
-    UserStore, WorkflowRevisionStore, WorkspaceStore,
+    EventLog, FactStore, InboxStore, LoginCodeStore, MemoryStore, NotificationStore,
+    ReadStateStore, RunStore, SecretStore, SessionStore, SkillStateStore, TaskRecord, TaskStore,
+    ToolProvider, UsageMeter, UserStore, WorkflowRevisionStore, WorkspaceStore,
 };
 // Separate line (#241) so this addition is a pure append, not a reflow of the
 // grouped import that sibling store-seam branches (#274, #596) also edit.
@@ -143,6 +143,8 @@ pub struct OpsStores {
     pub skills: Arc<dyn SkillStateStore>,
     /// Per-person, per-channel read markers (#755).
     pub read_state: Arc<dyn ReadStateStore>,
+    /// Durable notifications with per-person read state (#749).
+    pub notifications: Arc<dyn NotificationStore>,
     /// The company's human collaborators and their outstanding invites.
     pub users: Arc<dyn UserStore>,
     /// Live browser sessions for those users.
@@ -937,6 +939,11 @@ impl CompanyRuntime {
     /// Where each person has read to, per channel (#755).
     pub fn read_state(&self) -> &Arc<dyn ReadStateStore> {
         &self.ops.read_state
+    }
+
+    /// Durable notifications with per-person read state (#749).
+    pub fn notifications(&self) -> &Arc<dyn NotificationStore> {
+        &self.ops.notifications
     }
 
     /// This company's human collaborators and their invites.

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -20,6 +20,7 @@ pub mod inbox;
 pub mod journal;
 pub mod login_codes;
 pub mod memory;
+pub mod notifications;
 pub mod read_state;
 pub mod run_output;
 pub mod runs;
@@ -53,6 +54,7 @@ pub use inbox::{EmailRecord, InboxMeta, InboxStore};
 pub use journal::{Durability, JournalStore};
 pub use login_codes::{LoginCodeRecord, LoginCodeStore};
 pub use memory::MemoryStore;
+pub use notifications::{Notification, NotificationStore, NotificationView, Subject, SubjectKind};
 pub use read_state::{ChannelRead, ReadStateStore};
 pub use run_output::{
     MAX_RUN_OUTPUTS_PER_COMPANY, WorkflowRunOutputRecord, WorkflowRunOutputStore, bound_node_output,
@@ -108,6 +110,7 @@ mod test {
         _facts: &dyn crate::ports::facts::FactStore,
         _usage: &dyn crate::ports::usage::UsageMeter,
         _skills: &dyn crate::ports::skills_state::SkillStateStore,
+        _notifications: &dyn crate::ports::notifications::NotificationStore,
         _read_state: &dyn crate::ports::read_state::ReadStateStore,
         _users: &dyn crate::ports::users::UserStore,
         _sessions: &dyn crate::ports::sessions::SessionStore,

--- a/src/ports/notifications.rs
+++ b/src/ports/notifications.rs
@@ -1,0 +1,148 @@
+//! The [`NotificationStore`] port: durable notifications with per-person read
+//! state.
+//!
+//! The console has a live feed — `src/turn_stream.rs` publishes per-turn
+//! progress onto a broadcast bus, the operator SSE route fans it out, and
+//! `frontend/src/hooks/use-events.ts` turns it into toasts. That is a
+//! *transport*: it only works while a browser tab is open and watching. Close
+//! the tab and the event is gone (issue #577).
+//!
+//! This store holds the durable half: a notification is a stored thing with a
+//! kind, a subject, a created-at, and read state. It delivers nothing on its
+//! own — it is the substrate that out-of-browser delivery (#750) and the digest
+//! (#751) are built on.
+//!
+//! **Read state is per person, not per company.** A company has a roster, and
+//! "I have seen this" is per human. The record is company-wide; two operators
+//! see the same notifications with independent read state. This is deliberately
+//! *not* modelled as a `read` flag on the record — that is [`InboxStore`]'s
+//! shape, whose `mark_read` is scoped per inbox key with no user in the
+//! signature, so one admin opening it would mark it read for everyone (the trap
+//! called out on #749). Read state here keys on `(company, user,
+//! notification)`.
+//!
+//! [`InboxStore`]: crate::ports::inbox::InboxStore
+
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+use crate::Result;
+use crate::ports::types::CompanyId;
+
+/// What a notification is about. A closed set — the four subjects #577 names —
+/// so a backend can store it as a small tag rather than an open string.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SubjectKind {
+    Task,
+    Run,
+    Approval,
+    Workflow,
+}
+
+impl SubjectKind {
+    /// The wire/storage token for this kind. Stable — backends persist it, so a
+    /// rename here is a data migration, not a cosmetic change.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SubjectKind::Task => "task",
+            SubjectKind::Run => "run",
+            SubjectKind::Approval => "approval",
+            SubjectKind::Workflow => "workflow",
+        }
+    }
+
+    /// Parses the storage token back, rejecting anything unknown so a corrupt or
+    /// forward-versioned row surfaces rather than silently becoming a default.
+    ///
+    /// Named `from_token` rather than `from_str` so it is not mistaken for
+    /// [`std::str::FromStr`] (which would have to return `Result`, not
+    /// `Option`).
+    pub fn from_token(s: &str) -> Option<Self> {
+        match s {
+            "task" => Some(SubjectKind::Task),
+            "run" => Some(SubjectKind::Run),
+            "approval" => Some(SubjectKind::Approval),
+            "workflow" => Some(SubjectKind::Workflow),
+            _ => None,
+        }
+    }
+}
+
+/// The thing a notification points at: which kind of subject, and its id in that
+/// subject's own id space (a task id, a run id, an approval id, a workflow id).
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Subject {
+    pub kind: SubjectKind,
+    pub id: String,
+}
+
+/// One stored notification, company-scoped. Read state is deliberately absent
+/// here — it is per person, projected onto the record by
+/// [`NotificationStore::list`].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Notification {
+    /// Stable id within the company, minted with
+    /// [`generate_id`](crate::ports::generate_id) by the caller — the
+    /// [`EmailRecord`](crate::ports::inbox::EmailRecord) convention.
+    pub id: String,
+    /// The notification type: a free-form tag. A intentionally does **not**
+    /// define the vocabulary of what is "worth sending" — that judgement is the
+    /// one EPIC #558 exists to make, consumed by #750, and must not be made
+    /// twice (see #577 point 5).
+    pub kind: String,
+    /// What it is about.
+    pub subject: Subject,
+    /// Epoch-millis the notification was raised
+    /// ([`now_millis`](crate::ports::now_millis)).
+    pub created_at: u64,
+    /// One-line, operator-readable summary — the line a person reads.
+    pub title: String,
+}
+
+/// A notification as one person sees it: the record plus whether *they* have
+/// read it. Two people list the same records with independent `read_at`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationView {
+    #[serde(flatten)]
+    pub notification: Notification,
+    /// Epoch-millis this person first read it; `None` means unread for them.
+    pub read_at: Option<u64>,
+}
+
+/// Durable per-company notifications with per-person read state. Company A's
+/// notifications MUST be invisible to company B, and one person's read state
+/// MUST be invisible to another.
+#[async_trait]
+pub trait NotificationStore: Send + Sync {
+    /// Records a notification for the whole company.
+    async fn append(&self, company: &CompanyId, notification: &Notification) -> Result<()>;
+
+    /// Every notification in the company, each carrying **this** person's read
+    /// state.
+    ///
+    /// **Newest first** (by `created_at`, descending; ties broken by `id`
+    /// descending for a stable order). Part of the contract rather than an
+    /// accident of each backend: insertion order differs between a document
+    /// store and a table, and a caller paging a feed would see rows jump. The
+    /// conformance suite asserts it, so a backend returning insertion order
+    /// fails rather than passing quietly.
+    async fn list(&self, company: &CompanyId, user: &str) -> Result<Vec<NotificationView>>;
+
+    /// Marks notifications read for this person — the given `ids`, or every
+    /// notification in the company when `ids` is `None`.
+    ///
+    /// **A latch.** Once read it stays read; re-marking an already-read
+    /// notification is a no-op and preserves the original `read_at`. Ids that
+    /// name no notification are ignored. Returns the count still unread for this
+    /// person after the mark.
+    async fn mark_read(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        ids: Option<&[String]>,
+    ) -> Result<u64>;
+}

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -309,6 +309,7 @@ pub struct RuntimeBuilder {
     usage: Option<Arc<dyn UsageMeter>>,
     skills: Option<Arc<dyn SkillStateStore>>,
     read_state: Option<Arc<dyn crate::ports::read_state::ReadStateStore>>,
+    notifications: Option<Arc<dyn crate::ports::notifications::NotificationStore>>,
     users: Option<Arc<dyn UserStore>>,
     sessions: Option<Arc<dyn SessionStore>>,
     login_codes: Option<Arc<dyn LoginCodeStore>>,
@@ -416,6 +417,7 @@ impl RuntimeBuilder {
             usage: None,
             skills: None,
             read_state: None,
+            notifications: None,
             users: None,
             sessions: None,
             login_codes: None,
@@ -537,6 +539,7 @@ impl RuntimeBuilder {
         self.usage = Some(handles.usage.clone());
         self.skills = Some(handles.skills.clone());
         self.read_state = Some(handles.read_state.clone());
+        self.notifications = Some(handles.notifications.clone());
         self.users = Some(handles.users.clone());
         self.sessions = Some(handles.sessions.clone());
         self.login_codes = Some(handles.login_codes.clone());
@@ -679,6 +682,15 @@ impl RuntimeBuilder {
         read_state: Arc<dyn crate::ports::read_state::ReadStateStore>,
     ) -> Self {
         self.read_state = Some(read_state);
+        self
+    }
+
+    /// Swaps the durable notification store (default: fs-backed).
+    pub fn with_notifications(
+        mut self,
+        notifications: Arc<dyn crate::ports::notifications::NotificationStore>,
+    ) -> Self {
+        self.notifications = Some(notifications);
         self
     }
 
@@ -1026,6 +1038,7 @@ impl RuntimeBuilder {
                 usage: self.usage.unwrap_or_else(|| fs_ops.clone()),
                 skills: self.skills.unwrap_or_else(|| fs_ops.clone()),
                 read_state: self.read_state.unwrap_or_else(|| fs_ops.clone()),
+                notifications: self.notifications.unwrap_or_else(|| fs_ops.clone()),
                 users: self.users.unwrap_or_else(|| fs_ops.clone()),
                 sessions: self.sessions.unwrap_or_else(|| fs_ops.clone()),
                 login_codes: self.login_codes.unwrap_or_else(|| fs_ops.clone()),

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2392,6 +2392,13 @@ pub async fn assert_notification_store(notes: Arc<dyn NotificationStore>) {
     );
 
     // A latch: re-marking does not move the timestamp forward.
+    //
+    // Wait past a millisecond boundary first: within one millisecond a backend
+    // that OVERWRITES `read_at` on every mark writes the same value a latch
+    // would, and this assertion would then pass for the very shape it exists to
+    // reject. After the wait, an overwriting backend produces a strictly greater
+    // `read_at` (and this fails); a real latch is unchanged (and this holds).
+    tokio::time::sleep(std::time::Duration::from_millis(2)).await;
     notes
         .mark_read(&alpha, "ada", Some(&["n-new".to_string()]))
         .await

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -23,6 +23,7 @@ use crate::ports::facts::{FactKind, FactRecord, FactStore};
 use crate::ports::inbox::{EmailRecord, InboxMeta, InboxStore};
 use crate::ports::login_codes::{LoginCodeRecord, LoginCodeStore};
 use crate::ports::memory::MemoryStore;
+use crate::ports::notifications::{Notification, NotificationStore, Subject, SubjectKind};
 use crate::ports::now_millis;
 use crate::ports::run_output::{
     MAX_RUN_OUTPUTS_PER_COMPANY, WorkflowRunOutputRecord, WorkflowRunOutputStore,
@@ -2294,6 +2295,162 @@ pub async fn assert_read_state_store(reads: Arc<dyn crate::ports::read_state::Re
     assert_eq!(all.len(), 2);
     assert_eq!(all[0].channel_id, "dm:pm");
     assert_eq!(all[1].channel_id, "engineering");
+}
+
+/// Asserts the [`NotificationStore`] contract: per-company isolation, per-person
+/// read state, newest-first ordering, and the latch / `None`-marks-all
+/// semantics of `mark_read` (issue #749).
+///
+/// The property that matters most is **per-person read state**: one person
+/// marking a notification read must leave it unread for another. A `read` flag
+/// on the shared record — inbox's shape — would fail exactly this, which is why
+/// the port does not have one.
+pub async fn assert_notification_store(notes: Arc<dyn NotificationStore>) {
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+
+    let note = |id: &str, created_at: u64, subject: SubjectKind, subject_id: &str| Notification {
+        id: id.to_string(),
+        kind: "approval_blocked".to_string(),
+        subject: Subject {
+            kind: subject,
+            id: subject_id.to_string(),
+        },
+        created_at,
+        title: format!("notification {id}"),
+    };
+
+    // Empty: nobody has anything.
+    assert!(notes.list(&alpha, "ada").await.unwrap().is_empty());
+
+    // Two notifications, appended oldest-then-newest.
+    notes
+        .append(&alpha, &note("n-old", 100, SubjectKind::Task, "task-1"))
+        .await
+        .unwrap();
+    notes
+        .append(&alpha, &note("n-new", 200, SubjectKind::Approval, "appr-1"))
+        .await
+        .unwrap();
+
+    // Newest first, and unread for everyone until read.
+    let ada = notes.list(&alpha, "ada").await.unwrap();
+    assert_eq!(ada.len(), 2);
+    assert_eq!(ada[0].notification.id, "n-new");
+    assert_eq!(ada[1].notification.id, "n-old");
+    assert!(ada.iter().all(|v| v.read_at.is_none()));
+    // The subject rides through untouched.
+    assert_eq!(ada[0].notification.subject.kind, SubjectKind::Approval);
+    assert_eq!(ada[0].notification.subject.id, "appr-1");
+
+    // Append is idempotent by id (first write wins): re-appending an existing
+    // id neither duplicates the record nor mutates it. Backends must agree — a
+    // naive push/insert duplicates on fs/mongo but errors on the sqlite primary
+    // key, so this pins the shared contract.
+    notes
+        .append(&alpha, &note("n-old", 999, SubjectKind::Run, "changed"))
+        .await
+        .unwrap();
+    let after = notes.list(&alpha, "ada").await.unwrap();
+    assert_eq!(after.len(), 2, "re-appending an id must not duplicate");
+    let old = after.iter().find(|v| v.notification.id == "n-old").unwrap();
+    assert_eq!(
+        old.notification.created_at, 100,
+        "first write wins: created_at unchanged"
+    );
+    assert_eq!(
+        old.notification.subject.id, "task-1",
+        "first write wins: subject unchanged"
+    );
+
+    // Per person: Ada reads the new one; the count of what is still unread for
+    // her comes back, and Grace still sees it unread.
+    let still_unread = notes
+        .mark_read(&alpha, "ada", Some(&["n-new".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(still_unread, 1, "n-old is still unread for Ada");
+
+    let ada = notes.list(&alpha, "ada").await.unwrap();
+    let stamped = ada
+        .iter()
+        .find(|v| v.notification.id == "n-new")
+        .unwrap()
+        .read_at
+        .expect("Ada read n-new");
+    assert!(
+        ada.iter()
+            .find(|v| v.notification.id == "n-old")
+            .unwrap()
+            .read_at
+            .is_none()
+    );
+    let grace = notes.list(&alpha, "grace").await.unwrap();
+    assert!(
+        grace.iter().all(|v| v.read_at.is_none()),
+        "Ada's read must not touch Grace"
+    );
+
+    // A latch: re-marking does not move the timestamp forward.
+    notes
+        .mark_read(&alpha, "ada", Some(&["n-new".to_string()]))
+        .await
+        .unwrap();
+    let ada = notes.list(&alpha, "ada").await.unwrap();
+    assert_eq!(
+        ada.iter()
+            .find(|v| v.notification.id == "n-new")
+            .unwrap()
+            .read_at,
+        Some(stamped),
+        "re-mark must preserve the original read_at"
+    );
+
+    // Unknown ids are ignored, not an error, and change nothing.
+    let unread = notes
+        .mark_read(&alpha, "ada", Some(&["does-not-exist".to_string()]))
+        .await
+        .unwrap();
+    assert_eq!(unread, 1);
+
+    // `None` marks the whole company read for that person.
+    let unread = notes.mark_read(&alpha, "ada", None).await.unwrap();
+    assert_eq!(unread, 0);
+    let ada = notes.list(&alpha, "ada").await.unwrap();
+    assert!(ada.iter().all(|v| v.read_at.is_some()));
+    let grace = notes.list(&alpha, "grace").await.unwrap();
+    assert!(
+        grace.iter().all(|v| v.read_at.is_none()),
+        "Ada marking all read must not touch Grace"
+    );
+
+    // Ties in created_at break by id descending — a stable order the trait
+    // documents, not each backend's insertion order. These two arrive after
+    // Ada's `None` mark, so they are unread for her.
+    notes
+        .append(&alpha, &note("id-a", 300, SubjectKind::Run, "run-1"))
+        .await
+        .unwrap();
+    notes
+        .append(&alpha, &note("id-b", 300, SubjectKind::Workflow, "wf-1"))
+        .await
+        .unwrap();
+    let ada = notes.list(&alpha, "ada").await.unwrap();
+    assert_eq!(ada[0].notification.id, "id-b");
+    assert_eq!(ada[1].notification.id, "id-a");
+
+    // Per company: beta starts empty and stays independent of alpha.
+    assert!(notes.list(&beta, "ada").await.unwrap().is_empty());
+    notes
+        .append(&beta, &note("b-1", 100, SubjectKind::Task, "task-9"))
+        .await
+        .unwrap();
+    assert_eq!(notes.list(&beta, "ada").await.unwrap().len(), 1);
+    assert_eq!(
+        notes.list(&alpha, "ada").await.unwrap().len(),
+        4,
+        "beta's write must not change alpha"
+    );
 }
 
 pub async fn assert_skill_state_store(skills: Arc<dyn SkillStateStore>) {

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1172,13 +1172,17 @@ impl crate::ports::notifications::NotificationStore for FsOps {
         )
         .await?;
         let reads = load_json_vec::<StoredNotifRead>(&bundle.notification_reads_json()).await?;
+        // This person's markers, indexed once, so the join is linear rather than
+        // O(records × markers) — mirrors the map the mongo backend builds.
+        let mine: std::collections::HashMap<&str, u64> = reads
+            .iter()
+            .filter(|r| r.user_id == user)
+            .map(|r| (r.notification_id.as_str(), r.read_at))
+            .collect();
         let mut out: Vec<_> = records
             .into_iter()
             .map(|n| {
-                let read_at = reads
-                    .iter()
-                    .find(|r| r.user_id == user && r.notification_id == n.id)
-                    .map(|r| r.read_at);
+                let read_at = mine.get(n.id.as_str()).copied();
                 crate::ports::notifications::NotificationView {
                     notification: n,
                     read_at,
@@ -1223,6 +1227,7 @@ impl crate::ports::notifications::NotificationStore for FsOps {
             None => records.iter().map(|n| n.id.as_str()).collect(),
         };
         let now = crate::ports::now_millis();
+        let mut changed = false;
         for id in targets {
             // A latch: only stamp a marker that is not already there, so the
             // original `read_at` survives a re-mark.
@@ -1235,9 +1240,15 @@ impl crate::ports::notifications::NotificationStore for FsOps {
                     notification_id: id.to_string(),
                     read_at: now,
                 });
+                changed = true;
             }
         }
-        write_atomic(&path, &serde_json::to_string(&reads)?).await?;
+        // Only rewrite the marker file when a marker was actually added, so a
+        // repeated mark-all is a pure read rather than a rewrite of the whole
+        // file for no change.
+        if changed {
+            write_atomic(&path, &serde_json::to_string(&reads)?).await?;
+        }
         // Still-unread count for this person: records with no marker of theirs.
         let unread = records
             .iter()

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1125,6 +1125,133 @@ impl crate::ports::read_state::ReadStateStore for FsOps {
 }
 
 // ---------------------------------------------------------------------------
+// NotificationStore
+// ---------------------------------------------------------------------------
+
+/// One per-person read marker. Kept in its own document rather than as a field
+/// on the notification, because read state is per person (#749) — a flag on the
+/// shared record would mark it read for everyone the moment one admin opened it.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct StoredNotifRead {
+    user_id: String,
+    notification_id: String,
+    read_at: u64,
+}
+
+#[async_trait]
+impl crate::ports::notifications::NotificationStore for FsOps {
+    async fn append(
+        &self,
+        company: &CompanyId,
+        notification: &crate::ports::notifications::Notification,
+    ) -> Result<()> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let path = bundle.notifications_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut rows = load_json_vec::<crate::ports::notifications::Notification>(&path).await?;
+        // Idempotent by id (first write wins): a retried or replayed append must
+        // not duplicate the feed. Matches the sqlite primary key and the mongo
+        // unique index, so all three backends agree.
+        if !rows.iter().any(|n| n.id == notification.id) {
+            rows.push(notification.clone());
+            write_atomic(&path, &serde_json::to_string(&rows)?).await?;
+        }
+        Ok(())
+    }
+
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::notifications::NotificationView>> {
+        let bundle = self.bundle(company);
+        let records = load_json_vec::<crate::ports::notifications::Notification>(
+            &bundle.notifications_json(),
+        )
+        .await?;
+        let reads = load_json_vec::<StoredNotifRead>(&bundle.notification_reads_json()).await?;
+        let mut out: Vec<_> = records
+            .into_iter()
+            .map(|n| {
+                let read_at = reads
+                    .iter()
+                    .find(|r| r.user_id == user && r.notification_id == n.id)
+                    .map(|r| r.read_at);
+                crate::ports::notifications::NotificationView {
+                    notification: n,
+                    read_at,
+                }
+            })
+            .collect();
+        // Newest first, ties broken by id descending — the order the trait
+        // documents, not each backend's insertion order.
+        out.sort_by(|a, b| {
+            b.notification
+                .created_at
+                .cmp(&a.notification.created_at)
+                .then_with(|| b.notification.id.cmp(&a.notification.id))
+        });
+        Ok(out)
+    }
+
+    async fn mark_read(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        ids: Option<&[String]>,
+    ) -> Result<u64> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let records = load_json_vec::<crate::ports::notifications::Notification>(
+            &bundle.notifications_json(),
+        )
+        .await?;
+        let path = bundle.notification_reads_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut reads = load_json_vec::<StoredNotifRead>(&path).await?;
+        // Which notifications to mark: the named ids that actually exist, or
+        // every notification when `None`.
+        let targets: Vec<&str> = match ids {
+            Some(ids) => records
+                .iter()
+                .filter(|n| ids.iter().any(|i| i == &n.id))
+                .map(|n| n.id.as_str())
+                .collect(),
+            None => records.iter().map(|n| n.id.as_str()).collect(),
+        };
+        let now = crate::ports::now_millis();
+        for id in targets {
+            // A latch: only stamp a marker that is not already there, so the
+            // original `read_at` survives a re-mark.
+            let already = reads
+                .iter()
+                .any(|r| r.user_id == user && r.notification_id == id);
+            if !already {
+                reads.push(StoredNotifRead {
+                    user_id: user.to_string(),
+                    notification_id: id.to_string(),
+                    read_at: now,
+                });
+            }
+        }
+        write_atomic(&path, &serde_json::to_string(&reads)?).await?;
+        // Still-unread count for this person: records with no marker of theirs.
+        let unread = records
+            .iter()
+            .filter(|n| {
+                !reads
+                    .iter()
+                    .any(|r| r.user_id == user && r.notification_id == n.id)
+            })
+            .count() as u64;
+        Ok(unread)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -2208,6 +2335,13 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_read_state_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_notification_store() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_notification_store(Arc::new(FsOps::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -401,7 +401,9 @@ impl MongoStore {
         // re-mark is a no-op `E11000` and read stays a latch. Created outside the
         // fixed array above so adding them does not disturb its length.
         self.collection("notifications")
-            .create_index(nonunique(doc! {"company_id": 1, "created_ms": -1}))
+            .create_index(nonunique(
+                doc! {"company_id": 1, "created_ms": -1, "id": -1},
+            ))
             .await
             .map_err(mongo_err)?;
         // Unique per (company_id, id): makes `append` idempotent — a duplicate

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -395,6 +395,27 @@ impl MongoStore {
             .create_index(unique(doc! {"company_id": 1}))
             .await
             .map_err(mongo_err)?;
+        // Issue #749: durable notifications. The recency index backs the
+        // newest-first feed `NotificationStore::list` returns; the per-person
+        // read marker is unique on `(company_id, user_id, notification_id)` so a
+        // re-mark is a no-op `E11000` and read stays a latch. Created outside the
+        // fixed array above so adding them does not disturb its length.
+        self.collection("notifications")
+            .create_index(nonunique(doc! {"company_id": 1, "created_ms": -1}))
+            .await
+            .map_err(mongo_err)?;
+        // Unique per (company_id, id): makes `append` idempotent — a duplicate
+        // id within a company is rejected, matching the sqlite primary key.
+        self.collection("notifications")
+            .create_index(unique(doc! {"company_id": 1, "id": 1}))
+            .await
+            .map_err(mongo_err)?;
+        self.collection("notification_reads")
+            .create_index(unique(
+                doc! {"company_id": 1, "user_id": 1, "notification_id": 1},
+            ))
+            .await
+            .map_err(mongo_err)?;
         Ok(())
     }
 
@@ -2434,6 +2455,157 @@ impl crate::ports::read_state::ReadStateStore for MongoStore {
 }
 
 // ---------------------------------------------------------------------------
+// NotificationStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::notifications::NotificationStore for MongoStore {
+    async fn append(
+        &self,
+        company: &CompanyId,
+        notification: &crate::ports::notifications::Notification,
+    ) -> Result<()> {
+        // Idempotent by id (first write wins): `$setOnInsert` seeds the record
+        // only when it does not yet exist, so a retried or replayed append is a
+        // no-op rather than a duplicate. The unique (company_id, id) index in
+        // `ensure_indexes` is the backstop against a concurrent double insert.
+        // All three backends agree: no duplicate id within a company.
+        self.collection("notifications")
+            .update_one(
+                doc! {"company_id": company.as_ref(), "id": notification.id.as_str()},
+                doc! {"$setOnInsert": {
+                    "kind": notification.kind.as_str(),
+                    "subject_kind": notification.subject.kind.as_str(),
+                    "subject_id": notification.subject.id.as_str(),
+                    "title": notification.title.as_str(),
+                    "created_ms": notification.created_at as i64,
+                }},
+            )
+            .with_options(UpdateOptions::builder().upsert(true).build())
+            .await
+            .map_err(mongo_err)?;
+        Ok(())
+    }
+
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::notifications::NotificationView>> {
+        // This person's read markers first, into an id → read_ms map.
+        let mut reads: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+        let mut read_cursor = self
+            .collection("notification_reads")
+            .find(doc! {"company_id": company.as_ref(), "user_id": user})
+            .await
+            .map_err(mongo_err)?;
+        while let Some(d) = read_cursor.try_next().await.map_err(mongo_err)? {
+            reads.insert(
+                get_str(&d, "notification_id")?,
+                d.get_i64("read_ms").unwrap_or_default(),
+            );
+        }
+        // The records, newest first; the sort is the trait's contract.
+        let mut cursor = self
+            .collection("notifications")
+            .find(doc! {"company_id": company.as_ref()})
+            .sort(doc! {"created_ms": -1, "id": -1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(d) = cursor.try_next().await.map_err(mongo_err)? {
+            let id = get_str(&d, "id")?;
+            let subject_kind = get_str(&d, "subject_kind")?;
+            let subject_kind = crate::ports::notifications::SubjectKind::from_token(&subject_kind)
+                .ok_or_else(|| {
+                    crate::error::OpenCompanyError::Store(format!(
+                        "notification {id} has an unknown subject kind {subject_kind:?}"
+                    ))
+                })?;
+            let read_at = reads.get(&id).map(|v| *v as u64);
+            out.push(crate::ports::notifications::NotificationView {
+                notification: crate::ports::notifications::Notification {
+                    id,
+                    kind: get_str(&d, "kind")?,
+                    subject: crate::ports::notifications::Subject {
+                        kind: subject_kind,
+                        id: get_str(&d, "subject_id")?,
+                    },
+                    created_at: d.get_i64("created_ms").unwrap_or_default() as u64,
+                    title: get_str(&d, "title")?,
+                },
+                read_at,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn mark_read(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        ids: Option<&[String]>,
+    ) -> Result<u64> {
+        let now = crate::ports::now_millis() as i64;
+        // Which notifications to mark: the named ids that actually exist in this
+        // company, or every notification when `None`.
+        let targets: Vec<String> = match ids {
+            Some(ids) => {
+                let mut present = Vec::new();
+                for id in ids {
+                    let found = self
+                        .collection("notifications")
+                        .find_one(doc! {"company_id": company.as_ref(), "id": id.as_str()})
+                        .await
+                        .map_err(mongo_err)?;
+                    if found.is_some() {
+                        present.push(id.clone());
+                    }
+                }
+                present
+            }
+            None => {
+                let mut cursor = self
+                    .collection("notifications")
+                    .find(doc! {"company_id": company.as_ref()})
+                    .await
+                    .map_err(mongo_err)?;
+                let mut all = Vec::new();
+                while let Some(d) = cursor.try_next().await.map_err(mongo_err)? {
+                    all.push(get_str(&d, "id")?);
+                }
+                all
+            }
+        };
+        for id in &targets {
+            // `$setOnInsert` is the latch: it seeds `read_ms` only when the
+            // marker is first created, so a re-mark leaves the original instant.
+            self.collection("notification_reads")
+                .update_one(
+                    doc! {
+                        "company_id": company.as_ref(),
+                        "user_id": user,
+                        "notification_id": id.as_str(),
+                    },
+                    doc! {"$setOnInsert": {"read_ms": now}},
+                )
+                .with_options(UpdateOptions::builder().upsert(true).build())
+                .await
+                .map_err(mongo_err)?;
+        }
+        // Still-unread count for this person, derived from the same projection
+        // `list` uses so the two never disagree. Fully qualified because
+        // `MongoStore` implements several ports that each expose a `list`.
+        let unread = crate::ports::notifications::NotificationStore::list(self, company, user)
+            .await?
+            .iter()
+            .filter(|v| v.read_at.is_none())
+            .count() as u64;
+        Ok(unread)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -4132,6 +4304,13 @@ mod test {
     async fn conformance_read_state_store() {
         let Some(s) = store().await else { return };
         conformance::assert_read_state_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_notification_store() {
+        let Some(s) = store().await else { return };
+        conformance::assert_notification_store(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -417,6 +417,18 @@ impl Bundle {
         self.dir.join("read-state.json")
     }
 
+    /// Path to the durable notification records (`notifications.json`, #749).
+    pub fn notifications_json(&self) -> PathBuf {
+        self.dir.join("notifications.json")
+    }
+
+    /// Path to the per-person notification read markers
+    /// (`notification-reads.json`, #749) — kept beside the records rather than
+    /// on them, because read state is per person, not per company.
+    pub fn notification_reads_json(&self) -> PathBuf {
+        self.dir.join("notification-reads.json")
+    }
+
     /// The workspace subdirectory holding the seeded/edited file tree.
     pub fn workspace_dir(&self) -> PathBuf {
         self.dir.join("workspace")

--- a/src/store/select.rs
+++ b/src/store/select.rs
@@ -25,6 +25,7 @@ use crate::ports::inbox::InboxStore;
 use crate::ports::journal::JournalStore;
 use crate::ports::login_codes::LoginCodeStore;
 use crate::ports::memory::MemoryStore;
+use crate::ports::notifications::NotificationStore;
 use crate::ports::read_state::ReadStateStore;
 use crate::ports::run_output::WorkflowRunOutputStore;
 use crate::ports::runs::RunStore;
@@ -218,6 +219,8 @@ pub struct StorageHandles {
     pub skills: Arc<dyn SkillStateStore>,
     /// Per-person, per-channel read markers (#755).
     pub read_state: Arc<dyn ReadStateStore>,
+    /// Durable notifications with per-person read state (#749).
+    pub notifications: Arc<dyn NotificationStore>,
     pub users: Arc<dyn UserStore>,
     pub sessions: Arc<dyn SessionStore>,
     pub login_codes: Arc<dyn LoginCodeStore>,
@@ -486,6 +489,7 @@ fn open_sqlite(data_dir: &Path) -> Result<Option<StorageHandles>> {
         usage: store.clone(),
         skills: store.clone(),
         read_state: store.clone(),
+        notifications: store.clone(),
         users: store.clone(),
         sessions: store.clone(),
         login_codes: store.clone(),
@@ -528,6 +532,7 @@ async fn open_mongodb(settings: &StorageSettings) -> Result<Option<StorageHandle
         usage: store.clone(),
         skills: store.clone(),
         read_state: store.clone(),
+        notifications: store.clone(),
         users: store.clone(),
         sessions: store.clone(),
         login_codes: store.clone(),

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -209,6 +209,11 @@ CREATE TABLE IF NOT EXISTS notifications (
     created_ms   INTEGER NOT NULL,
     PRIMARY KEY (company_id, id)
 );
+-- Backs the documented newest-first feed (`NotificationStore::list`):
+-- `WHERE company_id = ? ORDER BY created_ms DESC, id DESC`, so a company's feed
+-- reads straight off the index instead of sorting at read time.
+CREATE INDEX IF NOT EXISTS notifications_feed
+    ON notifications (company_id, created_ms DESC, id DESC);
 CREATE TABLE IF NOT EXISTS notification_reads (
     company_id      TEXT NOT NULL,
     user_id         TEXT NOT NULL,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -199,6 +199,23 @@ CREATE TABLE IF NOT EXISTS channel_read_state (
     last_read_ms INTEGER NOT NULL,
     PRIMARY KEY (company_id, user_id, channel_id)
 );
+CREATE TABLE IF NOT EXISTS notifications (
+    company_id   TEXT NOT NULL,
+    id           TEXT NOT NULL,
+    kind         TEXT NOT NULL,
+    subject_kind TEXT NOT NULL,
+    subject_id   TEXT NOT NULL,
+    title        TEXT NOT NULL,
+    created_ms   INTEGER NOT NULL,
+    PRIMARY KEY (company_id, id)
+);
+CREATE TABLE IF NOT EXISTS notification_reads (
+    company_id      TEXT NOT NULL,
+    user_id         TEXT NOT NULL,
+    notification_id TEXT NOT NULL,
+    read_ms         INTEGER NOT NULL,
+    PRIMARY KEY (company_id, user_id, notification_id)
+);
 CREATE TABLE IF NOT EXISTS workspace_nodes (
     company_id TEXT NOT NULL,
     id         TEXT NOT NULL,
@@ -2518,6 +2535,152 @@ impl crate::ports::read_state::ReadStateStore for SqliteStore {
 }
 
 // ---------------------------------------------------------------------------
+// NotificationStore
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl crate::ports::notifications::NotificationStore for SqliteStore {
+    async fn append(
+        &self,
+        company: &CompanyId,
+        notification: &crate::ports::notifications::Notification,
+    ) -> Result<()> {
+        let conn = self.conn();
+        // `INSERT OR IGNORE` makes append idempotent by id (first write wins): a
+        // retried or replayed append is a no-op on the primary key rather than an
+        // error, matching the fs and mongo backends.
+        conn.execute(
+            "INSERT OR IGNORE INTO notifications \
+                 (company_id, id, kind, subject_kind, subject_id, title, created_ms) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+            params![
+                company.as_ref(),
+                notification.id.as_str(),
+                notification.kind.as_str(),
+                notification.subject.kind.as_str(),
+                notification.subject.id.as_str(),
+                notification.title.as_str(),
+                notification.created_at as i64,
+            ],
+        )
+        .map_err(sql_err)?;
+        Ok(())
+    }
+
+    async fn list(
+        &self,
+        company: &CompanyId,
+        user: &str,
+    ) -> Result<Vec<crate::ports::notifications::NotificationView>> {
+        let conn = self.conn();
+        // Read state is projected per person with a LEFT JOIN: a notification
+        // with no marker of this user's comes back with a NULL `read_ms`.
+        let mut stmt = conn
+            .prepare(
+                "SELECT n.id, n.kind, n.subject_kind, n.subject_id, n.title, n.created_ms, \
+                        r.read_ms \
+                 FROM notifications n \
+                 LEFT JOIN notification_reads r \
+                     ON r.company_id = n.company_id \
+                    AND r.notification_id = n.id \
+                    AND r.user_id = ?2 \
+                 WHERE n.company_id = ?1 \
+                 ORDER BY n.created_ms DESC, n.id DESC",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref(), user], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, i64>(5)?,
+                    r.get::<_, Option<i64>>(6)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (id, kind, subject_kind, subject_id, title, created_ms, read_ms) =
+                row.map_err(sql_err)?;
+            let subject_kind = crate::ports::notifications::SubjectKind::from_token(&subject_kind)
+                .ok_or_else(|| {
+                    crate::error::OpenCompanyError::Store(format!(
+                        "notification {id} has an unknown subject kind {subject_kind:?}"
+                    ))
+                })?;
+            out.push(crate::ports::notifications::NotificationView {
+                notification: crate::ports::notifications::Notification {
+                    id,
+                    kind,
+                    subject: crate::ports::notifications::Subject {
+                        kind: subject_kind,
+                        id: subject_id,
+                    },
+                    created_at: created_ms as u64,
+                    title,
+                },
+                read_at: read_ms.map(|v| v as u64),
+            });
+        }
+        Ok(out)
+    }
+
+    async fn mark_read(
+        &self,
+        company: &CompanyId,
+        user: &str,
+        ids: Option<&[String]>,
+    ) -> Result<u64> {
+        let conn = self.conn();
+        let now = crate::ports::now_millis() as i64;
+        // `INSERT OR IGNORE` is the latch: a PK conflict on an already-read row
+        // is skipped, so the original `read_ms` survives a re-mark. Only ids
+        // that name an existing notification in this company are inserted.
+        match ids {
+            Some(ids) => {
+                for id in ids {
+                    conn.execute(
+                        "INSERT OR IGNORE INTO notification_reads \
+                             (company_id, user_id, notification_id, read_ms) \
+                         SELECT ?1, ?2, ?3, ?4 \
+                         WHERE EXISTS \
+                             (SELECT 1 FROM notifications WHERE company_id = ?1 AND id = ?3)",
+                        params![company.as_ref(), user, id.as_str(), now],
+                    )
+                    .map_err(sql_err)?;
+                }
+            }
+            None => {
+                conn.execute(
+                    "INSERT OR IGNORE INTO notification_reads \
+                         (company_id, user_id, notification_id, read_ms) \
+                     SELECT ?1, ?2, id, ?3 FROM notifications WHERE company_id = ?1",
+                    params![company.as_ref(), user, now],
+                )
+                .map_err(sql_err)?;
+            }
+        }
+        let unread: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM notifications n \
+                 WHERE n.company_id = ?1 \
+                   AND NOT EXISTS \
+                       (SELECT 1 FROM notification_reads r \
+                        WHERE r.company_id = n.company_id \
+                          AND r.notification_id = n.id \
+                          AND r.user_id = ?2)",
+                params![company.as_ref(), user],
+                |r| r.get(0),
+            )
+            .map_err(sql_err)?;
+        Ok(unread as u64)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkspaceStore
 // ---------------------------------------------------------------------------
 
@@ -3380,6 +3543,11 @@ mod test {
     #[tokio::test]
     async fn conformance_read_state_store() {
         conformance::assert_read_state_store(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_notification_store() {
+        conformance::assert_notification_store(store()).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Part **A** of #577 (the notifications tracker). Adds a durable `NotificationStore` port — a stored notification (kind, subject, created-at) with **per-person read state** — implemented on all three backends (fs, SQLite, MongoDB) with port-conformance coverage. It delivers nothing on its own; it is the substrate that #750 (out-of-browser delivery) and #751 (digest) build on.

- **Per-`(user, notification)` read latch**, not a `read` flag on the record — `list(company, user)` projects the calling user's `read_at` onto each company-wide record. This avoids the `InboxStore` trap #749 documents (its `mark_read` is scoped per inbox key with no user, so one admin opening it would mark it read for everyone).
- **`append` is idempotent by id** (first write wins), so a replayed or retried append agrees across all three backends instead of erroring on one (SQLite primary key) and silently duplicating on two.
- **`mark_read`** is a latch (re-marking preserves the original `read_at`), `None` marks all, and it returns the still-unread count for that person.
- Wired through `StorageHandles` → `RuntimeBuilder` → `OpsStores` with a `Runtime::notifications()` accessor, mirroring the `read_state` port (#755).
- **Out of scope, by design:** no HTTP route, no producer, no console UI — #749 is the model + storage only.

Corrected #749's stale file list: the fs impl lives on `FsOps` in `store/fs_ops.rs` (not `fs.rs`), and `store/paths.rs` + `company/runtime.rs` also needed wiring.

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean — default **and** `--features sqlite,mongodb`
- [x] `cargo check` — default `--all-targets` and the `openhuman,mongodb` tenant build compile
- [x] Tests — lib suite (2358) + store suite (192) green; notification conformance on fs / SQLite / **MongoDB run against a live server** (not the silent self-skip when `OPENCOMPANY_TEST_MONGODB_URI` is unset)

Closes #749


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable notifications for tasks, runs, approvals, and workflows.
  * Notifications are listed newest-first with individual read status.
  * Added options to mark selected or all notifications as read and view remaining unread counts.
  * Notifications are supported across filesystem, SQLite, and MongoDB storage.
  * Added consistent notification persistence across runtime configurations.

* **Bug Fixes**
  * Duplicate notifications are ignored, and existing read timestamps are preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->