### PR TITLE
feat(policy): publishing to the company's own workspace runs unattended under auto (#903)

### DIFF
--- a/src/harness/policy.rs
+++ b/src/harness/policy.rs
@@ -1787,6 +1787,12 @@ mod tests {
                 "composio_execute",
                 serde_json::json!({ "tool": "GITHUB_LIST_PULL_REQUESTS" }),
             ),
+            // Issue #903: handing the finished work to the operator. It writes
+            // into the company's own workspace and artifact chain — no
+            // counterparty, no address — and the chain versions it, so the
+            // company can undo it alone. Parking it made every deliverable wait
+            // on a human; one 9-node pipeline run produced 15 such waits.
+            ("publish_artifact", serde_json::json!({})),
         ] {
             assert_eq!(
                 p.check(&request(tool, args)).await,
@@ -1795,6 +1801,28 @@ mod tests {
                  the agent's own work"
             );
         }
+
+        // Issue #903, the two ways an operator keeps a human on every hand-over.
+        // Both must survive the change above, or `auto` has quietly become the
+        // only tier and the choice is gone.
+        assert!(
+            matches!(
+                policy("supervised", &[], None)
+                    .check(&request("publish_artifact", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "a supervised desk must still see a publish before it lands"
+        );
+        assert!(
+            matches!(
+                policy("auto", &["publish_artifact"], None)
+                    .check(&request("publish_artifact", serde_json::json!({})))
+                    .await,
+                ToolPolicyDecision::RequireApproval { .. }
+            ),
+            "always_approve names it, and always_approve wins over every tier"
+        );
 
         // Still parks: arbitrary code, arbitrary addresses, a configured remote,
         // operator-authored guidance, third-party effects, real money on submit,
@@ -1809,7 +1837,6 @@ mod tests {
             ("workspace_create", serde_json::json!({})),
             ("workspace_delete", serde_json::json!({})),
             ("workspace_rename", serde_json::json!({})),
-            ("publish_artifact", serde_json::json!({})),
             ("media_generate_image", serde_json::json!({})),
             ("media_generate_video", serde_json::json!({})),
             ("mcp_call_tool", serde_json::json!({})),

--- a/src/policy/consequence.rs
+++ b/src/policy/consequence.rs
@@ -512,7 +512,19 @@ const DECLARED: &[Declared] = &[
     d("workspace_rename", EffectGroup::Other, Reach::Consequence),
     // ---- Publishing --------------------------------------------------------
     // Externally visible and not reversible by the company alone.
-    d("publish_artifact", EffectGroup::Publish, Reach::Consequence),
+    // `Reach::Consequence` because a publish does change state, and a
+    // `supervised` desk should still see one before it lands. But `Grantable`,
+    // not `PerCall` (issue #903): handing a finished file to the operator does
+    // not leave the company. `harness::publish` writes into the company's own
+    // workspace and artifact chain — no counterparty, no address, nothing sent
+    // — and the write is versioned (`…/artifacts/{id}/versions`, `…/diff`), so
+    // it is reversible by the company alone, unlike the tools this section's
+    // neighbours classify. `auto` already promises that the agent's own
+    // sandbox writes run unattended; this is that promise applied to the step
+    // that makes the work visible. An operator who wants a human on every
+    // hand-over keeps one by choosing `supervised`, or by naming
+    // `publish_artifact` in `always_approve`, which wins over every tier.
+    d_grantable("publish_artifact", EffectGroup::Publish, Reach::Consequence),
     // ---- Priced backend calls ----------------------------------------------
     // `web_search` is billed per request but changes nothing (issue #238).
     // Media generation moves real money on submit (issue #109); listing the
@@ -1453,6 +1465,14 @@ mod tests {
             "edit",
             "file_write",
             "memory_store",
+            // Issue #903, and the one entry that is not the agent's private
+            // sandbox: it writes into the company's shared workspace. Declared
+            // deliberately. A publish still reaches no counterparty and no
+            // address, and the artifact chain versions it, so the company can
+            // undo it alone — the two properties every other name here has.
+            // What it buys is that a finished deliverable reaches the operator
+            // without a per-file decision, which is the whole point of `auto`.
+            "publish_artifact",
         ];
 
         let crossers = |args: &serde_json::Value| {
@@ -1503,7 +1523,6 @@ mod tests {
             "workspace_write",
             "workspace_delete",
             "workspace_rename",
-            "publish_artifact",
             "media_generate_image",
             "media_generate_video",
             "mcp_call_tool",
@@ -1534,6 +1553,27 @@ mod tests {
         // cap is what holds spend.
         assert!(!c("web_search").parks_under_auto());
         assert!(c("web_search").reach.costs_money());
+
+        // The other boundary `auto` deliberately does not draw (issue #903):
+        // handing a finished file to the operator. `publish_artifact` changes
+        // state, so it keeps `Reach::Consequence` and still parks under
+        // `supervised` — but it reaches no counterparty and no address, writes
+        // only into the company's own workspace and artifact chain, and is
+        // versioned, so it is reversible by the company alone. Parking it under
+        // `auto` made every deliverable wait on a human: one 9-node pipeline
+        // run generated 15 of these.
+        assert!(
+            !c("publish_artifact").parks_under_auto(),
+            "handing a file to the operator does not leave the company"
+        );
+        assert!(
+            c("publish_artifact").reach.parks_under_supervision(),
+            "a supervised desk must still see a publish before it lands"
+        );
+        assert!(
+            !c("publish_artifact").reach.costs_money(),
+            "a publish is not a spend, so the daily cap must not bill for it"
+        );
     }
 
     /// The argument-classified half of the same line: a Composio read runs


### PR DESCRIPTION
## Summary

Handing a finished file to the operator parked for approval on an `auto` company. `publish_artifact` was `Reach::Consequence` + `Standing::PerCall`, and `parks_under_auto()` reads both — so every deliverable waited on a human.

Measured on a live tenant during the parity audit that produced #878/#880/#881/#884/#886/#887: a one-line "write the spec" request produced a complete spec and then stopped, unable to hand it over; one 9-node `feature_pipeline` run generated **15** publish approvals and delivered nothing until all were cleared by hand.

The declaration's own comment said "externally visible and not reversible by the company alone". Neither half holds here. `harness::publish` writes into the company's **own** workspace and artifact chain — no counterparty, no address, nothing sent — and the chain versions the write (`…/artifacts/{id}/versions`, `…/diff`), so the company can undo it alone. Its neighbours in that section (`curl`, `http_request`, `payment`, `filing.submit`) reach an arbitrary address or move money. Publishing a markdown file into the operator's own notes is not that.

The reach is still right — a publish does change state, and a `supervised` desk should see one before it lands. So the fix is on `Standing`, the field that separates "runs unattended under `auto`" from "parks under `supervised`": `d_grantable` instead of `d`.

Closes #903.

## API Or Behavior Changes

| Tier | Before | After |
|---|---|---|
| `auto` | parks | **runs unattended** |
| `supervised` | parks | parks (unchanged) |
| `readonly` | denied | denied (unchanged) |
| `always_approve` names it | parks | parks (unchanged — wins over every tier) |

An operator who wants a human on every hand-over keeps one by choosing `supervised`, or by naming `publish_artifact` in `always_approve`. `auto`'s own contract already promises the agent's own sandbox writes run unattended; this applies that promise to the step that makes the work visible.

**The widening, stated plainly:** an `auto` company's agents can now write into the shared workspace without a per-file decision. The write stays confined to the company's own store, versioned, attributed to the agent, and journaled — and both opt-outs above survive.

## Tests

- Full gated suite green: `cargo test --locked --features openhuman,tinycortex` → 3705 + 10 + 1 + 11 + 2 passing, 0 failed. `fmt` clean; `clippy --no-deps --all-targets -- -D warnings` clean.
- **Two existing guards failed first, and both were right to.** `the_auto_tier_line_is_pinned_tool_by_tool` refuses any tool crossing the auto line unless it is named there with a reason; `auto_runs_sandbox_writes_and_outward_reads_but_parks_anything_that_leaves` asserted publish "leaves the company". Neither was loosened — the crossing is now declared explicitly in both places with why publishing differs from its neighbours. That is the change being argued in the codebase rather than slipped past it.
- New assertions pin the full matrix: runs unattended under `auto`; still parks under `supervised`; `always_approve` still overrides; and a publish is not a spend, so the daily cap does not bill for it.
- **Verified live** on `agentic_software_company` against staging inference, reproducing the audit's exact request ("add password reset to the app. Write the spec and publish it."): the spec published **unattended** — a board card in `in_review` carrying the artifact at version 1, and an **empty approvals queue**. Before this change that same request stopped mid-turn and required an operator click.

## Documentation

None. The behaviour is documented where it is decided — the declaration comment and the two tier tests — and no spec page states the old rule.

## Related

Upstream cause of the approval volume #880 makes visible and #881 stops lying about. Found in the same audit as #878, #884, #886, #887.
