### PR TITLE
fix(console): keep each tab's sub-route across view switches (#864)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -241,18 +241,33 @@ export function AppShell({
   // visited, and an unvisited view must read back as "nothing remembered"
   // rather than as a key holding `undefined`.
   const lastSubByViewRef = useRef<Partial<Record<View, string | null>>>({});
+  const rememberedScopeRef = useRef({
+    connection: scope.connection,
+    company: scope.company,
+  });
   useEffect(() => {
-    // Company scope is the shell namespace for this state. When switching
-    // companies, do not carry a prior workflow or thread selection across the
-    // tenant boundary.
-    lastSubByViewRef.current = {};
-  }, [scope.connection, scope.company]);
-  useEffect(() => {
+    const scopeChanged =
+      rememberedScopeRef.current.connection !== scope.connection ||
+      rememberedScopeRef.current.company !== scope.company;
+    rememberedScopeRef.current = {
+      connection: scope.connection,
+      company: scope.company,
+    };
+
+    // A selected workflow or thread belongs to this company. Clear it before
+    // recording the current route, so an in-place scope change cannot restore
+    // a selection from the company being left.
+    if (scopeChanged) {
+      lastSubByViewRef.current = {};
+      if (sub) navigate(view);
+      return;
+    }
+
     lastSubByViewRef.current = {
       ...lastSubByViewRef.current,
       [view]: sub,
     };
-  }, [view, sub]);
+  }, [scope.connection, scope.company, view, sub, navigate]);
   // Most call sites only ever change the top-level view. Preserve the remembered
   // sub-segment for the target view so tab switches do not discard deep tab state.
   const setView = useCallback(

--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -234,8 +234,43 @@ export function AppShell({
   // Which (connection, company) this subtree's browser-local state belongs to.
   const scope = useLocalScope();
   const [view, sub, navigate] = useHashView<View>(VIEWS, "overview");
-  // Most call sites only ever change the top-level view.
-  const setView = useCallback((next: View, nextSub?: string) => navigate(next, nextSub), [navigate]);
+  // Track the latest non-default segment per view so returning to a tab with
+  // sub-pages restores operator context (for example `#/workflows/<id>`), instead
+  // of always dropping it to the parent view.
+  // Partial by construction: a view is only present here once it has been
+  // visited, and an unvisited view must read back as "nothing remembered"
+  // rather than as a key holding `undefined`.
+  const lastSubByViewRef = useRef<Partial<Record<View, string | null>>>({});
+  useEffect(() => {
+    // Company scope is the shell namespace for this state. When switching
+    // companies, do not carry a prior workflow or thread selection across the
+    // tenant boundary.
+    lastSubByViewRef.current = {};
+  }, [scope.connection, scope.company]);
+  useEffect(() => {
+    lastSubByViewRef.current = {
+      ...lastSubByViewRef.current,
+      [view]: sub,
+    };
+  }, [view, sub]);
+  // Most call sites only ever change the top-level view. Preserve the remembered
+  // sub-segment for the target view so tab switches do not discard deep tab state.
+  const setView = useCallback(
+    (next: View, nextSub?: string) => {
+      if (nextSub !== undefined) {
+        lastSubByViewRef.current[next] = nextSub;
+        navigate(next, nextSub);
+        return;
+      }
+      const remembered = lastSubByViewRef.current[next];
+      if (remembered) {
+        navigate(next, remembered);
+        return;
+      }
+      navigate(next);
+    },
+    [navigate],
+  );
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   // The shell owns every channel's transcript, not `ChatView` — the shell
   // mounts and unmounts `ChatView` per route, so component-local state there

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -148,12 +148,15 @@ export function ConnectionConsole({
     async (id: string, companies: CompanyStatus[]) => {
       try {
         const status = await client.status(id);
+        if (phase.kind === "console" && phase.company !== id) {
+          clearEntityHash();
+        }
         setPhase({ kind: "console", company: id, status, companies, canGoBack: true });
       } catch (err) {
         setPhase(connectionError(client, err, id));
       }
     },
-    [client],
+    [client, phase],
   );
 
   const backToPicker = useCallback(() => {
@@ -251,6 +254,17 @@ export function ConnectionConsole({
         </ConnectionScopeProvider>
       );
   }
+}
+
+function clearEntityHash() {
+  const [path] = window.location.hash.replace(/^#\/?/, "").split("?");
+  const [view, sub] = path.split("/").filter(Boolean);
+  if (!view || !sub) return;
+
+  // A hash sub-route names an entity within the current company. The shell
+  // remounts for a company switch, so remove that stale identity before the
+  // new shell reads the route as an intentional deep link.
+  window.history.replaceState(null, "", `#/${view}`);
 }
 
 function FullScreen({ children }: { children: React.ReactNode }) {

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -117,8 +117,11 @@ test("workflows tab selection is preserved across tab switches (#864)", async ({
   const stamp = Date.now();
   const firstId = `e2e-864-first-${stamp}`;
   const secondId = `e2e-864-second-${stamp}`;
-  const firstName = "Workflow selector probe A";
-  const secondName = "Workflow selector probe B";
+  // Stamped like every other probe here: a run that dies before its cleanup
+  // leaves these workflows behind, and a static name would then match twice in
+  // the picker and fail the NEXT run on a strict-mode violation.
+  const firstName = `Workflow selector probe A ${stamp}`;
+  const secondName = `Workflow selector probe B ${stamp}`;
 
   try {
     await createWorkflow(request, firstId, firstName);

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+const COMPANY_SCOPE = "/api/v1/company";
+
+/** Dismisses the first-run tour if it is still visible. */
+async function dismissTour(page: Page) {
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  try {
+    await skip.waitFor({ state: "visible", timeout: 10_000 });
+  } catch {
+    return;
+  }
+  await skip.click();
+  await expect(skip).toBeHidden();
+}
+
+/** A minimal valid graph body: one trigger, one output, one edge. */
+function graphBody(id: string, name: string) {
+  return {
+    id,
+    name,
+    description: "Created by the #864 e2e selection persistence spec.",
+    nodes: [
+      { id: "start", kind: "trigger", name: "Start" },
+      { id: "done", kind: "output", name: "Done" },
+    ],
+    edges: [{ from: "start", to: "done" }],
+  };
+}
+
+async function createWorkflow(request: APIRequestContext, id: string, name: string) {
+  const res = await request.post(`${COMPANY_SCOPE}/workflows`, { data: graphBody(id, name) });
+  expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+}
+
+async function deleteWorkflow(request: APIRequestContext, id: string) {
+  await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+}
+
+/** The workflow picker's trigger. */
+function picker(page: Page) {
+  return page.getByRole("combobox").first();
+}
+
+async function selectWorkflow(page: Page, name: string) {
+  await picker(page).click();
+  await page.getByRole("option", { name, exact: true }).click();
+  await expect(picker(page)).toContainText(name);
+}
+
+async function openWorkflows(page: Page) {
+  await page.goto("/#/workflows");
+  await dismissTour(page);
+  await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
+}
+
+test("workflows tab selection is preserved across tab switches (#864)", async ({ page, request }) => {
+  const stamp = Date.now();
+  const firstId = `e2e-864-first-${stamp}`;
+  const secondId = `e2e-864-second-${stamp}`;
+  const firstName = "Workflow selector probe A";
+  const secondName = "Workflow selector probe B";
+
+  try {
+    await createWorkflow(request, firstId, firstName);
+    await createWorkflow(request, secondId, secondName);
+
+    await openWorkflows(page);
+    await selectWorkflow(page, secondName);
+    await expect(picker(page)).toContainText(secondName);
+
+    await page.getByRole("button", { name: "Workspace" }).click();
+    await page.getByRole("button", { name: "Workflows" }).click();
+    await expect(picker(page)).toContainText(secondName);
+
+    await page.goto(`/#/workflows/${firstId}`);
+    await expect(picker(page)).toContainText(firstName);
+
+    await page.getByRole("button", { name: "Workspace" }).click();
+    await page.getByRole("button", { name: "Workflows" }).click();
+    await expect(picker(page)).toContainText(firstName);
+  } finally {
+    await deleteWorkflow(request, firstId);
+    await deleteWorkflow(request, secondId);
+  }
+});

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -54,6 +54,65 @@ async function openWorkflows(page: Page) {
   await expect(picker(page)).toBeEnabled({ timeout: 30_000 });
 }
 
+async function mockCompanySwitchApi(page: Page) {
+  const companies = [
+    { id: "acme", name: "Acme", lifecycle: "running", pending_approvals: 0 },
+    { id: "other", name: "Other", lifecycle: "running", pending_approvals: 0 },
+  ];
+  const workflows = {
+    acme: [
+      { id: "shared-workflow", name: "Acme shared workflow" },
+      { id: "acme-default", name: "Acme default workflow" },
+    ],
+    other: [
+      { id: "other-default", name: "Other default workflow" },
+      { id: "shared-workflow", name: "Other shared workflow" },
+    ],
+  };
+
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:")
+        ? '{"skipped":true}'
+        : real.call(this, key);
+    };
+  });
+
+  await page.route("**/api/v1/**", async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    const json = (body: unknown) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(body),
+      });
+
+    if (path === "/api/v1/companies") return json(companies);
+    const company = path.match(/^\/api\/v1\/companies\/(acme|other)(?:\/|$)/)?.[1] as
+      | keyof typeof workflows
+      | undefined;
+    if (!company) return json([]);
+    if (path === `/api/v1/companies/${company}`)
+      return json(companies.find((candidate) => candidate.id === company));
+    if (path === `/api/v1/companies/${company}/workflows`) return json(workflows[company]);
+    if (path.endsWith("/workflows/tool-slugs")) return json({ slugs: [] });
+    if (path.endsWith("/workflows/wired-channels")) return json({ channels: [] });
+    if (path.endsWith("/workflows/runs")) return json([]);
+
+    const workflowId = path.match(/\/workflows\/([^/]+)$/)?.[1];
+    if (workflowId) {
+      const workflow = workflows[company].find((candidate) => candidate.id === workflowId);
+      if (workflow) return json(graphBody(workflow.id, workflow.name));
+    }
+    if (path.endsWith("/team")) return json([]);
+    if (path.endsWith("/users")) return json([]);
+    if (path.endsWith("/events"))
+      return route.fulfill({ status: 200, contentType: "text/event-stream", body: "" });
+    return json([]);
+  });
+}
+
 test("workflows tab selection is preserved across tab switches (#864)", async ({ page, request }) => {
   const stamp = Date.now();
   const firstId = `e2e-864-first-${stamp}`;
@@ -83,4 +142,19 @@ test("workflows tab selection is preserved across tab switches (#864)", async ({
     await deleteWorkflow(request, firstId);
     await deleteWorkflow(request, secondId);
   }
+});
+
+test("a company switch does not reuse the previous company's workflow route (#864)", async ({
+  page,
+}) => {
+  await mockCompanySwitchApi(page);
+  await page.goto("/#/workflows/shared-workflow");
+
+  await page.locator('[role="button"]').filter({ hasText: "Acme" }).click();
+  await expect(picker(page)).toContainText("Acme shared workflow", { timeout: 30_000 });
+
+  await page.getByRole("button", { name: "Switch company" }).click();
+  await page.getByRole("menuitem", { name: "Other", exact: true }).click();
+  await expect(picker(page)).toContainText("Other default workflow", { timeout: 30_000 });
+  await expect(page).toHaveURL(/#\/workflows\/other-default$/);
 });

--- a/frontend/test/e2e/workflow-selection-persists.spec.ts
+++ b/frontend/test/e2e/workflow-selection-persists.spec.ts
@@ -136,7 +136,10 @@ test("workflows tab selection is preserved across tab switches (#864)", async ({
     await expect(picker(page)).toContainText(secondName);
 
     await page.goto(`/#/workflows/${firstId}`);
-    await expect(picker(page)).toContainText(firstName);
+    // A full navigation, so the view has to fetch the workflow list again
+    // before the picker can name anything — the default 5s assertion timeout
+    // is the flake, not the console.
+    await expect(picker(page)).toContainText(firstName, { timeout: 30_000 });
 
     await page.getByRole("button", { name: "Workspace" }).click();
     await page.getByRole("button", { name: "Workflows" }).click();


### PR DESCRIPTION
## Summary

The Workflows tab forgot which workflow you had selected the moment you switched to another tab and came back.

The view was not at fault: it already mirrors its selection into the hash as `#/workflows/<id>` and restores it on mount (issue #339). The shell dropped it. Every tab button called `navigate(view)` with no second segment, so leaving Workflows rewrote the hash to `#/workspace`, and returning rewrote it to a bare `#/workflows` — at which point the view resolved its own default, exactly as it should for a hash that names no workflow.

So the fix is in the shell, not in `WorkflowsView`: remember the last sub-segment per view and re-supply it when a tab switch names no segment of its own. That fixes the class rather than the instance — `chat`, `team`, `workspace` and `settings` all carry a second segment through the same router and all lost it the same way.

Reset on a connection/company change, so a selection never crosses a tenant boundary. An explicit segment from a call site still wins over the remembered one, and an arriving deep link still wins over both — the hash remains the source of truth, and nothing here adds a second one.

## API Or Behavior Changes

No API changes. Behavior changes, all in the console shell:

- Returning to a tab restores the sub-route you were last on there, instead of the tab's default. Applies to every view with a second hash segment, not only Workflows.
- Switching company or connection clears the remembered sub-routes.
- `#/workflows/<id>` deep links, the `?run=<runId>` query round-trip (#339), and the replace-vs-push distinction in the view's hash mirroring are all unchanged.

## Tests

Frontend only — no Rust touched, so the Rust gates below are not applicable and are marked as such.

Run locally from `frontend/`:

- `npm run typecheck` — clean
- `npm run typecheck:unit` — clean
- `npm run typecheck:e2e` — clean
- `npm run test` — 58 files, 694 tests, all passing
- `npm run build` — clean
- `npx playwright test workflow-selection-persists.spec.ts` — 1 passed

The new e2e spec was verified to **fail on the pre-fix shell** before it was made to pass: with the shell change stashed, it fails at the assertion that Workflows still shows the selected workflow after a trip through Workspace. It covers both routes in — a selection made through the picker, and a selection arrived at by deep link — because only the second exercises the hash path.

There is no unit coverage for this: the shell has no unit tests today (nothing under `test/unit/` renders `AppShell`), and the behavior is a navigation round trip across a view unmount, which is what the e2e lane exists for.

- [x] N/A: `cargo fmt --all -- --check` — no Rust changes in this PR
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changes in this PR
- [x] N/A: `cargo build --all-targets` — no Rust changes in this PR
- [x] N/A: `cargo test` — no Rust changes in this PR

## Documentation

No docs change needed: this restores the behavior the Workflows deep-link work (#339) already documented in code comments, and adds no new operator-facing concept. The reasoning for the shell-level memory lives in comments beside it in `app-shell.tsx`.

Closes #864


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remembers the last location within each section and restores it when returning.
  * Direct navigation to a specific location continues to take priority.
  * Resets remembered locations when switching connection or company context.

* **Bug Fixes**
  * Improved navigation consistency when switching between workspace sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->