### PR TITLE
fix: bound workflow copilot history replay

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -468,11 +468,20 @@ export class OpenCompanyClient {
    * A desk's persisted transcript (issue #65), so the console can rehydrate a
    * thread on login/reload instead of always starting empty. `desk` is the
    * thread id (as passed to {@link chat}); omitted reads the operator/General
-   * line. Hosts that don't expose `.../chat/history` yet return 404 — callers
-   * fall back to an empty transcript.
+   * line. `before` is an exclusive message-id cursor and `limit` bounds one
+   * page; callers decide whether an unavailable route is an empty transcript
+   * or an error they need to surface.
    */
-  getChatHistory(desk?: string | null, company?: string | null): Promise<ChatHistoryMessageDto[]> {
-    const qs = desk ? `?desk=${encodeURIComponent(desk)}` : "";
+  getChatHistory(
+    desk?: string | null,
+    company?: string | null,
+    options?: { before?: string; limit?: number },
+  ): Promise<ChatHistoryMessageDto[]> {
+    const query = new URLSearchParams();
+    if (desk) query.set("desk", desk);
+    if (options?.before) query.set("before", options.before);
+    if (options?.limit !== undefined) query.set("limit", String(options.limit));
+    const qs = query.size > 0 ? `?${query}` : "";
     return this.request<ChatHistoryMessageDto[]>(
       "GET",
       `${this.scope(company)}/chat/history${qs}`,

--- a/frontend/src/api/workflow-copilot.ts
+++ b/frontend/src/api/workflow-copilot.ts
@@ -430,27 +430,31 @@ export async function askCopilot(
 /**
  * Replays a workflow's copilot transcript from the company journal.
  *
- * Returns an empty transcript on ANY failure: a host predating
- * `…/chat/history` answers 404, and a copilot that refuses to open because it
- * could not replay old messages would be worse than one that starts blank.
+ * A failed replay is reported separately from an empty transcript so the panel
+ * can leave the copilot usable while making the degraded history visible.
  */
 export async function loadCopilotHistory(
   client: OpenCompanyClient,
   company: string | null,
   workflowId: string,
-): Promise<CopilotMessage[]> {
+): Promise<{ ok: true; messages: CopilotMessage[] } | { ok: false; error: Error }> {
   try {
-    const rows = await client.getChatHistory(copilotThreadId(workflowId), company);
-    return rows.map((row) => ({
-      id: row.id,
-      role: row.mine ? "operator" : "company",
-      // Strip the inlined grounding back off the operator's side, so a
-      // rehydrated transcript reads like the conversation the operator had.
-      text: row.mine ? questionOf(row.text) : row.text,
-      atMillis: row.atMillis,
-    }));
+    const rows = await client.getChatHistory(copilotThreadId(workflowId), company, { limit: 200 });
+    return {
+      ok: true,
+      messages: rows.map((row) => ({
+        id: row.id,
+        role: row.mine ? "operator" : "company",
+        // Strip the inlined grounding back off the operator's side, so a
+        // rehydrated transcript reads like the conversation the operator had.
+        text: row.mine ? questionOf(row.text) : row.text,
+        atMillis: row.atMillis,
+      })),
+    };
   } catch (e) {
-    console.debug("[workflow-copilot] no transcript to replay", e);
-    return [];
+    return {
+      ok: false,
+      error: e instanceof Error ? e : new Error("The copilot transcript could not be loaded."),
+    };
   }
 }

--- a/frontend/src/views/workflows/CopilotPanel.tsx
+++ b/frontend/src/views/workflows/CopilotPanel.tsx
@@ -131,6 +131,7 @@ export function CopilotPanel({
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [historyError, setHistoryError] = useState<string | null>(null);
   // The cognition path the company actually booted onto. `null` until the read
   // lands, or when the host does not serve the route.
   const [cognition, setCognition] = useState<CognitionPath | null>(null);
@@ -195,10 +196,16 @@ export function CopilotPanel({
     setReviews({});
     setThisSession(new Set());
     setError(null);
+    setHistoryError(null);
     setSending(false);
     (async () => {
       const replayed = await loadCopilotHistory(client, company, workflowId);
-      if (live) setMessages(replayed);
+      if (!live) return;
+      if (replayed.ok) {
+        setMessages(replayed.messages);
+      } else {
+        setHistoryError(`Previous copilot messages could not be loaded: ${replayed.error.message}`);
+      }
     })();
     return () => {
       live = false;
@@ -502,6 +509,11 @@ export function CopilotPanel({
       </div>
 
       <div ref={scrollRef} className="min-h-0 flex-1 space-y-3 overflow-auto px-3 py-3">
+        {historyError && (
+          <Alert variant="destructive" data-testid="workflow-copilot-history-error">
+            <AlertDescription>{historyError}</AlertDescription>
+          </Alert>
+        )}
         {/* What it can see and what it cannot do, stated before the first
             question rather than discovered after it.
 

--- a/frontend/test/unit/workflow-copilot.test.ts
+++ b/frontend/test/unit/workflow-copilot.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   composeCopilotMessage,
   copilotThreadId,
+  loadCopilotHistory,
   questionOf,
   type CopilotContext,
 } from "@/api/workflow-copilot";
@@ -45,6 +46,20 @@ describe("copilotThreadId", () => {
   /** The exact string `company::copilot::workflow_of_thread` parses. */
   it("is the prefix the host confines on", () => {
     expect(copilotThreadId("weekly_report")).toBe("workflow-copilot:weekly_report");
+  });
+});
+
+describe("loadCopilotHistory", () => {
+  it("distinguishes an unavailable transcript from an empty one", async () => {
+    const result = await loadCopilotHistory(
+      {
+        getChatHistory: vi.fn().mockRejectedValue(new Error("network unavailable")),
+      } as never,
+      "acme",
+      "weekly_report",
+    );
+
+    expect(result).toMatchObject({ ok: false, error: { message: "network unavailable" } });
   });
 });
 

--- a/src/ports/events.rs
+++ b/src/ports/events.rs
@@ -223,6 +223,25 @@ pub trait EventLog: Send + Sync {
         seq: EventSeq,
         limit: usize,
     ) -> Result<Vec<StoredEvent>>;
+    /// Reads up to `limit` events with sequence `< before`, newest first.
+    ///
+    /// An absent cursor means the current tail. Backends should implement this
+    /// directly when they can: transcript readers open at the tail, and doing
+    /// a forward `read_from(0, MAX)` merely to keep its last page turns every
+    /// chat open into an ever-growing allocation. The fallback keeps custom
+    /// test ports source-compatible; production stores override it.
+    async fn read_before(
+        &self,
+        id: &CompanyId,
+        before: Option<EventSeq>,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        let mut events = self.read_from(id, EventSeq::new(0), usize::MAX).await?;
+        events.retain(|event| before.is_none_or(|cursor| event.seq < cursor));
+        events.reverse();
+        events.truncate(limit);
+        Ok(events)
+    }
     /// Subscribes to events appended after the call.
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent>;
 

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -484,8 +484,7 @@ pub async fn author_labels(
 ///
 /// `before_seq` is an opaque EventLog cursor (a sequence position); only
 /// messages before it are considered. `first` caps how many of the remaining,
-/// most-recent messages come back. Returns the page plus the total count of
-/// matching messages (before the `first` cap, after the `before_seq` cut).
+/// most-recent messages come back.
 ///
 /// Shared by the GraphQL `Chat.history` resolver and the REST
 /// `GET .../chat/history` route so the two can never disagree about what a
@@ -497,18 +496,24 @@ pub async fn history_for_desk(
     viewer: &Viewer,
     before_seq: Option<u64>,
     first: usize,
-) -> Result<(Vec<MessageView>, i32), OpenCompanyError> {
+) -> Result<Vec<MessageView>, OpenCompanyError> {
     // A page is events rather than messages: a busy company can put unrelated
     // events between two chat turns. Walking backward keeps the newest `first`
     // transcript entries without ever materialising that unrelated journal.
     const EVENT_PAGE: usize = 512;
 
+    // A zero-sized GraphQL page is a valid request, and the REST limit can be
+    // clamped to zero. It must not touch the journal merely to construct an
+    // empty response.
+    if first == 0 {
+        return Ok(Vec::new());
+    }
+
     // One roster read per history, not one per message.
     let authors = author_labels(runtime).await?;
     let mut cursor = before_seq.map(EventSeq::new);
     let mut messages = Vec::with_capacity(first);
-    let mut total = 0i32;
-    loop {
+    while messages.len() < first {
         let page = runtime
             .events()
             .read_before(runtime.id(), cursor, EVENT_PAGE)
@@ -519,9 +524,9 @@ pub async fn history_for_desk(
         cursor = page.last().map(|event| event.seq);
         for event in page {
             if owns(desk_id, desk_name, &event.event) {
-                total += 1;
-                if messages.len() < first {
-                    messages.push(MessageView::project(event, viewer, &authors));
+                messages.push(MessageView::project(event, viewer, &authors));
+                if messages.len() == first {
+                    break;
                 }
             }
         }
@@ -533,13 +538,14 @@ pub async fn history_for_desk(
 
     // Reactions necessarily follow their message. Once the displayed window is
     // known, fold only toggles that could affect one of its messages, streaming
-    // forward from the window's oldest id to this request's cursor.
+    // forward from the window's oldest id through the current tail. The cursor
+    // limits *messages*, not the reaction snapshot: a later toggle still
+    // changes the state displayed on an older message.
     let wanted: HashSet<u64> = messages
         .iter()
         .filter_map(|message| message.id.parse::<u64>().ok())
         .collect();
     if let Some(oldest) = wanted.iter().min().copied() {
-        let upper = before_seq;
         let mut next = oldest.saturating_add(1);
         let mut fold = ReactionFold {
             state: HashMap::new(),
@@ -553,19 +559,14 @@ pub async fn history_for_desk(
             if page.is_empty() {
                 break;
             }
-            let mut reached_upper = false;
             for event in &page {
-                if upper.is_some_and(|before| event.seq.value() >= before) {
-                    reached_upper = true;
-                    break;
-                }
                 fold.observe(event, Some(&wanted));
             }
             next = page
                 .last()
                 .map(|event| event.seq.value() + 1)
                 .unwrap_or(next);
-            if reached_upper || page.len() < EVENT_PAGE {
+            if page.len() < EVENT_PAGE {
                 break;
             }
         }
@@ -574,7 +575,51 @@ pub async fn history_for_desk(
             message.reactions = reactions.remove(&message.id).unwrap_or_default();
         }
     }
-    Ok((messages, total))
+    Ok(messages)
+}
+
+/// Counts a desk's messages before a cursor without materialising them.
+///
+/// GraphQL's [`Page`](crate::server::graphql::pagination::Page) exposes an
+/// unpaginated `total`, while the REST transcript endpoint deliberately does
+/// not. Keep that potentially full journal walk out of [`history_for_desk`],
+/// so bounded transcript readers stop as soon as their requested window is
+/// complete.
+pub async fn history_total_for_desk(
+    runtime: &CompanyRuntime,
+    desk_id: &str,
+    desk_name: &str,
+    before_seq: Option<u64>,
+) -> Result<i32, OpenCompanyError> {
+    const EVENT_PAGE: usize = 512;
+
+    let mut next = EventSeq::new(0);
+    let mut total = 0i32;
+    loop {
+        let page = runtime
+            .events()
+            .read_from(runtime.id(), next, EVENT_PAGE)
+            .await?;
+        if page.is_empty() {
+            break;
+        }
+        for event in &page {
+            if before_seq.is_some_and(|before| event.seq.value() >= before) {
+                return Ok(total);
+            }
+            if owns(desk_id, desk_name, &event.event) {
+                total = total.saturating_add(1);
+            }
+        }
+        let Some(last) = page.last() else {
+            break;
+        };
+        next = EventSeq::new(last.seq.value().saturating_add(1));
+        if page.len() < EVENT_PAGE {
+            break;
+        }
+    }
+    Ok(total)
 }
 
 #[cfg(test)]

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -570,7 +570,7 @@ pub async fn history_for_desk(
             }
             next = page
                 .last()
-                .map(|event| event.seq.value() + 1)
+                .map(|event| event.seq.value().saturating_add(1))
                 .unwrap_or(next);
             if page.len() < EVENT_PAGE {
                 break;

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -26,6 +26,11 @@ use crate::server::ops::language::DEFAULT_DESK as GENERAL_DESK;
 /// across the two ids depending on which one happened to write it (issue #65).
 pub const MAIN_THREAD_ID: &str = "main";
 
+/// The largest message page either history surface may materialize. Keeping
+/// the limit beside the shared reader prevents a new caller from turning its
+/// `Vec` reservation back into an allocation controlled by the request.
+pub const CHAT_HISTORY_PAGE_LIMIT: usize = 200;
+
 /// Does this stored chat id mean the General desk?
 ///
 /// **Four spellings, one desk.** The console addresses its default thread as
@@ -505,6 +510,7 @@ pub async fn history_for_desk(
     // A zero-sized GraphQL page is a valid request, and the REST limit can be
     // clamped to zero. It must not touch the journal merely to construct an
     // empty response.
+    let first = first.min(CHAT_HISTORY_PAGE_LIMIT);
     if first == 0 {
         return Ok(Vec::new());
     }

--- a/src/server/chat_history.rs
+++ b/src/server/chat_history.rs
@@ -8,7 +8,7 @@
 //! it; both surfaces call through it instead of each keeping their own copy of
 //! the filter + projection logic.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
@@ -260,15 +260,14 @@ fn reaction_actor_key(by: &Option<Actor>) -> String {
 /// route's explicit `on` flag idempotent — and a row that ends up `off` is
 /// dropped entirely rather than kept as a zero. Order is first-set order, so a
 /// message's chips do not reshuffle between reads.
-fn fold_reactions(
-    stored: &[StoredEvent],
-    viewer: &Viewer,
-    authors: &HashMap<String, String>,
-) -> HashMap<String, Vec<ReactionView>> {
+struct ReactionFold {
     // (message, actor, emoji) → (position among first-seen keys, currently on).
-    let mut state: HashMap<(u64, String, String), (usize, bool)> = HashMap::new();
-    let mut seen = 0usize;
-    for event in stored {
+    state: HashMap<(u64, String, String), (usize, bool)>,
+    seen: usize,
+}
+
+impl ReactionFold {
+    fn observe(&mut self, event: &StoredEvent, wanted: Option<&HashSet<u64>>) {
         let CompanyEvent::ReactionToggled {
             message_seq,
             emoji,
@@ -276,46 +275,72 @@ fn fold_reactions(
             by,
         } = &event.event
         else {
-            continue;
+            return;
         };
+        if wanted.is_some_and(|ids| !ids.contains(&message_seq.value())) {
+            return;
+        }
         let key = (message_seq.value(), reaction_actor_key(by), emoji.clone());
-        match state.get_mut(&key) {
+        match self.state.get_mut(&key) {
             Some(slot) => slot.1 = *on,
             None => {
-                state.insert(key, (seen, *on));
-                seen += 1;
+                self.state.insert(key, (self.seen, *on));
+                self.seen += 1;
             }
         }
     }
 
-    let mut rows: Vec<(usize, u64, String, String)> = state
-        .into_iter()
-        .filter(|(_, (_, on))| *on)
-        .map(|((message, actor, emoji), (order, _))| (order, message, actor, emoji))
-        .collect();
-    rows.sort_unstable();
+    fn finish(
+        self,
+        viewer: &Viewer,
+        authors: &HashMap<String, String>,
+    ) -> HashMap<String, Vec<ReactionView>> {
+        let mut rows: Vec<(usize, u64, String, String)> = self
+            .state
+            .into_iter()
+            .filter(|(_, (_, on))| *on)
+            .map(|((message, actor, emoji), (order, _))| (order, message, actor, emoji))
+            .collect();
+        rows.sort_unstable();
 
-    let mut out: HashMap<String, Vec<ReactionView>> = HashMap::new();
-    for (_, message, actor, emoji) in rows {
-        let (by_label, mine) = match actor.strip_prefix("user:") {
-            Some(user_id) => (
-                authors
-                    .get(user_id)
-                    .cloned()
-                    .unwrap_or_else(|| "someone".to_string()),
-                *viewer == Viewer::User(user_id.to_string()),
-            ),
-            None => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
-        };
-        out.entry(message.to_string())
-            .or_default()
-            .push(ReactionView {
-                emoji,
-                by_label,
-                mine,
-            });
+        let mut out: HashMap<String, Vec<ReactionView>> = HashMap::new();
+        for (_, message, actor, emoji) in rows {
+            let (by_label, mine) = match actor.strip_prefix("user:") {
+                Some(user_id) => (
+                    authors
+                        .get(user_id)
+                        .cloned()
+                        .unwrap_or_else(|| "someone".to_string()),
+                    *viewer == Viewer::User(user_id.to_string()),
+                ),
+                None => ("operator".to_string(), matches!(viewer, Viewer::Operator)),
+            };
+            out.entry(message.to_string())
+                .or_default()
+                .push(ReactionView {
+                    emoji,
+                    by_label,
+                    mine,
+                });
+        }
+        out
     }
-    out
+}
+
+#[cfg(test)]
+fn fold_reactions(
+    stored: &[StoredEvent],
+    viewer: &Viewer,
+    authors: &HashMap<String, String>,
+) -> HashMap<String, Vec<ReactionView>> {
+    let mut fold = ReactionFold {
+        state: HashMap::new(),
+        seen: 0,
+    };
+    for event in stored {
+        fold.observe(event, None);
+    }
+    fold.finish(viewer, authors)
 }
 
 impl MessageView {
@@ -473,35 +498,81 @@ pub async fn history_for_desk(
     before_seq: Option<u64>,
     first: usize,
 ) -> Result<(Vec<MessageView>, i32), OpenCompanyError> {
-    let stored = runtime
-        .events()
-        .read_from(runtime.id(), EventSeq::new(0), usize::MAX)
-        .await?;
-    // One roster read per history, not one per message: the scan above is
-    // already O(log), and an N+1 on top of it would be worse.
+    // A page is events rather than messages: a busy company can put unrelated
+    // events between two chat turns. Walking backward keeps the newest `first`
+    // transcript entries without ever materialising that unrelated journal.
+    const EVENT_PAGE: usize = 512;
+
+    // One roster read per history, not one per message.
     let authors = author_labels(runtime).await?;
-    // Issue #364: reactions ride the same full-log read the messages do — a
-    // second pass over a list already in memory, not a second query. Folded
-    // before the messages are consumed, and attached only to messages this desk
-    // owns, so a reaction can no more cross a desk boundary than the message it
-    // is about can.
-    let mut reactions = fold_reactions(&stored, viewer, &authors);
+    let mut cursor = before_seq.map(EventSeq::new);
+    let mut messages = Vec::with_capacity(first);
+    let mut total = 0i32;
+    loop {
+        let page = runtime
+            .events()
+            .read_before(runtime.id(), cursor, EVENT_PAGE)
+            .await?;
+        if page.is_empty() {
+            break;
+        }
+        cursor = page.last().map(|event| event.seq);
+        for event in page {
+            if owns(desk_id, desk_name, &event.event) {
+                total += 1;
+                if messages.len() < first {
+                    messages.push(MessageView::project(event, viewer, &authors));
+                }
+            }
+        }
+    }
 
-    let mut messages: Vec<MessageView> = stored
-        .into_iter()
-        .filter(|event| owns(desk_id, desk_name, &event.event))
-        .filter(|event| before_seq.is_none_or(|before| event.seq.value() < before))
-        .map(|event| MessageView::project(event, viewer, &authors))
-        .map(|mut view| {
-            view.reactions = reactions.remove(&view.id).unwrap_or_default();
-            view
-        })
+    // `read_before` supplies each page newest-first, as does `messages` above.
+    // Restore chronological order for the renderer before attaching reactions.
+    messages.reverse();
+
+    // Reactions necessarily follow their message. Once the displayed window is
+    // known, fold only toggles that could affect one of its messages, streaming
+    // forward from the window's oldest id to this request's cursor.
+    let wanted: HashSet<u64> = messages
+        .iter()
+        .filter_map(|message| message.id.parse::<u64>().ok())
         .collect();
-
-    let total = messages.len() as i32;
-    // Keep the most recent `first`, still in chronological order.
-    if messages.len() > first {
-        messages.drain(0..messages.len() - first);
+    if let Some(oldest) = wanted.iter().min().copied() {
+        let upper = before_seq;
+        let mut next = oldest.saturating_add(1);
+        let mut fold = ReactionFold {
+            state: HashMap::new(),
+            seen: 0,
+        };
+        loop {
+            let page = runtime
+                .events()
+                .read_from(runtime.id(), EventSeq::new(next), EVENT_PAGE)
+                .await?;
+            if page.is_empty() {
+                break;
+            }
+            let mut reached_upper = false;
+            for event in &page {
+                if upper.is_some_and(|before| event.seq.value() >= before) {
+                    reached_upper = true;
+                    break;
+                }
+                fold.observe(event, Some(&wanted));
+            }
+            next = page
+                .last()
+                .map(|event| event.seq.value() + 1)
+                .unwrap_or(next);
+            if reached_upper || page.len() < EVENT_PAGE {
+                break;
+            }
+        }
+        let mut reactions = fold.finish(viewer, &authors);
+        for message in &mut messages {
+            message.reactions = reactions.remove(&message.id).unwrap_or_default();
+        }
     }
     Ok((messages, total))
 }

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -465,13 +465,20 @@ impl ChatGql {
             _ => Viewer::Operator,
         };
         let first = first.max(0) as usize;
-        let (messages, total) = chat_history::history_for_desk(
+        let messages = chat_history::history_for_desk(
             &self.runtime,
             &self.desk.id,
             &self.desk.name,
             &viewer,
             before_seq,
             first,
+        )
+        .await?;
+        let total = chat_history::history_total_for_desk(
+            &self.runtime,
+            &self.desk.id,
+            &self.desk.name,
+            before_seq,
         )
         .await?;
         Ok(Page {

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -464,7 +464,7 @@ impl ChatGql {
             Ok(GqlAuth::User(user)) => Viewer::User(user.user_id.clone()),
             _ => Viewer::Operator,
         };
-        let first = first.max(0) as usize;
+        let first = first.clamp(0, chat_history::CHAT_HISTORY_PAGE_LIMIT as i32) as usize;
         let messages = chat_history::history_for_desk(
             &self.runtime,
             &self.desk.id,

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -479,7 +479,7 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
     let app = router(state);
     let value = query(
         app,
-        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 10) { items { text } } } } }"}"#,
+        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 1) { total items { text } } } } }"}"#,
     )
     .await;
     let texts: Vec<&str> = value["data"]["company"]["chat"]["history"]["items"]
@@ -488,10 +488,13 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .iter()
         .map(|m| m["text"].as_str().unwrap())
         .collect();
-    assert!(texts.contains(&"canonical id"), "missing: {texts:?}");
     assert!(
         texts.contains(&"console default-thread id"),
-        "missing: {texts:?}"
+        "the newest matching message is the one page returns: {texts:?}"
+    );
+    assert_eq!(
+        value["data"]["company"]["chat"]["history"]["total"], 2,
+        "the GraphQL page keeps its unpaginated total without making the REST reader scan it"
     );
 }
 

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -488,14 +488,55 @@ async fn chat_history_finds_agent_replies_under_general_and_main() {
         .iter()
         .map(|m| m["text"].as_str().unwrap())
         .collect();
-    assert!(
-        texts.contains(&"console default-thread id"),
-        "the newest matching message is the one page returns: {texts:?}"
+    assert_eq!(
+        texts,
+        vec!["console default-thread id"],
+        "the page must contain only the newest matching message"
     );
     assert_eq!(
         value["data"]["company"]["chat"]["history"]["total"], 2,
         "the GraphQL page keeps its unpaginated total without making the REST reader scan it"
     );
+}
+
+/// A GraphQL caller controls `first`, but a history page must have the same
+/// hard ceiling as REST so a huge integer cannot become a huge Vec reservation.
+#[tokio::test]
+async fn chat_history_clamps_an_oversized_page_request() {
+    let home_dir = home();
+    let home = home_dir.path().to_path_buf();
+    let state = state_with_rich_company(&home).await;
+    let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+    for i in 0..201 {
+        runtime
+            .events()
+            .append(
+                runtime.id(),
+                crate::ports::types::CompanyEvent::AgentReply {
+                    parent: None,
+                    task_id: None,
+                    chat_id: "General".to_string(),
+                    agent_id: "maya".to_string(),
+                    text: format!("message {i}"),
+                    steps: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+    }
+
+    let value = query(
+        router(state),
+        r#"{"query":"{ company(id:\"acme\"){ chat(id:\"general\"){ history(first: 2147483647) { total items { text } } } } }"}"#,
+    )
+    .await;
+    let items = value["data"]["company"]["chat"]["history"]["items"]
+        .as_array()
+        .unwrap();
+    assert_eq!(items.len(), 200, "the requested page is capped");
+    assert_eq!(items[0]["text"], "message 1");
+    assert_eq!(items[199]["text"], "message 200");
+    assert_eq!(value["data"]["company"]["chat"]["history"]["total"], 201);
 }
 
 /// Issue #246 + #65: the card a reply opened is projected on **both** history

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -35,7 +35,9 @@ use crate::ports::types::{
 };
 use crate::runtime::grants::{GrantId, GrantScope, MAX_STANDING_GRANT_MILLIS};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
-use crate::server::chat_history::{MessageView, ReactionView, Viewer, history_for_desk};
+use crate::server::chat_history::{
+    CHAT_HISTORY_PAGE_LIMIT, MessageView, ReactionView, Viewer, history_for_desk,
+};
 use crate::server::error::ApiError;
 use crate::server::graphql::auth::GqlAuth;
 use crate::server::ops::language::{self, DEFAULT_DESK};
@@ -1551,12 +1553,6 @@ impl From<MessageView> for ChatHistoryMessageDto {
     }
 }
 
-/// How many messages `GET .../chat/history` returns. Generous enough to
-/// hydrate a console thread on load (issue #65) while still bounding the
-/// response on a very long transcript. REST callers can request a smaller
-/// page or walk backwards with `?before=<oldest-id>`.
-const CHAT_HISTORY_LIMIT: usize = 200;
-
 /// Resolves a `?desk=` selector to the `(id, name)` pair `history_for_desk`
 /// filters on.
 ///
@@ -1617,8 +1613,8 @@ async fn chat_history_response(
         .map_err(|e| ApiError(e).into_response())?;
     let limit = query
         .limit
-        .unwrap_or(CHAT_HISTORY_LIMIT)
-        .min(CHAT_HISTORY_LIMIT);
+        .unwrap_or(CHAT_HISTORY_PAGE_LIMIT)
+        .min(CHAT_HISTORY_PAGE_LIMIT);
     let messages = history_for_desk(&runtime, &desk_id, &desk_name, &viewer, query.before, limit)
         .await
         .map_err(|e| ApiError(e).into_response())?;

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1457,6 +1457,14 @@ struct ChatHistoryQuery {
     /// General/"main" line — the console's default thread (issue #65).
     #[serde(default)]
     desk: Option<String>,
+    /// Exclusive event cursor. Omitted reads the current tail; passing the
+    /// oldest id already held walks backward without rereading newer events.
+    #[serde(default)]
+    before: Option<u64>,
+    /// Maximum transcript messages to return. Capped server-side so a caller
+    /// cannot turn one history read back into an unbounded response.
+    #[serde(default)]
+    limit: Option<usize>,
 }
 
 /// One desk-history message, as the console renders it. Mirrors `ChatMessage`
@@ -1545,8 +1553,8 @@ impl From<MessageView> for ChatHistoryMessageDto {
 
 /// How many messages `GET .../chat/history` returns. Generous enough to
 /// hydrate a console thread on load (issue #65) while still bounding the
-/// response on a very long transcript; pagination is a GraphQL `Chat.history`
-/// concern, not this REST convenience route's.
+/// response on a very long transcript. REST callers can request a smaller
+/// page or walk backwards with `?before=<oldest-id>`.
 const CHAT_HISTORY_LIMIT: usize = 200;
 
 /// Resolves a `?desk=` selector to the `(id, name)` pair `history_for_desk`
@@ -1607,16 +1615,14 @@ async fn chat_history_response(
     let (desk_id, desk_name) = resolve_desk(&runtime, query.desk.as_deref())
         .await
         .map_err(|e| ApiError(e).into_response())?;
-    let (messages, _total) = history_for_desk(
-        &runtime,
-        &desk_id,
-        &desk_name,
-        &viewer,
-        None,
-        CHAT_HISTORY_LIMIT,
-    )
-    .await
-    .map_err(|e| ApiError(e).into_response())?;
+    let limit = query
+        .limit
+        .unwrap_or(CHAT_HISTORY_LIMIT)
+        .min(CHAT_HISTORY_LIMIT);
+    let (messages, _total) =
+        history_for_desk(&runtime, &desk_id, &desk_name, &viewer, query.before, limit)
+            .await
+            .map_err(|e| ApiError(e).into_response())?;
     Ok(Json(
         messages
             .into_iter()
@@ -3531,6 +3537,58 @@ mod test {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value.as_array().unwrap().len(), 0);
+    }
+
+    /// Issue #862: REST history carries the same cursor/window contract as the
+    /// paginated GraphQL surface. A copilot replay can therefore ask for the
+    /// tail it needs without the route reading past its cursor.
+    #[tokio::test]
+    async fn chat_history_route_honors_before_and_limit() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let mut seqs = Vec::new();
+        for text in ["oldest", "kept", "newest"] {
+            seqs.push(
+                runtime
+                    .events()
+                    .append(
+                        runtime.id(),
+                        CompanyEvent::AgentReply {
+                            parent: None,
+                            task_id: None,
+                            chat_id: "workflow-copilot:weekly_report".to_string(),
+                            agent_id: "ceo".to_string(),
+                            text: text.to_string(),
+                            steps: Vec::new(),
+                        },
+                    )
+                    .await
+                    .unwrap(),
+            );
+        }
+
+        let uri = format!(
+            "/api/v1/company/chat/history?desk=workflow-copilot:weekly_report&before={}&limit=1",
+            seqs[2].value()
+        );
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(uri)
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value[0]["text"], "kept");
+        assert_eq!(value.as_array().unwrap().len(), 1);
     }
 
     /* ---- issue #364: durable ids, threads, reactions, channel isolation ---- */

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1619,10 +1619,9 @@ async fn chat_history_response(
         .limit
         .unwrap_or(CHAT_HISTORY_LIMIT)
         .min(CHAT_HISTORY_LIMIT);
-    let (messages, _total) =
-        history_for_desk(&runtime, &desk_id, &desk_name, &viewer, query.before, limit)
-            .await
-            .map_err(|e| ApiError(e).into_response())?;
+    let messages = history_for_desk(&runtime, &desk_id, &desk_name, &viewer, query.before, limit)
+        .await
+        .map_err(|e| ApiError(e).into_response())?;
     Ok(Json(
         messages
             .into_iter()
@@ -3589,6 +3588,74 @@ mod test {
         let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(value[0]["text"], "kept");
         assert_eq!(value.as_array().unwrap().len(), 1);
+    }
+
+    /// A history cursor pages messages, not the current reaction state. A
+    /// toggle can be journaled after the cursor for a message still selected by
+    /// that cursor, and must therefore remain visible on the paged result.
+    #[tokio::test]
+    async fn chat_history_cursor_keeps_later_reactions_on_displayed_messages() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_company(&home, "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let message = runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::AgentReply {
+                    parent: None,
+                    task_id: None,
+                    chat_id: "General".to_string(),
+                    agent_id: "ceo".to_string(),
+                    text: "kept".to_string(),
+                    steps: Vec::new(),
+                },
+            )
+            .await
+            .unwrap();
+        let cursor = runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::FeedbackFiled {
+                    note: "cursor marker".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        runtime
+            .events()
+            .append(
+                runtime.id(),
+                CompanyEvent::ReactionToggled {
+                    message_seq: message,
+                    emoji: "👍".to_string(),
+                    on: true,
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let response = router(state)
+            .oneshot(
+                Request::builder()
+                    .uri(format!(
+                        "/api/v1/company/chat/history?before={}&limit=1",
+                        cursor.value()
+                    ))
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(value[0]["id"], message.value().to_string());
+        assert_eq!(value[0]["reactions"][0]["emoji"], "👍");
     }
 
     /* ---- issue #364: durable ids, threads, reactions, channel isolation ---- */

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -456,6 +456,57 @@ pub async fn assert_monotonic_event_seq(events: Arc<dyn EventLog>) {
     assert_eq!(tail[0].seq, EventSeq::new(3));
 }
 
+/// `read_before` returns a bounded, newest-first page before an exclusive
+/// cursor. This is the primitive transcript pagination uses, so every durable
+/// EventLog backend must exercise its production query/stream implementation.
+pub async fn assert_event_read_before(events: Arc<dyn EventLog>) {
+    let id = CompanyId::new("history-page");
+    let mut seqs = Vec::new();
+    for text in ["zero", "one", "two", "three"] {
+        seqs.push(
+            events
+                .append(
+                    &id,
+                    CompanyEvent::OperatorMessage {
+                        parent: None,
+                        text: text.to_string(),
+                        by: None,
+                        chat: None,
+                    },
+                )
+                .await
+                .unwrap(),
+        );
+    }
+
+    let tail = events.read_before(&id, None, 2).await.unwrap();
+    assert_eq!(
+        tail.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        vec![seqs[3], seqs[2]],
+        "the tail page must be newest-first"
+    );
+
+    let before = events.read_before(&id, Some(seqs[3]), 2).await.unwrap();
+    assert_eq!(
+        before.iter().map(|event| event.seq).collect::<Vec<_>>(),
+        vec![seqs[2], seqs[1]],
+        "the cursor is exclusive and the limit is enforced"
+    );
+
+    assert!(
+        events
+            .read_before(&id, Some(seqs[0]), 2)
+            .await
+            .unwrap()
+            .is_empty(),
+        "nothing precedes the first event"
+    );
+    assert!(
+        events.read_before(&id, None, 0).await.unwrap().is_empty(),
+        "a zero limit never reads a page"
+    );
+}
+
 /// Asserts the [`EventLog`] retention contract (issue #275): the default
 /// policy is inert, permanent kinds survive any policy, sequences are never
 /// renumbered or reused, and a pruned log still reads and appends correctly.

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -7,13 +7,14 @@
 //! Those locks live in one process-wide registry (`path_lock`) rather than on
 //! each store, so two instances over one bundle actually meet (issue #388).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::ops::Range;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 
 use async_trait::async_trait;
 use futures::stream::BoxStream;
+use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::{Mutex as TokioMutex, broadcast};
 
 use crate::Result;
@@ -908,6 +909,45 @@ impl EventLog for FsEventLog {
             .filter(|ev| ev.seq >= seq)
             .take(limit)
             .collect())
+    }
+
+    async fn read_before(
+        &self,
+        id: &CompanyId,
+        before: Option<EventSeq>,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let path = self.bundle(id).events_jsonl();
+        let file = match tokio::fs::File::open(&path).await {
+            Ok(file) => file,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(error) => return Err(io_err(&path, error)),
+        };
+        let mut lines = BufReader::new(file).lines();
+        let mut tail = VecDeque::with_capacity(limit);
+        while let Some(line) = lines
+            .next_line()
+            .await
+            .map_err(|error| io_err(&path, error))?
+        {
+            if line.trim().is_empty() {
+                continue;
+            }
+            let event: StoredEvent = serde_json::from_str(&line)?;
+            // Event logs are ordered by sequence. Once the cursor is reached,
+            // no later line belongs to this page, so do not scan the tail.
+            if before.is_some_and(|cursor| event.seq >= cursor) {
+                break;
+            }
+            if tail.len() == limit {
+                tail.pop_front();
+            }
+            tail.push_back(event);
+        }
+        Ok(tail.into_iter().rev().collect())
     }
 
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent> {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -927,7 +927,9 @@ impl EventLog for FsEventLog {
             Err(error) => return Err(io_err(&path, error)),
         };
         let mut lines = BufReader::new(file).lines();
-        let mut tail = VecDeque::with_capacity(limit);
+        // `usize::MAX` means an unlimited read for the EventLog port. Do not
+        // treat that sentinel as an allocation request before streaming lines.
+        let mut tail = VecDeque::new();
         while let Some(line) = lines
             .next_line()
             .await
@@ -1788,6 +1790,13 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_monotonic_event_seq(Arc::new(FsEventLog::new(&root))).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_event_read_before() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_event_read_before(Arc::new(FsEventLog::new(&root))).await;
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -4056,6 +4056,13 @@ mod test {
     }
 
     #[tokio::test]
+    async fn conformance_event_read_before() {
+        let Some(s) = store().await else { return };
+        conformance::assert_event_read_before(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
     async fn conformance_event_retention() {
         let Some(s) = store().await else { return };
         conformance::assert_event_retention(s.clone()).await;

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -665,6 +665,39 @@ impl EventLog for MongoStore {
         Ok(out)
     }
 
+    async fn read_before(
+        &self,
+        id: &CompanyId,
+        before: Option<EventSeq>,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let events = self.collection("events");
+        let mut filter = doc! { "company_id": id.as_ref() };
+        if let Some(cursor) = before {
+            filter.insert("seq", doc! { "$lt": cursor.value() as i64 });
+        }
+        let mut find = events.find(filter).sort(doc! { "seq": -1 });
+        match find_limit(limit) {
+            FindLimit::Empty => return Ok(Vec::new()),
+            FindLimit::Unlimited => {}
+            FindLimit::AtMost(n) => find = find.limit(n),
+        }
+        let mut cursor = find.await.map_err(mongo_err)?;
+        let mut out = Vec::new();
+        while let Some(doc) = cursor.try_next().await.map_err(mongo_err)? {
+            out.push(StoredEvent {
+                seq: EventSeq::new(get_i64(&doc, "seq")? as u64),
+                company: id.clone(),
+                event: serde_json::from_str(&get_str(&doc, "event_json")?)?,
+                at_millis: get_i64(&doc, "at_ms")? as u64,
+            });
+        }
+        Ok(out)
+    }
+
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent> {
         let rx = self.sender_for(id).subscribe();
         let stream = futures::stream::unfold(rx, |mut rx| async move {

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -632,6 +632,57 @@ impl EventLog for SqliteStore {
         Ok(out)
     }
 
+    async fn read_before(
+        &self,
+        id: &CompanyId,
+        before: Option<EventSeq>,
+        limit: usize,
+    ) -> Result<Vec<StoredEvent>> {
+        if limit == 0 {
+            return Ok(Vec::new());
+        }
+        let conn = self.conn();
+        let (sql, cursor) = match before {
+            Some(cursor) => (
+                "SELECT seq, event_json, at_ms FROM events WHERE company_id = ?1 AND seq < ?2 ORDER BY seq DESC LIMIT ?3",
+                Some(cursor.value() as i64),
+            ),
+            None => (
+                "SELECT seq, event_json, at_ms FROM events WHERE company_id = ?1 ORDER BY seq DESC LIMIT ?2",
+                None,
+            ),
+        };
+        let mut stmt = conn.prepare(sql).map_err(sql_err)?;
+        let rows = match cursor {
+            Some(cursor) => stmt.query_map(params![id.as_ref(), cursor, sql_limit(limit)], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                ))
+            }),
+            None => stmt.query_map(params![id.as_ref(), sql_limit(limit)], |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, i64>(2)?,
+                ))
+            }),
+        }
+        .map_err(sql_err)?;
+        let mut out = Vec::new();
+        for row in rows {
+            let (seq, event_json, at_ms) = row.map_err(sql_err)?;
+            out.push(StoredEvent {
+                seq: EventSeq::new(seq as u64),
+                company: id.clone(),
+                event: serde_json::from_str(&event_json)?,
+                at_millis: at_ms as u64,
+            });
+        }
+        Ok(out)
+    }
+
     fn subscribe(&self, id: &CompanyId) -> BoxStream<'static, StoredEvent> {
         let rx = self.sender_for(id).subscribe();
         let stream = futures::stream::unfold(rx, |mut rx| async move {

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -653,32 +653,45 @@ impl EventLog for SqliteStore {
             ),
         };
         let mut stmt = conn.prepare(sql).map_err(sql_err)?;
-        let rows = match cursor {
-            Some(cursor) => stmt.query_map(params![id.as_ref(), cursor, sql_limit(limit)], |r| {
-                Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, String>(1)?,
-                    r.get::<_, i64>(2)?,
-                ))
-            }),
-            None => stmt.query_map(params![id.as_ref(), sql_limit(limit)], |r| {
-                Ok((
-                    r.get::<_, i64>(0)?,
-                    r.get::<_, String>(1)?,
-                    r.get::<_, i64>(2)?,
-                ))
-            }),
-        }
-        .map_err(sql_err)?;
         let mut out = Vec::new();
-        for row in rows {
-            let (seq, event_json, at_ms) = row.map_err(sql_err)?;
-            out.push(StoredEvent {
-                seq: EventSeq::new(seq as u64),
-                company: id.clone(),
-                event: serde_json::from_str(&event_json)?,
-                at_millis: at_ms as u64,
-            });
+        if let Some(cursor) = cursor {
+            let rows = stmt
+                .query_map(params![id.as_ref(), cursor, sql_limit(limit)], |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, i64>(2)?,
+                    ))
+                })
+                .map_err(sql_err)?;
+            for row in rows {
+                let (seq, event_json, at_ms) = row.map_err(sql_err)?;
+                out.push(StoredEvent {
+                    seq: EventSeq::new(seq as u64),
+                    company: id.clone(),
+                    event: serde_json::from_str(&event_json)?,
+                    at_millis: at_ms as u64,
+                });
+            }
+        } else {
+            let rows = stmt
+                .query_map(params![id.as_ref(), sql_limit(limit)], |r| {
+                    Ok((
+                        r.get::<_, i64>(0)?,
+                        r.get::<_, String>(1)?,
+                        r.get::<_, i64>(2)?,
+                    ))
+                })
+                .map_err(sql_err)?;
+            for row in rows {
+                let (seq, event_json, at_ms) = row.map_err(sql_err)?;
+                out.push(StoredEvent {
+                    seq: EventSeq::new(seq as u64),
+                    company: id.clone(),
+                    event: serde_json::from_str(&event_json)?,
+                    at_millis: at_ms as u64,
+                });
+            }
         }
         Ok(out)
     }
@@ -3172,6 +3185,11 @@ mod test {
     async fn conformance_monotonic_event_seq() {
         let s = store();
         conformance::assert_monotonic_event_seq(s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_event_read_before() {
+        conformance::assert_event_read_before(store()).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- make workflow-copilot replay failures visible in the panel instead of silently rendering a blank transcript
- add bounded `before`/`limit` REST history reads and cursor-aware client support
- page history backward across filesystem, SQLite, and MongoDB event stores while preserving reactions

## API Or Behavior Changes

`GET .../chat/history` now accepts an exclusive `before` event cursor and a capped `limit` parameter. Copilot history loading distinguishes an empty transcript from an unavailable one.

## Tests

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo build --all-targets`
- [x] `cargo test`

## Documentation

No standalone documentation change needed: the public client method and server query parameters are documented inline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added backward pagination for chat history with cursors and configurable page sizes.
  - Chat history pages are capped at 200 messages by default.
  - GraphQL chat history now provides accurate total message counts alongside paginated results.
  - History preserves message order, reactions, and viewer-specific labels.

- **Bug Fixes**
  - Copilot history loading now reports errors instead of silently showing an empty transcript.
  - Displays an alert when conversation history cannot be loaded.

- **Tests**
  - Added coverage for history-loading failures, pagination, cursors, limits, and total counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->