### PR TITLE
fix(console): make restart, lifecycle, and tour controls take effect immediately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -456,17 +455,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1334,6 +1322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1779,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -2634,6 +2643,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2676,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3164,7 +3197,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -3176,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.8"
+version = "0.63.7"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3191,13 +3224,14 @@ dependencies = [
  "chrono-tz",
  "cron",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "dotenvy",
  "ed25519-dalek",
  "flate2",
  "fs2",
  "futures",
  "futures-util",
+ "git2",
  "glob",
  "hex",
  "hkdf",
@@ -3214,6 +3248,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest",
+ "ring",
  "rusqlite",
  "rustls",
  "schemars",
@@ -3232,16 +3267,13 @@ dependencies = [
  "tinycortex",
  "tinycortex-api",
  "tinyhumans-sdk",
- "tinymemory",
- "tinymemory-api",
- "tinymemory-core",
- "tinymemory-tinycortex",
+ "tinyjuice",
  "tinyplace",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3586,7 +3618,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4224,6 +4256,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4728,7 +4769,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "regex",
  "reqwest",
  "rusqlite",
  "serde",
@@ -4803,8 +4843,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "futures",
+ "git2",
+ "hex",
  "log",
  "parking_lot",
  "rand 0.10.2",
@@ -4819,7 +4861,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "uuid",
  "walkdir",
@@ -4842,6 +4884,8 @@ dependencies = [
 [[package]]
 name = "tinyflows"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5815f3dded76503a1b1867b55282941f50b3ecef4dcbfd0786640dc189250557"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4873,74 +4917,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory"
-version = "1.0.1"
+name = "tinyjuice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dde6760266db10b01d339438b651045e3815a52d00eeb40e2f41f22304d6cac"
 dependencies = [
- "anyhow",
  "async-trait",
+ "dirs 6.0.0",
+ "hex",
  "log",
- "serde",
- "serde_json",
- "tinymemory-api",
-]
-
-[[package]]
-name = "tinymemory-api"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "log",
- "schemars",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "uuid",
-]
-
-[[package]]
-name = "tinymemory-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "chrono",
- "dirs",
- "futures",
- "log",
- "parking_lot",
- "rand 0.8.7",
- "regex",
- "reqwest",
- "rusqlite",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tinyagents",
- "tinycortex",
- "tinycortex-api",
- "tinymemory",
- "tinymemory-api",
  "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "tinymemory-tinycortex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "tinycortex",
- "tinymemory",
- "tinymemory-api",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5101,17 +5095,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5125,14 +5140,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5141,8 +5170,14 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5384,6 +5419,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5971,6 +6012,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6172,6 +6222,10 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "tinyflows"
+version = "0.6.0"
 
 [[patch.unused]]
 name = "whisper-rs-sys"

--- a/docs/modules/server/authority.md
+++ b/docs/modules/server/authority.md
@@ -25,7 +25,7 @@ the world as, and which third-party accounts its agents act through:
 |---|---|
 | `composio` | `PUT …/composio/token`, `POST …/composio/authorize`, `DELETE …/composio/connections/{id}`, `PUT`/`DELETE …/composio/connections/{id}/default` |
 | `connections` (`oauth`) | `POST …/connections/{p}/start`, `POST …/connections/{p}/disconnect` |
-| `inference` | `PUT …/inference`, `DELETE …/inference` |
+| `inference` | `PUT …/inference`, `DELETE …/inference`, `POST …/inference/restart` |
 | `smtp` | `PUT …/smtp`, `POST …/smtp/test` (the caller names the recipient) |
 | `domain` | `PUT …/domain` |
 | `channels` | `PUT`/`DELETE …/channels/telegram`, `POST …/channels/telegram/webhook` |

--- a/docs/spec/runtime/rebuild.md
+++ b/docs/spec/runtime/rebuild.md
@@ -15,6 +15,36 @@ So first-time BYOK setup needed someone with pod access.
 
 This is the seam that removes it.
 
+## What triggers one
+
+Two routes, both requiring authority over the company:
+
+| Route | When |
+|---|---|
+| `PUT …/inference` | Automatically, when the save leaves the company `restart_required` |
+| `POST …/inference/restart` | On demand, from the console's **Restart now** button |
+
+The save path covers the transition this feature exists for: an operator
+configuring BYOK for the first time never sees the restart notice at all,
+because the rebuild happens inside the same request.
+
+The explicit route exists for the cases that path cannot reach — a company that
+was already sitting in the restart-required state before this landed, one whose
+rebuild failed transiently, and one an operator arrives at without touching the
+inference form. Without it the console's banner names a restart and offers no
+way to perform it, which is the dead end this whole document is about.
+
+It deliberately does **not** gate on `restart_required` first. A rebuild of a
+healthy company is a no-op from the operator's point of view — same journal,
+same parked approvals, same grants — so refusing would buy nothing and would
+introduce a race in which the check and the rebuild disagree. It would also
+refuse the case most worth allowing: an operator recovering a company whose
+state the console is reading wrongly.
+
+A host that wired no `RuntimeRebuilder` answers with the error naming the
+process restart that *would* work. The console surfaces that rather than
+reporting a success which changed nothing.
+
 ## The sequence (`src/runtime/rebuild.rs`)
 
 `runtime::rebuild_company(&state, id)`:

--- a/frontend/src/api/inference.ts
+++ b/frontend/src/api/inference.ts
@@ -118,6 +118,33 @@ export function revertInference(
   return client.del<InferenceMutation>(`${client.scopeFor(company)}/inference`);
 }
 
+/**
+ * Rebuild this company's runtime in place, now.
+ *
+ * The action behind the "Restart required" notice. Which brain a company runs
+ * is chosen when its runtime is built, so a company that booted with no
+ * inference source keeps echoing however the config changes underneath it.
+ * Saving already attempts this rebuild; this asks for it on its own, which is
+ * what a company already sitting in that state needs — or one whose rebuild
+ * failed the first time.
+ *
+ * In-flight work is preserved rather than dropped. The turn in progress
+ * completes, and the journal, parked approvals and single-use grants are handed
+ * to the successor — so an approval waiting on a person survives and nobody has
+ * to approve a tool call twice. Cycles arriving during the swap take a `503`
+ * and are retried against the successor.
+ *
+ * Rejects on a host that wired no rebuilder, with a message naming the process
+ * restart that would work instead. That is the honest answer, and the reason
+ * the console has to surface the failure rather than assume this always works.
+ */
+export function restartInference(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<InferenceMutation> {
+  return client.post<InferenceMutation>(`${client.scopeFor(company)}/inference/restart`, {});
+}
+
 /** Live-probe the resolved provider (one `ping` turn). */
 export function testInference(
   client: OpenCompanyClient,

--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -19,7 +19,33 @@ import { useLocalScope } from "@/connections/ConnectionContext";
 // react-joyride (and its floater/popper deps) is a fair chunk; only operators
 // who actually run the tour download it. Types above are `import type`, so they
 // erase and don't pull the module eagerly.
-const Joyride = lazy(() => import("react-joyride").then((m) => ({ default: m.Joyride })));
+//
+// Named so it can be *started* before it is needed — see `preloadTour`.
+const importJoyride = () => import("react-joyride");
+const Joyride = lazy(() => importJoyride().then((m) => ({ default: m.Joyride })));
+
+/**
+ * Start downloading the tour chunk before anything renders it.
+ *
+ * Lazy-loading it is right — most operators never run the tour — but it puts
+ * the download on the critical path of the click that starts one. "Replay tour"
+ * would show a toast saying the tour was starting and then nothing visible
+ * would happen until the chunk arrived, which on a cold cache or a slow
+ * connection is long enough to read as a button that does not work.
+ *
+ * So the fetch is moved to the moment someone shows intent — pointing at the
+ * button — instead of the moment they commit. By the time `session` flips and
+ * `Suspense` asks for the module, the dynamic import has usually already
+ * resolved and React renders it in the same frame.
+ *
+ * Safe to call as often as you like: `import()` caches its module promise, so
+ * every call after the first is a lookup rather than a request. Failures are
+ * swallowed because this is a prefetch and nothing depends on it — the real
+ * `lazy` boundary will report a genuinely broken chunk when it renders.
+ */
+export function preloadTour(): void {
+  void importJoyride().catch(() => {});
+}
 
 // react-joyride status values as string literals, so we don't statically import
 // the runtime `STATUS` enum (which would defeat the lazy load).

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -174,7 +174,21 @@ function LifecycleControls({
   feed: CompanyFeed;
 }) {
   const [busy, setBusy] = useState(false);
-  const state = feed.status.lifecycle;
+  /**
+   * The state this control just asked for, shown until the feed confirms it.
+   *
+   * Without this the buttons lag the click by two round trips: the action
+   * itself, and then the `refresh` that re-reads the company. `busy` cleared as
+   * soon as the action returned, so in between the operator saw re-enabled
+   * buttons still offering "Pause" on a company they had just paused — which
+   * reads as a click that did not register, and invites a second one.
+   *
+   * Cleared in `finally` rather than on success, so a *failed* action reverts
+   * to whatever the feed says instead of leaving the console asserting a state
+   * the host rejected.
+   */
+  const [pending, setPending] = useState<string | null>(null);
+  const state = pending ?? feed.status.lifecycle;
   const archived = state === "archived";
   const running = state === "running";
   const paused = state === "paused";
@@ -182,14 +196,21 @@ function LifecycleControls({
   async function run(action: LifecycleAction) {
     if (busy) return;
     setBusy(true);
+    // Before the await, so the buttons move on the click rather than on the
+    // response. This is the whole point of tracking it separately.
+    setPending(resultOf(action));
     try {
       await client.lifecycle(action, company);
       toast.success(`Company ${labelFor(action)}.`);
-      void feed.refresh();
+      // Awaited, unlike before: `pending` is dropped in `finally`, and dropping
+      // it while the refresh was still in flight would flip the buttons back to
+      // the stale lifecycle for exactly as long as that request took.
+      await feed.refresh();
     } catch (err) {
       const msg = err instanceof ApiError ? err.message : "something went wrong";
       toast.error(`Couldn't ${action} — ${msg}`);
     } finally {
+      setPending(null);
       setBusy(false);
     }
   }

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -30,6 +30,7 @@ import { StatusPill } from "@/components/status-pill";
 import { ThemeToggle } from "@/components/theme-toggle";
 import type { CompanyFeed } from "@/hooks/use-company";
 import { restartTour } from "@/tour/state";
+import { preloadTour } from "@/tour/TourController";
 import { useLocalScope } from "@/connections/ConnectionContext";
 
 interface Props {
@@ -134,6 +135,11 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
             </div>
             <Button
               variant="outline"
+              // The tour's code is lazily loaded, so without this the download
+              // starts on the click and the button appears to do nothing until
+              // it lands. Pointing at it is intent enough to fetch.
+              onPointerEnter={preloadTour}
+              onFocus={preloadTour}
               onClick={() => {
                 restartTour(scope);
                 toast.success("Starting the product tour.");

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -313,6 +313,28 @@ function InfoRow({ label, children }: { label: string; children: React.ReactNode
   );
 }
 
+/**
+ * The lifecycle an action lands the company in.
+ *
+ * Separate from {@link labelFor} even though three of the four strings match:
+ * that one writes a sentence to a person ("Company resumed.") and this one has
+ * to equal what the host reports in `status.lifecycle`, which is why `resume`
+ * differs. Sharing one function would make the two meanings drift into each
+ * other the first time either wording changed.
+ */
+function resultOf(action: LifecycleAction): string {
+  switch (action) {
+    case "pause":
+      return "paused";
+    case "resume":
+      return "running";
+    case "suspend":
+      return "suspended";
+    case "archive":
+      return "archived";
+  }
+}
+
 function labelFor(action: LifecycleAction): string {
   switch (action) {
     case "pause":

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import type { OpenCompanyClient } from "@/api/client";
 import {
   getInferenceStatus,
+  restartInference,
   revertInference,
   setInference,
   testInference,
@@ -159,7 +160,9 @@ export function InferenceSection({
 }) {
   const [load, setLoad] = useState<Load>("loading");
   const [status, setStatus] = useState<InferenceStatus | null>(null);
-  const [busy, setBusy] = useState<"save" | "reset" | "test" | "removeKey" | null>(null);
+  const [busy, setBusy] = useState<
+    "save" | "reset" | "test" | "removeKey" | "restart" | null
+  >(null);
   const [test, setTest] = useState<TestState>({ kind: "idle" });
 
   // Switch form.

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -388,13 +388,39 @@ export function InferenceSection({
                     data-testid="inference-restart-required"
                   >
                     <RotateCcw className="mt-px size-3.5 shrink-0" />
-                    <span>
-                      <span className="font-medium">Restart required.</span> This company started
-                      with no inference source, so it is running the offline echo brain and its
-                      scheduled workflows cannot fire. The brain is chosen at startup — this
-                      configuration is saved, but agents keep echoing until the company is
-                      restarted.
-                    </span>
+                    <div className="space-y-2">
+                      <span>
+                        <span className="font-medium">Restart required.</span> This company started
+                        with no inference source, so it is running the offline echo brain and its
+                        scheduled workflows cannot fire. The brain is chosen at startup — this
+                        configuration is saved, but agents keep echoing until the company is
+                        restarted.
+                      </span>
+                      {/* The action, not just the diagnosis. Telling a hosted
+                          operator to "restart the company" names something they
+                          have no way to do — the container is the unit of
+                          restart and the control plane has no button for it —
+                          so this rebuilds the runtime in place instead (#290).
+                          Only rendered for an admin, matching the route's own
+                          authority check, so a member is not shown a control
+                          that can only 403. */}
+                      {canManage && (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={busy !== null}
+                          data-testid="inference-restart-now"
+                          onClick={() => void restartNow()}
+                        >
+                          {busy === "restart" ? (
+                            <Loader2 className="size-3.5 animate-spin" />
+                          ) : (
+                            <RotateCcw className="size-3.5" />
+                          )}
+                          Restart now
+                        </Button>
+                      )}
+                    </div>
                   </div>
                 )}
                 {modelRows.length > 0 && (

--- a/frontend/src/views/connections/InferenceSection.tsx
+++ b/frontend/src/views/connections/InferenceSection.tsx
@@ -279,6 +279,38 @@ export function InferenceSection({
     }
   }
 
+  /**
+   * Rebuild the company's runtime now, clearing the restart-required state.
+   *
+   * The banner used to name a restart and offer no way to perform one, which is
+   * a dead end for exactly the operator most likely to hit it: a hosted tenant
+   * cannot restart its own container, and the control plane has no button for
+   * it either.
+   *
+   * The resulting status is read from the response rather than assumed. A host
+   * that wired no rebuilder genuinely cannot do this and says so, and reporting
+   * success there would replace a visible dead end with an invisible one.
+   */
+  async function restartNow() {
+    if (busy) return;
+    setBusy("restart");
+    try {
+      const result = await restartInference(client, company);
+      if (result.status.restartRequired) {
+        // The rebuild ran and the company is still on the old brain. Follow the
+        // host's note, which names the process restart that would work.
+        toast.warning("Still needs a restart.", { description: result.note });
+      } else {
+        toast.success("Restarted. Agents think with the new provider from their next turn.");
+      }
+      setStatus(result.status);
+    } catch (err) {
+      toast.error(err instanceof ApiError ? err.message : "Couldn't restart the company.");
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function reset() {
     if (busy) return;
     setBusy("reset");

--- a/frontend/test/unit/inference-restart.test.ts
+++ b/frontend/test/unit/inference-restart.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { restartInference } from "@/api/inference";
+import type { OpenCompanyClient } from "@/api/client";
+
+/**
+ * The action behind the "Restart required" notice.
+ *
+ * Before this, the notice named a restart and offered no way to perform one —
+ * a dead end for exactly the operator most likely to see it, since a hosted
+ * tenant cannot restart its own container and the control plane has no button
+ * for it either. These pin the client half: the route it calls, and the fact
+ * that the console reads the *resulting* status rather than assuming success.
+ */
+
+/** A client stub that records the call and answers with a staged body. */
+function stubClient(reply: unknown): {
+  client: OpenCompanyClient;
+  calls: Array<{ path: string; body: unknown }>;
+} {
+  const calls: Array<{ path: string; body: unknown }> = [];
+  const client = {
+    scopeFor: (company: string | null) =>
+      company ? `/api/v1/companies/${company}` : "/api/v1/company",
+    post: async (path: string, body: unknown) => {
+      calls.push({ path, body });
+      return reply;
+    },
+  } as unknown as OpenCompanyClient;
+  return { client, calls };
+}
+
+describe("restarting a company from the console", () => {
+  it("posts to the company's own restart route", async () => {
+    const { client, calls } = stubClient({ status: { restartRequired: false }, note: "" });
+    await restartInference(client, "acme");
+    expect(calls[0].path).toBe("/api/v1/companies/acme/inference/restart");
+  });
+
+  it("uses the single-company alias when no id is addressed", async () => {
+    // A prosumer `opencompany serve` has no company id, and hard-coding the
+    // multi-company form would 404 there.
+    const { client, calls } = stubClient({ status: { restartRequired: false }, note: "" });
+    await restartInference(client, null);
+    expect(calls[0].path).toBe("/api/v1/company/inference/restart");
+  });
+
+  it("reports the status the host came back with", async () => {
+    // The console must follow this rather than assume the rebuild worked: a
+    // host that wired no rebuilder genuinely cannot do it, and claiming success
+    // would swap a visible dead end for an invisible one.
+    const { client } = stubClient({
+      status: { restartRequired: true },
+      note: "restart the process",
+    });
+    const result = await restartInference(client, "acme");
+    expect(result.status.restartRequired).toBe(true);
+    expect(result.note).toContain("restart the process");
+  });
+});

--- a/frontend/test/unit/lifecycle-optimistic.test.ts
+++ b/frontend/test/unit/lifecycle-optimistic.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import type { LifecycleAction } from "@/api/client";
+
+/**
+ * What the lifecycle buttons show between the click and the host confirming.
+ *
+ * The controls read `pending ?? feed.status.lifecycle`, so the mapping from an
+ * action to the state it lands in is what makes a click visible immediately.
+ * Get it wrong and the console asserts a lifecycle the company is not in — a
+ * worse failure than the lag it replaced, because it looks authoritative.
+ *
+ * `resultOf` is not exported (it is a view-local helper), so this restates it
+ * and pins the one entry that is easy to get wrong.
+ */
+function resultOf(action: LifecycleAction): string {
+  switch (action) {
+    case "pause":
+      return "paused";
+    case "resume":
+      return "running";
+    case "suspend":
+      return "suspended";
+    case "archive":
+      return "archived";
+  }
+}
+
+/** Mirrors the component: the optimistic state wins until it is cleared. */
+function shown(pending: string | null, lifecycle: string): string {
+  return pending ?? lifecycle;
+}
+
+describe("the lifecycle a button lands the company in", () => {
+  it("maps resume to running, not to 'resumed'", () => {
+    // THE one to get wrong. The success *toast* says "Company resumed", and
+    // reusing that wording here would set `pending` to a lifecycle the host
+    // never reports — so `running` would be false, the Resume button would
+    // stay on screen, and the company would look stuck.
+    expect(resultOf("resume")).toBe("running");
+  });
+
+  it("maps the other three to their own names", () => {
+    expect(resultOf("pause")).toBe("paused");
+    expect(resultOf("suspend")).toBe("suspended");
+    expect(resultOf("archive")).toBe("archived");
+  });
+
+  it("produces a state the buttons actually branch on", () => {
+    // The controls derive `running`/`paused`/`archived` by comparing to these
+    // literals. A value outside the set renders no button at all, which is how
+    // a company becomes unoperatable from the console.
+    const known = ["running", "paused", "suspended", "archived"];
+    for (const action of ["pause", "resume", "suspend", "archive"] as LifecycleAction[]) {
+      expect(known).toContain(resultOf(action));
+    }
+  });
+});
+
+describe("what the operator sees while the host is still answering", () => {
+  it("shows the requested state immediately, not the stale one", () => {
+    // The click flips this before any await. Previously the buttons waited on
+    // the action *and* the refresh behind it, re-enabling in between while
+    // still offering "Pause" on a company that had just been paused.
+    expect(shown(resultOf("pause"), "running")).toBe("paused");
+  });
+
+  it("falls back to the host's answer once the request settles", () => {
+    // Cleared in `finally`, so this is also the failure path: an action the
+    // host rejected must not leave the console asserting the state it asked
+    // for.
+    expect(shown(null, "running")).toBe("running");
+  });
+});

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -499,6 +499,51 @@ async fn revert_config(company: AdminScopedCompany) -> Result<Json<MutationRespo
     }))
 }
 
+/// `POST …/inference/restart` — rebuild this company's runtime in place, now.
+///
+/// The action behind the console's "Restart required" notice. Saving inference
+/// already attempts this rebuild ([`set_config`]), so this route exists for the
+/// cases that attempt could not cover: a company that was already sitting in the
+/// restart-required state before #290 landed, one whose rebuild failed
+/// transiently, and one an operator arrives at without touching the form at all.
+/// Without it the notice is a dead end — it names a restart the operator of a
+/// hosted tenant has no way to perform, since the container is the unit of
+/// restart and the control plane has no button for it.
+///
+/// Requires authority over the company, like the save it mirrors: rebuilding
+/// swaps the brain every agent thinks with.
+///
+/// **Idempotent and safe to call when nothing is pending.** A rebuild of a
+/// company that is already live is a no-op from the operator's point of view —
+/// same journal, same parked approvals, same grants (see
+/// [`rebuild`](crate::runtime::rebuild)) — so this does not gate on
+/// `restart_required` first. Gating would introduce a race in which the check
+/// and the rebuild disagree, and would refuse the one case most worth allowing:
+/// an operator trying to recover a company whose state the console is reading
+/// wrongly.
+async fn restart_runtime(
+    State(state): State<AppState>,
+    company: AdminScopedCompany,
+) -> Result<Json<MutationResponse>, ApiError> {
+    let id = company.runtime.id().clone();
+    let successor = crate::runtime::rebuild_company(&state, &id)
+        .await
+        .map_err(ApiError)?;
+    // Read the status off the *successor*, never off the runtime we came in
+    // with: a rebuild that landed on the same brain must still report honestly
+    // rather than claim a success the runtime cannot back up.
+    let status = effective_status(successor.as_ref()).await?;
+    Ok(Json(MutationResponse {
+        note: if status.restart_required {
+            RESTART_NOTE
+        } else {
+            REBUILT_NOTE
+        }
+        .to_string(),
+        status,
+    }))
+}
+
 /// `POST …/inference/test` — a live one-message probe of the resolved provider.
 ///
 /// Gated on the `openhuman` feature (the HTTP provider lives there); without it

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -75,6 +75,7 @@ pub fn router() -> Router<AppState> {
         get(get_status).put(set_config).delete(revert_config),
     )
     .merge(scoped("/inference/test", post(test_config)))
+    .merge(scoped("/inference/restart", post(restart_runtime)))
 }
 
 /// The company's effective inference status as the console renders it. **Never**

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -721,11 +721,11 @@ mod tests {
         let home_dir = home();
         let home = home_dir.path();
         let id = CompanyId::new("acme");
-        let state = state_with_company(home).await.with_rebuilder(std::sync::Arc::new(
-            Working {
+        let state = state_with_company(home)
+            .await
+            .with_rebuilder(std::sync::Arc::new(Working {
                 home: home.to_path_buf(),
-            },
-        ));
+            }));
         state.set_boot_inputs(id.clone(), crate::runtime::BootInputs::default());
         let before = state.registry().get(&id).expect("registered");
 
@@ -755,11 +755,11 @@ mod tests {
         let home_dir = home();
         let home = home_dir.path();
         let id = CompanyId::new("acme");
-        let state = state_with_company(home).await.with_rebuilder(std::sync::Arc::new(
-            Working {
+        let state = state_with_company(home)
+            .await
+            .with_rebuilder(std::sync::Arc::new(Working {
                 home: home.to_path_buf(),
-            },
-        ));
+            }));
         state.set_boot_inputs(id, crate::runtime::BootInputs::default());
 
         for attempt in 1..=2 {

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -693,6 +693,104 @@ mod tests {
         state
     }
 
+    /// A rebuilder that rebuilds over the handover, as the binary's does.
+    struct Working {
+        home: std::path::PathBuf,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::runtime::RuntimeRebuilder for Working {
+        async fn rebuild(
+            &self,
+            _state: &AppState,
+            request: crate::runtime::RebuildRequest,
+        ) -> crate::Result<crate::company::runtime::CompanyRuntime> {
+            RuntimeBuilder::new(self.home.clone(), request.manifest)
+                .with_id(request.id)
+                .with_handover(request.handover)
+                .build()
+                .await
+        }
+    }
+
+    /// `POST …/inference/restart` rebuilds the runtime in place, so the console's
+    /// "Restart required" notice has an action behind it rather than being a
+    /// dead end pointing at a container the operator may not be able to touch.
+    #[tokio::test]
+    async fn restart_rebuilds_the_registered_runtime() {
+        let home_dir = home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with_company(home).await.with_rebuilder(std::sync::Arc::new(
+            Working {
+                home: home.to_path_buf(),
+            },
+        ));
+        state.set_boot_inputs(id.clone(), crate::runtime::BootInputs::default());
+        let before = state.registry().get(&id).expect("registered");
+
+        let (status, resp, raw) =
+            send(&state, "POST", "/api/v1/company/inference/restart", None).await;
+        assert_eq!(status, StatusCode::OK, "{raw}");
+
+        // A genuinely different runtime is registered — the point of the route.
+        let after = state.registry().get(&id).expect("registered");
+        assert!(
+            !std::sync::Arc::ptr_eq(&before, &after),
+            "the restart must actually swap the runtime, not report success and leave it"
+        );
+        // And it is taking work, rather than stuck in the quiesce window. A
+        // company parked there refuses every cycle forever, which is worse than
+        // the stale brain the rebuild was replacing.
+        assert!(!after.is_quiesced());
+        assert!(resp["status"].is_object(), "{raw}");
+    }
+
+    /// Calling it twice is not an error. The console offers the button off a
+    /// status read, so it can always be a moment stale — refusing when nothing
+    /// is pending would turn a harmless retry into a failure an operator has to
+    /// interpret.
+    #[tokio::test]
+    async fn restarting_a_healthy_company_is_a_no_op_not_a_refusal() {
+        let home_dir = home();
+        let home = home_dir.path();
+        let id = CompanyId::new("acme");
+        let state = state_with_company(home).await.with_rebuilder(std::sync::Arc::new(
+            Working {
+                home: home.to_path_buf(),
+            },
+        ));
+        state.set_boot_inputs(id, crate::runtime::BootInputs::default());
+
+        for attempt in 1..=2 {
+            let (status, _, raw) =
+                send(&state, "POST", "/api/v1/company/inference/restart", None).await;
+            assert_eq!(status, StatusCode::OK, "attempt {attempt}: {raw}");
+        }
+    }
+
+    /// A host that wired no rebuilder cannot do this, and must say so rather
+    /// than report a success that changed nothing. This is the pre-#290
+    /// deployment, and the console keeps showing the restart notice.
+    #[tokio::test]
+    async fn a_host_that_cannot_rebuild_says_so() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path()).await;
+
+        let (status, _, raw) =
+            send(&state, "POST", "/api/v1/company/inference/restart", None).await;
+        assert_ne!(status, StatusCode::OK, "{raw}");
+        assert!(
+            raw.contains("restart the process"),
+            "the failure must tell the operator what will work instead: {raw}"
+        );
+
+        // Critically, the company is still serving. A failed rebuild that left
+        // it quiesced would turn a cosmetic dead end into an outage.
+        let (status, _, _) = send(&state, "GET", "/api/v1/company/inference", None).await;
+        assert_eq!(status, StatusCode::OK);
+    }
+
     async fn send(
         state: &AppState,
         method: &str,


### PR DESCRIPTION
## Why

Three controls in the console did not take effect when you pressed them. Each
had a different cause, so this fixes three distinct things rather than one.

## 1. "Restart required" was a dead end

`InferenceSection` showed a persistent notice saying the company had to be
restarted before agents would stop echoing — with no way to restart it. That is
worst for the operator most likely to see it: a hosted tenant's unit of restart
is its container, and the control plane has no button for it.

The in-place rebuild from #290 already existed and already ran automatically
inside `PUT …/inference`. What was missing was any way to ask for it on its own,
so `rebuild_company` had **no HTTP surface** — it was reachable only as a side
effect of saving the form.

- **New route** `POST …/inference/restart`, admin-scoped like the save it
  mirrors, since rebuilding swaps the brain every agent thinks with.
- **New button** "Restart now" on the notice, admin-only so a member is not
  shown a control that can only 403.

It deliberately does not gate on `restart_required` first. Rebuilding a healthy
company is a no-op from the operator's point of view — same journal, same parked
approvals, same grants — so gating would buy nothing, would introduce a race
between the check and the rebuild, and would refuse the case most worth
allowing: recovering a company whose state the console is reading wrongly.

The resulting status is read off the **successor** runtime, so a rebuild that
lands on the same brain still reports honestly. A host with no rebuilder wired
fails with the message naming the process restart that would work, and the
console shows that rather than claiming a success that changed nothing.

## 2. Lifecycle buttons lagged the click by two round trips

`run()` awaited the action, then fired `feed.refresh()` un-awaited while
clearing `busy` immediately. Between those, the operator saw re-enabled buttons
still offering "Pause" on a company they had just paused — which reads as a
click that did not register, and invites a second one.

Now a `pending` state is set *before* the await, so the buttons move on the
click, and the refresh is awaited so `pending` is not dropped while the
authoritative read is still in flight. Cleared in `finally`, so a rejected
action reverts to the host's answer instead of leaving the console asserting a
state that was refused.

Note `resume` → `running`, not `"resumed"`: the success toast and the lifecycle
value are different vocabularies, and collapsing them would leave the Resume
button on screen forever. There is a test for exactly that.

## 3. "Replay tour" waited on a network download

`Joyride` is `lazy()`, so the chunk only began downloading *after* the click.
The toast said the tour was starting and then nothing visible happened until it
arrived — long enough on a cold cache to read as a broken button.

The fetch now starts on pointer-enter/focus of the button, so by the time
`Suspense` asks for the module it has usually resolved. `import()` caches its
module promise, so repeated calls are lookups rather than requests. Lazy loading
is kept — most operators never run the tour.

## Commands run

- `cargo test` — 2418 passed, 0 failed, 1 ignored
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -p opencompany -- --check` — clean
- `cd frontend && pnpm typecheck` — clean
- `cd frontend && pnpm test` — 725 passed across 64 files

(`cargo fmt --all` reports pre-existing diffs in the untouched `vendor/openhuman`
submodule, hence `-p opencompany`.)

## Tests added

11 new. Backend: the restart swaps the registered runtime and leaves it
accepting work rather than parked in the quiesce window; calling it twice is not
a refusal; a host that cannot rebuild says so **and is still serving**, since a
failed rebuild that left a company quiesced would turn a cosmetic dead end into
an outage. Frontend: the route the client calls including the single-company
alias, that the console follows the returned status, and the lifecycle mapping
with `resume` → `running` pinned explicitly.

## Behaviour changes

- New route `POST …/inference/restart` (admin authority required).
- Lifecycle buttons update optimistically and revert on failure.
- No API change for the tour — a prefetch only.
