### PR TITLE
feat(notifications): batch parked approvals into one digest

### DIFF
--- a/src/company/owners.rs
+++ b/src/company/owners.rs
@@ -118,3 +118,43 @@ pub(crate) async fn owner_recipients(
         }
     }
 }
+
+/// Sends one already-composed message to every server-resolved owner address.
+///
+/// The **send** half of owner delivery, split from [`owner_recipients`] (the
+/// **resolve** half) so a caller resolves the roster once and delivers to the
+/// set. A free function that owns its arguments so it can be spawned detached,
+/// and best-effort: a failed send is logged and the loop continues. Recipients
+/// must already be roster-resolved — this trusts them and names no policy, so a
+/// caller must never pass an address that did not come from
+/// [`owner_recipients`].
+pub(crate) async fn deliver_to_owners(
+    mail: crate::company::runtime::CompanyMail,
+    recipients: Vec<String>,
+    subject: String,
+    body: String,
+    company: CompanyId,
+) {
+    for to in recipients {
+        let email = crate::server::ops::mailer::OutboundEmail {
+            to: to.clone(),
+            subject: subject.clone(),
+            body: body.clone(),
+        };
+        if let Err(err) = mail
+            .sender
+            .send(
+                &crate::server::ops::mailer::MailCredentials::Smtp(mail.smtp.clone()),
+                &email,
+            )
+            .await
+        {
+            tracing::warn!(
+                company = %company,
+                to = %to,
+                error = %err,
+                "owner email failed to send",
+            );
+        }
+    }
+}

--- a/src/company/owners.rs
+++ b/src/company/owners.rs
@@ -149,9 +149,14 @@ pub(crate) async fn deliver_to_owners(
             )
             .await
         {
+            // The domain, not the address: enough to tell "this one mailbox
+            // rejected" from "the SMTP config is wrong", without putting a user
+            // identifier into log retention. Mirrors `owner_recipients`, which
+            // logs only the company and the error.
+            let recipient_domain = to.rsplit('@').next().unwrap_or("-");
             tracing::warn!(
                 company = %company,
-                to = %to,
+                recipient_domain = %recipient_domain,
                 error = %err,
                 "owner email failed to send",
             );

--- a/src/ports/notifications.rs
+++ b/src/ports/notifications.rs
@@ -145,4 +145,23 @@ pub trait NotificationStore: Send + Sync {
         user: &str,
         ids: Option<&[String]>,
     ) -> Result<u64>;
+
+    /// Every notification in the company that has **not** yet been included in a
+    /// digest delivery (issue #751), **oldest first** (by `created_at`
+    /// ascending; ties broken by `id` ascending), so a caller can read the
+    /// window's edges off the ends of the list.
+    ///
+    /// Delivery is per **company**, not per person: a notification is emailed
+    /// once, to the owner set, so this axis carries no user and is independent of
+    /// [`mark_read`](Self::mark_read)'s per-person read state. The ordering is
+    /// part of the contract and the conformance suite asserts it.
+    async fn undelivered(&self, company: &CompanyId) -> Result<Vec<Notification>>;
+
+    /// Marks notifications **delivered** — recorded as included in a digest, so a
+    /// later flush does not re-send them (issue #751).
+    ///
+    /// **A latch**, like [`mark_read`](Self::mark_read): once delivered it stays
+    /// delivered, re-marking is a no-op, and ids that name no notification are
+    /// ignored.
+    async fn mark_delivered(&self, company: &CompanyId, ids: &[String]) -> Result<()>;
 }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2163,10 +2163,11 @@ impl<'a> CycleHostImpl<'a> {
             thread = self.thread_id.as_deref().unwrap_or("-"),
             "[cycle] parked effect for operator approval"
         );
-        // Issue #750: a parked approval blocks work a person must act on. Raise a
-        // durable notification and reach the operator out-of-browser by email, so
-        // a request raised while nobody is watching does not sit parked for a day.
-        // Best-effort and strictly after the journal write above — see the method.
+        // Issue #750: a parked approval blocks work a person must act on. Raise
+        // the durable notification and leave it undelivered; out-of-browser
+        // delivery is the digest's job (issue #751), which batches an evening of
+        // parks into one email. Best-effort and strictly after the journal write
+        // above — see the method.
         self.notify_parked_approval(&approval_id, &effect).await;
         Ok(approval_id)
     }

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2004,56 +2004,6 @@ fn approval_notification_title(effect: &Effect) -> String {
     }
 }
 
-/// The plain-text body of the approval-alert email. Thin on purpose (see
-/// [`approval_notification_title`]): it names what parked and points the operator
-/// at the console, and carries no payload, so no argument value leaves the
-/// building and no second redaction surface is opened.
-fn approval_email_body(company_name: &str, effect: &Effect) -> String {
-    format!(
-        "A request in {company_name} is waiting for your approval and cannot proceed until you \
-         review it.\n\nWhat parked: {}\n\nOpen your OpenCompany console to approve or deny it.\n",
-        effect.kind,
-    )
-}
-
-/// Sends the approval-alert email to each server-resolved owner.
-///
-/// A free function rather than a method so it can be spawned detached (it owns
-/// its arguments and borrows nothing) and unit-tested directly against a
-/// `RecordingMailSender`. Every send is best-effort: a failure is logged and the
-/// loop continues, because the durable notification has already recorded the
-/// request and the parked journal entry is the binding record.
-async fn deliver_owner_approval_email(
-    mail: crate::company::runtime::CompanyMail,
-    recipients: Vec<String>,
-    subject: String,
-    body: String,
-    company: CompanyId,
-) {
-    for to in recipients {
-        let email = crate::server::ops::mailer::OutboundEmail {
-            to: to.clone(),
-            subject: subject.clone(),
-            body: body.clone(),
-        };
-        if let Err(err) = mail
-            .sender
-            .send(
-                &crate::server::ops::mailer::MailCredentials::Smtp(mail.smtp.clone()),
-                &email,
-            )
-            .await
-        {
-            tracing::warn!(
-                company = %company,
-                to = %to,
-                error = %err,
-                "approval notification email failed to send",
-            );
-        }
-    }
-}
-
 impl<'a> CycleHostImpl<'a> {
     fn new(
         company: CompanyId,
@@ -2221,27 +2171,21 @@ impl<'a> CycleHostImpl<'a> {
         Ok(approval_id)
     }
 
-    /// Records a durable notification for the parked approval (issue #749) and
-    /// reaches the operator out-of-browser by email (issue #750).
+    /// Records a durable notification for the parked approval (issues #749/#750).
     ///
-    /// **Best-effort.** The binding record is the parked journal entry written by
-    /// [`park`](Self::park); this is delivery on top of it, so every failure here
-    /// is logged and none propagates — a park that already happened must not be
-    /// undone by a store or mail error. The notification append and the recipient
-    /// resolution are awaited (fast, local reads); only the SMTP send is spawned,
-    /// so a slow mail server never stalls the parking turn.
+    /// **Best-effort and record-only.** The binding record is the parked journal
+    /// entry written by [`park`](Self::park); this appends the durable
+    /// notification on top of it, and any failure is logged rather than
+    /// propagated — a park that already happened must not be undone by a store
+    /// error. It does **not** email: out-of-browser delivery is the digest's job
+    /// (issue #751), which batches the overnight firehose into one message rather
+    /// than one per park (`CompanyScheduler::tick_digest`). The notification
+    /// carries only the effect kind + agent
+    /// (see [`approval_notification_title`]), never the payload.
     ///
-    /// **Server-side recipients only.** Addresses resolve from the company's own
-    /// roster via [`owner_recipients`](crate::workflows::delivery::owner_recipients)
-    /// — the same path the workflow `owner` destination uses (active admins +
-    /// standing admin invites + the bootstrap admin) — never from the effect. A
-    /// parked call names no address, and the email carries only the effect kind,
-    /// so no caller-supplied address is ever honoured and no payload leaks.
-    ///
-    /// The classification is consumed, not invented (issue #750 / #558): reaching
-    /// this method *is* the signal, because an effect is here only after the gate
-    /// judged it `Reach::Consequence` and parked it. Every parked approval blocks
-    /// work; that is the minimal rule, and the taxonomy stays #558's.
+    /// The classification is consumed, not invented (#750 / #558): reaching this
+    /// method *is* the signal — an effect is here only after the gate judged it
+    /// `Reach::Consequence` and parked it. Every parked approval blocks work.
     async fn notify_parked_approval(&self, approval_id: &ApprovalId, effect: &Effect) {
         let notification = crate::ports::notifications::Notification {
             id: crate::ports::generate_id(),
@@ -2265,49 +2209,6 @@ impl<'a> CycleHostImpl<'a> {
                 "approval parked and journaled, but recording its notification failed",
             );
         }
-
-        // Reach the operator out-of-browser. No mailbox wired on this deployment
-        // → the durable notification still stands; there is simply no email
-        // channel to reach.
-        let Some(mail) = self.rt.mail().cloned() else {
-            return;
-        };
-        let record = match self.rt.store().load(&self.company).await {
-            Ok(Some(record)) => record,
-            Ok(None) => return,
-            Err(err) => {
-                tracing::warn!(
-                    company = %self.company,
-                    error = %err,
-                    "approval notification: could not load the company record to resolve owners",
-                );
-                return;
-            }
-        };
-        // Recipients resolve server-side, from the roster — never from the effect.
-        let recipients = crate::company::owners::owner_recipients(
-            self.rt.users().as_ref(),
-            &self.company,
-            &record,
-            self.rt.bootstrap_admin(),
-        )
-        .await;
-        if recipients.is_empty() {
-            // No admin mailbox and no standing invite: nobody to email. The
-            // durable notification remains for whoever connects next.
-            return;
-        }
-        let subject = format!("{} — approval needed", record.manifest.company.name);
-        let body = approval_email_body(&record.manifest.company.name, effect);
-        // Spawn the SMTP send so a slow mail server never stalls the turn; the
-        // resolution above was local, only the network send is detached.
-        tokio::spawn(deliver_owner_approval_email(
-            mail,
-            recipients,
-            subject,
-            body,
-            self.company.clone(),
-        ));
     }
 
     /// Intercepts the `send_email` tool: parses `to`/`subject`/`body`, checks
@@ -6834,13 +6735,12 @@ mod test {
         assert!(notes[0].notification.title.contains("shell"));
     }
 
-    /// **The acceptance bar for issue #750.** A parked approval reaches the
-    /// operator out-of-browser by email. The recipient resolves server-side from
-    /// the roster — here the standing bootstrap admin of a fresh tenant — and the
-    /// From address is the company's own; the effect names no address and none is
-    /// honoured from it.
+    /// A parked approval is **record-only** (issue #751): it raises the durable
+    /// notification and queues it undelivered, but does **not** email on the
+    /// park — out-of-browser delivery is the digest's job, so the overnight
+    /// firehose becomes one message. This pins that the per-park send is gone.
     #[tokio::test]
-    async fn a_parked_approval_emails_the_owner() {
+    async fn a_parked_approval_records_but_does_not_email() {
         let home_dir = tmp_home();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
@@ -6871,58 +6771,26 @@ mod test {
             .unwrap();
         assert_eq!(report.parked.len(), 1);
 
-        // The notification is synchronous.
+        // The durable notification is recorded and queued for the digest...
         assert_eq!(
             rt.notifications().list(rt.id(), "x").await.unwrap().len(),
             1
         );
-
-        // The email send is spawned so a slow mail server never stalls the turn;
-        // drain the detached task with cooperative yields (current-thread test
-        // runtime), then assert it reached the server-resolved owner.
-        let mut sent = sender.sent();
-        for _ in 0..200 {
-            if !sent.is_empty() {
-                break;
-            }
-            tokio::task::yield_now().await;
-            sent = sender.sent();
-        }
         assert_eq!(
-            sent.len(),
+            rt.notifications().undelivered(rt.id()).await.unwrap().len(),
             1,
-            "a parked approval must reach the owner by email"
+            "the parked approval is queued undelivered for the digest"
         );
-        assert_eq!(sent[0].1.to, "boss@acme.test");
-        assert_eq!(sent[0].0, "ceo@acme.test");
-    }
 
-    /// The send fan-out reaches every server-resolved owner, and the From address
-    /// is the company's own — a unit test of the detached send used above.
-    #[tokio::test]
-    async fn approval_email_reaches_every_resolved_owner() {
-        let sender = Arc::new(RecordingMailSender::new());
-        let mail = CompanyMail {
-            sender: sender.clone(),
-            smtp: test_smtp("ceo@acme.test"),
-        };
-        deliver_owner_approval_email(
-            mail,
-            vec!["a@acme.test".into(), "b@acme.test".into()],
-            "Acme — approval needed".into(),
-            "please review".into(),
-            CompanyId::new("acme"),
-        )
-        .await;
-
-        let sent = sender.sent();
-        assert_eq!(sent.len(), 2);
-        let tos: std::collections::HashSet<String> =
-            sent.iter().map(|(_, e)| e.to.clone()).collect();
-        assert!(tos.contains("a@acme.test"));
-        assert!(tos.contains("b@acme.test"));
-        assert_eq!(sent[0].1.subject, "Acme — approval needed");
-        assert_eq!(sent[0].0, "ceo@acme.test");
+        // ...but the park itself sends no email — give any (wrongly) spawned send
+        // a chance to run, then assert silence. The digest, not the park, mails.
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert!(
+            sender.sent().is_empty(),
+            "the park must not email; the digest delivers"
+        );
     }
 
     /// The title names the asker when the effect carries one, and degrades to a

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -61,6 +61,17 @@ pub const PRUNE_CUTOFF_MINUTES: u64 = 14 * 24 * 60;
 // that violated it would fail the build, not a test.
 const _: () = assert!(PRUNE_CUTOFF_MINUTES > CATCHUP_WINDOW_MINUTES);
 
+/// Issue #751: the parked-approval digest holds new notifications until parks go
+/// quiet for this long, then flushes what accumulated as one email — so twenty
+/// raised over an evening arrive as one message, not twenty.
+const DIGEST_QUIET_MS: u64 = 30 * MINUTE_MS; // 30 minutes of quiet
+/// …or until the oldest held notification has waited this long, whichever comes
+/// first, so a company whose parks never fall quiet still gets its digest.
+const DIGEST_MAX_MS: u64 = 12 * 60 * MINUTE_MS; // 12 hours
+/// The fire-claim id that serialises the digest flush to one replica per minute,
+/// reusing the same at-most-once store the cron schedules claim on.
+const DIGEST_SCHEDULE_ID: &str = "notification-digest";
+
 /// The single catch-up instant to fire for a schedule at boot, or `None`.
 ///
 /// The one place the "fire at most one missed occurrence" rule lives, shared by
@@ -468,6 +479,140 @@ impl CompanyScheduler {
         Ok(expired)
     }
 
+    /// Issue #751: batch the parked-approval notifications a company accumulates
+    /// into ONE digest email rather than one per park.
+    ///
+    /// **Quiet-then-flush**, derived from the undelivered notifications' own
+    /// timestamps so it needs no extra state: hold while parks keep arriving, and
+    /// flush once things go quiet for [`DIGEST_QUIET_MS`] or the oldest held one
+    /// has waited out [`DIGEST_MAX_MS`]. An approval settled during the window is
+    /// dropped from the digest (and marked delivered so it never reappears), so
+    /// the digest never reports work already actioned. Best-effort, and
+    /// at-most-once per company per minute across replicas via the fire claim.
+    pub async fn tick_digest(&self) -> Result<usize> {
+        let runtime = self.runtime();
+        if runtime.ensure_running().await.is_err() {
+            return Ok(0);
+        }
+        let company = runtime.id();
+        let undelivered = runtime.notifications().undelivered(company).await?;
+        if undelivered.is_empty() {
+            return Ok(0);
+        }
+        // An approval settled during the window is noise the digest exists to
+        // remove — partition the queue on "still parked".
+        let pending: std::collections::HashSet<String> = runtime
+            .pending_approvals()
+            .into_iter()
+            .map(|a| a.id.to_string())
+            .collect();
+        // `pending_approvals()` is authoritative for "still parked": boot replay
+        // rehydrates every parked approval into the gate *before* the scheduler
+        // is spawned (`RuntimeBuilder::build` performs the replay), so an id
+        // absent here is resolved/expired, never merely "not loaded yet" — a
+        // still-pending approval is therefore never dropped as settled.
+        let mut settled = Vec::new();
+        let mut live = Vec::new();
+        for n in undelivered {
+            let still_relevant = match n.subject.kind {
+                crate::ports::notifications::SubjectKind::Approval => {
+                    pending.contains(&n.subject.id)
+                }
+                // A non-approval subject has no "settled" notion here; keep it.
+                _ => true,
+            };
+            if still_relevant {
+                live.push(n);
+            } else {
+                settled.push(n.id);
+            }
+        }
+        // Drop settled ones from the queue for good: marked delivered without
+        // ever being emailed, so a later flush never reconsiders them. This runs
+        // *before* the mailbox check below, so resolved approvals drain even on a
+        // company with no mail — which is what keeps the queue bounded (it can
+        // then only hold still-pending approvals, itself a bounded set).
+        if !settled.is_empty() {
+            runtime
+                .notifications()
+                .mark_delivered(company, &settled)
+                .await?;
+        }
+        if live.is_empty() {
+            return Ok(0);
+        }
+        // Quiet-then-flush, read off the live set's own timestamps.
+        let now = self.clock.now_millis();
+        let newest = live.iter().map(|n| n.created_at).max().unwrap_or(now);
+        let oldest = live.iter().map(|n| n.created_at).min().unwrap_or(now);
+        let quiet = now.saturating_sub(newest) >= DIGEST_QUIET_MS;
+        let capped = now.saturating_sub(oldest) >= DIGEST_MAX_MS;
+        if !quiet && !capped {
+            return Ok(0); // still accumulating — wait for a lull or the cap
+        }
+        // Resolve the channel server-side. No mailbox or no owner → leave the
+        // live set undelivered for a later flush when one exists (the console
+        // still shows them); never drop what was never emailed. The queue stays
+        // bounded across this branch: only still-pending approvals remain here
+        // (settled ones drained above), so it tracks the pending set, not time —
+        // and dropping them instead would silently suppress real approvals.
+        let Some(mail) = runtime.mail().cloned() else {
+            return Ok(0);
+        };
+        let record = match runtime.store().load(company).await {
+            Ok(Some(record)) => record,
+            Ok(None) => return Ok(0),
+            Err(err) => {
+                tracing::warn!(company = %company, %err, "digest: could not load the company record");
+                return Ok(0);
+            }
+        };
+        // Recipients resolve from the roster, never from a notification.
+        let recipients = crate::company::owners::owner_recipients(
+            runtime.users().as_ref(),
+            company,
+            &record,
+            runtime.bootstrap_admin(),
+        )
+        .await;
+        if recipients.is_empty() {
+            return Ok(0);
+        }
+        // At-most-once per company per minute across replicas.
+        let minute = now / MINUTE_MS;
+        if !runtime
+            .schedule_fires()
+            .claim_fire(company, DIGEST_SCHEDULE_ID, minute)
+            .await?
+        {
+            return Ok(0);
+        }
+        // Mark delivered BEFORE the send: a crash mid-send loses at most one
+        // email (the console still holds the notifications), whereas re-digesting
+        // would resurrect the very firehose #751 exists to remove.
+        let ids: Vec<String> = live.iter().map(|n| n.id.clone()).collect();
+        runtime
+            .notifications()
+            .mark_delivered(company, &ids)
+            .await?;
+        let count = live.len();
+        let subject = format!(
+            "{} — {count} approval{} awaiting review",
+            record.manifest.company.name,
+            if count == 1 { "" } else { "s" },
+        );
+        let body = build_digest_body(&record.manifest.company.name, &live);
+        // Spawn the SMTP send so a slow mail server never stalls the tick.
+        tokio::spawn(crate::company::owners::deliver_to_owners(
+            mail,
+            recipients,
+            subject,
+            body,
+            company.clone(),
+        ));
+        Ok(count)
+    }
+
     /// Spawns a background task that ticks on every minute boundary until
     /// `shutdown` is notified, then returns. Boot holds the join handle and the
     /// shared `shutdown` so the scheduler stops cleanly when the server does.
@@ -509,6 +654,9 @@ impl CompanyScheduler {
                         if let Err(err) = self.tick_maintenance().await {
                             tracing::warn!(company = %self.runtime.id(), %err, "approval sweep failed");
                         }
+                        if let Err(err) = self.tick_digest().await {
+                            tracing::warn!(company = %self.runtime.id(), %err, "notification digest failed");
+                        }
                     }
                 }
             }
@@ -526,20 +674,45 @@ pub(crate) fn millis_to_next_minute(now: u64) -> u64 {
     MINUTE_MS - into_minute
 }
 
+/// The plain-text body of a parked-approval digest (issue #751): the list of what
+/// is waiting, then where to act. Carries only each notification's title (the
+/// effect kind + agent, never the payload), so the digest opens no redaction
+/// surface the per-notification path did not.
+fn build_digest_body(
+    company_name: &str,
+    notifications: &[crate::ports::notifications::Notification],
+) -> String {
+    let count = notifications.len();
+    let mut body = format!(
+        "{count} approval{} in {company_name} {} waiting for your review:\n\n",
+        if count == 1 { "" } else { "s" },
+        if count == 1 { "is" } else { "are" },
+    );
+    for n in notifications {
+        body.push_str(&format!("  • {}\n", n.title));
+    }
+    body.push_str("\nOpen your OpenCompany console to approve or deny.\n");
+    body
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use async_trait::async_trait;
 
     use crate::company::CompanyManifest;
+    use crate::company::runtime::CompanyMail;
     use crate::policy::ManifestApprovalGate;
     use crate::ports::brain::{Brain, CycleHost};
+    use crate::ports::types::{Actor, ActorKind, Verdict};
     use crate::ports::types::{
         CompressedTrace, CycleRequest, CycleResult, Effect, EffectGroup, EventSeq, OutboundMessage,
         TokenUsage,
     };
     use crate::runtime::RuntimeBuilder;
     use crate::runtime::cron::CivilTime;
+    use crate::server::ops::mailer::RecordingMailSender;
+    use crate::server::ops::smtp::{SmtpCredentials, SmtpSecurity};
 
     fn tmp_home() -> tempfile::TempDir {
         tempfile::Builder::new()
@@ -1459,5 +1632,220 @@ mod test {
             "the retry makes up the missed fire"
         );
         assert_eq!(fired_count(&rt).await, 1);
+    }
+
+    // --- Notification digest (issue #751) -----------------------------------
+
+    /// A brain that parks one effect on each operator message, so a test can
+    /// accumulate parked approvals for the digest to batch.
+    struct ParkBrain {
+        effect: Effect,
+    }
+
+    #[async_trait]
+    impl Brain for ParkBrain {
+        async fn run_cycle(&self, req: CycleRequest, host: &dyn CycleHost) -> Result<CycleResult> {
+            for event in &req.events {
+                if let CompanyEvent::OperatorMessage { .. } = event {
+                    host.emit_effect(self.effect.clone()).await?;
+                }
+            }
+            Ok(CycleResult {
+                channel_responses: Vec::new(),
+                new_traces: vec![CompressedTrace::now(&req.cycle_id, "parked")],
+                ledger_deltas: Vec::new(),
+                token_usage: TokenUsage::default(),
+            })
+        }
+    }
+
+    /// A consequence effect that parks under `supervised`.
+    fn park_effect(kind: &str) -> Effect {
+        Effect {
+            kind: kind.into(),
+            group: EffectGroup::Sign,
+            amount_usd: None,
+            established_thread: false,
+            first_time_counterparty: false,
+            payload: serde_json::json!({}),
+            agent: Some("engineer".into()),
+            run_id: None,
+        }
+    }
+
+    fn test_smtp(from_email: &str) -> SmtpCredentials {
+        SmtpCredentials {
+            host: "smtp.example.com".into(),
+            port: 587,
+            security: SmtpSecurity::Starttls,
+            username: "user".into(),
+            password: "hunter2".into(),
+            from_name: "Acme".into(),
+            from_email: from_email.into(),
+        }
+    }
+
+    fn park_message() -> CompanyEvent {
+        CompanyEvent::OperatorMessage {
+            parent: None,
+            text: "do it".into(),
+            by: None,
+            chat: None,
+        }
+    }
+
+    /// **The acceptance bar for issue #751.** Twenty (here three) approvals
+    /// parked over an evening arrive as ONE digest, held until parks fall quiet,
+    /// and are not re-sent after delivery. The clock is injectable, so the window
+    /// is exercised with no sleeps.
+    #[tokio::test]
+    async fn digest_batches_parked_approvals_into_one_email_after_quiet() {
+        let home_dir = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(ParkBrain {
+                    effect: park_effect("shell"),
+                }))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .with_bootstrap_admin(Some("boss@acme.test".into()))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        // A base instant, then three parks — each records one undelivered
+        // notification stamped at ~base (real `now_millis()`).
+        let base = crate::ports::now_millis();
+        for _ in 0..3 {
+            rt.run_cycle(vec![park_message()]).await.unwrap();
+        }
+        assert_eq!(
+            rt.notifications().undelivered(rt.id()).await.unwrap().len(),
+            3
+        );
+        assert_eq!(rt.pending_approvals().len(), 3);
+
+        // Within the quiet window → hold, send nothing.
+        let clock = Arc::new(FakeClock::new(base + MINUTE_MS));
+        let scheduler = CompanyScheduler::new(rt.clone(), &[], clock.clone()).unwrap();
+        assert_eq!(
+            scheduler.tick_digest().await.unwrap(),
+            0,
+            "still accumulating"
+        );
+        assert!(sender.sent().is_empty());
+
+        // Past the quiet threshold → one digest of all three; queue drains.
+        clock.set(base + DIGEST_QUIET_MS + 2 * MINUTE_MS);
+        assert_eq!(scheduler.tick_digest().await.unwrap(), 3);
+        assert!(
+            rt.notifications()
+                .undelivered(rt.id())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // Drain the spawned send: exactly one email to the server-resolved owner,
+        // its subject naming the batch of three.
+        let mut sent = sender.sent();
+        for _ in 0..200 {
+            if !sent.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+            sent = sender.sent();
+        }
+        assert_eq!(sent.len(), 1, "three parks become one digest");
+        assert_eq!(sent[0].1.to, "boss@acme.test");
+        assert_eq!(sent[0].0, "ceo@acme.test");
+        assert!(
+            sent[0].1.subject.contains("3 approvals"),
+            "subject: {}",
+            sent[0].1.subject
+        );
+
+        // A second flush sends nothing more — everything was delivered.
+        assert_eq!(scheduler.tick_digest().await.unwrap(), 0);
+        for _ in 0..50 {
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(sender.sent().len(), 1, "no re-send after delivery");
+    }
+
+    /// An approval settled during the window is dropped from the digest and never
+    /// emailed — the digest reports no already-actioned work.
+    #[tokio::test]
+    async fn digest_drops_an_approval_settled_during_the_window() {
+        let home_dir = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(ParkBrain {
+                    effect: park_effect("shell"),
+                }))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .with_bootstrap_admin(Some("boss@acme.test".into()))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        let base = crate::ports::now_millis();
+        for _ in 0..2 {
+            rt.run_cycle(vec![park_message()]).await.unwrap();
+        }
+        let pending = rt.pending_approvals();
+        assert_eq!(pending.len(), 2);
+
+        // Settle one before the flush — it becomes noise the digest must skip.
+        rt.resolve_approval(
+            &pending[0].id,
+            Verdict::Deny,
+            Actor {
+                kind: ActorKind::Operator,
+                id: "boss".into(),
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(rt.pending_approvals().len(), 1);
+
+        // Flush past the quiet threshold.
+        let clock = Arc::new(FakeClock::new(base + DIGEST_QUIET_MS + 2 * MINUTE_MS));
+        let scheduler = CompanyScheduler::new(rt.clone(), &[], clock).unwrap();
+        // Only the still-pending one is digested; the settled one is dropped.
+        assert_eq!(scheduler.tick_digest().await.unwrap(), 1);
+        // Both leave the queue: the settled one marked delivered without an
+        // email, the live one delivered by the digest.
+        assert!(
+            rt.notifications()
+                .undelivered(rt.id())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let mut sent = sender.sent();
+        for _ in 0..200 {
+            if !sent.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+            sent = sender.sent();
+        }
+        assert_eq!(sent.len(), 1);
+        assert!(
+            sent[0].1.subject.contains("1 approval "),
+            "digest reports only the live one: {}",
+            sent[0].1.subject
+        );
     }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1848,4 +1848,73 @@ mod test {
             sent[0].1.subject
         );
     }
+
+    /// The `DIGEST_MAX_MS` cap flushes even when parks never fall quiet: the
+    /// newest notification is recent (inside the quiet window) but the oldest has
+    /// waited out the cap. Uses non-approval subjects, appended directly with
+    /// chosen timestamps, so the window logic is isolated from the pending-
+    /// approval gate and the fake clock alone drives it.
+    #[tokio::test]
+    async fn digest_flushes_on_the_max_cap_even_when_not_quiet() {
+        let home_dir = tmp_home();
+        let sender = Arc::new(RecordingMailSender::new());
+        let rt = Arc::new(
+            RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
+                .with_brain(Arc::new(ScheduleBrain))
+                .with_mail(CompanyMail {
+                    sender: sender.clone(),
+                    smtp: test_smtp("ceo@acme.test"),
+                })
+                .with_bootstrap_admin(Some("boss@acme.test".into()))
+                .build()
+                .await
+                .unwrap(),
+        );
+
+        // A clock well past the cap so the subtractions stay positive.
+        let now = 100 * DIGEST_MAX_MS;
+        let note = |id: &str, created_at: u64| crate::ports::notifications::Notification {
+            id: id.into(),
+            kind: "info".into(),
+            // Non-approval, so both stay "live" without a pending-approval gate.
+            subject: crate::ports::notifications::Subject {
+                kind: crate::ports::notifications::SubjectKind::Run,
+                id: format!("run-{id}"),
+            },
+            created_at,
+            title: format!("run {id}"),
+        };
+        // Oldest waited out the cap; newest just arrived (well inside quiet).
+        rt.notifications()
+            .append(rt.id(), &note("old", now - DIGEST_MAX_MS - 1))
+            .await
+            .unwrap();
+        rt.notifications()
+            .append(rt.id(), &note("new", now - 1))
+            .await
+            .unwrap();
+
+        let clock = Arc::new(FakeClock::new(now));
+        let scheduler = CompanyScheduler::new(rt.clone(), &[], clock).unwrap();
+        // Not quiet (newest is 1ms old) but capped (oldest past the cap) → flush.
+        assert_eq!(scheduler.tick_digest().await.unwrap(), 2);
+        assert!(
+            rt.notifications()
+                .undelivered(rt.id())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        let mut sent = sender.sent();
+        for _ in 0..200 {
+            if !sent.is_empty() {
+                break;
+            }
+            tokio::task::yield_now().await;
+            sent = sender.sent();
+        }
+        assert_eq!(sent.len(), 1, "the cap flushes one digest");
+        assert_eq!(sent[0].1.to, "boss@acme.test");
+    }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -1917,4 +1917,42 @@ mod test {
         assert_eq!(sent.len(), 1, "the cap flushes one digest");
         assert_eq!(sent[0].1.to, "boss@acme.test");
     }
+
+    /// The digest body lists every notification's title and carries no payload
+    /// (issue #372's redaction line), and it agrees in number with the count.
+    #[test]
+    fn digest_body_lists_titles_and_never_payload() {
+        let note = |id: &str, title: &str| crate::ports::notifications::Notification {
+            id: id.into(),
+            kind: "approval_blocked".into(),
+            subject: crate::ports::notifications::Subject {
+                kind: crate::ports::notifications::SubjectKind::Approval,
+                id: format!("appr-{id}"),
+            },
+            created_at: 0,
+            title: title.into(),
+        };
+
+        let body = build_digest_body(
+            "Acme",
+            &[
+                note("1", "send the $5000 invoice"),
+                note("2", "publish the post"),
+            ],
+        );
+        assert!(body.contains("2 approvals in Acme are waiting"), "{body}");
+        assert!(body.contains("send the $5000 invoice"));
+        assert!(body.contains("publish the post"));
+        assert!(body.contains("approve or deny"));
+
+        // Singular grammar for one, and the subject id (a would-be payload leak)
+        // never appears — only the title does.
+        let one = build_digest_body("Acme", &[note("9", "one thing")]);
+        assert!(one.contains("1 approval in Acme is waiting"), "{one}");
+        assert!(one.contains("one thing"));
+        assert!(
+            !one.contains("appr-9"),
+            "the digest must not leak subject ids"
+        );
+    }
 }

--- a/src/runtime/scheduler.rs
+++ b/src/runtime/scheduler.rs
@@ -518,8 +518,12 @@ impl CompanyScheduler {
                 crate::ports::notifications::SubjectKind::Approval => {
                     pending.contains(&n.subject.id)
                 }
-                // A non-approval subject has no "settled" notion here; keep it.
-                _ => true,
+                // This digest speaks only about parked approvals — its subject and
+                // body say so. Another notification kind belongs to whatever path
+                // owns it, so drain it here rather than mail it under the wrong
+                // heading; draining it also keeps the queue bounded, since a
+                // non-approval subject has no "settled" notion to remove it later.
+                _ => false,
             };
             if still_relevant {
                 live.push(n);
@@ -1850,17 +1854,20 @@ mod test {
     }
 
     /// The `DIGEST_MAX_MS` cap flushes even when parks never fall quiet: the
-    /// newest notification is recent (inside the quiet window) but the oldest has
-    /// waited out the cap. Uses non-approval subjects, appended directly with
-    /// chosen timestamps, so the window logic is isolated from the pending-
-    /// approval gate and the fake clock alone drives it.
+    /// newest record is recent (inside the quiet window) while the oldest has
+    /// waited out the cap. Both belong to one **still-pending approval** — a real
+    /// park plus a backdated companion record for that same approval id — so the
+    /// approval-only digest keeps them, and the fake clock alone drives the
+    /// cap-vs-quiet edge.
     #[tokio::test]
     async fn digest_flushes_on_the_max_cap_even_when_not_quiet() {
         let home_dir = tmp_home();
         let sender = Arc::new(RecordingMailSender::new());
         let rt = Arc::new(
             RuntimeBuilder::new(home_dir.path().to_path_buf(), manifest("supervised"))
-                .with_brain(Arc::new(ScheduleBrain))
+                .with_brain(Arc::new(ParkBrain {
+                    effect: park_effect("shell"),
+                }))
                 .with_mail(CompanyMail {
                     sender: sender.clone(),
                     smtp: test_smtp("ceo@acme.test"),
@@ -1871,32 +1878,36 @@ mod test {
                 .unwrap(),
         );
 
-        // A clock well past the cap so the subtractions stay positive.
-        let now = 100 * DIGEST_MAX_MS;
-        let note = |id: &str, created_at: u64| crate::ports::notifications::Notification {
-            id: id.into(),
-            kind: "info".into(),
-            // Non-approval, so both stay "live" without a pending-approval gate.
-            subject: crate::ports::notifications::Subject {
-                kind: crate::ports::notifications::SubjectKind::Run,
-                id: format!("run-{id}"),
-            },
-            created_at,
-            title: format!("run {id}"),
-        };
-        // Oldest waited out the cap; newest just arrived (well inside quiet).
+        // Park one real approval → it is pending, and its auto-notification is the
+        // recent (not-quiet) end of the window.
+        let base = crate::ports::now_millis();
+        rt.run_cycle(vec![park_message()]).await.unwrap();
+        let approval_id = rt.pending_approvals()[0].id.to_string();
+
+        // A second record for that SAME approval, backdated past the cap. Both are
+        // live (the approval is still pending), so the old one trips the cap while
+        // the fresh one keeps the window from being quiet.
         rt.notifications()
-            .append(rt.id(), &note("old", now - DIGEST_MAX_MS - 1))
-            .await
-            .unwrap();
-        rt.notifications()
-            .append(rt.id(), &note("new", now - 1))
+            .append(
+                rt.id(),
+                &crate::ports::notifications::Notification {
+                    id: "backdated".into(),
+                    kind: "approval_blocked".into(),
+                    subject: crate::ports::notifications::Subject {
+                        kind: crate::ports::notifications::SubjectKind::Approval,
+                        id: approval_id,
+                    },
+                    created_at: base - DIGEST_MAX_MS - 1,
+                    title: "an old parked approval".into(),
+                },
+            )
             .await
             .unwrap();
 
-        let clock = Arc::new(FakeClock::new(now));
+        // Clock just after the parks: newest is seconds old (not quiet), oldest is
+        // past the cap → the flush is the cap's doing alone.
+        let clock = Arc::new(FakeClock::new(base + 5_000));
         let scheduler = CompanyScheduler::new(rt.clone(), &[], clock).unwrap();
-        // Not quiet (newest is 1ms old) but capped (oldest past the cap) → flush.
         assert_eq!(scheduler.tick_digest().await.unwrap(), 2);
         assert!(
             rt.notifications()

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2451,6 +2451,51 @@ pub async fn assert_notification_store(notes: Arc<dyn NotificationStore>) {
         4,
         "beta's write must not change alpha"
     );
+
+    // --- Delivery (issue #751): a per-company, once-only marker, independent of
+    // the per-person read state above ---
+
+    // Nothing delivered yet, so every record is undelivered — oldest first
+    // (created_at ascending, id ascending), the reverse of the read feed.
+    let undel = notes.undelivered(&alpha).await.unwrap();
+    assert_eq!(undel.len(), 4);
+    assert_eq!(undel[0].id, "n-old"); // created 100
+    assert_eq!(undel[1].id, "n-new"); // created 200
+    assert_eq!(undel[2].id, "id-a"); // created 300, id asc
+    assert_eq!(undel[3].id, "id-b"); // created 300
+
+    // Delivery is independent of read: Ada marked things read above, yet all
+    // four are still undelivered — read is per person, delivery is per company.
+    notes
+        .mark_delivered(&alpha, &["n-old".to_string(), "n-new".to_string()])
+        .await
+        .unwrap();
+    let undel = notes.undelivered(&alpha).await.unwrap();
+    assert_eq!(undel.len(), 2, "delivered ones drop from undelivered");
+    assert_eq!(undel[0].id, "id-a");
+    assert_eq!(undel[1].id, "id-b");
+
+    // A latch, and unknown ids ignored: re-marking a delivered id and marking a
+    // bogus id change nothing.
+    notes
+        .mark_delivered(&alpha, &["n-old".to_string(), "does-not-exist".to_string()])
+        .await
+        .unwrap();
+    assert_eq!(notes.undelivered(&alpha).await.unwrap().len(), 2);
+
+    // Per company: beta's delivery is its own — its notification is undelivered
+    // even though alpha delivered.
+    let beta_undel = notes.undelivered(&beta).await.unwrap();
+    assert_eq!(beta_undel.len(), 1);
+    assert_eq!(beta_undel[0].id, "b-1");
+
+    // Drain the rest of alpha → alpha fully delivered, beta untouched.
+    notes
+        .mark_delivered(&alpha, &["id-a".to_string(), "id-b".to_string()])
+        .await
+        .unwrap();
+    assert!(notes.undelivered(&alpha).await.unwrap().is_empty());
+    assert_eq!(notes.undelivered(&beta).await.unwrap().len(), 1);
 }
 
 pub async fn assert_skill_state_store(skills: Arc<dyn SkillStateStore>) {

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -2496,6 +2496,13 @@ pub async fn assert_notification_store(notes: Arc<dyn NotificationStore>) {
         .unwrap();
     assert!(notes.undelivered(&alpha).await.unwrap().is_empty());
     assert_eq!(notes.undelivered(&beta).await.unwrap().len(), 1);
+
+    // Delivery is a marker, not a deletion: the console feed still shows every
+    // record after the digest has emailed it. This is the invariant the digest
+    // relies on when it marks delivered *before* sending — a backend that
+    // dropped the record on `mark_delivered` would break the console and must
+    // fail here rather than pass by only checking `undelivered`.
+    assert_eq!(notes.list(&alpha, "ada").await.unwrap().len(), 4);
 }
 
 pub async fn assert_skill_state_store(skills: Arc<dyn SkillStateStore>) {

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -1138,6 +1138,14 @@ struct StoredNotifRead {
     read_at: u64,
 }
 
+/// One per-company delivery marker (#751): a notification a digest has already
+/// emailed. No user — delivery is to the owner set, once, for the whole company.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct StoredDelivered {
+    notification_id: String,
+    delivered_at: u64,
+}
+
 #[async_trait]
 impl crate::ports::notifications::NotificationStore for FsOps {
     async fn append(
@@ -1248,6 +1256,67 @@ impl crate::ports::notifications::NotificationStore for FsOps {
             })
             .count() as u64;
         Ok(unread)
+    }
+
+    async fn undelivered(
+        &self,
+        company: &CompanyId,
+    ) -> Result<Vec<crate::ports::notifications::Notification>> {
+        let bundle = self.bundle(company);
+        let records = load_json_vec::<crate::ports::notifications::Notification>(
+            &bundle.notifications_json(),
+        )
+        .await?;
+        let delivered =
+            load_json_vec::<StoredDelivered>(&bundle.notification_delivered_json()).await?;
+        let delivered_ids: std::collections::HashSet<&str> = delivered
+            .iter()
+            .map(|d| d.notification_id.as_str())
+            .collect();
+        let mut out: Vec<_> = records
+            .into_iter()
+            .filter(|n| !delivered_ids.contains(n.id.as_str()))
+            .collect();
+        // Oldest first, ties broken by id ascending — the order the trait
+        // documents, so the caller can read the window edges off the ends.
+        out.sort_by(|a: &crate::ports::notifications::Notification, b| {
+            a.created_at
+                .cmp(&b.created_at)
+                .then_with(|| a.id.cmp(&b.id))
+        });
+        Ok(out)
+    }
+
+    async fn mark_delivered(&self, company: &CompanyId, ids: &[String]) -> Result<()> {
+        let bundle = self.bundle(company);
+        bundle.ensure_dirs().await?;
+        let records = load_json_vec::<crate::ports::notifications::Notification>(
+            &bundle.notifications_json(),
+        )
+        .await?;
+        let path = bundle.notification_delivered_json();
+        let lock = path_lock(&path);
+        let _guard = lock.lock().await;
+        let mut delivered = load_json_vec::<StoredDelivered>(&path).await?;
+        let now = crate::ports::now_millis();
+        let mut changed = false;
+        for id in ids {
+            // Only mark an id that names an existing notification, and only once
+            // (a latch): the original delivery instant survives a re-mark.
+            let exists = records.iter().any(|n| &n.id == id);
+            let already = delivered.iter().any(|d| &d.notification_id == id);
+            if exists && !already {
+                delivered.push(StoredDelivered {
+                    notification_id: id.clone(),
+                    delivered_at: now,
+                });
+                changed = true;
+            }
+        }
+        if changed {
+            write_atomic(&path, &serde_json::to_string(&delivered)?).await?;
+        }
+        Ok(())
     }
 }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -416,6 +416,13 @@ impl MongoStore {
             ))
             .await
             .map_err(mongo_err)?;
+        // Issue #751: the per-company delivery marker. Unique on
+        // `(company_id, notification_id)` so a re-mark is a no-op `E11000` and
+        // delivery stays a latch.
+        self.collection("notification_delivered")
+            .create_index(unique(doc! {"company_id": 1, "notification_id": 1}))
+            .await
+            .map_err(mongo_err)?;
         Ok(())
     }
 
@@ -2602,6 +2609,84 @@ impl crate::ports::notifications::NotificationStore for MongoStore {
             .filter(|v| v.read_at.is_none())
             .count() as u64;
         Ok(unread)
+    }
+
+    async fn undelivered(
+        &self,
+        company: &CompanyId,
+    ) -> Result<Vec<crate::ports::notifications::Notification>> {
+        // The delivered ids first, into a set.
+        let mut delivered: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut dcur = self
+            .collection("notification_delivered")
+            .find(doc! {"company_id": company.as_ref()})
+            .await
+            .map_err(mongo_err)?;
+        while let Some(d) = dcur.try_next().await.map_err(mongo_err)? {
+            delivered.insert(get_str(&d, "notification_id")?);
+        }
+        // Records oldest-first, minus the delivered ones.
+        let mut cursor = self
+            .collection("notifications")
+            .find(doc! {"company_id": company.as_ref()})
+            .sort(doc! {"created_ms": 1, "id": 1})
+            .await
+            .map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(d) = cursor.try_next().await.map_err(mongo_err)? {
+            let id = get_str(&d, "id")?;
+            if delivered.contains(&id) {
+                continue;
+            }
+            let subject_kind = get_str(&d, "subject_kind")?;
+            let subject_kind = crate::ports::notifications::SubjectKind::from_token(&subject_kind)
+                .ok_or_else(|| {
+                    crate::error::OpenCompanyError::Store(format!(
+                        "notification has an unknown subject kind {subject_kind:?}"
+                    ))
+                })?;
+            out.push(crate::ports::notifications::Notification {
+                id,
+                kind: get_str(&d, "kind")?,
+                subject: crate::ports::notifications::Subject {
+                    kind: subject_kind,
+                    id: get_str(&d, "subject_id")?,
+                },
+                created_at: d.get_i64("created_ms").unwrap_or_default() as u64,
+                title: get_str(&d, "title")?,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn mark_delivered(&self, company: &CompanyId, ids: &[String]) -> Result<()> {
+        let now = crate::ports::now_millis() as i64;
+        for id in ids {
+            // Only mark an id that names an existing notification in this company.
+            let exists = self
+                .collection("notifications")
+                .find_one(doc! {"company_id": company.as_ref(), "id": id.as_str()})
+                .await
+                .map_err(mongo_err)?
+                .is_some();
+            if !exists {
+                continue;
+            }
+            // `$setOnInsert` is the latch: it seeds `delivered_ms` only when the
+            // marker is first created, so a re-mark leaves the original instant.
+            self.collection("notification_delivered")
+                .update_one(
+                    doc! {
+                        "company_id": company.as_ref(),
+                        "notification_id": id.as_str(),
+                    },
+                    doc! {"$setOnInsert": {"delivered_ms": now}},
+                )
+                .with_options(UpdateOptions::builder().upsert(true).build())
+                .await
+                .map_err(mongo_err)?;
+        }
+        Ok(())
     }
 }
 

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2674,7 +2674,8 @@ impl crate::ports::notifications::NotificationStore for MongoStore {
             }
             // `$setOnInsert` is the latch: it seeds `delivered_ms` only when the
             // marker is first created, so a re-mark leaves the original instant.
-            self.collection("notification_delivered")
+            if let Err(e) = self
+                .collection("notification_delivered")
                 .update_one(
                     doc! {
                         "company_id": company.as_ref(),
@@ -2684,7 +2685,15 @@ impl crate::ports::notifications::NotificationStore for MongoStore {
                 )
                 .with_options(UpdateOptions::builder().upsert(true).build())
                 .await
-                .map_err(mongo_err)?;
+            {
+                // Two concurrent first marks can both miss the existing doc and
+                // race their upserts into one `E11000` on the unique index. The
+                // marker is present either way, so treat the duplicate as the
+                // no-op the latch promises rather than propagating it.
+                if !is_duplicate_key(&e) {
+                    return Err(mongo_err(e));
+                }
+            }
         }
         Ok(())
     }

--- a/src/store/paths.rs
+++ b/src/store/paths.rs
@@ -429,6 +429,14 @@ impl Bundle {
         self.dir.join("notification-reads.json")
     }
 
+    /// Path to the per-company notification delivery markers
+    /// (`notification-delivered.json`, #751) — which notifications a digest has
+    /// already emailed. Company-level, not per person, so it sits in its own
+    /// document beside the records.
+    pub fn notification_delivered_json(&self) -> PathBuf {
+        self.dir.join("notification-delivered.json")
+    }
+
     /// The workspace subdirectory holding the seeded/edited file tree.
     pub fn workspace_dir(&self) -> PathBuf {
         self.dir.join("workspace")

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -216,6 +216,12 @@ CREATE TABLE IF NOT EXISTS notification_reads (
     read_ms         INTEGER NOT NULL,
     PRIMARY KEY (company_id, user_id, notification_id)
 );
+CREATE TABLE IF NOT EXISTS notification_delivered (
+    company_id      TEXT NOT NULL,
+    notification_id TEXT NOT NULL,
+    delivered_ms    INTEGER NOT NULL,
+    PRIMARY KEY (company_id, notification_id)
+);
 CREATE TABLE IF NOT EXISTS workspace_nodes (
     company_id TEXT NOT NULL,
     id         TEXT NOT NULL,
@@ -2677,6 +2683,76 @@ impl crate::ports::notifications::NotificationStore for SqliteStore {
             )
             .map_err(sql_err)?;
         Ok(unread as u64)
+    }
+
+    async fn undelivered(
+        &self,
+        company: &CompanyId,
+    ) -> Result<Vec<crate::ports::notifications::Notification>> {
+        let conn = self.conn();
+        // Every notification with no delivery marker, oldest first — a LEFT JOIN
+        // where the delivered row is NULL.
+        let mut stmt = conn
+            .prepare(
+                "SELECT n.id, n.kind, n.subject_kind, n.subject_id, n.title, n.created_ms \
+                 FROM notifications n \
+                 LEFT JOIN notification_delivered d \
+                     ON d.company_id = n.company_id AND d.notification_id = n.id \
+                 WHERE n.company_id = ?1 AND d.notification_id IS NULL \
+                 ORDER BY n.created_ms ASC, n.id ASC",
+            )
+            .map_err(sql_err)?;
+        let rows = stmt
+            .query_map(params![company.as_ref()], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                    r.get::<_, String>(3)?,
+                    r.get::<_, String>(4)?,
+                    r.get::<_, i64>(5)?,
+                ))
+            })
+            .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (id, kind, subject_kind, subject_id, title, created_ms) = row.map_err(sql_err)?;
+            let subject_kind = crate::ports::notifications::SubjectKind::from_token(&subject_kind)
+                .ok_or_else(|| {
+                    crate::error::OpenCompanyError::Store(format!(
+                        "notification {id} has an unknown subject kind {subject_kind:?}"
+                    ))
+                })?;
+            out.push(crate::ports::notifications::Notification {
+                id,
+                kind,
+                subject: crate::ports::notifications::Subject {
+                    kind: subject_kind,
+                    id: subject_id,
+                },
+                created_at: created_ms as u64,
+                title,
+            });
+        }
+        Ok(out)
+    }
+
+    async fn mark_delivered(&self, company: &CompanyId, ids: &[String]) -> Result<()> {
+        let conn = self.conn();
+        let now = crate::ports::now_millis() as i64;
+        // `INSERT OR IGNORE` is the latch; the `WHERE EXISTS` gate marks only ids
+        // that name a real notification in this company.
+        for id in ids {
+            conn.execute(
+                "INSERT OR IGNORE INTO notification_delivered \
+                     (company_id, notification_id, delivered_ms) \
+                 SELECT ?1, ?2, ?3 \
+                 WHERE EXISTS (SELECT 1 FROM notifications WHERE company_id = ?1 AND id = ?2)",
+                params![company.as_ref(), id.as_str(), now],
+            )
+            .map_err(sql_err)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary

Part **C** of #577 — **stacked on #865 (Part B)**, itself on #860 (Part A). Review those first; this PR's base retargets up the stack as they merge.

Turns B's per-park approval email into a periodic **digest**, so a company that parks twenty approvals over an evening sends **one** message.

- **`NotificationStore` gains a per-company delivery axis** — `undelivered(company)` + `mark_delivered(company, ids)` — on fs, SQLite and MongoDB with conformance coverage. Independent of A's per-user *read* state.
- **`CompanyScheduler::tick_digest`** (in the per-minute spawn loop) runs a **quiet-then-flush** window derived from the undelivered set's own timestamps: hold while parks arrive, flush once things go quiet for 30 min or the oldest has waited 12 h. The clock is injectable → testable with no sleeps.
- **Settled approvals are dropped** from the digest (and marked delivered), gated on `pending_approvals()`, so it never reports already-actioned work. Boot replay rehydrates the parked map before the scheduler starts, so absence there means *resolved*, never "not yet loaded".
- **At-most-once** per company per minute via the shared fire claim; marked delivered **before** the spawned send, so a crash never resurrects the firehose.
- **The park is now record-only** — `notify_parked_approval` appends the notification; the owner send moved to `company::owners::deliver_to_owners`, which the digest drives. Recipients resolve server-side; the digest body carries only each notification's title, never payload.

Out of scope: push notifications; the in-console notification centre UI; any change to what qualifies as worth sending (B's classification, consumed unchanged).

## Test plan

- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` (default) clean
- [x] `cargo clippy --all-targets --features sqlite,mongodb -- -D warnings` clean
- [x] `cargo check --features openhuman,mongodb` — the tenant build compiles
- [x] Tests — full lib suite green (no regression from the park reshape); digest **batch-after-quiet** + **settled-drop** tests driven by an injectable clock (no sleeps); delivery conformance on fs / SQLite / **MongoDB (live server)**

Closes #751


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added digest emails for parked approvals, batching notifications during a quiet period or flushing them after a maximum age.
  * Notifications are delivered to company owners and tracked to prevent duplicate emails.
  * Delivery continues for other recipients when an individual email fails.
  * Added durable, company-specific delivery tracking across supported storage options.

* **Bug Fixes**
  * Parked approvals no longer trigger immediate individual emails.
  * Settled approval notifications are excluded from digests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->