### PR TITLE
feat(console): make the web console multi-host with a carried session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -456,17 +455,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1334,6 +1322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1779,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -2634,6 +2643,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2676,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3164,7 +3197,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -3176,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.8"
+version = "0.63.7"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3191,13 +3224,14 @@ dependencies = [
  "chrono-tz",
  "cron",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "dotenvy",
  "ed25519-dalek",
  "flate2",
  "fs2",
  "futures",
  "futures-util",
+ "git2",
  "glob",
  "hex",
  "hkdf",
@@ -3214,6 +3248,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest",
+ "ring",
  "rusqlite",
  "rustls",
  "schemars",
@@ -3232,16 +3267,13 @@ dependencies = [
  "tinycortex",
  "tinycortex-api",
  "tinyhumans-sdk",
- "tinymemory",
- "tinymemory-api",
- "tinymemory-core",
- "tinymemory-tinycortex",
+ "tinyjuice",
  "tinyplace",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3586,7 +3618,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4224,6 +4256,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4728,7 +4769,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "regex",
  "reqwest",
  "rusqlite",
  "serde",
@@ -4803,8 +4843,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "futures",
+ "git2",
+ "hex",
  "log",
  "parking_lot",
  "rand 0.10.2",
@@ -4819,7 +4861,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "uuid",
  "walkdir",
@@ -4842,6 +4884,8 @@ dependencies = [
 [[package]]
 name = "tinyflows"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5815f3dded76503a1b1867b55282941f50b3ecef4dcbfd0786640dc189250557"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4873,74 +4917,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory"
-version = "1.0.1"
+name = "tinyjuice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dde6760266db10b01d339438b651045e3815a52d00eeb40e2f41f22304d6cac"
 dependencies = [
- "anyhow",
  "async-trait",
+ "dirs 6.0.0",
+ "hex",
  "log",
- "serde",
- "serde_json",
- "tinymemory-api",
-]
-
-[[package]]
-name = "tinymemory-api"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "log",
- "schemars",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "uuid",
-]
-
-[[package]]
-name = "tinymemory-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "chrono",
- "dirs",
- "futures",
- "log",
- "parking_lot",
- "rand 0.8.7",
- "regex",
- "reqwest",
- "rusqlite",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tinyagents",
- "tinycortex",
- "tinycortex-api",
- "tinymemory",
- "tinymemory-api",
  "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "tinymemory-tinycortex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "tinycortex",
- "tinymemory",
- "tinymemory-api",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5101,17 +5095,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5125,14 +5140,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5141,8 +5170,14 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5384,6 +5419,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5971,6 +6012,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6172,6 +6222,10 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "tinyflows"
+version = "0.6.0"
 
 [[patch.unused]]
 name = "whisper-rs-sys"

--- a/docs/spec/README.md
+++ b/docs/spec/README.md
@@ -105,6 +105,7 @@ L0  Substrate       api.tinyhumans.ai, openhuman-core, tiny.place, filesystem
 | [runtime/repos.md](runtime/repos.md) | Bound repositories: mirror cache, credential handling, quota |
 | [runtime/data-root.md](runtime/data-root.md) | Data-root resolution, the single-writer lock, instance identity |
 | [runtime/desktop.md](runtime/desktop.md) | The desktop client: connections, transport seam, embedded host |
+| [runtime/hub-console.md](runtime/hub-console.md) | One console deployment operating many hosts on other origins |
 | [security/agent-isolation.md](security/agent-isolation.md) | What confines an agent and what does not — enforced controls, the gaps, and the capability that survives every planned control |
 | [company-as-agent/README.md](company-as-agent/README.md) | Companies as economy citizens |
 | [company-as-agent/identity.md](company-as-agent/identity.md) | Wallet, handle, Agent Card |

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -106,6 +106,8 @@ Supporting docs:
   sessions, invites, and chat attribution
 - [auth-modes.md](auth-modes.md) — the configured sign-in mode: `email`,
   `wallet`, or `none` (no sign-in, for the desktop app), and what each changes
+- [hub-console.md](hub-console.md) — one console deployment operating many hosts
+  on other origins: the carried session, CORS, and what it costs
 
 ## Responsibilities
 

--- a/docs/spec/runtime/config.md
+++ b/docs/spec/runtime/config.md
@@ -123,7 +123,7 @@ that does and does not imply.
 | `OPENCOMPANY_MAIL_SECURITY` | `starttls` | `none` \| `starttls` \| `ssl` |
 | `OPENCOMPANY_MAIL_USERNAME` / `_PASSWORD` | — | SMTP auth. Redacted from `Debug` and never logged |
 | `OPENCOMPANY_MAIL_FROM_NAME` | — | Display name on the `From` header |
-| `OPENCOMPANY_CORS_ORIGINS` | — (CORS off) | Comma-separated exact origins allowed to send the session cookie cross-origin, e.g. `http://localhost:5173`. `*` is refused: a wildcard is illegal with credentials |
+| `OPENCOMPANY_CORS_ORIGINS` | — (CORS off) | Comma-separated exact origins allowed to make credentialed cross-origin requests, e.g. `http://localhost:5173` for a Vite dev server or `https://app.example.com` for a [hub console](hub-console.md). `*` is refused: a wildcard is illegal with credentials |
 | `OPENCOMPANY_PLATFORM_TOKEN` | — (no machine credential) | The shared platform secret. A bearer equal to it is the `tenant:platform` principal, with the `platform` scope |
 | `OPENCOMPANY_PLATFORM_JWT_SECRET` | — (signed tenant tokens not accepted) | HS256 secret that signs tenant-scoped machine tokens. No shipped literal and no fallback: unset means the path does not exist. Set on a build without `platform-jwt` (in the default feature set) and the host **refuses to boot** |
 

--- a/docs/spec/runtime/hub-console.md
+++ b/docs/spec/runtime/hub-console.md
@@ -1,0 +1,53 @@
+# The hub console
+
+One deployment of the operator console, at its own origin, operating many hosts
+that live on other origins — typically one subdomain per tenant.
+
+Read [Users and sessions](users.md) first: this document assumes the two session
+carriers described there, and the hub exists because only one of them works
+across origins.
+
+The console can be deployed **once**, at its own origin, and operate many hosts
+living on other origins — typically one subdomain per tenant. The same bundle
+serves both shapes; a hub build sets `VITE_OC_HUB=1` (or is opened with `?hub`).
+
+What changes, and what does not:
+
+| | Same-origin console | Hub console |
+|---|---|---|
+| Bootstrap connection | its own origin | none — its origin serves assets only |
+| Which hosts it knows | the one that served it | the ones someone added, in `localStorage` |
+| Session carrier | `HttpOnly` cookie | `x-opencompany-session`, held by the page |
+| Event stream | `EventSource` | `fetch` — `EventSource` cannot set a header |
+
+The console holds N hosts either way; that has been true since connections
+landed. A hub differs only in having no host at its own origin to seed the list
+with.
+
+**Each tenant must allow-list the hub's origin** in
+`OPENCOMPANY_CORS_ORIGINS`, or the browser blocks every response. There is no
+wildcard: the session is a credential, and `Access-Control-Allow-Origin: *` is
+forbidden with credentials.
+
+## The cost, stated plainly
+
+A hub console holds its session tokens in `localStorage`, so script execution on
+the hub's origin reaches every host its operator has signed in to — where a
+same-origin console's `HttpOnly` cookie would have survived it. This is a real
+reduction and is accepted only because the alternative is not a safer console
+but no console: the cookie is never sent cross-site, and `SameSite=None` would
+merely turn it into a third-party cookie Safari discards.
+
+Two things bound it. The credential is a *session* — revocable from the host's
+device list, expiring on its own — and it is only ever chosen where a cookie
+could not have worked, a decision derived from the address rather than
+configured (`needsCarriedSession`), so it cannot be turned on by mistake for a
+deployment that had a cookie available.
+
+## Magic links land on the host, not the hub
+
+A login link is built by the host out of its own base URL, so following one
+opens that host's own console rather than the hub. Within the hub, the working
+sign-in paths are password, wallet, and ecosystem sign-in. Redirecting a link
+back to a hub origin would require the host to know that origin, which nothing
+tells it today.

--- a/docs/spec/runtime/hub-console.md
+++ b/docs/spec/runtime/hub-console.md
@@ -7,11 +7,24 @@ Read [Users and sessions](users.md) first: this document assumes the two session
 carriers described there, and the hub exists because only one of them works
 across origins.
 
-The console can be deployed **once**, at its own origin, and operate many hosts
-living on other origins — typically one subdomain per tenant. The same bundle
-serves both shapes; a hub build sets `VITE_OC_HUB=1` (or is opened with `?hub`).
+The same bundle serves both shapes; a hub build sets `VITE_OC_HUB=1`, or is
+opened with `?hub`.
 
-What changes, and what does not:
+## Deploying one
+
+```sh
+# The hub: static assets, no host behind them.
+VITE_OC_HUB=1 pnpm build
+
+# Each tenant, so the browser will let the hub read its responses.
+OPENCOMPANY_CORS_ORIGINS=https://app.example.com opencompany serve --company …
+```
+
+Operators then add hosts from the "+" in the connection rail
+(`https://acme.example.com`), and each is remembered in `localStorage`. There is
+no directory service: a hub knows exactly the hosts somebody told it about.
+
+## What changes, and what does not
 
 | | Same-origin console | Hub console |
 |---|---|---|

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -281,9 +281,89 @@ all, and a cross-site `fetch` that sets a custom one is preflighted, which CORS
 answers for allow-listed origins only. The header is the stricter carrier — it
 is never attached ambiently the way a cookie is.
 
-**Nothing issues one to a browser.** A session token reaches a browser only as
-`Set-Cookie`, where `HttpOnly` keeps it away from JavaScript. Device pairing is
-the intended issuer for clients that need the header form.
+**A browser gets the cookie unless it asks otherwise, and it only asks when the
+cookie cannot work.** The default is unchanged and is what every same-origin
+console still gets: the token reaches the browser only as `Set-Cookie`, where
+`HttpOnly` keeps it away from JavaScript. Device pairing remains the issuer for
+native clients.
+
+The exception is the hub console below, which is cross-origin with every host it
+operates and therefore receives no cookie at all.
+
+### Asking for the header carrier
+
+A client that cannot receive a cookie sends `x-opencompany-session-carrier:
+header` on a sign-in request. The response then carries the ready-made header
+value as `session` in its JSON body and sets **no** cookie:
+
+```http
+POST /api/v1/companies/acme/auth/verify
+x-opencompany-session-carrier: header
+
+200 OK
+{ "id": "…", "email": "ada@example.com", …, "session": "acme.<token>" }
+```
+
+One session, one carrier — deliberately. Issuing both would leave the cookie
+half as a third-party cookie that some browsers keep and others discard, so
+whether logging out actually ended the session would vary by browser.
+
+Every browser login path routes through one `mint_session`, so all four —
+magic link, password, hub sign-in and wallet — support this identically.
+
+Opting in this way is safe for the same reason the header carrier itself is: a
+cross-site HTML form cannot set a request header, and a cross-site `fetch` that
+sets one is preflighted, which CORS answers for allow-listed origins only. A
+hostile page therefore cannot make someone's browser request the readable
+carrier on its behalf. Anything other than `header` — absent, empty, or a value
+nobody defined — degrades to the cookie rather than to no session.
+
+## The hub console
+
+The console can be deployed **once**, at its own origin, and operate many hosts
+living on other origins — typically one subdomain per tenant. The same bundle
+serves both shapes; a hub build sets `VITE_OC_HUB=1` (or is opened with `?hub`).
+
+What changes, and what does not:
+
+| | Same-origin console | Hub console |
+|---|---|---|
+| Bootstrap connection | its own origin | none — its origin serves assets only |
+| Which hosts it knows | the one that served it | the ones someone added, in `localStorage` |
+| Session carrier | `HttpOnly` cookie | `x-opencompany-session`, held by the page |
+| Event stream | `EventSource` | `fetch` — `EventSource` cannot set a header |
+
+The console holds N hosts either way; that has been true since connections
+landed. A hub differs only in having no host at its own origin to seed the list
+with.
+
+**Each tenant must allow-list the hub's origin** in
+`OPENCOMPANY_CORS_ORIGINS`, or the browser blocks every response. There is no
+wildcard: the session is a credential, and `Access-Control-Allow-Origin: *` is
+forbidden with credentials.
+
+### The cost, stated plainly
+
+A hub console holds its session tokens in `localStorage`, so script execution on
+the hub's origin reaches every host its operator has signed in to — where a
+same-origin console's `HttpOnly` cookie would have survived it. This is a real
+reduction and is accepted only because the alternative is not a safer console
+but no console: the cookie is never sent cross-site, and `SameSite=None` would
+merely turn it into a third-party cookie Safari discards.
+
+Two things bound it. The credential is a *session* — revocable from the host's
+device list, expiring on its own — and it is only ever chosen where a cookie
+could not have worked, a decision derived from the address rather than
+configured (`needsCarriedSession`), so it cannot be turned on by mistake for a
+deployment that had a cookie available.
+
+### Magic links land on the host, not the hub
+
+A login link is built by the host out of its own base URL, so following one
+opens that host's own console rather than the hub. Within the hub, the working
+sign-in paths are password, wallet, and ecosystem sign-in. Redirecting a link
+back to a hub origin would require the host to know that origin, which nothing
+tells it today.
 
 ## Device pairing
 

--- a/docs/spec/runtime/users.md
+++ b/docs/spec/runtime/users.md
@@ -287,8 +287,8 @@ console still gets: the token reaches the browser only as `Set-Cookie`, where
 `HttpOnly` keeps it away from JavaScript. Device pairing remains the issuer for
 native clients.
 
-The exception is the hub console below, which is cross-origin with every host it
-operates and therefore receives no cookie at all.
+The exception is the [hub console](hub-console.md), which is cross-origin with
+every host it operates and therefore receives no cookie at all.
 
 ### Asking for the header carrier
 
@@ -317,53 +317,6 @@ sets one is preflighted, which CORS answers for allow-listed origins only. A
 hostile page therefore cannot make someone's browser request the readable
 carrier on its behalf. Anything other than `header` — absent, empty, or a value
 nobody defined — degrades to the cookie rather than to no session.
-
-## The hub console
-
-The console can be deployed **once**, at its own origin, and operate many hosts
-living on other origins — typically one subdomain per tenant. The same bundle
-serves both shapes; a hub build sets `VITE_OC_HUB=1` (or is opened with `?hub`).
-
-What changes, and what does not:
-
-| | Same-origin console | Hub console |
-|---|---|---|
-| Bootstrap connection | its own origin | none — its origin serves assets only |
-| Which hosts it knows | the one that served it | the ones someone added, in `localStorage` |
-| Session carrier | `HttpOnly` cookie | `x-opencompany-session`, held by the page |
-| Event stream | `EventSource` | `fetch` — `EventSource` cannot set a header |
-
-The console holds N hosts either way; that has been true since connections
-landed. A hub differs only in having no host at its own origin to seed the list
-with.
-
-**Each tenant must allow-list the hub's origin** in
-`OPENCOMPANY_CORS_ORIGINS`, or the browser blocks every response. There is no
-wildcard: the session is a credential, and `Access-Control-Allow-Origin: *` is
-forbidden with credentials.
-
-### The cost, stated plainly
-
-A hub console holds its session tokens in `localStorage`, so script execution on
-the hub's origin reaches every host its operator has signed in to — where a
-same-origin console's `HttpOnly` cookie would have survived it. This is a real
-reduction and is accepted only because the alternative is not a safer console
-but no console: the cookie is never sent cross-site, and `SameSite=None` would
-merely turn it into a third-party cookie Safari discards.
-
-Two things bound it. The credential is a *session* — revocable from the host's
-device list, expiring on its own — and it is only ever chosen where a cookie
-could not have worked, a decision derived from the address rather than
-configured (`needsCarriedSession`), so it cannot be turned on by mistake for a
-deployment that had a cookie available.
-
-### Magic links land on the host, not the hub
-
-A login link is built by the host out of its own base URL, so following one
-opens that host's own console rather than the hub. Within the hub, the working
-sign-in paths are password, wallet, and ecosystem sign-in. Redirecting a link
-back to a hub origin would require the host to know that origin, which nothing
-tells it today.
 
 ## Device pairing
 

--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -22,8 +22,25 @@ a scoped REST surface:
 - Multi-company: `/api/v1/companies/{id}/…`
 - Single-company alias: `/api/v1/company/…`
 
-The typed client (`src/api/client.ts`) resolves that scope, adds the operator
-`Bearer` token, and is the only place HTTP happens.
+The typed client (`src/api/client.ts`) resolves that scope, attaches whatever
+credential its connection holds, and is the only place HTTP happens.
+
+The console holds **N hosts at once** (`src/connections/`), one client per
+connection. Three deployment shapes fall out of that:
+
+- **Same-origin** — served by the host it operates. The session is an `HttpOnly`
+  cookie that nothing in the page can read. The ordinary case, unchanged.
+- **Hub** — one deployment at its own origin operating hosts on other origins,
+  built with `VITE_OC_HUB=1`. No cookie crosses an origin, so it carries a
+  session token itself in `x-opencompany-session`, and its event stream runs
+  over `fetch` because `EventSource` cannot set a header. See
+  [hub-console.md](../docs/spec/runtime/hub-console.md).
+- **Desktop** — routes through its own Rust core, where neither CORS nor the
+  cookie rules apply. See [desktop.md](../docs/spec/runtime/desktop.md).
+
+Which applies is **derived, not configured**: `needsCarriedSession` compares the
+host's origin with the document's, so a console cannot be told to hold a token
+where a cookie would have worked.
 
 Every surface is built to one pattern so the backend can land incrementally:
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -394,6 +394,7 @@ function Console() {
       <ConnectionRail
         connections={connections}
         selected={active?.id ?? null}
+        hub={config.hub}
         onSelect={setSelected}
         onAdd={(baseUrl) => {
           const id = addConnection({ baseUrl });
@@ -410,7 +411,7 @@ function Console() {
         className="min-w-0 flex-1"
         style={
           {
-            "--oc-rail-inset": connectionRailVisible(connections.length)
+            "--oc-rail-inset": connectionRailVisible(connections.length, config.hub)
               ? CONNECTION_RAIL_WIDTH
               : "0px",
           } as CSSProperties

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -172,6 +172,17 @@ function Console() {
       // desktop given an explicit host through `?api=` or an injected
       // `OPENCOMPANY_CONFIG` still gets its bootstrap connection.
       if (!isAddressableBaseUrl(config.baseUrl)) return null;
+      // A hub's own origin serves this bundle and nothing else — there is no
+      // host there and there never will be. Adding one anyway reproduces #613
+      // in the browser exactly: a connection that cannot work, selected on
+      // load, presenting a failure in front of the hosts that are healthy. The
+      // hosts a hub knows are the remembered ones, which `restoreConnections`
+      // above has already put back.
+      //
+      // As with the desktop, only the same-origin *default* is refused: a hub
+      // opened with an explicit `?api=` still gets its bootstrap connection,
+      // which is how a link to one specific host is shared.
+      if (config.hub && config.baseUrl === "") return null;
       return addConnection({
         baseUrl: config.baseUrl,
         defaultCompany: config.company,

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -64,6 +64,19 @@ export interface Me {
 }
 
 /**
+ * What a successful sign-in returns.
+ *
+ * `session` is present only when the client asked the host to mint a session it
+ * would carry itself — a console on a different origin from its host, where no
+ * cookie can work. See `Credential` in `connections/types.ts`.
+ *
+ * A caller that receives one **must store it** (`adoptSession`), or the sign-in
+ * appears to succeed and the very next request is anonymous: the token comes
+ * back exactly once and only its hash is kept server-side.
+ */
+export type SignIn = Me & { session?: string };
+
+/**
  * The answer to "send me a link".
  *
  * `sent` is always true, for everyone, including addresses with no account —

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -107,8 +107,8 @@ export async function verifyCode(
   client: OpenCompanyClient,
   company: string | null,
   code: string,
-): Promise<Me> {
-  return client.post<Me>(`${client.scopeFor(company)}/auth/verify`, { code });
+): Promise<SignIn> {
+  return client.postSignIn<SignIn>(`${client.scopeFor(company)}/auth/verify`, { code });
 }
 
 /** One ecosystem sign-in button, as the host describes it. */
@@ -161,8 +161,8 @@ export async function signInWithHubToken(
   client: OpenCompanyClient,
   company: string | null,
   token: string,
-): Promise<Me> {
-  return client.post<Me>(`${client.scopeFor(company)}/auth/hub`, { token });
+): Promise<SignIn> {
+  return client.postSignIn<SignIn>(`${client.scopeFor(company)}/auth/hub`, { token });
 }
 
 /** Exchanges an email and password for a session. */
@@ -171,8 +171,8 @@ export async function loginWithPassword(
   company: string | null,
   email: string,
   password: string,
-): Promise<Me> {
-  return client.post<Me>(`${client.scopeFor(company)}/auth/login`, { email, password });
+): Promise<SignIn> {
+  return client.postSignIn<SignIn>(`${client.scopeFor(company)}/auth/login`, { email, password });
 }
 
 /** Who the current session belongs to; throws 401 when signed out. */
@@ -233,7 +233,10 @@ export async function verifyWalletSignature(
   nonce: string,
   signature: string,
 ): Promise<Me> {
-  return client.post<Me>(`${client.scopeFor(company)}/auth/wallet/verify`, { nonce, signature });
+  return client.postSignIn<SignIn>(`${client.scopeFor(company)}/auth/wallet/verify`, {
+    nonce,
+    signature,
+  });
 }
 
 /** Revokes this session, server-side and in the browser. */

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,8 +1,16 @@
 // The user-authentication surface: magic link, password, session.
 //
-// The session itself is an HttpOnly cookie, so none of this returns or stores a
-// token — the browser holds it and `credentials: "include"` in the client sends
-// it. There is nothing here for an XSS to read.
+// For a console served by the host it talks to — every same-origin deployment,
+// which is the normal one — the session is an HttpOnly cookie: none of this
+// returns or stores a token, the browser holds it, and `credentials: "include"`
+// in the client sends it. There is nothing here for an XSS to read.
+//
+// A console on a *different* origin from its host gets no cookie at all: the
+// host sets it `SameSite=Lax` and the browser withholds it from every
+// cross-site request. Those sign-ins ask for a token instead and return it as
+// `SignIn.session`, which the caller stores on the connection. See
+// `Credential` in `connections/types.ts` for what that costs and why it is
+// still the right trade where the alternative is no console at all.
 
 import type { OpenCompanyClient } from "./client";
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -156,9 +156,9 @@ export async function fetchHubProviders(
  * The token arrives in the URL as `?token=…&key=auth` after the hub completes
  * OAuth and redirects back here. It is not an identity this console can read or
  * check — it is handed straight to the host, which asks the hub whose it is and
- * then applies this company's own roster. So this returns the same `Me` a magic
- * link would, and the browser keeps nothing either way: the session comes back
- * as an HttpOnly cookie and the token is stripped from the URL.
+ * then applies this company's own roster. So this returns the same result a
+ * magic link would, and the hub's token is spent here and stripped from the URL
+ * rather than kept — whichever carrier the session itself comes back in.
  *
  * The distinguishable failures are `hub_rejected` (expired or forged — sign in
  * again), `not_a_member` (a real ecosystem account with no access here), and

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -289,7 +289,14 @@ export class OpenCompanyClient {
    * know which transport it is on, and every future caller would too.
    */
   subscribeToEvents(company: string | null | undefined, handlers: StreamHandlers): () => void {
-    return this.transport.subscribe(`${this.baseUrl}${this.scope(company)}/events`, handlers);
+    return this.transport.subscribe(
+      `${this.baseUrl}${this.scope(company)}/events`,
+      handlers,
+      // The same credential the request path carries. A stream authenticated
+      // differently from the requests beside it would load every view and then
+      // never update one.
+      this.authHeaders(),
+    );
   }
 
   /** A typed POST, for surfaces that live outside this class (e.g. auth). */

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -304,6 +304,37 @@ export class OpenCompanyClient {
     return this.request<T>("POST", path, body);
   }
 
+  /**
+   * Whether a sign-in through this client yields a session it must hold itself.
+   *
+   * Exposed so a caller knows to *store* what {@link postSignIn} returns. It is
+   * the same question `needsCarriedSession` answers, kept on the client so no
+   * view has to re-derive it from a base url.
+   */
+  get carriesOwnSession(): boolean {
+    return needsCarriedSession(this.baseUrl);
+  }
+
+  /**
+   * A POST to a sign-in route, asking for a carrier this client can use.
+   *
+   * Separate from {@link post} so the carrier request cannot leak onto an
+   * ordinary call: the header is meaningless everywhere but a route that mints
+   * a session, and a client sending it indiscriminately would be asserting
+   * something about itself on every request it makes.
+   *
+   * On a same-origin console this is exactly `post` — no header, and the host
+   * replies with the `HttpOnly` cookie it always did.
+   */
+  postSignIn<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>(
+      "POST",
+      path,
+      body,
+      this.carriesOwnSession ? { "x-opencompany-session-carrier": "header" } : undefined,
+    );
+  }
+
   /** A typed PATCH, for surfaces that live outside this class (e.g. auth). */
   patch<T>(path: string, body?: unknown): Promise<T> {
     return this.request<T>("PATCH", path, body);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -8,7 +8,7 @@
 
 import type { ConsoleConfig } from "../config";
 import type { TaskDeliverable } from "./tasks";
-import { defaultTransport } from "./transport";
+import { defaultTransport, needsCarriedSession } from "./transport";
 import type { StreamHandlers, Transport, TransportResponse } from "./transport";
 import {
   type AgentDetailDto,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -103,7 +103,7 @@ export class OpenCompanyClient {
   private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
     const headers: Record<string, string> = {};
     if (body !== undefined) headers["content-type"] = "application/json";
-    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    Object.assign(headers, this.authHeaders());
 
     let res: TransportResponse;
     try {
@@ -156,7 +156,7 @@ export class OpenCompanyClient {
    */
   async postForm<T>(path: string, form: FormData): Promise<T> {
     const headers: Record<string, string> = {};
-    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    Object.assign(headers, this.authHeaders());
 
     let res: Response;
     try {
@@ -208,7 +208,7 @@ export class OpenCompanyClient {
    */
   async getDocument(path: string): Promise<{ text: string; filename?: string }> {
     const headers: Record<string, string> = {};
-    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    Object.assign(headers, this.authHeaders());
 
     let res: TransportResponse;
     try {
@@ -244,7 +244,7 @@ export class OpenCompanyClient {
    */
   async getBlob(path: string): Promise<Blob> {
     const headers: Record<string, string> = {};
-    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    Object.assign(headers, this.authHeaders());
 
     let res: Response;
     try {

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -48,10 +48,11 @@ export class OpenCompanyClient {
   readonly baseUrl: string;
   readonly defaultCompany: string | null;
   private readonly token: string | null;
+  private readonly session: string | null;
   private readonly transport: Transport;
 
   constructor(
-    config: Pick<ConsoleConfig, "baseUrl" | "company" | "operatorToken">,
+    config: Pick<ConsoleConfig, "baseUrl" | "company" | "operatorToken" | "sessionHeader">,
     // Injected so a desktop shell can route the same client through its own
     // core, and so tests can drive one without a network. Defaults to the
     // browser's `fetch`/`EventSource`, which is what every web build uses.
@@ -60,7 +61,32 @@ export class OpenCompanyClient {
     this.baseUrl = config.baseUrl;
     this.defaultCompany = config.company;
     this.token = config.operatorToken;
+    this.session = config.sessionHeader ?? null;
     this.transport = transport;
+  }
+
+  /**
+   * The credential headers every request carries, whichever kind this client
+   * holds.
+   *
+   * One method rather than the line repeated at each call site, because a
+   * request path that forgot one would not fail loudly — it would silently
+   * make an *anonymous* request, and the surfaces that read fine anonymously
+   * would look like they worked.
+   *
+   * Both may be present: a platform bearer authenticates the *hosting layer*
+   * and a session authenticates a *person*, and a hub console holding a
+   * platform token still signs its operator in per tenant.
+   */
+  private authHeaders(): Record<string, string> {
+    const headers: Record<string, string> = {};
+    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    // Only ever set for a connection that cannot use a cookie — a console on a
+    // different origin from its host. Same-origin consoles leave this null and
+    // keep the HttpOnly cookie, which nothing here can read. See
+    // `SESSION_CARRIER_HEADER` in the host's `users/cookie.rs`.
+    if (this.session) headers["x-opencompany-session"] = this.session;
+    return headers;
   }
 
   /** Resolves the `/companies/{id}` vs single-company `/company` route prefix. */

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -80,7 +80,9 @@ export class OpenCompanyClient {
    */
   private authHeaders(): Record<string, string> {
     const headers: Record<string, string> = {};
-    if (this.token) headers["authorization"] = `Bearer ${this.token}`;
+    if (this.token) {
+      headers["authorization"] = `Bearer ${this.token}`;
+    }
     // Only ever set for a connection that cannot use a cookie — a console on a
     // different origin from its host. Same-origin consoles leave this null and
     // keep the HttpOnly cookie, which nothing here can read. See

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -100,10 +100,15 @@ export class OpenCompanyClient {
   /** Called on any 401, so the app can drop to the login view. */
   onUnauthorized: (() => void) | null = null;
 
-  private async request<T>(method: string, path: string, body?: unknown): Promise<T> {
+  private async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    extraHeaders?: Record<string, string>,
+  ): Promise<T> {
     const headers: Record<string, string> = {};
     if (body !== undefined) headers["content-type"] = "application/json";
-    Object.assign(headers, this.authHeaders());
+    Object.assign(headers, this.authHeaders(), extraHeaders);
 
     let res: TransportResponse;
     try {

--- a/frontend/src/api/transport/browser.ts
+++ b/frontend/src/api/transport/browser.ts
@@ -78,3 +78,139 @@ export class BrowserTransport implements Transport {
     return () => source.close();
   }
 }
+
+/**
+ * How long to wait before reopening a stream that dropped.
+ *
+ * `EventSource` reconnects on its own; this lane has to do it by hand, and the
+ * delay is what stops a host that closes the connection immediately from
+ * becoming a request loop. Three seconds is `EventSource`'s own common default.
+ */
+const RECONNECT_DELAY_MS = 3_000;
+
+/**
+ * An SSE stream over `fetch`, for a credential `EventSource` cannot carry.
+ *
+ * Deliberately a *minimal* reader rather than a general SSE implementation: it
+ * parses the one framing the host emits (`data:` lines, blank-line separated)
+ * and ignores `event:`, `id:` and `retry:`, none of which the console reads. A
+ * fuller parser here would be a second protocol to keep correct for no caller.
+ *
+ * It reproduces exactly the two things the `EventSource` lane promises its
+ * caller and nothing more: `onOpen` when the stream is live, and an `onError`
+ * whose `reconnecting` says whether anything further will arrive. A 401 is
+ * terminal — retrying a refused credential just refuses it again — while a
+ * dropped connection is retried, which is the split `EventSource` makes for
+ * itself and which `use-events.ts` already branches on.
+ */
+function streamWithFetch(
+  url: string,
+  handlers: StreamHandlers,
+  headers: Record<string, string>,
+): () => void {
+  // Not `let cancelled = false` plus a check: the read below blocks until the
+  // next frame arrives, which on a quiet company is minutes. Aborting is what
+  // makes unsubscribing take effect immediately rather than at the next event.
+  const abort = new AbortController();
+  let retry: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+
+  const open = async (): Promise<void> => {
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: { ...headers, accept: "text/event-stream" },
+        signal: abort.signal,
+        // Harmless where the credential is a header, and correct for a host
+        // that also set a cookie — matching the request lane exactly.
+        credentials: "include",
+      });
+    } catch {
+      // An abort lands here too, and must not be reported as a failure: the
+      // caller asked for this and is no longer listening.
+      if (!stopped) fail({ reconnecting: true });
+      return;
+    }
+
+    if (res.status === 401 || res.status === 403) {
+      // A refused credential will be refused again. Say so once, terminally,
+      // so the caller falls back to polling instead of hammering the host.
+      fail({ reconnecting: false });
+      return;
+    }
+    if (!res.ok || !res.body) {
+      // No body means no stream — a 404, or a host that answered with
+      // something that is not an event stream at all.
+      fail({ reconnecting: false });
+      return;
+    }
+
+    handlers.onOpen?.();
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    // Frames are split on a blank line, so a partial one has to survive across
+    // reads: a chunk boundary falls wherever the network put it, not where the
+    // protocol did.
+    let buffer = "";
+    for (;;) {
+      let chunk: ReadableStreamReadResult<Uint8Array>;
+      try {
+        chunk = await reader.read();
+      } catch {
+        if (!stopped) fail({ reconnecting: true });
+        return;
+      }
+      if (chunk.done) {
+        // The host closed a stream that was working. Reopen — this is the
+        // ordinary end of a long-lived connection, not a failure.
+        if (!stopped) fail({ reconnecting: true });
+        return;
+      }
+      buffer += decoder.decode(chunk.value, { stream: true });
+      // Everything up to the last frame boundary is complete; the remainder is
+      // the start of the next frame and stays in the buffer.
+      const frames = buffer.split("\n\n");
+      buffer = frames.pop() ?? "";
+      for (const frame of frames) {
+        const data = dataOf(frame);
+        if (data !== null) handlers.onMessage(data);
+      }
+    }
+  };
+
+  const fail = (info: { reconnecting: boolean }): void => {
+    if (stopped) return;
+    handlers.onError?.(info);
+    if (!info.reconnecting) return;
+    retry = setTimeout(() => {
+      if (!stopped) void open();
+    }, RECONNECT_DELAY_MS);
+  };
+
+  void open();
+
+  return () => {
+    stopped = true;
+    if (retry !== null) clearTimeout(retry);
+    abort.abort();
+  };
+}
+
+/**
+ * The payload of one SSE frame, or `null` when it carries none.
+ *
+ * A frame may spread its payload over several `data:` lines, which the protocol
+ * says to rejoin with newlines. Comment lines (`:` first) are keep-alives and
+ * must not be delivered as an empty event — the console would try to parse one
+ * as JSON on every heartbeat.
+ */
+function dataOf(frame: string): string | null {
+  const lines = frame
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    // `data: x` and `data:x` are the same frame; exactly one leading space is
+    // part of the framing rather than of the payload.
+    .map((line) => line.slice(5).replace(/^ /, ""));
+  return lines.length > 0 ? lines.join("\n") : null;
+}

--- a/frontend/src/api/transport/browser.ts
+++ b/frontend/src/api/transport/browser.ts
@@ -44,7 +44,21 @@ export class BrowserTransport implements Transport {
     };
   }
 
-  subscribe(url: string, handlers: StreamHandlers): () => void {
+  subscribe(
+    url: string,
+    handlers: StreamHandlers,
+    headers?: Record<string, string>,
+  ): () => void {
+    // A session carried in a header cannot ride an `EventSource` — the API has
+    // no way to set one. Falling through to it anyway would open the stream
+    // *anonymously*: the host answers 401, the console quietly degrades to its
+    // poll, and a hub console would render as a company where nothing ever
+    // happens rather than as one it is not signed in to. So a credentialed
+    // stream takes the fetch lane instead.
+    if (headers && Object.keys(headers).length > 0) {
+      return streamWithFetch(url, handlers, headers);
+    }
+
     // `EventSource` throws in an environment that has none, and on a malformed
     // URL. Both mean "no stream here"; the caller falls back to its poll.
     const source = new EventSource(url, { withCredentials: true });

--- a/frontend/src/api/transport/index.ts
+++ b/frontend/src/api/transport/index.ts
@@ -77,6 +77,43 @@ export function isAddressableBaseUrl(baseUrl: string): boolean {
 }
 
 /**
+ * Whether this client must carry its own session to `baseUrl`, instead of
+ * letting the browser attach a cookie.
+ *
+ * **Derived from the address, never configured.** "Can a cookie work here"
+ * already has an exact answer — the host sets its session cookie
+ * `SameSite=Lax`, so it rides same-origin requests and is withheld from every
+ * cross-site one — and a flag restating that would be a second source of truth
+ * free to disagree with the first. When it disagreed the symptom would be a
+ * console that signs in successfully and is then treated as anonymous by every
+ * request after it, which reads as a server bug.
+ *
+ * So: same origin means the cookie, and the cookie stays the better credential
+ * wherever it is available, because nothing in the page can read it. A
+ * different origin means no cookie is coming and the console has to hold a
+ * token itself — which is what a hub console is built out of.
+ *
+ * False in the desktop whatever the address, and that is not an oversight: its
+ * requests go through `ProxyTransport` to the Rust core, which attaches the
+ * credential it holds in the keychain. Having the webview carry one too would
+ * put a token in the page for no benefit, on the one runtime that had
+ * successfully kept it out.
+ */
+export function needsCarriedSession(baseUrl: string): boolean {
+  if (isDesktopRuntime()) return false;
+  // The empty string *is* same-origin, by the convention `ConsoleConfig` sets.
+  if (baseUrl === "") return false;
+  if (typeof window === "undefined") return false;
+  try {
+    return new URL(baseUrl, window.location.href).origin !== window.location.origin;
+  } catch {
+    // An unparseable address reaches nothing, so it needs no credential.
+    // Reporting that is `isAddressableBaseUrl`'s job, not this function's.
+    return false;
+  }
+}
+
+/**
  * Whether a secret may be sent to `baseUrl`.
  *
  * **HTTPS, or a host that is this machine.** A device session is a person's

--- a/frontend/src/api/transport/proxy.ts
+++ b/frontend/src/api/transport/proxy.ts
@@ -90,6 +90,15 @@ export class ProxyTransport implements Transport {
     };
   }
 
+  /**
+   * Opens the stream through the core.
+   *
+   * Takes no `headers`, unlike the interface allows: the core resolves this
+   * connection's credential from its own registration and the keychain, and is
+   * the only thing that ever holds a device token. Accepting one here would let
+   * the console hand the core a credential to use, which is exactly the
+   * arrangement the keychain exists to prevent.
+   */
   subscribe(url: string, handlers: StreamHandlers): () => void {
     const { invoke, Channel } = bridge();
     const channel = new Channel<string>();

--- a/frontend/src/api/transport/types.ts
+++ b/frontend/src/api/transport/types.ts
@@ -75,6 +75,17 @@ export interface Transport {
    *
    * Throws when streaming is unavailable in this environment, which the caller
    * treats as "poll instead" rather than as an error worth surfacing.
+   *
+   * `headers` carries the same credential the request path uses. It is passed
+   * rather than left implicit because a stream that authenticated differently
+   * from the requests beside it is the subtlest possible bug: the views would
+   * load fine and simply never update, which reads as "quiet company" rather
+   * than as "unauthorized". A transport that cannot set headers must degrade
+   * loudly instead — see `BrowserTransport.subscribe`.
    */
-  subscribe(url: string, handlers: StreamHandlers): () => void;
+  subscribe(
+    url: string,
+    handlers: StreamHandlers,
+    headers?: Record<string, string>,
+  ): () => void;
 }

--- a/frontend/src/components/connection-rail.tsx
+++ b/frontend/src/components/connection-rail.tsx
@@ -38,6 +38,14 @@ interface Props {
   selected: ConnectionId | null;
   onSelect: (id: ConnectionId) => void;
   onAdd: (baseUrl: string) => void;
+  /**
+   * Whether this is a hub deployment, which draws the rail at any count.
+   *
+   * Passed rather than read from config here, so this component keeps taking
+   * everything it renders from its props and stays drivable from a test
+   * without a global to arrange.
+   */
+  hub?: boolean;
 }
 
 /** How a connection's state reads, and what colour says so. */

--- a/frontend/src/components/connection-rail.tsx
+++ b/frontend/src/components/connection-rail.tsx
@@ -94,11 +94,11 @@ export function connectionRailVisible(count: number, hub = false): boolean {
   return count >= 2 || hub || isDesktopRuntime();
 }
 
-export function ConnectionRail({ connections, selected, onSelect, onAdd }: Props) {
+export function ConnectionRail({ connections, selected, onSelect, onAdd, hub }: Props) {
   const [adding, setAdding] = useState(false);
   const [url, setUrl] = useState("");
 
-  if (!connectionRailVisible(connections.length)) return null;
+  if (!connectionRailVisible(connections.length, hub)) return null;
 
   return (
     <nav

--- a/frontend/src/components/connection-rail.tsx
+++ b/frontend/src/components/connection-rail.tsx
@@ -76,15 +76,22 @@ export const CONNECTION_RAIL_WIDTH = "3.5rem";
  * second host — so the working case became the one with no way out of it,
  * which is the dead end the zero exception existed to prevent.
  *
- * A browser is unaffected: `isDesktopRuntime()` is false there, so one host
- * still draws nothing.
+ * **A hub always draws it too**, for the same reason and by the same argument.
+ * A hub has no bootstrap connection either (its origin serves assets, not a
+ * host), so it holds exactly the hosts someone added — and at zero the "+" in
+ * this rail is the only way to add the first one. Hiding the rail at one host
+ * would strand a hub with a single host as surely as it stranded the desktop.
+ *
+ * An ordinary same-origin browser console is unaffected: neither
+ * `isDesktopRuntime()` nor `hub` is true there, so one host still draws
+ * nothing.
  *
  * Exported so the shell can offset the sidebar by the same condition that
  * draws the rail — two copies of this rule is how the sidebar ends up clipped
  * under it again.
  */
-export function connectionRailVisible(count: number): boolean {
-  return count >= 2 || isDesktopRuntime();
+export function connectionRailVisible(count: number, hub = false): boolean {
+  return count >= 2 || hub || isDesktopRuntime();
 }
 
 export function ConnectionRail({ connections, selected, onSelect, onAdd }: Props) {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -23,6 +23,32 @@ export interface ConsoleConfig {
    * no longer exists — there is no shared-secret path into a company.
    */
   operatorToken: string | null;
+  /**
+   * A ready-made `x-opencompany-session` value, when this client carries its
+   * own session instead of relying on a cookie.
+   *
+   * Never resolved from the environment or the URL — only supplied per
+   * connection by `connectionConfig`, after a sign-in that asked the host for
+   * the header carrier. It lives here because it describes *how a client
+   * authenticates*, which is what this type is for; anywhere else and the
+   * client would be taking its credential from two places.
+   */
+  sessionHeader: string | null;
+  /**
+   * Whether this deployment is a **hub**: one console serving many hosts that
+   * live on other origins, rather than a console served by the host it
+   * operates.
+   *
+   * The difference is entirely in the bootstrap. An ordinary console assumes
+   * its own origin is a host and opens a connection to it; a hub's origin
+   * serves static assets and nothing else, so that assumption yields a
+   * connection which can only ever fail — the browser's exact equivalent of the
+   * dead same-origin row the desktop used to carry (issue #613).
+   *
+   * A hub holds no directory of its own. The hosts it knows are the ones
+   * somebody added, remembered in `localStorage` by `profileStore`.
+   */
+  hub: boolean;
 }
 
 declare global {

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -77,6 +77,11 @@ function fromQuery(): Partial<ConsoleConfig> {
   // makes — see `signInWithHubToken`, which hands it to the host once and lets
   // it go. `key=auth` is the hub's own marker for that redirect.
   if (token !== null && q.get("key") !== "auth") out.operatorToken = token;
+  // `?hub` and `?hub=1` both mean yes; `?hub=0` and `?hub=false` mean no, so a
+  // hub build can be turned *off* for a debugging session without editing the
+  // deployment. Absent leaves it to the layers below rather than forcing false.
+  const hub = q.get("hub");
+  if (hub !== null) out.hub = isTruthy(hub);
   return out;
 }
 
@@ -86,7 +91,22 @@ function fromEnv(): Partial<ConsoleConfig> {
   if (env.VITE_OC_API) out.baseUrl = env.VITE_OC_API;
   if (env.VITE_OC_COMPANY) out.company = env.VITE_OC_COMPANY;
   if (env.VITE_OC_TOKEN) out.operatorToken = env.VITE_OC_TOKEN;
+  if (env.VITE_OC_HUB) out.hub = isTruthy(env.VITE_OC_HUB);
   return out;
+}
+
+/**
+ * Reads a flag written the way a person writes one.
+ *
+ * Vite env values are always strings, so `VITE_OC_HUB=false` is truthy in
+ * JavaScript — a build that meant to turn the hub off would silently turn it
+ * on, and the symptom (a bootstrap connection that cannot be reached) looks
+ * nothing like the cause.
+ */
+function isTruthy(value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  // An empty value is the bare `?hub` form, which is an assertion, not a blank.
+  return normalized !== "0" && normalized !== "false" && normalized !== "no";
 }
 
 /** Resolves the effective console configuration once, at startup. */

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -2,10 +2,15 @@
 //
 // The console works against ANY OpenCompany host and ANY company. Resolution
 // order (first match wins), so the same build drops in anywhere:
-//   1. URL query params: ?api=<url>&company=<id>&token=<t>
+//   1. URL query params: ?api=<url>&company=<id>&token=<t>&hub
 //   2. window.OPENCOMPANY_CONFIG (injected in index.html for static hosting)
-//   3. Vite build-time env: VITE_OC_API / VITE_OC_COMPANY / VITE_OC_TOKEN
-//   4. Defaults: same-origin API, single-company mode (no id)
+//   3. Vite build-time env: VITE_OC_API / VITE_OC_COMPANY / VITE_OC_TOKEN /
+//      VITE_OC_HUB
+//   4. Defaults: same-origin API, single-company mode (no id), not a hub
+//
+// What this resolves is the console's **bootstrap** connection, not the set of
+// hosts it can hold — that has been a list since connections landed, and a hub
+// build (see `hub`) resolves no bootstrap connection at all.
 
 export interface ConsoleConfig {
   /** Base URL of the OpenCompany host. Empty string means same-origin. */

--- a/frontend/src/config.ts
+++ b/frontend/src/config.ts
@@ -122,5 +122,9 @@ export function resolveConfig(): ConsoleConfig {
     baseUrl,
     company: merged.company ?? null,
     operatorToken: merged.operatorToken ?? null,
+    // Never configured at this level: a session belongs to one connection, and
+    // this resolves at most one connection's *address*. See `ConsoleConfig`.
+    sessionHeader: null,
+    hub: merged.hub ?? false,
   };
 }

--- a/frontend/src/connections/profileStore.ts
+++ b/frontend/src/connections/profileStore.ts
@@ -165,6 +165,22 @@ function isLegacyEmbedded(profile: ConnectionProfile): boolean {
  * A platform bearer is redacted to its kind before writing: `localStorage` is
  * readable by any script that reaches the page, and the token is `?token=` URL
  * material re-derived on the next load, never something storage needs to hold.
+ *
+ * ## The one secret this file does write
+ *
+ * A `session` credential is persisted **in full** — a deliberate exception to
+ * this module's opening rule, and the only one. Redacting it would protect
+ * nothing and simply break the feature: unlike a platform bearer there is
+ * nowhere to re-derive it from, so a redacted session means signing in to every
+ * host again on every page load, and a console that does that is one people
+ * stop using.
+ *
+ * The cost is real and worth stating plainly. Script execution on a hub's
+ * origin reaches every host its operator has signed in to, where a same-origin
+ * console's `HttpOnly` cookie would have survived it. Two things bound it: the
+ * token is a *session*, revocable from the host's device list and expiring on
+ * its own, and this credential is only ever chosen for a connection where a
+ * cookie could not have worked at all (see `Credential`).
  */
 function persistedCredential(credential: Credential): Credential {
   if (credential.kind === "platform") return { kind: "platform" };

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -496,6 +496,36 @@ export function unpairConnection(id: ConnectionId): void {
   adoptCredential(id, { kind: "cookie" });
 }
 
+/**
+ * Records the session a cross-origin sign-in just returned.
+ *
+ * Called with the `session` from a {@link SignIn}, and it must be called or the
+ * sign-in is wasted: the host returns that token exactly once, keeps only its
+ * hash, and — because no cookie was set — the console has no other way to prove
+ * who it is. The symptom of forgetting is a login that appears to succeed and a
+ * console that is anonymous from the next request onward.
+ *
+ * Replaces the client, through `adoptCredential`, so every request after this
+ * carries the new session rather than the one it was constructed with.
+ */
+export function adoptSession(id: ConnectionId, session: string): void {
+  adoptCredential(id, { kind: "session", value: session });
+}
+
+/**
+ * Drops a carried session, locally.
+ *
+ * The counterpart of {@link adoptSession} for signing out. Revoking it
+ * server-side is `logout`'s job and happens first — clearing here alone would
+ * leave a live token on the host for the rest of its TTL, and clearing there
+ * alone would leave this client presenting a token that no longer works.
+ */
+export function clearSession(id: ConnectionId): void {
+  const existing = getConnection(id);
+  if (existing?.credential.kind !== "session") return;
+  adoptCredential(id, { kind: "cookie" });
+}
+
 export function removeConnection(id: ConnectionId): void {
   entries = entries.filter((e) => e.connection.id !== id);
   forgetProfile(id);

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -591,11 +591,16 @@ async function readIdentity(client: OpenCompanyClient): Promise<InstanceIdentity
  * question here is what turns that refusal into something a person can act on;
  * see the note on `mayCarryACredential`.
  *
- * Desktop only. A browser's credential is a cookie the browser decides about,
- * with `Secure` and the origin's own rules doing this job — narrowing the web
- * build here would refuse the plain-HTTP deployments `opencompany serve` is
- * built for, on the transport where the console is not the thing holding the
- * secret.
+ * Desktop only **for the ambient credentials**. A browser's cookie is one the
+ * browser decides about, with `Secure` and the origin's own rules doing this
+ * job — narrowing the web build there would refuse the plain-HTTP deployments
+ * `opencompany serve` is built for, on the transport where the console is not
+ * the thing holding the secret.
+ *
+ * A `session` credential is the exception, and gated everywhere: a hub console
+ * holds that token itself and puts it on the wire itself, so "the browser is
+ * deciding" stops being true. The runtime it happens to run in changes nothing
+ * about what an unencrypted hop exposes.
  *
  * Read off the profile's credential *kind*, which is a claim about this machine
  * rather than the secret itself: a `device` entry means the keychain holds a

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -605,11 +605,22 @@ async function readIdentity(client: OpenCompanyClient): Promise<InstanceIdentity
  * gating on the credential rather than on the scheme.
  */
 function insecurelyCredentialed(connection: Connection | undefined): string | null {
-  if (!connection || !isDesktopRuntime()) return null;
-  const carries =
-    connection.credential.kind === "device" ||
-    (connection.credential.kind === "platform" && Boolean(connection.credential.token));
-  if (!carries || mayCarryACredential(connection.baseUrl)) return null;
+  if (!connection) return null;
+  // A same-origin connection is the browser's own origin, whose rules already
+  // decide this; there is no url to judge and nothing to protect it from that
+  // is not already inside the page.
+  if (connection.baseUrl === "") return null;
+  // A session is a secret **this page holds and sends**, in every runtime — so
+  // unlike the two below it is gated in the browser as well. The exposure is
+  // identical to the desktop's: a person's standing authority on a company,
+  // travelling in clear text past every device on the path.
+  const carriesInAnyRuntime = connection.credential.kind === "session";
+  const carriesOnDesktop =
+    isDesktopRuntime() &&
+    (connection.credential.kind === "device" ||
+      (connection.credential.kind === "platform" && Boolean(connection.credential.token)));
+  if (!carriesInAnyRuntime && !carriesOnDesktop) return null;
+  if (mayCarryACredential(connection.baseUrl)) return null;
   // Names the credential generically: this covers a paired device session and a
   // platform bearer from `?token=`, and the person reading it needs the reason
   // rather than which of the two it was.

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -512,20 +512,6 @@ export function adoptSession(id: ConnectionId, session: string): void {
   adoptCredential(id, { kind: "session", value: session });
 }
 
-/**
- * Drops a carried session, locally.
- *
- * The counterpart of {@link adoptSession} for signing out. Revoking it
- * server-side is `logout`'s job and happens first — clearing here alone would
- * leave a live token on the host for the rest of its TTL, and clearing there
- * alone would leave this client presenting a token that no longer works.
- */
-export function clearSession(id: ConnectionId): void {
-  const existing = getConnection(id);
-  if (existing?.credential.kind !== "session") return;
-  adoptCredential(id, { kind: "cookie" });
-}
-
 export function removeConnection(id: ConnectionId): void {
   entries = entries.filter((e) => e.connection.id !== id);
   forgetProfile(id);

--- a/frontend/src/connections/registry.ts
+++ b/frontend/src/connections/registry.ts
@@ -303,6 +303,12 @@ function sameCredential(a: Credential, b: Credential): boolean {
   // comparison is what makes the bootstrap's live token count as a change.
   if (a.kind === "platform" && b.kind === "platform") return a.token === b.token;
   if (a.kind === "device" && b.kind === "device") return a.ref === b.ref;
+  // Signing in again mints a *new* session, so the values differ and the client
+  // has to be rebuilt around the new one. Comparing only the kind here would
+  // leave the console presenting the session it just replaced — which keeps
+  // working until the old one expires or is revoked, making it the kind of bug
+  // that surfaces an hour later and nowhere near its cause.
+  if (a.kind === "session" && b.kind === "session") return a.value === b.value;
   return true;
 }
 

--- a/frontend/src/connections/types.ts
+++ b/frontend/src/connections/types.ts
@@ -50,7 +50,30 @@ export type Credential =
    * is a marker meaning "this host authenticates as the platform" — the live
    * token is re-derived from the URL on the next load.
    */
-  | { kind: "platform"; token?: string };
+  | { kind: "platform"; token?: string }
+  /**
+   * A personal session this client carries itself, in `x-opencompany-session`.
+   *
+   * The credential a **hub console** uses: one deployment of this app serving
+   * many hosts on *other* origins. A cookie cannot work there — the host sets
+   * it `SameSite=Lax`, so the browser withholds it from every cross-site
+   * request the console makes, and `SameSite=None` would only turn it into a
+   * third-party cookie Safari discards outright. The host mints this form on
+   * request instead; see `SESSION_CARRIER_HEADER` in its `users/cookie.rs`.
+   *
+   * `value` is the whole ready-made header value, `<company>.<token>`, exactly
+   * as the host returned it. Kept assembled rather than split because the
+   * company half may have been resolved through the single-company alias, where
+   * this client never learned an id to rebuild it from.
+   *
+   * **Unlike every other credential here, this one is a secret that lives in
+   * the page.** It is persisted, because the alternative is signing in again on
+   * every reload, and it is therefore readable by anything achieving script
+   * execution on the console's origin. That is a real reduction from the
+   * `HttpOnly` cookie a same-origin console gets, and it is the reason this
+   * kind is never chosen for a connection that could have used a cookie.
+   */
+  | { kind: "session"; value: string };
 
 /**
  * Where a connection stands right now.

--- a/frontend/src/connections/types.ts
+++ b/frontend/src/connections/types.ts
@@ -144,7 +144,7 @@ export interface Connection {
 /** The fields needed to construct a connection's client. */
 export function connectionConfig(
   connection: Connection,
-): Pick<ConsoleConfig, "baseUrl" | "company" | "operatorToken"> {
+): Pick<ConsoleConfig, "baseUrl" | "company" | "operatorToken" | "sessionHeader"> {
   return {
     baseUrl: connection.baseUrl,
     company: connection.defaultCompany,
@@ -152,6 +152,8 @@ export function connectionConfig(
       connection.credential.kind === "platform"
         ? (connection.credential.token ?? null)
         : null,
+    sessionHeader:
+      connection.credential.kind === "session" ? connection.credential.value : null,
   };
 }
 

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -81,12 +81,20 @@ export function ConnectionConsole({
   // Re-probe this connection and re-run the boot effect. A reload would tear
   // down every *other* connection's stream to recover this one; bumping the
   // epoch keeps the recovery local.
-  const reBoot = useCallback(() => {
-    void probe(connectionId).then(() => {
-      setPhase({ kind: "loading" });
-      setBootEpoch((n) => n + 1);
-    });
-  }, [connectionId]);
+  const reBoot = useCallback(
+    (result?: SignIn) => {
+      // Store the session *before* probing. A cross-origin sign-in's token is
+      // the only proof this connection has — no cookie was set — and adopting
+      // it replaces the client, so a probe that ran first would authenticate
+      // with the pre-sign-in client and conclude the host still refuses us.
+      if (result?.session) adoptSession(connectionId, result.session);
+      void probe(connectionId).then(() => {
+        setPhase({ kind: "loading" });
+        setBootEpoch((n) => n + 1);
+      });
+    },
+    [connectionId],
+  );
 
   useEffect(() => {
     // `forceLogin` forces the sign-in view until the *first* boot; a sign-in

--- a/frontend/src/views/ConnectionConsole.tsx
+++ b/frontend/src/views/ConnectionConsole.tsx
@@ -11,13 +11,14 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { Loader2 } from "lucide-react";
 
 import { OpenCompanyClient } from "@/api/client";
+import type { SignIn } from "@/api/auth";
 import { ApiError, type CompanyStatus } from "@/api/types";
 import { AppShell } from "@/components/app-shell";
 import { CompanyPicker } from "@/components/company-picker";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
-import { probe, useConnection } from "@/connections/registry";
+import { adoptSession, probe, useConnection } from "@/connections/registry";
 import type { ConnectionId } from "@/connections/types";
 import { Login } from "@/views/Login";
 

--- a/frontend/src/views/Login.tsx
+++ b/frontend/src/views/Login.tsx
@@ -11,7 +11,7 @@ import {
   verifyWalletSignature,
   type AuthConfig,
   type HubProvider,
-  type Me,
+  type SignIn,
 } from "@/api/auth";
 import { connectWallet, hasWallet, NoWalletError, signMessage } from "@/lib/wallet";
 import type { OpenCompanyClient } from "@/api/client";
@@ -55,8 +55,14 @@ interface Props {
    * it, which matters as soon as they invite anyone else to their own host.
    */
   suggestedEmail?: string;
-  /** A code lifted out of a magic-link URL, redeemed on mount by the caller. */
-  onSignedIn: (me: Me) => void;
+  /**
+   * Reports a completed sign-in.
+   *
+   * Handed the whole {@link SignIn}, not just the user, because a cross-origin
+   * sign-in returns a session the caller has to store — this view is not where
+   * a credential belongs, but it is the only place that sees one arrive.
+   */
+  onSignedIn: (result: SignIn) => void;
 }
 
 type Mode = "link" | "password";

--- a/frontend/test/unit/fetch-event-stream.test.ts
+++ b/frontend/test/unit/fetch-event-stream.test.ts
@@ -1,0 +1,179 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BrowserTransport } from "@/api/transport";
+
+/**
+ * The event stream a cross-origin console has to use.
+ *
+ * `EventSource` cannot set a request header, so a console carrying its own
+ * session cannot use it — it would open the stream anonymously, take a 401, and
+ * fall back to polling. The console would then render a company where nothing
+ * ever happens, which looks like a quiet company rather than a broken one.
+ *
+ * So a credentialed stream is read over `fetch` instead, and this file pins the
+ * parts `EventSource` was doing for free. Framing is the one to watch: chunks
+ * arrive where the network splits them, not where the protocol does, so a
+ * parser that assumes one read is one frame works perfectly in development and
+ * drops events under load.
+ */
+
+/** A response whose body yields `chunks` in order, as an SSE stream would. */
+function streamOf(chunks: string[], status = 200): Response {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: {
+      getReader: () => ({
+        read: async () =>
+          i < chunks.length
+            ? { done: false, value: encoder.encode(chunks[i++]) }
+            : // Never resolves again: a live stream simply waits. Ending would
+              // trip the reconnect path and confuse what each test is pinning.
+              new Promise<never>(() => {}),
+      }),
+    },
+  } as unknown as Response;
+}
+
+/** Lets assertions run after the reader's promises have settled. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("the fetch event stream", () => {
+  it("carries the credential EventSource could not", async () => {
+    const fetchMock = vi.fn(async () => streamOf([]));
+    vi.stubGlobal("fetch", fetchMock);
+
+    new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: () => {} },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+
+    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const headers = init.headers as Record<string, string>;
+    expect(headers["x-opencompany-session"]).toBe("acme.tok");
+    expect(headers["accept"]).toBe("text/event-stream");
+  });
+
+  it("delivers one event per frame", async () => {
+    vi.stubGlobal("fetch", async () => streamOf(['data: {"a":1}\n\ndata: {"b":2}\n\n']));
+    const seen: string[] = [];
+
+    new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: (d) => seen.push(d) },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+
+    expect(seen).toEqual(['{"a":1}', '{"b":2}']);
+  });
+
+  it("reassembles a frame split across chunks", async () => {
+    // THE regression this parser exists to prevent. A chunk boundary falls
+    // wherever the network put it — mid-payload here — and a reader that
+    // treated each read as a frame would emit two truncated events and lose
+    // the real one, only under load.
+    vi.stubGlobal("fetch", async () => streamOf(['data: {"a"', ':1}\n\n']));
+    const seen: string[] = [];
+
+    new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: (d) => seen.push(d) },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+
+    expect(seen).toEqual(['{"a":1}']);
+  });
+
+  it("ignores keep-alive comments", async () => {
+    // A heartbeat is not an event. Delivering one as an empty string would have
+    // the console attempt `JSON.parse("")` on every beat.
+    vi.stubGlobal("fetch", async () => streamOf([': ping\n\ndata: real\n\n']));
+    const seen: string[] = [];
+
+    new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: (d) => seen.push(d) },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+
+    expect(seen).toEqual(["real"]);
+  });
+
+  it("gives up on a refused credential instead of retrying it", async () => {
+    // A 401 will be a 401 next time too. Reporting it as retryable would turn a
+    // signed-out console into a request loop against the host.
+    vi.stubGlobal("fetch", async () => streamOf([], 401));
+    const errors: Array<{ reconnecting: boolean }> = [];
+
+    new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: () => {}, onError: (e) => errors.push(e) },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+
+    expect(errors).toEqual([{ reconnecting: false }]);
+  });
+
+  it("stops reading once unsubscribed", async () => {
+    // The read blocks until the next frame, which on a quiet company is
+    // minutes. Without the abort, unsubscribing would take effect at the next
+    // event rather than immediately — and a switched-away host would keep
+    // delivering into a dead view.
+    let aborted = false;
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      init.signal?.addEventListener("abort", () => {
+        aborted = true;
+      });
+      return streamOf([]);
+    });
+
+    const stop = new BrowserTransport().subscribe(
+      "https://acme.example.com/api/v1/company/events",
+      { onMessage: () => {} },
+      { "x-opencompany-session": "acme.tok" },
+    );
+    await settle();
+    stop();
+
+    expect(aborted).toBe(true);
+  });
+
+  it("leaves an uncredentialed stream on EventSource", () => {
+    // The same-origin console must keep the browser's own reconnect and cookie
+    // handling. Routing it through this lane would be a rewrite of a working
+    // path for no gain.
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const constructed: string[] = [];
+    vi.stubGlobal(
+      "EventSource",
+      class {
+        static readonly CLOSED = 2;
+        readyState = 0;
+        constructor(url: string) {
+          constructed.push(url);
+        }
+        close() {}
+      },
+    );
+
+    new BrowserTransport().subscribe("/api/v1/company/events", { onMessage: () => {} });
+
+    expect(constructed).toEqual(["/api/v1/company/events"]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/test/unit/fetch-event-stream.test.ts
+++ b/frontend/test/unit/fetch-event-stream.test.ts
@@ -59,7 +59,7 @@ describe("the fetch event stream", () => {
     await settle();
 
     const [, init] = fetchMock.mock.calls[0];
-    const headers = init.headers as Record<string, string>;
+    const headers = init?.headers as Record<string, string>;
     expect(headers["x-opencompany-session"]).toBe("acme.tok");
     expect(headers["accept"]).toBe("text/event-stream");
   });

--- a/frontend/test/unit/fetch-event-stream.test.ts
+++ b/frontend/test/unit/fetch-event-stream.test.ts
@@ -48,7 +48,7 @@ afterEach(() => {
 
 describe("the fetch event stream", () => {
   it("carries the credential EventSource could not", async () => {
-    const fetchMock = vi.fn(async () => streamOf([]));
+    const fetchMock = vi.fn(async (_url: string, _init?: RequestInit) => streamOf([]));
     vi.stubGlobal("fetch", fetchMock);
 
     new BrowserTransport().subscribe(

--- a/frontend/test/unit/fetch-event-stream.test.ts
+++ b/frontend/test/unit/fetch-event-stream.test.ts
@@ -58,7 +58,7 @@ describe("the fetch event stream", () => {
     );
     await settle();
 
-    const [, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    const [, init] = fetchMock.mock.calls[0];
     const headers = init.headers as Record<string, string>;
     expect(headers["x-opencompany-session"]).toBe("acme.tok");
     expect(headers["accept"]).toBe("text/event-stream");

--- a/frontend/test/unit/hub-carried-session.test.ts
+++ b/frontend/test/unit/hub-carried-session.test.ts
@@ -1,0 +1,240 @@
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { OpenCompanyClient } from "@/api/client";
+import type {
+  StreamHandlers,
+  Transport,
+  TransportRequest,
+  TransportResponse,
+} from "@/api/transport";
+import { needsCarriedSession } from "@/api/transport";
+import {
+  addConnection,
+  adoptSession,
+  clearSession,
+  getConnection,
+  resetConnections,
+} from "@/connections/registry";
+import { readProfiles } from "@/connections/profileStore";
+import { connectionConfig } from "@/connections/types";
+import { connectionRailVisible } from "@/components/connection-rail";
+
+/**
+ * A **hub** console: one deployment of this app operating hosts that live on
+ * other origins, reached as subdomains.
+ *
+ * The whole feature turns on one fact — a cross-origin console never receives
+ * the session cookie, because the host sets it `SameSite=Lax`. So it asks for a
+ * token and carries it itself. These tests pin the three places that can
+ * silently undo that:
+ *
+ *   1. *deciding* a connection needs to carry one (get it wrong and a console
+ *      either drops its cookie for no reason, or holds a token it never sends);
+ *   2. *sending* it, on requests and on the event stream alike;
+ *   3. *keeping* it across a reload, which is the only reason it is persisted.
+ *
+ * Each failure is quiet. None of them throws — they produce a console that
+ * signs in successfully and is anonymous immediately afterwards.
+ */
+
+/** Records what it was handed, and answers with whatever the test staged. */
+class StubTransport implements Transport {
+  readonly seen: TransportRequest[] = [];
+  readonly streams: Array<{ url: string; headers?: Record<string, string> }> = [];
+
+  constructor(private readonly text: string = "{}") {}
+
+  async request(req: TransportRequest): Promise<TransportResponse> {
+    this.seen.push(req);
+    return {
+      status: 200,
+      statusText: "",
+      url: req.url,
+      text: this.text,
+      header: () => null,
+    };
+  }
+
+  subscribe(
+    url: string,
+    _handlers: StreamHandlers,
+    headers?: Record<string, string>,
+  ): () => void {
+    this.streams.push({ url, headers });
+    return () => {};
+  }
+}
+
+function clientWith(session: string | null, transport: Transport): OpenCompanyClient {
+  return new OpenCompanyClient(
+    {
+      baseUrl: "https://acme.example.com",
+      company: null,
+      operatorToken: null,
+      sessionHeader: session,
+    },
+    transport,
+  );
+}
+
+beforeEach(() => {
+  resetConnections();
+  window.localStorage.clear();
+});
+
+describe("deciding which connections carry their own session", () => {
+  it("leaves a same-origin console on its cookie", () => {
+    // The cookie is strictly better wherever it works — nothing in the page can
+    // read it — so the carried token must never be chosen when it is available.
+    expect(needsCarriedSession("")).toBe(false);
+    expect(needsCarriedSession(window.location.origin)).toBe(false);
+  });
+
+  it("carries its own session to another origin", () => {
+    // The case the hub is built out of: `app.example.com` operating
+    // `acme.example.com`. A shared parent domain does not make these same-origin
+    // and does not make `SameSite=Lax` send the cookie.
+    expect(needsCarriedSession("https://acme.example.com")).toBe(true);
+    expect(needsCarriedSession("https://other.test")).toBe(true);
+  });
+
+  it("treats a different port on this host as another origin", () => {
+    // The classic near-miss: an origin is scheme + host + *port*, and a cookie
+    // is not shared across ports any more than across hosts.
+    const elsewhere = `${window.location.protocol}//${window.location.hostname}:31337`;
+    expect(needsCarriedSession(elsewhere)).toBe(true);
+  });
+});
+
+describe("sending a carried session", () => {
+  it("puts it on every request", async () => {
+    const t = new StubTransport();
+    await clientWith("acme.tok", t).get("/api/v1/company/status");
+    expect(t.seen[0].headers["x-opencompany-session"]).toBe("acme.tok");
+  });
+
+  it("puts it on the event stream too", () => {
+    // The subtlest way to get this wrong. A stream that authenticates
+    // differently from the requests beside it loads every view correctly and
+    // then never updates one — which reads as a quiet company, not as an
+    // unauthorized client.
+    const t = new StubTransport();
+    clientWith("acme.tok", t).subscribeToEvents(null, { onMessage: () => {} });
+    expect(t.streams[0].headers?.["x-opencompany-session"]).toBe("acme.tok");
+  });
+
+  it("sends nothing extra when there is no carried session", async () => {
+    // A same-origin console must be byte-identical to what it was before this
+    // existed, or the cookie deployment starts depending on the hub's code path.
+    const t = new StubTransport();
+    await clientWith(null, t).get("/api/v1/company/status");
+    expect(t.seen[0].headers["x-opencompany-session"]).toBeUndefined();
+  });
+
+  it("asks for the header carrier only when signing in, and only cross-origin", async () => {
+    // The carrier header is an assertion about this client. Sending it on
+    // ordinary calls would make every request carry a claim it has no business
+    // making; never sending it would mean a hub sign-in silently mints a cookie
+    // it cannot receive.
+    const t = new StubTransport();
+    const client = clientWith(null, t);
+    await client.postSignIn("/api/v1/company/auth/verify", { code: "x" });
+    await client.post("/api/v1/company/chat", { message: "hi" });
+
+    expect(t.seen[0].headers["x-opencompany-session-carrier"]).toBe("header");
+    expect(t.seen[1].headers["x-opencompany-session-carrier"]).toBeUndefined();
+  });
+
+  it("does not ask for the header carrier on a same-origin sign-in", async () => {
+    const t = new StubTransport();
+    const client = new OpenCompanyClient(
+      { baseUrl: "", company: null, operatorToken: null, sessionHeader: null },
+      t,
+    );
+    await client.postSignIn("/api/v1/company/auth/verify", { code: "x" });
+    expect(t.seen[0].headers["x-opencompany-session-carrier"]).toBeUndefined();
+  });
+});
+
+describe("keeping a carried session", () => {
+  it("survives a reload", () => {
+    // The only reason this token is persisted at all. Without it a hub asks for
+    // a fresh sign-in to every host on every page load, which is not a console
+    // anyone keeps using.
+    const id = addConnection({ baseUrl: "https://acme.example.com" });
+    adoptSession(id, "acme.tok");
+
+    const stored = readProfiles().find((p) => p.id === id);
+    expect(stored?.credential).toEqual({ kind: "session", value: "acme.tok" });
+  });
+
+  it("reaches the client that a connection's requests go through", () => {
+    const id = addConnection({ baseUrl: "https://acme.example.com" });
+    adoptSession(id, "acme.tok");
+
+    const connection = getConnection(id);
+    expect(connection).toBeDefined();
+    expect(connectionConfig(connection!).sessionHeader).toBe("acme.tok");
+  });
+
+  it("replaces the previous session rather than keeping it", () => {
+    // Signing in again mints a new token and the old one stops working. A
+    // client left holding the previous value keeps working until that one
+    // expires, so the bug surfaces long after the change that caused it.
+    const id = addConnection({ baseUrl: "https://acme.example.com" });
+    adoptSession(id, "acme.first");
+    adoptSession(id, "acme.second");
+
+    expect(getConnection(id)?.credential).toEqual({
+      kind: "session",
+      value: "acme.second",
+    });
+  });
+
+  it("is dropped on sign-out, in storage as well as in memory", () => {
+    // Clearing only the in-memory copy would restore the dead token on the next
+    // reload and present a revoked credential to the host forever.
+    const id = addConnection({ baseUrl: "https://acme.example.com" });
+    adoptSession(id, "acme.tok");
+    clearSession(id);
+
+    expect(getConnection(id)?.credential).toEqual({ kind: "cookie" });
+    expect(readProfiles().find((p) => p.id === id)?.credential).toEqual({ kind: "cookie" });
+  });
+
+  it("refuses to send a session over plain http to a remote host", () => {
+    // The token is a person's standing authority on a company. Unlike a cookie,
+    // this page holds it and puts it on the wire itself, so `Secure` is not
+    // doing this job for us.
+    const id = addConnection({ baseUrl: "http://acme.example.com" });
+    adoptSession(id, "acme.tok");
+
+    return probeRefuses(id);
+  });
+});
+
+/** Probing an insecurely credentialed connection must fail it, not attempt it. */
+async function probeRefuses(id: string): Promise<void> {
+  const { probe } = await import("@/connections/registry");
+  await probe(id);
+  const connection = getConnection(id);
+  expect(connection?.status).toBe("down");
+  expect(connection?.error).toMatch(/not encrypted/);
+}
+
+describe("the connection rail in a hub", () => {
+  it("is drawn at any count, including none", () => {
+    // A hub has no bootstrap connection, so it can genuinely hold zero hosts —
+    // and the "+" in this rail is the only way to add the first one. Hiding the
+    // rail there is a dead end with no way out of it.
+    expect(connectionRailVisible(0, true)).toBe(true);
+    expect(connectionRailVisible(1, true)).toBe(true);
+  });
+
+  it("still stays out of the way of an ordinary single-host console", () => {
+    expect(connectionRailVisible(1, false)).toBe(false);
+    expect(connectionRailVisible(2, false)).toBe(true);
+  });
+});

--- a/frontend/test/unit/hub-carried-session.test.ts
+++ b/frontend/test/unit/hub-carried-session.test.ts
@@ -13,7 +13,6 @@ import { needsCarriedSession } from "@/api/transport";
 import {
   addConnection,
   adoptSession,
-  clearSession,
   getConnection,
   resetConnections,
 } from "@/connections/registry";
@@ -191,17 +190,6 @@ describe("keeping a carried session", () => {
       kind: "session",
       value: "acme.second",
     });
-  });
-
-  it("is dropped on sign-out, in storage as well as in memory", () => {
-    // Clearing only the in-memory copy would restore the dead token on the next
-    // reload and present a revoked credential to the host forever.
-    const id = addConnection({ baseUrl: "https://acme.example.com" });
-    adoptSession(id, "acme.tok");
-    clearSession(id);
-
-    expect(getConnection(id)?.credential).toEqual({ kind: "cookie" });
-    expect(readProfiles().find((p) => p.id === id)?.credential).toEqual({ kind: "cookie" });
   });
 
   it("refuses to send a session over plain http to a remote host", () => {

--- a/frontend/test/unit/task-workflow-proposal.test.ts
+++ b/frontend/test/unit/task-workflow-proposal.test.ts
@@ -156,7 +156,10 @@ function bodyOf(req: TransportRequest): Record<string, unknown> {
 
 describe("client.chat deliverable", () => {
   function clientOn(t: Transport) {
-    return new OpenCompanyClient({ baseUrl: "", company: null, operatorToken: null }, t);
+    return new OpenCompanyClient(
+      { baseUrl: "", company: null, operatorToken: null, sessionHeader: null },
+      t,
+    );
   }
 
   it("omits deliverable for an ordinary (once) message, keeping the pre-#580 shape", async () => {

--- a/frontend/test/unit/transport-seam.test.ts
+++ b/frontend/test/unit/transport-seam.test.ts
@@ -90,6 +90,7 @@ function clientOn(
       baseUrl: config.baseUrl ?? "",
       company: config.company ?? null,
       operatorToken: config.operatorToken ?? null,
+      sessionHeader: null,
     },
     transport,
   );

--- a/frontend/test/unit/workspace-binary.test.ts
+++ b/frontend/test/unit/workspace-binary.test.ts
@@ -31,7 +31,7 @@ function client(handler: (req: { method: string; url: string; body?: string }) =
     subscribe: () => () => {},
   };
   return new OpenCompanyClient(
-    { baseUrl: "", company: "acme", operatorToken: "t0ken" },
+    { baseUrl: "", company: "acme", operatorToken: "t0ken", sessionHeader: null },
     transport as never,
   );
 }

--- a/frontend/test/unit/workspace-repair.test.ts
+++ b/frontend/test/unit/workspace-repair.test.ts
@@ -26,7 +26,7 @@ function client(handler: (req: { method: string; url: string }) => unknown) {
     subscribe: () => () => {},
   };
   return new OpenCompanyClient(
-    { baseUrl: "", company: "acme", operatorToken: "t0ken" },
+    { baseUrl: "", company: "acme", operatorToken: "t0ken", sessionHeader: null },
     transport as never,
   );
 }

--- a/frontend/test/unit/workspace-search.test.ts
+++ b/frontend/test/unit/workspace-search.test.ts
@@ -24,7 +24,7 @@ function client(handler: (req: { method: string; url: string }) => unknown) {
     subscribe: () => () => {},
   };
   return new OpenCompanyClient(
-    { baseUrl: "", company: "acme", operatorToken: "t0ken" },
+    { baseUrl: "", company: "acme", operatorToken: "t0ken", sessionHeader: null },
     transport as never,
   );
 }

--- a/src/server/users/cookie.rs
+++ b/src/server/users/cookie.rs
@@ -329,6 +329,65 @@ mod test {
         assert_eq!(cookie(&HeaderMap::new(), "t"), None);
     }
 
+    fn carrier(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(SESSION_CARRIER_HEADER, value.parse().unwrap());
+        h
+    }
+
+    #[test]
+    fn the_header_carrier_is_opt_in() {
+        assert!(wants_header_carrier(&carrier("header")));
+        // Case and surrounding space are the client's business, not a refusal.
+        assert!(wants_header_carrier(&carrier("Header")));
+        assert!(wants_header_carrier(&carrier("  header ")));
+    }
+
+    #[test]
+    fn anything_else_means_the_cookie() {
+        // The default must be the HttpOnly carrier, so an absent, empty or
+        // unrecognised value degrades to the safer one rather than to none.
+        assert!(!wants_header_carrier(&HeaderMap::new()));
+        for value in ["", "cookie", "bearer", "headers", "header-ish", "1"] {
+            assert!(
+                !wants_header_carrier(&carrier(value)),
+                "{value:?} must not select the header carrier"
+            );
+        }
+    }
+
+    #[test]
+    fn the_session_header_value_is_what_the_parser_reads_back() {
+        // The two are each other's inverse, and a round trip is the only
+        // assertion that stays true if either side's format changes.
+        let rendered = session_header_value(&CompanyId::new("acme"), "tok").unwrap();
+        assert_eq!(rendered, "acme.tok");
+        let mut h = HeaderMap::new();
+        h.insert(SESSION_HEADER, rendered.parse().unwrap());
+        let (company, token) = session_from_header(&h).unwrap();
+        assert_eq!(company.as_ref(), "acme");
+        assert_eq!(token, "tok");
+    }
+
+    #[test]
+    fn a_company_that_cannot_name_a_cookie_cannot_name_a_header_either() {
+        // Both carriers gate on `may_carry_session`, so an id is either
+        // addressable by both or by neither. An id expressible in one carrier
+        // only would be a company reachable by desktop and not by browser.
+        for id in ["", "evil;Secure", "a.b", "with space"] {
+            let company = CompanyId::new(id);
+            assert_eq!(session_cookie_name(&company), None, "{id:?}");
+            assert_eq!(session_header_value(&company, "tok"), None, "{id:?}");
+        }
+    }
+
+    #[test]
+    fn an_empty_token_never_renders_a_header() {
+        // `session_from_header` refuses an empty token, so rendering one would
+        // hand back a value that cannot authenticate anything.
+        assert_eq!(session_header_value(&CompanyId::new("acme"), ""), None);
+    }
+
     #[test]
     fn set_cookie_carries_the_defensive_attributes() {
         let rendered = set_cookie("oc_session_acme", "tok", 3600, false);

--- a/src/server/users/cookie.rs
+++ b/src/server/users/cookie.rs
@@ -47,6 +47,65 @@ const SESSION_COOKIE_PREFIX: &str = "oc_session_";
 /// `http` stores.
 pub const SESSION_HEADER: &str = "x-opencompany-session";
 
+/// The header a client sets to ask for a session it can carry itself.
+///
+/// ## Why a login has to be asked which carrier to mint
+///
+/// A cookie is the right carrier for a console served by the host it talks to,
+/// and it is simply unavailable to one that is not. A hub console on
+/// `app.example.com` addressing a tenant on `acme.example.com` is cross-site,
+/// so [`set_cookie`]'s `SameSite=Lax` withholds the session from every request
+/// it would make. Loosening that to `SameSite=None` would only trade a cookie
+/// the browser never sends for a third-party cookie Safari discards outright.
+///
+/// Such a client therefore asks for the token itself and presents it in
+/// [`SESSION_HEADER`], exactly as a paired device already does. This header is
+/// how it asks. The alternative — sniffing a cross-origin `Origin` — would make
+/// the carrier a property of where the request came from rather than of what
+/// the client is able to store, and would silently switch carriers on a console
+/// that had a perfectly good cookie.
+///
+/// ## Why opting in this way is safe
+///
+/// A custom request header cannot be set by a cross-site HTML form, and a
+/// cross-site `fetch` that sets one is preflighted — which
+/// [`cors`](crate::server::cors) answers for allow-listed origins only. So a
+/// hostile page cannot make someone's browser ask for the readable carrier on
+/// its behalf. A console that never sends this header keeps the `HttpOnly`
+/// cookie it has always had, unchanged.
+pub const SESSION_CARRIER_HEADER: &str = "x-opencompany-session-carrier";
+
+/// The [`SESSION_CARRIER_HEADER`] value that selects the header carrier.
+const CARRIER_HEADER: &str = "header";
+
+/// Whether this request asked for a session it will carry in a header.
+///
+/// Anything else — absent, empty, `cookie`, a value nobody defined — means the
+/// cookie. An unrecognised carrier degrades to the safer one rather than to no
+/// session at all.
+pub fn wants_header_carrier(headers: &HeaderMap) -> bool {
+    headers
+        .get(SESSION_CARRIER_HEADER)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v.trim().eq_ignore_ascii_case(CARRIER_HEADER))
+}
+
+/// Renders the [`SESSION_HEADER`] value for a freshly minted session.
+///
+/// Assembled here rather than by the client because the addressed company may
+/// have been resolved through the single-company alias, where the caller never
+/// learned an id to prefix with. Returns `None` for a company that cannot carry
+/// a session, mirroring [`session_cookie_name`] — both carriers agree on which
+/// ids are expressible, which is the whole reason [`may_carry_session`] is
+/// shared between them.
+pub fn session_header_value(company: &CompanyId, token: &str) -> Option<String> {
+    let id = company.as_ref();
+    if !may_carry_session(id) || token.is_empty() {
+        return None;
+    }
+    Some(format!("{id}.{token}"))
+}
+
 /// Whether `id` may carry a session at all.
 ///
 /// Restricted to `[A-Za-z0-9_-]`: a superset-safe subset of RFC 6265's token

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -534,6 +534,25 @@ async fn mint_session(
     .await
     .map_err(|e| ApiError(e).into_response())?;
 
+    // The header carrier hands the token to the client and sets **no** cookie.
+    // Setting both would leave one session reachable two ways, and the cookie
+    // half would be a third-party cookie that some browsers keep and others
+    // drop — so whether logging out cleared the session would depend on the
+    // browser. One session, one carrier.
+    if cookie::wants_header_carrier(headers) {
+        let Some(session) = cookie::session_header_value(company, &plaintext) else {
+            return Err(ApiError(OpenCompanyError::InvalidRequest(
+                "this company's id cannot carry a session header".to_string(),
+            ))
+            .into_response());
+        };
+        return Ok(Json(SignInResult {
+            user: me_result(company, user),
+            session: Some(session),
+        })
+        .into_response());
+    }
+
     let insecure = !state.config().host_base_url().starts_with("https://");
     let set = cookie::set_cookie(
         &name,
@@ -541,7 +560,10 @@ async fn mint_session(
         token::SESSION_TTL_MILLIS / 1000,
         insecure,
     );
-    let body = Json(me_result(runtime.id(), user));
+    let body = Json(SignInResult {
+        user: me_result(company, user),
+        session: None,
+    });
     Ok(([(header::SET_COOKIE, set)], body).into_response())
 }
 

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -496,7 +496,13 @@ pub(crate) async fn create_session(
     Ok(plaintext)
 }
 
-/// Mints a browser session for `user` and renders the `Set-Cookie` response.
+/// Mints a browser session for `user` and renders it in the carrier they asked
+/// for: a `Set-Cookie` by default, or the token in the body for a client that
+/// cannot receive a cookie at all (see [`cookie::SESSION_CARRIER_HEADER`]).
+///
+/// One choke point for every browser login path — magic link, password, hub and
+/// wallet — so a carrier is added once rather than four times, and no path can
+/// acquire one without the session-minting invariants in [`create_session`].
 async fn mint_session(
     state: &AppState,
     runtime: &CompanyRuntime,
@@ -506,6 +512,9 @@ async fn mint_session(
     let company = runtime.id();
     // A company whose id cannot safely name a cookie cannot hold a session;
     // refuse rather than emit a header its id could have chosen attributes for.
+    // Checked for both carriers, not just the cookie: `session_header_value`
+    // enforces the same rule, so failing here keeps the refusal in one place
+    // and keeps the two carriers addressable by exactly the same set of ids.
     let Some(name) = cookie::session_cookie_name(company) else {
         return Err(ApiError(OpenCompanyError::InvalidRequest(
             "this company's id cannot carry a session cookie".to_string(),

--- a/src/server/users/routes.rs
+++ b/src/server/users/routes.rs
@@ -173,6 +173,25 @@ pub struct MeResult {
     must_change_password: bool,
 }
 
+/// What a successful sign-in returns.
+///
+/// [`MeResult`] is flattened rather than nested so this stays byte-identical to
+/// what every login route returned before the header carrier existed — a client
+/// that never asks for one sees no `session` field and needs no change.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SignInResult {
+    #[serde(flatten)]
+    user: MeResult,
+    /// The ready-made [`SESSION_HEADER`](cookie::SESSION_HEADER) value, present
+    /// **only** when the client asked for the header carrier.
+    ///
+    /// Returned exactly once, like a device pairing's token: only its hash is
+    /// stored, so a client that drops it has to sign in again.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    session: Option<String>,
+}
+
 // ---------------------------------------------------------------------------
 // Shared failures
 // ---------------------------------------------------------------------------

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -244,6 +244,171 @@ async fn login_via_link(state: &AppState, sender: &RecordingMailSender, email: &
     session_cookie(&response)
 }
 
+// ---------------------------------------------------------------------------
+// The header carrier — a hub console that cannot receive a cookie
+// ---------------------------------------------------------------------------
+
+/// A login request that asks for a session the client will carry itself.
+fn post_wanting_header_carrier(uri: &str, body: serde_json::Value) -> Request<Body> {
+    Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json")
+        .header(super::cookie::SESSION_CARRIER_HEADER, "header")
+        .body(Body::from(body.to_string()))
+        .unwrap()
+}
+
+fn get_with_session_header(uri: &str, session: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .header(super::cookie::SESSION_HEADER, session)
+        .body(Body::empty())
+        .unwrap()
+}
+
+/// Signs `email` in asking for the header carrier, returning the whole body.
+async fn login_wanting_header_carrier(
+    state: &AppState,
+    sender: &RecordingMailSender,
+    email: &str,
+) -> (axum::http::HeaderMap, serde_json::Value) {
+    let code = request_code(state, sender, email).await;
+    let app = router(state.clone());
+    let response = app
+        .oneshot(post_wanting_header_carrier(
+            "/api/v1/companies/acme/auth/verify",
+            serde_json::json!({ "code": code }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let headers = response.headers().clone();
+    (headers, body_json(response).await)
+}
+
+#[tokio::test]
+async fn the_header_carrier_returns_a_session_that_authenticates() {
+    // The whole point of the carrier: a console on another origin gets a
+    // credential it can actually present, because a cookie would never be sent.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let (_, json) = login_wanting_header_carrier(&state, &sender, "ada@example.com").await;
+
+    let session = json["session"]
+        .as_str()
+        .expect("the header carrier must return a session")
+        .to_string();
+    assert!(
+        session.starts_with("acme."),
+        "the value must name its company so a client need not know how the \
+         addressed company was resolved: {session}"
+    );
+
+    let app = router(state.clone());
+    let response = app
+        .oneshot(get_with_session_header(
+            "/api/v1/companies/acme/auth/me",
+            &session,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "the returned session must authenticate the next request"
+    );
+    assert_eq!(body_json(response).await["email"], "ada@example.com");
+}
+
+#[tokio::test]
+async fn the_header_carrier_sets_no_cookie() {
+    // One session, one carrier. Setting both would leave the cookie half as a
+    // third-party cookie some browsers keep and others drop, so whether logging
+    // out actually ended the session would vary by browser.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let (headers, _) = login_wanting_header_carrier(&state, &sender, "ada@example.com").await;
+    assert!(
+        headers.get("set-cookie").is_none(),
+        "a client that asked to carry the session must not also be given a cookie"
+    );
+}
+
+#[tokio::test]
+async fn a_login_that_asks_for_nothing_is_unchanged() {
+    // The carrier is opt-in, and every existing console is the opt-out case:
+    // it must still get its HttpOnly cookie and must never see a token in the
+    // body, which is precisely what it has no way to store safely.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let code = request_code(&state, &sender, "ada@example.com").await;
+    let app = router(state.clone());
+    let response = app
+        .oneshot(post(
+            "/api/v1/companies/acme/auth/verify",
+            serde_json::json!({ "code": code }),
+        ))
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let set = response
+        .headers()
+        .get("set-cookie")
+        .expect("the default carrier is still the cookie")
+        .to_str()
+        .unwrap()
+        .to_string();
+    assert!(set.contains("HttpOnly"), "{set}");
+    let json = body_json(response).await;
+    assert!(
+        json.get("session").is_none(),
+        "a cookie client must never be handed the raw token: {json}"
+    );
+    // And the body it always returned is still there, unflattened by the change.
+    assert_eq!(json["email"], "ada@example.com");
+}
+
+#[tokio::test]
+async fn a_header_carried_session_can_be_logged_out() {
+    // Revocation has to reach the session however it was carried, or a hub
+    // console's "sign out" would clear its own storage and leave a live token
+    // on the server for the rest of its TTL.
+    let home = home();
+    let (state, sender) = state_with_mail(home.path()).await;
+    let (_, json) = login_wanting_header_carrier(&state, &sender, "ada@example.com").await;
+    let session = json["session"].as_str().unwrap().to_string();
+
+    let app = router(state.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/companies/acme/auth/logout")
+                .header(super::cookie::SESSION_HEADER, &session)
+                .header("content-type", "application/json")
+                .body(Body::from("{}"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let app = router(state.clone());
+    let after = app
+        .oneshot(get_with_session_header(
+            "/api/v1/companies/acme/auth/me",
+            &session,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(
+        after.status(),
+        StatusCode::UNAUTHORIZED,
+        "the token must be dead server-side, not merely dropped by the client"
+    );
+}
+
 /// Looks a user's id up through the admin roster.
 async fn user_id(state: &AppState, admin: &str, email: &str) -> String {
     let app = router(state.clone());


### PR DESCRIPTION
## Why

The console is currently deployed once per host: each `opencompany serve` serves
its own copy at its own origin, and only the desktop can hold several hosts at
once. This makes the **web** console multi-host too, so one deployment at
`app.example.com` can operate tenants at `acme.example.com`,
`globex.example.com`, and so on.

## What was already there

Most of the multi-connection machinery existed and was never desktop-gated:
`src/connections/` already holds N hosts, mints a stable id per host, and scopes
every `localStorage` key by `(connection, company)`. The `x-opencompany-session`
header carrier existed too, and was already honoured on every plane — GraphQL,
REST `ops/`, and the operator routes all resolve through `resolve_principal`.

The web build simply bootstrapped one same-origin connection. So this PR is
mostly three gaps, not a rewrite.

## The three gaps

**1. No login route ever returned the token.** A client now opts in with
`x-opencompany-session-carrier: header` and gets `session: "<company>.<token>"`
in the body, with no `Set-Cookie`. It lands in `mint_session` — the single choke
point all four browser login paths share — so magic link, password, hub and
wallet get it at once, and none of them can acquire a carrier while skipping the
session-minting invariants.

One session, one carrier: issuing both would leave the cookie half as a
third-party cookie some browsers keep and others discard, so whether logging out
actually ended the session would vary by browser.

**2. `EventSource` cannot set a header.** A hub's event stream would have opened
anonymously, taken a 401, and silently degraded to polling — rendering as a
quiet company rather than a broken one. Credentialed streams now run over
`fetch` with a minimal SSE reader (`data:` frames, blank-line separated),
reproducing exactly the `onOpen`/`onError{reconnecting}` contract the
`EventSource` lane promises.

**3. Nothing decided which connections carry a token.** `needsCarriedSession`
derives it by comparing the host's origin with the document's, rather than
taking a flag. A flag would be a second source of truth free to disagree with
`SameSite=Lax`, and when it disagreed the symptom is a console that signs in
successfully and is anonymous from the next request onward.

Hub mode (`VITE_OC_HUB=1`, or `?hub`) then only has to suppress the same-origin
bootstrap connection — adding one would reproduce #613 in the browser: a dead
connection selected on load in front of the healthy ones.

## The tradeoff, stated rather than buried

A hub holds session tokens in `localStorage`, so script execution on the hub's
origin reaches every host its operator has signed in to, where an `HttpOnly`
cookie would have survived it. This is a real reduction and is documented as
such in `profileStore.ts`, `connections/types.ts`, and `docs/spec/runtime/hub-console.md`.

It is accepted because the alternative is not a safer console but no console:
the cookie is never sent cross-site, and `SameSite=None` would only make it a
third-party cookie Safari discards. It is bounded by being a revocable,
expiring session, and by being unreachable for any deployment where a cookie
would have worked.

**Nothing changes for a same-origin console.** No carrier header, no token in
the body, same `HttpOnly` cookie — asserted by
`a_login_that_asks_for_nothing_is_unchanged`.

## Deploying

```sh
VITE_OC_HUB=1 pnpm build                                    # the hub
OPENCOMPANY_CORS_ORIGINS=https://app.example.com opencompany serve …   # each tenant
```

Hosts are added from the "+" in the connection rail and remembered in
`localStorage`. There is no directory service — a hub knows exactly the hosts
somebody told it about.

## Known limitation

Magic links land on the tenant, not the hub: the host builds the link from its
own base URL, so following one opens that host's own console. Password, wallet
and ecosystem sign-in work in the hub. Redirecting links back would require the
host to know the hub's origin, which nothing tells it today. Documented in
`hub-console.md` rather than half-solved.

## Commands run

- `cargo test` — 2424 passed, 0 failed, 1 ignored
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -p opencompany -- --check` — clean
- `pnpm typecheck` — clean
- `pnpm test` — 738 passed across 64 files

## Tests added

21 new: the carrier's opt-in and its degrade-to-cookie default, the round trip
between `session_header_value` and `session_from_header`, that the returned
token actually authenticates and can be logged out, that a cookie client is
unchanged, origin classification (including the same-host-different-port
near-miss), credential propagation onto requests *and* the event stream,
persistence across a reload, and SSE frame reassembly across a chunk boundary —
the failure that only shows up under load.

## Behaviour changes

- New opt-in request header `x-opencompany-session-carrier` on the four sign-in
  routes; absent means the previous behaviour exactly.
- Sign-in responses may carry a `session` field (only when asked).
- `Transport.subscribe` takes an optional `headers` argument.
- A `session` credential is refused over plain HTTP to a non-loopback host, in
  the browser as well as the desktop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hub console support for multi-host, cross-origin deployments.
  * Added optional header-based sessions for browser sign-in flows, including password, magic-link, hub, and wallet authentication.
  * Added authenticated cross-origin event streaming and improved connection-rail visibility in hub mode.

* **Documentation**
  * Documented hub deployment, session handling, CORS requirements, security considerations, and configuration examples.

* **Bug Fixes**
  * Improved session recovery and authentication behavior across same-origin, cross-origin, and desktop deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->