### PR TITLE
fix(store): set deliverable on the conformance history event

### DIFF
--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -479,6 +479,7 @@ pub async fn assert_event_read_before(events: Arc<dyn EventLog>) {
                         text: text.to_string(),
                         by: None,
                         chat: None,
+                        deliverable: None,
                     },
                 )
                 .await


### PR DESCRIPTION
## Summary

`main` has not compiled since #870 merged. One missing field:

```
error[E0063]: missing field `deliverable` in initializer of `ports::types::CompanyEvent`
   --> src/store/conformance.rs:477:21
```

This adds it. One line, no behaviour change — `None` is what every other construction site in that helper passes.

## Problem

A union break, not a mistake in either pull request:

- At #870's merge base (`7009e829`), `CompanyEvent::OperatorMessage` had **no** `deliverable` field and `src/store/conformance.rs` had **seven** construction sites.
- #859 added the field and updated all seven.
- #870 branched before that and added an **eighth** site — correct against its own base.

The two touch different lines, so there is no textual conflict. GitHub reported `MERGEABLE`, both were green individually, and the merge is red.

Every Rust lane is affected, so this blocks every open pull request in the repository, not just the one that surfaced it (#856).

## Solution

Set `deliverable: None` on the eighth site.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`
- [x] `cargo test --locked` — 2401 passed, 0 failed
- [x] `cargo test --locked --features sqlite --lib store::sqlite` — 38 passed
- [x] `cargo build --locked --bin opencompany`
- [x] `cargo build --locked --features openhuman,tinycortex --all-targets`

Verified in a tree containing this fix on top of current `main`; the gated clippy and mongodb lanes were still running when this was opened and are covered by CI here.

## Impact

Unblocks CI for the whole repository. No runtime behaviour changes — the only edit is inside a test-support helper.

## Related

Surfaced while fixing #856, whose lanes failed earlier at `cargo metadata --locked` and so never reached this error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated operator message event handling to correctly represent messages without a deliverable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->