### PR TITLE
fix(console): paint the canvas for a run the console did not see start (#863)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -354,6 +354,12 @@ export function WorkflowsView({
   // consults it so a console WITH a working stream never double-paints a run it
   // already watched, and one without it still gets the journaled answer.
   const liveRanRef = useRef<Set<string>>(new Set());
+  // Issue #863: the run this canvas adopted from the history rather than from a
+  // start frame. Held so the trail STAYS on screen once that run settles — the
+  // history read that reports it finished is the same read that stops reporting
+  // it as in flight, and dropping the seed on that tick would blank a canvas the
+  // operator has been watching fill in.
+  const adoptedFromHistoryRef = useRef<string | null>(null);
 
   // ---- Issue #339: the canvas as a link target -----------------------------
   //
@@ -1010,9 +1016,37 @@ export function WorkflowsView({
   // land in one render, and an accumulating reducer would see only the last —
   // losing a `workflow_run_started` that way strands every node frame behind
   // it. Recomputing from the window instead has no such state to lose.
+  //
+  // Issue #863: seeded with the run the HOST says is open, for the case the
+  // window cannot cover. The window only holds what arrived since this console
+  // connected, so a run that was already walking when the tab was opened (a
+  // cron fire, a run started from chat, a reload, an `EventSource` reconnect)
+  // has no start frame here and used to paint nothing at all — the whole run,
+  // blank, which is what #863 reports. The history read already carries that
+  // run with `running: true` and the nodes it has finished so far.
+  const inFlightSeed = useMemo(() => {
+    if (!selectedId || runsFor !== selectedId) return null;
+    // Only a run this console has NOT been following: a run whose frames are in
+    // the window folds from them, which is both fresher and the path every
+    // existing guarantee is written against.
+    const row = runs.find(
+      (r) => r.runId && (r.running || r.runId === adoptedFromHistoryRef.current),
+    );
+    if (!row?.runId) return null;
+    if (liveRanRef.current.has(row.runId) && row.runId !== adoptedFromHistoryRef.current) {
+      return null;
+    }
+    return {
+      runId: row.runId,
+      states: statesFromRun(row),
+      elapsed: elapsedFromRun(row),
+      scheduled: row.scheduled,
+    };
+  }, [runs, runsFor, selectedId]);
+
   const liveRun = useMemo(
-    () => foldLiveRun(runEvents, selectedId, graph),
-    [runEvents, selectedId, graph],
+    () => foldLiveRun(runEvents, selectedId, graph, inFlightSeed),
+    [runEvents, selectedId, graph, inFlightSeed],
   );
 
   // The optimistic frontier is only for the gap before the first frame. Once
@@ -1021,8 +1055,13 @@ export function WorkflowsView({
   useEffect(() => {
     if (!liveRun) return;
     liveRanRef.current.add(liveRun.runId);
+    // Issue #863: remember an adoption that came from the history rather than
+    // from a start frame, so the seed survives the run settling.
+    if (inFlightSeed && inFlightSeed.runId === liveRun.runId) {
+      adoptedFromHistoryRef.current = liveRun.runId;
+    }
     setOptimistic(null);
-  }, [liveRun]);
+  }, [liveRun, inFlightSeed]);
 
   // Issue #528: adopt the live run's id while the synchronous POST is still in
   // flight.
@@ -1097,6 +1136,10 @@ export function WorkflowsView({
     setActiveRunId(null);
     setResult(null);
     setRunRefusal(null);
+    // Issue #863: the adopted run belonged to the workflow being left. Holding
+    // it across the switch would keep painting one graph's trail onto another's
+    // canvas the moment the two share a node id.
+    adoptedFromHistoryRef.current = null;
   }, [selectedId, company]);
 
   // Issue #339: `?run=<runId>` — open the canvas showing that past run.

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -37,6 +37,23 @@ export interface LiveRun {
   scheduled: boolean;
 }
 
+/** A run the host says is still in flight, read from the run history (issue
+ * #863) so the canvas can join a run it did not watch from the beginning.
+ *
+ * The frame window only holds what arrived since this console connected, so
+ * everything before that — a cron fire, a run started from chat, the run that
+ * was already walking when the tab was opened or the page reloaded, the frames
+ * lost while an `EventSource` reconnected — is invisible to it. The host
+ * journals the same trail durably and serves it on `…/workflows/runs` with
+ * `running: true`, which is what this carries in. */
+export interface InFlightRun {
+  runId: string;
+  /** The nodes the host has already recorded as finished for this run. */
+  states: Record<string, NodeRunState>;
+  elapsed: Record<string, number>;
+  scheduled: boolean;
+}
+
 /** Folds the run-progress frame window (issue #371) into the canvas state for
  * the workflow on screen.
  *
@@ -48,11 +65,20 @@ export interface LiveRun {
  * is matched on its run id. One SSE connection carries every run in the
  * company, so without that a cron fire would repaint a canvas an operator is
  * watching, and two concurrent runs of the same graph would interleave into one
- * incoherent picture. */
+ * incoherent picture.
+ *
+ * Issue #863: `inFlight` is the run the *host* says is open, and it is what
+ * this fold adopts when the window carries no start frame for the selected
+ * workflow. Without it a console that joined mid-run painted nothing at all —
+ * not a partial trail, nothing — for the whole run, because the fold's only
+ * way to learn a run's id was a `workflow_run_started` frame it had missed.
+ * The window still wins when it has a start of its own: a live start is newer
+ * than any history read, and a rerun must supersede the run before it. */
 export function foldLiveRun(
   events: CompanyStreamEvent[],
   selectedId: string | null,
   graph: WorkflowGraph | null,
+  inFlight?: InFlightRun | null,
 ): LiveRun | null {
   if (!selectedId || !graph) return null;
 
@@ -65,7 +91,7 @@ export function foldLiveRun(
       break;
     }
   }
-  if (startIndex === -1) return null;
+  if (startIndex === -1) return inFlight ? foldFromHistory(events, graph, inFlight) : null;
   const started = events[startIndex];
   if (started.type !== "workflow_run_started") return null;
 
@@ -76,9 +102,56 @@ export function foldLiveRun(
   // host from here (#382), not derived.
   const states = initialRunState(graph);
   const elapsed: Record<string, number> = {};
-  let active = true;
+  const active = applyFrames(events, startIndex + 1, runId, selectedId, states, elapsed);
 
-  for (let i = startIndex + 1; i < events.length; i++) {
+  settle(states, active);
+  return { runId, states, elapsed, active, scheduled };
+}
+
+/** The same fold, for a run this console did not see start (issue #863).
+ *
+ * Seeded from the host's own record of the run rather than from a start frame,
+ * then brought up to date with every frame in the window that belongs to it —
+ * so a console that joined mid-run shows the trail so far AND keeps painting as
+ * the rest of the graph walks.
+ *
+ * The whole window is scanned, not a suffix: there is no start frame to scan
+ * from, and every frame is matched on the run id anyway, so a frame belonging
+ * to some other run cannot be picked up wherever it sits. */
+function foldFromHistory(
+  events: CompanyStreamEvent[],
+  graph: WorkflowGraph,
+  inFlight: InFlightRun,
+): LiveRun {
+  const states = { ...initialRunState(graph), ...inFlight.states };
+  const elapsed = { ...inFlight.elapsed };
+  // `selectedId` is not passed on: a run id is the stronger match, and the
+  // host told us this run is the selected workflow's. A pre-#371 finish frame
+  // (no run id) is deliberately NOT honoured here — with no start frame to pair
+  // it with, "the run on screen" is a guess, and guessing a run settled would
+  // clear a live node on a console that is watching it correctly.
+  const active = applyFrames(events, 0, inFlight.runId, null, states, elapsed);
+
+  settle(states, active);
+  return { runId: inFlight.runId, states, elapsed, active, scheduled: inFlight.scheduled };
+}
+
+/** Applies every frame belonging to `runId` from `from` onward, and reports
+ * whether the run is still active afterwards.
+ *
+ * `selectedId` widens the settle check to a `workflow_run_finished` that
+ * carries no run id (a pre-#371 host); pass `null` where there is no start
+ * frame to pair such a frame with. */
+function applyFrames(
+  events: CompanyStreamEvent[],
+  from: number,
+  runId: string,
+  selectedId: string | null,
+  states: Record<string, NodeRunState>,
+  elapsed: Record<string, number>,
+): boolean {
+  let active = true;
+  for (let i = from; i < events.length; i++) {
     const e = events[i];
     // Issue #382: the engine now reports when a node BEGINS, so "running" is a
     // fact rather than the old topology-derived frontier guess. Light the node
@@ -100,24 +173,27 @@ export function foldLiveRun(
       elapsed[e.nodeId] = e.elapsedMs;
       continue;
     }
-    if (e.type === "workflow_run_finished" && e.workflowId === selectedId) {
+    if (e.type === "workflow_run_finished") {
       // A pre-#371 host sends no runId; treat that as "the run on screen"
       // rather than ignoring it, else the canvas would spin forever.
-      if (!e.runId || e.runId === runId) active = false;
+      if (e.runId === runId) active = false;
+      else if (!e.runId && selectedId !== null && e.workflowId === selectedId) active = false;
     }
   }
+  return active;
+}
 
-  if (!active) {
-    // Nothing is executing any more, so any node still marked "running" is an
-    // ORPHAN — a start whose finish never arrived because the run was cancelled
-    // or crashed on it. Clear those; the REPORTED ok/error marks stay, as the
-    // answer to "how far did it get?", until a reselect or a rerun.
-    for (const [id, state] of Object.entries(states)) {
-      if (state === "running") delete states[id];
-    }
+/** Clears the orphans a settled run leaves behind.
+ *
+ * Nothing is executing any more, so any node still marked "running" is an
+ * ORPHAN — a start whose finish never arrived because the run was cancelled or
+ * crashed on it. Clear those; the REPORTED ok/error marks stay, as the answer
+ * to "how far did it get?", until a reselect or a rerun. */
+function settle(states: Record<string, NodeRunState>, active: boolean): void {
+  if (active) return;
+  for (const [id, state] of Object.entries(states)) {
+    if (state === "running") delete states[id];
   }
-
-  return { runId, states, elapsed, active, scheduled };
 }
 
 /** A node's display name, falling back to its id when the graph is not loaded

--- a/frontend/test/e2e/mock-brain.mjs
+++ b/frontend/test/e2e/mock-brain.mjs
@@ -130,6 +130,36 @@ const MARKER = "__MOCK_LLM__";
 /** Prefix of the "call exactly this tool" directive, followed by a JSON object. */
 const TOOL_CALL_DIRECTIVE = "__MOCK_TOOL_CALL__";
 
+/**
+ * "Take this long to answer", followed by milliseconds — e.g.
+ * `__MOCK_SLOW_MS__ 1500` (issue #863).
+ *
+ * Every other reply here is immediate, which is the right default and also why
+ * a whole class of behaviour was untestable: a workflow whose nodes each answer
+ * in a millisecond finishes before a spec can observe the run in flight at all.
+ * A spec that needs to watch a run WHILE it walks the graph — the live canvas —
+ * puts this in the run request, and the agent nodes downstream inherit it.
+ *
+ * Read off the message text rather than an environment variable on purpose: the
+ * mock brain is started once for the whole suite by `playwright.config.ts`, so
+ * an env knob would be a property of the lane and not of the spec that needs it.
+ */
+const SLOW_DIRECTIVE = "__MOCK_SLOW_MS__";
+
+/** Milliseconds the reply should be held back, read off the directive above. */
+function slowMillis(messages) {
+  for (const message of messages) {
+    const content = typeof message?.content === "string" ? message.content : "";
+    const at = content.indexOf(SLOW_DIRECTIVE);
+    if (at === -1) continue;
+    const ms = Number.parseInt(content.slice(at + SLOW_DIRECTIVE.length).trim(), 10);
+    // A cap, because this runs inside a suite with real timeouts: a typo'd
+    // directive must slow one reply down, never wedge the lane.
+    if (Number.isFinite(ms) && ms > 0) return Math.min(ms, 10_000);
+  }
+  return 0;
+}
+
 /** The cue that makes the orchestrator open exactly one board card. */
 const SPAWN_DIRECTIVE = "SPAWNONE";
 
@@ -634,6 +664,13 @@ const server = createServer((request, response) => {
         return;
       }
       if (path.endsWith("/chat/completions")) {
+        // Issue #863: hold the reply back when the prompt asks for it, so a
+        // spec can watch a workflow run while it is still walking the graph.
+        const held = slowMillis(Array.isArray(body?.messages) ? body.messages : []);
+        if (held > 0) {
+          setTimeout(() => sendJson(response, 200, chatCompletion(body)), held);
+          return;
+        }
         sendJson(response, 200, chatCompletion(body));
       } else if (path.endsWith("/embeddings")) {
         sendJson(response, 200, embeddings(body));

--- a/frontend/test/e2e/workflow-canvas-live.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-live.spec.ts
@@ -1,0 +1,184 @@
+import { expect, test, type APIRequestContext, type Page } from "@playwright/test";
+
+import { LIVE_BRAIN, LIVE_BRAIN_REASON } from "./capabilities";
+
+/**
+ * Issue #863: the canvas paints per-node state WHILE a run walks the graph.
+ *
+ * Two halves, and the second is the one that was broken. A console watching
+ * from the start folds the run out of the `workflow_run_started` /
+ * `workflow_node_started` / `workflow_node_finished` frames it saw (#371,
+ * #382). A console that joined LATE has none of them — the frame window only
+ * holds what arrived after it connected — and used to paint nothing at all for
+ * the entire run: not a partial trail, nothing, until the run settled and the
+ * operator went looking in the history. That is every cron fire, every run
+ * started from another surface, every reload mid-run, and every `EventSource`
+ * reconnect.
+ *
+ * Both cases need a run slow enough to be observed in flight, which is what the
+ * mock brain's `__MOCK_SLOW_MS__` directive is for: each agent node carries it
+ * in its summary, so every node takes a beat instead of a millisecond.
+ */
+
+const COMPANY_SCOPE = "/api/v1/company";
+
+/** Each agent node holds this long, so a run of N of them takes N × this. */
+const NODE_MS = 1_200;
+
+test.describe("workflow canvas during a live run", () => {
+  // Agent nodes have to actually execute for the host to bracket them with
+  // per-node frames, which is the whole subject here.
+  test.skip(!LIVE_BRAIN, LIVE_BRAIN_REASON);
+
+  /** Dismisses the first-run tour if it is up; its overlay swallows clicks. */
+  async function dismissTour(page: Page) {
+    const skip = page.getByRole("button", { name: "Skip for now" });
+    try {
+      await skip.waitFor({ state: "visible", timeout: 10_000 });
+    } catch {
+      return;
+    }
+    await skip.click();
+  }
+
+  /** A chain of agent nodes: `start → n0 → … → done`. */
+  function chain(id: string, name: string, steps: number) {
+    return {
+      id,
+      name,
+      description: "Created by the #863 live-canvas spec.",
+      nodes: [
+        { id: "start", kind: "trigger", name: "Start" },
+        ...Array.from({ length: steps }, (_, i) => ({
+          id: `n${i}`,
+          kind: "agent",
+          name: `Step ${i}`,
+          agent: "writer",
+          // The directive rides the NODE, not the run request: the request text
+          // is not what an agent node prompts with, so a directive placed there
+          // never reaches the brain and every node answers in a millisecond.
+          summary: `__MOCK_SLOW_MS__ ${NODE_MS} draft a line`,
+        })),
+        { id: "done", kind: "output", name: "Done" },
+      ],
+      edges: [
+        { from: "start", to: "n0" },
+        ...Array.from({ length: steps - 1 }, (_, i) => ({ from: `n${i}`, to: `n${i + 1}` })),
+        { from: `n${steps - 1}`, to: "done" },
+      ],
+    };
+  }
+
+  async function createWorkflow(request: APIRequestContext, id: string, steps: number) {
+    const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
+      data: chain(id, `Live canvas ${id}`, steps),
+    });
+    expect(res.ok(), `create ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+  }
+
+  /** The per-node run marks the canvas is painting right now. */
+  async function painted(page: Page): Promise<Record<string, string>> {
+    return page.evaluate(() =>
+      Object.fromEntries(
+        Array.from(document.querySelectorAll("[data-run-state]")).map((el) => [
+          el.querySelector(".truncate")?.textContent?.trim() ?? "?",
+          el.getAttribute("data-run-state") ?? "",
+        ]),
+      ),
+    );
+  }
+
+  /** Polls the canvas until `predicate` holds, or gives up with what it saw. */
+  async function until(
+    page: Page,
+    predicate: (marks: Record<string, string>) => boolean,
+    timeoutMs = 30_000,
+  ): Promise<Record<string, string>> {
+    const deadline = Date.now() + timeoutMs;
+    let last: Record<string, string> = {};
+    while (Date.now() < deadline) {
+      last = await painted(page);
+      if (predicate(last)) return last;
+      await page.waitForTimeout(200);
+    }
+    return last;
+  }
+
+  test("a console watching from the start sees each node light up (#863)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const id = `e2e-863-watching-${Date.now()}`;
+    await createWorkflow(request, id, 3);
+
+    try {
+      await page.goto(`/#/workflows/${id}`);
+      await dismissTour(page);
+      await expect(page.getByRole("combobox").first()).toContainText(`Live canvas ${id}`, {
+        timeout: 30_000,
+      });
+
+      // Start the run from the host side so the click cannot be what paints:
+      // the frames are, which is the claim.
+      void request.post(`${COMPANY_SCOPE}/workflows/${id}/run`, {
+        data: { request: "draft something" },
+        timeout: 120_000,
+      });
+
+      // Mid-run, not after: a node marked while others are still unmarked is
+      // exactly the trail the issue says is missing.
+      const marks = await until(page, (m) => Object.values(m).some((s) => s === "running"));
+      expect(
+        Object.values(marks).some((s) => s === "running"),
+        `expected a node to be marked running mid-run; canvas showed ${JSON.stringify(marks)}`,
+      ).toBeTruthy();
+
+      const settled = await until(page, (m) => m["Done"] === "ok", 60_000);
+      expect(settled["Step 0"], JSON.stringify(settled)).toBe("ok");
+    } finally {
+      await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+    }
+  });
+
+  test("a console that opens mid-run still paints the trail so far (#863)", async ({
+    page,
+    request,
+  }) => {
+    test.setTimeout(120_000);
+    const id = `e2e-863-late-${Date.now()}`;
+    await createWorkflow(request, id, 4);
+
+    try {
+      // The run starts with NO console attached: this is the cron fire, the run
+      // launched from chat, the reload, the reconnect.
+      const run = request.post(`${COMPANY_SCOPE}/workflows/${id}/run`, {
+        data: { request: "draft something" },
+        timeout: 120_000,
+      });
+
+      // Join once the run is a couple of nodes in.
+      await page.waitForTimeout(NODE_MS * 2);
+      await page.goto(`/#/workflows/${id}`);
+      await dismissTour(page);
+
+      const marks = await until(
+        page,
+        (m) => Object.values(m).some((s) => s === "ok" || s === "running"),
+        30_000,
+      );
+      expect(
+        Object.values(marks).some((s) => s === "ok" || s === "running"),
+        `a console joining mid-run painted nothing; canvas showed ${JSON.stringify(marks)}`,
+      ).toBeTruthy();
+
+      // And it keeps painting from the frames that arrive after it joined,
+      // through to the end of the run.
+      const settled = await until(page, (m) => m["Done"] === "ok", 60_000);
+      expect(settled["Done"], JSON.stringify(settled)).toBe("ok");
+      await run;
+    } finally {
+      await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
+    }
+  });
+});

--- a/frontend/test/e2e/workflow-canvas-live.spec.ts
+++ b/frontend/test/e2e/workflow-canvas-live.spec.ts
@@ -69,6 +69,24 @@ test.describe("workflow canvas during a live run", () => {
     };
   }
 
+  /** Starts a run and keeps its result, so a POST that fails says so.
+   *
+   * The specs here watch the canvas WHILE the run is open, so the promise
+   * cannot be awaited at the call site. Dropping it instead would turn a failed
+   * run into an unhandled rejection and leave the polling below reporting an
+   * empty canvas — a symptom of the failure rather than the failure. Await the
+   * returned promise once the canvas assertions are done. */
+  function startRun(request: APIRequestContext, id: string): Promise<void> {
+    return request
+      .post(`${COMPANY_SCOPE}/workflows/${id}/run`, {
+        data: { request: "draft something" },
+        timeout: 120_000,
+      })
+      .then(async (res) => {
+        expect(res.ok(), `run ${id}: ${res.status()} ${await res.text()}`).toBeTruthy();
+      });
+  }
+
   async function createWorkflow(request: APIRequestContext, id: string, steps: number) {
     const res = await request.post(`${COMPANY_SCOPE}/workflows`, {
       data: chain(id, `Live canvas ${id}`, steps),
@@ -121,10 +139,13 @@ test.describe("workflow canvas during a live run", () => {
 
       // Start the run from the host side so the click cannot be what paints:
       // the frames are, which is the claim.
-      void request.post(`${COMPANY_SCOPE}/workflows/${id}/run`, {
-        data: { request: "draft something" },
-        timeout: 120_000,
-      });
+      //
+      // NOT awaited here on purpose — the assertions below are about the canvas
+      // WHILE the run is open, and awaiting it first would leave nothing to
+      // watch. Its failure is kept rather than dropped: an unhandled rejection
+      // would otherwise strand the polling below on a run that never began, and
+      // report the empty canvas instead of the reason for it.
+      const run = startRun(request, id);
 
       // Mid-run, not after: a node marked while others are still unmarked is
       // exactly the trail the issue says is missing.
@@ -136,6 +157,7 @@ test.describe("workflow canvas during a live run", () => {
 
       const settled = await until(page, (m) => m["Done"] === "ok", 60_000);
       expect(settled["Step 0"], JSON.stringify(settled)).toBe("ok");
+      await run;
     } finally {
       await request.delete(`${COMPANY_SCOPE}/workflows/${id}`).catch(() => undefined);
     }
@@ -147,30 +169,34 @@ test.describe("workflow canvas during a live run", () => {
   }) => {
     test.setTimeout(120_000);
     const id = `e2e-863-late-${Date.now()}`;
-    await createWorkflow(request, id, 4);
+    // Six steps, so the run is still walking well after the console has loaded
+    // and there is a node that has NOT finished to contrast the trail against.
+    await createWorkflow(request, id, 6);
 
     try {
       // The run starts with NO console attached: this is the cron fire, the run
       // launched from chat, the reload, the reconnect.
-      const run = request.post(`${COMPANY_SCOPE}/workflows/${id}/run`, {
-        data: { request: "draft something" },
-        timeout: 120_000,
-      });
+      const run = startRun(request, id);
 
       // Join once the run is a couple of nodes in.
       await page.waitForTimeout(NODE_MS * 2);
       await page.goto(`/#/workflows/${id}`);
       await dismissTour(page);
 
-      const marks = await until(
-        page,
-        (m) => Object.values(m).some((s) => s === "ok" || s === "running"),
-        30_000,
-      );
+      // `Step 0` finished BEFORE this console existed, so no frame it will ever
+      // receive can mark it: the only way it can be painted is the adopted
+      // history. Pinned against a later node that has not finished yet, because
+      // asserting merely that *something* is painted would pass on the trigger
+      // alone — which `initialRunState` marks from the graph, seed or no seed.
+      const marks = await until(page, (m) => m["Step 0"] === "ok" && !m["Step 5"], 30_000);
       expect(
-        Object.values(marks).some((s) => s === "ok" || s === "running"),
-        `a console joining mid-run painted nothing; canvas showed ${JSON.stringify(marks)}`,
-      ).toBeTruthy();
+        marks,
+        `expected the pre-join trail to be painted; canvas showed ${JSON.stringify(marks)}`,
+      ).toMatchObject({ "Step 0": "ok" });
+      expect(
+        marks["Step 5"],
+        `Step 5 should not have finished this early; canvas showed ${JSON.stringify(marks)}`,
+      ).toBeUndefined();
 
       // And it keeps painting from the frames that arrive after it joined,
       // through to the end of the run.

--- a/frontend/test/unit/workflow-live-run.test.ts
+++ b/frontend/test/unit/workflow-live-run.test.ts
@@ -156,6 +156,91 @@ describe("foldLiveRun reports running from node-started frames", () => {
   });
 });
 
+/**
+ * Issue #863: a console that did not see the run start.
+ *
+ * The frame window only holds what arrived since this console connected, so a
+ * run already walking when the tab was opened — a cron fire, a run started from
+ * chat, a reload, an `EventSource` reconnect — has no `workflow_run_started` in
+ * it. The fold used to return `null` there, which painted NOTHING for the whole
+ * run: not a partial trail, nothing. The host serves that run on
+ * `…/workflows/runs` with `running: true` and the nodes it has finished, and
+ * that read is what the fold now adopts.
+ */
+describe("foldLiveRun joins a run it did not see start", () => {
+  const seed = (runId: string, states: Record<string, "ok" | "error" | "running">) => ({
+    runId,
+    states,
+    elapsed: { ceo: 12 },
+    scheduled: false,
+  });
+
+  it("paints nothing without a seed — the regression #863 reports", () => {
+    // No start frame in the window: every later frame is stranded behind the
+    // one thing the fold used to need.
+    expect(foldLiveRun([nodeStarted("r1", "ceo")], "greet", GRAPH)).toBeNull();
+  });
+
+  it("adopts the host's in-flight run and keeps its recorded trail", () => {
+    const live = foldLiveRun([], "greet", GRAPH, seed("r1", { ceo: "ok" }));
+    expect(live?.runId).toBe("r1");
+    expect(live?.active).toBe(true);
+    expect(live?.states.ceo).toBe("ok");
+    expect(live?.elapsed.ceo).toBe(12);
+    // Still seeded from the graph, so the trigger reads as fired.
+    expect(live?.states.start).toBe("ok");
+  });
+
+  it("keeps painting from the frames that arrive after it joins", () => {
+    const live = foldLiveRun(
+      [nodeStarted("r1", "done"), nodeFinished("r1", "done", "ok")],
+      "greet",
+      GRAPH,
+      seed("r1", { ceo: "ok" }),
+    );
+    expect(live?.states).toMatchObject({ start: "ok", ceo: "ok", done: "ok" });
+  });
+
+  it("settles when the run it adopted finishes", () => {
+    const live = foldLiveRun(
+      [nodeStarted("r1", "done"), finished("r1")],
+      "greet",
+      GRAPH,
+      seed("r1", { ceo: "ok" }),
+    );
+    expect(live?.active).toBe(false);
+    // The orphan sweep applies to an adopted run exactly as it does to a
+    // watched one: `done` started and never finished.
+    expect(live?.states.done).toBeUndefined();
+    expect(live?.states.ceo).toBe("ok");
+  });
+
+  it("ignores frames belonging to another run while it is adopted", () => {
+    const live = foldLiveRun(
+      [nodeStarted("r2", "done"), finished("r2")],
+      "greet",
+      GRAPH,
+      seed("r1", { ceo: "ok" }),
+    );
+    expect(live?.active).toBe(true);
+    expect(live?.states.done).toBeUndefined();
+  });
+
+  it("a live start frame outranks the seed — a rerun supersedes the run before", () => {
+    const live = foldLiveRun(
+      [start("r2"), nodeStarted("r2", "ceo")],
+      "greet",
+      GRAPH,
+      seed("r1", { ceo: "ok", done: "ok" }),
+    );
+    expect(live?.runId).toBe("r2");
+    // The older run's finished nodes are gone: this is a different run, and
+    // carrying its predecessor's marks over would be a lie about this one.
+    expect(live?.states.done).toBeUndefined();
+    expect(live?.states.ceo).toBe("running");
+  });
+});
+
 describe("workflow_node_started routing", () => {
   function subscribers() {
     return {


### PR DESCRIPTION
## Summary

The Workflows canvas painted nothing while a run walked the graph — but only for a console that was not already connected when the run started. That turned out to be the whole bug, and it is a much bigger set of cases than it sounds: every cron fire, every run started from chat or another surface, every reload mid-run, and every `EventSource` reconnect.

The canvas folds its live state out of the SSE frame window, and the fold's only way to learn which run it is watching was a `workflow_run_started` frame. That window holds nothing from before this console connected, so a console joining late had no start frame, the fold returned null, and the canvas painted **nothing at all** for the entire run — not a partial trail, nothing — until the operator went looking in the run history afterwards.

The host has known all along. `…/workflows/runs` already serves the open run with `running: true` and the nodes it has finished so far. This teaches the fold to adopt that run when the window has no start frame of its own, and then keep folding every frame that arrives after it joined.

## What was verified first, and what the evidence showed

The issue said the root cause was unconfirmed and listed candidates. It was diagnosed before anything was changed, by instrumenting a real host: a timestamped log of every `workflow_*` SSE frame alongside a 100ms sample of the canvas's per-node marks, on one clock.

- **A console watching from the start already works.** Frames arrive spread across the run and the canvas paints in step with them — a node showed `running` 57ms after the run began, while later nodes were still unmarked. So the host emission path (#371/#382), the SSE projection, the event routing and the fold are all correct as they stand. None of the issue's candidate causes held up.
- **A console that joins mid-run painted nothing.** With a run of six agent nodes taking ~2s each, twenty seconds of sampling produced exactly one distinct canvas state: empty. Nothing painted during the run, and nothing after it finished either.

That second case is what this PR fixes. The first is now pinned by a test so it cannot quietly regress.

## API Or Behavior Changes

No API changes — this reads a field the run-history route already returns.

Behavior:

- A console that opens, reloads, or reconnects while a run is in flight now shows that run's per-node trail and keeps painting as the rest of the graph walks.
- The adopted trail stays on screen when the run settles, instead of vanishing on the history refresh that reports it finished.
- Unchanged by design: a live `workflow_run_started` still outranks the seed (a rerun supersedes the run before it); every frame is still matched on run id, so a concurrent run cannot bleed onto a canvas being watched; a node status that is not exactly `ok` is still an error; the orphan sweep still clears `running` marks on a settled run; an explicitly overlaid past run still wins over the live fold; the adoption is cleared on a workflow or company switch.

## Tests

Run locally from `frontend/`:

- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — all clean
- `npm run test` — 58 files, 700 tests, all passing
- `npm run build` — clean
- `npx playwright test` (default lane) — 139 passed, 14 skipped, 1 failed: `mcp.spec.ts:47`, which fails identically with every change in this branch stashed (it is an artifact of running a feature-built host in the default lane, not this work)
- `PW_LIVE_BRAIN=1 npx playwright test workflow-canvas-live.spec.ts` — 2 passed

Both new layers were verified **red before green**:

- the six new fold cases: 4 of them fail against the pre-fix fold;
- the new e2e "console opens mid-run": fails on the pre-fix console with `a console joining mid-run painted nothing; canvas showed {}`, and its sibling "watching from the start" passes both before and after — which is the honest split, since that half was never broken.

The e2e needed a run slow enough to be observed in flight, so the mock brain gained a `__MOCK_SLOW_MS__ <ms>` prompt directive (capped, opt-in per prompt, no effect on any existing spec). It rides each agent node's summary rather than the run request — the run request text is not what an agent node prompts with, which is worth knowing for the next spec that needs a slow run.

Manual verification was done through the instrumented probes described above, on a locally built host with `--features openhuman,tinycortex,mcp`, rather than by eye — the timeline they print is a stronger record than a screenshot.

- [x] N/A: `cargo fmt --all -- --check` — no Rust changes in this PR
- [x] N/A: `cargo clippy --all-targets -- -D warnings` — no Rust changes in this PR
- [x] N/A: `cargo build --all-targets` — no Rust changes in this PR
- [x] N/A: `cargo test` — no Rust changes in this PR

## Documentation

No docs change: no route, feature or operator-facing concept changed. The reasoning lives beside the code — why the seed exists, why a live start frame outranks it, and why the adopted run survives settling — in `workflows/graph.ts` and `WorkflowsView.tsx`.

Closes #863
