### PR TITLE
fix(workspace): surface a workspace tool's real failure and write node content atomically (#887)

### DIFF
--- a/docs/spec/runtime/ports-cognition.md
+++ b/docs/spec/runtime/ports-cognition.md
@@ -145,6 +145,24 @@ rendered identically:
 - **`result` — what came back.** An intrinsic OpenCompany tool's own message; a
   shape (`"12 items"`, `"4.2k characters"`) for anything else; a
   plain-language cause on a failure.
+
+That sentence was not fully retired by #411, and saying so matters more than
+the tidier telling: #411 fixed the *classified* failures, and everything the
+classifier had no arm for still landed on `Unknown` and rendered as the same
+catch-all. The workspace tools were the whole family in that gap — issue #887
+found `workspace_read` writing five distinct, actionable sentences for its five
+failure exits and the operator being shown "Something went wrong with this
+action." for all of them, which is why the underlying fault in a live turn
+could not be diagnosed at all. #887 closed that fall-through by widening
+`INTRINSIC_TOOLS` to the workspace family.
+
+Membership in that list is an audit, not a one-line edit. A tool qualifies when
+its message is OC-authored copy **and** every one of its failure exits is free
+of host paths and raw store errors — `OpenCompanyError::StoreIo` renders an
+absolute host path, and what lands in `result` is shown on the console *and*
+written into the persisted trace. #887 therefore sanitised every workspace exit
+first and added the names second; the reverse order would have published the
+host's filesystem layout into every agent turn.
 - **`failure` — why it stopped**, as a typed `TurnStepFailure`
   (`unauthorized` · `timeout` · `declined` · `blocked_by_policy` ·
   `missing_permission` · `missing_app` · `unavailable` · `failed`), projected

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -160,6 +160,15 @@ pub trait WorkspaceStore: Send + Sync {
 Nodes are folders or files (`NodeKind`); `[[wikilink]]` backlinks are derived
 at read time by the GraphQL layer.
 
+**No torn reads (#887).** A `read` concurrent with a `write` on the same node
+returns one whole revision or the other — never an error, and never a prefix.
+sqlite and mongodb get this from a row update and a document replace; `fs` gets
+it from a tmp-file-plus-rename (`store::fs::write_atomic{,_bytes}`), which is
+what it was missing. `conformance::assert_workspace_read_never_tears` holds all
+three to it. The half that made this a data-integrity bug rather than a noisy
+one: a prefix that happens to end on a codepoint boundary *decodes cleanly*, so
+an agent grounds its answer in half a document with nothing failing anywhere.
+
 **Bytes (#553).** A node holds prose or it holds a payload, never both. A
 binary node is a `File` whose `mime`, `size` and `sha256` are all `Some`;
 `mime` alone is the discriminator every surface keys off. `size` and `sha256`

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -474,14 +474,35 @@ fn humanize(tool_name: &str) -> String {
     }
 }
 
-/// OpenCompany's own orchestrator tools (issue #112 et al). Their output is
-/// **OC-authored, operator-facing copy** — the tool's own `ToolResult` message
-/// (e.g. "workflow needs exactly one trigger"), not a remote or untrusted body
-/// — so it is safe *and* useful to surface verbatim (bounded) rather than
-/// collapsing it to a class or a shape. Contrast `mcp_call_tool`, whose output
-/// is a remote server body and therefore never leaves this module as content.
-/// Keep this list in lockstep with
-/// [`orchestrator_tools`](crate::harness::orchestrator::orchestrator_tools).
+/// The tools whose own `ToolResult` message is surfaced verbatim (bounded by
+/// [`RESULT_MAX`]) instead of being collapsed to a failure class.
+///
+/// **Membership rule** — a name belongs here when BOTH hold:
+///
+/// 1. The message is **OC-authored, operator-facing copy** — the tool wrote the
+///    sentence itself (e.g. "a workflow needs exactly one trigger"), rather than
+///    relaying a remote or untrusted body. Contrast `mcp_call_tool`, whose
+///    output is a remote server's body and therefore never leaves this module
+///    as content.
+/// 2. The message is **free of host paths and raw store errors** on every one of
+///    the tool's failure exits. This half is not a formality: what lands here is
+///    shown on the console step timeline AND written into the persisted turn
+///    trace, so a `{e}` interpolation of
+///    [`OpenCompanyError`](crate::error::OpenCompanyError) — whose `StoreIo`
+///    Display embeds an absolute host path — would publish the host's
+///    filesystem layout the moment its tool joined this list.
+///
+/// Rule 2 was implicit while the list held only orchestrator tools, and issue
+/// #887 is what made it load-bearing: the whole workspace family interpolated
+/// the store error, so each tool's exits had to be audited and sanitised
+/// (`workspace_tools::store_reason`) BEFORE its name was added here. Adding a
+/// name is therefore an audit of that tool's exits, not a one-line edit.
+///
+/// The orchestrator half must stay in lockstep with
+/// [`orchestrator_tools`](crate::harness::orchestrator::orchestrator_tools); the
+/// workspace half with
+/// [`workspace_tools`](crate::harness::workspace_tools::workspace_tools). Both
+/// are pinned mechanically by `intrinsic_tools_covers_every_oc_authored_tool`.
 const INTRINSIC_TOOLS: &[&str] = &[
     "query_company",
     "spawn_task",
@@ -505,6 +526,20 @@ const INTRINSIC_TOOLS: &[&str] = &[
     // rendered as a bare class instead of the sentence the tool wrote.
     "assign_task",
     "review_task",
+    // #887's family. `workspace_read` is the one the issue was filed against —
+    // it writes five different sentences for its five failure exits and the
+    // operator saw the same catch-all for all of them, which is precisely why
+    // the underlying fault could not be diagnosed. The other six are here on
+    // the same audit: every exit is a sentence the tool wrote, and since the
+    // sanitisation commit none of them carries a host path or a raw store
+    // error.
+    "workspace_list",
+    "workspace_read",
+    "workspace_search",
+    "workspace_create",
+    "workspace_write",
+    "workspace_rename",
+    "workspace_delete",
 ];
 
 /// Bound on an OC-authored message surfaced as a step result.
@@ -852,19 +887,24 @@ mod tests {
         )
     }
 
-    /// The lockstep [`INTRINSIC_TOOLS`] claims, made mechanical. Every
-    /// orchestrator tool name is a `pub const`, so drift between the two lists
-    /// now fails here instead of silently downgrading a tool's own sentence to
-    /// a bare failure class (which is how `assign_task` / `review_task` sat
-    /// missing from #186 until #461).
+    /// The lockstep [`INTRINSIC_TOOLS`] claims, made mechanical. Every name it
+    /// carries is a `pub const` on the module that wires the tool, so drift
+    /// between the lists fails here instead of silently downgrading a tool's own
+    /// sentence to a bare failure class (which is how `assign_task` /
+    /// `review_task` sat missing from #186 until #461, and how the whole
+    /// workspace family sat missing until #887).
     #[test]
-    fn intrinsic_tools_covers_every_orchestrator_tool() {
+    fn intrinsic_tools_covers_every_oc_authored_tool() {
         use crate::harness::orchestrator::{
             ADD_AGENT_TOOL, ASSIGN_TASK_TOOL, CREATE_WORKFLOW_TOOL, QUERY_COMPANY_TOOL,
             READ_RUN_OUTPUT_TOOL, REVIEW_TASK_TOOL, RUN_WORKFLOW_TOOL,
         };
         use crate::harness::workflow_admin::{
             DELETE_WORKFLOW_TOOL, READ_WORKFLOW_TOOL, UPDATE_WORKFLOW_TOOL,
+        };
+        use crate::harness::workspace_tools::{
+            WORKSPACE_CREATE_TOOL, WORKSPACE_DELETE_TOOL, WORKSPACE_LIST_TOOL, WORKSPACE_READ_TOOL,
+            WORKSPACE_RENAME_TOOL, WORKSPACE_SEARCH_TOOL, WORKSPACE_WRITE_TOOL,
         };
         use crate::runtime::delegation_tools::{DELEGATE_TO_DESK_TOOL, SPAWN_TASK_TOOL};
 
@@ -881,16 +921,52 @@ mod tests {
             ADD_AGENT_TOOL,
             ASSIGN_TASK_TOOL,
             REVIEW_TASK_TOOL,
+            // Issue #887. The whole family, because a tool's refusal is worth
+            // exactly as much on a write as on a read — and because leaving
+            // siblings out is how a list like this rots.
+            WORKSPACE_LIST_TOOL,
+            WORKSPACE_READ_TOOL,
+            WORKSPACE_SEARCH_TOOL,
+            WORKSPACE_CREATE_TOOL,
+            WORKSPACE_WRITE_TOOL,
+            WORKSPACE_RENAME_TOOL,
+            WORKSPACE_DELETE_TOOL,
         ];
         for name in expected {
             assert!(
                 INTRINSIC_TOOLS.contains(&name),
-                "{name} is wired by `orchestrator_tools` but absent from INTRINSIC_TOOLS"
+                "{name} is a wired OC-authored tool but is absent from INTRINSIC_TOOLS"
             );
         }
         // Exact, not just covering: a name here that no longer exists upstream
         // would surface a stale tool's output as OC-authored copy.
         assert_eq!(INTRINSIC_TOOLS.len(), expected.len(), "{INTRINSIC_TOOLS:?}");
+    }
+
+    /// The catch-all this issue is named after must still be reachable — for
+    /// the tools that genuinely have nothing OC-authored to say.
+    ///
+    /// Without this, "surface the tool's message" could be implemented as
+    /// "surface every tool's message", which is the `mcp_call_tool` leak the
+    /// membership rule exists to prevent. So the same failing output is
+    /// asserted BOTH ways round: verbatim for a workspace tool, collapsed to
+    /// the class for a remote one.
+    #[test]
+    fn a_non_intrinsic_tools_output_is_still_collapsed_to_its_class() {
+        let output = "Could not read `Standards/Engineering standards.md`: the workspace store \
+                      failed (store_io).";
+        let classified = oh::tools::status::classify(output, false);
+
+        let intrinsic = failure_result("workspace_read", output, &classified);
+        assert_eq!(intrinsic.as_deref(), Some(output));
+
+        let remote = failure_result("mcp_call_tool", output, &classified);
+        assert_eq!(remote.as_deref(), Some(classified.cause_plain.trim()));
+        assert_ne!(
+            remote.as_deref(),
+            Some(output),
+            "a remote server's body must never leave this module as content"
+        );
     }
 
     /// Reads a file out of the vendored OpenHuman checkout, for the tests that

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2494,6 +2494,11 @@ mod tests {
     // two: `workspace_read` wrote five distinct sentences and the step renderer
     // replaced every one of them with the classifier's catch-all.
 
+    /// The catch-all `ClassifiedFailure::Unknown` renders, from
+    /// `vendor/openhuman/src/openhuman/tools/status/ops.rs`. Every one of
+    /// `workspace_read`'s five failure exits used to collapse into this.
+    const GENERIC_CAUSE: &str = "Something went wrong with this action.";
+
     /// An obviously-fake absolute host path, in the shape
     /// [`crate::error::OpenCompanyError::StoreIo`] embeds. Planted so a leak is
     /// detectable by substring rather than by eye.
@@ -2654,6 +2659,132 @@ mod tests {
                 "{name} withheld the error without naming its code: {written}"
             );
         }
+    }
+
+    /// Assert the step shows the tool's OWN sentence: not the catch-all, and a
+    /// genuine prefix of what the tool wrote rather than a restatement of it.
+    #[track_caller]
+    fn assert_own_sentence(outcome: &ToolResult, needle: &str) {
+        assert!(outcome.is_error, "this exit is supposed to be a failure");
+        let written = outcome.output();
+        let shown = step_result(WORKSPACE_READ_TOOL, outcome)
+            .expect("a failed step must say what came back");
+
+        assert_ne!(
+            shown, GENERIC_CAUSE,
+            "the tool wrote `{written}` and the timeline threw it away"
+        );
+        assert!(
+            shown.contains(needle),
+            "expected `{needle}` in the step result, got `{shown}`"
+        );
+        // `failure_result` bounds the message at `RESULT_MAX` and marks a cut
+        // with `…`, so equality only holds for the short ones. What must hold
+        // for all five is that the shown text came out of the tool verbatim.
+        let unbounded = shown.trim_end_matches('…');
+        assert!(
+            written.starts_with(unbounded),
+            "the step must surface the tool's own text, not a paraphrase.\n\
+             tool wrote: {written}\n\
+             step shows: {shown}"
+        );
+    }
+
+    /// Issue #887's deliverable, exit by exit.
+    ///
+    /// `workspace_read` has five ways to fail and writes a different, actionable
+    /// sentence for each. Before this, all five arrived at the operator as
+    /// [`GENERIC_CAUSE`] — which is why the live turn that opened the issue could
+    /// not be diagnosed at all: the message naming the cause was the thing being
+    /// discarded.
+    #[tokio::test]
+    async fn every_read_failure_reaches_the_timeline_as_its_own_sentence() {
+        let id = CompanyId::new("acme");
+
+        // 1. The index read failed — nothing about the tree is knowable.
+        let store: Arc<dyn WorkspaceStore> =
+            Arc::new(FixedTree::failing_tree(small_tree(), planted_store_io));
+        let tool = WorkspaceReadTool::new(ws(store, id.clone()));
+        let outcome = tool
+            .execute(json!({"path": "Standards/Engineering standards.md"}))
+            .await
+            .unwrap();
+        assert_own_sentence(&outcome, "Could not read the company workspace");
+
+        // 2. The path resolves to nothing.
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceReadTool::new(ws(store, id.clone()));
+        let outcome = tool
+            .execute(json!({"path": "Nope/missing.md"}))
+            .await
+            .unwrap();
+        assert_own_sentence(&outcome, "No workspace note matches");
+
+        // 3. The target is a folder, and the useful next call is a listing.
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceReadTool::new(ws(store, id.clone()));
+        let outcome = tool.execute(json!({"path": "Standards"})).await.unwrap();
+        assert_own_sentence(&outcome, "is a folder, not a note");
+
+        // 4. The note was deleted between the tree read and the body read.
+        let store: Arc<dyn WorkspaceStore> =
+            Arc::new(FixedTree::failing_read(small_tree(), ReadFault::Vanished));
+        let tool = WorkspaceReadTool::new(ws(store, id.clone()));
+        let outcome = tool
+            .execute(json!({"path": "Standards/Engineering standards.md"}))
+            .await
+            .unwrap();
+        assert_own_sentence(&outcome, "was removed while you were reading it");
+
+        // 5. The body read itself failed at the store.
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree::failing_read(
+            small_tree(),
+            ReadFault::Failed(planted_store_io),
+        ));
+        let tool = WorkspaceReadTool::new(ws(store, id));
+        let outcome = tool
+            .execute(json!({"path": "Standards/Engineering standards.md"}))
+            .await
+            .unwrap();
+        assert_own_sentence(
+            &outcome,
+            "Could not read `Standards/Engineering standards.md`",
+        );
+    }
+
+    /// The one signal that tells the two candidate root causes apart.
+    ///
+    /// A duplicated ancestor makes a path ambiguous. `workspace_read` refuses —
+    /// picking one and silently reading it is how the wrong operator-owned note
+    /// gets quoted — while `workspace_list` still lists both, because listing
+    /// does not have to choose. That asymmetry (read fails, list succeeds) is
+    /// exactly the shape the live turn showed, so a refactor that "helpfully"
+    /// resolved the ambiguity would erase the evidence.
+    #[tokio::test]
+    async fn an_ambiguous_path_refuses_the_read_while_the_listing_still_succeeds() {
+        let nodes = vec![
+            file("n-one", "Charter.md", None),
+            file("n-two", "Charter.md", None),
+        ];
+        let id = CompanyId::new("acme");
+
+        let read = WorkspaceReadTool::new(ws(Arc::new(FixedTree::new(nodes.clone())), id.clone()));
+        let outcome = read.execute(json!({"path": "Charter.md"})).await.unwrap();
+        assert_own_sentence(&outcome, "is ambiguous");
+        let shown = step_result(WORKSPACE_READ_TOOL, &outcome).unwrap();
+        assert!(
+            shown.contains("n-one") && shown.contains("n-two"),
+            "the refusal must name the ids so the agent can re-issue by id: {shown}"
+        );
+
+        let list = WorkspaceListTool::new(ws(Arc::new(FixedTree::new(nodes)), id));
+        let listing = list.execute(json!({})).await.unwrap();
+        assert!(
+            !listing.is_error,
+            "listing does not have to choose, so it must not fail: {}",
+            text(&listing)
+        );
+        assert!(text(&listing).contains("Charter.md"));
     }
 
     // -- workspace_search (issue #607) ---------------------------------------
@@ -3172,6 +3303,9 @@ mod tests {
     /// How a [`FixedTree`] answers the body read, when a test asks it to fail.
     #[derive(Clone, Copy)]
     pub(super) enum ReadFault {
+        /// The node was there in the tree and is gone by the time the body read
+        /// runs — raced with an operator delete.
+        Vanished,
         /// The store itself failed. A factory rather than a value because
         /// [`crate::error::OpenCompanyError`] is not `Clone` (it carries a
         /// `std::io::Error`).
@@ -3240,6 +3374,7 @@ mod tests {
         ) -> crate::Result<Option<(WorkspaceNode, String)>> {
             match self.read_fault {
                 None => unreachable!("the listing never reads a body"),
+                Some(ReadFault::Vanished) => Ok(None),
                 Some(ReadFault::Failed(make)) => Err(make()),
             }
         }

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -641,6 +641,58 @@ fn echo_path(path: &str) -> String {
     }
 }
 
+/// The reason clause for a failure the **store** handed back, as the agent and
+/// the operator are allowed to see it (issue #887).
+///
+/// Every tool in this module used to interpolate the error's own `Display` into
+/// its refusal. That was survivable only while nothing read those refusals:
+/// since #887 a workspace tool's message is surfaced verbatim on the console
+/// step timeline and written into the persisted turn trace, and
+/// [`OpenCompanyError::StoreIo`] renders as `could not read {path}: {source}`
+/// where `{path}` is an **absolute host filesystem path** (`src/error.rs`).
+/// Sanitising is therefore the hard precondition for surfacing, not a polish
+/// pass — doing it the other way round publishes the host's directory layout to
+/// every agent turn and every stored trace.
+///
+/// So an I/O- or backend-shaped fault contributes only its stable
+/// machine-readable [`code`](OpenCompanyError::code); the full error, path and
+/// all, goes to the host log at `warn` where an operator can reach it.
+///
+/// The listed variants are surfaced verbatim instead, and the rule is what they
+/// have in common rather than a hand-picked allowlist: each one's payload is
+/// OC-authored prose about the **caller's own request** or about a limit the
+/// company itself set — a refused argument, a name collision, an exhausted
+/// quota. None of it is host state the caller did not already supply, and
+/// collapsing it to `invalid_request` would throw away the one sentence telling
+/// the agent what to do differently.
+fn store_reason(e: &crate::error::OpenCompanyError) -> String {
+    use crate::error::OpenCompanyError as E;
+
+    tracing::warn!(
+        error = %e,
+        code = %e.code(),
+        "[workspace] a workspace tool failed at the store; the agent-facing message carries \
+         the code only"
+    );
+
+    match e {
+        E::InvalidRequest(_)
+        | E::Conflict(_)
+        | E::NotFound(_)
+        | E::CompanyNotFound(_)
+        | E::WorkspaceQuota(_)
+        | E::BudgetExceeded(_)
+        | E::LifecycleConflict(_)
+        | E::Quiescing(_) => e.to_string(),
+        opaque => format!(
+            "the workspace store failed ({code}). A retry with different arguments will not \
+             change that — say so and move on. An operator can find the details in the \
+             server log",
+            code = opaque.code(),
+        ),
+    }
+}
+
 /// A fresh random token for one read's content fence.
 ///
 /// The fence delimits operator/agent-authored prose that the model must treat
@@ -793,7 +845,8 @@ impl Tool for WorkspaceListTool {
             Ok(index) => index,
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read the company workspace: {e}"
+                    "Could not read the company workspace: {reason}.",
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -954,7 +1007,8 @@ impl Tool for WorkspaceReadTool {
             Ok(index) => index,
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read the company workspace: {e}"
+                    "Could not read the company workspace: {reason}.",
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1018,8 +1072,9 @@ impl Tool for WorkspaceReadTool {
             }
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read `{}`: {e}",
-                    entry.path
+                    "Could not read `{path}`: {reason}.",
+                    path = entry.path,
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1212,7 +1267,8 @@ impl Tool for WorkspaceSearchTool {
             // anything else is a store fault.
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not search the company workspace: {e}"
+                    "Could not search the company workspace: {reason}.",
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1437,7 +1493,8 @@ impl Tool for WorkspaceWriteTool {
             Ok(index) => index,
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read the company workspace: {e}"
+                    "Could not read the company workspace: {reason}.",
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1507,8 +1564,9 @@ impl Tool for WorkspaceWriteTool {
             }
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read `{}` before overwriting it: {e}",
-                    entry.path
+                    "Could not read `{path}` before overwriting it: {reason}.",
+                    path = entry.path,
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1603,8 +1661,9 @@ impl Tool for WorkspaceWriteTool {
                 )))
             }
             Err(e) => Ok(ToolResult::error(format!(
-                "Could not overwrite `{}`: {e}",
-                entry.path
+                "Could not overwrite `{path}`: {reason}.",
+                path = entry.path,
+                reason = store_reason(&e),
             ))),
         }
     }
@@ -1737,7 +1796,8 @@ impl Tool for WorkspaceCreateTool {
             Ok(index) => index,
             Err(e) => {
                 return Ok(ToolResult::error(format!(
-                    "Could not read the company workspace: {e}"
+                    "Could not read the company workspace: {reason}.",
+                    reason = store_reason(&e),
                 )));
             }
         };
@@ -1801,8 +1861,10 @@ impl Tool for WorkspaceCreateTool {
                         Ok(id) => Some(id),
                         Err(e) => {
                             return Ok(ToolResult::error(format!(
-                                "Could not create your own workspace folder `{parent}`: {e}",
+                                "Could not create your own workspace folder `{parent}`: \
+                                 {reason}.",
                                 parent = echo_path(&parent_path),
+                                reason = store_reason(&e),
                             )));
                         }
                     }
@@ -1859,8 +1921,9 @@ impl Tool for WorkspaceCreateTool {
                 ),
             })),
             Err(e) => Ok(ToolResult::error(format!(
-                "Could not create `{path}`: {e}",
+                "Could not create `{path}`: {reason}.",
                 path = echo_path(&normalized),
+                reason = store_reason(&e),
             ))),
         }
     }
@@ -2424,6 +2487,175 @@ mod tests {
         assert!(!after.contains("Review every PR."), "{after}");
     }
 
+    // -- what a failure actually tells the operator (issue #887) -------------
+    //
+    // These assert against the **rendered step**, not against the `ToolResult`
+    // the tool returned, because the whole defect was in the gap between the
+    // two: `workspace_read` wrote five distinct sentences and the step renderer
+    // replaced every one of them with the classifier's catch-all.
+
+    /// An obviously-fake absolute host path, in the shape
+    /// [`crate::error::OpenCompanyError::StoreIo`] embeds. Planted so a leak is
+    /// detectable by substring rather than by eye.
+    const PLANTED_HOST_PATH: &str = "/planted/host/only/data/acme/workspace/n-eng.md";
+
+    /// The store fault every leak test injects: the `InvalidData` a torn read
+    /// off `fs` actually produces, wrapped in the variant whose `Display`
+    /// carries the host path.
+    fn planted_store_io() -> crate::error::OpenCompanyError {
+        crate::error::OpenCompanyError::StoreIo {
+            path: std::path::PathBuf::from(PLANTED_HOST_PATH),
+            source: std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "stream did not contain valid UTF-8",
+            ),
+        }
+    }
+
+    /// What the console step timeline shows as this call's result.
+    ///
+    /// Folds a realistic start/complete pair through the real
+    /// [`fold_steps`](crate::harness::steps::fold_steps) — including running the
+    /// vendored classifier, since `failure: None` is what the tinyagents path
+    /// actually sends — so this is the operator's view, not a paraphrase of it.
+    fn step_result(tool_name: &str, outcome: &ToolResult) -> Option<String> {
+        use oh::agent::progress::AgentProgress;
+
+        let output = outcome.output();
+        let steps = crate::harness::steps::fold_steps(vec![
+            AgentProgress::ToolCallStarted {
+                call_id: "c1".to_string(),
+                tool_name: tool_name.to_string(),
+                arguments: Value::Null,
+                iteration: 1,
+                display_label: None,
+                display_detail: None,
+            },
+            AgentProgress::ToolCallCompleted {
+                call_id: "c1".to_string(),
+                tool_name: tool_name.to_string(),
+                success: !outcome.is_error,
+                output_chars: output.chars().count(),
+                output: output.clone(),
+                arguments: None,
+                elapsed_ms: 51,
+                iteration: 1,
+                failure: None,
+            },
+        ]);
+        steps.into_iter().next().expect("one step").result
+    }
+
+    /// A tree with one folder and one note inside it, for the fault doubles.
+    fn small_tree() -> Vec<WorkspaceNode> {
+        vec![
+            folder("f-standards", "Standards", None),
+            file("n-eng", "Engineering standards.md", Some("f-standards")),
+        ]
+    }
+
+    /// The precondition for surfacing anything at all.
+    ///
+    /// `StoreIo`'s `Display` is `could not read {path}: {source}` and that
+    /// `{path}` is an absolute host path. Surfacing the tool's message without
+    /// sanitising first would publish the host's filesystem layout into every
+    /// agent's context AND into the persisted turn trace — which is why the
+    /// sanitisation landed before the `INTRINSIC_TOOLS` entry, not after it.
+    ///
+    /// Every workspace tool that reads the index is covered, not just the two
+    /// exits issue #887 named: they all interpolated the same error.
+    #[tokio::test]
+    async fn no_workspace_failure_carries_a_host_path() {
+        let id = CompanyId::new("acme");
+        let faulty = || -> Arc<dyn WorkspaceStore> {
+            Arc::new(FixedTree::failing_tree(small_tree(), planted_store_io))
+        };
+        let note = json!({"path": "Standards/Engineering standards.md"});
+
+        let mut outcomes: Vec<(&str, ToolResult)> = vec![
+            (
+                WORKSPACE_READ_TOOL,
+                WorkspaceReadTool::new(ws(faulty(), id.clone()))
+                    .execute(note.clone())
+                    .await
+                    .unwrap(),
+            ),
+            (
+                WORKSPACE_LIST_TOOL,
+                WorkspaceListTool::new(ws(faulty(), id.clone()))
+                    .execute(json!({}))
+                    .await
+                    .unwrap(),
+            ),
+            (
+                WORKSPACE_SEARCH_TOOL,
+                WorkspaceSearchTool::new(ws(faulty(), id.clone()))
+                    .execute(json!({"query": "review"}))
+                    .await
+                    .unwrap(),
+            ),
+            (
+                WORKSPACE_CREATE_TOOL,
+                WorkspaceCreateTool::new(ws(faulty(), id.clone()))
+                    .execute(json!({"path": "Standards/new.md", "kind": "file"}))
+                    .await
+                    .unwrap(),
+            ),
+            (
+                WORKSPACE_WRITE_TOOL,
+                WorkspaceWriteTool::new(ws(faulty(), id.clone()))
+                    .execute(json!({
+                        "path": "Standards/Engineering standards.md",
+                        "content": "x",
+                        "expected_updated_at": 2_000,
+                    }))
+                    .await
+                    .unwrap(),
+            ),
+        ];
+        // And the one exit that fails *after* the tree resolved.
+        outcomes.push((
+            WORKSPACE_READ_TOOL,
+            WorkspaceReadTool::new(ws(
+                Arc::new(FixedTree::failing_read(
+                    small_tree(),
+                    ReadFault::Failed(planted_store_io),
+                )),
+                id,
+            ))
+            .execute(note)
+            .await
+            .unwrap(),
+        ));
+
+        for (name, outcome) in &outcomes {
+            assert!(outcome.is_error, "{name} was supposed to fail");
+            let written = outcome.output();
+            let shown = step_result(name, outcome).unwrap_or_default();
+            for text in [&written, &shown] {
+                assert!(
+                    !text.contains(PLANTED_HOST_PATH),
+                    "{name} leaked the host path: {text}"
+                );
+                // The prefix too, so a truncated or reformatted path is caught.
+                assert!(
+                    !text.contains("/planted/"),
+                    "{name} leaked part of the host path: {text}"
+                );
+                assert!(
+                    !text.contains("stream did not contain valid UTF-8"),
+                    "{name} leaked the raw io::Error: {text}"
+                );
+            }
+            // What replaces it has to be actionable, so the operator can find
+            // the withheld detail: the stable code.
+            assert!(
+                written.contains("store_io"),
+                "{name} withheld the error without naming its code: {written}"
+            );
+        }
+    }
+
     // -- workspace_search (issue #607) ---------------------------------------
 
     /// A hit carries everything needed to act on it without a second call:
@@ -2937,25 +3169,79 @@ mod tests {
         assert_eq!(body.len(), big.len(), "the oversized note was clobbered");
     }
 
-    /// A store that answers `tree()` from a fixed node list and nothing else.
+    /// How a [`FixedTree`] answers the body read, when a test asks it to fail.
+    #[derive(Clone, Copy)]
+    pub(super) enum ReadFault {
+        /// The store itself failed. A factory rather than a value because
+        /// [`crate::error::OpenCompanyError`] is not `Clone` (it carries a
+        /// `std::io::Error`).
+        Failed(fn() -> crate::error::OpenCompanyError),
+    }
+
+    /// A store that answers `tree()` from a fixed node list, and can be told to
+    /// fail either of the two calls a read makes.
     ///
     /// The listing bounds have to be exercised against a tree big enough to hit
     /// them and containing nodes no real backend will create for us — a
     /// dangling parent, to raise `unaddressable`. `FsOps` refuses both, so the
     /// only way to reach that rendering is to hand the index the tree directly.
-    struct FixedTree(Vec<WorkspaceNode>);
+    ///
+    /// Issue #887 added the faults for the same reason one level along: a
+    /// store-level I/O failure, and a node that vanishes between the tree read
+    /// and the body read, are exactly what a healthy filesystem will not do on
+    /// request — and they are two of `workspace_read`'s five failure exits.
+    pub(super) struct FixedTree {
+        nodes: Vec<WorkspaceNode>,
+        tree_fault: Option<fn() -> crate::error::OpenCompanyError>,
+        read_fault: Option<ReadFault>,
+    }
+
+    impl FixedTree {
+        pub(super) fn new(nodes: Vec<WorkspaceNode>) -> Self {
+            Self {
+                nodes,
+                tree_fault: None,
+                read_fault: None,
+            }
+        }
+
+        /// `tree()` — and therefore every tool's index read — fails.
+        pub(super) fn failing_tree(
+            nodes: Vec<WorkspaceNode>,
+            fault: fn() -> crate::error::OpenCompanyError,
+        ) -> Self {
+            Self {
+                tree_fault: Some(fault),
+                ..Self::new(nodes)
+            }
+        }
+
+        /// The tree resolves normally; the body read is the one that fails.
+        pub(super) fn failing_read(nodes: Vec<WorkspaceNode>, fault: ReadFault) -> Self {
+            Self {
+                read_fault: Some(fault),
+                ..Self::new(nodes)
+            }
+        }
+    }
 
     #[async_trait]
     impl WorkspaceStore for FixedTree {
         async fn tree(&self, _company: &CompanyId) -> crate::Result<Vec<WorkspaceNode>> {
-            Ok(self.0.clone())
+            match self.tree_fault {
+                Some(make) => Err(make()),
+                None => Ok(self.nodes.clone()),
+            }
         }
         async fn read(
             &self,
             _company: &CompanyId,
             _id: &str,
         ) -> crate::Result<Option<(WorkspaceNode, String)>> {
-            unreachable!("the listing never reads a body")
+            match self.read_fault {
+                None => unreachable!("the listing never reads a body"),
+                Some(ReadFault::Failed(make)) => Err(make()),
+            }
         }
         async fn write(
             &self,
@@ -3030,7 +3316,7 @@ mod tests {
             unreachable!("the listing never reads a payload")
         }
         async fn is_empty(&self, _company: &CompanyId) -> crate::Result<bool> {
-            Ok(self.0.is_empty())
+            Ok(self.nodes.is_empty())
         }
     }
 
@@ -3065,7 +3351,7 @@ mod tests {
             ));
         }
 
-        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree::new(nodes));
         let list = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
         let out = text(&list.execute(json!({})).await.unwrap());
 
@@ -3115,7 +3401,7 @@ mod tests {
         nodes.push(file("n-orphan-a", "orphan-a.md", Some("gone")));
         nodes.push(file("n-orphan-b", "orphan-b.md", Some("gone")));
 
-        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree(nodes));
+        let store: Arc<dyn WorkspaceStore> = Arc::new(FixedTree::new(nodes));
         let list = WorkspaceListTool::new(ws(store, CompanyId::new("acme")));
         let out = text(&list.execute(json!({})).await.unwrap());
 

--- a/src/harness/workspace_tools/lifecycle.rs
+++ b/src/harness/workspace_tools/lifecycle.rs
@@ -75,7 +75,7 @@ use crate::ports::workspace::NodeKind;
 
 use super::{
     CompanyWorkspace, Entry, PathIndex, WORKSPACE_CREATE_TOOL, WORKSPACE_LIST_TOOL,
-    WORKSPACE_READ_TOOL, WORKSPACE_WRITE_TOOL, echo_path,
+    WORKSPACE_READ_TOOL, WORKSPACE_WRITE_TOOL, echo_path, store_reason,
 };
 
 /// Tool name: delete one node from the agent's own workspace folder.
@@ -167,7 +167,8 @@ async fn resolve_in_index(
         Ok(index) => index,
         Err(e) => {
             return Err(ToolResult::error(format!(
-                "Could not read the company workspace: {e}"
+                "Could not read the company workspace: {reason}.",
+                reason = store_reason(&e),
             )));
         }
     };
@@ -423,8 +424,9 @@ impl Tool for WorkspaceDeleteTool {
                 shown = echo_path(&entry.path),
             ))),
             Err(e) => Ok(ToolResult::error(format!(
-                "Could not delete `{shown}`: {e}",
+                "Could not delete `{shown}`: {reason}.",
                 shown = echo_path(&entry.path),
+                reason = store_reason(&e),
             ))),
         }
     }
@@ -668,8 +670,9 @@ impl Tool for WorkspaceRenameTool {
                 rev = node.updated_at_millis,
             ))),
             Err(e) => Ok(ToolResult::error(format!(
-                "Could not move `{shown}`: {e}",
+                "Could not move `{shown}`: {reason}.",
                 shown = echo_path(&entry.path),
+                reason = store_reason(&e),
             ))),
         }
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -3423,6 +3423,146 @@ pub async fn assert_workspace_folder_claims(ws: Arc<dyn WorkspaceStore>) {
     assert_eq!(&after.node().id, &ids[0]);
 }
 
+/// Asserts that a reader concurrent with a writer on the SAME node never errors
+/// and never observes a partial body (issue #887).
+///
+/// This is a statement about
+/// [`WorkspaceStore::read`](crate::ports::workspace::WorkspaceStore::read), so
+/// it is stated here rather than as an `fs` test: every backend a hosted tenant
+/// can run has to answer for it. sqlite and mongodb already do — a row update
+/// and a document replace are atomic — which is exactly why the guarantee
+/// belongs to the port and not to whichever backend happened to have it.
+///
+/// The `fs` backend did not. It wrote node content with a bare
+/// `tokio::fs::write`, whose `O_TRUNC` leaves the file short for the whole of
+/// the write, while `read` takes no lock. A reader landing in that window sees a
+/// prefix, and the two ways that surfaces are not equally visible:
+///
+/// * the cut lands **mid-codepoint** → `read_to_string` fails with
+///   `InvalidData`, which at least produces a red step; and
+/// * the cut lands **on** a codepoint boundary → the read **succeeds** with half
+///   a document, the agent grounds an answer in it, and nothing anywhere says
+///   so.
+///
+/// A retry only ever addresses the first. So the body is deliberately built from
+/// multi-byte characters and checked for **equality with a whole revision**
+/// rather than for decodability: length and content, not just "no error".
+pub async fn assert_workspace_read_never_tears(ws: Arc<dyn WorkspaceStore>) {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// How many times the note is rewritten end to end.
+    const ROUNDS: usize = 60;
+    /// Concurrent readers. More than one, because a single reader spends much of
+    /// its time not inside the window.
+    const READERS: usize = 4;
+    /// Repeats of the 8-byte unit below, giving a ~512 KiB body — large enough
+    /// that the write is not one instantaneous syscall.
+    const UNITS: usize = 64 * 1024;
+
+    let company = CompanyId::new("alpha");
+    // Every character is multi-byte, so a cut at an odd offset splits one. That
+    // is the visible half of the failure; the silent half is a cut that does
+    // not, which the equality check below is what catches.
+    let whole_a: String = "αβγδ".repeat(UNITS);
+    let whole_b: String = "εζηθ".repeat(UNITS);
+    assert_eq!(
+        whole_a.len(),
+        whole_b.len(),
+        "the two revisions must be the same size, so a short read cannot be \
+         mistaken for the other revision"
+    );
+
+    let node = WorkspaceNode {
+        id: "torn-note".to_string(),
+        name: "Torn.md".to_string(),
+        kind: NodeKind::File,
+        parent_id: None,
+        updated_at_millis: now_millis(),
+        created_by: WorkspaceOrigin::Operator,
+        updated_by: WorkspaceOrigin::Operator,
+        mime: None,
+        size: None,
+        sha256: None,
+    };
+    ws.create(&company, &node, Some(&whole_a))
+        .await
+        .expect("seed the note");
+
+    let done = Arc::new(AtomicBool::new(false));
+
+    let readers: Vec<_> = (0..READERS)
+        .map(|_| {
+            let ws = Arc::clone(&ws);
+            let company = company.clone();
+            let done = Arc::clone(&done);
+            let (a, b) = (whole_a.clone(), whole_b.clone());
+            tokio::spawn(async move {
+                let mut observed = 0usize;
+                while !done.load(Ordering::Relaxed) {
+                    let body = match ws.read(&company, "torn-note").await {
+                        Ok(Some((_, body))) => body,
+                        Ok(None) => {
+                            return Err(
+                                "the note vanished; nothing in this test deletes it".to_string()
+                            );
+                        }
+                        Err(e) => {
+                            return Err(format!(
+                                "a read concurrent with a write FAILED ({e}). \
+                                 `read` has no failure mode of its own here — the note exists \
+                                 and is unchanged in size; this is the writer's truncation \
+                                 window observed from the outside."
+                            ));
+                        }
+                    };
+                    if body != a && body != b {
+                        return Err(format!(
+                            "a read concurrent with a write observed a PARTIAL body: \
+                             {seen} bytes, where either whole revision is {whole}. \
+                             It decoded cleanly, so nothing failed and nothing was logged — \
+                             an agent would have grounded its answer in this.",
+                            seen = body.len(),
+                            whole = a.len(),
+                        ));
+                    }
+                    observed += 1;
+                    // Yield so a current-thread runtime interleaves the writer.
+                    tokio::task::yield_now().await;
+                }
+                Ok(observed)
+            })
+        })
+        .collect();
+
+    for round in 0..ROUNDS {
+        let body = if round % 2 == 0 { &whole_b } else { &whole_a };
+        ws.write(&company, "torn-note", body, WorkspaceOrigin::Operator)
+            .await
+            .expect("the writer itself must not fail");
+    }
+    done.store(true, Ordering::Relaxed);
+
+    let mut total = 0usize;
+    for reader in readers {
+        match reader.await.expect("a reader task panicked") {
+            Ok(observed) => total += observed,
+            Err(why) => panic!("{why}"),
+        }
+    }
+    assert!(
+        total > 0,
+        "no read ran while the note was being rewritten, so this case proved nothing"
+    );
+
+    // And the note is one of the two whole revisions once everything settles.
+    let (_, final_body) = ws
+        .read(&company, "torn-note")
+        .await
+        .expect("the settled read")
+        .expect("the note is still there");
+    assert!(final_body == whole_a || final_body == whole_b);
+}
+
 /// A folder node for the binary suite.
 fn folder_node(id: &str, name: &str) -> WorkspaceNode {
     WorkspaceNode {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -564,13 +564,34 @@ pub(crate) async fn read_lines_lossy(path: &Path) -> Result<Vec<String>> {
 
 /// Atomically writes `contents` to `path` via a temp file + rename.
 pub(crate) async fn write_atomic(path: &Path, contents: &str) -> Result<()> {
+    write_atomic_bytes(path, contents.as_bytes()).await
+}
+
+/// Atomically writes `bytes` to `path` via a temp file + rename.
+///
+/// The byte-taking half of [`write_atomic`], which delegates here so the
+/// tmp-then-rename dance has exactly one implementation: a second copy is how
+/// one of the two paths ends up missing the `create_dir_all`, or renaming
+/// before the write is flushed, with nothing to say the two ever disagreed.
+///
+/// What the rename buys is that **no reader ever sees a partial file** (issue
+/// #887). A plain `tokio::fs::write` opens with `O_TRUNC` and then streams: for
+/// the whole of that window the file on disk is short, and a concurrent reader
+/// gets whatever had landed. On a workspace note that surfaces two ways, and
+/// the quieter one is worse — `read_to_string` fails with `InvalidData` when the
+/// cut lands mid-codepoint, which at least produces a red step, but when the cut
+/// lands *on* a codepoint boundary the read **succeeds** and the agent grounds
+/// an answer in half a document with nothing anywhere saying so. A `rename(2)`
+/// over the same directory is atomic, so the reader sees the old file or the new
+/// one and never a prefix of either.
+pub(crate) async fn write_atomic_bytes(path: &Path, bytes: &[u8]) -> Result<()> {
     if let Some(parent) = path.parent() {
         tokio::fs::create_dir_all(parent)
             .await
             .map_err(|e| io_err(parent, e))?;
     }
     let tmp = path.with_extension(format!("tmp-{}", generate_id()));
-    tokio::fs::write(&tmp, contents)
+    tokio::fs::write(&tmp, bytes)
         .await
         .map_err(|e| io_err(&tmp, e))?;
     tokio::fs::rename(&tmp, path)

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -2376,6 +2376,19 @@ mod test {
         conformance::assert_workspace_folder_claims(Arc::new(FsOps::new(&root))).await;
     }
 
+    /// Issue #887, and the backend the case was written against: this is the
+    /// one that failed it. Node content was written with a bare
+    /// `tokio::fs::write`, so a reader inside the `O_TRUNC` window saw a
+    /// prefix — visibly when the cut split a codepoint, silently when it did
+    /// not. Multi-threaded because the race is between two blocking-pool
+    /// threads, which a current-thread runtime makes far rarer.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn conformance_workspace_read_never_tears() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_workspace_read_never_tears(Arc::new(FsOps::new(&root))).await;
+    }
+
     #[tokio::test]
     async fn workspace_files_land_on_disk_under_folders() {
         let root_dir = tmp_root();

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -47,7 +47,9 @@ use crate::ports::workflow_revisions::{
     sort_newest_first as sort_revisions_newest_first,
 };
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
-use crate::store::fs::{append_line, io_err, path_lock, read_jsonl, read_optional, write_atomic};
+use crate::store::fs::{
+    append_line, io_err, path_lock, read_jsonl, read_optional, write_atomic, write_atomic_bytes,
+};
 use crate::store::paths::Bundle;
 
 /// One filesystem store implementing every WS3 console port over a company
@@ -1320,14 +1322,7 @@ impl WorkspaceStore for FsOps {
         node.updated_by = author;
         let node = node.clone();
         let file = self.physical_path(company, &index, id)?;
-        if let Some(parent) = file.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| io_err(parent, e))?;
-        }
-        tokio::fs::write(&file, content)
-            .await
-            .map_err(|e| io_err(&file, e))?;
+        write_atomic(&file, content).await?;
         self.save_index(company, &index).await?;
         Ok(node)
     }
@@ -1376,14 +1371,7 @@ impl WorkspaceStore for FsOps {
                     .map_err(|e| io_err(&physical, e))?;
             }
             NodeKind::File => {
-                if let Some(parent) = physical.parent() {
-                    tokio::fs::create_dir_all(parent)
-                        .await
-                        .map_err(|e| io_err(parent, e))?;
-                }
-                tokio::fs::write(&physical, content.unwrap_or(""))
-                    .await
-                    .map_err(|e| io_err(&physical, e))?;
+                write_atomic(&physical, content.unwrap_or("")).await?;
             }
         }
         self.save_index(company, &index).await
@@ -1502,14 +1490,7 @@ impl WorkspaceStore for FsOps {
         // The same sanitized derivation the text path uses, so a binary node
         // cannot reach a path a note could not.
         let physical = self.physical_path(company, &index, &node.id)?;
-        if let Some(parent) = physical.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| io_err(parent, e))?;
-        }
-        tokio::fs::write(&physical, bytes)
-            .await
-            .map_err(|e| io_err(&physical, e))?;
+        write_atomic_bytes(&physical, bytes).await?;
         self.save_index(company, &index).await?;
         // The stamped node, so the digest a caller records can only have come
         // from the store (issue #668).
@@ -1534,14 +1515,7 @@ impl WorkspaceStore for FsOps {
         crate::ports::workspace::rebind_binary(node, bytes, mime, author)?;
         let node = node.clone();
         let file = self.physical_path(company, &index, id)?;
-        if let Some(parent) = file.parent() {
-            tokio::fs::create_dir_all(parent)
-                .await
-                .map_err(|e| io_err(parent, e))?;
-        }
-        tokio::fs::write(&file, bytes)
-            .await
-            .map_err(|e| io_err(&file, e))?;
+        write_atomic_bytes(&file, bytes).await?;
         self.save_index(company, &index).await?;
         Ok(node)
     }

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -4384,6 +4384,16 @@ mod test {
         drop_db(&s).await;
     }
 
+    /// Issue #887's no-torn-read contract, on the other backend hosted tenants
+    /// run. A document replace is atomic, so this passed before the `fs` fix
+    /// and passes after — the contract is the port's, not one backend's.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn conformance_workspace_read_never_tears() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_read_never_tears(s.clone()).await;
+        drop_db(&s).await;
+    }
+
     /// The sqlite pin's mirror, on the other backend hosted tenants run
     /// (issue #700).
     ///

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3641,6 +3641,15 @@ mod test {
         conformance::assert_workspace_folder_claims(store()).await;
     }
 
+    /// Issue #887's no-torn-read contract. This backend passed it before the
+    /// `fs` fix and passes it after — which is the point of stating it on the
+    /// port: the guarantee is owed by every backend a tenant can run, not by
+    /// whichever one happened to have it for free.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn conformance_workspace_read_never_tears() {
+        conformance::assert_workspace_read_never_tears(store()).await;
+    }
+
     /// Issue #700's emptiness predicate, against the backend that can actually
     /// hold the shape it has to survive.
     ///


### PR DESCRIPTION
## Summary

`workspace_read` writes a specific sentence for each of its failure exits, and the step renderer threw them all away. `failure_result` surfaces a tool's own message only for members of `INTRINSIC_TOOLS`, and no `workspace_*` tool was on that list — so every failure was replaced by the unmatched-class fallback, `"Something went wrong with this action."`, rendered verbatim in the console. `steps.rs` already named this exact string as a known gap.

That is why the reported symptom was undiagnosable: the evidence needed to explain it was the thing being discarded. Three of ten steps in one observed turn failed this way while sibling reads and a `list` over the same prefix succeeded.

Order matters here. Two exits interpolated the raw error, and `StoreIo`'s Display embeds an absolute host path — so surfacing first would have pushed host paths into the console and the persisted trace. This sanitises first, then surfaces.

It also closes the most likely underlying cause: node content was written with bare `tokio::fs::write` while the index was written atomically and reads take no lock, so a reader inside the truncation window fails — which explains the list-succeeds / read-fails asymmetry exactly.

Closes #887.

## API Or Behavior Changes

- A failed `workspace_*` step now shows the tool's own reason instead of the generic sentence. Five distinct outcomes are now distinguishable: index-read failure, path resolves to nothing, target is a folder, vanished mid-read, body read failed at the store.
- Store errors are reduced to a stable `code()` plus fixed prose; the full error, with its host path, goes to the host log only.
- Workspace node content and blob writes are now atomic (tmp + rename). This removes both the visible `InvalidData` failure and the silent short read that occurs when truncation lands on a codepoint boundary.
- New port contract: a concurrent reader never errors and never observes a partial body. All three backends are held to it.

## Tests

- Gated lane green post-merge (143 in the touched modules), plus `cargo test --locked` (2413), the sqlite lane, `assert-feature-lanes.sh`, `run-scoped-suite.sh`, and the frontend (3 typechecks, 717 vitest, build) with **zero frontend changes**.
- **All five exits asserted end-to-end** through the real `fold_steps` against `TurnStep.result` — and all five confirmed collapsing to the generic string on base, captured before the fix.
- **Leak guard**: re-run with the sanitiser stubbed back to raw `to_string()`, it fails and prints the planted host path.
- **The conformance case caught a real defect on its first run** — a reader observing a 0-byte body that decoded cleanly. That is the silent half of the race demonstrated rather than theorised, and it is precisely what a retry-based fix could never have seen.

## Documentation

`docs/spec/runtime/ports-cognition.md` — corrected; it still presented the generic sentence as pre-#411 history. `docs/spec/runtime/ports-console.md` — records the new port guarantee, which had nowhere else to live.

## Notes for the reviewer

**A retry was considered and rejected.** It leaves the truncation window open and cannot see the worse failure it produces: when truncation lands *on* a codepoint boundary the read **succeeds** with a partial note, so an agent grounds an answer in half a document with no failed step at all. Fixing the writer removes both.

**Scope came out wider than planned, in the safe direction.** Rather than adding `workspace_read` alone, every error exit of all seven workspace tools was enumerated — 13 raw interpolations — and routed through one sanitiser, so no follow-up is owed for the siblings.

**Not fully verified:** the backend half is proven to `TurnStep.result` through the real fold, but the UI half is inspection only. The 200-char message in a CSS-truncated row has not been eyeballed — worth one staging pass before merge.

Filed **#894** for the sqlite duplicate-sibling gap found while investigating (mongodb already has two partial unique indexes; only sqlite has none, so the issue's original "sqlite/mongodb" framing was half wrong). The mongodb `swap_files` item was deliberately **not** filed: the deleted document is the private staging node, so whether it breaches the port contract is arguable.

**Pre-existing, not from this branch:** the gated lane needs `RUST_MIN_STACK` — filed as #895.
