### PR TITLE
fix(workflows): a blocked node reports blocked, and a run says what it parked (#881, #880)

### DIFF
--- a/docs/modules/server/workflow-routes.md
+++ b/docs/modules/server/workflow-routes.md
@@ -211,6 +211,45 @@ curl -X POST "$HOST/api/v1/company/workflows/weekly_digest/run" \
 }
 ```
 
+### A run that stopped for a person (issues #881, #880)
+
+When a tool call inside an agent node's turn is parked for approval, the node
+produces no deliverable and its branch stops. The run still answers `200` — a
+step waiting on a person is not a failure — and says so structurally:
+
+```jsonc
+{
+  "output": null,
+  "pendingApprovals": ["spec"],
+  "deliveries": [],
+  "nodes": [ { "nodeId": "spec", "status": "blocked", "elapsedMs": 42000 } ],
+  "blockedNodes": [
+    { "nodeId": "spec", "tools": ["publish_artifact"], "approvalIds": ["appr-1"] }
+  ],
+  "approvals": [
+    { "nodeId": "spec", "tool": "publish_artifact",
+      "outcome": "parked", "approvalId": "appr-1" }
+  ]
+}
+```
+
+`blockedNodes` and `approvals` are omitted entirely when empty, so a run that
+blocked on nobody is byte-unchanged. Both also ride the `WorkflowRunFinished`
+journal event, `GET …/workflows/runs` (where each blocked node's chip is
+relabelled from the `error` the engine reported) and the SSE
+`workflow_run_finished` frame — one shape on all four surfaces.
+
+`approvals` is a **receipt of what the run parked**, not a live count of what is
+outstanding: nothing flips a row when the operator approves. Its `outcome` is
+`parked`, `parkFailed` (the store refused the write, or no approvals queue is
+wired — **nobody will be asked about that call**) or `discarded` (the turn gated
+more calls than the per-turn cap allows; the drain drops the excess, so such a
+row carries no `tool`).
+
+**Approving does not continue the run.** An agent node is not re-enterable, so
+the operator decides the card and runs the workflow again. See
+[`workflow-vocabulary.md`](../../spec/runtime/workflow-vocabulary.md) for why.
+
 Swap `{ "kind": "owner" }` for `{ "kind": "email", "target": "ada@example.com" }`
 and a recipient who has never written in comes back as
 `"status": "skipped"` with the reason, having sent nothing:

--- a/docs/spec/runtime/workflow-events.md
+++ b/docs/spec/runtime/workflow-events.md
@@ -47,9 +47,13 @@ the known escape hatch if cron volume ever demands it.
 ### What these events deliberately do not carry
 
 **No node output and no error text.** The engine's `ExecutionStep` carries the
-node's output items; `WorkflowNodeFinished` carries a node id, a two-valued
-status and a duration, and `WorkflowNodeStatus` has no `String` arm — so there
-is no `format!` that could put a node's own words on the journal.
+node's output items; `WorkflowNodeFinished` carries a node id, a three-valued
+status (`ok` / `error` / `blocked`, issue #881) and a duration, and every
+`WorkflowNodeStatus` arm is a **unit** variant — so there is no `format!` that
+could put a node's own words on the journal. #881 added a reading and kept that
+invariant: what a blocked node is blocked *on* travels structurally on
+`WorkflowRunFinished.blocked_nodes` (node id, tool names, approval ids), never
+as prose.
 `WorkflowNodeStarted` (issue #382) is even thinner: the node has not run, so it
 carries the ids alone — no status, no duration, and never any input. This is the
 same stance the live turn-progress frames take on tool args, and it matters
@@ -180,3 +184,14 @@ pre-#382 guess marked both arms of a branch until the real finishes corrected it
 A failing node **is** reported exactly too: a node that dies under the default
 `stop` policy still emits a finish step with `Error` status before the run ends,
 so failure attribution is exact rather than inferred.
+
+That is also true of a **blocked** node (issue #881), and it is why the journal
+line says `error` there. A node whose agent turn had a tool call parked halts its
+branch by returning a capability error, so the observer reports `Error` — the
+engine's own honest account of what it saw. The host knows *why*, and
+reclassifies on the way out: `WorkflowRun` marks the node `blocked` and the run
+settles with no error at all, and `GET …/workflows/runs` relabels the folded node
+row against the finish's `blocked_nodes` list so the history's chips agree with
+its terminal reading. The durable node row is deliberately left as the engine
+wrote it — rewriting it would make the live progress frames disagree with the
+engine that produced them.

--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -72,6 +72,64 @@ node config. A destination-bearing `output` node therefore lowers to the same
 bare pass-through `transform` as one without a destination — pinned by the
 `an_output_destination_never_reaches_the_engine_graph` test in `translate.rs`.
 
+## A node has three outcomes, and the third is the host's (issues #881, #880)
+
+`WorkflowNodeStatus` is `ok` / `error` / **`blocked`**. The engine reports only
+the first two — it knows success and failure and nothing else — so `blocked` is
+a **host** reading, applied on the way out. That is the same move
+`WorkflowRun.cancelled` makes for a deliberate stop: a cancelled run is not a
+failed one, and neither is a blocked one.
+
+A node blocks when a tool call **inside its agent turn** was parked for operator
+approval. This is a different mechanism from an authored or policy gate on a
+`tool_call` *node*, and the difference is the whole of #881:
+
+| | gate on a `tool_call` node | gate on a call inside an agent turn |
+| --- | --- | --- |
+| Who sees it | the engine — the node carries `requires_approval` | nobody outside the agent: the call is refused inside the model's tool loop |
+| What the run does | pauses; the node id lands on `pending_approvals` | before #881: **finished green**, with the model's prose about the blockage as the node's output |
+| What approving does | resumes the lineage through [`workflow_resume`](../../../src/runtime/workflow_resume.rs) | nothing to this run — see below |
+
+Since #881 the second column stops the branch: the capability returns an error,
+which under the default `on_error = "stop"` halts the run at that node with no
+retry, and the host relabels the node `blocked`, unions its id into
+`pending_approvals`, and settles the run **without** an error.
+
+**Approving does not resume a blocked run, deliberately.** An agent node is not
+re-enterable: `NodeControl::Interrupt` discards the activation's state and
+re-runs the node from the top, so resuming would spend a fresh inference turn,
+call the same gated tool, and park a *new* card — approve, re-run, re-park,
+forever. The engine says as much itself (`StopReason::Paused` maps to "resuming
+a paused agent is not supported yet"). The operator decides the card and runs
+the workflow again.
+
+An author who writes `on_error = "continue"` or `"route"` on a blocked node
+still gets a surviving branch — they asked for it — and the run-level record
+stays truthful either way.
+
+### What a run says it parked
+
+`WorkflowRun.approvals` is one row per approval the run parked: `{ nodeId, tool,
+outcome, approvalId }`, where `outcome` is `parked` / `parkFailed` /
+`discarded`. The two failure arms are the point — before this, a park that could
+not be performed was recorded only by a `tracing::error!`, which is the sole
+trace that a call the operator will never be asked about was dropped.
+
+It is named for what the run **parked**, not for what is still outstanding, and
+the console's wording follows: *"parked N approvals"*, never *"waiting on N"*.
+A receipt of an event cannot go stale; a settle-time count of what is still
+waiting becomes a fresh lie the moment somebody approves one. The Approvals
+page is the live source of truth.
+
+Two neighbouring fields mean narrower things and are not substitutes:
+`pending_approvals` is node ids (the engine's gate nodes plus the host's blocked
+ones), and `deliveries` is per-`output`-node routing only. Both were truthfully
+empty on the runs that prompted #880.
+
+Every new field carries `#[serde(default)]`. `CompanyEvent::WorkflowRunFinished`
+is replayed at boot, so a field without one makes every pre-existing journal
+line fail to parse — silent history loss, not a compile error.
+
 ## The engine-only kinds OpenCompany rejects
 
 The engine catalog carries four kinds the parser does **not** accept:

--- a/frontend/src/api/workflow-copilot.ts
+++ b/frontend/src/api/workflow-copilot.ts
@@ -166,7 +166,10 @@ export interface RosterEntry {
  * from the same function that sends it means the disclosure cannot drift from
  * the truth.
  */
-export function composeCopilotMessage(context: CopilotContext, question: string): string {
+export function composeCopilotMessage(
+  context: CopilotContext,
+  question: string,
+): string {
   const { graph, runs, runsKnown, roster, toolSlugs, toolSlugsKnown } = context;
   // `editable: false` means the graph is defined by a file in the company
   // source tree. Named for what it IS rather than for the flag's polarity: this
@@ -188,7 +191,9 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     `## Workflow`,
     `Name: ${graph.name}`,
     `Id: ${graph.id}`,
-    graph.description ? `Description: ${graph.description}` : `Description: (none)`,
+    graph.description
+      ? `Description: ${graph.description}`
+      : `Description: (none)`,
     sourceDefined
       ? `Editable from the console: NO — this workflow is defined by a file in the company source tree (workflows/${graph.id}.toml). You can explain it, but changes have to be made in the company repository, not here.`
       : `Editable from the console: yes, through the workflow editor.`,
@@ -201,7 +206,8 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     const bits = [`- ${node.id} [${node.kind}] "${node.name}"`];
     if (node.summary) bits.push(`summary: ${node.summary}`);
     if (node.agent) bits.push(`agent: ${node.agent}`);
-    if (node.schedule) bits.push(`schedule (5-field cron, UTC): ${node.schedule}`);
+    if (node.schedule)
+      bits.push(`schedule (5-field cron, UTC): ${node.schedule}`);
     if (node.requiresApproval) bits.push(`requires approval before proceeding`);
     if (node.onError) bits.push(`on error: ${node.onError}`);
     if (node.retry) bits.push(`retry: ${JSON.stringify(node.retry)}`);
@@ -223,7 +229,9 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     lines.push(`- (none — the nodes are not joined)`);
   } else {
     for (const edge of graph.edges) {
-      lines.push(`- ${edge.from} → ${edge.to}${edge.label ? ` [${edge.label}]` : ""}`);
+      lines.push(
+        `- ${edge.from} → ${edge.to}${edge.label ? ` [${edge.label}]` : ""}`,
+      );
     }
   }
 
@@ -260,9 +268,13 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     `An \`agent\` node names its teammate with the top-level \`agent\` field (a roster id below), NOT inside \`config\`.`,
   );
   if (roster === undefined) {
-    lines.push(`(The roster could not be listed here. Do not invent teammate ids.)`);
+    lines.push(
+      `(The roster could not be listed here. Do not invent teammate ids.)`,
+    );
   } else if (roster.length === 0) {
-    lines.push(`(This company has no roster teammates, so do not propose an \`agent\` step.)`);
+    lines.push(
+      `(This company has no roster teammates, so do not propose an \`agent\` step.)`,
+    );
   } else {
     for (const member of roster) {
       lines.push(`- ${member.id}${member.role ? ` — ${member.role}` : ""}`);
@@ -275,9 +287,13 @@ export function composeCopilotMessage(context: CopilotContext, question: string)
     `A \`tool_call\` node names its tool with \`config.slug\`, set to one of these EXACT slugs. Do not invent a slug (there is no \`github_integration\`, etc.).`,
   );
   if (!toolSlugsKnown || toolSlugs === undefined) {
-    lines.push(`(The granted tools could not be listed here. Do not invent a tool slug.)`);
+    lines.push(
+      `(The granted tools could not be listed here. Do not invent a tool slug.)`,
+    );
   } else if (toolSlugs.length === 0) {
-    lines.push(`(No tools are granted to this company's workflows, so do not propose a \`tool_call\` step.)`);
+    lines.push(
+      `(No tools are granted to this company's workflows, so do not propose a \`tool_call\` step.)`,
+    );
   } else {
     for (const slug of toolSlugs) lines.push(`- ${slug}`);
   }
@@ -369,19 +385,30 @@ function describeRun(run: WorkflowRunOutcome): string {
   const trail = nodes.length
     ? ` steps: ${nodes.map((n) => `${n.nodeId}=${n.status}(${n.elapsedMs}ms)`).join(", ")};`
     : "";
-  const undelivered = run.deliveries.filter((d) => d.status !== "sent" && d.status !== "pending");
+  const undelivered = run.deliveries.filter(
+    (d) => d.status !== "sent" && d.status !== "pending",
+  );
   const delivery = run.deliveries.length
     ? ` deliveries: ${run.deliveries.map((d) => `${d.node}→${d.kind}=${d.status}`).join(", ")};`
     : "";
+  // Issue #881: the blocked reading is named before the delivery one and before
+  // the bare "finished". A blocked run has no error, is not cancelled and
+  // routed nothing, so without this arm it grounded the copilot with the word
+  // "finished" about a run that produced no deliverable — and the copilot would
+  // then reason from that as fact.
+  const blocked = run.blockedNodes ?? [];
+  const parked = run.approvals?.length ?? 0;
   const outcome = run.running
     ? "still running"
     : run.error
       ? `FAILED: ${run.error}`
       : run.cancelled
         ? "stopped by an operator before it finished"
-        : undelivered.length
-          ? `finished, but ${undelivered.length} report(s) were not delivered`
-          : "finished";
+        : blocked.length
+          ? `BLOCKED at ${blocked.map((b) => b.nodeId).join(", ")} — produced no deliverable and the steps after did not run; parked ${parked} approval(s), which does NOT continue this run`
+          : undelivered.length
+            ? `finished, but ${undelivered.length} report(s) were not delivered`
+            : "finished";
   const approvals = run.pendingApprovals.length
     ? ` awaiting approval: ${run.pendingApprovals.join(", ")};`
     : "";
@@ -423,7 +450,11 @@ export async function askCopilot(
   question: string,
 ): Promise<string[]> {
   const message = composeCopilotMessage(context, question);
-  const reply = await client.chat(message, company, copilotThreadId(workflowId));
+  const reply = await client.chat(
+    message,
+    company,
+    copilotThreadId(workflowId),
+  );
   return reply.responses.map((r) => r.text);
 }
 
@@ -437,9 +468,15 @@ export async function loadCopilotHistory(
   client: OpenCompanyClient,
   company: string | null,
   workflowId: string,
-): Promise<{ ok: true; messages: CopilotMessage[] } | { ok: false; error: Error }> {
+): Promise<
+  { ok: true; messages: CopilotMessage[] } | { ok: false; error: Error }
+> {
   try {
-    const rows = await client.getChatHistory(copilotThreadId(workflowId), company, { limit: 200 });
+    const rows = await client.getChatHistory(
+      copilotThreadId(workflowId),
+      company,
+      { limit: 200 },
+    );
     return {
       ok: true,
       messages: rows.map((row) => ({
@@ -454,7 +491,10 @@ export async function loadCopilotHistory(
   } catch (e) {
     return {
       ok: false,
-      error: e instanceof Error ? e : new Error("The copilot transcript could not be loaded."),
+      error:
+        e instanceof Error
+          ? e
+          : new Error("The copilot transcript could not be loaded."),
     };
   }
 }

--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -96,7 +96,10 @@ export interface WorkflowDestination {
  * side alone fails `cargo test` rather than shipping a picker the server rejects
  * (or withholding one it accepts). Issue #260.
  */
-export const DESTINATION_KINDS: { value: WorkflowDestination["kind"]; label: string }[] = [
+export const DESTINATION_KINDS: {
+  value: WorkflowDestination["kind"];
+  label: string;
+}[] = [
   { value: "owner", label: "Owner — the company's admins" },
   { value: "email", label: "Email — a specific address" },
   { value: "channel", label: "Channel — a wired chat channel" },
@@ -160,7 +163,8 @@ export interface WorkflowGraph {
  * comes back to flip the row to `sent`. The Approvals view is the live source of
  * truth — approving there actually sends the mail.
  */
-export type DeliveryStatus = "sent" | "pending" | "skipped" | "denied" | "failed";
+export type DeliveryStatus =
+  "sent" | "pending" | "skipped" | "denied" | "failed";
 
 /**
  * One attempt to route a reached `output` node's report to its destination.
@@ -240,6 +244,17 @@ export interface WorkflowRunResult {
    * run", i.e. the run was real.
    */
   dryRun?: boolean;
+  /**
+   * The nodes this run blocked on a person (issue #881) — the run drawer is
+   * where an operator who pressed Run first learns the pipeline delivered
+   * nothing, and why. Absent when nothing blocked.
+   */
+  blockedNodes?: WorkflowBlockedNode[];
+  /**
+   * The approvals this run parked (issue #880). A receipt of what it opened,
+   * never a count of what is still outstanding.
+   */
+  approvals?: WorkflowRunApprovalRow[];
 }
 
 /**
@@ -275,7 +290,9 @@ export type WorkflowRunResponse = WorkflowRunResult | WorkflowRunAccepted;
  * than merely not crash: the settled body is a perfectly good answer, so the
  * console simply uses it.
  */
-export function isDetached(response: WorkflowRunResponse): response is WorkflowRunAccepted {
+export function isDetached(
+  response: WorkflowRunResponse,
+): response is WorkflowRunAccepted {
   return (response as WorkflowRunAccepted).detached === true;
 }
 
@@ -297,13 +314,58 @@ export function isDryRun(response: WorkflowRunResponse): boolean {
   return (response as WorkflowRunResult).dryRun === true;
 }
 
-/** One node's outcome inside a run (issue #371). */
+/** One node's outcome inside a run (issue #371, third reading #881). */
 export interface WorkflowRunNode {
   nodeId: string;
-  /** Whether the node succeeded or errored. */
-  status: "ok" | "error";
+  /**
+   * Whether the node succeeded, errored, or **blocked** (issue #881).
+   *
+   * `blocked` is neither of the other two: the node stopped because a tool call
+   * in its turn was parked for a person, so it produced no deliverable and
+   * nothing after it ran. Rendering it as a failure sends an operator hunting
+   * for a bug when the fix is a click in Approvals; rendering it as `ok` is the
+   * lie the issue was filed about.
+   */
+  status: "ok" | "error" | "blocked";
   /** Wall-clock duration of the node's execution, in milliseconds. */
   elapsedMs: number;
+}
+
+/** One node a run blocked on a person (issue #881). */
+export interface WorkflowBlockedNode {
+  nodeId: string;
+  /** The tools whose calls were gated. Names only — never arguments. */
+  tools: string[];
+  /** The approvals this node's gated calls opened. Absent when every park failed. */
+  approvalIds?: string[];
+  /**
+   * How many of the node's gated calls could NOT be queued for approval.
+   *
+   * Strictly worse than a parked one: there is no card, so pointing the
+   * operator at Approvals would send them to an empty page. Absent when zero.
+   */
+  unparkable?: number;
+}
+
+/** What became of one gated tool call a run tried to park (issue #880). */
+export type WorkflowApprovalOutcome = "parked" | "parkFailed" | "discarded";
+
+/**
+ * One approval a run parked (issue #880) — a **receipt**, not a live status.
+ *
+ * Read it as "this run opened this card", never as "this card is still
+ * waiting": nothing comes back to flip a row once the operator approves. The
+ * Approvals page is the live source of truth. Wording follows from that — the
+ * console says "parked N approvals", never "waiting on N".
+ */
+export interface WorkflowRunApprovalRow {
+  /** The agent node whose turn made the call. Absent when node identity was unavailable. */
+  nodeId?: string;
+  /** The tool whose call was gated. Absent on a `discarded` row — see the outcome. */
+  tool?: string;
+  outcome: WorkflowApprovalOutcome;
+  /** The card the operator can decide, on the `parked` arm. */
+  approvalId?: string;
 }
 
 /**
@@ -372,6 +434,24 @@ export interface WorkflowRunOutcome {
    * nothing — so absent must read as "nothing to tell you", not "unknown".
    */
   notices?: string[];
+  /**
+   * The nodes this run blocked on a person (issue #881).
+   *
+   * NOT a failure and NOT a pause. The branch stopped, but approving does not
+   * continue this run — an agent node is not re-enterable, so the operator
+   * decides the card and runs the workflow again. Absent on a host predating
+   * #881 and on every run that blocked on nobody, so absent must read as
+   * "nothing blocked".
+   */
+  blockedNodes?: WorkflowBlockedNode[];
+  /**
+   * The approvals this run parked (issue #880) — including the parks that
+   * failed, which are the rows that matter most: nobody will ever be asked
+   * about those calls.
+   *
+   * A receipt of what the run opened, never a count of what is outstanding.
+   */
+  approvals?: WorkflowRunApprovalRow[];
 }
 
 export function listWorkflows(
@@ -412,7 +492,9 @@ export function listWorkflowToolSlugs(
   company: string | null,
 ): Promise<string[]> {
   return client
-    .get<WorkflowToolSlugsResponse>(`${client.scopeFor(company)}/workflows/tool-slugs`)
+    .get<WorkflowToolSlugsResponse>(
+      `${client.scopeFor(company)}/workflows/tool-slugs`,
+    )
     .then((r) => r.slugs);
 }
 
@@ -435,7 +517,9 @@ export function listWiredChannels(
   company: string | null,
 ): Promise<string[]> {
   return client
-    .get<WiredChannelsResponse>(`${client.scopeFor(company)}/workflows/wired-channels`)
+    .get<WiredChannelsResponse>(
+      `${client.scopeFor(company)}/workflows/wired-channels`,
+    )
     .then((r) => r.channels);
 }
 
@@ -593,7 +677,10 @@ export function createWorkflow(
   company: string | null,
   graph: WorkflowGraph,
 ): Promise<WorkflowGraph> {
-  return client.post<WorkflowGraph>(`${client.scopeFor(company)}/workflows`, graph);
+  return client.post<WorkflowGraph>(
+    `${client.scopeFor(company)}/workflows`,
+    graph,
+  );
 }
 
 /**

--- a/frontend/src/components/workflow-node.tsx
+++ b/frontend/src/components/workflow-node.tsx
@@ -13,6 +13,9 @@ const RUN_STATE_LABEL: Record<NodeRunState, string> = {
   running: "running",
   ok: "done",
   error: "failed",
+  // Issue #881: the word an operator can act on. Not "failed" — nothing broke —
+  // and not "done", which is precisely the claim this state exists to stop.
+  blocked: "needs approval",
 };
 
 /** Badge tint per run state — read alongside the ring, never instead of it, so
@@ -21,6 +24,7 @@ const RUN_STATE_BADGE: Record<NodeRunState, string> = {
   running: "bg-status-running-soft text-status-running-text",
   ok: "bg-status-done-soft text-status-done-text",
   error: "bg-status-failed-soft text-status-failed-text",
+  blocked: "bg-status-blocked-soft text-[var(--status-blocked-text)]",
 };
 
 /** A custom xyflow node: emoji + colored header, name, and a one-line summary.
@@ -42,12 +46,23 @@ export function WorkflowNode({ data, selected }: NodeProps) {
       )}
       data-run-state={runState}
     >
-      <Handle type="target" position={Position.Left} className="!size-2 !border-2 !bg-background" />
-      <div className={cn("flex items-center gap-2 rounded-t-[10px] px-3 py-2", colors.chip)}>
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!size-2 !border-2 !bg-background"
+      />
+      <div
+        className={cn(
+          "flex items-center gap-2 rounded-t-[10px] px-3 py-2",
+          colors.chip,
+        )}
+      >
         <span className="text-base leading-none" aria-hidden>
           {d.emoji}
         </span>
-        <div className="min-w-0 flex-1 truncate text-sm font-semibold">{d.name}</div>
+        <div className="min-w-0 flex-1 truncate text-sm font-semibold">
+          {d.name}
+        </div>
         {runState && (
           <span
             className={cn(
@@ -71,10 +86,16 @@ export function WorkflowNode({ data, selected }: NodeProps) {
       <div className="px-3 py-2 text-2xs leading-snug text-muted-foreground">
         {d.summary}
         {typeof d.elapsedMs === "number" && (
-          <span className="ml-1 font-mono opacity-70">· {formatElapsed(d.elapsedMs)}</span>
+          <span className="ml-1 font-mono opacity-70">
+            · {formatElapsed(d.elapsedMs)}
+          </span>
         )}
       </div>
-      <Handle type="source" position={Position.Right} className="!size-2 !border-2 !bg-background" />
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!size-2 !border-2 !bg-background"
+      />
     </div>
   );
 }

--- a/frontend/src/hooks/use-events.ts
+++ b/frontend/src/hooks/use-events.ts
@@ -2,7 +2,11 @@ import { useEffect, useRef } from "react";
 import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
-import type { DeliveryReport } from "@/api/workflows";
+import type {
+  DeliveryReport,
+  WorkflowBlockedNode,
+  WorkflowRunApprovalRow,
+} from "@/api/workflows";
 
 /**
  * One attention item off the company → operator SSE feed (issue #66). Mirrors
@@ -32,7 +36,13 @@ export type CompanyStreamEvent =
       parentId?: string;
     }
   | { type: "task_dispatched"; seq: number; atMillis: number; taskId: string }
-  | { type: "task_steered"; seq: number; atMillis: number; taskId: string; action: string }
+  | {
+      type: "task_steered";
+      seq: number;
+      atMillis: number;
+      taskId: string;
+      action: string;
+    }
   // A board card was written (issue #464) — the frame the board had no way to
   // learn about anything from. Emitted by the host's task store, so it fires
   // for a card opened from chat intake, from a delegation, from the publish
@@ -132,9 +142,27 @@ export type CompanyStreamEvent =
       kind: string;
       chatId?: string;
     }
-  | { type: "approval_resolved"; seq: number; atMillis: number; approvalId: string; verdict: string }
-  | { type: "lifecycle_changed"; seq: number; atMillis: number; from: string; to: string }
-  | { type: "payment_received"; seq: number; atMillis: number; amountUsd: number; memo: string }
+  | {
+      type: "approval_resolved";
+      seq: number;
+      atMillis: number;
+      approvalId: string;
+      verdict: string;
+    }
+  | {
+      type: "lifecycle_changed";
+      seq: number;
+      atMillis: number;
+      from: string;
+      to: string;
+    }
+  | {
+      type: "payment_received";
+      seq: number;
+      atMillis: number;
+      amountUsd: number;
+      memo: string;
+    }
   // A workflow run finished (issue #228), from either entry point. The whole
   // point is the *scheduled* case: nobody is watching a cron run, so without
   // this an owner summary that failed to send would be silent until someone
@@ -165,6 +193,20 @@ export type CompanyStreamEvent =
        * majority of runs. Not a failure — see `WorkflowRunOutcome.notices`.
        */
       notices?: string[];
+      /**
+       * The nodes this run blocked on a person (issue #881). Absent when
+       * nothing blocked.
+       *
+       * A blocked run carries NO `error` and is not `cancelled`, so without
+       * reading this a console watching a run settle would paint it green —
+       * and then the history it reloads a moment later would say it blocked.
+       */
+      blockedNodes?: WorkflowBlockedNode[];
+      /**
+       * The approvals this run parked (issue #880) — a receipt of what it
+       * opened, including the parks that failed.
+       */
+      approvals?: WorkflowRunApprovalRow[];
     }
   // Issue #371/#382: the live per-node progress trail. A run announces itself,
   // then brackets each non-trigger node with a *started* frame as it begins and
@@ -547,7 +589,10 @@ export function useEvents(
  * picker), so which subscriber a type reaches is worth pinning directly rather
  * than only through a mounted hook.
  */
-export function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers): void {
+export function handleEvent(
+  event: CompanyStreamEvent,
+  subscribers: Subscribers,
+): void {
   const {
     onAgentReply,
     onTaskEvent,
@@ -648,9 +693,12 @@ export function handleEvent(event: CompanyStreamEvent, subscribers: Subscribers)
       // Refresh first, then say so. The refresh is what settles an inline card
       // whose decision was made on the Approvals page (or in another tab).
       onApprovalEvent?.(event);
-      toast(event.verdict === "approve" ? "Approval granted" : "Approval denied", {
-        description: "An approval was just resolved.",
-      });
+      toast(
+        event.verdict === "approve" ? "Approval granted" : "Approval denied",
+        {
+          description: "An approval was just resolved.",
+        },
+      );
       break;
     case "lifecycle_changed":
       toast(`Company is now ${event.to}`, {

--- a/frontend/src/lib/workflow-sample.ts
+++ b/frontend/src/lib/workflow-sample.ts
@@ -33,7 +33,7 @@ export interface WorkflowNodeData extends Record<string, unknown> {
  * console lights the node up because it was told to, not because it inferred it.
  * `ok` and `error` come from the finish frame, exact as before.
  */
-export type NodeRunState = "running" | "ok" | "error";
+export type NodeRunState = "running" | "ok" | "error" | "blocked";
 
 /**
  * Ring + glow per run state, layered over the node's own kind accent.
@@ -43,13 +43,23 @@ export type NodeRunState = "running" | "ok" | "error";
  * comes from the identity palette — the two never reach for the same hue.
  */
 export const RUN_STATE_CLASSES: Record<NodeRunState, string> = {
-  running: "ring-2 ring-status-running/70 shadow-status-running/20 animate-pulse",
+  running:
+    "ring-2 ring-status-running/70 shadow-status-running/20 animate-pulse",
   ok: "ring-2 ring-status-done/60",
   error: "ring-2 ring-status-failed/80",
+  // Issue #881. Deliberately the blocked token rather than the failed one: the
+  // node did not break, it is parked until a person decides. Red would send an
+  // operator looking for a bug when the fix is a click in Approvals — and it
+  // would put a run that is merely waiting into the same visual bucket as one
+  // that fell over.
+  blocked: "ring-2 ring-status-blocked/80",
 };
 
 /** Per-kind emoji + accent, mirroring OpenHuman's node-kind metadata. */
-export const NODE_KIND_META: Record<string, { emoji: string; color: NodeColor }> = {
+export const NODE_KIND_META: Record<
+  string,
+  { emoji: string; color: NodeColor }
+> = {
   trigger: { emoji: "⚡", color: "sage" },
   agent: { emoji: "🤖", color: "primary" },
   tool_call: { emoji: "🔧", color: "amber" },
@@ -77,7 +87,10 @@ export const NODE_KIND_META: Record<string, { emoji: string; color: NodeColor }>
  * The key names are the accents the sample data already refers to; they name a
  * slot, not a colour.
  */
-export const COLOR_CLASSES: Record<NodeColor, { border: string; chip: string }> = {
+export const COLOR_CLASSES: Record<
+  NodeColor,
+  { border: string; chip: string }
+> = {
   primary: { border: "border-primary/40", chip: "bg-primary/10" },
   sage: { border: "border-tone-3/40", chip: "bg-tone-3/10" },
   amber: { border: "border-tone-5/40", chip: "bg-tone-5/10" },
@@ -86,6 +99,9 @@ export const COLOR_CLASSES: Record<NodeColor, { border: string; chip: string }> 
 };
 
 /** Emoji + accent for a node kind, falling back for an unknown kind. */
-export function nodeKindMeta(kind: string): { emoji: string; color: NodeColor } {
+export function nodeKindMeta(kind: string): {
+  emoji: string;
+  color: NodeColor;
+} {
   return NODE_KIND_META[kind] ?? { emoji: "•", color: "neutral" };
 }

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -395,18 +395,20 @@ function RunHistoryRow({
           {run.deliveries.length > 0 && (
             <DeliveryRows deliveries={run.deliveries} />
           )}
-          // Issue #846. This is the arm that was missing, and its absence is
-          how a // run waiting on a human came to report success: a paused run
-          has no // error, no cancellation, is not `running` (the engine settled
-          it) and // routed nothing, so it fell through every branch to the
-          "Finished" line // below — while its gate sat undecided on the
-          Approvals page. // // "Not finished" is the claim, stated in the
-          operator's terms rather // than the engine's. The run object really is
-          settled; what has not // happened is the work, and the work is what
-          the operator is asking // about. Naming the nodes matters as much as
-          the state: a scheduled run // that silently did nothing is exactly the
-          failure this reads as, and // the fix is a click, so the row says
-          which click.
+          {/* Issue #846. This is the arm that was missing, and its absence is
+              how a run waiting on a human came to report success: a paused run
+              has no error, no cancellation, is not `running` (the engine
+              settled it) and routed nothing, so it fell through every branch
+              to the "Finished" line below — while its gate sat undecided on
+              the Approvals page.
+
+              "Not finished" is the claim, stated in the operator's terms
+              rather than the engine's. The run object really is settled;
+              what has not happened is the work, and the work is what the
+              operator is asking about. Naming the nodes matters as much as
+              the state: a scheduled run that silently did nothing is exactly
+              the failure this reads as, and the fix is a click, so the row
+              says which click. */}
           <p
             className="text-2xs text-[var(--status-blocked-text)]"
             data-testid="workflow-run-awaiting"

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -357,8 +357,17 @@ function RunHistoryRow({
           className="text-2xs text-[var(--status-blocked-text)]"
           data-testid="workflow-run-blocked"
         >
+          {/* Issue #900: the verb used to be unconditionally "needs your
+              approval", even when every one of the blocked node's calls was
+              unparkable — a call nobody will ever be asked about. That read
+              as a promise of a card that does not exist, and contradicted the
+              closing sentence below whenever `parked` was 0. */}
           Not finished — {blocked.map((b) => `“${b.nodeId}”`).join(", ")}{" "}
-          {blocked.length === 1 ? "needs" : "need"} your approval, so{" "}
+          {parked > 0
+            ? blocked.length === 1
+              ? "needs your approval"
+              : "need your approval"
+            : "could not be queued for approval"}, so{" "}
           {blocked.length === 1 ? "it" : "they"} produced nothing and the steps
           after {blocked.length === 1 ? "it" : "them"} did not run.{" "}
           {parked > 0 &&

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -18,8 +18,8 @@ import type {
 import { failedNodeOf } from "./graph";
 import {
   awaitingCount,
+  decidableApprovalCount,
   isBlocked,
-  parkedApprovalCount,
   relativeTime,
   runTone,
   undeliveredCount,
@@ -221,7 +221,12 @@ function RunHistoryRow({
   // Issue #881 / #880: read once, so the chip, the badge and the terminal line
   // below cannot disagree about whether this run stopped for a person.
   const blocked = run.blockedNodes ?? [];
-  const parked = parkedApprovalCount(run);
+  // Issue #900: `decidableApprovalCount`, not `parkedApprovalCount` — this
+  // paragraph tells the operator a card is waiting, so it must count only
+  // the receipts that actually landed one. Counting a failed park here said
+  // "needs your approval" and "decide it in Approvals" about a call the very
+  // next sentence admitted nobody would ever be asked about.
+  const parked = decidableApprovalCount(run);
   // The loud half: calls nobody will ever be asked about, because the park
   // itself failed or the excess was dropped past the per-turn cap. Strictly
   // worse than a parked one — there is no card to click.

--- a/frontend/src/views/workflows/RunHistoryPanel.tsx
+++ b/frontend/src/views/workflows/RunHistoryPanel.tsx
@@ -16,7 +16,14 @@ import type {
 } from "@/api/workflows";
 
 import { failedNodeOf } from "./graph";
-import { awaitingCount, relativeTime, runTone, undeliveredCount } from "./run-health";
+import {
+  awaitingCount,
+  isBlocked,
+  parkedApprovalCount,
+  relativeTime,
+  runTone,
+  undeliveredCount,
+} from "./run-health";
 
 /** Badge styling per delivery outcome. A report that did NOT go out must not
  * look like one that did — `denied` and `failed` are the two an operator has to
@@ -46,18 +53,27 @@ export function DeliveryRows({ deliveries }: { deliveries: DeliveryReport[] }) {
       <div className="flex items-center gap-2">
         <span className="text-xs font-medium">Report delivery</span>
         {pending > 0 && (
-          <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft">
+          <Badge
+            variant="outline"
+            className="h-4 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft"
+          >
             {pending} awaiting approval
           </Badge>
         )}
         {undelivered > 0 && (
-          <Badge variant="outline" className="h-4 px-1.5 text-3xs font-normal border-status-failed/40 bg-status-failed-soft">
+          <Badge
+            variant="outline"
+            className="h-4 px-1.5 text-3xs font-normal border-status-failed/40 bg-status-failed-soft"
+          >
             {undelivered} not delivered
           </Badge>
         )}
       </div>
       {deliveries.map((d, i) => (
-        <div key={`${d.node}-${d.target ?? ""}-${i}`} className="flex flex-wrap items-baseline gap-1.5">
+        <div
+          key={`${d.node}-${d.target ?? ""}-${i}`}
+          className="flex flex-wrap items-baseline gap-1.5"
+        >
           <Badge
             variant="outline"
             className={`h-4 px-1.5 text-3xs font-normal ${DELIVERY_TONE[d.status] ?? ""}`}
@@ -112,11 +128,13 @@ export function LastRunChip({ run }: { run: WorkflowRunOutcome }) {
           : run.cancelled
             ? " stopped"
             : undelivered > 0
-            ? ` · ${undelivered} not delivered`
-            : awaiting > 0
-              ? ` · ${awaiting} awaiting approval`
-              : ""}
-      <span className="text-muted-foreground">· {relativeTime(run.atMillis)}</span>
+              ? ` · ${undelivered} not delivered`
+              : awaiting > 0
+                ? ` · ${awaiting} awaiting approval`
+                : ""}
+      <span className="text-muted-foreground">
+        · {relativeTime(run.atMillis)}
+      </span>
     </Badge>
   );
 }
@@ -151,7 +169,9 @@ export function RunHistoryPanel({
         <div className="flex items-center gap-2">
           <span className="text-sm font-medium">Run history</span>
           {workflowName && (
-            <span className="truncate text-xs text-muted-foreground">{workflowName}</span>
+            <span className="truncate text-xs text-muted-foreground">
+              {workflowName}
+            </span>
           )}
           <Badge variant="secondary">{runs.length}</Badge>
         </div>
@@ -198,6 +218,14 @@ function RunHistoryRow({
 }) {
   const tone = runTone(run);
   const nodes = run.nodes ?? [];
+  // Issue #881 / #880: read once, so the chip, the badge and the terminal line
+  // below cannot disagree about whether this run stopped for a person.
+  const blocked = run.blockedNodes ?? [];
+  const parked = parkedApprovalCount(run);
+  // The loud half: calls nobody will ever be asked about, because the park
+  // itself failed or the excess was dropped past the per-turn cap. Strictly
+  // worse than a parked one — there is no card to click.
+  const unparkable = blocked.reduce((n, b) => n + (b.unparkable ?? 0), 0);
   const failedNode = failedNodeOf(run);
   return (
     <div
@@ -212,16 +240,32 @@ function RunHistoryRow({
           {run.scheduled ? "scheduled" : "manual"}
         </Badge>
         <span className="text-2xs text-muted-foreground">
-          {new Date(run.atMillis).toLocaleString()} · {relativeTime(run.atMillis)}
+          {new Date(run.atMillis).toLocaleString()} ·{" "}
+          {relativeTime(run.atMillis)}
         </span>
-        {run.pendingApprovals.length > 0 && (
+        {/* Issue #880: what the run PARKED, in those words. A blocked run's
+            `pendingApprovals` names the nodes it stopped at, which is a
+            different count from the cards it opened — and "pending" is the
+            phrasing that goes stale, since nothing here is refreshed when the
+            operator approves one. The receipt wins where there is one. */}
+        {parked > 0 ? (
           <Badge
             variant="outline"
             className="h-4 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft"
+            data-testid="workflow-run-parked"
           >
-            {run.pendingApprovals.length} pending approval
-            {run.pendingApprovals.length === 1 ? "" : "s"}
+            parked {parked} approval{parked === 1 ? "" : "s"}
           </Badge>
+        ) : (
+          run.pendingApprovals.length > 0 && (
+            <Badge
+              variant="outline"
+              className="h-4 px-1.5 text-3xs font-normal border-status-blocked/40 bg-status-blocked-soft"
+            >
+              {run.pendingApprovals.length} pending approval
+              {run.pendingApprovals.length === 1 ? "" : "s"}
+            </Badge>
+          )
         )}
         {run.running && (
           <Badge
@@ -249,7 +293,10 @@ function RunHistoryRow({
           "it failed HERE". Absent for a run journaled before #371 — those rows
           render exactly as they always did. */}
       {nodes.length > 0 && (
-        <div className="mb-1 flex flex-wrap gap-1" data-testid="workflow-run-nodes">
+        <div
+          className="mb-1 flex flex-wrap gap-1"
+          data-testid="workflow-run-nodes"
+        >
           {nodes.map((node) => (
             <RunNodeChip key={`${node.nodeId}-${node.elapsedMs}`} node={node} />
           ))}
@@ -264,7 +311,9 @@ function RunHistoryRow({
                 failing node as an errored step, so this is exact. When it does
                 not (a graph that would not compile, a capability that could not
                 be built), say nothing about nodes rather than guessing. */}
-            {failedNode ? `This run failed at “${failedNode}”: ` : "This run failed: "}
+            {failedNode
+              ? `This run failed at “${failedNode}”: `
+              : "This run failed: "}
             {run.error}
           </AlertDescription>
         </Alert>
@@ -282,8 +331,43 @@ function RunHistoryRow({
           {nodes.length > 0
             ? ` after ${nodes.length} step${nodes.length === 1 ? "" : "s"}`
             : " before any step finished"}
-          . The steps above completed; the one still running was stopped where it
-          was. Any approvals it had already raised are still waiting for you.
+          . The steps above completed; the one still running was stopped where
+          it was. Any approvals it had already raised are still waiting for you.
+        </p>
+      ) : isBlocked(run) ? (
+        // Issue #881, the fourth terminal reading — and the one that had NO
+        // arm at all, which is how a run that delivered nothing came to read as
+        // a clean success. A blocked run carries no error, is not cancelled,
+        // is not running, and routed no report, so it fell straight through to
+        // the "Finished — this run routed no reports" line below. That sentence
+        // is what lied.
+        //
+        // Deliberately not a destructive Alert: nothing broke. Same amber the
+        // gated-call notice already uses — "needs your attention, nothing is
+        // wrong" — and the same 11px rung as its siblings.
+        //
+        // Wording is the review item here. "Parked N approvals", never "waiting
+        // on N": nothing refreshes this row when the operator approves one, so
+        // an outstanding count is stale on arrival, while a record of what the
+        // run parked stays true. And it says plainly that approving does not
+        // continue THIS run — an agent step is not resumable, so the operator
+        // has to run the workflow again or they will sit waiting for a
+        // continuation that never comes.
+        <p
+          className="text-2xs text-[var(--status-blocked-text)]"
+          data-testid="workflow-run-blocked"
+        >
+          Not finished — {blocked.map((b) => `“${b.nodeId}”`).join(", ")}{" "}
+          {blocked.length === 1 ? "needs" : "need"} your approval, so{" "}
+          {blocked.length === 1 ? "it" : "they"} produced nothing and the steps
+          after {blocked.length === 1 ? "it" : "them"} did not run.{" "}
+          {parked > 0 &&
+            `This run parked ${parked} approval${parked === 1 ? "" : "s"}. `}
+          {unparkable > 0 &&
+            `${unparkable} call${unparkable === 1 ? "" : "s"} could not be queued for approval at all, so you will not be asked about ${unparkable === 1 ? "it" : "them"}. `}
+          {parked > 0
+            ? `Decide ${parked === 1 ? "it" : "them"} in Approvals, then run the workflow again — approving does not continue this run.`
+            : "Nothing here can be approved; change the policy and run the workflow again."}
         </p>
       ) : run.running ? (
         // Same root cause as the tone bug: a run still walking its graph has no
@@ -299,29 +383,32 @@ function RunHistoryRow({
               reached BEFORE the gate. Those rows are shown as they always were,
               with the waiting line above rather than instead of them: replacing
               them would trade one silent omission for another. */}
-          {run.deliveries.length > 0 && <DeliveryRows deliveries={run.deliveries} />}
-        // Issue #846. This is the arm that was missing, and its absence is how a
-        // run waiting on a human came to report success: a paused run has no
-        // error, no cancellation, is not `running` (the engine settled it) and
-        // routed nothing, so it fell through every branch to the "Finished" line
-        // below — while its gate sat undecided on the Approvals page.
-        //
-        // "Not finished" is the claim, stated in the operator's terms rather
-        // than the engine's. The run object really is settled; what has not
-        // happened is the work, and the work is what the operator is asking
-        // about. Naming the nodes matters as much as the state: a scheduled run
-        // that silently did nothing is exactly the failure this reads as, and
-        // the fix is a click, so the row says which click.
-        <p
-          className="text-2xs text-[var(--status-blocked-text)]"
-          data-testid="workflow-run-awaiting"
-        >
-          Not finished — waiting for your approval on{" "}
-          {run.pendingApprovals.map((node) => `“${node}”`).join(", ")}. Nothing past{" "}
-          {run.pendingApprovals.length === 1 ? "it" : "them"} has run
-          {run.deliveries.length === 0 ? ", and no reports were routed" : ""}. Approve or decline
-          it in Approvals to carry the run on.
-        </p>
+          {run.deliveries.length > 0 && (
+            <DeliveryRows deliveries={run.deliveries} />
+          )}
+          // Issue #846. This is the arm that was missing, and its absence is
+          how a // run waiting on a human came to report success: a paused run
+          has no // error, no cancellation, is not `running` (the engine settled
+          it) and // routed nothing, so it fell through every branch to the
+          "Finished" line // below — while its gate sat undecided on the
+          Approvals page. // // "Not finished" is the claim, stated in the
+          operator's terms rather // than the engine's. The run object really is
+          settled; what has not // happened is the work, and the work is what
+          the operator is asking // about. Naming the nodes matters as much as
+          the state: a scheduled run // that silently did nothing is exactly the
+          failure this reads as, and // the fix is a click, so the row says
+          which click.
+          <p
+            className="text-2xs text-[var(--status-blocked-text)]"
+            data-testid="workflow-run-awaiting"
+          >
+            Not finished — waiting for your approval on{" "}
+            {run.pendingApprovals.map((node) => `“${node}”`).join(", ")}.
+            Nothing past {run.pendingApprovals.length === 1 ? "it" : "them"} has
+            run
+            {run.deliveries.length === 0 ? ", and no reports were routed" : ""}.
+            Approve or decline it in Approvals to carry the run on.
+          </p>
         </>
       ) : run.deliveries.length > 0 ? (
         // Deliberately the SAME component the live run drawer uses, so a report
@@ -363,19 +450,37 @@ function RunHistoryRow({
 
 /** One node's outcome in a history row: its id, how it went, how long it took. */
 function RunNodeChip({ node }: { node: WorkflowRunNode }) {
-  const ok = node.status === "ok";
+  // Issue #881: three tones, not two. A blocked step is neither green nor red —
+  // painting it red sends an operator hunting for a bug when the fix is a click
+  // in Approvals, and painting it green is the lie the issue was filed about.
+  // The amber token is the console's standing "needs a person, nothing is
+  // broken" state, which a gated call already reads as elsewhere.
+  const tone =
+    node.status === "ok"
+      ? {
+          border: "border-status-done/40 bg-status-done-soft",
+          dot: "bg-status-done",
+        }
+      : node.status === "blocked"
+        ? {
+            border: "border-status-blocked/50 bg-status-blocked-soft",
+            dot: "bg-status-blocked",
+          }
+        : {
+            border: "border-status-failed/50 bg-status-failed-soft",
+            dot: "bg-status-failed",
+          };
   return (
     <span
-      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-3xs ${
-        ok
-          ? "border-status-done/40 bg-status-done-soft"
-          : "border-status-failed/50 bg-status-failed-soft"
-      }`}
+      className={`inline-flex items-center gap-1 rounded border px-1.5 py-0.5 text-3xs ${tone.border}`}
+      data-testid={`workflow-run-node-${node.status}`}
     >
-      <span className={`size-1.5 rounded-full ${ok ? "bg-status-done" : "bg-status-failed"}`} />
+      <span className={`size-1.5 rounded-full ${tone.dot}`} />
       <span className="font-medium">{node.nodeId}</span>
       <span className="font-mono opacity-70">
-        {node.elapsedMs < 1000 ? `${node.elapsedMs}ms` : `${(node.elapsedMs / 1000).toFixed(1)}s`}
+        {node.elapsedMs < 1000
+          ? `${node.elapsedMs}ms`
+          : `${(node.elapsedMs / 1000).toFixed(1)}s`}
       </span>
     </span>
   );

--- a/frontend/src/views/workflows/RunResultPanel.tsx
+++ b/frontend/src/views/workflows/RunResultPanel.tsx
@@ -8,7 +8,11 @@ import { useMemo } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 
-import type { WorkflowGraph, WorkflowRunNode, WorkflowRunResult } from "@/api/workflows";
+import type {
+  WorkflowGraph,
+  WorkflowRunNode,
+  WorkflowRunResult,
+} from "@/api/workflows";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -40,7 +44,9 @@ export function RunResultPanel({
     [result.output, graph],
   );
   const deliveries = result.deliveries ?? [];
-  const pendingDeliveryCount = deliveries.filter((d) => d.status === "pending").length;
+  const pendingDeliveryCount = deliveries.filter(
+    (d) => d.status === "pending",
+  ).length;
   const undeliveredCount = deliveries.filter(
     (d) => d.status !== "sent" && d.status !== "pending",
   ).length;
@@ -48,6 +54,10 @@ export function RunResultPanel({
   // (already `skipped`) read as "would have gone to …" rather than as failures.
   const isDry = result.dryRun === true;
   const nodeTimeline = result.nodes ?? [];
+  // Issues #881 / #880. Read once so the badge, the sentence and the step chips
+  // cannot disagree about whether this run stopped for a person.
+  const blockedNodes = result.blockedNodes ?? [];
+  const parkedCount = result.approvals?.length ?? 0;
 
   return (
     <div className="border-t bg-card/60" data-testid="workflow-run-result">
@@ -68,20 +78,45 @@ export function RunResultPanel({
             </Badge>
           )}
           {pendingDeliveryCount > 0 && (
-            <Badge variant="outline" className="border-status-blocked/40 bg-status-blocked-soft">
-              {pendingDeliveryCount} report{pendingDeliveryCount === 1 ? "" : "s"} awaiting approval
+            <Badge
+              variant="outline"
+              className="border-status-blocked/40 bg-status-blocked-soft"
+            >
+              {pendingDeliveryCount} report
+              {pendingDeliveryCount === 1 ? "" : "s"} awaiting approval
             </Badge>
           )}
           {undeliveredCount > 0 && (
-            <Badge variant="outline" className="border-status-failed/40 bg-status-failed-soft">
-              {undeliveredCount} report{undeliveredCount === 1 ? "" : "s"} not delivered
+            <Badge
+              variant="outline"
+              className="border-status-failed/40 bg-status-failed-soft"
+            >
+              {undeliveredCount} report{undeliveredCount === 1 ? "" : "s"} not
+              delivered
             </Badge>
           )}
-          {result.pendingApprovals.length > 0 && (
-            <Badge variant="outline" className="border-status-blocked/40 bg-status-blocked-soft">
-              {result.pendingApprovals.length} pending approval
-              {result.pendingApprovals.length === 1 ? "" : "s"}
+          {/* Issue #880: what this run PARKED, in those words. Nothing here is
+              refreshed when the operator approves a card, so a "pending" count
+              is stale the moment they do; a receipt of what the run opened
+              stays true. The live answer lives on the Approvals page. */}
+          {parkedCount > 0 ? (
+            <Badge
+              variant="outline"
+              className="border-status-blocked/40 bg-status-blocked-soft"
+              data-testid="workflow-run-result-parked"
+            >
+              parked {parkedCount} approval{parkedCount === 1 ? "" : "s"}
             </Badge>
+          ) : (
+            result.pendingApprovals.length > 0 && (
+              <Badge
+                variant="outline"
+                className="border-status-blocked/40 bg-status-blocked-soft"
+              >
+                {result.pendingApprovals.length} pending approval
+                {result.pendingApprovals.length === 1 ? "" : "s"}
+              </Badge>
+            )
           )}
         </div>
         <Button variant="ghost" size="sm" onClick={onClose}>
@@ -91,10 +126,30 @@ export function RunResultPanel({
       <div className="max-h-72 overflow-auto px-4 pb-3">
         {request && (
           <p className="mb-2 text-xs text-muted-foreground">
-            <span className="font-medium text-foreground">Requested:</span> {request}
+            <span className="font-medium text-foreground">Requested:</span>{" "}
+            {request}
           </p>
         )}
-        {result.pendingApprovals.length > 0 && (
+        {/* Issue #881: the sentence the drawer never had. A blocked run comes
+            back with no error, nothing delivered and — before this — eight
+            green node cards, so the operator's only reading was "it worked".
+            It says plainly that approving does not continue THIS run: an agent
+            step is not resumable, so they must run the workflow again. */}
+        {blockedNodes.length > 0 && (
+          <p
+            className="mb-2 text-xs text-[var(--status-blocked-text)]"
+            data-testid="workflow-run-result-blocked"
+          >
+            Not finished — {blockedNodes.map((b) => `“${b.nodeId}”`).join(", ")}{" "}
+            {blockedNodes.length === 1 ? "needs" : "need"} your approval, so{" "}
+            {blockedNodes.length === 1 ? "it" : "they"} produced nothing and the
+            steps after {blockedNodes.length === 1 ? "it" : "them"} did not run.{" "}
+            {parkedCount > 0
+              ? `This run parked ${parkedCount} approval${parkedCount === 1 ? "" : "s"}; decide ${parkedCount === 1 ? "it" : "them"} in Approvals, then run the workflow again — approving does not continue this run.`
+              : "Nothing here can be approved; change the policy and run the workflow again."}
+          </p>
+        )}
+        {blockedNodes.length === 0 && result.pendingApprovals.length > 0 && (
           <p className="mb-2 text-xs text-muted-foreground">
             Waiting on: {result.pendingApprovals.join(", ")}
           </p>
@@ -111,7 +166,10 @@ export function RunResultPanel({
         )}
 
         {nodeResults && nodeResults.length > 0 ? (
-          <div className="mb-2 space-y-2" data-testid="workflow-run-node-results">
+          <div
+            className="mb-2 space-y-2"
+            data-testid="workflow-run-node-results"
+          >
             {nodeResults.map((n) => (
               <NodeResultCard key={n.id} node={n} />
             ))}
@@ -159,7 +217,9 @@ function NodeResultCard({ node }: { node: NodeResult }) {
           )}
           {m.text ? (
             <div className="prose prose-sm max-w-none dark:prose-invert">
-              <ReactMarkdown remarkPlugins={[remarkGfm]}>{m.text}</ReactMarkdown>
+              <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                {m.text}
+              </ReactMarkdown>
             </div>
           ) : (
             <p className="text-sm text-muted-foreground">—</p>
@@ -192,22 +252,31 @@ function NodeTimeline({
     >
       <span className="text-xs font-medium">Steps</span>
       {nodes.map((n, i) => (
-        <div key={`${n.nodeId}-${i}`} className="flex flex-wrap items-baseline gap-1.5">
+        <div
+          key={`${n.nodeId}-${i}`}
+          className="flex flex-wrap items-baseline gap-1.5"
+        >
           <Badge
             variant="outline"
+            /* Issue #881: three tones. The default arm was "anything that is
+               not an error is green", which painted a blocked step — one that
+               produced nothing — exactly like a step that delivered. */
             className={`h-4 px-1.5 text-3xs font-normal ${
               n.status === "error"
                 ? "border-status-failed/40 bg-status-failed-soft"
-                : "border-status-done/40 bg-status-done-soft"
+                : n.status === "blocked"
+                  ? "border-status-blocked/50 bg-status-blocked-soft"
+                  : "border-status-done/40 bg-status-done-soft"
             }`}
           >
             {n.status}
           </Badge>
           <span className="text-2xs">{nameById.get(n.nodeId) ?? n.nodeId}</span>
-          <span className="text-2xs text-muted-foreground">{n.elapsedMs} ms</span>
+          <span className="text-2xs text-muted-foreground">
+            {n.elapsedMs} ms
+          </span>
         </div>
       ))}
     </div>
   );
 }
-

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -7,12 +7,13 @@
 
 import type { Edge, Node } from "@xyflow/react";
 
-import type {
-  WorkflowGraph,
-  WorkflowRunOutcome,
-} from "@/api/workflows";
+import type { WorkflowGraph, WorkflowRunOutcome } from "@/api/workflows";
 import type { CompanyStreamEvent } from "@/hooks/use-events";
-import { nodeKindMeta, type NodeRunState, type WorkflowNodeData } from "@/lib/workflow-sample";
+import {
+  nodeKindMeta,
+  type NodeRunState,
+  type WorkflowNodeData,
+} from "@/lib/workflow-sample";
 
 /** Horizontal gap between layers and vertical gap between nodes in a layer. */
 const COL_GAP = 300;
@@ -91,7 +92,8 @@ export function foldLiveRun(
       break;
     }
   }
-  if (startIndex === -1) return inFlight ? foldFromHistory(events, graph, inFlight) : null;
+  if (startIndex === -1)
+    return inFlight ? foldFromHistory(events, graph, inFlight) : null;
   const started = events[startIndex];
   if (started.type !== "workflow_run_started") return null;
 
@@ -102,7 +104,14 @@ export function foldLiveRun(
   // host from here (#382), not derived.
   const states = initialRunState(graph);
   const elapsed: Record<string, number> = {};
-  const active = applyFrames(events, startIndex + 1, runId, selectedId, states, elapsed);
+  const active = applyFrames(
+    events,
+    startIndex + 1,
+    runId,
+    selectedId,
+    states,
+    elapsed,
+  );
 
   settle(states, active);
   return { runId, states, elapsed, active, scheduled };
@@ -133,7 +142,13 @@ function foldFromHistory(
   const active = applyFrames(events, 0, inFlight.runId, null, states, elapsed);
 
   settle(states, active);
-  return { runId: inFlight.runId, states, elapsed, active, scheduled: inFlight.scheduled };
+  return {
+    runId: inFlight.runId,
+    states,
+    elapsed,
+    active,
+    scheduled: inFlight.scheduled,
+  };
 }
 
 /** Applies every frame belonging to `runId` from `from` onward, and reports
@@ -160,16 +175,22 @@ function applyFrames(
     // back to running.
     if (e.type === "workflow_node_started") {
       if (e.runId !== runId) continue;
-      if (states[e.nodeId] !== "ok" && states[e.nodeId] !== "error") {
+      if (
+        states[e.nodeId] !== "ok" &&
+        states[e.nodeId] !== "error" &&
+        states[e.nodeId] !== "blocked"
+      ) {
         states[e.nodeId] = "running";
       }
       continue;
     }
     if (e.type === "workflow_node_finished") {
       if (e.runId !== runId) continue;
-      // Anything that is not "ok" is treated as a failure: an unknown status
-      // word from a newer host must never paint a node as succeeded.
-      states[e.nodeId] = e.status === "ok" ? "ok" : "error";
+      // Issue #881: three reported readings now, not two. `blocked` is named
+      // explicitly and everything else that is not "ok" stays a failure — an
+      // unknown status word from a newer host must never paint a node as
+      // succeeded, and must not be quietly promoted to "blocked" either.
+      states[e.nodeId] = nodeStateFrom(e.status);
       elapsed[e.nodeId] = e.elapsedMs;
       continue;
     }
@@ -177,7 +198,8 @@ function applyFrames(
       // A pre-#371 host sends no runId; treat that as "the run on screen"
       // rather than ignoring it, else the canvas would spin forever.
       if (e.runId === runId) active = false;
-      else if (!e.runId && selectedId !== null && e.workflowId === selectedId) active = false;
+      else if (!e.runId && selectedId !== null && e.workflowId === selectedId)
+        active = false;
     }
   }
   return active;
@@ -210,7 +232,9 @@ export function nodeName(graph: WorkflowGraph | null, nodeId: string): string {
  * now REPORTED by the host's `workflow_node_started` frame (issue #382), so this
  * no longer guesses a frontier by lighting up a trigger's successors — that guess
  * over-marked both arms of a branch until the real finishes corrected it. */
-export function initialRunState(graph: WorkflowGraph): Record<string, NodeRunState> {
+export function initialRunState(
+  graph: WorkflowGraph,
+): Record<string, NodeRunState> {
   const state: Record<string, NodeRunState> = {};
   for (const node of graph.nodes) {
     if (node.kind !== "trigger") continue;
@@ -224,16 +248,33 @@ export function initialRunState(graph: WorkflowGraph): Record<string, NodeRunSta
  * No `running` ever comes out of this: the run is over. A node the run never
  * reached simply has no entry, so it renders unmarked — "not reached" and not
  * "still to come", which for a failed run is the honest reading. */
-export function statesFromRun(run: WorkflowRunOutcome): Record<string, NodeRunState> {
+export function statesFromRun(
+  run: WorkflowRunOutcome,
+): Record<string, NodeRunState> {
   const state: Record<string, NodeRunState> = {};
   for (const node of run.nodes ?? []) {
-    state[node.nodeId] = node.status === "ok" ? "ok" : "error";
+    state[node.nodeId] = nodeStateFrom(node.status);
   }
   return state;
 }
 
+/** Maps a reported node status onto a canvas state (issue #881).
+ *
+ * One place, so the live trail and a past run's overlay cannot disagree about
+ * what "blocked" looks like. Fail-safe in the same direction it always was:
+ * only the two words the host actually reports are trusted, and anything else
+ * — including a status a newer host invents — paints as a failure rather than
+ * as a success or as the gentler amber. */
+function nodeStateFrom(status: string): NodeRunState {
+  if (status === "ok") return "ok";
+  if (status === "blocked") return "blocked";
+  return "error";
+}
+
 /** Per-node durations of a past run, keyed for the canvas. */
-export function elapsedFromRun(run: WorkflowRunOutcome): Record<string, number> {
+export function elapsedFromRun(
+  run: WorkflowRunOutcome,
+): Record<string, number> {
   const out: Record<string, number> = {};
   for (const node of run.nodes ?? []) out[node.nodeId] = node.elapsedMs;
   return out;
@@ -255,7 +296,10 @@ export function elapsedFromRun(run: WorkflowRunOutcome): Record<string, number> 
  * * nothing ran at all — a graph that would not compile, or a capability that
  *   could not be built.
  */
-export function failureLocation(run: WorkflowRunOutcome, graph: WorkflowGraph | null): string {
+export function failureLocation(
+  run: WorkflowRunOutcome,
+  graph: WorkflowGraph | null,
+): string {
   const failed = failedNodeOf(run);
   if (failed) return `it failed at “${nodeName(graph, failed)}”.`;
   const ran = run.nodes?.length ?? 0;
@@ -270,9 +314,17 @@ export function failureLocation(run: WorkflowRunOutcome, graph: WorkflowGraph | 
  * The engine reports a failing node as an `error` step before the run ends, so
  * this is exact rather than inferred. `null` when the run failed with no
  * errored node — a graph that would not compile, a capability that could not be
- * built — where naming a node would be a fabrication. */
+ * built — where naming a node would be a fabrication.
+ *
+ * Issue #881: a `blocked` node is explicitly NOT a failure. It stopped for a
+ * person, and the run that stopped with it carries no error at all — so
+ * returning it here would have the panel say "it failed at X" about a step that
+ * is merely waiting. `WorkflowRunOutcome.blockedNodes` names those instead. */
 export function failedNodeOf(run: WorkflowRunOutcome): string | null {
-  return (run.nodes ?? []).find((n) => n.status !== "ok")?.nodeId ?? null;
+  return (
+    (run.nodes ?? []).find((n) => n.status !== "ok" && n.status !== "blocked")
+      ?.nodeId ?? null
+  );
 }
 
 /** Lays a saved graph out left→right by longest-path depth, stacking siblings

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -68,6 +68,25 @@ export function parkedApprovalCount(run: WorkflowRunOutcome): number {
 }
 
 /**
+ * The approvals this run parked that are actually sitting on the Approvals
+ * page right now (issue #900) — `outcome === "parked"` only.
+ *
+ * {@link parkedApprovalCount} deliberately folds in the parks that failed and
+ * the calls that were discarded, because those are "the rows that matter
+ * most: nobody will ever be asked about those calls" (see
+ * `WorkflowRunOutcome.approvals` in `api/workflows.ts`). That is the right
+ * receipt for "what happened to this run's gated calls" — but wrong for any
+ * copy that tells the operator something is waiting to be decided. A run
+ * whose every park failed has `parkedApprovalCount` of 1 and zero cards on
+ * Approvals; telling the operator to "decide it in Approvals" would send them
+ * to an empty page. Use this count wherever the sentence claims a card
+ * exists.
+ */
+export function decidableApprovalCount(run: WorkflowRunOutcome): number {
+  return (run.approvals ?? []).filter((a) => a.outcome === "parked").length;
+}
+
+/**
  * Whether this run stopped short because a step is waiting on a person (issue
  * #881).
  *

--- a/frontend/src/views/workflows/run-health.ts
+++ b/frontend/src/views/workflows/run-health.ts
@@ -25,7 +25,9 @@ const PENDING_STATUS: string = "pending";
  * is a report parked for an operator's approval, so counting it here would
  * badge a working approvals queue as a failure. */
 export function undeliveredCount(deliveries: DeliveryReport[]): number {
-  return deliveries.filter((d) => d.status !== "sent" && d.status !== PENDING_STATUS).length;
+  return deliveries.filter(
+    (d) => d.status !== "sent" && d.status !== PENDING_STATUS,
+  ).length;
 }
 
 /** Reports waiting on an operator's verdict rather than on a fix. */
@@ -50,6 +52,33 @@ export function pendingCount(deliveries: DeliveryReport[]): number {
  */
 export function awaitingCount(run: WorkflowRunOutcome): number {
   return (run.pendingApprovals?.length ?? 0) + pendingCount(run.deliveries);
+}
+
+/**
+ * The approvals this run **parked** (issue #880).
+ *
+ * A receipt, and the wording everywhere this feeds must follow from that:
+ * "parked N approvals", never "waiting on N". Nothing comes back to decrement
+ * this once the operator approves a card, so a "still waiting" phrasing becomes
+ * a fresh lie the moment they do — and the Approvals page, which IS live, is
+ * where that question belongs.
+ */
+export function parkedApprovalCount(run: WorkflowRunOutcome): number {
+  return run.approvals?.length ?? 0;
+}
+
+/**
+ * Whether this run stopped short because a step is waiting on a person (issue
+ * #881).
+ *
+ * Its own reading rather than a fold into {@link runTone}'s chain, because a
+ * blocked run is the shape that fooled every existing check: it carries no
+ * `error`, it is not `cancelled`, it is not `running`, and it routed no report
+ * — so before this it fell through every arm to the green "ok" and told the
+ * operator that a pipeline which delivered nothing had succeeded.
+ */
+export function isBlocked(run: WorkflowRunOutcome): boolean {
+  return (run.blockedNodes?.length ?? 0) > 0;
 }
 
 /** A compact "N minutes ago" for a run timestamp — enough to tell last night's
@@ -82,8 +111,12 @@ export function relativeTime(atMillis: number): string {
  * because roughly 1 in 12 men cannot separate the red/green pair and a bare
  * dot puts the whole signal on hue.
  */
-export function runTone(run: WorkflowRunOutcome): { dot: string; label: string } {
-  if (isRunning(run)) return { dot: "animate-pulse bg-status-running", label: "running" };
+export function runTone(run: WorkflowRunOutcome): {
+  dot: string;
+  label: string;
+} {
+  if (isRunning(run))
+    return { dot: "animate-pulse bg-status-running", label: "running" };
   if (run.error) return { dot: "bg-status-failed", label: "failed" };
   // Issue #383: checked before the delivery reads, and deliberately NOT red. A
   // stop somebody asked for is not a fault, and a cancelled run has no
@@ -91,6 +124,13 @@ export function runTone(run: WorkflowRunOutcome): { dot: string; label: string }
   // the green "ok" and read as a clean success. Idle is the state for "nothing
   // is happening and nothing went wrong".
   if (run.cancelled) return { dot: "bg-status-idle", label: "stopped" };
+  // Issue #881: checked BEFORE the delivery reads and before `awaitingCount`,
+  // and deliberately not red. A blocked run stopped short of its work but
+  // nothing about it failed, and its own delivery rows are empty — so without
+  // this arm it fell through to the green "ok". The label says what happened to
+  // the run, not what is owed: "blocked" is the state, and the count of what it
+  // parked belongs on the row beneath.
+  if (isBlocked(run)) return { dot: "bg-status-blocked", label: "blocked" };
   if (undeliveredCount(run.deliveries) > 0)
     return { dot: "bg-status-failed", label: "not delivered" };
   // Blocked, not running. This was the running colour, which said "the machine
@@ -101,7 +141,8 @@ export function runTone(run: WorkflowRunOutcome): { dot: string; label: string }
   // parked no report — it never reached an output node — so the delivery-only
   // read scored it green and the operator was told a run that did none of its
   // work had succeeded.
-  if (awaitingCount(run) > 0) return { dot: "bg-status-blocked", label: "awaiting approval" };
+  if (awaitingCount(run) > 0)
+    return { dot: "bg-status-blocked", label: "awaiting approval" };
   return { dot: "bg-status-done", label: "ok" };
 }
 

--- a/frontend/test/unit/workflow-copilot.test.ts
+++ b/frontend/test/unit/workflow-copilot.test.ts
@@ -189,4 +189,38 @@ describe("composeCopilotMessage", () => {
     );
     expect(empty).toMatch(/no tools are granted/i);
   });
+
+  /**
+   * Issue #900. `describeRun`'s blocked arm is the copilot's half of the same
+   * fix `RunHistoryPanel` gets on the console side: a blocked run has no
+   * `error`, is not `cancelled`, is not `running` and routed no report, so
+   * without this arm it grounded the copilot with the bare "finished" reading
+   * — the same lie #881 removed from the history panel would otherwise still
+   * reach the model here.
+   */
+  it("grounds the copilot on a blocked run instead of reading it as finished", () => {
+    const blockedRun = {
+      seq: 1,
+      atMillis: 1_700_000_000_000,
+      workflowId: "weekly_report",
+      scheduled: false,
+      runId: "run-1",
+      deliveries: [],
+      pendingApprovals: ["collect"],
+      blockedNodes: [{ nodeId: "collect", tools: ["shell"], approvalIds: ["appr-1"] }],
+      approvals: [
+        { nodeId: "collect", tool: "shell", outcome: "parked" as const, approvalId: "appr-1" },
+      ],
+    };
+    const message = composeCopilotMessage(
+      { ...context, runs: [blockedRun] },
+      "why didn't this run send anything?",
+    );
+    expect(message).toContain("BLOCKED at collect");
+    expect(message).toContain("parked 1 approval(s)");
+    expect(message).toMatch(/does NOT continue this run/);
+    // The bare "finished" reading this arm exists to replace must not also
+    // appear for this run.
+    expect(message).not.toMatch(/collect.*finished/);
+  });
 });

--- a/frontend/test/unit/workflow-run-blocked.test.ts
+++ b/frontend/test/unit/workflow-run-blocked.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+
+import type { WorkflowGraph, WorkflowRunOutcome } from "@/api/workflows";
+import type { CompanyStreamEvent } from "@/hooks/use-events";
+import {
+  failedNodeOf,
+  foldLiveRun,
+  statesFromRun,
+} from "@/views/workflows/graph";
+import {
+  isBlocked,
+  parkedApprovalCount,
+  runTone,
+} from "@/views/workflows/run-health";
+
+/**
+ * How the console reads a run that stopped because a step is waiting on a
+ * person (issues #881, #880).
+ *
+ * The shape is what makes this worth pinning: a blocked run carries **no**
+ * error, is **not** cancelled, is **not** running, and routed **no** report — so
+ * every existing check fell through to the green "ok" and told the operator
+ * that a pipeline which delivered nothing had succeeded. Each test below is one
+ * of those fall-throughs.
+ */
+
+/** A settled run with nothing wrong with it — the base every case varies. */
+function run(over: Partial<WorkflowRunOutcome> = {}): WorkflowRunOutcome {
+  return {
+    seq: 1,
+    atMillis: 1_700_000_000_000,
+    workflowId: "feature_pipeline",
+    scheduled: false,
+    runId: "run-1",
+    deliveries: [],
+    pendingApprovals: [],
+    ...over,
+  };
+}
+
+/** A run whose first step blocked on a parked `publish_artifact`. */
+function blockedRun(
+  over: Partial<WorkflowRunOutcome> = {},
+): WorkflowRunOutcome {
+  return run({
+    pendingApprovals: ["spec"],
+    nodes: [{ nodeId: "spec", status: "blocked", elapsedMs: 42_000 }],
+    blockedNodes: [
+      { nodeId: "spec", tools: ["publish_artifact"], approvalIds: ["appr-1"] },
+    ],
+    approvals: [
+      {
+        nodeId: "spec",
+        tool: "publish_artifact",
+        outcome: "parked",
+        approvalId: "appr-1",
+      },
+    ],
+    ...over,
+  });
+}
+
+describe("a blocked run's health reading", () => {
+  it("is not green — the fall-through this whole change exists to close", () => {
+    // Before #881 this exact object scored `ok`: no error, not cancelled, not
+    // running, no undelivered reports.
+    expect(runTone(blockedRun()).label).toBe("blocked");
+    expect(runTone(blockedRun()).dot).toContain("status-blocked");
+  });
+
+  it("is not red either — nothing failed, and a fix is one click away", () => {
+    expect(runTone(blockedRun()).dot).not.toContain("status-failed");
+  });
+
+  it("leaves an ordinary run's reading exactly as it was", () => {
+    expect(runTone(run()).label).toBe("ok");
+    expect(isBlocked(run())).toBe(false);
+    // A host predating #881 sends no `blockedNodes` key at all, and absent must
+    // read as "nothing blocked" rather than as unknown.
+    expect(isBlocked(run({ blockedNodes: undefined }))).toBe(false);
+  });
+
+  it("still reports a genuine failure as a failure", () => {
+    // The guard that matters in the other direction: blocked must never
+    // outrank an error, or a real break hides behind an approval.
+    expect(runTone(run({ error: "boom", blockedNodes: [] })).label).toBe(
+      "failed",
+    );
+  });
+});
+
+describe("what the run parked", () => {
+  it("counts the receipt, not the outstanding cards", () => {
+    // Two parked calls under one blocked node: the count comes off the
+    // per-call receipts, which is what the console's wording is built from.
+    const two = blockedRun({
+      approvals: [
+        {
+          nodeId: "spec",
+          tool: "publish_artifact",
+          outcome: "parked",
+          approvalId: "a1",
+        },
+        {
+          nodeId: "spec",
+          tool: "publish_artifact",
+          outcome: "parked",
+          approvalId: "a2",
+        },
+      ],
+    });
+    expect(parkedApprovalCount(two)).toBe(2);
+  });
+
+  it("counts a park that FAILED too — those are the loudest rows", () => {
+    // A failed park means the operator will never be asked about that call. It
+    // must not silently vanish from the run's account of itself.
+    const failed = blockedRun({
+      blockedNodes: [
+        { nodeId: "spec", tools: ["publish_artifact"], unparkable: 1 },
+      ],
+      approvals: [
+        { nodeId: "spec", tool: "publish_artifact", outcome: "parkFailed" },
+      ],
+    });
+    expect(parkedApprovalCount(failed)).toBe(1);
+    expect(isBlocked(failed)).toBe(true);
+  });
+
+  it("reports zero for a run that parked nothing", () => {
+    expect(parkedApprovalCount(run())).toBe(0);
+  });
+});
+
+describe("a blocked node on the canvas", () => {
+  it("overlays as blocked, not as a failure", () => {
+    expect(statesFromRun(blockedRun())).toEqual({ spec: "blocked" });
+  });
+
+  it("is not named as the node the run failed at", () => {
+    // `failureLocation` reads this, and it is only ever asked about a run with
+    // an `error`. A blocked run has none — returning its node here would print
+    // "it failed at spec" about a step that is merely waiting.
+    expect(failedNodeOf(blockedRun())).toBeNull();
+    expect(
+      failedNodeOf(
+        run({ nodes: [{ nodeId: "send", status: "error", elapsedMs: 1 }] }),
+      ),
+    ).toBe("send");
+  });
+
+  it("paints blocked from a live frame, and still fails safe on an unknown status", () => {
+    const graph: WorkflowGraph = {
+      id: "feature_pipeline",
+      name: "Feature pipeline",
+      nodes: [
+        { id: "start", kind: "trigger", name: "Start" },
+        { id: "spec", kind: "agent", name: "Spec", agent: "ceo" },
+        { id: "done", kind: "output", name: "Done" },
+      ],
+      edges: [
+        { from: "start", to: "spec" },
+        { from: "spec", to: "done" },
+      ],
+    };
+    const frames = (status: string): CompanyStreamEvent[] => [
+      {
+        type: "workflow_run_started",
+        seq: 1,
+        atMillis: 1,
+        workflowId: "feature_pipeline",
+        runId: "run-1",
+        scheduled: false,
+      },
+      {
+        type: "workflow_node_finished",
+        seq: 2,
+        atMillis: 2,
+        workflowId: "feature_pipeline",
+        runId: "run-1",
+        nodeId: "spec",
+        status,
+        elapsedMs: 42,
+      },
+    ];
+
+    expect(
+      foldLiveRun(frames("blocked"), "feature_pipeline", graph)?.states.spec,
+    ).toBe("blocked");
+    // A status word a newer host invents must not be promoted to the gentler
+    // amber any more than it may be painted green.
+    expect(
+      foldLiveRun(frames("wat"), "feature_pipeline", graph)?.states.spec,
+    ).toBe("error");
+  });
+});

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -675,6 +675,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
 
         let wired = wire_event(7, &event);
@@ -715,6 +717,8 @@ mod test {
             cancelled: true,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
 
         let wired = wire_event(7, &event);

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2141,6 +2141,65 @@ impl std::fmt::Debug for CompanyRuntime {
 mod tests {
     use super::{emergency_from_load, task_enters_in_progress, task_enters_planning};
 
+    /// Issue #880: which parked approvals name a workflow run, and which must
+    /// not.
+    ///
+    /// The discrimination is the whole content of the change, because
+    /// `Effect::run_id` carries two id spaces — issue #242's task attempt and
+    /// the workflow run — and `generate_id` is only process-locally unique, so
+    /// the value cannot be inspected to tell them apart. Getting this wrong in
+    /// the permissive direction would print a task-attempt id on an approvals
+    /// card as though it were a workflow run.
+    #[test]
+    fn only_an_unlinked_park_with_a_run_id_names_a_workflow_run() {
+        use crate::ports::types::{ApprovalId, Effect, EffectGroup};
+        use crate::runtime::journal::{PendingApproval, TaskLink};
+
+        let parked = |task: Option<TaskLink>, run_id: Option<&str>| PendingApproval {
+            id: ApprovalId::new("appr-1"),
+            effect: Effect {
+                kind: "publish_artifact".to_string(),
+                group: EffectGroup::Other,
+                amount_usd: None,
+                established_thread: false,
+                first_time_counterparty: false,
+                payload: serde_json::json!({}),
+                agent: Some("ceo".to_string()),
+                run_id: run_id.map(str::to_string),
+            },
+            at_millis: 1,
+            task,
+            thread: None,
+            batch: None,
+        };
+
+        // A workflow park: `park_and_journal` records it explicitly unlinked
+        // (#333) and the run stamps its id.
+        assert_eq!(
+            super::workflow_run_of(&parked(Some(TaskLink::Unlinked), Some("run-1"))),
+            Some("run-1".to_string())
+        );
+        // A board task's attempt: same field, different id space. Must NOT be
+        // reported as a workflow run.
+        assert_eq!(
+            super::workflow_run_of(&parked(
+                Some(TaskLink::Task {
+                    id: "card-1".to_string()
+                }),
+                Some("attempt-1")
+            )),
+            None
+        );
+        // A chat turn: unlinked, but nothing stamped a run onto it.
+        assert_eq!(
+            super::workflow_run_of(&parked(Some(TaskLink::Unlinked), None)),
+            None
+        );
+        // A pre-#333 line records no link at all, so the park site is unknown.
+        // Conservative rather than guessing — the same fallback rule #333 set.
+        assert_eq!(super::workflow_run_of(&parked(None, Some("run-1"))), None);
+    }
+
     #[cfg(feature = "openhuman")]
     use std::sync::{Arc, Mutex};
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1228,7 +1228,7 @@ impl CompanyRuntime {
                 ResolveReceipt::AlreadyResolved => {
                     return Ok(CycleRunner::new(&rt).already_resolved_report());
                 }
-                ResolveReceipt::Settled(event) => event,
+                ResolveReceipt::Settled(event) => *event,
             };
             rt.continue_turn(event).await
         })
@@ -1823,6 +1823,9 @@ impl CompanyRuntime {
             .pending()
             .into_iter()
             .map(|p| ApprovalSummary {
+                // Read before the field moves below (issue #880): the answer
+                // needs the task link *and* the effect together.
+                workflow_run_id: workflow_run_of(&p),
                 id: p.id,
                 kind: p.effect.kind.clone(),
                 amount_usd: p.effect.amount_usd,
@@ -2100,6 +2103,28 @@ impl CompanyRuntime {
         }
         Ok(())
     }
+}
+
+/// The **workflow** run waiting on a parked approval, if any (issue #880).
+///
+/// `Effect::run_id` holds two different id spaces — issue #242's task-attempt id
+/// and, on the workflow path, a workflow run id — and `generate_id` is only
+/// process-locally unique, so the value alone cannot say which it is. The park
+/// *site* can, and it is recorded: a task attempt parks inside its dispatch
+/// cycle and is linked to that card, while every workflow park goes through
+/// `park_and_journal` and is recorded explicitly `Unlinked` (#333). A chat turn
+/// is unlinked too but stamps no run id at all, so requiring both is exact.
+///
+/// Deliberately conservative in the ambiguous direction: an approval with no
+/// recorded link (`None`, i.e. a pre-#333 journal line) reports nothing rather
+/// than guessing, which is the same fallback rule #333 set for the task link.
+fn workflow_run_of(parked: &crate::runtime::journal::PendingApproval) -> Option<String> {
+    matches!(
+        parked.task,
+        Some(crate::runtime::journal::TaskLink::Unlinked)
+    )
+    .then(|| parked.effect.run_id.clone())
+    .flatten()
 }
 
 impl std::fmt::Debug for CompanyRuntime {

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -3353,6 +3353,13 @@ impl Tool for RunWorkflowTool {
                         "workflow": file.id,
                         "run_id": ctx.run_id,
                         "pending_approvals": run.pending_approvals.len(),
+                        // Issue #881: structural counts beside the prose, so a
+                        // model reading only the JSON still learns the run
+                        // delivered nothing. Issue #880's is the *parked*
+                        // count — a receipt, never a "still outstanding"
+                        // snapshot.
+                        "blocked_nodes": run.blocked_nodes.len(),
+                        "approvals_parked": run.approvals.len(),
                     }),
                     md,
                 ))
@@ -3454,13 +3461,48 @@ fn summarize_run(
         _ => md.push_str("_No per-node output was produced._\n"),
     }
 
-    if run.pending_approvals.is_empty() {
-        md.push_str("\nThe run reached its terminal node(s) without pausing for approval.\n");
-    } else {
+    // Issue #881: a blocked node and a paused gate are BOTH in
+    // `pending_approvals`, and they need different sentences. Approving a
+    // paused gate continues the run; approving a blocked node's card does not —
+    // an agent node is not re-enterable, so the only way forward is to run the
+    // workflow again. Telling the model "resolve these for the run to continue"
+    // about a blocked node would have it wait for a continuation that is never
+    // coming.
+    let blocked: Vec<&str> = run
+        .blocked_nodes
+        .iter()
+        .map(|b| b.node_id.as_str())
+        .collect();
+    let paused: Vec<&str> = run
+        .pending_approvals
+        .iter()
+        .map(String::as_str)
+        .filter(|id| !blocked.contains(id))
+        .collect();
+    if !blocked.is_empty() {
+        md.push_str(&format!(
+            "\n**Blocked, waiting on a person** at: {}. {} produced no output and nothing after \
+             {} ran, because a tool call in the step needed approval. This run parked {} \
+             approval(s) and will NOT continue on its own — the approval has to be decided and \
+             the workflow run again.\n",
+            blocked.join(", "),
+            if blocked.len() == 1 {
+                "That step"
+            } else {
+                "Those steps"
+            },
+            if blocked.len() == 1 { "it" } else { "them" },
+            run.approvals.len()
+        ));
+    }
+    if !paused.is_empty() {
         md.push_str(&format!(
             "\n**Paused for approval** at: {}. Resolve these for the run to continue.\n",
-            run.pending_approvals.join(", ")
+            paused.join(", ")
         ));
+    }
+    if blocked.is_empty() && paused.is_empty() {
+        md.push_str("\nThe run reached its terminal node(s) without pausing for approval.\n");
     }
 
     // Footer: the previews above are the *last* item of each node, clipped, so
@@ -4394,6 +4436,8 @@ mod tests {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         });
 
         assert!(!summary.contains(RECIPIENT), "{summary}");
@@ -4422,6 +4466,8 @@ mod tests {
             cancelled: true,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         });
 
         assert!(summary.contains("stopped"), "{summary}");
@@ -6624,6 +6670,8 @@ name = "Morning"
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             })
         }
     }
@@ -6749,6 +6797,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         });
         let calls = runner_impl.calls.clone();
         let runner: Arc<dyn WorkflowRunner> = Arc::new(runner_impl);
@@ -6794,6 +6844,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -6894,6 +6946,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -6930,6 +6984,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7133,6 +7189,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7200,6 +7258,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7277,6 +7337,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7377,6 +7439,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7994,6 +8058,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         let md = summarize_run(&file, &run, "run-xyz", RunOutputStored::Stored);
         assert!(md.contains("last of 3 items — third"), "{md}");
@@ -8009,6 +8075,8 @@ name = "Morning"
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         let md = summarize_run(&file, &run_one, "run-1", RunOutputStored::Stored);
         assert!(md.contains("1 item(s) — only"), "{md}");
@@ -8046,6 +8114,8 @@ name = "Morning"
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -8075,6 +8145,8 @@ name = "Morning"
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cancel_cache.clone(),
@@ -8111,6 +8183,8 @@ name = "Morning"
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),
@@ -8173,6 +8247,8 @@ name = "Morning"
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             },
             WorkflowRefQueue::default(),
             cache.clone(),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -7011,6 +7011,95 @@ name = "Morning"
         assert!(out.contains("worker"), "{out}");
     }
 
+    /// Issue #900 (tinysweeper `missing-test`): `summarize_run`'s blocked branch
+    /// had no coverage at all, and the doc comment on `blocked` / `paused`
+    /// (issue #881) — that a blocked node and a paused gate need separate
+    /// sentences even though both ride `pending_approvals` — was untested along
+    /// with it. One node blocks, a second is an ordinary paused gate: the
+    /// summary must name the blocked node under "Blocked, waiting on a person"
+    /// (never under "Paused for approval", which would tell the agent the run
+    /// resumes on its own) and the paused node under "Paused for approval"
+    /// only. The structural JSON counts (issue #881) must agree.
+    #[tokio::test]
+    async fn run_workflow_tool_separates_blocked_nodes_from_paused_gates() {
+        let dir = tempfile::tempdir().unwrap();
+        seed_demo_workflow(dir.path());
+
+        let runner: Arc<dyn WorkflowRunner> = Arc::new(StubRunner::new(WorkflowRun {
+            output: json!({ "nodes": { "worker": { "items": [] } } }),
+            // Issue #881: the union — the blocked node's id rides here too, and
+            // `summarize_run` is what has to keep it out of the "Paused for
+            // approval" line.
+            pending_approvals: vec!["worker".to_string(), "gate".to_string()],
+            deliveries: Vec::new(),
+            cancelled: false,
+            nodes: Vec::new(),
+            notices: Vec::new(),
+            board: Vec::new(),
+            blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                node_id: "worker".to_string(),
+                tools: vec!["publish_artifact".to_string()],
+                approval_ids: vec!["appr-1".to_string()],
+                unparkable: 0,
+            }],
+            approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                node_id: Some("worker".to_string()),
+                tool: Some("publish_artifact".to_string()),
+                outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                approval_id: Some("appr-1".to_string()),
+            }],
+        }));
+        let handle = WorkflowRunnerHandle::default();
+        handle.set(&runner);
+
+        let refs = WorkflowRefQueue::default();
+        let tool = RunWorkflowTool::new(
+            CompanyId::new("acme"),
+            Some(dir.path().to_path_buf()),
+            Arc::new(MemStore::default()),
+            handle,
+            crate::runtime::RunSupervisor::default(),
+            None,
+            refs,
+            RunOutputCache::default(),
+        );
+        let result = tool
+            .execute(json!({ "id": "demo" }))
+            .await
+            .expect("execute");
+        assert!(!result.is_error);
+        let out = result.output_for_llm(true);
+        assert!(
+            out.contains("Blocked, waiting on a person") && out.contains("worker"),
+            "{out}"
+        );
+        assert!(
+            out.contains("Paused for approval") && out.contains("gate"),
+            "{out}"
+        );
+        // The blocked node must not also read as an ordinary paused gate — that
+        // sentence promises the run continues once it is decided, which is
+        // false for a block (issue #881).
+        let paused_line = out
+            .lines()
+            .find(|l| l.contains("Paused for approval"))
+            .expect("a Paused for approval line");
+        assert!(!paused_line.contains("worker"), "{out}");
+
+        let payload = match &result.content[0] {
+            openhuman_core::openhuman::skills::types::ToolContent::Json { data } => data.clone(),
+            other => panic!("expected JSON payload, got {other:?}"),
+        };
+        assert_eq!(
+            payload.get("blocked_nodes").and_then(Value::as_u64),
+            Some(1)
+        );
+        assert_eq!(
+            payload.get("approvals_parked").and_then(Value::as_u64),
+            Some(1)
+        );
+    }
+
     #[tokio::test]
     async fn run_workflow_tool_errors_when_no_runner_is_wired() {
         let dir = tempfile::tempdir().unwrap();

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -3355,11 +3355,23 @@ impl Tool for RunWorkflowTool {
                         "pending_approvals": run.pending_approvals.len(),
                         // Issue #881: structural counts beside the prose, so a
                         // model reading only the JSON still learns the run
-                        // delivered nothing. Issue #880's is the *parked*
-                        // count — a receipt, never a "still outstanding"
-                        // snapshot.
+                        // delivered nothing.
                         "blocked_nodes": run.blocked_nodes.len(),
-                        "approvals_parked": run.approvals.len(),
+                        // Issue #900: `outcome == Parked` only, unlike
+                        // `WorkflowRun::approvals`'s own receipt semantics
+                        // (which deliberately count `ParkFailed` / `Discarded`
+                        // too — see that field's doc comment). This key has no
+                        // sibling field to carry the failure count the way the
+                        // console's prose does with "N calls could not be
+                        // queued", so a bare `approvals_parked` here has to
+                        // mean what its name says: cards actually sitting on
+                        // the Approvals page, not every receipt this run
+                        // filed.
+                        "approvals_parked": run
+                            .approvals
+                            .iter()
+                            .filter(|a| a.outcome == crate::ports::WorkflowApprovalOutcome::Parked)
+                            .count(),
                     }),
                     md,
                 ))
@@ -7042,12 +7054,23 @@ name = "Morning"
                 approval_ids: vec!["appr-1".to_string()],
                 unparkable: 0,
             }],
-            approvals: vec![crate::ports::WorkflowRunApprovalRow {
-                node_id: Some("worker".to_string()),
-                tool: Some("publish_artifact".to_string()),
-                outcome: crate::ports::WorkflowApprovalOutcome::Parked,
-                approval_id: Some("appr-1".to_string()),
-            }],
+            approvals: vec![
+                crate::ports::WorkflowRunApprovalRow {
+                    node_id: Some("worker".to_string()),
+                    tool: Some("publish_artifact".to_string()),
+                    outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                    approval_id: Some("appr-1".to_string()),
+                },
+                // Issue #900: a receipt for a call that did NOT land a card.
+                // `run.approvals.len()` would count this as a second "parked"
+                // approval; the JSON's `approvals_parked` must not.
+                crate::ports::WorkflowRunApprovalRow {
+                    node_id: Some("worker".to_string()),
+                    tool: Some("publish_artifact".to_string()),
+                    outcome: crate::ports::WorkflowApprovalOutcome::ParkFailed,
+                    approval_id: None,
+                },
+            ],
         }));
         let handle = WorkflowRunnerHandle::default();
         handle.set(&runner);
@@ -7094,9 +7117,12 @@ name = "Morning"
             payload.get("blocked_nodes").and_then(Value::as_u64),
             Some(1)
         );
+        // Issue #900: two receipts on this run (one parked, one that failed to
+        // park), and the JSON count must name only the decidable one.
         assert_eq!(
             payload.get("approvals_parked").and_then(Value::as_u64),
-            Some(1)
+            Some(1),
+            "approvals_parked must exclude the ParkFailed receipt: {payload}"
         );
     }
 

--- a/src/ports/mod.rs
+++ b/src/ports/mod.rs
@@ -80,7 +80,8 @@ pub use workflow_revisions::{
     MAX_WORKFLOW_REVISIONS, WorkflowRevisionRecord, WorkflowRevisionStore,
 };
 pub use workflow_runner::{
-    DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowBoardAction, WorkflowRun,
+    DeliveryReason, DeliveryReport, DeliveryStatus, RunCancel, WorkflowApprovalOutcome,
+    WorkflowBlockedNode, WorkflowBoardAction, WorkflowRun, WorkflowRunApprovalRow,
     WorkflowRunBoardRow, WorkflowRunContext, WorkflowRunNodeRow, WorkflowRunner,
 };
 pub use workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -15,7 +15,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::company::{CompanyManifest, POLICY_MODES, Policy};
 use crate::ports::ids::{agent_slug, generate_id, now_millis};
-use crate::ports::workflow_runner::{DeliveryReport, WorkflowRunBoardRow};
+use crate::ports::workflow_runner::{
+    DeliveryReport, WorkflowBlockedNode, WorkflowRunApprovalRow, WorkflowRunBoardRow,
+};
 
 // ---------------------------------------------------------------------------
 // Identifiers
@@ -1065,6 +1067,34 @@ pub enum CompanyEvent {
         /// them.
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         board: Vec<WorkflowRunBoardRow>,
+        /// One row per node this run blocked on a human (issue #881) — the
+        /// same rows the synchronous run response hands back.
+        ///
+        /// What makes a **scheduled** run's blockage readable at all: nobody
+        /// was watching the response, so without this the only evidence a 3am
+        /// run stopped short is an approval card nothing ties back to a run.
+        ///
+        /// `#[serde(default)]` + `skip_serializing_if` so a line written
+        /// before this field existed replays — the event is folded at boot, so
+        /// a field without a default would make every pre-existing journal
+        /// line fail to parse, which is silent history loss rather than a
+        /// compile error — and a run that blocked on nobody serializes
+        /// byte-for-byte as it did before.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        blocked_nodes: Vec<WorkflowBlockedNode>,
+        /// One row per approval this run parked (issue #880) — a receipt of
+        /// what it opened, not a snapshot of what is still outstanding.
+        ///
+        /// The field the three `feature_pipeline` runs needed: they parked
+        /// fifteen `publish_artifact` cards between them and their run records
+        /// said nothing, because `pendingApprovals` means the engine's gate
+        /// nodes and `deliveries` means `output`-node routing. Both were
+        /// honest; neither was an answer.
+        ///
+        /// Same `#[serde(default)]` + `skip_serializing_if` contract as
+        /// `blocked_nodes` above, and for the same replay reason.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        approvals: Vec<WorkflowRunApprovalRow>,
     },
     /// A workflow run began (issue #371) — the opening bracket of a run's
     /// per-node progress trail.
@@ -1433,12 +1463,15 @@ impl CompanyEvent {
     }
 }
 
-/// How one workflow node's execution came out (issue #371).
+/// How one workflow node's execution came out (issue #371, third arm #881).
 ///
-/// A closed two-value set on purpose: it is the entire payload of
+/// A closed set of **unit** variants on purpose: it is the entire payload of
 /// [`CompanyEvent::WorkflowNodeFinished`] beyond the structural ids, and having
 /// no `String` arm is what guarantees, by construction, that a node's own error
-/// text cannot reach the journal or the wire through this event.
+/// text cannot reach the journal or the wire through this event. Issue #881
+/// added a third reading and kept that invariant — [`Blocked`](Self::Blocked)
+/// carries nothing, and what it is blocked *on* travels structurally on
+/// [`WorkflowRun::blocked_nodes`](crate::ports::WorkflowRun) instead.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkflowNodeStatus {
@@ -1446,6 +1479,21 @@ pub enum WorkflowNodeStatus {
     Ok,
     /// The node's executor errored (after any retries were exhausted).
     Error,
+    /// The node stopped because it needs a human, not because anything went
+    /// wrong (issue #881): a tool call inside its turn was parked for operator
+    /// approval, so the node produced no deliverable and its branch does not
+    /// continue.
+    ///
+    /// **Never reported by the engine.** tinyflows knows only success and
+    /// failure, and an agent node whose turn parked a gated call returns a
+    /// capability error so the branch halts — mechanically the right channel,
+    /// since `on_error` defaults to `"stop"` and `retry.max_attempts` to `1`.
+    /// The *host* then reclassifies that node's row, exactly as
+    /// [`WorkflowRun::cancelled`](crate::ports::WorkflowRun) reclassifies a
+    /// stopped run: a blocked node is not a failed one, and rolling it into the
+    /// failure count would hide real failures among approvals nobody has
+    /// answered yet.
+    Blocked,
 }
 
 /// A `CompanyEvent` durably appended to the log with its sequence and time.
@@ -5038,6 +5086,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -5056,6 +5106,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
     }
@@ -5086,6 +5138,8 @@ mod test {
                 cancelled: false,
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             }
         );
         // …and serializing it back emits nothing extra.
@@ -5127,6 +5181,8 @@ mod test {
                 title: Some("Reply to the auditor".to_string()),
                 assignee: None,
             }],
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
         let out = serde_json::to_string(&event).expect("serialize");
@@ -5146,6 +5202,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         let out = serde_json::to_string(&untouched).expect("serialize");
         assert!(!out.contains("board"), "{out}");
@@ -5184,6 +5242,8 @@ mod test {
             cancelled: true,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         };
         assert_eq!(round_trip(&event), event);
 
@@ -5235,7 +5295,14 @@ mod test {
     /// slow run from a wedged one.
     #[test]
     fn workflow_node_finished_round_trips_both_statuses() {
-        for status in [WorkflowNodeStatus::Ok, WorkflowNodeStatus::Error] {
+        for status in [
+            WorkflowNodeStatus::Ok,
+            WorkflowNodeStatus::Error,
+            // Issue #881's third arm. Pinned in the same loop rather than a
+            // test of its own so a fourth reading cannot be added without
+            // someone editing this list.
+            WorkflowNodeStatus::Blocked,
+        ] {
             let event = CompanyEvent::WorkflowNodeFinished {
                 workflow_id: "digest".to_string(),
                 run_id: "run-1".to_string(),
@@ -5298,6 +5365,8 @@ mod test {
                 cancelled: false,
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             }
         );
     }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -5314,6 +5314,63 @@ mod test {
         }
     }
 
+    /// A `WorkflowRunFinished` line written before #881 / #880 still replays.
+    ///
+    /// **This is not a nicety.** The event is folded at boot, so a new field
+    /// without `#[serde(default)]` would make every pre-existing journal line
+    /// fail to parse — and the failure mode is a company silently losing its
+    /// whole run history, not a compile error. Pinned against a hand-written
+    /// legacy payload rather than a round-trip, because a round-trip can only
+    /// ever prove the new shape agrees with itself.
+    #[test]
+    fn a_pre_881_run_finished_line_still_replays() {
+        let legacy = serde_json::json!({
+            "kind": "WorkflowRunFinished",
+            "workflow_id": "digest",
+            "scheduled": true,
+            "run_id": "run-1",
+            "pending_approvals": ["review"],
+            "cancelled": false
+        });
+        let event: CompanyEvent =
+            serde_json::from_value(legacy).expect("a pre-#881 journal line must still parse");
+        let CompanyEvent::WorkflowRunFinished {
+            blocked_nodes,
+            approvals,
+            pending_approvals,
+            ..
+        } = &event
+        else {
+            panic!("expected a WorkflowRunFinished, got {event:?}");
+        };
+        assert!(blocked_nodes.is_empty());
+        assert!(approvals.is_empty());
+        assert_eq!(pending_approvals, &vec!["review".to_string()]);
+    }
+
+    /// A run that blocked on nobody serializes byte-for-byte as it did before
+    /// #881 / #880 — which is nearly every run, so this is what keeps the
+    /// journal from growing two empty arrays per line.
+    #[test]
+    fn a_run_that_blocked_on_nobody_adds_no_keys() {
+        let event = CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".to_string(),
+            scheduled: false,
+            run_id: Some("run-1".to_string()),
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
+        };
+        let json = serde_json::to_value(&event).expect("serialize");
+        assert!(json.get("blocked_nodes").is_none(), "{json}");
+        assert!(json.get("approvals").is_none(), "{json}");
+    }
+
     /// Every field on both #371 variants is required, and that is the point:
     /// the correlation id is what groups a run's nodes with its outcome, so a
     /// line without one would be unfoldable. Nothing is `skip_serializing_if`,

--- a/src/ports/workflow_runner.rs
+++ b/src/ports/workflow_runner.rs
@@ -26,8 +26,24 @@ pub struct WorkflowRun {
     /// The final run state after the terminal node(s) completed. Its shape is
     /// the engine's `{ "run": …, "nodes": { "<id>": { "items": [ … ] } } }` map.
     pub output: Value,
-    /// Node ids that paused the run awaiting human approval. Empty for a run
-    /// that reached its terminal node(s) without gating.
+    /// Node ids the run is waiting on a human for. Empty for a run that
+    /// reached its terminal node(s) without stopping for anybody.
+    ///
+    /// **Two producers, deliberately unioned** (issue #881). The original is
+    /// the tinyflows engine's own gate-node list: a `tool_call` node marked
+    /// `requires_approval` pauses the engine, lands here, and resumes through
+    /// [`workflow_resume`](crate::runtime::workflow_resume). The second is a
+    /// node the *host* blocked — an agent node whose turn had a tool call
+    /// parked for approval (see [`blocked_nodes`](Self::blocked_nodes)), which
+    /// the engine never learns about because the refusal happens inside the
+    /// model's tool loop.
+    ///
+    /// They are unioned because the question this field answers — "which nodes
+    /// is this run waiting on me for?" — has the same answer for both, and the
+    /// console renders every entry as a node name. What differs is what
+    /// approving does: a paused gate resumes the run, a blocked node does not
+    /// (see [`blocked_nodes`](Self::blocked_nodes)), which is why the two stay
+    /// separable through that field rather than only through this one.
     pub pending_approvals: Vec<String>,
     /// One row per attempt to route a reached `output` node's report to its
     /// configured destination (issue #170), in graph order.
@@ -115,6 +131,164 @@ pub struct WorkflowRun {
     /// deserialized from a payload written before this field existed.
     #[serde(default)]
     pub board: Vec<WorkflowRunBoardRow>,
+    /// One row per node this run **blocked** on a human (issue #881), in the
+    /// order the nodes reported.
+    ///
+    /// A node blocks when a tool call inside its agent turn was parked for
+    /// operator approval. Before this, that node returned the model's apology
+    /// as its output, reported `ok`, and the graph carried the apology into the
+    /// next node's input — so a run that delivered nothing finished green.
+    ///
+    /// **Not a failure, and not a pause either.** The branch stops (see
+    /// [`WorkflowNodeStatus::Blocked`](crate::ports::types::WorkflowNodeStatus))
+    /// but the run is not parked for auto-resume: an agent node is not
+    /// re-enterable, so resuming would run a fresh turn that parks a *new*
+    /// approval, forever. Approving lets the operator re-run; it does not
+    /// continue this one.
+    ///
+    /// `#[serde(default)]` so a `WorkflowRun` deserialized from a payload
+    /// written before this field existed still loads, as empty — which is every
+    /// run that blocked on nobody.
+    #[serde(default)]
+    pub blocked_nodes: Vec<WorkflowBlockedNode>,
+    /// One row per approval this run **parked** (issue #880), in the order the
+    /// parks were attempted.
+    ///
+    /// Three real feature-pipeline runs each reported every node `ok` with an
+    /// empty [`pending_approvals`](Self::pending_approvals) and an empty
+    /// [`deliveries`](Self::deliveries) while the company's approval queue held
+    /// fifteen `publish_artifact` cards those very runs had opened. Both of
+    /// those fields were *truthful* — they mean the engine's gate nodes and
+    /// `output`-node routing respectively — and neither answers what the run
+    /// view is asked. This field does.
+    ///
+    /// # It is a receipt, which is why it is named for what the run parked
+    ///
+    /// Not `pending_approvals_opened`, not "still outstanding". A settle-time
+    /// snapshot of what is *still* waiting rots into a fresh lie the moment the
+    /// operator approves one; a record that this run parked two cards is true
+    /// forever. The console's wording follows from the name — "parked N
+    /// approvals", never "waiting on N".
+    ///
+    /// **The failure rows are the ones that matter most.** Before this, a park
+    /// that could not be performed — no approvals queue wired, or a store that
+    /// refused the write — was recorded only by a `tracing::error!`, which is
+    /// the sole trace that a call the operator will never be asked about was
+    /// dropped. A failure row is a receipt, never a node failure; the same
+    /// stance [`WorkflowRunBoardRow`] takes for a board write that did not land.
+    ///
+    /// `#[serde(default)]` so a payload written before this field existed still
+    /// loads, and `skip_serializing_if` so a run that parked nothing — nearly
+    /// all of them — serializes byte-for-byte as it did.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub approvals: Vec<WorkflowRunApprovalRow>,
+}
+
+/// One node a workflow run blocked on a human (issue #881).
+///
+/// **Structural only**, the same discipline [`WorkflowRunBoardRow`] keeps: the
+/// node, the tools whose calls were gated, and the ids of the cards that were
+/// opened. No model prose, no policy error text — so a blocked node cannot
+/// become a channel for a turn's apology into the journal, the run response, or
+/// a host log. The console writes its own sentence from these ids.
+///
+/// One shape rides all three surfaces — the `WorkflowRunFinished` journal
+/// event, `GET …/workflows/runs`, and the synchronous run response — hence the
+/// camelCase serde here rather than at each HTTP DTO. The [`DeliveryReport`]
+/// precedent, for the same reason.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowBlockedNode {
+    /// The node that blocked.
+    pub node_id: String,
+    /// The tools whose calls the node's turn had gated, deduplicated and in
+    /// first-seen order. A tool *name*, never its arguments.
+    pub tools: Vec<String>,
+    /// The approvals this node's gated calls actually opened.
+    ///
+    /// Empty when every park failed — which is strictly worse than a parked
+    /// one, because then nobody can unblock the node at all. The per-call
+    /// receipts on [`WorkflowRun::approvals`] say which of the two happened.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub approval_ids: Vec<String>,
+    /// How many of this node's gated calls could **not** be parked.
+    ///
+    /// Non-zero is the loud case: the call was refused, the operator will never
+    /// be asked about it, and re-running is the only way forward. Skipped when
+    /// zero, which is the ordinary case.
+    #[serde(default, skip_serializing_if = "is_zero")]
+    pub unparkable: usize,
+}
+
+/// `skip_serializing_if` predicate for a count that is almost always zero.
+fn is_zero(n: &usize) -> bool {
+    *n == 0
+}
+
+/// What became of one gated tool call a workflow run tried to park (issue
+/// #880), as a closed set.
+///
+/// Three arms because there are exactly three real outcomes at the drain, and
+/// an operator reading a run wants to tell them apart: the card is on the
+/// Approvals page, the card could not be written, or the call was dropped
+/// before parking was even attempted. Carries no payload by construction, so
+/// nothing a model or a store wrote can ride an outcome into a log.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum WorkflowApprovalOutcome {
+    /// A decidable card is on the Approvals page. The row's `approvalId` names
+    /// it.
+    Parked,
+    /// The park was attempted and did not land — the store refused the write,
+    /// or this runtime has no approvals queue wired at all. **Nobody will ever
+    /// be asked about this call.**
+    ParkFailed,
+    /// The call was dropped before parking: the turn gated more calls than
+    /// [`MAX_APPROVAL_REQUESTS_PER_TURN`](crate::harness::policy::MAX_APPROVAL_REQUESTS_PER_TURN)
+    /// allows and this one was in the excess. The drain caps and drops in one
+    /// step, so which tool it was is not recoverable — hence a row with no
+    /// `tool`.
+    Discarded,
+}
+
+impl WorkflowApprovalOutcome {
+    /// Whether this row records a call the operator will **never** be asked
+    /// about.
+    pub fn unparkable(&self) -> bool {
+        matches!(self, Self::ParkFailed | Self::Discarded)
+    }
+}
+
+/// One gated tool call a workflow run's agent node tried to park (issue #880).
+///
+/// **Structural only** — the node, the tool's name, the outcome, and the
+/// approval id when one was minted. No arguments, no policy reason, no store
+/// error text: the same rule [`WorkflowRunBoardRow`] follows, so a row cannot
+/// become a channel for a turn's payload into the journal or a host log.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkflowRunApprovalRow {
+    /// The agent node whose turn made the call.
+    ///
+    /// Absent only where node identity is unavailable — the vendored
+    /// `AgentRunner` trait boundary carries no node id of its own, so a graph
+    /// authored without one leaves this unset rather than inventing a name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub node_id: Option<String>,
+    /// The tool whose call was gated.
+    ///
+    /// Absent on [`Discarded`](WorkflowApprovalOutcome::Discarded): the drain
+    /// caps and drops the excess in one step, so by the time the count is known
+    /// the entries are gone. A row with no tool is the honest shape — "one more
+    /// call was dropped" — rather than a name guessed from the survivors.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool: Option<String>,
+    /// What became of the park attempt.
+    pub outcome: WorkflowApprovalOutcome,
+    /// The card the operator can decide, on the
+    /// [`Parked`](WorkflowApprovalOutcome::Parked) arm.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_id: Option<String>,
 }
 
 /// One node's structural outcome inside a run (issue #542).

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -153,7 +153,12 @@ pub enum ResolveReceipt {
     /// The verdict is journaled and any approved effect settled — the grant is
     /// minted, or the native effect executed. The carried `ApprovalResolved` is
     /// the event the follow-up cycle must run so the brain learns the verdict.
-    Settled(CompanyEvent),
+    ///
+    /// Boxed: `CompanyEvent` is a wide enum (its largest variant is the
+    /// workflow-run outcome), and holding it inline made every
+    /// `AlreadyResolved` — the common answer — pay that width. Indirection here
+    /// costs one allocation on the settled path only.
+    Settled(Box<CompanyEvent>),
 }
 
 impl ResolveReceipt {
@@ -786,11 +791,13 @@ approval.]"
         // The follow-up event, so the brain learns the verdict. Returning it
         // (rather than appending it here) keeps the event logged exactly once:
         // the cycle that runs it is the thing that appends it.
-        Ok(ResolveReceipt::Settled(CompanyEvent::ApprovalResolved {
-            approval_id: id.clone(),
-            verdict,
-            by,
-        }))
+        Ok(ResolveReceipt::Settled(Box::new(
+            CompanyEvent::ApprovalResolved {
+                approval_id: id.clone(),
+                verdict,
+                by,
+            },
+        )))
     }
 
     /// Applies an approved effect: **mint a grant** when it came from a harness
@@ -1154,11 +1161,13 @@ approval.]"
         // The follow-up event, so the brain learns the approval resolved (with
         // an edit). `CompanyEvent` is closed, so the verdict rides as `Approve`;
         // the edit itself lives in the journal audit trail.
-        Ok(ResolveReceipt::Settled(CompanyEvent::ApprovalResolved {
-            approval_id: id.clone(),
-            verdict: Verdict::Approve,
-            by,
-        }))
+        Ok(ResolveReceipt::Settled(Box::new(
+            CompanyEvent::ApprovalResolved {
+                approval_id: id.clone(),
+                verdict: Verdict::Approve,
+                by,
+            },
+        )))
     }
 
     /// Replays the journal to rebuild the executed-key set, the approval queue,

--- a/src/runtime/types.rs
+++ b/src/runtime/types.rs
@@ -170,6 +170,40 @@ pub struct ApprovalSummary {
     /// page and in no thread, exactly as before.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub thread: Option<String>,
+    /// The **workflow run** waiting on this approval (issue #880), when one is.
+    ///
+    /// The other direction of #880's fix: [`WorkflowRun::approvals`](crate::ports::WorkflowRun)
+    /// lets a run say what it parked; this lets a card say which run parked it.
+    /// Without it the Approvals page shows fifteen `publish_artifact` cards
+    /// with nothing tying any of them to the three runs that opened them.
+    ///
+    /// # Why this is not simply `effect.run_id`
+    ///
+    /// [`Effect::run_id`](crate::ports::types::Effect::run_id) is **overloaded**.
+    /// It is documented as issue #242's *task-attempt* id — a
+    /// [`RunRecord`](crate::ports::runs::RunRecord), stamped at the dispatch
+    /// boundary — and the workflow path also writes a *workflow* run id into it
+    /// (`workflows::caps::park_gated_calls` and
+    /// `runtime::workflow_resume::gate_effect`, the latter saying so in its own
+    /// comment). Two different id spaces in one field, and
+    /// [`generate_id`](crate::ports::ids::generate_id) is only process-locally
+    /// unique, so the ids cannot be told apart by inspection.
+    ///
+    /// The discriminator is the *park site*, which is recorded: a task attempt
+    /// parks inside its dispatch cycle and is linked
+    /// [`TaskLink::Task`](crate::runtime::journal::TaskLink), while every
+    /// workflow park goes through
+    /// [`DeliveryParking::park_and_journal`](crate::workflows::DeliveryParking)
+    /// and is recorded explicitly [`Unlinked`](TaskLink::Unlinked) (#333). So
+    /// "a run id on an approval that belongs to no card" is a workflow run, by
+    /// construction rather than by guess — and a chat turn, which is also
+    /// unlinked, stamps no run id at all.
+    ///
+    /// Omitted when absent, the additive pattern the two fields above follow: an
+    /// old console ignores the key and a new one reads its absence as "no run
+    /// behind this card", which is the truth for every chat and scheduler park.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub workflow_run_id: Option<String>,
     /// Whether the operator may grant this tool **broadly** — one standing
     /// permission covering any arguments until a deadline (issue #374).
     ///

--- a/src/runtime/workflow_outcome.rs
+++ b/src/runtime/workflow_outcome.rs
@@ -88,6 +88,8 @@ struct Settled {
     cancelled: bool,
     notices: Vec<String>,
     board: Vec<WorkflowRunBoardRow>,
+    blocked_nodes: Vec<crate::ports::WorkflowBlockedNode>,
+    approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
 }
 
 impl From<Result<&WorkflowRun, &str>> for Settled {
@@ -117,6 +119,8 @@ impl From<Result<&WorkflowRun, &str>> for Settled {
                 cancelled: run.cancelled,
                 notices: run.notices.clone(),
                 board: run.board.clone(),
+                blocked_nodes: run.blocked_nodes.clone(),
+                approvals: run.approvals.clone(),
             },
             Err(err) => Self {
                 deliveries: Vec::new(),
@@ -125,6 +129,16 @@ impl From<Result<&WorkflowRun, &str>> for Settled {
                 cancelled: false,
                 notices: Vec::new(),
                 board: Vec::new(),
+                // Issues #881 / #880: the `Ok` arm only, same trade as `board`
+                // above and worth naming for the same reason. A run whose node
+                // blocked settles `Ok` by design — a blocked node is not a
+                // failed one — so this arm is genuinely a failure, and a
+                // failure returns no `WorkflowRun` to read rows off. Any
+                // approval such a run parked is still on the operator's
+                // Approvals page; what is lost is this event's *listing* of
+                // it, not the card.
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             },
         }
     }
@@ -154,6 +168,8 @@ pub async fn record_run_finished(
         cancelled: settled.cancelled,
         notices: settled.notices,
         board: settled.board,
+        blocked_nodes: settled.blocked_nodes,
+        approvals: settled.approvals,
     };
 
     if let Err(err) = events.append(company, event).await {
@@ -411,6 +427,8 @@ mod test {
             nodes: Vec::new(),
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }
     }
 
@@ -777,6 +795,8 @@ mod test {
                     cancelled: false,
                     notices: Vec::new(),
                     board: Vec::new(),
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
                 },
             )
             .await

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -1498,6 +1498,8 @@ mod decide_tests {
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             })
         }
     }

--- a/src/runtime/workflow_scheduler.rs
+++ b/src/runtime/workflow_scheduler.rs
@@ -1227,6 +1227,8 @@ mod test {
                             nodes: Vec::new(),
                             notices: Vec::new(),
                             board: Vec::new(),
+                            blocked_nodes: Vec::new(),
+                            approvals: Vec::new(),
                         });
                     }
                 }
@@ -1240,6 +1242,8 @@ mod test {
                 nodes: Vec::new(),
                 notices: Vec::new(),
                 board: Vec::new(),
+                blocked_nodes: Vec::new(),
+                approvals: Vec::new(),
             })
         }
     }
@@ -2087,6 +2091,8 @@ to = "done"
                 cancelled,
                 notices: _,
                 board: _,
+                blocked_nodes: _,
+                approvals: _,
             } = event
             else {
                 unreachable!("filtered above")

--- a/src/server/approval_visibility.rs
+++ b/src/server/approval_visibility.rs
@@ -158,6 +158,7 @@ mod tests {
             agent: Some("ops".to_string()),
             payload: Some(serde_json::json!({ "to": "board@example.test" })),
             thread: None,
+            workflow_run_id: None,
             broadly_grantable: false,
             contents_hidden: false,
             batch: Some("turn-1".to_string()),

--- a/src/server/graphql/company.rs
+++ b/src/server/graphql/company.rs
@@ -355,6 +355,13 @@ pub struct ApprovalGql {
     /// otherwise means "this effect involves no money", and a Member looking at
     /// a withheld payment would read it as a free action.
     pub contents_hidden: bool,
+    /// The workflow run waiting on this approval, when one is (issue #880).
+    ///
+    /// Structural — a run id, nothing more — and it is what lets a reader join
+    /// a card on the Approvals page back to the run that opened it. Null for
+    /// every park with no workflow behind it (a chat turn, a scheduler tick, a
+    /// board task's attempt), which is the majority.
+    pub workflow_run_id: Option<String>,
 }
 
 impl From<crate::runtime::types::ApprovalSummary> for ApprovalGql {
@@ -365,6 +372,7 @@ impl From<crate::runtime::types::ApprovalSummary> for ApprovalGql {
             amount_usd: summary.amount_usd,
             at_millis: summary.at_millis as f64,
             contents_hidden: summary.contents_hidden,
+            workflow_run_id: summary.workflow_run_id,
         }
     }
 }

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -42,6 +42,15 @@ type Approval {
 	a withheld payment would read it as a free action.
 	"""
 	contentsHidden: Boolean!
+	"""
+	The workflow run waiting on this approval, when one is (issue #880).
+
+	Structural — a run id, nothing more — and it is what lets a reader join
+	a card on the Approvals page back to the run that opened it. Null for
+	every park with no workflow behind it (a chat turn, a scheduler tick, a
+	board task's attempt), which is the majority.
+	"""
+	workflowRunId: String
 }
 
 """

--- a/src/server/graphql/schema.graphql
+++ b/src/server/graphql/schema.graphql
@@ -44,7 +44,7 @@ type Approval {
 	contentsHidden: Boolean!
 	"""
 	The workflow run waiting on this approval, when one is (issue #880).
-
+	
 	Structural — a run id, nothing more — and it is what lets a reader join
 	a card on the Approvals page back to the run that opened it. Null for
 	every park with no workflow behind it (a chat turn, a scheduler tick, a

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -5643,6 +5643,67 @@ mod test {
         assert_eq!(v["deliveries"].as_array().unwrap().len(), 0);
     }
 
+    /// Issues #881 / #880: the blocked arm reaches the console live.
+    ///
+    /// Without it a console watching a run settle would be told it finished
+    /// cleanly — no error, not cancelled, nothing delivered — and then the
+    /// history it reloads a moment later would say the run blocked. The two
+    /// surfaces read the same journal event, so they must project the same
+    /// facts.
+    #[test]
+    fn projects_workflow_run_finished_with_its_blocked_nodes_and_parked_approvals() {
+        let v = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: true,
+            run_id: Some("run-b".into()),
+            deliveries: Vec::new(),
+            pending_approvals: vec!["spec".into()],
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+            blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                node_id: "spec".into(),
+                tools: vec!["publish_artifact".into()],
+                approval_ids: vec!["appr-1".into()],
+                unparkable: 0,
+            }],
+            approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                node_id: Some("spec".into()),
+                tool: Some("publish_artifact".into()),
+                outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                approval_id: Some("appr-1".into()),
+            }],
+        }))
+        .expect("workflow_run_finished is an attention signal");
+        assert_eq!(v["blockedNodes"][0]["nodeId"], "spec");
+        assert_eq!(v["blockedNodes"][0]["tools"][0], "publish_artifact");
+        assert_eq!(v["approvals"][0]["outcome"], "parked");
+        assert!(
+            v.get("error").is_none(),
+            "a run waiting on a person did not fail: {v}"
+        );
+
+        // The presence-check discipline: a run that blocked on nobody sends
+        // neither key, so an existing frame is byte-unchanged.
+        let clean = super::project_event(&stored(CompanyEvent::WorkflowRunFinished {
+            workflow_id: "digest".into(),
+            scheduled: true,
+            run_id: None,
+            deliveries: Vec::new(),
+            pending_approvals: Vec::new(),
+            error: None,
+            cancelled: false,
+            notices: Vec::new(),
+            board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
+        }))
+        .expect("projects");
+        assert!(clean.get("blockedNodes").is_none(), "{clean}");
+        assert!(clean.get("approvals").is_none(), "{clean}");
+    }
+
     /// Issue #371: the live per-node trail. Both arms project, both carry the
     /// run id that ties them to the run's settle-frame, and — the point — the
     /// node arm carries a status and a duration and nothing else.

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -931,6 +931,8 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             cancelled,
             notices,
             board,
+            blocked_nodes,
+            approvals,
         } => {
             let mut o = envelope("workflow_run_finished");
             o["workflowId"] = json!(workflow_id);
@@ -970,6 +972,18 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             // the moment it settles, rather than only on the next history read.
             if !board.is_empty() {
                 o["board"] = json!(board);
+            }
+            // Issues #881 / #880: the same presence-check discipline again, and
+            // projected for the same reason `deliveries` is — a console
+            // watching a run live must not be told it finished cleanly while
+            // the history it reloads a moment later says it blocked. Both rows
+            // are structural by construction (node ids, tool names, approval
+            // ids), so this arm forwards no payload it has to choose to scrub.
+            if !blocked_nodes.is_empty() {
+                o["blockedNodes"] = json!(blocked_nodes);
+            }
+            if !approvals.is_empty() {
+                o["approvals"] = json!(approvals);
             }
             o
         }
@@ -5575,6 +5589,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["type"], "workflow_run_finished");
@@ -5619,6 +5635,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }))
         .expect("workflow_run_finished is an attention signal");
         assert_eq!(v["error"], "no inference source for agent node `worker`");
@@ -5732,6 +5750,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }))
         .expect("projected");
         assert_eq!(with_id["runId"], "run-9");
@@ -5746,6 +5766,8 @@ mod test {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         }))
         .expect("projected");
         assert!(legacy.get("runId").is_none(), "{legacy}");

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2718,6 +2718,114 @@ mod tests {
         );
     }
 
+    /// Issues #881 / #880: the synchronous run response carries the blocked
+    /// nodes and the parked-approval receipts, in the same camelCase shape the
+    /// journal event and the history route use.
+    ///
+    /// The operator who pressed Run is the reader these exist for: before this,
+    /// a pipeline whose first step had its `publish_artifact` parked came back
+    /// with every node green and an empty body, and there was nothing anywhere
+    /// in the response that said otherwise.
+    ///
+    /// Omission matters as much, for the same reason it does on `board`: a run
+    /// that blocked on nobody sends neither key, so every existing caller's body
+    /// is byte-unchanged.
+    #[test]
+    fn the_run_response_carries_blocked_nodes_and_parked_approvals() {
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: Value::Null,
+            pending_approvals: vec!["spec".into()],
+            deliveries: Vec::new(),
+            run_id: "run-1".into(),
+            cancelled: false,
+            nodes: vec![WorkflowRunNode {
+                node_id: "spec".into(),
+                status: WorkflowNodeStatus::Blocked,
+                elapsed_ms: 42,
+            }],
+            dry_run: false,
+            board: Vec::new(),
+            blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                node_id: "spec".into(),
+                tools: vec!["publish_artifact".into()],
+                approval_ids: vec!["appr-1".into()],
+                unparkable: 0,
+            }],
+            approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                node_id: Some("spec".into()),
+                tool: Some("publish_artifact".into()),
+                outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                approval_id: Some("appr-1".into()),
+            }],
+        })
+        .expect("serialize");
+        assert_eq!(json["nodes"][0]["status"], "blocked");
+        assert_eq!(json["blockedNodes"][0]["nodeId"], "spec");
+        assert_eq!(json["blockedNodes"][0]["tools"][0], "publish_artifact");
+        assert_eq!(json["blockedNodes"][0]["approvalIds"][0], "appr-1");
+        assert!(
+            json["blockedNodes"][0].get("unparkable").is_none(),
+            "the ordinary case — every call was parked — stays off the wire: {json}"
+        );
+        assert_eq!(json["approvals"][0]["outcome"], "parked");
+        assert_eq!(json["approvals"][0]["approvalId"], "appr-1");
+
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: serde_json::json!({ "nodes": {} }),
+            pending_approvals: Vec::new(),
+            deliveries: Vec::new(),
+            run_id: "run-2".into(),
+            cancelled: false,
+            nodes: Vec::new(),
+            dry_run: false,
+            board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
+        })
+        .expect("serialize");
+        assert!(json.get("blockedNodes").is_none(), "{json}");
+        assert!(json.get("approvals").is_none(), "{json}");
+    }
+
+    /// A park that could NOT happen is on the wire as loudly as one that did
+    /// (issue #880).
+    ///
+    /// This is the arm whose only previous record was a `tracing::error!` — the
+    /// operator will never be asked about the call, so a run that hides it is
+    /// telling them the least when it matters most.
+    #[test]
+    fn a_failed_park_is_reported_rather_than_only_logged() {
+        let json = serde_json::to_value(RunWorkflowResponse {
+            output: Value::Null,
+            pending_approvals: vec!["spec".into()],
+            deliveries: Vec::new(),
+            run_id: "run-3".into(),
+            cancelled: false,
+            nodes: Vec::new(),
+            dry_run: false,
+            board: Vec::new(),
+            blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                node_id: "spec".into(),
+                tools: vec!["publish_artifact".into()],
+                approval_ids: Vec::new(),
+                unparkable: 2,
+            }],
+            approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                node_id: Some("spec".into()),
+                tool: Some("publish_artifact".into()),
+                outcome: crate::ports::WorkflowApprovalOutcome::ParkFailed,
+                approval_id: None,
+            }],
+        })
+        .expect("serialize");
+        assert_eq!(json["blockedNodes"][0]["unparkable"], 2);
+        assert_eq!(json["approvals"][0]["outcome"], "parkFailed");
+        assert!(
+            json["approvals"][0].get("approvalId").is_none(),
+            "there is no card, so naming one would point at nothing: {json}"
+        );
+    }
+
     /// The run response carries `deliveries` in camelCase — this is the ONLY
     /// place an operator learns a report was not delivered, since a delivery
     /// failure never fails the run.
@@ -3693,6 +3801,86 @@ mod tests {
             assert_eq!(nodes[0]["elapsedMs"], 42);
             assert_eq!(nodes[1]["nodeId"], "send");
             assert_eq!(nodes[1]["status"], "error");
+        }
+
+        /// Issues #881 / #880 at the HTTP boundary: a blocked run reads as
+        /// blocked in the history, and **its node chip is relabelled too**.
+        ///
+        /// The node row is journaled live, node by node, long before anything
+        /// knows the run stopped for an approval rather than a fault — so the
+        /// durable `WorkflowNodeFinished` says `error`, honestly, in the
+        /// engine's own terms. Without the read-side relabel the panel would
+        /// show a run that says "blocked" beside a node chip that says
+        /// "failed", and an operator would go hunting for a bug that is not
+        /// there.
+        #[tokio::test]
+        async fn run_history_reports_a_blocked_node_and_the_approvals_it_parked() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, id) = hosted_state(&home).await;
+
+            journal_start(&state, &id, "digest", "run-b", false).await;
+            // The engine's own account: the capability returned an error, so
+            // the observer reported `error`.
+            journal_node(
+                &state,
+                &id,
+                "digest",
+                "run-b",
+                "spec",
+                WorkflowNodeStatus::Error,
+            )
+            .await;
+            let runtime = state.registry().get(&id).expect("registered");
+            runtime
+                .events()
+                .append(
+                    &id,
+                    CompanyEvent::WorkflowRunFinished {
+                        workflow_id: "digest".to_string(),
+                        scheduled: false,
+                        run_id: Some("run-b".to_string()),
+                        deliveries: Vec::new(),
+                        pending_approvals: vec!["spec".to_string()],
+                        // The whole point: a blocked run carries NO error.
+                        error: None,
+                        cancelled: false,
+                        notices: Vec::new(),
+                        board: Vec::new(),
+                        blocked_nodes: vec![crate::ports::WorkflowBlockedNode {
+                            node_id: "spec".to_string(),
+                            tools: vec!["publish_artifact".to_string()],
+                            approval_ids: vec!["appr-1".to_string()],
+                            unparkable: 0,
+                        }],
+                        approvals: vec![crate::ports::WorkflowRunApprovalRow {
+                            node_id: Some("spec".to_string()),
+                            tool: Some("publish_artifact".to_string()),
+                            outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+                            approval_id: Some("appr-1".to_string()),
+                        }],
+                    },
+                )
+                .await
+                .expect("append");
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/runs", None))
+                .await
+                .unwrap();
+            let body = json_body(response).await;
+            let rows = body.as_array().expect("array");
+            assert_eq!(rows.len(), 1, "{body}");
+            assert!(
+                rows[0].get("error").is_none(),
+                "a run waiting on a person did not fail: {body}"
+            );
+            assert_eq!(rows[0]["blockedNodes"][0]["nodeId"], "spec");
+            assert_eq!(rows[0]["approvals"][0]["outcome"], "parked");
+            assert_eq!(
+                rows[0]["nodes"][0]["status"], "blocked",
+                "the node chip must agree with the run's terminal reading: {body}"
+            );
         }
 
         /// A run whose host died leaves a start with no finish, and it folds as

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -1144,6 +1144,19 @@ struct RunWorkflowResponse {
     /// run that touched no card.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     board: Vec<crate::ports::WorkflowRunBoardRow>,
+    /// The nodes this run blocked on a human (issue #881).
+    ///
+    /// The same rows `GET …/workflows/runs` returns and the same rows the
+    /// `WorkflowRunFinished` event carries — one shape across all three, so a
+    /// console reads a blocked run identically whether it awaited it or found
+    /// it in the history. Omitted when empty, so a run that blocked on nobody
+    /// is byte-unchanged.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    blocked_nodes: Vec<crate::ports::WorkflowBlockedNode>,
+    /// The approvals this run parked (issue #880) — what it opened, not what
+    /// is still outstanding.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
 }
 
 /// The `detach: true` response (issue #383): the run's id, handed back before
@@ -1170,7 +1183,11 @@ struct DetachedRunResponse {
 /// always returned, `202 Accepted` for a run that has been accepted and started
 /// but has not finished — which is precisely what `202` means.
 enum RunWorkflowOk {
-    Settled(RunWorkflowResponse),
+    /// Boxed: the settled body is far wider than the detached one (it carries
+    /// the run's output, node trail, deliveries, board rows and — since #881 /
+    /// #880 — its blocked nodes and parked-approval receipts), and holding it
+    /// inline made the 202 path pay that width too.
+    Settled(Box<RunWorkflowResponse>),
     Detached(DetachedRunResponse),
 }
 
@@ -1326,7 +1343,7 @@ async fn run_workflow(
     // aborted — the run's outcome was never journaled, so there is nothing
     // truthful to hand back and this is a genuine 500 rather than a run result.
     match handle.await {
-        Ok(Ok(run)) => Ok(RunWorkflowOk::Settled(RunWorkflowResponse {
+        Ok(Ok(run)) => Ok(RunWorkflowOk::Settled(Box::new(RunWorkflowResponse {
             output: run.output,
             pending_approvals: run.pending_approvals,
             deliveries: run.deliveries,
@@ -1342,7 +1359,13 @@ async fn run_workflow(
             // that pressed Run learns what the run did to the board without a
             // second read of the history.
             board: run.board,
-        })),
+            // Issues #881 / #880: likewise. An operator who pressed Run and
+            // watched eight green nodes come back is exactly the reader these
+            // two exist for — the run drawer is where they first learn the
+            // pipeline delivered nothing and why.
+            blocked_nodes: run.blocked_nodes,
+            approvals: run.approvals,
+        }))),
         Ok(Err(err)) => Err(ApiError(err).into_response()),
         Err(join) => {
             tracing::error!(
@@ -1852,6 +1875,27 @@ struct WorkflowRunOutcome {
     /// Omitted when empty, like `notices` — which is nearly every run.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     board: Vec<crate::ports::WorkflowRunBoardRow>,
+    /// The nodes this run blocked on a human (issue #881) — one row per node
+    /// whose agent turn had a tool call parked, so it produced no deliverable
+    /// and nothing after it ran.
+    ///
+    /// Projected **verbatim** from the port row, like `board` and `deliveries`
+    /// above: it is already camelCase and already structural, and a second
+    /// transcription is only a place for the two shapes to drift.
+    ///
+    /// This is what stops a blocked run reading as a clean one. Its nodes'
+    /// rows arrive relabelled too — see the settle arm in [`list_runs`], which
+    /// flips each blocked node's journaled `error` status to `blocked`.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    blocked_nodes: Vec<crate::ports::WorkflowBlockedNode>,
+    /// The approvals this run parked (issue #880) — a receipt of what it
+    /// opened, the failed parks included.
+    ///
+    /// Named for what the run *parked*, never for what is still outstanding: a
+    /// receipt cannot go stale, whereas a settle-time "still waiting on N"
+    /// count becomes a fresh lie the moment somebody approves one.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
 }
 
 /// One node's outcome inside a run (issue #371).
@@ -1975,6 +2019,11 @@ async fn list_runs(
                     // even one whose nodes have already opened cards. The rows
                     // arrive with the settle below.
                     board: Vec::new(),
+                    // Issues #881 / #880: same — only a finish carries these.
+                    // A run in flight has blocked on nobody *yet*, and any
+                    // approval it has already parked is listed once it settles.
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
                 });
             }
             CompanyEvent::WorkflowNodeFinished {
@@ -2008,6 +2057,8 @@ async fn list_runs(
                 cancelled,
                 notices,
                 board,
+                blocked_nodes,
+                approvals,
             } => {
                 if !matches(&workflow_id) {
                     continue;
@@ -2027,6 +2078,18 @@ async fn list_runs(
                     entry.cancelled = cancelled;
                     entry.notices = notices;
                     entry.board = board;
+                    // Issue #881: the node rows for this run were folded from
+                    // `WorkflowNodeFinished` events the engine wrote, and the
+                    // engine reported a blocked node as `error` — honestly, in
+                    // its own terms: the capability really did return an error,
+                    // which is what halted the branch. The finish is the first
+                    // point that knows *why*, so the relabelling happens here,
+                    // on the read, rather than by rewriting the durable node
+                    // rows. Same host-side reclassification the run record
+                    // itself performs; see `workflows::runner`.
+                    relabel_blocked(&mut entry.nodes, &blocked_nodes);
+                    entry.blocked_nodes = blocked_nodes;
+                    entry.approvals = approvals;
                     continue;
                 }
                 // …else stand alone. Two ways to get here, both legitimate: a
@@ -2049,6 +2112,12 @@ async fn list_runs(
                     cancelled,
                     notices,
                     board,
+                    // No start row means no node rows either, so there is
+                    // nothing here to relabel — the blocked list is still
+                    // carried, because it is the only thing that tells this
+                    // orphaned row apart from a clean finish.
+                    blocked_nodes,
+                    approvals,
                 });
             }
             _ => {}
@@ -2061,6 +2130,26 @@ async fn list_runs(
     runs.reverse();
     runs.truncate(limit);
     Ok(Json(runs))
+}
+
+/// Relabels a run's node rows for the nodes it blocked on a human (issue #881).
+///
+/// The read-side half of the host reclassification. `WorkflowNodeFinished` is
+/// written live, node by node, long before anything knows the run stopped for an
+/// approval rather than a fault — so the durable row says `error` and stays that
+/// way. Fixing it up here, against the finish's own blocked list, is what keeps
+/// the history panel's node chips agreeing with the run's terminal reading; the
+/// alternative is a run that says "blocked" beside a node chip that says
+/// "failed".
+fn relabel_blocked(nodes: &mut [WorkflowRunNode], blocked: &[crate::ports::WorkflowBlockedNode]) {
+    if blocked.is_empty() {
+        return;
+    }
+    for node in nodes.iter_mut() {
+        if blocked.iter().any(|b| b.node_id == node.node_id) {
+            node.status = WorkflowNodeStatus::Blocked;
+        }
+    }
 }
 
 #[cfg(test)]
@@ -2598,6 +2687,8 @@ mod tests {
                 title: None,
                 assignee: Some("ceo".into()),
             }],
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         })
         .expect("serialize");
         assert_eq!(json["board"][0]["action"], "assigned");
@@ -2617,6 +2708,8 @@ mod tests {
             nodes: Vec::new(),
             dry_run: false,
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         })
         .expect("serialize");
         assert!(
@@ -2648,6 +2741,8 @@ mod tests {
             nodes: Vec::new(),
             dry_run: false,
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["node"], "done");
@@ -2681,6 +2776,8 @@ mod tests {
             nodes: Vec::new(),
             dry_run: false,
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"][0]["status"], "pending");
@@ -2699,6 +2796,8 @@ mod tests {
             nodes: Vec::new(),
             dry_run: false,
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         })
         .unwrap();
         assert_eq!(json["deliveries"], serde_json::json!([]));
@@ -3297,6 +3396,8 @@ mod tests {
                         cancelled: false,
                         notices: Vec::new(),
                         board: Vec::new(),
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
                     },
                 )
                 .await
@@ -3532,6 +3633,8 @@ mod tests {
                         cancelled: false,
                         notices: Vec::new(),
                         board: Vec::new(),
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
                     },
                 )
                 .await
@@ -4669,6 +4772,8 @@ mod tests {
                             nodes: Vec::new(),
                             notices: Vec::new(),
                             board: Vec::new(),
+                            blocked_nodes: Vec::new(),
+                            approvals: Vec::new(),
                         });
                     }
                 }
@@ -4681,6 +4786,8 @@ mod tests {
                     nodes: Vec::new(),
                     notices: Vec::new(),
                     board: Vec::new(),
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
                 })
             }
         }
@@ -5310,6 +5417,8 @@ label = "ok"
                     }],
                     notices: Vec::new(),
                     board: Vec::new(),
+                    blocked_nodes: Vec::new(),
+                    approvals: Vec::new(),
                 })
             }
         }

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -8775,6 +8775,8 @@ async fn the_run_history_carries_a_runs_board_rows() {
                 title: Some("Reply to the auditor".into()),
                 assignee: None,
             }],
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         },
         // A second run that touched no card, so the omission is asserted on a
         // real row rather than on an absence that could be the fold failing.
@@ -8788,6 +8790,8 @@ async fn the_run_history_carries_a_runs_board_rows() {
             cancelled: false,
             notices: Vec::new(),
             board: Vec::new(),
+            blocked_nodes: Vec::new(),
+            approvals: Vec::new(),
         },
     ] {
         runtime.events().append(&company, event).await.unwrap();

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -137,10 +137,11 @@ fn record() -> CompanyRecord {
     }
 }
 
-/// Runs the two-agent pipeline against `turns`, returning the settled run, the
-/// journal, and the full transcript of what the model was sent.
-async fn run_pipeline(
+/// Runs `graph` against `turns`, returning the settled run, the journal, and
+/// the full transcript of what the model was sent.
+async fn run_pipeline_over(
     dir: &std::path::Path,
+    graph: &str,
     turns: Vec<Turn>,
 ) -> (WorkflowRun, Arc<RuntimeJournal>, String) {
     let (base_url, script) = spawn_script_recording(turns).await;
@@ -149,7 +150,7 @@ async fn run_pipeline(
     let pool = Arc::new(HarnessPool::new());
     pool.ensure(&record, &deps).await.expect("roster builds");
 
-    let file = parse_workflow(&pipeline_graph()).expect("graph parses");
+    let file = parse_workflow(graph).expect("graph parses");
     let run = super::runner::run_workflow(
         pool,
         deps,
@@ -164,6 +165,15 @@ async fn run_pipeline(
     let seen = script.seen.lock().unwrap().clone();
     let transcript = serde_json::to_string(&seen).expect("serialize the requests");
     (run, journal, transcript)
+}
+
+/// Runs the two-agent pipeline against `turns`, returning the settled run, the
+/// journal, and the full transcript of what the model was sent.
+async fn run_pipeline(
+    dir: &std::path::Path,
+    turns: Vec<Turn>,
+) -> (WorkflowRun, Arc<RuntimeJournal>, String) {
+    run_pipeline_over(dir, &pipeline_graph(), turns).await
 }
 
 /// The headline (issue #881). Four claims, and the third is the one that
@@ -296,6 +306,121 @@ async fn a_node_that_parks_nothing_still_reports_ok_and_its_branch_continues() {
     assert!(run.approvals.is_empty());
     assert!(run.pending_approvals.is_empty());
     assert!(journal.pending().is_empty());
+}
+
+/// `work`, same as [`pipeline_graph`], but marked `on_error = "continue"`: the
+/// author has asked the branch to survive a failing node rather than halt it.
+fn pipeline_graph_continues_past_a_block() -> String {
+    format!(
+        r#"
+id = "pipeline"
+name = "Pipeline"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Write the quarterly spec."
+agent = "ceo"
+on_error = "continue"
+[[node]]
+id = "next"
+kind = "agent"
+name = "Next"
+summary = "{DOWNSTREAM_INSTRUCTION}"
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "next"
+[[edge]]
+from = "next"
+to = "done"
+"#
+    )
+}
+
+/// Issue #900 (tinysweeper `missing-test`): the halt-path headline test above
+/// pins `reclassify_blocked` as called from [`blocked_run`], but the run
+/// function calls it a **second** time — at the "reached the end normally" arm
+/// — for exactly this case: an author who wrote `on_error = "continue"` (or
+/// `"route"`) asked the block not to halt the branch. Nothing before this test
+/// proved that second call site actually ran, so a regression there (an errant
+/// early return, a condition that skipped the reclassify call) would silently
+/// go back to reporting an unparkable turn's apology as node `ok` — the exact
+/// #881 bug, just reachable only through `on_error = continue` instead of the
+/// default.
+#[tokio::test]
+async fn a_blocked_node_under_on_error_continue_still_reports_blocked_and_lets_the_branch_run() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _journal, transcript) = run_pipeline_over(
+        dir.path(),
+        &pipeline_graph_continues_past_a_block(),
+        vec![
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "write-spec" }),
+            },
+            Turn::Say("The spec is in my sandbox but the hand-off is blocked again."),
+            Turn::Say("Published."),
+        ],
+    )
+    .await;
+
+    // `on_error = continue` means the branch survives the block — unlike the
+    // halt-path headline test above, `next` DOES run.
+    assert!(
+        transcript.contains(DOWNSTREAM_INSTRUCTION),
+        "on_error=continue must let the branch past a blocked node run: {transcript}"
+    );
+    assert!(
+        run.nodes
+            .iter()
+            .any(|n| n.node_id == "next" && n.status == WorkflowNodeStatus::Ok),
+        "the downstream node must have a settled row too: {:?}",
+        run.nodes
+    );
+
+    // But the run-level truth must not get lost on the way: `work` is still
+    // reported as blocked, never `ok` and never a plain `error` that would
+    // hide the block behind an unremarkable failure.
+    let work = run
+        .nodes
+        .iter()
+        .find(|n| n.node_id == "work")
+        .expect("the blocked node still reports a row");
+    assert_eq!(work.status, WorkflowNodeStatus::Blocked, "{:?}", run.nodes);
+    assert_eq!(run.blocked_nodes.len(), 1, "{:?}", run.blocked_nodes);
+    assert_eq!(run.blocked_nodes[0].node_id, "work");
+
+    // …and `reclassify_blocked`'s union into `pending_approvals` runs on this
+    // arm too, not only on the halt arm `blocked_run` covers.
+    assert!(
+        run.pending_approvals.contains(&"work".to_string()),
+        "{:?}",
+        run.pending_approvals
+    );
+    assert_eq!(run.approvals.len(), 1, "{:?}", run.approvals);
+    assert_eq!(run.approvals[0].outcome, WorkflowApprovalOutcome::Parked);
+
+    // Issue #900: the continued arm tells the operator what blocked via a
+    // notice too — not only via the (easy to miss) node chip — same as the
+    // halt arm does.
+    assert!(
+        run.notices.iter().any(|n| n.contains("parked 1 approval")),
+        "a continued run must still say what blocked, in the same words the \
+         halted arm uses: {:?}",
+        run.notices
+    );
 }
 
 /// Issue #880's regression, reproducing the audit exactly.

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -1,0 +1,458 @@
+//! Issues #881 and #880 — end-to-end proof that a node whose deliverable was
+//! parked for approval does **not** report `ok`, does **not** hand its apology
+//! to the next node, and that the run says what it parked.
+//!
+//! # Why the existing tests all stayed green through this
+//!
+//! Every part worked. `ApprovalPolicy` gated the call — tested.
+//! `park_gated_calls` opened a decidable card — tested by
+//! [`gated_tool_turn_test`](crate::workflows::gated_tool_turn_test), which is
+//! this file's direct ancestor and shares its whole fixture. The engine marked
+//! the node from the capability's return value — tested upstream. What nobody
+//! tested was the *seam*: a gated call inside an agent node's turn is refused
+//! **inside the model's tool loop**, so the turn ends normally, the capability
+//! returns `Ok`, and the engine has no way to know the node produced nothing.
+//! The model then writes prose about the blockage, and `translate`'s
+//! `input = "=items"` binding delivers that prose to the next node as if it were
+//! the artifact. Eight green nodes, nothing shipped.
+//!
+//! So these drive the **real** path — real graph, real `run_workflow`, real
+//! `HarnessAgentRunner`, real `HarnessPool`, real `ApprovalPolicy`, real gate,
+//! real on-disk journal — and stub one thing: the model's choices, via a
+//! scripted OpenAI-compatible endpoint on loopback.
+//!
+//! The load-bearing assertion is
+//! [`a_blocked_node_stops_the_branch_and_never_hands_its_apology_downstream`]'s
+//! third claim: the **downstream node's own instruction never reached the
+//! model**. Asserting only that the first node is marked `blocked` would pass on
+//! a fix that relabelled the row and let the edge fire anyway, which is the half
+//! of the bug that actually loses the work.
+
+use std::sync::Arc;
+
+use serde_json::{Value, json};
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::harness::HarnessPool;
+use crate::ports::types::{CompanyId, CompanyRecord, WorkflowNodeStatus};
+use crate::ports::{WorkflowApprovalOutcome, WorkflowRun, WorkflowRunContext};
+use crate::runtime::journal::RuntimeJournal;
+
+use super::gated_tool_turn_test::{Turn, deps, spawn_script_recording};
+
+/// The instruction authored on the node **after** the one that blocks.
+///
+/// Read back out of the scripted endpoint's request log: if this string was
+/// never sent to the model, the second node never ran. That is the direct proof
+/// the apology did not travel, and it cannot be satisfied by relabelling a
+/// status.
+const DOWNSTREAM_INSTRUCTION: &str = "Publish the finished spec to the newsroom.";
+
+/// `start -> work(agent, gates a tool) -> next(agent) -> done` — the shape of
+/// every real pipeline this broke on: one teammate produces an artifact, the
+/// next builds on it.
+fn pipeline_graph() -> String {
+    format!(
+        r#"
+id = "pipeline"
+name = "Pipeline"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "work"
+kind = "agent"
+name = "Work"
+summary = "Write the quarterly spec."
+agent = "ceo"
+[[node]]
+id = "next"
+kind = "agent"
+name = "Next"
+summary = "{DOWNSTREAM_INSTRUCTION}"
+agent = "ceo"
+[[node]]
+id = "done"
+kind = "output"
+name = "Done"
+[[edge]]
+from = "start"
+to = "work"
+[[edge]]
+from = "work"
+to = "next"
+[[edge]]
+from = "next"
+to = "done"
+"#
+    )
+}
+
+/// A company that gates `shell` under **full** autonomy.
+///
+/// The same `always_approve` choice `gated_tool_turn_test` makes and for the
+/// same reason: parking under the *strongest* tier shows the block comes from
+/// the policy's explicit gate rather than from a supervised-mode classifier.
+/// A local copy rather than the sibling's fixture because this graph needs the
+/// teammate to be addressable from two nodes, which is what makes "the second
+/// node never ran" a statement about the graph rather than about the roster.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = ["shell"]
+
+[tools]
+allow = ["shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        id: CompanyId::new("acme"),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Runs the two-agent pipeline against `turns`, returning the settled run, the
+/// journal, and the full transcript of what the model was sent.
+async fn run_pipeline(
+    dir: &std::path::Path,
+    turns: Vec<Turn>,
+) -> (WorkflowRun, Arc<RuntimeJournal>, String) {
+    let (base_url, script) = spawn_script_recording(turns).await;
+    let (deps, journal) = deps(base_url, dir);
+    let record = record();
+    let pool = Arc::new(HarnessPool::new());
+    pool.ensure(&record, &deps).await.expect("roster builds");
+
+    let file = parse_workflow(&pipeline_graph()).expect("graph parses");
+    let run = super::runner::run_workflow(
+        pool,
+        deps,
+        &record,
+        &file,
+        json!({ "request": "the quarterly spec" }),
+        &WorkflowRunContext::new(false),
+    )
+    .await
+    .expect("a blocked run settles rather than failing — a node waiting on a person did not fail");
+
+    let seen = script.seen.lock().unwrap().clone();
+    let transcript = serde_json::to_string(&seen).expect("serialize the requests");
+    (run, journal, transcript)
+}
+
+/// The headline (issue #881). Four claims, and the third is the one that
+/// matters: the downstream node never ran.
+#[tokio::test]
+async fn a_blocked_node_stops_the_branch_and_never_hands_its_apology_downstream() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, journal, transcript) = run_pipeline(
+        dir.path(),
+        vec![
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "write-spec" }),
+            },
+            // Verbatim the shape the issue reported: the model is refused inside
+            // its own tool loop and writes prose about it, which before this
+            // became the node's output and the next node's input.
+            Turn::Say("The spec is in my sandbox but the hand-off is blocked again."),
+        ],
+    )
+    .await;
+
+    // (a) The node that blocked is `blocked`, not `ok` and not `error`.
+    let work = run
+        .nodes
+        .iter()
+        .find(|n| n.node_id == "work")
+        .expect("the blocked node still reports a row — it ran, it just produced nothing");
+    assert_eq!(
+        work.status,
+        WorkflowNodeStatus::Blocked,
+        "a node whose deliverable was parked is neither green nor failed: {:?}",
+        run.nodes
+    );
+
+    // (b) The downstream node has no row at all — "not reached", which is the
+    // honest reading for a branch that halted above it.
+    assert!(
+        !run.nodes.iter().any(|n| n.node_id == "next"),
+        "the node after a blocked one must not run: {:?}",
+        run.nodes
+    );
+
+    // (c) The direct proof, and the one a status relabel cannot fake: the
+    // downstream node's own instruction never reached the model, so the apology
+    // was never delivered to anybody.
+    assert!(
+        !transcript.contains(DOWNSTREAM_INSTRUCTION),
+        "the blocked node's apology must not travel to the next node's turn: {transcript}"
+    );
+
+    // (d) Issue #395's property is unweakened: the card is still decidable.
+    assert!(
+        journal.pending().iter().any(|p| p.effect.kind == "shell"),
+        "blocking the node must not cost the operator the card they have to decide"
+    );
+
+    // (e) The run says which node blocked and on what (#881) …
+    assert_eq!(run.blocked_nodes.len(), 1, "{:?}", run.blocked_nodes);
+    let blocked = &run.blocked_nodes[0];
+    assert_eq!(blocked.node_id, "work");
+    assert_eq!(blocked.tools, vec!["shell".to_string()]);
+    assert_eq!(
+        blocked.approval_ids.len(),
+        1,
+        "the block names the card that unblocks it"
+    );
+    assert_eq!(
+        blocked.unparkable, 0,
+        "the card was written, so nothing here is unaskable"
+    );
+
+    // …and lists it among what it is waiting on a person for.
+    assert!(
+        run.pending_approvals.contains(&"work".to_string()),
+        "a blocked node is something the run is waiting on a human for: {:?}",
+        run.pending_approvals
+    );
+
+    // (f) …and the run carries a receipt of what it parked (#880).
+    assert_eq!(run.approvals.len(), 1, "{:?}", run.approvals);
+    assert_eq!(run.approvals[0].node_id.as_deref(), Some("work"));
+    assert_eq!(run.approvals[0].tool.as_deref(), Some("shell"));
+    assert_eq!(run.approvals[0].outcome, WorkflowApprovalOutcome::Parked);
+    assert!(run.approvals[0].approval_id.is_some());
+
+    // (g) Blocked is NOT failed. A run that stopped for a person must not land
+    // in the failure count, or a real failure hides among the approvals.
+    assert!(!run.cancelled);
+    assert!(
+        run.notices.iter().any(|n| n.contains("parked 1 approval")),
+        "the operator is told what the run parked, in those words: {:?}",
+        run.notices
+    );
+}
+
+/// The paired counter-test. Without it, a "fix" that simply stopped returning
+/// `Ok` from every agent node would pass the headline above.
+#[tokio::test]
+async fn a_node_that_parks_nothing_still_reports_ok_and_its_branch_continues() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, journal, transcript) = run_pipeline(
+        dir.path(),
+        vec![Turn::Say("Here is the spec."), Turn::Say("Published.")],
+    )
+    .await;
+
+    let work = run
+        .nodes
+        .iter()
+        .find(|n| n.node_id == "work")
+        .expect("the node ran");
+    assert_eq!(
+        work.status,
+        WorkflowNodeStatus::Ok,
+        "an ordinary agent node is unaffected by the block path"
+    );
+    assert!(
+        run.nodes
+            .iter()
+            .any(|n| n.node_id == "next" && n.status == WorkflowNodeStatus::Ok),
+        "the branch must still continue when nothing was parked: {:?}",
+        run.nodes
+    );
+    assert!(
+        transcript.contains(DOWNSTREAM_INSTRUCTION),
+        "the downstream node's turn really did happen: {transcript}"
+    );
+    assert!(run.blocked_nodes.is_empty());
+    assert!(run.approvals.is_empty());
+    assert!(run.pending_approvals.is_empty());
+    assert!(journal.pending().is_empty());
+}
+
+/// Issue #880's regression, reproducing the audit exactly.
+///
+/// Three real `feature_pipeline` runs reported every node `ok` with
+/// `pendingApprovals: []` and `deliveries: []` while the company's queue held
+/// fifteen `publish_artifact` cards those runs had opened. Both of those fields
+/// were **truthful** — one means the engine's gate nodes, the other means
+/// `output`-node routing — and neither could answer the question. This pins that
+/// the receipt does.
+#[tokio::test]
+async fn a_run_that_parked_a_card_says_so_even_though_it_paused_no_gate_and_routed_no_report() {
+    let dir = tempfile::tempdir().unwrap();
+    let (run, _journal, _transcript) = run_pipeline(
+        dir.path(),
+        vec![
+            Turn::Call {
+                tool: "shell",
+                args: json!({ "command": "publish" }),
+            },
+            Turn::Say("Blocked on approval."),
+        ],
+    )
+    .await;
+
+    // The engine paused no gate: this graph has no `requires_approval` node, so
+    // every id here came from the host's block, not from the engine.
+    let engine_gates: Vec<&String> = run
+        .pending_approvals
+        .iter()
+        .filter(|id| !run.blocked_nodes.iter().any(|b| &&b.node_id == id))
+        .collect();
+    assert!(
+        engine_gates.is_empty(),
+        "no engine gate paused this run; the entries are the host's blocked nodes: {engine_gates:?}"
+    );
+
+    // And it routed no report — the graph's `output` node was never reached.
+    assert!(
+        run.deliveries.is_empty(),
+        "truthfully empty, and truthfully not an answer: {:?}",
+        run.deliveries
+    );
+
+    // The field that IS the answer.
+    assert_eq!(
+        run.approvals.len(),
+        1,
+        "a run that parked a card must say so somewhere: {:?}",
+        run.approvals
+    );
+}
+
+#[cfg(test)]
+mod pure {
+    use super::*;
+    use crate::ports::WorkflowBlockedNode;
+    use crate::workflows::caps::ParkedCalls;
+
+    /// The block trigger, pinned exhaustively over the shapes a drain can hand
+    /// back. Emptiness is the whole decision — a node blocks on the bare
+    /// presence of a gated call, never on a guess about which one "mattered".
+    #[test]
+    fn only_a_drain_that_gated_nothing_leaves_the_node_alone() {
+        let cases = [
+            (ParkedCalls::default(), true),
+            (
+                ParkedCalls {
+                    tools: vec!["publish_artifact".to_string()],
+                    approval_ids: vec!["appr-1".to_string()],
+                    unparkable: 0,
+                },
+                false,
+            ),
+            // A park that FAILED still blocks, and is strictly worse: there is
+            // no card, so nobody will be asked.
+            (
+                ParkedCalls {
+                    tools: vec!["publish_artifact".to_string()],
+                    approval_ids: Vec::new(),
+                    unparkable: 1,
+                },
+                false,
+            ),
+            // Excess discarded past the per-turn cap: the drain dropped the
+            // entries, so there is no tool name — and the node still blocks.
+            (
+                ParkedCalls {
+                    tools: Vec::new(),
+                    approval_ids: Vec::new(),
+                    unparkable: 3,
+                },
+                false,
+            ),
+        ];
+        for (parked, expected) in cases {
+            assert_eq!(parked.is_empty(), expected, "{parked:?}");
+        }
+    }
+
+    /// The wording rule, and the main review item on this change: the operator
+    /// is told what the run **parked**, never what it is "waiting on". A receipt
+    /// cannot go stale; a settle-time outstanding count becomes a fresh lie the
+    /// moment somebody approves one of the cards.
+    #[test]
+    fn the_operator_sentence_is_a_receipt_not_a_snapshot() {
+        let notice = super::super::runner::blocked_notice(&WorkflowBlockedNode {
+            node_id: "spec".to_string(),
+            tools: vec!["publish_artifact".to_string()],
+            approval_ids: vec!["appr-1".to_string(), "appr-2".to_string()],
+            unparkable: 0,
+        });
+        assert!(notice.contains("parked 2 approvals"), "{notice}");
+        assert!(
+            !notice.to_lowercase().contains("waiting on"),
+            "a stale-able snapshot phrasing must not appear: {notice}"
+        );
+        assert!(
+            notice.contains("the steps after it did not run"),
+            "the consequence is the part the operator actually needs: {notice}"
+        );
+    }
+
+    /// A park that could not happen reads differently from one that did, and
+    /// says so out loud: there is no card to decide, so pointing the operator at
+    /// Approvals would send them to an empty page.
+    #[test]
+    fn an_unparkable_call_is_not_worded_as_something_to_approve() {
+        let notice = super::super::runner::blocked_notice(&WorkflowBlockedNode {
+            node_id: "spec".to_string(),
+            tools: vec!["publish_artifact".to_string()],
+            approval_ids: Vec::new(),
+            unparkable: 1,
+        });
+        assert!(
+            notice.contains("could not be queued for approval"),
+            "{notice}"
+        );
+        assert!(!notice.contains("parked"), "{notice}");
+    }
+
+    /// A `WorkflowRun` written before either field existed still loads — the
+    /// `#[serde(default)]` contract, which for `WorkflowRunFinished` is the
+    /// difference between replaying a company's history at boot and losing it.
+    #[test]
+    fn a_pre_881_run_payload_still_deserializes() {
+        let legacy = json!({
+            "output": Value::Null,
+            "pending_approvals": [],
+            "deliveries": [],
+            "cancelled": false,
+            "nodes": [],
+            "notices": [],
+            "board": []
+        });
+        let run: WorkflowRun = serde_json::from_value(legacy).expect("a pre-#881 payload loads");
+        assert!(run.blocked_nodes.is_empty());
+        assert!(run.approvals.is_empty());
+    }
+}

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -114,6 +114,10 @@ pub struct RunContext<'a> {
     pub notices: RunNotices,
     /// Where an agent node's board writes are recorded (issue #661 / M5).
     pub board: RunBoard,
+    /// Where an agent node records that it blocked on a human (issue #881).
+    pub blocks: RunBlocks,
+    /// Where an agent node records the approvals its turn parked (issue #880).
+    pub approvals: RunApprovals,
 }
 
 /// Assembles the [`Capabilities`] bundle for a run of `workflow_id`.
@@ -166,6 +170,8 @@ pub async fn build_capabilities(
         dry_run,
         notices,
         board,
+        blocks,
+        approvals,
     } = run;
     let company = record.id.clone();
     // Issue #562: the tier actually in force — the operator's console override
@@ -336,6 +342,8 @@ pub async fn build_capabilities(
             run_request,
             notices,
             board,
+            blocks,
+            approvals,
             board_claim,
         ));
         (Arc::new(tools), Arc::new(http), state, Some(agent))
@@ -472,6 +480,10 @@ pub struct HarnessAgentRunner {
     notices: RunNotices,
     /// Where this node's board writes are recorded (issue #661 / M5).
     board: RunBoard,
+    /// Where this node records that it blocked on a human (issue #881).
+    blocks: RunBlocks,
+    /// Where this node records the approvals its turn parked (issue #880).
+    approvals: RunApprovals,
     /// The run's [`DrainClaim::Board`](crate::harness::orchestrator::DrainClaim)
     /// claim, taken once by [`build_capabilities`] and held for the whole run.
     ///
@@ -543,6 +555,106 @@ impl RunBoard {
     }
 }
 
+/// Where an agent node records that it **blocked** on a human (issue #881).
+///
+/// [`RunNotices`]' shape, beside it and for the structural reason spelled out
+/// there — and here that reason is not incidental, it is the bug. `run_agent`'s
+/// return value *becomes the node's output*, so a non-output fact riding it
+/// lands in the next node's `=items` binding. That is exactly how a gated
+/// `publish_artifact` came to hand the model's apology downstream: the node had
+/// nowhere but its output to say "I was blocked", so it said it there. The
+/// blockage goes sideways instead, and the node's output goes nowhere at all.
+///
+/// Cheap to clone; every clone appends to the same list, which is what lets a
+/// run's several agent nodes — including concurrent siblings — each contribute.
+#[derive(Clone, Default)]
+pub struct RunBlocks {
+    inner: Arc<std::sync::Mutex<Vec<crate::ports::WorkflowBlockedNode>>>,
+}
+
+impl RunBlocks {
+    /// Records that one node blocked.
+    pub fn push(&self, blocked: crate::ports::WorkflowBlockedNode) {
+        self.inner
+            .lock()
+            .expect("run blocks poisoned")
+            .push(blocked);
+    }
+
+    /// Takes everything recorded so far, leaving the collector empty.
+    pub fn take(&self) -> Vec<crate::ports::WorkflowBlockedNode> {
+        std::mem::take(&mut *self.inner.lock().expect("run blocks poisoned"))
+    }
+}
+
+/// Where an agent node records the approvals its turn **parked** (issue #880).
+///
+/// The third channel in the [`RunNotices`] / [`RunBoard`] family, for the same
+/// structural reason and one more: these rows are *receipts*, and a receipt has
+/// to survive the thing it is a receipt for. A card is durable the moment
+/// `park_and_journal` writes it, so the row must outlive the node — and outlive
+/// the run's failure too, which is why the collector is owned by the runner
+/// rather than by the capability bundle the engine future drops.
+///
+/// Cheap to clone; every clone appends to the same list.
+#[derive(Clone, Default)]
+pub struct RunApprovals {
+    inner: Arc<std::sync::Mutex<Vec<crate::ports::WorkflowRunApprovalRow>>>,
+}
+
+impl RunApprovals {
+    /// Records the rows one post-turn drain produced, in order.
+    pub fn extend(&self, rows: Vec<crate::ports::WorkflowRunApprovalRow>) {
+        if rows.is_empty() {
+            return;
+        }
+        self.inner
+            .lock()
+            .expect("run approvals poisoned")
+            .extend(rows);
+    }
+
+    /// Takes everything recorded so far, leaving the collector empty.
+    pub fn take(&self) -> Vec<crate::ports::WorkflowRunApprovalRow> {
+        std::mem::take(&mut *self.inner.lock().expect("run approvals poisoned"))
+    }
+}
+
+/// What one node's post-turn approval drain did (issue #881).
+///
+/// [`park_gated_calls`](HarnessAgentRunner::park_gated_calls) used to return
+/// `()`, so everything it learned died at its own log line — which is the whole
+/// of why a blocked node reported `ok`. This is that knowledge, handed back.
+///
+/// **Emptiness is the trigger.** A summary with no tools means the turn gated
+/// nothing and the node is ordinary; anything else means the node produced no
+/// deliverable and its branch must not continue. Keyed off the bare presence of
+/// gated calls rather than a guess about which of them "mattered" — the same
+/// bare-count trigger
+/// [`settled_run_status`](crate::harness::lifecycle::settled_run_status) uses,
+/// and for the same reason: the alternative is a heuristic about intent, or
+/// sniffing the model's prose for an apology.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ParkedCalls {
+    /// The tools whose calls were gated, deduplicated, in first-seen order.
+    pub tools: Vec<String>,
+    /// The approvals actually opened — what the operator can decide.
+    pub approval_ids: Vec<String>,
+    /// How many gated calls could not be parked at all: the park failed, or
+    /// this runtime has no approvals queue wired, or the call was in the excess
+    /// the drain discarded. **Nobody will be asked about these**, which is
+    /// strictly worse than being blocked on a card, and the node's diagnosis
+    /// says so separately.
+    pub unparkable: usize,
+}
+
+impl ParkedCalls {
+    /// Whether this turn gated anything at all — the block trigger.
+    pub fn is_empty(&self) -> bool {
+        self.tools.is_empty() && self.unparkable == 0
+    }
+}
+
 impl HarnessAgentRunner {
     /// Builds a runner over an already-populated pool for `company`, carrying
     /// the run's id (issue #395) and the operator's run request (issue #154)
@@ -558,6 +670,8 @@ impl HarnessAgentRunner {
         run_request: Option<String>,
         notices: RunNotices,
         board: RunBoard,
+        blocks: RunBlocks,
+        approvals: RunApprovals,
         board_claim: Arc<crate::harness::orchestrator::DelegationClaim>,
     ) -> Self {
         Self {
@@ -570,6 +684,8 @@ impl HarnessAgentRunner {
             run_request,
             notices,
             board,
+            blocks,
+            approvals,
             board_claim,
         }
     }
@@ -733,7 +849,34 @@ impl HarnessAgentRunner {
     /// were sitting in the cycle's way. Now the claim's `Drop` takes them as the
     /// dropped future unwinds, so the entries never outlive the run and no
     /// other turn has to sweep up after it.
-    async fn park_gated_calls(&self) {
+    ///
+    /// # It returns what it learned (issues #881, #880)
+    ///
+    /// This used to return `()`, and every one of its three outcomes ended at a
+    /// `tracing` line. That is the whole mechanism behind #881: the one function
+    /// that knew a node's deliverable had been parked told nobody, so `run_agent`
+    /// returned `Ok` and the engine marked the node green. It now hands back a
+    /// [`ParkedCalls`] summary the caller turns into a blocked node, and files a
+    /// per-call [`WorkflowRunApprovalRow`](crate::ports::WorkflowRunApprovalRow)
+    /// receipt on [`RunApprovals`] for every one of the three outcomes —
+    /// including, especially, the two that failed.
+    ///
+    /// No differencing is needed to know which requests are "ours": the bucket
+    /// is already run-scoped ([`ApprovalScope::Run`], issue #439), so everything
+    /// the drain returns was queued by this run's own turn.
+    async fn park_gated_calls(&self, node_id: Option<&str>) -> ParkedCalls {
+        let mut summary = ParkedCalls::default();
+        let mut rows: Vec<crate::ports::WorkflowRunApprovalRow> = Vec::new();
+        let row = |tool: Option<String>,
+                   outcome: crate::ports::WorkflowApprovalOutcome,
+                   approval_id: Option<String>| {
+            crate::ports::WorkflowRunApprovalRow {
+                node_id: node_id.map(str::to_string),
+                tool,
+                outcome,
+                approval_id,
+            }
+        };
         let queue = &self.deps.approval_requests;
         // Issue #242's stamp. The `from` is now 0 because the scope *is* the
         // entitlement: every entry in this bucket was pushed by this run's own
@@ -752,7 +895,7 @@ impl HarnessAgentRunner {
         let discarded = drained.discarded;
         let requests = drained.requests;
         if requests.is_empty() {
-            return;
+            return summary;
         }
 
         // Issue #638: told to the operator, not only logged. Raised BEFORE the
@@ -775,6 +918,20 @@ impl HarnessAgentRunner {
                 "workflow agent node: more gated tool calls than one run may park; the excess \
                  was discarded"
             );
+            // Issue #880: a receipt per dropped call, with no tool name — the
+            // drain caps and drops in one step, so by the time the count is
+            // known the entries are gone. A row that says "one more was
+            // dropped" is honest; a tool guessed from the survivors would not
+            // be. These are the worst rows on the surface: nobody is being
+            // asked about these calls at all.
+            summary.unparkable += discarded;
+            for _ in 0..discarded {
+                rows.push(row(
+                    None,
+                    crate::ports::WorkflowApprovalOutcome::Discarded,
+                    None,
+                ));
+            }
         }
 
         let Some(parking) = self
@@ -792,10 +949,27 @@ impl HarnessAgentRunner {
                 "workflow agent node: gated tool calls could NOT be parked — this runtime has \
                  no approvals queue wired; the operator will not be asked about them"
             );
-            return;
+            // Issue #880: the loudest arm, and the one that had no record at
+            // all beyond the line above. Every request here is a call the
+            // operator will never see a card for, so each gets a receipt and
+            // each counts as unparkable — which is what makes the node's
+            // diagnosis say "could not be parked" rather than the much softer
+            // "waiting on approval".
+            summary.unparkable += requests.len();
+            for request in requests {
+                push_tool(&mut summary.tools, &request.tool);
+                rows.push(row(
+                    Some(request.tool.clone()),
+                    crate::ports::WorkflowApprovalOutcome::ParkFailed,
+                    None,
+                ));
+            }
+            self.approvals.extend(rows);
+            return summary;
         };
 
         for request in requests {
+            push_tool(&mut summary.tools, &request.tool);
             // The delivery precedent: a workflow run has no board card behind it
             // and no conversation to raise the request in, so it is recorded
             // explicitly unlinked (#333) and stays Approvals-page-only (#379).
@@ -808,23 +982,56 @@ impl HarnessAgentRunner {
                 )
                 .await
             {
-                Ok(approval_id) => tracing::info!(
-                    company = %self.company,
-                    run_id = %self.run_id,
-                    tool = %request.tool,
-                    approval_id = %approval_id,
-                    "workflow agent node: parked a gated tool call for operator approval"
-                ),
-                Err(err) => tracing::error!(
-                    company = %self.company,
-                    run_id = %self.run_id,
-                    tool = %request.tool,
-                    %err,
-                    "workflow agent node: failed to park a gated tool call; the operator will \
-                     not be asked about it"
-                ),
+                Ok(approval_id) => {
+                    tracing::info!(
+                        company = %self.company,
+                        run_id = %self.run_id,
+                        tool = %request.tool,
+                        approval_id = %approval_id,
+                        "workflow agent node: parked a gated tool call for operator approval"
+                    );
+                    // Issue #881: the knowledge that used to die on the line
+                    // above. This id is what the node's block is decidable
+                    // through, and what the run's receipt names.
+                    summary.approval_ids.push(approval_id.to_string());
+                    rows.push(row(
+                        Some(request.tool.clone()),
+                        crate::ports::WorkflowApprovalOutcome::Parked,
+                        Some(approval_id.to_string()),
+                    ));
+                }
+                Err(err) => {
+                    tracing::error!(
+                        company = %self.company,
+                        run_id = %self.run_id,
+                        tool = %request.tool,
+                        %err,
+                        "workflow agent node: failed to park a gated tool call; the operator will \
+                         not be asked about it"
+                    );
+                    summary.unparkable += 1;
+                    rows.push(row(
+                        Some(request.tool.clone()),
+                        crate::ports::WorkflowApprovalOutcome::ParkFailed,
+                        None,
+                    ));
+                }
             }
         }
+        self.approvals.extend(rows);
+        summary
+    }
+}
+
+/// Appends `tool` to a first-seen-ordered, deduplicated list.
+///
+/// A turn that calls the same gated tool three times should say the tool's name
+/// once — the count of *calls* is on the approval rows, and repeating the name
+/// in the blocked-node summary would only make the console's sentence read as
+/// though three different things were blocked.
+fn push_tool(tools: &mut Vec<String>, tool: &str) {
+    if !tools.iter().any(|seen| seen == tool) {
+        tools.push(tool.to_string());
     }
 }
 
@@ -845,6 +1052,17 @@ impl AgentRunner for HarnessAgentRunner {
         // input is appended under a labelled heading, then the #154 run topic.
         let instruction = append_upstream_input(&message_from_request(&request), &request);
         let message = compose_turn_message(&instruction, self.run_request.as_deref());
+        // Issue #881: which node this is. `translate` writes it in the
+        // first-class config layer beside `agent_ref` (config cannot shadow
+        // it), because the vendored `AgentRunner` boundary carries no node
+        // identity of its own. `None` for a hand-built request in a test, or a
+        // graph compiled before #881 — the block is then recorded at run level,
+        // which is the honest fallback rather than a name invented here.
+        let node_id = request
+            .get("node_id")
+            .and_then(Value::as_str)
+            .filter(|id| !id.is_empty())
+            .map(str::to_string);
         tracing::debug!(
             company = %self.company,
             agent = agent_ref,
@@ -891,23 +1109,123 @@ impl AgentRunner for HarnessAgentRunner {
             //
             // Inside the scope, so the drain reads this run's bucket rather than
             // whatever `Unscoped` happens to hold.
-            claim.scoped(Box::pin(self.park_gated_calls())).await;
+            //
+            // Issue #880: the receipts it files therefore survive a failed turn
+            // too. Only the #881 *block* below is gated on the turn having
+            // succeeded — a turn that genuinely errored is a failure, and
+            // reclassifying it as "blocked" would hide one behind an approval
+            // nobody has answered.
+            let parked = claim
+                .scoped(Box::pin(self.park_gated_calls(node_id.as_deref())))
+                .await;
             // Issue #661 (M5): likewise on both arms, and for the same reason. A
             // turn that failed after calling `spawn_task` had already been told the
             // card would be opened; refusing to drain would make that receipt false
             // and destroy the write when the scope ends.
             Box::pin(self.drain_board_writes()).await;
-            outcome
+            (outcome, parked)
         });
-        let outcome = self.board_claim.scoped(turn).await;
+        let (outcome, parked) = self.board_claim.scoped(turn).await;
         let outcome = outcome
             .map_err(|e| EngineError::Capability(format!("harness agent '{agent_ref}': {e}")))?;
+
+        // ── Issue #881: a node whose deliverable was parked is BLOCKED ───────
+        //
+        // The turn "succeeded" — the model was refused inside its own tool
+        // loop, wrote prose about it, and ended normally — so before this the
+        // node returned `Ok`, the engine recorded `Success`, the edge fired,
+        // and the `=items` binding delivered the apology to the next node as
+        // if it were the spec it was supposed to be. Every node green, nothing
+        // delivered.
+        //
+        // `Err` is the right channel and not merely a convenient one: `on_error`
+        // defaults to `"stop"` and `retry.max_attempts` to `1`, so the branch
+        // halts at this node with no retry re-running the turn. What it is NOT
+        // is a failure — `WorkflowRun` reclassifies the node's row to
+        // [`WorkflowNodeStatus::Blocked`](crate::ports::types::WorkflowNodeStatus)
+        // and settles the run without an error, exactly as `cancelled` keeps a
+        // deliberate stop out of the failure count.
+        //
+        // Deliberately NOT an engine pause. `NodeControl::Interrupt` discards
+        // the activation's state and re-runs the node from the top on resume —
+        // and an agent node is not re-enterable, so resuming would spend
+        // another whole inference turn, call the same gated tool, and park a
+        // NEW card. Approve → re-run → re-park, forever. The engine says so
+        // itself: `StopReason::Paused` maps to "resuming a paused agent is not
+        // supported yet".
+        if !parked.is_empty() {
+            self.blocks.push(crate::ports::WorkflowBlockedNode {
+                node_id: node_id.clone().unwrap_or_else(|| agent_ref.to_string()),
+                tools: parked.tools.clone(),
+                approval_ids: parked.approval_ids.clone(),
+                unparkable: parked.unparkable,
+            });
+            return Err(EngineError::Capability(blocked_diagnosis(
+                node_id.as_deref(),
+                agent_ref,
+                &parked,
+            )));
+        }
+
         // Mirror the engine's `{ json, text, raw }` envelope shape: expose the
         // reply as `text` so a downstream `=item.text` binding resolves. A
         // workflow node carries no chat bubble, so the turn's steps are dropped
         // here (they surface only on operator/desk chat replies).
         Ok(json!({ "text": outcome.reply, "agent_ref": agent_ref }))
     }
+}
+
+/// The sentence a blocked node fails with (issue #881).
+///
+/// Modelled on the standard the `weekly-competitor-analysis` diagnosis set: name
+/// the node, the teammate, the tool(s), the policy surface, how many approvals
+/// are involved, and — the part an operator most needs — that the node produced
+/// no deliverable, so nothing downstream of it ran.
+///
+/// **"Waiting on N approvals" and "N calls could not be parked" are different
+/// sentences on purpose.** The second is strictly worse: there is no card, so
+/// there is nothing to approve and no way to unblock the node short of changing
+/// the policy and re-running. Collapsing them would tell an operator to go look
+/// at an Approvals page that has nothing on it.
+///
+/// Composed from the structural summary, never from a store's error text or the
+/// model's prose — this string reaches host logs.
+fn blocked_diagnosis(node_id: Option<&str>, agent_ref: &str, parked: &ParkedCalls) -> String {
+    let node = node_id.unwrap_or(agent_ref);
+    let tools = if parked.tools.is_empty() {
+        "a tool call".to_string()
+    } else {
+        parked
+            .tools
+            .iter()
+            .map(|t| format!("`{t}`"))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let waiting = parked.approval_ids.len();
+    let mut what = Vec::new();
+    if waiting > 0 {
+        what.push(format!(
+            "{waiting} approval{} {} waiting for you",
+            if waiting == 1 { "" } else { "s" },
+            if waiting == 1 { "is" } else { "are" }
+        ));
+    }
+    if parked.unparkable > 0 {
+        what.push(format!(
+            "{} call{} could NOT be queued for approval at all, so nobody will be asked about \
+             {}",
+            parked.unparkable,
+            if parked.unparkable == 1 { "" } else { "s" },
+            if parked.unparkable == 1 { "it" } else { "them" }
+        ));
+    }
+    format!(
+        "workflow node '{node}' is blocked: {tools} needed approval before {agent_ref} could \
+         finish, so the node produced no deliverable and nothing after it ran. {}. Approving \
+         does not continue this run — decide the card, then run the workflow again.",
+        what.join("; ")
+    )
 }
 
 /// Extracts the turn message from an agent node's resolved config: the `prompt`
@@ -1248,6 +1566,8 @@ mod tests {
             None,
             notices.clone(),
             RunBoard::default(),
+            RunBlocks::default(),
+            RunApprovals::default(),
             board_claim,
         );
 
@@ -1273,7 +1593,7 @@ mod tests {
                 }
             })
             .await;
-        claim.scoped(runner.park_gated_calls()).await;
+        claim.scoped(runner.park_gated_calls(Some("work"))).await;
         (notices.take(), queue)
     }
 
@@ -1554,6 +1874,8 @@ mod tests {
                 dry_run: false,
                 notices: RunNotices::default(),
                 board: RunBoard::default(),
+                blocks: Default::default(),
+                approvals: Default::default(),
             },
         )
         .await
@@ -1598,6 +1920,8 @@ mod tests {
                 dry_run: true,
                 notices: RunNotices::default(),
                 board: RunBoard::default(),
+                blocks: Default::default(),
+                approvals: Default::default(),
             },
         )
         .await
@@ -1753,6 +2077,8 @@ mod tests {
                 dry_run: false, // live: the workspace mkdir runs
                 notices: RunNotices::default(),
                 board: RunBoard::default(),
+                blocks: Default::default(),
+                approvals: Default::default(),
             },
         )
         .await
@@ -1804,6 +2130,8 @@ mod tests {
                 dry_run: true, // dry: no workspace mkdir at all
                 notices: RunNotices::default(),
                 board: RunBoard::default(),
+                blocks: Default::default(),
+                approvals: Default::default(),
             },
         )
         .await

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -894,9 +894,6 @@ impl HarnessAgentRunner {
         let notice = drained.overflow_notice();
         let discarded = drained.discarded;
         let requests = drained.requests;
-        if requests.is_empty() {
-            return summary;
-        }
 
         // Issue #638: told to the operator, not only logged. Raised BEFORE the
         // parking guard below, and that ordering is a fix in itself — the guard
@@ -932,6 +929,15 @@ impl HarnessAgentRunner {
                     None,
                 ));
             }
+        }
+        if requests.is_empty() {
+            // Issue #900: this used to return before the discarded handling
+            // above ran, so a drain that discarded every request and parked
+            // none filed no receipt at all — `summary.unparkable` stayed 0 and
+            // the node read as clean. The discard bookkeeping now happens
+            // first; this only has to flush what it recorded.
+            self.approvals.extend(rows);
+            return summary;
         }
 
         let Some(parking) = self

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -92,17 +92,23 @@ pub(super) enum Turn {
 }
 
 /// A scripted OpenAI-compatible `/chat/completions` endpoint.
-struct Script {
+pub(super) struct Script {
     turns: Mutex<Vec<Turn>>,
     /// Every request body the model was sent, in order (issue #453). The tool
     /// results of a turn come back to the model inside the *next* request, so
-    /// this is where a test reads what a refused tool actually told it.
-    seen: Mutex<Vec<Value>>,
+    /// this is where a test reads what a refused tool actually told it — and,
+    /// since #881, what a node downstream of a blocked one was never sent.
+    pub(super) seen: Mutex<Vec<Value>>,
 }
 
 /// Serve the script on loopback and return its base URL, handing back the
 /// shared script so a test can read what the model was sent.
-async fn spawn_script_recording(turns: Vec<Turn>) -> (String, Arc<Script>) {
+///
+/// `pub(super)` since #881: proving a blocked node's branch did **not** continue
+/// means reading what the model was never asked, so the sibling
+/// [`blocked_node_test`](crate::workflows::blocked_node_test) needs the recorder
+/// rather than only the URL.
+pub(super) async fn spawn_script_recording(turns: Vec<Turn>) -> (String, Arc<Script>) {
     let script = Arc::new(Script {
         turns: Mutex::new(turns),
         seen: Mutex::new(Vec::new()),
@@ -301,7 +307,13 @@ async fn run_gated(dir: &std::path::Path) -> (Arc<RuntimeJournal>, HarnessDeps, 
         &ctx,
     )
     .await
-    .expect("the run completes — a gated tool refuses the call, it does not fail the node");
+    // Issue #881 changed what "completes" means here: the node now BLOCKS, so
+    // the run settles short of its output node. It still settles `Ok` — a node
+    // waiting on a person is not a failed one — which is what this `expect`
+    // pins. The parking claims below are unaffected: blocking the node must not
+    // cost the operator the card, and `blocked_node_test` asserts the same
+    // thing from the other side.
+    .expect("the run settles — a gated tool blocks the node, it does not fail the run");
     (journal, deps, run_id)
 }
 
@@ -422,7 +434,8 @@ async fn a_workflow_node_is_refused_in_turn_instead_of_having_its_verdict_destro
     )
     .await
     .expect(
-        "the run completes — a refused board action refuses the call, it does not fail the node",
+        "the run completes — a refused board action refuses the call, it does not fail the node. \
+         It is NOT a #881 block either: a board refusal parks no approval, so the node stays ok",
     );
 
     // The model was told, in its own turn, that the card did NOT move.

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -19,6 +19,11 @@
 /// downstream agent node's turn (an `agent -> agent` pipeline passes data).
 #[cfg(test)]
 mod agent_upstream_input_test;
+/// Issues #881 / #880: end-to-end proof that a node whose deliverable was
+/// parked for approval reports `blocked`, stops its branch instead of handing
+/// its apology downstream, and that the run says what it parked.
+#[cfg(test)]
+mod blocked_node_test;
 /// Issue #661 (M5): end-to-end proof that a workflow node can open and re-own a
 /// board card, and that everything it may not do stays refused.
 #[cfg(test)]

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -834,14 +834,23 @@ async fn run_workflow_inner(
 /// where a blocked node is joined by a genuinely broken one must still report
 /// the failure: hiding a real error behind "waiting on approval" is the same
 /// class of lie #881 exists to remove, pointed the other way.
+///
+/// Requires **at least one** errored row before it will vouch for the
+/// reclassification (issue #900). `Iterator::all` is vacuously `true` on an
+/// empty iterator, so without this an engine failure that named no node at
+/// all — a setup or validation error the engine raised before any node ran —
+/// would satisfy the check by default and get relabelled as a plain block,
+/// dropping the real failure exactly as the doc comment above says this guard
+/// exists to prevent.
 fn only_blocked_nodes_errored(
     nodes: &[crate::ports::WorkflowRunNodeRow],
     blocked: &[crate::ports::WorkflowBlockedNode],
 ) -> bool {
-    nodes
+    let mut errored = nodes
         .iter()
         .filter(|row| row.status == WorkflowNodeStatus::Error)
-        .all(|row| blocked.iter().any(|b| b.node_id == row.node_id))
+        .peekable();
+    errored.peek().is_some() && errored.all(|row| blocked.iter().any(|b| b.node_id == row.node_id))
 }
 
 /// Reclassifies a blocked node's row and lists it as something the run is
@@ -1733,6 +1742,77 @@ to = "done"
         assert!(run.deliveries.is_empty());
         assert!(run.pending_approvals.is_empty());
         assert!(run.nodes.is_empty());
+    }
+
+    /// Issue #900's regression: `Iterator::all` is vacuously `true` on an
+    /// empty iterator, so before this guard required at least one errored row,
+    /// an engine failure that named no node at all satisfied
+    /// `only_blocked_nodes_errored` by default and would have been
+    /// relabelled as a plain block — exactly the "hide a real error behind
+    /// waiting on approval" lie the function's own doc comment says it exists
+    /// to prevent.
+    #[test]
+    fn no_errored_nodes_never_counts_as_only_blocked_nodes_errored() {
+        let blocked = vec![crate::ports::WorkflowBlockedNode {
+            node_id: "work".to_string(),
+            tools: vec!["shell".to_string()],
+            approval_ids: vec!["appr-1".to_string()],
+            unparkable: 0,
+        }];
+        // No node row reported `Error` at all — a setup/validation failure the
+        // engine raised before any node ran, for instance.
+        let nodes: Vec<crate::ports::WorkflowRunNodeRow> = Vec::new();
+        assert!(
+            !only_blocked_nodes_errored(&nodes, &blocked),
+            "an engine error naming no errored node must never be waved through as \
+             a plain block"
+        );
+    }
+
+    /// The guard's positive case still holds: when every errored row is one the
+    /// host blocked, reclassification is safe.
+    #[test]
+    fn every_errored_node_blocked_counts_as_only_blocked_nodes_errored() {
+        let blocked = vec![crate::ports::WorkflowBlockedNode {
+            node_id: "work".to_string(),
+            tools: vec!["shell".to_string()],
+            approval_ids: vec!["appr-1".to_string()],
+            unparkable: 0,
+        }];
+        let nodes = vec![crate::ports::WorkflowRunNodeRow {
+            node_id: "work".to_string(),
+            status: WorkflowNodeStatus::Error,
+            elapsed_ms: 10,
+        }];
+        assert!(only_blocked_nodes_errored(&nodes, &blocked));
+    }
+
+    /// The guard's whole reason to exist: a genuinely broken node alongside a
+    /// blocked one must still fail the check, so the real error is not hidden.
+    #[test]
+    fn a_genuinely_errored_node_alongside_a_blocked_one_fails_the_guard() {
+        let blocked = vec![crate::ports::WorkflowBlockedNode {
+            node_id: "work".to_string(),
+            tools: vec!["shell".to_string()],
+            approval_ids: vec!["appr-1".to_string()],
+            unparkable: 0,
+        }];
+        let nodes = vec![
+            crate::ports::WorkflowRunNodeRow {
+                node_id: "work".to_string(),
+                status: WorkflowNodeStatus::Error,
+                elapsed_ms: 10,
+            },
+            crate::ports::WorkflowRunNodeRow {
+                node_id: "other".to_string(),
+                status: WorkflowNodeStatus::Error,
+                elapsed_ms: 5,
+            },
+        ];
+        assert!(
+            !only_blocked_nodes_errored(&nodes, &blocked),
+            "a genuinely broken node must not be masked by an unrelated block"
+        );
     }
 
     /// A dry run writes NOTHING durable — no output snapshot, matching its "the

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -806,6 +806,15 @@ async fn run_workflow_inner(
     let mut pending_approvals = outcome.pending_approvals;
     let blocked_nodes = blocks.take();
     reclassify_blocked(&mut nodes, &mut pending_approvals, &blocked_nodes);
+    // Issue #900: `blocked_run` (the halt arm) tells the operator what blocked
+    // via a `notices` sentence, not only via the node's own status — the
+    // per-node chip is easy to miss on a run that otherwise looks fine, and a
+    // continued run finishing "green" beside a blocked node is exactly that
+    // case. Same sentence, same source (`blocked_notice`), so the two arms
+    // cannot drift into disagreement about what a block reads as.
+    for b in &blocked_nodes {
+        notices.push(blocked_notice(b));
+    }
 
     Ok(WorkflowRun {
         output: outcome.output,

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -952,7 +952,7 @@ fn blocked_run(settled: BlockedRun) -> WorkflowRun {
 /// approvals", never "waiting on N" — because a settle-time count of what is
 /// still outstanding is stale the moment the operator approves one, while a
 /// record of what this run parked is true forever.
-fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> String {
+pub(super) fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> String {
     let tools = if blocked.tools.is_empty() {
         "a tool call".to_string()
     } else {

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -298,6 +298,14 @@ async fn run_workflow_inner(
     // (and with it the bundle and its board claim) still leaves every row already
     // collected readable here: a card is real once written, so it must stay listed.
     let board = super::caps::RunBoard::default();
+    // Issue #881 / #880: the two sideways channels an agent node reports through
+    // — that it blocked, and what it parked. Owned out here for exactly the
+    // reason `board` is: a blocked node halts the run, which drops the engine
+    // future and the capability bundle with it, and both of these facts have to
+    // survive that. An approval card is durable the moment it is written, so a
+    // run that ended badly must still be able to say it opened one.
+    let blocks = super::caps::RunBlocks::default();
+    let approvals = super::caps::RunApprovals::default();
     let capabilities = super::caps::build_capabilities(
         pool,
         deps,
@@ -309,6 +317,8 @@ async fn run_workflow_inner(
             dry_run,
             notices: notices.clone(),
             board: board.clone(),
+            blocks: blocks.clone(),
+            approvals: approvals.clone(),
         },
     )
     .await?;
@@ -543,8 +553,43 @@ async fn run_workflow_inner(
     // `cancelled_run()` reports the stop with an empty body, and the trail is the
     // journal, not this return.
     let outcome = match outcome_opt {
-        Some(outcome) => outcome.map_err(map_engine_error)?,
-        None => return Ok(cancelled_run(notices.take(), board.take())),
+        Some(Ok(outcome)) => outcome,
+        // Issue #881: the engine failed the run. Before deciding that is what
+        // happened, ask whether every node that errored was one the host
+        // *blocked* on an approval — because `on_error` defaults to `"stop"`,
+        // a blocked agent node reaches the caller as exactly this `Err`.
+        //
+        // The containment check is what keeps this from hiding a real failure:
+        // a run whose blocked node is joined by a genuinely broken one still
+        // reports the error, and the block survives on the approval receipts.
+        Some(Err(err)) => {
+            let blocked = blocks.take();
+            if blocked.is_empty() || !only_blocked_nodes_errored(&nodes, &blocked) {
+                return Err(map_engine_error(err));
+            }
+            tracing::info!(
+                company = %record.id,
+                workflow = %workflow.id,
+                %run_id,
+                nodes = ?blocked.iter().map(|b| &b.node_id).collect::<Vec<_>>(),
+                "workflow: the run stopped because a node is waiting on an operator, not because \
+                 it failed"
+            );
+            return Ok(blocked_run(BlockedRun {
+                nodes,
+                blocked,
+                notices,
+                board: board.take(),
+                approvals: approvals.take(),
+            }));
+        }
+        None => {
+            return Ok(cancelled_run(
+                notices.take(),
+                board.take(),
+                approvals.take(),
+            ));
+        }
     };
 
     // Issue #398: the **clean** node-boundary cancel. The engine observed the
@@ -588,6 +633,18 @@ async fn run_workflow_inner(
             // were never drained, so it has no card and no row: consistent, and the
             // same judgement `park_gated_calls` documents for gated calls.)
             board: board.take(),
+            // Issue #881: a node the host blocked cannot be reached on this arm
+            // — a block halts the run, which is the `Err` arm above, not a
+            // clean node-boundary cancel. Taken rather than hard-coded empty so
+            // the claim stays a test's to make.
+            blocked_nodes: blocks.take(),
+            // Issue #880: NOT zeroed, unlike `deliveries` / `pending_approvals`
+            // one field up. Those describe what the run would still do; this
+            // describes what it already did. A run stopped after parking two
+            // approvals really did park them — the cards are on the operator's
+            // Approvals page right now — so dropping the rows would leave two
+            // cards no run admits to opening. Same argument as `board` above.
+            approvals: approvals.take(),
         });
     }
 
@@ -611,6 +668,11 @@ async fn run_workflow_inner(
             // rather than hard-coded empty so the claim is a *test's* to make (see
             // `a_dry_run_of_a_spawning_graph_writes_no_card`), following #542.
             board: board.take(),
+            // Issues #881 / #880: empty by the same construction. `DryRunAgent`
+            // runs no turn, so no tool call is gated, so nothing blocks and
+            // nothing parks. Taken rather than hard-coded for the same reason.
+            blocked_nodes: blocks.take(),
+            approvals: approvals.take(),
         });
     }
 
@@ -736,9 +798,18 @@ async fn run_workflow_inner(
     )
     .await;
 
+    // Issue #881: a node can block and the run still reach here — an author who
+    // wrote `on_error = "continue"` or `"route"` asked for the branch to survive
+    // the block, and gets it. The run-level record stays truthful either way, so
+    // the post-pass runs on this arm too rather than only on the halted one.
+    let mut nodes = nodes;
+    let mut pending_approvals = outcome.pending_approvals;
+    let blocked_nodes = blocks.take();
+    reclassify_blocked(&mut nodes, &mut pending_approvals, &blocked_nodes);
+
     Ok(WorkflowRun {
         output: outcome.output,
-        pending_approvals: outcome.pending_approvals,
+        pending_approvals,
         deliveries,
         cancelled: false,
         nodes,
@@ -749,7 +820,176 @@ async fn run_workflow_inner(
         // Issue #661 (M5): every card this run's nodes opened or re-owned. Empty
         // for every run whose nodes touched no card, which is nearly all of them.
         board: board.take(),
+        blocked_nodes,
+        // Issue #880: every approval this run's nodes parked, whether or not
+        // any node blocked. A run can park a card and still finish — the
+        // author's `on_error` decides — and the receipt is owed in both cases.
+        approvals: approvals.take(),
     })
+}
+
+/// Whether every node that reported an error is one the host blocked.
+///
+/// The guard on reclassifying an engine failure as a block (issue #881). A run
+/// where a blocked node is joined by a genuinely broken one must still report
+/// the failure: hiding a real error behind "waiting on approval" is the same
+/// class of lie #881 exists to remove, pointed the other way.
+fn only_blocked_nodes_errored(
+    nodes: &[crate::ports::WorkflowRunNodeRow],
+    blocked: &[crate::ports::WorkflowBlockedNode],
+) -> bool {
+    nodes
+        .iter()
+        .filter(|row| row.status == WorkflowNodeStatus::Error)
+        .all(|row| blocked.iter().any(|b| b.node_id == row.node_id))
+}
+
+/// Reclassifies a blocked node's row and lists it as something the run is
+/// waiting on (issue #881).
+///
+/// Host-side on purpose. The engine reported `Error` and that report is honest —
+/// the capability *did* return an error, which is what halted the branch. What
+/// the engine cannot know is *why*, so the host, which does, relabels the row
+/// on the way out. The
+/// [`ExecutionStep` → `NodeProgress`](ProgressObserver::on_step_finish) mapping
+/// is deliberately left alone: it is the engine's own account of what happened,
+/// and rewriting it there would make the live progress frames disagree with the
+/// engine.
+///
+/// The blocked ids are **unioned into** `pending_approvals` rather than replacing
+/// it: a run can both pause at a `requires_approval` gate and block an agent
+/// node, and the console renders every entry as a node name.
+fn reclassify_blocked(
+    nodes: &mut [crate::ports::WorkflowRunNodeRow],
+    pending_approvals: &mut Vec<String>,
+    blocked: &[crate::ports::WorkflowBlockedNode],
+) {
+    if blocked.is_empty() {
+        return;
+    }
+    for row in nodes.iter_mut() {
+        if blocked.iter().any(|b| b.node_id == row.node_id) {
+            row.status = WorkflowNodeStatus::Blocked;
+        }
+    }
+    for b in blocked {
+        if !pending_approvals.contains(&b.node_id) {
+            pending_approvals.push(b.node_id.clone());
+        }
+    }
+}
+
+/// What a run halted by a blocked node settles with (issue #881).
+///
+/// Bundled rather than passed as five arguments to [`blocked_run`], the same
+/// choice [`super::caps::RunContext`] makes and for the same reason: every field
+/// is one run's, and none of them means anything without the others.
+struct BlockedRun {
+    nodes: Vec<crate::ports::WorkflowRunNodeRow>,
+    blocked: Vec<crate::ports::WorkflowBlockedNode>,
+    notices: super::caps::RunNotices,
+    board: Vec<crate::ports::WorkflowRunBoardRow>,
+    approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
+}
+
+/// Settles a run that stopped because a node is waiting on an operator (issue
+/// #881).
+///
+/// **`Ok`, and no `error`.** The engine returned `Err`, because a capability
+/// error under the default `on_error = "stop"` is how a branch halts — but a
+/// node waiting for a human is not a node that failed, and journalling it as one
+/// would put every blocked run in the failure count and hide real failures among
+/// them. This is precisely the reclassification
+/// [`WorkflowRun::cancelled`](crate::ports::WorkflowRun) already performs for a
+/// deliberate stop: "a cancelled run is not a failed one", and neither is a
+/// blocked one.
+///
+/// Each emptiness below is a claim rather than a shrug:
+///
+/// * **no `output`** — the engine returned an error, not a final state. There is
+///   no partial state to report, and the per-node output snapshot the console
+///   inspector reads is likewise not written: nothing settled to persist. The
+///   blocked node in particular produced nothing, which is the entire point;
+/// * **no `deliveries`** — `deliver_outputs` runs off the settled output, which
+///   does not exist here. An absent row already means "not reached" everywhere
+///   else, and a run that stopped short must not mail anybody a report of work
+///   it did not finish.
+///
+/// `notices` carries the operator-facing sentence, composed from the structural
+/// blocked rows so the wording lives in one place and no model prose or store
+/// error text can ride it.
+fn blocked_run(settled: BlockedRun) -> WorkflowRun {
+    let BlockedRun {
+        mut nodes,
+        blocked,
+        notices,
+        board,
+        approvals,
+    } = settled;
+    for b in &blocked {
+        notices.push(blocked_notice(b));
+    }
+    let mut pending_approvals = Vec::new();
+    reclassify_blocked(&mut nodes, &mut pending_approvals, &blocked);
+    WorkflowRun {
+        output: Value::Null,
+        pending_approvals,
+        deliveries: Vec::new(),
+        cancelled: false,
+        nodes,
+        notices: notices.take(),
+        board,
+        blocked_nodes: blocked,
+        approvals,
+    }
+}
+
+/// The operator's sentence for one blocked node (issue #881).
+///
+/// Composed here, from the structural row, rather than lifted off the
+/// capability's error string: that string reaches host logs, and the two
+/// audiences want different things. Worded as a **receipt** — "parked N
+/// approvals", never "waiting on N" — because a settle-time count of what is
+/// still outstanding is stale the moment the operator approves one, while a
+/// record of what this run parked is true forever.
+fn blocked_notice(blocked: &crate::ports::WorkflowBlockedNode) -> String {
+    let tools = if blocked.tools.is_empty() {
+        "a tool call".to_string()
+    } else {
+        blocked
+            .tools
+            .iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    let parked = blocked.approval_ids.len();
+    let mut tail = String::new();
+    if parked > 0 {
+        tail.push_str(&format!(
+            " It parked {parked} approval{}; decide {} in Approvals and run the workflow again.",
+            if parked == 1 { "" } else { "s" },
+            if parked == 1 { "it" } else { "them" }
+        ));
+    }
+    if blocked.unparkable > 0 {
+        tail.push_str(&format!(
+            " {} call{} could not be queued for approval at all, so you will not be asked about \
+             {}.",
+            blocked.unparkable,
+            if blocked.unparkable == 1 { "" } else { "s" },
+            if blocked.unparkable == 1 {
+                "it"
+            } else {
+                "them"
+            }
+        ));
+    }
+    format!(
+        "The step \"{}\" needed your approval for {tools}, so it produced nothing and the steps \
+         after it did not run.{tail}",
+        blocked.node_id
+    )
 }
 
 /// Persists a settled run's per-node output to the durable, console-facing
@@ -1026,6 +1266,7 @@ async fn park_pending_gates(
 fn cancelled_run(
     notices: Vec<String>,
     board: Vec<crate::ports::WorkflowRunBoardRow>,
+    approvals: Vec<crate::ports::WorkflowRunApprovalRow>,
 ) -> WorkflowRun {
     WorkflowRun {
         output: Value::Null,
@@ -1039,6 +1280,16 @@ fn cancelled_run(
         nodes: Vec::new(),
         notices,
         board,
+        // Issue #881: a hard abort drops the engine future mid-await, so no
+        // node ever reported a block — and a block is reported only by a node
+        // that finished its turn. Empty by construction, not by omission.
+        blocked_nodes: Vec::new(),
+        // Issue #880: threaded in, NOT emptied, for exactly the reason `board`
+        // is. An approval card is durable the moment it is written, so a run
+        // that parked two and was then hard-aborted really did park them —
+        // zeroing the rows would leave two cards on the operator's Approvals
+        // page that no run admits to opening.
+        approvals,
     }
 }
 
@@ -1444,9 +1695,26 @@ to = "done"
             title: Some("Reply to the auditor".to_string()),
             assignee: None,
         };
+        // Issue #880: a parked approval is threaded in for the same reason the
+        // board row is — the card is already on the operator's Approvals page,
+        // so a hard abort must not un-say that the run opened it.
+        let parked = crate::ports::WorkflowRunApprovalRow {
+            node_id: Some("work".to_string()),
+            tool: Some("publish_artifact".to_string()),
+            outcome: crate::ports::WorkflowApprovalOutcome::Parked,
+            approval_id: Some("appr-1".to_string()),
+        };
         let run = cancelled_run(
             vec!["something was discarded".to_string()],
             vec![row.clone()],
+            vec![parked.clone()],
+        );
+
+        assert_eq!(
+            run.approvals,
+            vec![parked],
+            "a run stopped after parking an approval really did park it; zeroing the receipt \
+             would leave a card no run admits to opening"
         );
 
         assert!(run.cancelled);

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -172,6 +172,14 @@ fn translate_node(def: &WorkflowNodeDef) -> Node {
             if let Some(agent) = def.agent.as_deref().filter(|a| !a.is_empty()) {
                 config.insert("agent_ref".to_string(), json!(agent));
             }
+            // Issue #881: which node this is. The vendored `AgentRunner` trait
+            // hands the capability only the resolved config and the trusted
+            // `agent_ref` — the node's own id is lost at that boundary — so a
+            // node that blocks on an approval could not say *which* node
+            // blocked. Written in the first-class layer beside `agent_ref`, and
+            // for the same reason: config must not be able to rebind a node's
+            // identity to another node's name.
+            config.insert("node_id".to_string(), json!(def.id));
         }
         // A `tool_call` needs a `slug` (the config overlay above carries it). The
         // masking node-id default was removed (issue #661): author-time

--- a/src/workflows/translate.rs
+++ b/src/workflows/translate.rs
@@ -451,7 +451,10 @@ mod tests {
                 "agent_ref": "brand_strategist",
                 "prompt": "Turns the brief into an angle + outline.",
                 // Issue #782: the upstream-output binding every agent node carries.
-                "input": "=items"
+                "input": "=items",
+                // Issue #881: the node's own id, so the agent capability can say
+                // WHICH node blocked when its turn parks an approval.
+                "node_id": "strategist"
             })
         );
         // The gate carries its boolean discriminant (issue #661): a condition
@@ -471,7 +474,9 @@ mod tests {
                 "agent_ref": "copywriter",
                 "prompt": "Assemble the publish-ready post and hero-image reference, then hand off for operator sign-off.",
                 // Issue #782: the upstream-output binding every agent node carries.
-                "input": "=items"
+                "input": "=items",
+                // Issue #881: as above.
+                "node_id": "publish"
             })
         );
         assert_eq!(config("done"), json!({}));


### PR DESCRIPTION
## Summary

A workflow run reported every node `ok` and delivered nothing, and could not show what it was waiting on.

There are two independent approval mechanisms and only one was wired to run semantics. A gate on a `tool_call` **node** pauses the engine properly. A gate on a tool call **inside an agent node's turn** — which is what `publish_artifact` under `opencompany-approval` is — never reaches the engine at all: the call is refused inside the model's tool loop, the model writes prose about it, and the turn ends normally. `park_gated_calls` parked a card and returned `()`, so `run_agent` returned `Ok`, the engine recorded `Success`, the edge fired, and the `=items` binding handed the apology to the next node as if it were the spec.

Observed on a hosted tenant: three 9-node `feature_pipeline` runs, every node green, `pendingApprovals: []` and `deliveries: []`, while the company queue held 15 `publish_artifact` approvals those runs had created.

`deliveries` and `pending_approvals` were never hardcoded empty — they are plumbed and *truthfully* zero, because they mean engine gate-node ids and `output`-node routing respectively. Neither answers what the run view is asked. So this adds the fact that was missing rather than redefining theirs.

Closes #881. Closes #880.

## API Or Behavior Changes

- `WorkflowNodeStatus` gains a `Blocked` unit arm. A node whose gated call parked is no longer `ok`, and the branch stops rather than passing prose downstream.
- `WorkflowRun` gains `blocked_nodes` and `approvals`, both `#[serde(default)]` — mandatory, since `WorkflowRunFinished` is replayed at boot and a field without it would make every pre-existing journal line fail to parse.
- `approvals` is a **receipt of what the run parked**, not a snapshot of what is outstanding. A receipt cannot go stale; a settle-time count rots into a fresh lie the moment someone approves. The console says "parked N approvals", never "waiting on N" — pinned by a test.
- Receipts are filed for **all three** outcomes: parked, park-failed, and discarded past the cap. The two failure arms previously had no record but a `tracing::error!` — those are calls the operator will never be asked about.
- Two counting conventions now exist side by side, deliberately: the receipt count (`parkedApprovalCount`, `approvals_parked`) answers "what happened to this run's gated calls" and includes the failures on purpose; the new `decidableApprovalCount` (`outcome === "parked"` only) answers "what can the operator actually decide right now". Anything that tells the operator a card is waiting — "needs your approval", "decide it in Approvals" — uses the second, so a run whose every park failed never claims a card exists that isn't there.
- A continued run (`on_error = "continue" | "route"` past a blocked node) now files the same `blocked_notice` the halted arm always did, so the block is not only visible on the per-node chip.
- `ApprovalSummary` gains `workflow_run_id`, so the Approvals page can name the run waiting on you.
- Surfaced on all four readers (run response, `list_runs`, SSE, the `run_workflow` agent tool) plus the console's third chip tone and terminal wording.

## Tests

- `cargo fmt --all -- --check`, `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`, and `RUST_MIN_STACK=33554432 cargo test --locked --features openhuman,tinycortex` (3755, 0 failed) all clean against current `main`. Console: all three typecheck projects, `vitest run` (728), `build` — all clean.
- **Both headline gates proved to fail on pre-fix behaviour, reproducing the reported symptom exactly**: `work` reported `ok`, `next` and `done` ran, `approvals` empty. The strongest assertion is that the downstream node's scripted endpoint receives **zero** requests — direct proof the apology did not travel.
- A paired counter-test keeps the clean path honest: an agent node that parks nothing still reports `Ok` and its downstream node still runs. Without it, a fix that merely stopped returning `Ok` would pass.
- Added in review: a regression test drives the real `on_error = "continue"` path through the harness pool end to end — block, branch continues, node still reports `Blocked`, receipt and notice still land — not just the pure `reclassify_blocked` unit. `summarize_run`'s blocked-node branch is now covered (block vs. paused-gate wording never cross-contaminate; a `ParkFailed` receipt alongside a `Parked` one proves `approvals_parked` counts only the decidable row). The blocked-run paragraph's approval count now excludes failed/discarded parks so a run with zero decidable cards never says "needs your approval".
- Back-compat: a pre-change `WorkflowRun` and a pre-existing journal line still deserialize.

## Documentation

`docs/spec/runtime/workflow-vocabulary.md`, `docs/spec/runtime/workflow-events.md`, `docs/modules/server/workflow-routes.md` — the third node status, the blocked terminal reading, and the receipt semantics.

## Notes for the reviewer

**Two deviations from the plan, both deliberate.**

1. The plan assumed a blocked run reaches the settle arm. It does not — an agent capability `Err` under the default `on_error = "stop"` makes the engine return `Err` from `run`, which would have reported a *failure*. `runner.rs` now intercepts that and settles a blocked run, guarded by `only_blocked_nodes_errored` so a genuine failure alongside a block still reports as a failure.
2. `Effect.run_id` is an overloaded key. A dedicated field means 88 struct literals; a new `TaskLink` variant is unsafe (34 `matches!` sites the compiler would not force). The recorded **park site** is the discriminator instead — `TaskLink::Unlinked` plus a stamped run id is a workflow park by construction — pinned in all four directions.

**Honest limits, none papered over.** Approving still does not resume a run: the operator must re-run, and a workflow node holds no `PublishClaim` so `publish_artifact` refuses regardless — which is why deliveries stayed 0 on the audited tenant even after all 15 approvals were granted. That forward path is filed as **#899**, not left as a TODO. Artifacts-by-run is out of scope (`ArtifactRecord` is keyed by `task_id`). `on_error = "continue" | "route"` still lets a branch survive a block — the author asked for that, and the run-level record stays truthful. Over-blocking is deliberate: a node that parked one approval but also produced a deliverable now halts, matching `settled_run_status`'s bare-count trigger; the alternatives are guessing which parked call mattered or sniffing the model's prose. One more, surfaced in review: when the guard that keeps a genuine failure from being mislabeled as a block itself rejects (a real error joined a block, or a block with no errored node row), the run returns `Err` and any approvals already parked before that point are not listed on *this run's own record* — `Result<WorkflowRun>`'s `Err` variant can't carry a `WorkflowRun`. The card itself is not at risk (`park_and_journal` durably parks it on the live queue before this function ever decides `Ok` vs `Err`), and today's only caller on that path journals just `err.to_string()` regardless, so there is no run-history row to attach a receipt list to either way. Threading `board`/`notices`/`approvals` through the error path (and widening the journal call that would carry them) is real work, filed as a follow-up rather than rushed here under review-loop pressure.

**Not fully verified:** manual end-to-end on a live tenant was not run — it needs real inference plus a company whose policy parks `publish_artifact`. The nearest automated equivalent *is* run and drives the real path end to end. Worth a staging pass before merge.

**Pre-existing, not from this branch:** `workflows::board_turn_test` stack-overflows locally without `RUST_MIN_STACK` — same family as #895.

## Related

- #899 — the missing replay path for an approved agent-internal call
- #846 — the `tool_call`-node replay ledger #899 needs a sibling to
