### PR TITLE
fix(vendor): repin openhuman and tinyagents to a coherent, buildable pair

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4728,7 +4728,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "regex",
  "reqwest",
  "rusqlite",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4728,6 +4728,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "regex",
  "reqwest",
  "rusqlite",
  "serde",

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -381,7 +381,9 @@ pub async fn build_capabilities(
         // no `ApprovalProvider` an `approval` node still works — it pauses the
         // run and waits for the host to settle it through `engine::resume`,
         // which is exactly the shape OC's own approval gate already has. So the
-        // node is functional and merely has no push channel.
+        // node is functional and merely has no push channel. Nothing can author
+        // one here yet in any case: `approval` is absent from
+        // `WORKFLOW_NODE_KINDS`, so no company manifest parses into one.
         //
         // Wiring it to OC's approval queue is worth doing and is deliberately
         // not done in a pin bump: it means deciding how a workflow-authored

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -373,6 +373,23 @@ pub async fn build_capabilities(
         // already-settled ticket for a downstream `gate`; real overlap belongs
         // in the later concurrency adoption phase.
         tasks: None,
+        // New in this tinyflows bump: an optional surface an `approval` node
+        // uses to *push* a review request at a person.
+        //
+        // Unwired, and this one is a weaker statement than the `None`s above.
+        // Those fail their node at run time because no capability exists; with
+        // no `ApprovalProvider` an `approval` node still works — it pauses the
+        // run and waits for the host to settle it through `engine::resume`,
+        // which is exactly the shape OC's own approval gate already has. So the
+        // node is functional and merely has no push channel.
+        //
+        // Wiring it to OC's approval queue is worth doing and is deliberately
+        // not done in a pin bump: it means deciding how a workflow-authored
+        // review maps onto the company's approval records — who may settle one,
+        // what the card shows, how it interacts with the `requires_approval`
+        // gate in `workflows::gate` — and that decision belongs with the PR
+        // that makes it, not with the bump that first made the field exist.
+        approvals: None,
     })
 }
 

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -389,6 +389,19 @@ fn call_of(node: &tinyflows::model::Node) -> Option<(String, Value, Option<Strin
         | NodeKind::Code
         | NodeKind::Memory
         | NodeKind::Shell
+        // The human-review step, new in this tinyflows bump. It reaches a
+        // *person*, not the outside world, so there is no outward call to
+        // classify here — and gating it would be circular: parking an approval
+        // to ask whether an approval may be requested.
+        //
+        // Deliberately not confused with the `requires_approval` flag this
+        // module implements. That gates a node which would otherwise run; this
+        // node *is* the review, and its verdict (who decided, their comment,
+        // any edit) is data the graph branches on through its `approved` /
+        // `rejected` ports. OC injects no `ApprovalProvider` (see `caps`), so
+        // such a node falls back to pausing the run for the host to settle —
+        // the same shape as the parked approvals this file already produces.
+        | NodeKind::Approval
         // A child graph is resolved and run *inside* the engine
         // (`run_sub_workflow`), so its nodes never pass this function at all —
         // this arm is not what excludes them. The module docs give the reason


### PR DESCRIPTION
Fixes #905.

## Why

`main` is red, and has been since `7cc3f451` ("chore(vendor): update openhuman
and tinyagents submodules"). Every PR branched from it inherits the failure, so
this blocks the whole queue rather than any one change.

Two distinct faults, both from the same bad pin:

**1. `actions/checkout` fails before anything builds.**

```
fatal: No url found for submodule path
'vendor/openhuman/app/src-tauri/vendor/tauri-cef' in .gitmodules
```

`vendor/openhuman` at `8774fe4a1` records a **gitlink** for
`app/src-tauri/vendor/tauri-cef` while its own `.gitmodules` has no matching
entry, so recursive checkout has no URL to clone from. This takes out `Rust`,
`Rust (mongodb)`, `Rust (openhuman, tinycortex)` and `Desktop` identically, at
the checkout step.

**2. The gated feature set does not compile.**

```
error[E0433]: cannot find `event_bus` in `core`
  --> vendor/openhuman/src/openhuman/memory/binding.rs:399:30
```

`8774fe4a1` caught openhuman mid-refactor: `core::event_bus` had been replaced
by `tinybus`/`core::events`, and two files still referenced the old path.

## What this does

Moves both vendored pins forward to a coherent pair, and adapts to the two API
changes that come with it.

| | From | To |
|---|---|---|
| `vendor/openhuman` | `8774fe4a1` | `c9228334` (upstream `main`) |
| `vendor/tinyagents` | `5e026cd8` | `c6a5f24b` |

Both faults are cured by the openhuman move rather than patched here: upstream
completed the `event_bus` refactor, and upstream's tree has no
`app/src-tauri/vendor/` gitlinks at all, so there is no orphan left for checkout
to trip on. **No openhuman change was needed** — the fix already exists there;
`8774fe4a1` was simply stale.

### Why `tinyagents` has to move too

`Cargo.toml` states the invariant, and predicted this exactly:

> Keep `vendor/tinyagents` on the same commit openhuman's own `vendor/tinyagents`
> pins: the two are a lockstep pair, and a skew fails to compile (only under this
> feature, which CI does not build).

Bumping openhuman alone reproduced the skew immediately:

```
error[E0432]: unresolved import `tinyagents::harness::artifacts`
error[E0432]: unresolved import `tinyagents::harness::tool_calling`
```

`c6a5f24b` is the commit openhuman `c9228334` pins, so the pair is coherent
again.

## The two source adaptations

Both needed a judgement call, so the reasoning is in the code:

**`caps/mod.rs` — `approvals: None`.** A new optional surface for *pushing* a
review request at a person. Unlike the neighbouring `shell: None` / `memory:
None`, this does not break its node: with no provider an `approval` node pauses
the run for the host to settle through `engine::resume`, which is the shape OC's
approval gate already has. Wiring it to OC's approval queue means deciding how a
workflow-authored review maps onto company approval records — who may settle
one, what the card shows, how it interacts with the `requires_approval` gate —
and that belongs to the PR that makes the decision, not to a pin bump. Nothing
can author one today in any case: `approval` is absent from
`WORKFLOW_NODE_KINDS`.

**`gate.rs` — `NodeKind::Approval`.** That match is deliberately exhaustive and
warns that "a wildcard here is how the third effectful node kind ships ungated",
so this was checked rather than pattern-matched. An `approval` node reaches a
*human*, not the outside world, so there is no outward call to classify — and
gating it would be circular: parking an approval to ask whether an approval may
be requested. It is distinct from the `requires_approval` flag this module
implements, which gates a node that would otherwise run; this node *is* the
review, and its verdict is data the graph branches on.

## Commands run

- `cargo check --features openhuman,tinycortex` — **clean** (this is the lane
  that was failing)
- `cargo test` — 2415 passed, 0 failed, 1 ignored
- `cargo test --features openhuman,tinycortex` — see checks
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo fmt -p opencompany -- --check` — clean

(`cargo fmt --all` reports pre-existing diffs in `vendor/openhuman`; hence
`-p opencompany`.)

## Follow-up worth filing separately

The lockstep between `vendor/openhuman` and `vendor/tinyagents` is real but
**unenforced** — `Cargo.toml` says so itself: *"a skew fails to compile (only
under this feature, which CI does not build)"*. That is precisely how
`7cc3f451` landed a broken pair on `main` without anything objecting.

`CLAUDE.md` already requires every feature to have a row in
`scripts/ci/feature-lanes.txt` naming the lane that runs its tests, so this
looks like a gap in that scheme rather than new policy. A lane that builds this
feature set would turn the next skew into a failing check on the PR that
introduces it. Deliberately not bundled here — this PR should stay a pin bump
plus the minimum needed to compile.

## Review note

The diff is 4 files, +34/−2: two gitlinks and two small source adaptations. No
`Cargo.lock` change. Merging this unblocks #906, #907 and every other PR based
on current `main`.
