### PR TITLE
fix(companies): grant search to the software company and make the posture a partition (#878)

### DIFF
--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -8,13 +8,24 @@ output = "An entire SaaS product"
 human_role = "Product direction"
 
 [tools]
-# Full tool belt. `*` covers files/docs/shell/code/web/subagent; `media` and
-# `composio` are listed literally because `*` deliberately excludes those two
-# (real-money + per-tenant-credential) namespaces. media/composio/mcp also
-# require their Cargo features compiled into the tenant image, and each is
-# fail-closed at runtime until its credential/config is present (Composio
-# bearer, media backend, per-server MCP config).
-allow = ["*", "media", "composio"]
+# Full tool belt plus the metered `web_search` (#238, granted here in #878):
+# this company's agents are asked to research prior art, APIs, competitors and
+# CVEs, and nothing in the `web` namespace can *find* a URL — `web_fetch` /
+# `http_request` only read one the agent already has.
+#
+# Every entry below is load-bearing. `allow` REPLACES the default
+# (`["*", "media", "composio"]`); it never extends it. `*` covers
+# files/docs/shell/code/web/subagent but deliberately excludes the opt-in
+# namespaces, so `media`, `composio` and `search` are each listed literally.
+# media/composio/mcp also require their Cargo features compiled into the tenant
+# image, and each is fail-closed at runtime until its credential/config is
+# present (Composio bearer, media backend, per-server MCP config). Reducing this
+# line to `["search"]` would silently strip the whole belt from every agent in
+# the company.
+#
+# Search spend is bounded by `[tools].search_daily_calls` (200/day by default);
+# setting it to `0` pauses search without editing this list.
+allow = ["*", "media", "composio", "search"]
 
 # There is deliberately no `[tools.composio].toolkits` here. Absent means "open
 # mode": defer to the backend's own server-enforced allowlist, which is every

--- a/src/company/content_test.rs
+++ b/src/company/content_test.rs
@@ -90,15 +90,23 @@ fn every_company_skill_and_workspace_parses() {
     }
 }
 
-/// Templates whose shipped skills (`web-research`, `seo-audit`,
-/// `competitor-scan`) instruct agents to search the web and cite sources, so
-/// each must carry an explicit `search` grant (issue #312).
-const SEARCH_GRANTED_COMPANIES: [&str; 6] = [
+/// Templates that must carry an explicit `search` grant (issues #312, #878).
+///
+/// The reason is the work the roster is described as doing, not anything on
+/// disk under the company: the search-dependent skills (`web-research`,
+/// `seo-audit`, `competitor-scan`) live in the *repo-level* `skills/` registry,
+/// which is global and unscoped, so an operator can install any of them into
+/// any company at runtime. No company ships a copy in its own `skills/` dir.
+/// Whether a template belongs here is therefore a judgement about its charter —
+/// research, editorial, marketing, legal, product engineering — recorded here
+/// because it cannot be derived from content.
+const SEARCH_GRANTED_COMPANIES: [&str; 7] = [
     "agentic_consultation_firm",
     "agentic_design_studio",
     "agentic_law_firm",
     "agentic_marketing_agency",
     "agentic_media_company",
+    "agentic_software_company",
     "signals_opportunity_studio",
 ];
 
@@ -107,15 +115,43 @@ const SEARCH_GRANTED_COMPANIES: [&str; 6] = [
 /// flaky), and `openhuman_demo` is a walkthrough nobody opted into spend for.
 const SEARCH_DENIED_COMPANIES: [&str; 2] = ["e2e_harness", "openhuman_demo"];
 
+/// Templates that simply do not grant `search` today. Unlike
+/// [`SEARCH_DENIED_COMPANIES`] there is no rule keeping them off the priced
+/// path — nobody has decided their roster needs the web. Moving one into
+/// [`SEARCH_GRANTED_COMPANIES`] is an ordinary product call, not a violation.
+///
+/// This list exists so the posture is a *partition* rather than an allow-list.
+/// An allow-list asserts a decision someone remembered, so it cannot notice a
+/// company nobody remembered: `agentic_software_company` shipped with nine
+/// agents and no search grant, and the suite stayed green for it (issue #878).
+/// [`every_company_declares_a_search_posture`] asserts this list plus the other
+/// two covers `companies/` exactly, so a new template fails CI until whoever
+/// adds it writes the decision down here.
+const SEARCH_UNGRANTED_COMPANIES: [&str; 12] = [
+    "agentic_accounting_firm",
+    "agentic_customer_support",
+    "agentic_enterprise_sales",
+    "agentic_game_business",
+    "agentic_game_studio",
+    "agentic_influencer_business",
+    "agentic_pharma_startup",
+    "agentic_realestate_company",
+    "agentic_recruiting_company",
+    "agentic_venture_capital",
+    "agentic_venture_studio",
+    "startup_accelerator",
+];
+
 /// The subset of [`SEARCH_GRANTED_COMPANIES`] that restates the default belt
 /// verbatim and appends `search`. `signals_opportunity_studio` is deliberately
 /// excluded: it overrides the default down to a research-only belt on purpose.
-const FULL_BELT_PLUS_SEARCH: [&str; 5] = [
+const FULL_BELT_PLUS_SEARCH: [&str; 6] = [
     "agentic_consultation_firm",
     "agentic_design_studio",
     "agentic_law_firm",
     "agentic_marketing_agency",
     "agentic_media_company",
+    "agentic_software_company",
 ];
 
 fn load_company(name: &str) -> CompanyManifest {
@@ -180,6 +216,115 @@ fn fixture_templates_never_grant_search() {
             !grants_search_explicit(&grants),
             "{name}: must not grant `search` — a priced network call here \
              makes the fixture non-hermetic (found {grants:?})"
+        );
+    }
+}
+
+/// Every shipped company must appear in exactly one of the three search-posture
+/// lists, and the three together must cover `companies/` exactly (issue #878).
+///
+/// The guard #312 left behind was allow-list shaped: it checked that the six
+/// companies someone listed do grant `search`, and said nothing about the
+/// fifteen it did not list. `agentic_software_company` therefore shipped nine
+/// agents whose `web_search` was never wired, with a green suite. An allow-list
+/// can only ever assert a decision somebody remembered.
+///
+/// A partition inverts that. Adding a template to `companies/` fails this test
+/// as unclassified until its author states the posture; deleting one fails it as
+/// stale. And the classification cannot be made true by editing the list alone:
+/// every `SEARCH_UNGRANTED_COMPANIES` entry is re-derived from its manifest
+/// through the real `effective_grants` narrowing, so a company that actually
+/// grants search cannot hide in the ungranted bucket.
+#[test]
+fn every_company_declares_a_search_posture() {
+    use std::collections::BTreeSet;
+
+    let buckets: [(&str, &[&str]); 3] = [
+        ("SEARCH_GRANTED_COMPANIES", &SEARCH_GRANTED_COMPANIES),
+        ("SEARCH_DENIED_COMPANIES", &SEARCH_DENIED_COMPANIES),
+        ("SEARCH_UNGRANTED_COMPANIES", &SEARCH_UNGRANTED_COMPANIES),
+    ];
+
+    // (a) Each list is duplicate-free, and no company sits in two of them —
+    // otherwise "exactly one posture" degrades to "at least one".
+    for (name, list) in buckets {
+        let unique: BTreeSet<&str> = list.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            list.len(),
+            "{name} lists a company twice: {list:?}"
+        );
+    }
+    for (index, (left_name, left)) in buckets.iter().enumerate() {
+        for (right_name, right) in &buckets[index + 1..] {
+            let left_set: BTreeSet<&str> = left.iter().copied().collect();
+            let overlap: Vec<&str> = right
+                .iter()
+                .copied()
+                .filter(|name| left_set.contains(name))
+                .collect();
+            assert!(
+                overlap.is_empty(),
+                "{left_name} and {right_name} both claim {overlap:?} — a \
+                 company has exactly one search posture"
+            );
+        }
+    }
+
+    // (b) The union is exactly what is on disk.
+    let declared: BTreeSet<&str> = buckets
+        .iter()
+        .flat_map(|(_, list)| list.iter().copied())
+        .collect();
+    let on_disk: BTreeSet<String> = subdirs(&repo_root().join("companies"))
+        .iter()
+        .map(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or_else(|| panic!("non-UTF-8 company dir {}", path.display()))
+                .to_string()
+        })
+        .collect();
+    assert!(!on_disk.is_empty(), "no companies found under companies/");
+
+    let unclassified: Vec<&str> = on_disk
+        .iter()
+        .map(String::as_str)
+        .filter(|name| !declared.contains(name))
+        .collect();
+    assert!(
+        unclassified.is_empty(),
+        "companies/{unclassified:?} declare no search posture. Every template \
+         must be listed in exactly one of SEARCH_GRANTED_COMPANIES (its roster \
+         needs the web), SEARCH_DENIED_COMPANIES (it must never reach the \
+         priced backend) or SEARCH_UNGRANTED_COMPANIES (no decision to grant \
+         it yet). Grants are not inherited from `*` — a company left out of the \
+         granted list has `web_search` wired for none of its agents (#878)."
+    );
+
+    let stale: Vec<&str> = declared
+        .iter()
+        .copied()
+        .filter(|name| !on_disk.contains(*name))
+        .collect();
+    assert!(
+        stale.is_empty(),
+        "{stale:?} are listed in a search-posture const but no longer exist \
+         under companies/ — delete the entries"
+    );
+
+    // (c) The ungranted bucket is verified against the manifests, not taken on
+    // trust: a company that does grant search cannot be parked here.
+    for name in SEARCH_UNGRANTED_COMPANIES {
+        let manifest = load_company(name);
+        let grants = effective_grants(&manifest);
+        assert!(
+            !grants_search_explicit(&grants),
+            "{name}: sits in SEARCH_UNGRANTED_COMPANIES but its effective \
+             grants ({grants:?}) do include `search`. If the grant is \
+             intentional, move it to SEARCH_GRANTED_COMPANIES so \
+             `research_templates_grant_search_at_both_layers` checks every \
+             agent actually receives it."
         );
     }
 }


### PR DESCRIPTION
## Summary

`agentic_software_company` allowed `["*", "media", "composio"]`, and `grants_search_explicit` deliberately does not let a bare `*` confer `search` — each call is a priced managed request, so it is opt-in like `media` and `composio`. The gate in `build.rs` therefore never fired and `web_search` was wired for none of the company's 9 agents. Verified on a hosted tenant: `searchGranted:false` while `searchCredentialConfigured:true` — the credential was there, the grant was not.

The manifest line is the small half. The real defect is that `content_test.rs` already guarded this invariant through a hand-written `SEARCH_GRANTED_COMPANIES: [&str; 6]` — an array that asserts a decision someone remembered, so it cannot notice a company nobody remembered. #312 added the guard and its six companies in one change, which is how the suite stayed green while an uncovered company was broken.

So this appends `"search"` and converts the allowlist into an exhaustive partition: every company dir must land in granted, denied, or ungranted, the union is asserted equal to what is on disk, and every ungranted entry is re-derived through the real `effective_grants` narrowing. Adding a company now fails CI until someone classifies it.

Closes #878.

## API Or Behavior Changes

- All 9 agents in `agentic_software_company` gain `web_search`. `GET …/capabilities` reports `searchGranted:true`; `GET …/workflows/tool-slugs` now offers `web_search` in the builder palette.
- Spend: metered and non-parking, bounded by the inherited `DEFAULT_SEARCH_DAILY_CALLS` (200/day). `search_daily_calls` is left unset to match the five granted siblings; an operator can set it to `0` to pause without touching `allow`.
- Grants are a boot snapshot — `[tools].allow` is not a hot-reload fingerprint — so a hosted tenant needs its **pod recreated** on the new image. A rolling redeploy that reuses the pod will still report `searchGranted:false`.

## Tests

- `cargo test --locked` — 2413 passed. Gated `openhuman,tinycortex` `company::content_test` — 10 passed. `fmt` clean; both clippy invocations from `ci.yml` clean.
- **The new gate provably fails on old code**, 5 negative proofs each firing at the intended assertion: company left unclassified; a throwaway `companies/zz_probe` dir; a dropped ungranted entry; a nonexistent company (stale); and a granted company parked in the ungranted bucket, caught by the `effective_grants` re-derivation. Plus a disjointness proof.
- **The fix itself is regression-proven**: reverting only the manifest token, with the const updates in place, makes `research_templates_grant_search_at_both_layers` fail naming this company. The manifest edit is load-bearing, not decorative.
- Verified live on both a default and an `openhuman` build: `capabilities` returns `searchGranted:true`, cap 200, `searchCredentialConfigured:false` (correct with no managed credential locally). `GET /team` shows `search` in all 9 agents' effective grants.
- No `feature-lanes.txt` row needed: `content_test` is declared `#[cfg(test)]` with no feature gate, so it runs in the plain lane.

## Documentation

No doc change. Verified `docs/spec/runtime/manifest.md` and `docs/spec/company-brain/grants.md` carry no per-company table. The stale doc comment on `SEARCH_GRANTED_COMPANIES` — which claimed the rule was derived from per-company `skills/` content — is rewritten; `grep -rln web_search companies/*/skills/` returns zero, because the search-dependent skills live only in the repo-level `skills/` registry and reach a company through a runtime operator install.

## Notes for the reviewer

**`SEARCH_UNGRANTED_COMPANIES` is a "nobody decided yet" bucket, not 12 more bugs.** It is distinct from the pre-existing `SEARCH_DENIED_COMPANIES` (`e2e_harness`, `openhuman_demo`), which is a hard rule. The twelve are templates that declare no `[tools]` block at all.

**This makes #874 live against this company.** `tool-slugs` now advertises `web_search` while `searchCredentialConfigured:false` on any deployment without the managed credential — that is #874 reproducing exactly as it predicts, not a defect here. Land this first, then validate #874 against this company.

One cross-branch coupling to know about: the partition means any future branch that adds or deletes a company dir will fail `company::content_test` until it classifies the dir.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled search capabilities for the Agentic Software Company.
  * Search access now follows explicit permissions and includes a daily usage limit.
* **Safety & Reliability**
  * Optional tools fail safely when unavailable, preventing unauthorized or unexpected tool use.
* **Tests**
  * Expanded coverage to verify search permissions are consistently configured across company templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->