### PR TITLE
feat(agents): per-agent definition files, custom prompts, and three-level tool scoping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,7 +408,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -456,17 +455,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-macros"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1334,6 +1322,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,6 +1779,18 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "libgit2-sys",
+ "log",
 ]
 
 [[package]]
@@ -2634,6 +2643,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
+name = "libgit2-sys"
+version = "0.18.7+1.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2676,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3164,7 +3197,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -3176,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.8"
+version = "0.63.7"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3191,13 +3224,14 @@ dependencies = [
  "chrono-tz",
  "cron",
  "directories",
- "dirs",
+ "dirs 5.0.1",
  "dotenvy",
  "ed25519-dalek",
  "flate2",
  "fs2",
  "futures",
  "futures-util",
+ "git2",
  "glob",
  "hex",
  "hkdf",
@@ -3214,6 +3248,7 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest",
+ "ring",
  "rusqlite",
  "rustls",
  "schemars",
@@ -3232,16 +3267,13 @@ dependencies = [
  "tinycortex",
  "tinycortex-api",
  "tinyhumans-sdk",
- "tinymemory",
- "tinymemory-api",
- "tinymemory-core",
- "tinymemory-tinycortex",
+ "tinyjuice",
  "tinyplace",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml",
+ "toml 1.1.4+spec-1.1.0",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3586,7 +3618,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -4224,6 +4256,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4728,7 +4769,6 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "regex",
  "reqwest",
  "rusqlite",
  "serde",
@@ -4803,8 +4843,10 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs",
+ "dirs 5.0.1",
  "futures",
+ "git2",
+ "hex",
  "log",
  "parking_lot",
  "rand 0.10.2",
@@ -4819,7 +4861,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml",
+ "toml 0.8.23",
  "tracing",
  "uuid",
  "walkdir",
@@ -4842,6 +4884,8 @@ dependencies = [
 [[package]]
 name = "tinyflows"
 version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5815f3dded76503a1b1867b55282941f50b3ecef4dcbfd0786640dc189250557"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4873,74 +4917,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinymemory"
-version = "1.0.1"
+name = "tinyjuice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dde6760266db10b01d339438b651045e3815a52d00eeb40e2f41f22304d6cac"
 dependencies = [
- "anyhow",
  "async-trait",
+ "dirs 6.0.0",
+ "hex",
  "log",
- "serde",
- "serde_json",
- "tinymemory-api",
-]
-
-[[package]]
-name = "tinymemory-api"
-version = "0.1.1"
-dependencies = [
- "anyhow",
- "async-trait",
- "chrono",
- "log",
- "schemars",
+ "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.20",
- "uuid",
-]
-
-[[package]]
-name = "tinymemory-core"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "axum",
- "chrono",
- "dirs",
- "futures",
- "log",
- "parking_lot",
- "rand 0.8.7",
- "regex",
- "reqwest",
- "rusqlite",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "thiserror 2.0.20",
- "tinyagents",
- "tinycortex",
- "tinycortex-api",
- "tinymemory",
- "tinymemory-api",
  "tokio",
- "tracing",
- "url",
- "uuid",
- "walkdir",
-]
-
-[[package]]
-name = "tinymemory-tinycortex"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "async-trait",
- "tinycortex",
- "tinymemory",
- "tinymemory-api",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -5101,17 +5095,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5125,14 +5140,28 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5141,8 +5170,14 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow",
+ "winnow 1.0.4",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5384,6 +5419,12 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5971,6 +6012,15 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6172,6 +6222,10 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
+
+[[patch.unused]]
+name = "tinyflows"
+version = "0.6.0"
 
 [[patch.unused]]
 name = "whisper-rs-sys"

--- a/companies/agentic_accounting_firm/agents/audit_prep.toml
+++ b/companies/agentic_accounting_firm/agents/audit_prep.toml
@@ -1,0 +1,2 @@
+role = "Audit Preparer"
+description = "Assemble documentation for audits."

--- a/companies/agentic_accounting_firm/agents/bookkeeper.toml
+++ b/companies/agentic_accounting_firm/agents/bookkeeper.toml
@@ -1,2 +1,8 @@
 role = "Bookkeeper"
 description = "Record transactions and reconcile accounts."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_accounting_firm/agents/bookkeeper.toml
+++ b/companies/agentic_accounting_firm/agents/bookkeeper.toml
@@ -1,0 +1,2 @@
+role = "Bookkeeper"
+description = "Record transactions and reconcile accounts."

--- a/companies/agentic_accounting_firm/agents/forecaster.toml
+++ b/companies/agentic_accounting_firm/agents/forecaster.toml
@@ -1,0 +1,2 @@
+role = "Forecaster"
+description = "Build financial forecasts and budgets."

--- a/companies/agentic_accounting_firm/agents/payroll_agent.toml
+++ b/companies/agentic_accounting_firm/agents/payroll_agent.toml
@@ -1,0 +1,2 @@
+role = "Payroll Agent"
+description = "Run payroll and related filings."

--- a/companies/agentic_accounting_firm/agents/tax_preparer.toml
+++ b/companies/agentic_accounting_firm/agents/tax_preparer.toml
@@ -1,0 +1,2 @@
+role = "Tax Preparer"
+description = "Prepare tax filings."

--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Accounting Firm harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Accounting Firm harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_accounting_firm/company.toml
+++ b/companies/agentic_accounting_firm/company.toml
@@ -7,31 +7,6 @@ name = "Agentic Accounting Firm"
 output = "Books, taxes, payroll, and forecasts"
 human_role = "Sign-off on filings"
 
-[[agent]]
-id = "bookkeeper"
-role = "Bookkeeper"
-description = "Record transactions and reconcile accounts."
-
-[[agent]]
-id = "tax_preparer"
-role = "Tax Preparer"
-description = "Prepare tax filings."
-
-[[agent]]
-id = "payroll_agent"
-role = "Payroll Agent"
-description = "Run payroll and related filings."
-
-[[agent]]
-id = "forecaster"
-role = "Forecaster"
-description = "Build financial forecasts and budgets."
-
-[[agent]]
-id = "audit_prep"
-role = "Audit Preparer"
-description = "Assemble documentation for audits."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_consultation_firm/agents/deck_builder.toml
+++ b/companies/agentic_consultation_firm/agents/deck_builder.toml
@@ -1,0 +1,2 @@
+role = "Deck Builder"
+description = "Produce client-ready presentations."

--- a/companies/agentic_consultation_firm/agents/financial_modeler.toml
+++ b/companies/agentic_consultation_firm/agents/financial_modeler.toml
@@ -1,0 +1,2 @@
+role = "Financial Modeler"
+description = "Build the supporting financial models."

--- a/companies/agentic_consultation_firm/agents/implementation_planner.toml
+++ b/companies/agentic_consultation_firm/agents/implementation_planner.toml
@@ -1,0 +1,2 @@
+role = "Implementation Planner"
+description = "Turn strategy into an execution roadmap."

--- a/companies/agentic_consultation_firm/agents/industry_analyst.toml
+++ b/companies/agentic_consultation_firm/agents/industry_analyst.toml
@@ -1,0 +1,2 @@
+role = "Industry Analyst"
+description = "Industry, market, and competitive analysis."

--- a/companies/agentic_consultation_firm/agents/interviewer.toml
+++ b/companies/agentic_consultation_firm/agents/interviewer.toml
@@ -1,0 +1,2 @@
+role = "Interviewer"
+description = "Conduct and synthesize stakeholder interviews."

--- a/companies/agentic_consultation_firm/agents/researcher.toml
+++ b/companies/agentic_consultation_firm/agents/researcher.toml
@@ -1,2 +1,8 @@
 role = "Researcher"
 description = "Desk research and evidence gathering."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_consultation_firm/agents/researcher.toml
+++ b/companies/agentic_consultation_firm/agents/researcher.toml
@@ -1,0 +1,2 @@
+role = "Researcher"
+description = "Desk research and evidence gathering."

--- a/companies/agentic_consultation_firm/agents/strategist.toml
+++ b/companies/agentic_consultation_firm/agents/strategist.toml
@@ -1,0 +1,2 @@
+role = "Strategist"
+description = "Synthesize findings into strategy recommendations."

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Consulting Firm harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Consulting Firm harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_consultation_firm/company.toml
+++ b/companies/agentic_consultation_firm/company.toml
@@ -24,41 +24,6 @@ human_role = "Executive workshops"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
-[[agent]]
-id = "researcher"
-role = "Researcher"
-description = "Desk research and evidence gathering."
-
-[[agent]]
-id = "interviewer"
-role = "Interviewer"
-description = "Conduct and synthesize stakeholder interviews."
-
-[[agent]]
-id = "industry_analyst"
-role = "Industry Analyst"
-description = "Industry, market, and competitive analysis."
-
-[[agent]]
-id = "strategist"
-role = "Strategist"
-description = "Synthesize findings into strategy recommendations."
-
-[[agent]]
-id = "financial_modeler"
-role = "Financial Modeler"
-description = "Build the supporting financial models."
-
-[[agent]]
-id = "deck_builder"
-role = "Deck Builder"
-description = "Produce client-ready presentations."
-
-[[agent]]
-id = "implementation_planner"
-role = "Implementation Planner"
-description = "Turn strategy into an execution roadmap."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_customer_support/agents/bug_reporter.toml
+++ b/companies/agentic_customer_support/agents/bug_reporter.toml
@@ -1,0 +1,2 @@
+role = "Bug Reporter"
+description = "File actionable bug reports."

--- a/companies/agentic_customer_support/agents/docs_writer.toml
+++ b/companies/agentic_customer_support/agents/docs_writer.toml
@@ -1,0 +1,2 @@
+role = "Docs Writer"
+description = "Write and maintain help docs."

--- a/companies/agentic_customer_support/agents/escalation_manager.toml
+++ b/companies/agentic_customer_support/agents/escalation_manager.toml
@@ -1,0 +1,2 @@
+role = "Escalation Manager"
+description = "Route and manage escalations."

--- a/companies/agentic_customer_support/agents/refund_handler.toml
+++ b/companies/agentic_customer_support/agents/refund_handler.toml
@@ -1,0 +1,2 @@
+role = "Refund Handler"
+description = "Process refunds within policy."

--- a/companies/agentic_customer_support/agents/support_agent.toml
+++ b/companies/agentic_customer_support/agents/support_agent.toml
@@ -1,0 +1,2 @@
+role = "Support Agent"
+description = "Resolve inbound customer tickets."

--- a/companies/agentic_customer_support/agents/support_agent.toml
+++ b/companies/agentic_customer_support/agents/support_agent.toml
@@ -1,2 +1,8 @@
 role = "Support Agent"
 description = "Resolve inbound customer tickets."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Customer Support Company harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -7,31 +7,6 @@ name = "Agentic Customer Support Company"
 output = "Resolved tickets and current documentation"
 human_role = "Escalation and policy"
 
-[[agent]]
-id = "support_agent"
-role = "Support Agent"
-description = "Resolve inbound customer tickets."
-
-[[agent]]
-id = "docs_writer"
-role = "Docs Writer"
-description = "Write and maintain help docs."
-
-[[agent]]
-id = "bug_reporter"
-role = "Bug Reporter"
-description = "File actionable bug reports."
-
-[[agent]]
-id = "escalation_manager"
-role = "Escalation Manager"
-description = "Route and manage escalations."
-
-[[agent]]
-id = "refund_handler"
-role = "Refund Handler"
-description = "Process refunds within policy."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_customer_support/company.toml
+++ b/companies/agentic_customer_support/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Customer Support Company harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_design_studio/agents/brand_designer.toml
+++ b/companies/agentic_design_studio/agents/brand_designer.toml
@@ -1,2 +1,8 @@
 role = "Brand Designer"
 description = "Identity systems, logos, and guidelines."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_design_studio/agents/brand_designer.toml
+++ b/companies/agentic_design_studio/agents/brand_designer.toml
@@ -1,0 +1,2 @@
+role = "Brand Designer"
+description = "Identity systems, logos, and guidelines."

--- a/companies/agentic_design_studio/agents/illustrator.toml
+++ b/companies/agentic_design_studio/agents/illustrator.toml
@@ -1,0 +1,2 @@
+role = "Illustrator"
+description = "Custom illustration and iconography."

--- a/companies/agentic_design_studio/agents/motion_designer.toml
+++ b/companies/agentic_design_studio/agents/motion_designer.toml
@@ -1,0 +1,2 @@
+role = "Motion Designer"
+description = "Animation and motion graphics."

--- a/companies/agentic_design_studio/agents/ui_designer.toml
+++ b/companies/agentic_design_studio/agents/ui_designer.toml
@@ -1,0 +1,2 @@
+role = "UI Designer"
+description = "Product UI and design systems."

--- a/companies/agentic_design_studio/agents/user_researcher.toml
+++ b/companies/agentic_design_studio/agents/user_researcher.toml
@@ -1,0 +1,2 @@
+role = "User Researcher"
+description = "User testing and design validation."

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -24,31 +24,6 @@ human_role = "Creative direction sign-off"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
-[[agent]]
-id = "brand_designer"
-role = "Brand Designer"
-description = "Identity systems, logos, and guidelines."
-
-[[agent]]
-id = "ui_designer"
-role = "UI Designer"
-description = "Product UI and design systems."
-
-[[agent]]
-id = "motion_designer"
-role = "Motion Designer"
-description = "Animation and motion graphics."
-
-[[agent]]
-id = "illustrator"
-role = "Illustrator"
-description = "Custom illustration and iconography."
-
-[[agent]]
-id = "user_researcher"
-role = "User Researcher"
-description = "User testing and design validation."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Design Studio harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_design_studio/company.toml
+++ b/companies/agentic_design_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Design Studio harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_enterprise_sales/agents/contract_generator.toml
+++ b/companies/agentic_enterprise_sales/agents/contract_generator.toml
@@ -1,0 +1,2 @@
+role = "Contract Generator"
+description = "Generate contracts from templates."

--- a/companies/agentic_enterprise_sales/agents/crm_updater.toml
+++ b/companies/agentic_enterprise_sales/agents/crm_updater.toml
@@ -1,0 +1,2 @@
+role = "CRM Updater"
+description = "Keep CRM records accurate and current."

--- a/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
+++ b/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
@@ -1,0 +1,2 @@
+role = "Follow-up Agent"
+description = "Nurture and follow up on pipeline."

--- a/companies/agentic_enterprise_sales/agents/lead_gen.toml
+++ b/companies/agentic_enterprise_sales/agents/lead_gen.toml
@@ -1,0 +1,2 @@
+role = "Lead Generation"
+description = "Generate and qualify leads."

--- a/companies/agentic_enterprise_sales/agents/lead_gen.toml
+++ b/companies/agentic_enterprise_sales/agents/lead_gen.toml
@@ -1,2 +1,8 @@
 role = "Lead Generation"
 description = "Generate and qualify leads."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
+++ b/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
@@ -1,0 +1,2 @@
+role = "Outreach Personalizer"
+description = "Craft personalized outreach at scale."

--- a/companies/agentic_enterprise_sales/agents/proposal_writer.toml
+++ b/companies/agentic_enterprise_sales/agents/proposal_writer.toml
@@ -1,0 +1,2 @@
+role = "Proposal Writer"
+description = "Write tailored proposals."

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Enterprise Sales Organization harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -7,36 +7,6 @@ name = "Agentic Enterprise Sales Organization"
 output = "Qualified pipeline and proposals"
 human_role = "Closing strategic accounts"
 
-[[agent]]
-id = "lead_gen"
-role = "Lead Generation"
-description = "Generate and qualify leads."
-
-[[agent]]
-id = "outreach_personalizer"
-role = "Outreach Personalizer"
-description = "Craft personalized outreach at scale."
-
-[[agent]]
-id = "crm_updater"
-role = "CRM Updater"
-description = "Keep CRM records accurate and current."
-
-[[agent]]
-id = "proposal_writer"
-role = "Proposal Writer"
-description = "Write tailored proposals."
-
-[[agent]]
-id = "contract_generator"
-role = "Contract Generator"
-description = "Generate contracts from templates."
-
-[[agent]]
-id = "follow_up_agent"
-role = "Follow-up Agent"
-description = "Nurture and follow up on pipeline."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_enterprise_sales/company.toml
+++ b/companies/agentic_enterprise_sales/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Enterprise Sales Organization harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_game_business/agents/analytics_analyst.toml
+++ b/companies/agentic_game_business/agents/analytics_analyst.toml
@@ -1,0 +1,2 @@
+role = "Analytics Analyst"
+description = "Track KPIs, LTV, retention, and cohorts."

--- a/companies/agentic_game_business/agents/community_manager.toml
+++ b/companies/agentic_game_business/agents/community_manager.toml
@@ -1,0 +1,2 @@
+role = "Community Manager"
+description = "Grow and moderate the player community."

--- a/companies/agentic_game_business/agents/liveops_manager.toml
+++ b/companies/agentic_game_business/agents/liveops_manager.toml
@@ -1,0 +1,2 @@
+role = "LiveOps Manager"
+description = "Plan and run events and content updates."

--- a/companies/agentic_game_business/agents/monetization_designer.toml
+++ b/companies/agentic_game_business/agents/monetization_designer.toml
@@ -1,0 +1,2 @@
+role = "Monetization Designer"
+description = "Design offers, pricing, and the in-game economy."

--- a/companies/agentic_game_business/agents/player_support.toml
+++ b/companies/agentic_game_business/agents/player_support.toml
@@ -1,0 +1,2 @@
+role = "Player Support"
+description = "Resolve player issues and refunds."

--- a/companies/agentic_game_business/agents/store_optimizer.toml
+++ b/companies/agentic_game_business/agents/store_optimizer.toml
@@ -1,0 +1,2 @@
+role = "Store Optimizer"
+description = "App-store optimization and conversion."

--- a/companies/agentic_game_business/agents/user_acquisition.toml
+++ b/companies/agentic_game_business/agents/user_acquisition.toml
@@ -1,0 +1,2 @@
+role = "User Acquisition"
+description = "Run paid and organic UA campaigns."

--- a/companies/agentic_game_business/agents/user_acquisition.toml
+++ b/companies/agentic_game_business/agents/user_acquisition.toml
@@ -1,2 +1,8 @@
 role = "User Acquisition"
 description = "Run paid and organic UA campaigns."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_game_business/company.toml
+++ b/companies/agentic_game_business/company.toml
@@ -7,41 +7,6 @@ name = "Agentic Game Business"
 output = "LiveOps, user acquisition, and monetization for a live game"
 human_role = "Monetization and growth strategy"
 
-[[agent]]
-id = "user_acquisition"
-role = "User Acquisition"
-description = "Run paid and organic UA campaigns."
-
-[[agent]]
-id = "monetization_designer"
-role = "Monetization Designer"
-description = "Design offers, pricing, and the in-game economy."
-
-[[agent]]
-id = "liveops_manager"
-role = "LiveOps Manager"
-description = "Plan and run events and content updates."
-
-[[agent]]
-id = "store_optimizer"
-role = "Store Optimizer"
-description = "App-store optimization and conversion."
-
-[[agent]]
-id = "analytics_analyst"
-role = "Analytics Analyst"
-description = "Track KPIs, LTV, retention, and cohorts."
-
-[[agent]]
-id = "community_manager"
-role = "Community Manager"
-description = "Grow and moderate the player community."
-
-[[agent]]
-id = "player_support"
-role = "Player Support"
-description = "Resolve player issues and refunds."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_game_business/company.toml
+++ b/companies/agentic_game_business/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Game Business harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_game_business/company.toml
+++ b/companies/agentic_game_business/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Game Business harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_game_studio/agents/asset_generator.toml
+++ b/companies/agentic_game_studio/agents/asset_generator.toml
@@ -1,0 +1,2 @@
+role = "Asset Generator"
+description = "Generate art, audio, and 3D assets."

--- a/companies/agentic_game_studio/agents/balance_designer.toml
+++ b/companies/agentic_game_studio/agents/balance_designer.toml
@@ -1,0 +1,2 @@
+role = "Balance Designer"
+description = "Tune difficulty and game balance."

--- a/companies/agentic_game_studio/agents/gameplay_engineer.toml
+++ b/companies/agentic_game_studio/agents/gameplay_engineer.toml
@@ -1,0 +1,2 @@
+role = "Gameplay Engineer"
+description = "Implement gameplay systems and code."

--- a/companies/agentic_game_studio/agents/marketer.toml
+++ b/companies/agentic_game_studio/agents/marketer.toml
@@ -1,0 +1,2 @@
+role = "Marketer"
+description = "Market and promote the launch."

--- a/companies/agentic_game_studio/agents/narrative_designer.toml
+++ b/companies/agentic_game_studio/agents/narrative_designer.toml
@@ -1,0 +1,2 @@
+role = "Narrative Designer"
+description = "Story, characters, and dialogue."

--- a/companies/agentic_game_studio/agents/qa_tester.toml
+++ b/companies/agentic_game_studio/agents/qa_tester.toml
@@ -1,0 +1,2 @@
+role = "QA Tester"
+description = "Find and report bugs."

--- a/companies/agentic_game_studio/agents/world_builder.toml
+++ b/companies/agentic_game_studio/agents/world_builder.toml
@@ -1,2 +1,8 @@
 role = "World Builder"
 description = "Design worlds, lore, and settings."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_game_studio/agents/world_builder.toml
+++ b/companies/agentic_game_studio/agents/world_builder.toml
@@ -1,0 +1,2 @@
+role = "World Builder"
+description = "Design worlds, lore, and settings."

--- a/companies/agentic_game_studio/company.toml
+++ b/companies/agentic_game_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Game Studio harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_game_studio/company.toml
+++ b/companies/agentic_game_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Game Studio harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_game_studio/company.toml
+++ b/companies/agentic_game_studio/company.toml
@@ -7,41 +7,6 @@ name = "Agentic Game Studio"
 output = "Shippable games"
 human_role = "Creative and design direction"
 
-[[agent]]
-id = "world_builder"
-role = "World Builder"
-description = "Design worlds, lore, and settings."
-
-[[agent]]
-id = "narrative_designer"
-role = "Narrative Designer"
-description = "Story, characters, and dialogue."
-
-[[agent]]
-id = "gameplay_engineer"
-role = "Gameplay Engineer"
-description = "Implement gameplay systems and code."
-
-[[agent]]
-id = "asset_generator"
-role = "Asset Generator"
-description = "Generate art, audio, and 3D assets."
-
-[[agent]]
-id = "qa_tester"
-role = "QA Tester"
-description = "Find and report bugs."
-
-[[agent]]
-id = "balance_designer"
-role = "Balance Designer"
-description = "Tune difficulty and game balance."
-
-[[agent]]
-id = "marketer"
-role = "Marketer"
-description = "Market and promote the launch."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_influencer_business/agents/analytics_analyst.toml
+++ b/companies/agentic_influencer_business/agents/analytics_analyst.toml
@@ -1,0 +1,2 @@
+role = "Analytics Analyst"
+description = "Analyze performance and advise."

--- a/companies/agentic_influencer_business/agents/community_manager.toml
+++ b/companies/agentic_influencer_business/agents/community_manager.toml
@@ -1,0 +1,2 @@
+role = "Community Manager"
+description = "Engage and moderate the community."

--- a/companies/agentic_influencer_business/agents/publisher.toml
+++ b/companies/agentic_influencer_business/agents/publisher.toml
@@ -1,0 +1,2 @@
+role = "Publisher"
+description = "Schedule and post content."

--- a/companies/agentic_influencer_business/agents/scriptwriter.toml
+++ b/companies/agentic_influencer_business/agents/scriptwriter.toml
@@ -1,2 +1,8 @@
 role = "Scriptwriter"
 description = "Write video and post scripts."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_influencer_business/agents/scriptwriter.toml
+++ b/companies/agentic_influencer_business/agents/scriptwriter.toml
@@ -1,0 +1,2 @@
+role = "Scriptwriter"
+description = "Write video and post scripts."

--- a/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
+++ b/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
@@ -1,0 +1,2 @@
+role = "Sponsorship Outreach"
+description = "Source and negotiate sponsorships."

--- a/companies/agentic_influencer_business/agents/thumbnail_designer.toml
+++ b/companies/agentic_influencer_business/agents/thumbnail_designer.toml
@@ -1,0 +1,2 @@
+role = "Thumbnail Designer"
+description = "Generate thumbnails and cover art."

--- a/companies/agentic_influencer_business/agents/trend_scout.toml
+++ b/companies/agentic_influencer_business/agents/trend_scout.toml
@@ -1,0 +1,2 @@
+role = "Trend Scout"
+description = "Detect trends and content opportunities."

--- a/companies/agentic_influencer_business/agents/video_editor.toml
+++ b/companies/agentic_influencer_business/agents/video_editor.toml
@@ -1,0 +1,2 @@
+role = "Video Editor"
+description = "Edit video content."

--- a/companies/agentic_influencer_business/company.toml
+++ b/companies/agentic_influencer_business/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Influencer Business harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_influencer_business/company.toml
+++ b/companies/agentic_influencer_business/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Influencer Business harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_influencer_business/company.toml
+++ b/companies/agentic_influencer_business/company.toml
@@ -7,46 +7,6 @@ name = "Agentic Influencer Business"
 output = "A creator brand that never sleeps"
 human_role = "Occasional appearance or AI avatar"
 
-[[agent]]
-id = "scriptwriter"
-role = "Scriptwriter"
-description = "Write video and post scripts."
-
-[[agent]]
-id = "trend_scout"
-role = "Trend Scout"
-description = "Detect trends and content opportunities."
-
-[[agent]]
-id = "video_editor"
-role = "Video Editor"
-description = "Edit video content."
-
-[[agent]]
-id = "thumbnail_designer"
-role = "Thumbnail Designer"
-description = "Generate thumbnails and cover art."
-
-[[agent]]
-id = "publisher"
-role = "Publisher"
-description = "Schedule and post content."
-
-[[agent]]
-id = "analytics_analyst"
-role = "Analytics Analyst"
-description = "Analyze performance and advise."
-
-[[agent]]
-id = "community_manager"
-role = "Community Manager"
-description = "Engage and moderate the community."
-
-[[agent]]
-id = "sponsorship_outreach"
-role = "Sponsorship Outreach"
-description = "Source and negotiate sponsorships."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_law_firm/agents/compliance_agent.toml
+++ b/companies/agentic_law_firm/agents/compliance_agent.toml
@@ -1,0 +1,2 @@
+role = "Compliance Agent"
+description = "Check regulatory compliance."

--- a/companies/agentic_law_firm/agents/contract_drafter.toml
+++ b/companies/agentic_law_firm/agents/contract_drafter.toml
@@ -1,0 +1,2 @@
+role = "Contract Drafter"
+description = "Draft contracts and legal documents."

--- a/companies/agentic_law_firm/agents/discovery_agent.toml
+++ b/companies/agentic_law_firm/agents/discovery_agent.toml
@@ -1,0 +1,2 @@
+role = "Discovery Agent"
+description = "Run and review document discovery."

--- a/companies/agentic_law_firm/agents/legal_researcher.toml
+++ b/companies/agentic_law_firm/agents/legal_researcher.toml
@@ -1,2 +1,8 @@
 role = "Legal Researcher"
 description = "Case law and legal research."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_law_firm/agents/legal_researcher.toml
+++ b/companies/agentic_law_firm/agents/legal_researcher.toml
@@ -1,0 +1,2 @@
+role = "Legal Researcher"
+description = "Case law and legal research."

--- a/companies/agentic_law_firm/agents/litigation_support.toml
+++ b/companies/agentic_law_firm/agents/litigation_support.toml
@@ -1,0 +1,2 @@
+role = "Litigation Support"
+description = "Prepare materials for litigation."

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Law Firm harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -24,31 +24,6 @@ human_role = "Approving filings"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
-[[agent]]
-id = "legal_researcher"
-role = "Legal Researcher"
-description = "Case law and legal research."
-
-[[agent]]
-id = "contract_drafter"
-role = "Contract Drafter"
-description = "Draft contracts and legal documents."
-
-[[agent]]
-id = "litigation_support"
-role = "Litigation Support"
-description = "Prepare materials for litigation."
-
-[[agent]]
-id = "discovery_agent"
-role = "Discovery Agent"
-description = "Run and review document discovery."
-
-[[agent]]
-id = "compliance_agent"
-role = "Compliance Agent"
-description = "Check regulatory compliance."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_law_firm/company.toml
+++ b/companies/agentic_law_firm/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Law Firm harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_marketing_agency/agents/analytics_analyst.toml
+++ b/companies/agentic_marketing_agency/agents/analytics_analyst.toml
@@ -1,0 +1,2 @@
+role = "Analytics Analyst"
+description = "Measure performance and report."

--- a/companies/agentic_marketing_agency/agents/brand_strategist.toml
+++ b/companies/agentic_marketing_agency/agents/brand_strategist.toml
@@ -1,0 +1,2 @@
+role = "Brand Strategist"
+description = "Positioning and brand strategy."

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -22,8 +22,11 @@ not specific enough to ship.
 # fails silently and confidently.
 prompt_files = ["prompts/house-style.md"]
 
-# Live workspace documents, re-read on every roster rebuild and placed last in
-# the prompt. Unlike `prompt_files` these are operator-owned and may not exist
-# yet, so a missing one is skipped. Editing either file reaches the next turn
-# without a restart.
+# Live workspace documents, placed last in the prompt once the harness carries
+# them. Unlike `prompt_files` these are operator-owned and may not exist yet, so
+# a missing one is skipped rather than refused.
+#
+# Selection and reading are implemented; the harness wiring that spends them is
+# not yet, so this line is declarative today. See
+# docs/spec/runtime/orchestration/context-routing.md.
 context = ["Brand/Brand voice.md", "Playbooks/Campaign checklist.md"]

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -1,2 +1,29 @@
 role = "Copywriter"
 description = "Write ads, pages, and campaign copy."
+
+# A custom prompt is appended to the generated persona, never substituted for
+# it: the generated line is what binds this agent to *this* role at *this*
+# company, and replacing it would cost the agent its identity. What belongs here
+# is how the role works, not who it is.
+prompt = """
+Write for the reader, not the client. Open on the problem they already have,
+in their words. Never open on the company.
+
+One idea per sentence. Cut every adjective you cannot defend with a number or
+an example. If a line would survive being pasted into a competitor's ad, it is
+not specific enough to ship.
+"""
+
+# Checked-in briefing documents, resolved relative to this `agents/` directory
+# and read at manifest load. These are version controlled beside the agent, so
+# they are placed early in the prompt where a provider cache can reuse them; a
+# path that does not exist is a manifest error rather than a skipped entry,
+# because a role whose prompt was written around a briefing it never received
+# fails silently and confidently.
+prompt_files = ["prompts/house-style.md"]
+
+# Live workspace documents, re-read on every roster rebuild and placed last in
+# the prompt. Unlike `prompt_files` these are operator-owned and may not exist
+# yet, so a missing one is skipped. Editing either file reaches the next turn
+# without a restart.
+context = ["Brand/Brand voice.md", "Playbooks/Campaign checklist.md"]

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -1,0 +1,2 @@
+role = "Copywriter"
+description = "Write ads, pages, and campaign copy."

--- a/companies/agentic_marketing_agency/agents/creative_director.toml
+++ b/companies/agentic_marketing_agency/agents/creative_director.toml
@@ -1,0 +1,2 @@
+role = "Creative Director"
+description = "Own creative concept and direction."

--- a/companies/agentic_marketing_agency/agents/creative_director.toml
+++ b/companies/agentic_marketing_agency/agents/creative_director.toml
@@ -1,2 +1,8 @@
 role = "Creative Director"
 description = "Own creative concept and direction."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_marketing_agency/agents/email_marketer.toml
+++ b/companies/agentic_marketing_agency/agents/email_marketer.toml
@@ -1,0 +1,2 @@
+role = "Email Marketer"
+description = "Design and send lifecycle email."

--- a/companies/agentic_marketing_agency/agents/landing_page_builder.toml
+++ b/companies/agentic_marketing_agency/agents/landing_page_builder.toml
@@ -1,0 +1,2 @@
+role = "Landing Page Builder"
+description = "Build and test conversion pages."

--- a/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
+++ b/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
@@ -1,0 +1,2 @@
+role = "Paid Ads Manager"
+description = "Plan and run paid-acquisition campaigns."

--- a/companies/agentic_marketing_agency/agents/prompts/house-style.md
+++ b/companies/agentic_marketing_agency/agents/prompts/house-style.md
@@ -1,0 +1,34 @@
+# House style
+
+Rules that apply to every piece of copy this agency ships, regardless of client
+or channel. Where a client's brand guide disagrees, the brand guide wins — say
+so rather than quietly following it, so the conflict is visible.
+
+## Sentences
+
+- One idea per sentence. If you need a semicolon, you need a full stop.
+- Active voice. "We shipped it", not "it was shipped".
+- Cut hedges: *arguably*, *fairly*, *quite*, *somewhat*, *in many ways*.
+
+## Claims
+
+- Every claim needs a number, a named source, or a concrete example. A claim
+  with none of the three is an opinion, and opinions belong to the client.
+- Never write a superlative you cannot attribute. "Fastest" needs a benchmark
+  and a comparison set.
+- If the strongest honest version of a claim is weak, write the weak version.
+  A claim the client cannot defend costs more than the one it replaced.
+
+## Structure
+
+- Lead with the reader's problem. The company's name is not a hook.
+- One call to action per page. Two is zero.
+- Headings are sentences, not labels: "Cut onboarding to a day", not
+  "Onboarding".
+
+## What to refuse
+
+- Copy that implies a guarantee the product does not make.
+- Testimonials, statistics, or endorsements you were not given a source for.
+  Ask for the source; do not invent a plausible one.
+- Comparisons naming a competitor without a documented, checkable basis.

--- a/companies/agentic_marketing_agency/agents/seo_specialist.toml
+++ b/companies/agentic_marketing_agency/agents/seo_specialist.toml
@@ -1,0 +1,2 @@
+role = "SEO Specialist"
+description = "Organic search strategy and optimization."

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -24,46 +24,6 @@ human_role = "Campaign review and sign-off"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
-[[agent]]
-id = "creative_director"
-role = "Creative Director"
-description = "Own creative concept and direction."
-
-[[agent]]
-id = "copywriter"
-role = "Copywriter"
-description = "Write ads, pages, and campaign copy."
-
-[[agent]]
-id = "seo_specialist"
-role = "SEO Specialist"
-description = "Organic search strategy and optimization."
-
-[[agent]]
-id = "paid_ads_manager"
-role = "Paid Ads Manager"
-description = "Plan and run paid-acquisition campaigns."
-
-[[agent]]
-id = "landing_page_builder"
-role = "Landing Page Builder"
-description = "Build and test conversion pages."
-
-[[agent]]
-id = "email_marketer"
-role = "Email Marketer"
-description = "Design and send lifecycle email."
-
-[[agent]]
-id = "analytics_analyst"
-role = "Analytics Analyst"
-description = "Measure performance and report."
-
-[[agent]]
-id = "brand_strategist"
-role = "Brand Strategist"
-description = "Positioning and brand strategy."
-
 # Group chats — the desks the human talks to. Each pulls in a few agents.
 # Members must be ids from the roster above.
 [[group_chat]]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Marketing Agency harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Marketing Agency harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_marketing_agency/company.toml
+++ b/companies/agentic_marketing_agency/company.toml
@@ -25,7 +25,13 @@ human_role = "Campaign review and sign-off"
 allow = ["*", "media", "composio", "search"]
 
 # Group chats — the desks the human talks to. Each pulls in a few agents.
-# Members must be ids from the roster above.
+# Members must be ids declared under `agents/`.
+#
+# A desk is also a scoping level: its optional `tools` is the middle term of
+# `[tools].allow ∩ desk.tools ∩ agent.tools`. Stating a ceiling here restricts
+# every member at once, so a teammate seated on the desk later inherits the
+# restriction instead of quietly arriving with the company's full belt. Omitting
+# it (as `strategy` and `growth` do below) narrows nothing.
 [[group_chat]]
 id = "strategy"
 name = "Strategy desk"
@@ -37,6 +43,21 @@ id = "creative"
 name = "Creative studio"
 description = "Copy, design, and campaigns."
 members = ["creative_director", "copywriter", "landing_page_builder"]
+# The creative desk writes; it does not spend on generated media or on billed
+# search. Both are simply left out rather than denied, because every level of
+# this narrowing is subtractive — a desk can only remove capability, never add
+# it, so omission *is* the mechanism.
+#
+# `*` is listed because it is not a wildcard over everything: it covers
+# files/docs/shell/code/web/subagent and deliberately excludes the opt-in
+# namespaces (`media`, `composio`, `search`, `repo`), which is exactly the line
+# this desk wants. The company grants `media`/`composio`/`search` above; none of
+# them reach these three agents.
+#
+# Members of this desk sit on no other desk. That matters: a teammate on two
+# desks takes the UNION of their ceilings, so seating one of these agents on an
+# unrestricted desk would hand the company grant straight back.
+tools = ["*"]
 
 [[group_chat]]
 id = "growth"

--- a/companies/agentic_media_company/agents/illustrator.toml
+++ b/companies/agentic_media_company/agents/illustrator.toml
@@ -1,0 +1,2 @@
+role = "Illustrator"
+description = "Create article illustrations."

--- a/companies/agentic_media_company/agents/publisher.toml
+++ b/companies/agentic_media_company/agents/publisher.toml
@@ -1,0 +1,2 @@
+role = "Publisher"
+description = "Publish to the CMS."

--- a/companies/agentic_media_company/agents/seo_optimizer.toml
+++ b/companies/agentic_media_company/agents/seo_optimizer.toml
@@ -1,0 +1,2 @@
+role = "SEO Optimizer"
+description = "Optimize articles for search."

--- a/companies/agentic_media_company/agents/social_distributor.toml
+++ b/companies/agentic_media_company/agents/social_distributor.toml
@@ -1,0 +1,2 @@
+role = "Social Distributor"
+description = "Distribute across social channels."

--- a/companies/agentic_media_company/agents/source_verifier.toml
+++ b/companies/agentic_media_company/agents/source_verifier.toml
@@ -1,0 +1,2 @@
+role = "Source Verifier"
+description = "Verify sources and fact-check."

--- a/companies/agentic_media_company/agents/story_scout.toml
+++ b/companies/agentic_media_company/agents/story_scout.toml
@@ -1,2 +1,8 @@
 role = "Story Scout"
 description = "Find and pitch story ideas."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_media_company/agents/story_scout.toml
+++ b/companies/agentic_media_company/agents/story_scout.toml
@@ -1,0 +1,2 @@
+role = "Story Scout"
+description = "Find and pitch story ideas."

--- a/companies/agentic_media_company/agents/translator.toml
+++ b/companies/agentic_media_company/agents/translator.toml
@@ -1,0 +1,2 @@
+role = "Translator"
+description = "Localize stories across languages."

--- a/companies/agentic_media_company/agents/writer.toml
+++ b/companies/agentic_media_company/agents/writer.toml
@@ -1,0 +1,2 @@
+role = "Writer"
+description = "Write and edit articles."

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -24,46 +24,6 @@ human_role = "Editorial standards"
 # setting it to `0` pauses search without editing this list.
 allow = ["*", "media", "composio", "search"]
 
-[[agent]]
-id = "story_scout"
-role = "Story Scout"
-description = "Find and pitch story ideas."
-
-[[agent]]
-id = "source_verifier"
-role = "Source Verifier"
-description = "Verify sources and fact-check."
-
-[[agent]]
-id = "writer"
-role = "Writer"
-description = "Write and edit articles."
-
-[[agent]]
-id = "illustrator"
-role = "Illustrator"
-description = "Create article illustrations."
-
-[[agent]]
-id = "translator"
-role = "Translator"
-description = "Localize stories across languages."
-
-[[agent]]
-id = "seo_optimizer"
-role = "SEO Optimizer"
-description = "Optimize articles for search."
-
-[[agent]]
-id = "publisher"
-role = "Publisher"
-description = "Publish to the CMS."
-
-[[agent]]
-id = "social_distributor"
-role = "Social Distributor"
-description = "Distribute across social channels."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Media Company harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_media_company/company.toml
+++ b/companies/agentic_media_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Media Company harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_pharma_startup/agents/literature_reviewer.toml
+++ b/companies/agentic_pharma_startup/agents/literature_reviewer.toml
@@ -1,0 +1,2 @@
+role = "Literature Reviewer"
+description = "Review and synthesize scientific literature."

--- a/companies/agentic_pharma_startup/agents/literature_reviewer.toml
+++ b/companies/agentic_pharma_startup/agents/literature_reviewer.toml
@@ -1,2 +1,8 @@
 role = "Literature Reviewer"
 description = "Review and synthesize scientific literature."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_pharma_startup/agents/molecule_discovery.toml
+++ b/companies/agentic_pharma_startup/agents/molecule_discovery.toml
@@ -1,0 +1,2 @@
+role = "Molecule Discovery"
+description = "Propose candidate molecules."

--- a/companies/agentic_pharma_startup/agents/simulation_agent.toml
+++ b/companies/agentic_pharma_startup/agents/simulation_agent.toml
@@ -1,0 +1,2 @@
+role = "Simulation Agent"
+description = "Run in-silico simulations and screening."

--- a/companies/agentic_pharma_startup/agents/trial_planner.toml
+++ b/companies/agentic_pharma_startup/agents/trial_planner.toml
@@ -1,0 +1,2 @@
+role = "Trial Planner"
+description = "Design and plan clinical trials."

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Pharma Startup harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -7,26 +7,6 @@ name = "Agentic Pharma Startup"
 output = "Candidate molecules and trial plans"
 human_role = "Laboratory work"
 
-[[agent]]
-id = "literature_reviewer"
-role = "Literature Reviewer"
-description = "Review and synthesize scientific literature."
-
-[[agent]]
-id = "molecule_discovery"
-role = "Molecule Discovery"
-description = "Propose candidate molecules."
-
-[[agent]]
-id = "simulation_agent"
-role = "Simulation Agent"
-description = "Run in-silico simulations and screening."
-
-[[agent]]
-id = "trial_planner"
-role = "Trial Planner"
-description = "Design and plan clinical trials."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_pharma_startup/company.toml
+++ b/companies/agentic_pharma_startup/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Pharma Startup harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_realestate_company/agents/contractor_coordinator.toml
+++ b/companies/agentic_realestate_company/agents/contractor_coordinator.toml
@@ -1,0 +1,2 @@
+role = "Contractor Coordinator"
+description = "Coordinate contractors and renovations."

--- a/companies/agentic_realestate_company/agents/deal_underwriter.toml
+++ b/companies/agentic_realestate_company/agents/deal_underwriter.toml
@@ -1,0 +1,2 @@
+role = "Deal Underwriter"
+description = "Underwrite deals and model returns."

--- a/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
+++ b/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
@@ -1,0 +1,2 @@
+role = "Neighborhood Analyst"
+description = "Analyze neighborhoods, comps, and trends."

--- a/companies/agentic_realestate_company/agents/property_scout.toml
+++ b/companies/agentic_realestate_company/agents/property_scout.toml
@@ -1,0 +1,2 @@
+role = "Property Scout"
+description = "Find and screen candidate properties."

--- a/companies/agentic_realestate_company/agents/property_scout.toml
+++ b/companies/agentic_realestate_company/agents/property_scout.toml
@@ -1,2 +1,8 @@
 role = "Property Scout"
 description = "Find and screen candidate properties."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_realestate_company/agents/tenant_manager.toml
+++ b/companies/agentic_realestate_company/agents/tenant_manager.toml
@@ -1,0 +1,2 @@
+role = "Tenant Manager"
+description = "Manage tenants and property operations."

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Real Estate Company harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -7,31 +7,6 @@ name = "Agentic Real Estate Company"
 output = "Underwritten deals and managed properties"
 human_role = "Purchase approvals"
 
-[[agent]]
-id = "property_scout"
-role = "Property Scout"
-description = "Find and screen candidate properties."
-
-[[agent]]
-id = "neighborhood_analyst"
-role = "Neighborhood Analyst"
-description = "Analyze neighborhoods, comps, and trends."
-
-[[agent]]
-id = "deal_underwriter"
-role = "Deal Underwriter"
-description = "Underwrite deals and model returns."
-
-[[agent]]
-id = "contractor_coordinator"
-role = "Contractor Coordinator"
-description = "Coordinate contractors and renovations."
-
-[[agent]]
-id = "tenant_manager"
-role = "Tenant Manager"
-description = "Manage tenants and property operations."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_realestate_company/company.toml
+++ b/companies/agentic_realestate_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Real Estate Company harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_recruiting_company/agents/candidate_sourcer.toml
+++ b/companies/agentic_recruiting_company/agents/candidate_sourcer.toml
@@ -1,2 +1,8 @@
 role = "Candidate Sourcer"
 description = "Source candidates for open roles."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_recruiting_company/agents/candidate_sourcer.toml
+++ b/companies/agentic_recruiting_company/agents/candidate_sourcer.toml
@@ -1,0 +1,2 @@
+role = "Candidate Sourcer"
+description = "Source candidates for open roles."

--- a/companies/agentic_recruiting_company/agents/interviewer.toml
+++ b/companies/agentic_recruiting_company/agents/interviewer.toml
@@ -1,0 +1,2 @@
+role = "Interviewer"
+description = "Conduct first-round interviews."

--- a/companies/agentic_recruiting_company/agents/offer_generator.toml
+++ b/companies/agentic_recruiting_company/agents/offer_generator.toml
@@ -1,0 +1,2 @@
+role = "Offer Generator"
+description = "Draft and generate offers."

--- a/companies/agentic_recruiting_company/agents/outreach_agent.toml
+++ b/companies/agentic_recruiting_company/agents/outreach_agent.toml
@@ -1,0 +1,2 @@
+role = "Outreach Agent"
+description = "Run personalized candidate outreach."

--- a/companies/agentic_recruiting_company/agents/resume_analyst.toml
+++ b/companies/agentic_recruiting_company/agents/resume_analyst.toml
@@ -1,0 +1,2 @@
+role = "Resume Analyst"
+description = "Screen and rank resumes against the spec."

--- a/companies/agentic_recruiting_company/agents/scheduler.toml
+++ b/companies/agentic_recruiting_company/agents/scheduler.toml
@@ -1,0 +1,2 @@
+role = "Scheduler"
+description = "Coordinate interview scheduling."

--- a/companies/agentic_recruiting_company/company.toml
+++ b/companies/agentic_recruiting_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Recruiting Company harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_recruiting_company/company.toml
+++ b/companies/agentic_recruiting_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Recruiting Company harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_recruiting_company/company.toml
+++ b/companies/agentic_recruiting_company/company.toml
@@ -7,36 +7,6 @@ name = "Agentic Recruiting Company"
 output = "Sourced, screened, and scheduled candidates"
 human_role = "Final hiring decisions"
 
-[[agent]]
-id = "candidate_sourcer"
-role = "Candidate Sourcer"
-description = "Source candidates for open roles."
-
-[[agent]]
-id = "outreach_agent"
-role = "Outreach Agent"
-description = "Run personalized candidate outreach."
-
-[[agent]]
-id = "resume_analyst"
-role = "Resume Analyst"
-description = "Screen and rank resumes against the spec."
-
-[[agent]]
-id = "interviewer"
-role = "Interviewer"
-description = "Conduct first-round interviews."
-
-[[agent]]
-id = "scheduler"
-role = "Scheduler"
-description = "Coordinate interview scheduling."
-
-[[agent]]
-id = "offer_generator"
-role = "Offer Generator"
-description = "Draft and generate offers."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_research_lab/agents/analyst.toml
+++ b/companies/agentic_research_lab/agents/analyst.toml
@@ -1,0 +1,4 @@
+role = "Analyst"
+description = "Compute, model, and check numbers against the claims on record."
+# Gets the code index so the second program does not rebuild the first.
+context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "INDEX.md"]

--- a/companies/agentic_research_lab/agents/critic.toml
+++ b/companies/agentic_research_lab/agents/critic.toml
@@ -1,0 +1,8 @@
+role = "Critic"
+description = "Attack the lab's own conclusions before the operator sees them."
+# Deliberately narrow. No BOARD.md: a post is asserted, not established, and a
+# critic weighing evidence beside an unevidenced hunch is one prompt away from
+# weighing the hunch. No BRIEF.md either — the brief is the lab's own summary of
+# what it believes, and a critic given it argues with the summary rather than
+# with the evidence.
+context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]

--- a/companies/agentic_research_lab/agents/curator.toml
+++ b/companies/agentic_research_lab/agents/curator.toml
@@ -1,0 +1,5 @@
+role = "Curator"
+description = "Owns the brief. Keeps one current statement of what the lab knows, within budget."
+# The single writer of BRIEF.md, and the one role that sees everything, because
+# its whole job is compressing everything into the document the others read.
+context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md", "INDEX.md"]

--- a/companies/agentic_research_lab/agents/inventor.toml
+++ b/companies/agentic_research_lab/agents/inventor.toml
@@ -1,0 +1,5 @@
+role = "Inventor"
+description = "Propose a different line of attack when the current one stalls."
+# Must see what has already been tried and closed, or it re-proposes it — the
+# one thing this role exists not to do.
+context = ["GOAL.md", "BRIEF.md", "THREADS.md", "CLAIMS.md", "BOARD.md"]

--- a/companies/agentic_research_lab/agents/librarian.toml
+++ b/companies/agentic_research_lab/agents/librarian.toml
@@ -1,0 +1,6 @@
+role = "Librarian"
+description = "Find and download primary sources. Never reads them."
+# Needs the frontier of what is worth fetching and what is already held, so it
+# does not re-download what the lab has. Not given the brief's conclusions: a
+# fetcher that knows what the lab wants to be true searches for it.
+context = ["GOAL.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]

--- a/companies/agentic_research_lab/agents/orchestrator.toml
+++ b/companies/agentic_research_lab/agents/orchestrator.toml
@@ -1,0 +1,5 @@
+role = "Research Lead"
+description = "Break a question into lines of inquiry, delegate them, and combine the results."
+tier = "orchestrator"
+# Sees everything that decides what to do next, including the assertion board.
+context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md", "BOARD.md", "INDEX.md"]

--- a/companies/agentic_research_lab/agents/scholar.toml
+++ b/companies/agentic_research_lab/agents/scholar.toml
@@ -1,0 +1,5 @@
+role = "Scholar"
+description = "Read what the librarian gathered and record what each source actually establishes, as claims."
+# Draws the evidence edges, so it must see the existing claims to know what is
+# already established and what a new source contradicts.
+context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]

--- a/companies/agentic_research_lab/agents/tool_builder.toml
+++ b/companies/agentic_research_lab/agents/tool_builder.toml
@@ -1,0 +1,3 @@
+role = "Tool Builder"
+description = "Write and run the programs the analyst needs, and keep the shared library."
+context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]

--- a/companies/agentic_research_lab/company.toml
+++ b/companies/agentic_research_lab/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Research Lab harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 #
 # This company is the acceptance test for the orchestration work described in

--- a/companies/agentic_research_lab/company.toml
+++ b/companies/agentic_research_lab/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Research Lab harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 #
 # This company is the acceptance test for the orchestration work described in

--- a/companies/agentic_research_lab/company.toml
+++ b/companies/agentic_research_lab/company.toml
@@ -48,76 +48,12 @@ search_daily_calls = 200
 # routing is reviewable as data rather than inferred from prose.
 # ---------------------------------------------------------------------------
 
-[[agent]]
-id = "orchestrator"
-role = "Research Lead"
-description = "Break a question into lines of inquiry, delegate them, and combine the results."
-tier = "orchestrator"
-# Sees everything that decides what to do next, including the assertion board.
-context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md", "BOARD.md", "INDEX.md"]
 # No `delegates_to`. That field is the *per-member* opt-in: it wires
 # `spawn_task` + `delegate_to_desk` onto a non-orchestrator agent and narrows
 # the latter to the desks named. This agent carries `tier = "orchestrator"`, so
 # it already holds the full delegating authority unrestricted, and this company
 # declares no desks for `delegate_to_desk` to address anyway. Listing `["*"]`
 # here would read as "may delegate anywhere" while resolving to nothing.
-
-[[agent]]
-id = "librarian"
-role = "Librarian"
-description = "Find and download primary sources. Never reads them."
-# Needs the frontier of what is worth fetching and what is already held, so it
-# does not re-download what the lab has. Not given the brief's conclusions: a
-# fetcher that knows what the lab wants to be true searches for it.
-context = ["GOAL.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]
-
-[[agent]]
-id = "scholar"
-role = "Scholar"
-description = "Read what the librarian gathered and record what each source actually establishes, as claims."
-# Draws the evidence edges, so it must see the existing claims to know what is
-# already established and what a new source contradicts.
-context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]
-
-[[agent]]
-id = "analyst"
-role = "Analyst"
-description = "Compute, model, and check numbers against the claims on record."
-# Gets the code index so the second program does not rebuild the first.
-context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "INDEX.md"]
-
-[[agent]]
-id = "tool_builder"
-role = "Tool Builder"
-description = "Write and run the programs the analyst needs, and keep the shared library."
-context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]
-
-[[agent]]
-id = "inventor"
-role = "Inventor"
-description = "Propose a different line of attack when the current one stalls."
-# Must see what has already been tried and closed, or it re-proposes it — the
-# one thing this role exists not to do.
-context = ["GOAL.md", "BRIEF.md", "THREADS.md", "CLAIMS.md", "BOARD.md"]
-
-[[agent]]
-id = "critic"
-role = "Critic"
-description = "Attack the lab's own conclusions before the operator sees them."
-# Deliberately narrow. No BOARD.md: a post is asserted, not established, and a
-# critic weighing evidence beside an unevidenced hunch is one prompt away from
-# weighing the hunch. No BRIEF.md either — the brief is the lab's own summary of
-# what it believes, and a critic given it argues with the summary rather than
-# with the evidence.
-context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]
-
-[[agent]]
-id = "curator"
-role = "Curator"
-description = "Owns the brief. Keeps one current statement of what the lab knows, within budget."
-# The single writer of BRIEF.md, and the one role that sees everything, because
-# its whole job is compressing everything into the document the others read.
-context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md", "INDEX.md"]
 
 # ---------------------------------------------------------------------------
 # Desks.

--- a/companies/agentic_software_company/agents/backend_engineer.toml
+++ b/companies/agentic_software_company/agents/backend_engineer.toml
@@ -1,0 +1,2 @@
+role = "Backend Engineer"
+description = "Build and operate the backend and services."

--- a/companies/agentic_software_company/agents/customer_support.toml
+++ b/companies/agentic_software_company/agents/customer_support.toml
@@ -1,0 +1,2 @@
+role = "Customer Support"
+description = "Resolve customer issues and feed insight back."

--- a/companies/agentic_software_company/agents/designer.toml
+++ b/companies/agentic_software_company/agents/designer.toml
@@ -1,0 +1,2 @@
+role = "Designer"
+description = "Product and UX design."

--- a/companies/agentic_software_company/agents/devrel.toml
+++ b/companies/agentic_software_company/agents/devrel.toml
@@ -1,0 +1,2 @@
+role = "Developer Relations"
+description = "Engage developers with demos, content, and community."

--- a/companies/agentic_software_company/agents/docs_writer.toml
+++ b/companies/agentic_software_company/agents/docs_writer.toml
@@ -1,0 +1,2 @@
+role = "Documentation Writer"
+description = "Write and maintain product documentation."

--- a/companies/agentic_software_company/agents/frontend_engineer.toml
+++ b/companies/agentic_software_company/agents/frontend_engineer.toml
@@ -1,0 +1,2 @@
+role = "Frontend Engineer"
+description = "Build the user-facing frontend."

--- a/companies/agentic_software_company/agents/product_manager.toml
+++ b/companies/agentic_software_company/agents/product_manager.toml
@@ -1,0 +1,2 @@
+role = "Product Manager"
+description = "Own the roadmap, specs, and prioritization."

--- a/companies/agentic_software_company/agents/product_manager.toml
+++ b/companies/agentic_software_company/agents/product_manager.toml
@@ -1,2 +1,8 @@
 role = "Product Manager"
 description = "Own the roadmap, specs, and prioritization."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_software_company/agents/qa_engineer.toml
+++ b/companies/agentic_software_company/agents/qa_engineer.toml
@@ -1,0 +1,2 @@
+role = "QA Engineer"
+description = "Test features and catch regressions."

--- a/companies/agentic_software_company/agents/security_engineer.toml
+++ b/companies/agentic_software_company/agents/security_engineer.toml
@@ -1,0 +1,2 @@
+role = "Security Engineer"
+description = "Security review, hardening, and response."

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Software Company harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -43,51 +43,6 @@ allow = ["*", "media", "composio", "search"]
 # appear would restore the cap it was meant to relieve. Narrow it only to
 # genuinely narrow this company.
 
-[[agent]]
-id = "product_manager"
-role = "Product Manager"
-description = "Own the roadmap, specs, and prioritization."
-
-[[agent]]
-id = "designer"
-role = "Designer"
-description = "Product and UX design."
-
-[[agent]]
-id = "backend_engineer"
-role = "Backend Engineer"
-description = "Build and operate the backend and services."
-
-[[agent]]
-id = "frontend_engineer"
-role = "Frontend Engineer"
-description = "Build the user-facing frontend."
-
-[[agent]]
-id = "qa_engineer"
-role = "QA Engineer"
-description = "Test features and catch regressions."
-
-[[agent]]
-id = "security_engineer"
-role = "Security Engineer"
-description = "Security review, hardening, and response."
-
-[[agent]]
-id = "docs_writer"
-role = "Documentation Writer"
-description = "Write and maintain product documentation."
-
-[[agent]]
-id = "customer_support"
-role = "Customer Support"
-description = "Resolve customer issues and feed insight back."
-
-[[agent]]
-id = "devrel"
-role = "Developer Relations"
-description = "Engage developers with demos, content, and community."
-
 # Group chats — the desks the human talks to. Each pulls in a few agents from
 # the roster above; the first member is the desk's lead (the routing target).
 [[group_chat]]

--- a/companies/agentic_software_company/company.toml
+++ b/companies/agentic_software_company/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Software Company harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_venture_capital/agents/code_analyst.toml
+++ b/companies/agentic_venture_capital/agents/code_analyst.toml
@@ -1,0 +1,2 @@
+role = "Code Analyst"
+description = "Analyze codebases, product, and technical traction."

--- a/companies/agentic_venture_capital/agents/deck_evaluator.toml
+++ b/companies/agentic_venture_capital/agents/deck_evaluator.toml
@@ -1,0 +1,2 @@
+role = "Deck Evaluator"
+description = "Evaluate pitch decks and business models."

--- a/companies/agentic_venture_capital/agents/founder_sourcer.toml
+++ b/companies/agentic_venture_capital/agents/founder_sourcer.toml
@@ -1,0 +1,2 @@
+role = "Founder Sourcer"
+description = "Source founders and deal flow."

--- a/companies/agentic_venture_capital/agents/founder_sourcer.toml
+++ b/companies/agentic_venture_capital/agents/founder_sourcer.toml
@@ -1,2 +1,8 @@
 role = "Founder Sourcer"
 description = "Source founders and deal flow."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_venture_capital/agents/market_sizer.toml
+++ b/companies/agentic_venture_capital/agents/market_sizer.toml
@@ -1,0 +1,2 @@
+role = "Market Sizer"
+description = "Size markets and model opportunity."

--- a/companies/agentic_venture_capital/agents/portfolio_support.toml
+++ b/companies/agentic_venture_capital/agents/portfolio_support.toml
@@ -1,0 +1,2 @@
+role = "Portfolio Support"
+description = "Support portfolio companies post-investment."

--- a/companies/agentic_venture_capital/agents/reference_checker.toml
+++ b/companies/agentic_venture_capital/agents/reference_checker.toml
@@ -1,0 +1,2 @@
+role = "Reference Checker"
+description = "Run founder and customer reference checks."

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Venture Capital Firm harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Venture Capital Firm harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_venture_capital/company.toml
+++ b/companies/agentic_venture_capital/company.toml
@@ -7,36 +7,6 @@ name = "Agentic Venture Capital Firm"
 output = "Investment memos and a managed portfolio"
 human_role = "Investment decisions"
 
-[[agent]]
-id = "founder_sourcer"
-role = "Founder Sourcer"
-description = "Source founders and deal flow."
-
-[[agent]]
-id = "deck_evaluator"
-role = "Deck Evaluator"
-description = "Evaluate pitch decks and business models."
-
-[[agent]]
-id = "code_analyst"
-role = "Code Analyst"
-description = "Analyze codebases, product, and technical traction."
-
-[[agent]]
-id = "reference_checker"
-role = "Reference Checker"
-description = "Run founder and customer reference checks."
-
-[[agent]]
-id = "market_sizer"
-role = "Market Sizer"
-description = "Size markets and model opportunity."
-
-[[agent]]
-id = "portfolio_support"
-role = "Portfolio Support"
-description = "Support portfolio companies post-investment."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_venture_studio/agents/customer_support.toml
+++ b/companies/agentic_venture_studio/agents/customer_support.toml
@@ -1,0 +1,2 @@
+role = "Customer Support"
+description = "Resolve customer issues and feed insight back to product."

--- a/companies/agentic_venture_studio/agents/designer.toml
+++ b/companies/agentic_venture_studio/agents/designer.toml
@@ -1,0 +1,2 @@
+role = "Designer"
+description = "Own product and brand design."

--- a/companies/agentic_venture_studio/agents/engineer.toml
+++ b/companies/agentic_venture_studio/agents/engineer.toml
@@ -1,0 +1,2 @@
+role = "Engineer"
+description = "Build and ship the product."

--- a/companies/agentic_venture_studio/agents/finance.toml
+++ b/companies/agentic_venture_studio/agents/finance.toml
@@ -1,0 +1,2 @@
+role = "Finance"
+description = "Financial modeling, runway, and reporting."

--- a/companies/agentic_venture_studio/agents/founder.toml
+++ b/companies/agentic_venture_studio/agents/founder.toml
@@ -1,0 +1,2 @@
+role = "Founder"
+description = "Turn a thesis into a company: vision, roadmap, and priorities."

--- a/companies/agentic_venture_studio/agents/lawyer.toml
+++ b/companies/agentic_venture_studio/agents/lawyer.toml
@@ -1,0 +1,2 @@
+role = "Lawyer"
+description = "Incorporation, contracts, and compliance."

--- a/companies/agentic_venture_studio/agents/marketer.toml
+++ b/companies/agentic_venture_studio/agents/marketer.toml
@@ -1,0 +1,2 @@
+role = "Marketer"
+description = "Positioning, demand generation, and launches."

--- a/companies/agentic_venture_studio/agents/opportunity_scout.toml
+++ b/companies/agentic_venture_studio/agents/opportunity_scout.toml
@@ -1,0 +1,2 @@
+role = "Opportunity Scout"
+description = "Surface and score market opportunities and startup theses."

--- a/companies/agentic_venture_studio/agents/opportunity_scout.toml
+++ b/companies/agentic_venture_studio/agents/opportunity_scout.toml
@@ -1,2 +1,8 @@
 role = "Opportunity Scout"
 description = "Surface and score market opportunities and startup theses."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/agentic_venture_studio/agents/recruiter.toml
+++ b/companies/agentic_venture_studio/agents/recruiter.toml
@@ -1,0 +1,2 @@
+role = "Recruiter"
+description = "Source and staff each venture with agents or humans."

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Venture Studio harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -7,51 +7,6 @@ name = "Agentic Venture Studio"
 output = "A portfolio of startups"
 human_role = "Capital allocation and major strategic decisions"
 
-[[agent]]
-id = "opportunity_scout"
-role = "Opportunity Scout"
-description = "Surface and score market opportunities and startup theses."
-
-[[agent]]
-id = "founder"
-role = "Founder"
-description = "Turn a thesis into a company: vision, roadmap, and priorities."
-
-[[agent]]
-id = "engineer"
-role = "Engineer"
-description = "Build and ship the product."
-
-[[agent]]
-id = "designer"
-role = "Designer"
-description = "Own product and brand design."
-
-[[agent]]
-id = "marketer"
-role = "Marketer"
-description = "Positioning, demand generation, and launches."
-
-[[agent]]
-id = "lawyer"
-role = "Lawyer"
-description = "Incorporation, contracts, and compliance."
-
-[[agent]]
-id = "finance"
-role = "Finance"
-description = "Financial modeling, runway, and reporting."
-
-[[agent]]
-id = "customer_support"
-role = "Customer Support"
-description = "Resolve customer issues and feed insight back to product."
-
-[[agent]]
-id = "recruiter"
-role = "Recruiter"
-description = "Source and staff each venture with agents or humans."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/agentic_venture_studio/company.toml
+++ b/companies/agentic_venture_studio/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Agentic Venture Studio harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/e2e_harness/agents/ceo.toml
+++ b/companies/e2e_harness/agents/ceo.toml
@@ -1,0 +1,6 @@
+role = "Chief Executive"
+description = "Sets direction, answers about the company, and delegates the work."
+tier = "orchestrator"
+# `workspace.read` is read-only by design: writes need a bare `workspace` or an
+# explicit `workspace.write`, so this cannot silently overwrite operator notes.
+tools = ["mcp:*", "composio", "workspace.read"]

--- a/companies/e2e_harness/agents/engineer.toml
+++ b/companies/e2e_harness/agents/engineer.toml
@@ -1,0 +1,3 @@
+role = "Engineer"
+description = "Explains how things are built and proposes technical plans."
+tools = ["mcp:*", "composio", "workspace.read"]

--- a/companies/e2e_harness/agents/writer.toml
+++ b/companies/e2e_harness/agents/writer.toml
@@ -1,0 +1,11 @@
+role = "Writer"
+description = "Turns rough notes into short, clear written drafts."
+# The one agent that may edit a note, so the "an agent wrote it, the operator
+# sees it" round trip is demonstrable out of the box.
+tools = ["mcp:*", "composio", "workspace"]
+# Issue #304 — one capped teammate so the Team page has a live per-agent budget
+# to render, and `team-budget.spec.ts` can assert the capped/uncapped split for
+# real rather than against a fixture. Deliberately generous: the harness runs on
+# the offline echo brain, which meters no cost, so spend stays $0.00 and this
+# cap never trips during a suite run.
+budget_usd_daily = 5.0

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -9,7 +9,7 @@
 #   * `workflows/committed.toml`, a source-defined workflow the console must
 #     refuse to edit or delete — see `frontend/test/e2e/workflow-edit-delete.spec.ts`.
 #
-# Every [[agent]] becomes one live openhuman agent when built with the
+# Every `agents/<id>.toml` becomes one live openhuman agent when built with the
 # `openhuman` feature and an inference credential is present. Without a
 # credential the same company still boots on the offline echo brain — which is
 # all the load check needs.

--- a/companies/e2e_harness/company.toml
+++ b/companies/e2e_harness/company.toml
@@ -52,35 +52,6 @@ admins = ["harness-e2e@tinyhumans.ai"]
 # wildcard can never buy a metered request.
 allow = ["composio", "mcp:*", "workspace", "workspace.*", "web"]
 
-[[agent]]
-id = "ceo"
-role = "Chief Executive"
-description = "Sets direction, answers about the company, and delegates the work."
-tier = "orchestrator"
-# `workspace.read` is read-only by design: writes need a bare `workspace` or an
-# explicit `workspace.write`, so this cannot silently overwrite operator notes.
-tools = ["mcp:*", "composio", "workspace.read"]
-
-[[agent]]
-id = "engineer"
-role = "Engineer"
-description = "Explains how things are built and proposes technical plans."
-tools = ["mcp:*", "composio", "workspace.read"]
-
-[[agent]]
-id = "writer"
-role = "Writer"
-description = "Turns rough notes into short, clear written drafts."
-# The one agent that may edit a note, so the "an agent wrote it, the operator
-# sees it" round trip is demonstrable out of the box.
-tools = ["mcp:*", "composio", "workspace"]
-# Issue #304 — one capped teammate so the Team page has a live per-agent budget
-# to render, and `team-budget.spec.ts` can assert the capped/uncapped split for
-# real rather than against a fixture. Deliberately generous: the harness runs on
-# the offline echo brain, which meters no cost, so spend stays $0.00 and this
-# cap never trips during a suite run.
-budget_usd_daily = 5.0
-
 [[group_chat]]
 id = "engineering"
 name = "Engineering desk"

--- a/companies/openhuman_demo/agents/ceo.toml
+++ b/companies/openhuman_demo/agents/ceo.toml
@@ -1,0 +1,9 @@
+role = "Chief Executive"
+description = "Sets direction, answers about the company, and delegates the work."
+# The operator↔company chat responder. `orchestrator` makes the CEO answer from
+# whole-company context and delegate to the desks below. `mcp:*` grants the
+# remote MCP tool servers declared in `[[mcp_server]]`.
+tier = "orchestrator"
+# `workspace.read` is read-only by design: writes need a bare `workspace` or an
+# explicit `workspace.write`, so this cannot silently overwrite operator notes.
+tools = ["mcp:*", "workspace.read"]

--- a/companies/openhuman_demo/agents/ceo.toml
+++ b/companies/openhuman_demo/agents/ceo.toml
@@ -1,8 +1,8 @@
 role = "Chief Executive"
 description = "Sets direction, answers about the company, and delegates the work."
 # The operator↔company chat responder. `orchestrator` makes the CEO answer from
-# whole-company context and delegate to the desks below. `mcp:*` grants the
-# remote MCP tool servers declared in `[[mcp_server]]`.
+# whole-company context and delegate to the desks declared in `company.toml`.
+# `mcp:*` grants the remote MCP tool servers declared in `[[mcp_server]]`.
 tier = "orchestrator"
 # `workspace.read` is read-only by design: writes need a bare `workspace` or an
 # explicit `workspace.write`, so this cannot silently overwrite operator notes.

--- a/companies/openhuman_demo/agents/engineer.toml
+++ b/companies/openhuman_demo/agents/engineer.toml
@@ -1,0 +1,3 @@
+role = "Engineer"
+description = "Explains how things are built and proposes technical plans."
+tools = ["mcp:*", "workspace.read"]

--- a/companies/openhuman_demo/agents/writer.toml
+++ b/companies/openhuman_demo/agents/writer.toml
@@ -1,0 +1,5 @@
+role = "Writer"
+description = "Turns rough notes into short, clear written drafts."
+# The one agent that may edit a note, so the "an agent wrote it, the operator
+# sees it" round trip is demonstrable out of the box.
+tools = ["mcp:*", "workspace"]

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -33,32 +33,6 @@ mode = "full"
 # `workspace.read`, and `workspace.*` covers the sub-grants but not the bare one.
 allow = ["mcp:*", "workspace", "workspace.*"]
 
-[[agent]]
-id = "ceo"
-role = "Chief Executive"
-description = "Sets direction, answers about the company, and delegates the work."
-# The operator↔company chat responder. `orchestrator` makes the CEO answer from
-# whole-company context and delegate to the desks below. `mcp:*` grants the
-# remote MCP tool servers declared in `[[mcp_server]]`.
-tier = "orchestrator"
-# `workspace.read` is read-only by design: writes need a bare `workspace` or an
-# explicit `workspace.write`, so this cannot silently overwrite operator notes.
-tools = ["mcp:*", "workspace.read"]
-
-[[agent]]
-id = "engineer"
-role = "Engineer"
-description = "Explains how things are built and proposes technical plans."
-tools = ["mcp:*", "workspace.read"]
-
-[[agent]]
-id = "writer"
-role = "Writer"
-description = "Turns rough notes into short, clear written drafts."
-# The one agent that may edit a note, so the "an agent wrote it, the operator
-# sees it" round trip is demonstrable out of the box.
-tools = ["mcp:*", "workspace"]
-
 # Desks (group chats) the orchestrator can hand a turn to. Each desk's first
 # member is its lead; `delegate_to_desk` runs that member's turn.
 [[group_chat]]

--- a/companies/openhuman_demo/company.toml
+++ b/companies/openhuman_demo/company.toml
@@ -1,6 +1,6 @@
 # A minimal company for the embedded OpenHuman harness (issue #9).
 #
-# Every [[agent]] becomes one live openhuman agent, wired with memory, an
+# Every `agents/<id>.toml` becomes one live openhuman agent, wired with memory, an
 # approval policy, and the hosted inference provider. Run it with the harness
 # brain by setting an inference credential in the environment:
 #

--- a/companies/signals_opportunity_studio/agents/opportunity_analyst.toml
+++ b/companies/signals_opportunity_studio/agents/opportunity_analyst.toml
@@ -1,0 +1,5 @@
+role = "Opportunity Analyst"
+description = "Cluster signals into pains and rank the resulting opportunities by evidence and size."
+tier = "reasoning"
+tools = ["web.*", "docs.*", "search"]
+budget_usd_daily = 8.0

--- a/companies/signals_opportunity_studio/agents/research_agent.toml
+++ b/companies/signals_opportunity_studio/agents/research_agent.toml
@@ -1,0 +1,5 @@
+role = "Research Agent"
+description = "Deep-dive the top opportunities and compile the operator's weekly brief."
+tier = "reasoning"
+tools = ["web.*", "docs.*", "search"]
+budget_usd_daily = 8.0

--- a/companies/signals_opportunity_studio/agents/signal_scout.toml
+++ b/companies/signals_opportunity_studio/agents/signal_scout.toml
@@ -1,0 +1,9 @@
+role = "Signal Scout"
+description = "Continuously gather raw market signals from web, forums, and inbound channels."
+tier = "subconscious"
+# `search` is listed alongside `web.*` because the two are not interchangeable:
+# `web.*` reads a URL the agent already has, `search` is the only way to find
+# one. It must appear here AND in `[tools].allow` below — the per-agent list
+# narrows the company-wide one, so either edit alone is a silent no-op (#312).
+tools = ["web.*", "search"]
+budget_usd_daily = 5.0

--- a/companies/signals_opportunity_studio/agents/signal_scout.toml
+++ b/companies/signals_opportunity_studio/agents/signal_scout.toml
@@ -1,9 +1,20 @@
 role = "Signal Scout"
 description = "Continuously gather raw market signals from web, forums, and inbound channels."
-tier = "subconscious"
+# Was `tier = "subconscious"`. This teammate has always been the company's
+# orchestrator — it was declared first in `company.toml`, and with nobody tagged
+# `orchestrator` the roster's first entry takes the job. Moving the roster into
+# one file per teammate made that ordering alphabetical, so the tier is now
+# stated rather than inherited from where the block happened to sit.
+#
+# The old value was incidental, not a decision: an agent cannot be both the
+# orchestrator and `subconscious`, and it was the orchestrator in fact. Naming
+# the tier it actually runs as also moves it onto the agentic model workload,
+# which is the one that matches the routing it was already doing.
+tier = "orchestrator"
 # `search` is listed alongside `web.*` because the two are not interchangeable:
 # `web.*` reads a URL the agent already has, `search` is the only way to find
-# one. It must appear here AND in `[tools].allow` below — the per-agent list
-# narrows the company-wide one, so either edit alone is a silent no-op (#312).
+# one. It must appear here AND in `[tools].allow` in `company.toml` — the
+# per-agent list narrows the company-wide one, so either edit alone is a silent
+# no-op (#312).
 tools = ["web.*", "search"]
 budget_usd_daily = 5.0

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -19,34 +19,6 @@ output = "A ranked weekly opportunity brief the operator can act on"
 human_role = "Deciding which opportunities to fund and pursue"
 handle = "signalstudio"
 
-[[agent]]
-id = "signal_scout"
-role = "Signal Scout"
-description = "Continuously gather raw market signals from web, forums, and inbound channels."
-tier = "subconscious"
-# `search` is listed alongside `web.*` because the two are not interchangeable:
-# `web.*` reads a URL the agent already has, `search` is the only way to find
-# one. It must appear here AND in `[tools].allow` below — the per-agent list
-# narrows the company-wide one, so either edit alone is a silent no-op (#312).
-tools = ["web.*", "search"]
-budget_usd_daily = 5.0
-
-[[agent]]
-id = "opportunity_analyst"
-role = "Opportunity Analyst"
-description = "Cluster signals into pains and rank the resulting opportunities by evidence and size."
-tier = "reasoning"
-tools = ["web.*", "docs.*", "search"]
-budget_usd_daily = 8.0
-
-[[agent]]
-id = "research_agent"
-role = "Research Agent"
-description = "Deep-dive the top opportunities and compile the operator's weekly brief."
-tier = "reasoning"
-tools = ["web.*", "docs.*", "search"]
-budget_usd_daily = 8.0
-
 [brain]
 mode = "hosted"
 max_passes = 12

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -10,7 +10,7 @@
 #   * reasoning → the brain clusters pain, ranks opportunities, drafts the digest
 #   * cadence  → [[schedule]] entries drive the weekly scan/rank/report loop
 #
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/signals_opportunity_studio/company.toml
+++ b/companies/signals_opportunity_studio/company.toml
@@ -10,7 +10,7 @@
 #   * reasoning → the brain clusters pain, ranks opportunities, drafts the digest
 #   * cadence  → [[schedule]] entries drive the weekly scan/rank/report loop
 #
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/startup_accelerator/agents/application_screener.toml
+++ b/companies/startup_accelerator/agents/application_screener.toml
@@ -1,0 +1,2 @@
+role = "Application Screener"
+description = "Score and shortlist applications against the thesis."

--- a/companies/startup_accelerator/agents/curriculum_designer.toml
+++ b/companies/startup_accelerator/agents/curriculum_designer.toml
@@ -1,0 +1,2 @@
+role = "Curriculum Designer"
+description = "Design and schedule the program curriculum."

--- a/companies/startup_accelerator/agents/demo_day_producer.toml
+++ b/companies/startup_accelerator/agents/demo_day_producer.toml
@@ -1,0 +1,2 @@
+role = "Demo Day Producer"
+description = "Prepare pitches and stage demo day."

--- a/companies/startup_accelerator/agents/investor_liaison.toml
+++ b/companies/startup_accelerator/agents/investor_liaison.toml
@@ -1,0 +1,2 @@
+role = "Investor Liaison"
+description = "Make warm, targeted investor introductions."

--- a/companies/startup_accelerator/agents/mentor_matcher.toml
+++ b/companies/startup_accelerator/agents/mentor_matcher.toml
@@ -1,0 +1,2 @@
+role = "Mentor Matcher"
+description = "Pair startups with the right mentors and resources."

--- a/companies/startup_accelerator/agents/portfolio_support.toml
+++ b/companies/startup_accelerator/agents/portfolio_support.toml
@@ -1,0 +1,2 @@
+role = "Portfolio Support"
+description = "Support alumni after the program."

--- a/companies/startup_accelerator/agents/progress_coach.toml
+++ b/companies/startup_accelerator/agents/progress_coach.toml
@@ -1,0 +1,2 @@
+role = "Progress Coach"
+description = "Track weekly milestones and unblock founders."

--- a/companies/startup_accelerator/agents/startup_scout.toml
+++ b/companies/startup_accelerator/agents/startup_scout.toml
@@ -1,2 +1,8 @@
 role = "Startup Scout"
 description = "Source promising founders and startups into the pipeline."
+# Declared explicitly because the roster now lives in one file per teammate
+# (`agents/*.toml`), which is read in filename order. Before the move this
+# company tagged nobody and relied on `[[agent]]` declaration order, where this
+# teammate came first. Stating the tier keeps the same agent orchestrating
+# instead of handing the job to whoever sorts first alphabetically.
+tier = "orchestrator"

--- a/companies/startup_accelerator/agents/startup_scout.toml
+++ b/companies/startup_accelerator/agents/startup_scout.toml
@@ -1,0 +1,2 @@
+role = "Startup Scout"
+description = "Source promising founders and startups into the pipeline."

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -7,46 +7,6 @@ name = "Startup Accelerator"
 output = "A funded, mentored startup cohort"
 human_role = "Investment and demo-day decisions"
 
-[[agent]]
-id = "startup_scout"
-role = "Startup Scout"
-description = "Source promising founders and startups into the pipeline."
-
-[[agent]]
-id = "application_screener"
-role = "Application Screener"
-description = "Score and shortlist applications against the thesis."
-
-[[agent]]
-id = "mentor_matcher"
-role = "Mentor Matcher"
-description = "Pair startups with the right mentors and resources."
-
-[[agent]]
-id = "curriculum_designer"
-role = "Curriculum Designer"
-description = "Design and schedule the program curriculum."
-
-[[agent]]
-id = "progress_coach"
-role = "Progress Coach"
-description = "Track weekly milestones and unblock founders."
-
-[[agent]]
-id = "demo_day_producer"
-role = "Demo Day Producer"
-description = "Prepare pitches and stage demo day."
-
-[[agent]]
-id = "investor_liaison"
-role = "Investor Liaison"
-description = "Make warm, targeted investor introductions."
-
-[[agent]]
-id = "portfolio_support"
-role = "Portfolio Support"
-description = "Support alumni after the program."
-
 # Workflow graphs to enable. The graphs live in this company's workflows/
 # directory (one file per id), not inline here.
 [workflows]

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Startup Accelerator harness.
-# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`, backed by
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/companies/startup_accelerator/company.toml
+++ b/companies/startup_accelerator/company.toml
@@ -1,5 +1,5 @@
 # Agent roster for the Startup Accelerator harness.
-# The OpenCompany host instantiates one runtime agent per [[agent]], backed by
+# The OpenCompany host instantiates one runtime agent per `agents/<id>.toml`,
 # the vendored OpenHuman / TinyAgents modules.
 
 [company]

--- a/docs/modules/company/README.md
+++ b/docs/modules/company/README.md
@@ -10,7 +10,22 @@ phases — see [`docs/spec/roadmap.md`](../../spec/roadmap.md).
 
 - `CompanyManifest::from_path` — locate, read, parse, and validate a manifest
   from a file or a directory. `discover` prefers `company.toml` over the legacy
-  `agents.toml`.
+  `agents.toml`. When the bundle carries an `agents/` directory the roster is
+  read from those per-teammate files instead of from `[[agent]]`; declaring both
+  forms is a validation error. A caller that needs the `Located` value for
+  itself goes through `from_located` rather than `from_file`, so the
+  bundle-roster check cannot be skipped by taking a different route in.
+- `agent_file` — the `agents/<id>.toml` loader: filename-as-id, deterministic
+  ordering, and `prompt_files` resolved against the bundle. See
+  [runtime/agents.md](../../spec/runtime/agents.md).
+- `prompt` — how a teammate's system prompt is composed from its definition and
+  the documents routed to it, including the budget clamp.
+- `context_routing` — the per-tier default table and the class-based exclusions
+  deciding which workspace documents reach a role. See
+  [context-routing.md](../../spec/runtime/orchestration/context-routing.md).
+- `tool_catalog` — one list of everything a company can grant: built-in
+  families, MCP servers, Composio toolkits. See
+  [runtime/tools.md](../../spec/runtime/tools.md).
 - `CompanyManifest::validate` — return every problem in prosumer language
   (e.g. "`[policy].mode` must be one of readonly, supervised, full — you wrote
   `supervized`"), never serde traces. Problems are collected and reported

--- a/docs/spec/runtime/README.md
+++ b/docs/spec/runtime/README.md
@@ -44,6 +44,14 @@ Supporting docs:
   explicit-publish rule, `(task, source)` identity, body caps and reference
   bodies, and the single follow-up nudge
 - [manifest.md](manifest.md) — `company.toml` schema
+- [agents.md](agents.md) — how a teammate is declared: the inline `[[agent]]`
+  form and the one-file-per-teammate `agents/<id>.toml` bundle form, custom
+  prompts, checked-in briefing documents versus routed workspace documents, and
+  the `classes` routing exclusions
+- [tools.md](tools.md) — the three-level tool grant
+  (`[tools].allow ∩ desk.tools ∩ agent.tools`), why an empty grant list means
+  "inherit" rather than "nothing", the four namespaces `*` never confers, the
+  unified tool catalog, and the seed-wins rule for console desk overrides
 - [lifecycle.md](lifecycle.md) — company state machine and durability
 - [planning.md](planning.md) — the board's Planning station: one tool-less model
   call per card, the host-gathered evidence pack, the prerequisite verdict

--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -95,6 +95,13 @@ Static material first, volatile last. The prompt prefix is what a provider cache
 reuses across turns, so a workspace note the operator edits between two turns
 must not invalidate the briefing behind it.
 
+> **Step 5 is not yet wired into the harness.** The selection
+> (`routed_documents`), the workspace read (`resolve_routed_documents`) and the
+> rendering (`context_section`) are implemented and tested; carrying the result
+> through `HarnessDeps` into `build::build_agent` is the remaining step. See
+> [context-routing.md](orchestration/context-routing.md#the-rule). Steps 1–4
+> are live.
+
 **`prompt` is appended, never substituted.** The generated line is what binds the
 agent to *this* role at *this* company; a prompt that replaced it would silently
 cost the agent its identity and hand it back the runtime's own assistant

--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -1,0 +1,181 @@
+# Agent definitions
+
+*How a teammate is declared, and what reaches its system prompt.*
+
+Terms: [glossary](../glossary.md). Tool scoping is
+[tools.md](tools.md); which workspace documents a role is routed is
+[orchestration/context-routing.md](orchestration/context-routing.md).
+
+---
+
+## Two authoring forms
+
+A company's roster may be written either way:
+
+**Inline** — `[[agent]]` blocks in `company.toml`. Unchanged, still valid, still
+the smallest thing that works.
+
+**Per file** — one `agents/<id>.toml` per teammate under the company bundle.
+
+```
+companies/acme/
+├── company.toml          # everything except the roster
+├── agents/
+│   ├── copywriter.toml   # the id is the filename
+│   ├── seo_specialist.toml
+│   └── prompts/
+│       └── house-style.md
+└── workspace/
+```
+
+The per-file form exists because a teammate is more than four fields once it
+carries a custom prompt and its own briefing documents. A multi-line TOML string
+inside an array-of-tables is unreadable at roster length, and prose belongs
+beside the agent it configures.
+
+### The two forms are exclusive
+
+A bundle with both an `agents/` directory and `[[agent]]` entries is a
+**validation error**, not a precedence rule. Either precedence rule silently
+discards teammates an operator wrote down, and the roster is the one part of a
+manifest where a silent omission stays invisible until the missing teammate
+fails to answer.
+
+### The filename is the id
+
+`agents/copywriter.toml` declares the agent `copywriter`. An `id` key inside the
+file is accepted only when it agrees with the stem; a mismatch is an error
+naming both, because silently preferring one leaves an operator renaming the
+other and wondering why nothing changed.
+
+Files are read **sorted by stem**. Roster order is load-bearing — a company that
+tags nobody `tier = "orchestrator"` gets its first-listed teammate — and
+readdir order varies by filesystem, so an unsorted read would make which agent
+runs the company depend on which machine parsed the bundle. A company that
+relied on declaration order under the inline form MUST state
+`tier = "orchestrator"` when moving to the per-file form.
+
+Only the immediate directory is read. `agents/prompts/` holds documents, not
+teammates.
+
+## Schema
+
+Every key below is available in **both** forms — one type, one validator, one
+consumer, so adopting a custom prompt does not require adopting the bundle
+layout first.
+
+```toml
+# agents/copywriter.toml
+role = "Copywriter"                     # required
+description = "Write ads and campaign copy."
+tier = "reasoning"                      # cognition hint; never selects a model
+tools = ["docs.*", "mcp:notion"]        # grant globs — see tools.md
+delegates_to = ["creative"]             # desks this agent may hand work to
+budget_usd_daily = 5.0                  # per-agent daily cap
+
+prompt = """                            # appended to the generated persona
+Write for the reader, not the client.
+"""
+prompt_files = ["prompts/house-style.md"]   # checked-in, bundle-relative
+context = ["Brand/Brand voice.md"]          # live workspace documents
+classes = ["evidence"]                      # routing exclusions — see below
+```
+
+## The prompt
+
+An agent's system prompt is assembled in this order, and the order is a decision:
+
+1. the generated **persona** — who this teammate is, at which company;
+2. its inline **`prompt`**;
+3. its **`prompt_files`** bodies;
+4. tool briefs (workspace, publishing, skills catalogue);
+5. its routed **`context`** documents.
+
+Static material first, volatile last. The prompt prefix is what a provider cache
+reuses across turns, so a workspace note the operator edits between two turns
+must not invalidate the briefing behind it.
+
+**`prompt` is appended, never substituted.** The generated line is what binds the
+agent to *this* role at *this* company; a prompt that replaced it would silently
+cost the agent its identity and hand it back the runtime's own assistant
+persona. What belongs in `prompt` is how the role works, not who it is.
+
+### `prompt_files` versus `context`
+
+They are the static and dynamic halves of the same idea, and they differ on
+exactly one rule that matters:
+
+| | `prompt_files` | `context` |
+| --- | --- | --- |
+| Source | the company bundle, under `agents/` | the live workspace tree |
+| Read | once, at manifest load | on every roster rebuild |
+| Missing file | **validation error** | skipped |
+| Position | early (cache-stable) | last (volatile) |
+
+The missing-file split is deliberate. A `context` entry names operator-owned
+live state that may legitimately not exist yet. A `prompt_files` entry names a
+file in the same commit as the agent referencing it, so a typo there yields a
+role whose prompt was written around a briefing it silently never received —
+which fails confidently rather than visibly.
+
+A `prompt_files` path may not escape `agents/`. The check is on path components,
+before touching the filesystem, rather than by canonicalizing: canonical
+comparison resolves symlinks, and whether a bundle is valid must not depend on
+how the checkout was laid out on the reading machine.
+
+### Budgets
+
+Each document section is clamped to `PROMPT_FILE_BUDGET_CHARS` (10,000
+codepoints, a tokenizer-free upper bound on the brief budget in
+[alignment.md](orchestration/alignment.md)). The clamp keeps the **leading**
+portion, cuts on a character boundary, and appends a visible marker.
+
+The budget applies to the **section**, not per document: a role routed five
+documents and a role routed one spend from the same prompt. Clamping happens at
+assembly, where the text is spent — refusing the read would cost the company the
+whole document, while clamping the tail costs only the tail.
+
+An empty or whitespace-only document is dropped rather than rendered as a bare
+heading. An empty section reads to the model as a source that exists and says
+nothing, which is worse than its absence.
+
+## `classes`
+
+The explicit epistemic classification
+[context-routing.md](orchestration/context-routing.md) requires. Three values,
+each subtracting one document:
+
+| Class | Excludes | Prevents |
+| --- | --- | --- |
+| `evidence` | the assertion board | a role weighing evidence scoring an unevidenced sentence beside a real one |
+| `judge` | the scratch | provisional working-out read as progress, which keeps a loop retrying |
+| `directive` | the claim ledger | a role carrying out an instruction filing that instruction as a finding |
+
+Declaring none is *unclassified*, which imposes no exclusion and is the right
+default: an ordinary teammate is not judging anything.
+
+An exclusion **outranks** both the tier default and an explicit `context` list.
+That is what makes a declared class a control rather than a suggestion someone
+can edit away. The universal method document is exempt — it is method, not
+assertion, and a role excluded from it could not follow it.
+
+The classification MUST be declared, never inferred from `role`: `role` is prose
+an operator writes for humans, so matching on it would make a company that
+renames "Critic" to "Reviewer" silently lose an exclusion, and a control a
+rename can switch off is not a control.
+
+## Where this lives
+
+| Concern | File |
+| --- | --- |
+| Bundle loading, `prompt_files` resolution | `src/company/agent_file.rs` |
+| Prompt composition and clamping | `src/company/prompt.rs` |
+| Routing table and exclusions | `src/company/context_routing.rs` |
+| Roster type and constants | `src/company/types.rs` |
+| Manifest wiring and validation | `src/company/manifest.rs` |
+
+The first three are **always compiled**, though the harness that spends the
+prompt is behind the `openhuman` feature. Composition, clamping and the
+exclusion table are pure decisions with real edge cases, and the exclusions are
+controls — they deserve tests in every build, not only where the agent runtime
+links.

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -213,17 +213,33 @@ its tool grants or its desk membership — the roster row carried none of them, 
 checking what a company actually grants an agent was not possible from outside
 the process.
 
-The `tools` object is the reason the route earns its keep. It carries three
-lists, because only the third is the answer:
+The `tools` object is the reason the route earns its keep. It carries four
+lists, because only the last is the answer:
 
 | field | meaning |
 |---|---|
-| `requested` | the agent's own `[[agent]].tools` globs. **Empty means the company's standard grant**, not "no tools" |
-| `companyAllow` | the `[tools].allow` ceiling the request is intersected with |
-| `effective` | what the agent actually holds |
+| `requested` | the agent's own `tools` globs. **Empty means the company's standard grant**, not "no tools" |
+| `companyAllow` | the `[tools].allow` ceiling |
+| `deskAllow` | the union of the `tools` ceilings of the desks this agent sits on, already narrowed by `companyAllow`. **Empty means no desk narrows anything** |
+| `effective` | what the agent actually holds, after all three levels |
 
-`effective` is computed by the same `agent_effective_grants` the harness calls
-when it builds the agent, so the readout cannot drift from what is enforced.
+The three ceilings shrink monotonically, so a console can render them as a
+chain. Both "empty" readings above are the same trap in two places: an empty
+grant list means *inherit*, never *nothing*, and a surface rendering it as "no
+tools" has inverted the meaning.
+
+`effective` is computed by the same `agent_scoped_grants` the harness calls when
+it builds the agent, so the readout cannot drift from what is enforced. The
+constructor takes the company record and agent id rather than a pre-extracted
+allow-list, because the desk level cannot be derived from the company grant
+alone — that shape is what makes "forgot to apply the desk ceiling"
+unrepresentable at a call site rather than something three callers each have to
+remember.
+
+`GET …/tools/catalog` is the companion read: every grantable thing this company
+has — built-in families, `[[mcp_server]]` entries, `[tools.composio]` toolkits —
+in one vocabulary, each row carrying the exact grant token an operator would
+write. See [runtime/tools.md](tools.md).
 `isOrchestrator` is likewise resolved by the roster rule (a `tier =
 "orchestrator"` agent, else the first declared) rather than read off `tier`, so
 a company that tags nobody still names its orchestrator.

--- a/docs/spec/runtime/api-write-plane.md
+++ b/docs/spec/runtime/api-write-plane.md
@@ -43,6 +43,7 @@ POST   …/skills/{slug}/install              install a registry/company skill
 POST   …/skills/{slug}/uninstall            uninstall a skill
 PUT    …/skills/{slug}                       enable / disable a skill
 POST   …/team                               add an operator-overlay teammate
+GET    …/tools/catalog                       everything this company can grant
 GET    …/team/{agentId}                      one agent in full (tier, tools, desks)
 PATCH  …/team/{agentId}                      edit an overlay teammate
 DELETE …/team/{agentId}                      remove an overlay teammate

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -35,6 +35,13 @@ tier = "reasoning"                 # cognition tier hint (see glossary)
 tools = ["docs.*", "email.send"]   # tool grant globs
 delegates_to = ["research"]        # desks this agent may hand work to ("*" = all)
 budget_usd_daily = 5.0             # per-agent daily spend cap (UTC day)
+prompt = "Write for the reader."   # appended to the generated persona
+prompt_files = ["prompts/tone.md"] # checked-in briefing docs, under `agents/`
+context = ["BRIEF.md"]             # live workspace docs routed into the prompt
+classes = ["evidence"]             # routing exclusions: evidence | judge | directive
+# A roster may instead live one file per teammate under `agents/<id>.toml`, with
+# these same keys and the filename as the id. The two forms are exclusive —
+# declaring both is a validation error. See runtime/agents.md.
 
 # ── new tables (all optional) ──────────────────────────────────────────
 [users]

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -129,10 +129,22 @@ prompt = "Weekly review and operator digest"
 
 - **`[company]`** becomes the seed of the [Charter](../company-brain/charter.md).
   `handle` is only used when `[place].discoverable = true`.
-- **`[[agent]]`** entries define the Roster. `tier` is a hint the brain may
-  use when delegating; it never selects a model (the backend maps tiers to
-  SKUs). `tools` and `budget_usd_daily` intersect with the company-wide
-  `[tools].allow` and `[budget]` — the most restrictive wins.
+- **`[[agent]]`** entries define the Roster — or, equivalently, one
+  `agents/<id>.toml` file per teammate under the company bundle, carrying the
+  same keys with the filename as the id. The two forms are **exclusive**:
+  declaring both is a validation error rather than a precedence rule, because
+  either precedence would silently discard teammates somebody wrote down. Full
+  schema, including `prompt` / `prompt_files` / `context` / `classes`, in
+  [runtime/agents.md](agents.md).
+
+  `tier` is a hint the brain may use when delegating; it never selects a model
+  (the backend maps tiers to SKUs). `tools` and `budget_usd_daily` intersect
+  with the company-wide `[tools].allow` and `[budget]` — the most restrictive
+  wins. Tool grants resolve through **three** levels,
+  `[tools].allow ∩ [[group_chat]].tools ∩ [[agent]].tools`, every one of them
+  narrow-only and an empty one a pass-through; see
+  [runtime/tools.md](tools.md), which also covers why an empty grant list means
+  "inherit" rather than "nothing".
 
   **`delegates_to`** (issue #176) is the one per-agent key that is *not* a
   narrowing of a company-wide list: it is an **opt-in**. Empty — the default,

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -79,9 +79,17 @@ enabled = true                     # built-in chat; default true
 [channels.email]
 provider = "openhuman"             # delegate to an OpenHuman channel
 
+[[group_chat]]
+id = "creative"                    # a desk: who the human talks to
+name = "Creative studio"
+members = ["copywriter"]           # ids from the roster
+tools = ["docs.*"]                 # NEW: this desk's tool ceiling. Optional;
+                                   # empty narrows nothing. See runtime/tools.md
+
 [tools]
 provider = "openhuman"             # openhuman (default) | builtin
-allow = ["web.*", "docs.*", "search"]  # company-wide grant; agents intersect
+allow = ["web.*", "docs.*", "search"]  # company-wide ceiling. Desks and agents
+                                   # narrow it: allow ∩ desk.tools ∩ agent.tools
                                    # `search` must be named — `*` never grants it
 search_daily_calls = 200           # per-company daily web_search cap (0 = paused)
 max_delegation_depth = 2           # how deep one message's hand-off chain may run

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -71,9 +71,16 @@ working context at all.
 **Representation note.** `Agent.context` is `Option<Vec<String>>`, not a
 defaulted `Vec<String>`: `None` is an omitted key, `Some(vec![])` is an
 explicit `context = []`, and only that split lets the manifest layer carry
-the distinction above at all. The field is otherwise inert until the routing
-layer lands — `role_context` does not exist yet, so nothing reads either
-variant today.
+the distinction above at all.
+
+**Implemented** in `src/company/context_routing.rs` (`routed_documents`), which
+is always compiled and carries the table above plus the exclusions below as
+tested code. Documents are resolved against the workspace before the
+(synchronous) agent build and folded into the system prompt last, after the
+static `prompt_files` — see [runtime/agents.md](../agents.md) for the prompt
+order and why volatile material goes at the end. A routed document that changes
+moves the roster fingerprint, so an edit reaches the next turn rather than the
+next restart.
 
 ## Exclusions are load-bearing
 

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -73,14 +73,20 @@ defaulted `Vec<String>`: `None` is an omitted key, `Some(vec![])` is an
 explicit `context = []`, and only that split lets the manifest layer carry
 the distinction above at all.
 
-**Implemented** in `src/company/context_routing.rs` (`routed_documents`), which
-is always compiled and carries the table above plus the exclusions below as
-tested code. Documents are resolved against the workspace before the
-(synchronous) agent build and folded into the system prompt last, after the
-static `prompt_files` — see [runtime/agents.md](../agents.md) for the prompt
-order and why volatile material goes at the end. A routed document that changes
-moves the roster fingerprint, so an edit reaches the next turn rather than the
-next restart.
+**Implemented** in `src/company/context_routing.rs`, always compiled and tested:
+`routed_documents` carries the table above and the exclusions below;
+`resolve_routed_documents` reads the selected notes out of a `WorkspaceStore`,
+skipping any that do not exist. Rendering into a prompt section is
+`crate::company::prompt::context_section`.
+
+**Not yet wired into the harness.** The agent build is synchronous, so the
+resolved documents have to be fetched ahead of it and carried on `HarnessDeps`
+— the pattern `mcp_servers`, `composio` and the skill deltas already follow in
+`Harness::ensure_roster` — and folded into the persona last, after the static
+`prompt_files`. Until that lands, `context` selects documents that nothing
+spends. The remaining work is: resolve per roster member in `ensure_roster`,
+install on `fresh_deps`, fingerprint the result so an edited note rebuilds the
+roster, and append `context_section` in `build::build_agent`.
 
 ## Exclusions are load-bearing
 

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -122,9 +122,17 @@ into, not of the manifest text**:
 - Roster teammates default to **unclassified**, which imposes no exclusion and
   is the correct default: an ordinary teammate is not judging anything.
 - A company that wants an exclusion on a roster teammate states it, rather than
-  having it guessed. The manifest key for this is deliberately left to the
-  implementing change, but it MUST be an explicit declaration — a `classes`
-  list or equivalent — and never a match on `role`.
+  having it guessed. **The manifest key is `classes`**, a list taking any of
+  `evidence`, `judge` and `directive` — one per rule above, in that order. An
+  unrecognized entry is a validation error rather than an ignored string: a
+  typo'd exclusion is an exclusion that is not applied, and the whole point of
+  declaring the class is that it cannot be lost silently.
+
+An exclusion **outranks** both the tier default and an explicit `context` list.
+That is what makes a declared class a control rather than a routing line
+somebody can edit away. The universal method document is the one exemption — it
+is method, not assertion, so no class has cause to withhold it, and a role
+excluded from the method could not follow it.
 
 The rule this preserves: an exclusion applies because something *declared* the
 role's job, and a company can add one but cannot silently remove one by

--- a/docs/spec/runtime/tools.md
+++ b/docs/spec/runtime/tools.md
@@ -1,0 +1,149 @@
+# Tool grants and scoping
+
+*How a company decides what each of its agents can reach.*
+
+Terms: [glossary](../glossary.md). The approval gate — a separate axis, covering
+whether a granted tool's call needs a human first — is
+[company-brain/grants.md](../company-brain/grants.md).
+
+---
+
+## The three levels
+
+A teammate's tool belt is resolved by intersecting three declarations, in order:
+
+```
+[tools].allow  ∩  desk.tools  ∩  agent.tools
+```
+
+Every level is **narrow-only**. There is no path through the resolution that
+yields a grant `[tools].allow` does not already cover, which is what makes the
+lower two levels safe to hand to an operator: the worst a desk or an agent
+declaration can do is remove capability.
+
+Each level is **optional**, and an omitted level is a pass-through rather than a
+denial. This matters more than it looks:
+
+> An empty grant list means **"inherit"**, not **"nothing"**.
+
+An agent with no `tools` line holds its desk's ceiling; a desk with no `tools`
+line imposes the company's. Any surface that renders an empty list as "no tools"
+has inverted the meaning — see `AgentToolsDto` in
+`src/server/ops/team_agent.rs`, whose field docs carry the same warning.
+
+Resolution lives in one function,
+[`agent_scoped_grants`](../../../src/runtime/builder.rs), and every reader goes
+through it: the harness that wires the belt, the console's agent card, and the
+roster list. A second implementation anywhere is a bug — the console showing a
+tool the gate refuses is the exact failure this single-source rule prevents.
+
+### Levels in detail
+
+**Company — `[tools].allow`.** The ceiling. Defaults to
+`["*", "media", "composio"]`.
+
+**Desk — `[[group_chat]].tools`.** A department's ceiling. A company organises
+its teammates into desks — a finance desk, a creative desk — and this is where
+"nobody on this desk reaches the web" is stated once instead of repeated on
+every member and hoped for on the next member added.
+
+**Agent — `agents/<id>.toml` `tools`.** The individual's request.
+
+### Agents on several desks take the union
+
+A teammate on more than one desk takes the **union** of those desks' ceilings
+before the intersection with the company grant.
+
+Union rather than intersection, because desk membership is additive: joining the
+growth desk is how a marketer gains the ad tools. Intersecting would make each
+extra desk silently *revoke* capability, so adding someone to a desk could break
+work they were already doing.
+
+The consequence, which MUST be understood before relying on a desk ceiling: **a
+desk with no ceiling narrows nothing**, so a teammate on both a restricted desk
+and an unrestricted one ends up unrestricted. A company that means to restrict a
+teammate states the ceiling on every desk that teammate sits on, or states it on
+the teammate. This is the safe direction — the widest it can resolve to is the
+company grant itself — but it is not the intuitive one.
+
+## The wildcard does not mean everything
+
+`*` covers `files`, `docs`, `shell`, `code`, `web` and `subagent`. It
+deliberately does **not** confer four namespaces, each of which must be named:
+
+| Namespace | Why it must be named |
+| --- | --- |
+| `media` | Spends real money per generated image or video. |
+| `composio` | Reaches the tenant's connected third-party accounts and moves real side effects — sends email, opens PRs. |
+| `search` | Every call is a billed request on the managed platform. |
+| `repo` | Materializes a third party's source inside a sandbox where the agent may also hold `shell`. |
+
+`repo.write` is tighter still: only the exact string confers it. A bare `repo`
+grant carries read access and nothing else, because read and write are separate
+decisions — a company that adopted the read tier must not silently acquire
+agents that push.
+
+Each rule has its own predicate beside the manifest types
+(`grants_media_explicit` and siblings in `src/company/types.rs`). Nothing may
+re-derive these answers from the generic glob matcher: it reports `*` as
+covering everything, which is right for the ordinary families and wrong for
+these four.
+
+## The catalog
+
+`src/company/tool_catalog.rs` enumerates everything a company can grant —
+built-in families, `[[mcp_server]]` entries, and `[tools.composio]` toolkits —
+in one vocabulary, served at `GET {scope}/tools/catalog`.
+
+It is a **projection, never a source of truth**. Every entry carries the exact
+grant token an operator would write, and resolves it through the same matcher
+the roster build uses. An entry advertising a grant the gate does not honour is
+a bug in the catalog, not a new kind of permission; a test asserts the
+round-trip.
+
+Two flags on each entry exist because the naive rendering is wrong:
+
+- `granted` — whether `[tools].allow` currently confers it, resolved through the
+  per-namespace predicates above rather than the glob matcher.
+- `coveredByWildcard` — whether `*` would confer it, so a console rendering `*`
+  as "everything" can say which four families it does not in fact cover.
+
+A disabled `[[mcp_server]]` is listed with `granted: false` rather than omitted:
+an operator needs to see that the server exists and is switched off, which an
+absent row cannot say.
+
+## Runtime overrides
+
+An operator may narrow a desk from the console. The override is stored on the
+company record (`overlay_desk_tools`) and read through
+`CompanyRecord::effective_desk_tools`, never directly — the same
+`overlay_* → effective_*` discipline the spend cap and approval tier follow, so
+the write path and both read surfaces cannot drift.
+
+Two properties are load-bearing:
+
+**Version control wins when it speaks.** On a rebuild, a desk's override is
+dropped if that desk's seed `tools` changed
+(`carry_desk_tool_overrides`, `src/runtime/builder.rs`). A console override
+outliving a seed that narrowed the desk would be a runtime widening surviving
+the operator revoking it in version control — the failure the `[tools]` /
+`[policy]` seed-wins rule exists to prevent, and a per-desk grant is squarely
+within it. The check is **per desk**, not whole-block: editing the finance desk
+says nothing about the creative desk.
+
+**A change reaches the next turn, not the next restart.** A tool belt is wired
+once per roster, not once per call, so desk scoping participates in the roster
+staleness fingerprint (`desk_scope_fingerprint`, `src/harness/mod.rs`). The
+fingerprint covers which desks exist, who sits on them, and each ceiling —
+because seating a teammate on a restricted desk narrows its belt just as surely
+as editing that desk's ceiling does.
+
+## What this does not do
+
+Grants decide which tools are **wired**. They do not decide whether a wired
+tool's call proceeds — that is the approval gate
+([company-brain/grants.md](../company-brain/grants.md)) — nor how much a
+namespace may spend, which is the capability plan (`[plan]`), nor what an agent
+can reach once it holds `shell`. On that last point see
+[security/agent-isolation.md](../security/agent-isolation.md), which is blunt
+about what is not enforced.

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -93,6 +93,7 @@ async fn main() -> anyhow::Result<()> {
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -247,3 +247,241 @@ fn resolve_prompt_files(
         Err(problems)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Writes a bundle with the given `agents/` files and returns its root.
+    fn bundle(files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let agents = dir.path().join(AGENTS_DIR);
+        std::fs::create_dir_all(&agents).expect("agents dir");
+        for (name, body) in files {
+            let path = agents.join(name);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("parent dir");
+            }
+            std::fs::write(path, body).expect("write");
+        }
+        dir
+    }
+
+    fn problems_of(err: crate::error::OpenCompanyError) -> Vec<String> {
+        match err {
+            crate::error::OpenCompanyError::ManifestInvalid { problems, .. } => problems,
+            other => panic!("expected ManifestInvalid, got {other}"),
+        }
+    }
+
+    #[test]
+    fn an_absent_or_empty_agents_directory_is_not_a_bundle_roster() {
+        let empty = tempfile::tempdir().expect("tempdir");
+        assert!(
+            !has_agent_files(empty.path()),
+            "a bundle with no `agents/` at all keeps its `[[agent]]` roster"
+        );
+
+        // Present but empty: still not a roster. Treating it as one would blank
+        // the roster of a company whose `company.toml` has a perfectly good one.
+        let dir = bundle(&[]);
+        assert!(!has_agent_files(dir.path()));
+    }
+
+    #[test]
+    fn loads_agents_sorted_by_stem_not_directory_order() {
+        // Written in an order that is not sorted, so a readdir-order
+        // implementation would visibly disagree. Roster order decides which
+        // teammate is the orchestrator when nobody is tagged, so this is
+        // load-bearing rather than cosmetic.
+        let dir = bundle(&[
+            ("zara.toml", "role = \"Zara\"\n"),
+            ("alice.toml", "role = \"Alice\"\n"),
+            ("mike.toml", "role = \"Mike\"\n"),
+        ]);
+
+        let agents = load_agents(dir.path()).expect("loads");
+        let ids: Vec<&str> = agents.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, ["alice", "mike", "zara"]);
+    }
+
+    #[test]
+    fn the_filename_is_the_id_and_a_declared_id_must_agree() {
+        let dir = bundle(&[("copywriter.toml", "role = \"Copywriter\"\n")]);
+        let agents = load_agents(dir.path()).expect("loads");
+        assert_eq!(agents[0].id, "copywriter");
+
+        let dir = bundle(&[(
+            "copywriter.toml",
+            "id = \"copy_writer\"\nrole = \"Copywriter\"\n",
+        )]);
+        let problems = problems_of(load_agents(dir.path()).expect_err("mismatched id is refused"));
+        assert_eq!(problems.len(), 1);
+        // The message must name both halves: an operator who renamed one of them
+        // needs to know which one the runtime believed.
+        assert!(problems[0].contains("copy_writer"), "{problems:?}");
+        assert!(problems[0].contains("copywriter"), "{problems:?}");
+    }
+
+    #[test]
+    fn a_non_snake_case_filename_is_refused() {
+        let dir = bundle(&[("CopyWriter.toml", "role = \"Copywriter\"\n")]);
+        let problems = problems_of(load_agents(dir.path()).expect_err("refused"));
+        assert!(
+            problems[0].contains("snake_case"),
+            "the message must say what shape is wanted: {problems:?}"
+        );
+    }
+
+    #[test]
+    fn a_missing_role_is_refused() {
+        let dir = bundle(&[("copywriter.toml", "description = \"writes\"\n")]);
+        let problems = problems_of(load_agents(dir.path()).expect_err("refused"));
+        assert!(problems[0].contains("`role`"), "{problems:?}");
+    }
+
+    #[test]
+    fn every_problem_across_every_file_is_reported_at_once() {
+        // Two broken files, two distinct problems in the second. An operator
+        // fixing one problem per run is the failure this collects to avoid.
+        let dir = bundle(&[
+            ("Bad_Name.toml", "role = \"Fine\"\n"),
+            (
+                "other.toml",
+                "role = \"\"\nprompt_files = [\"nope.md\", \"../escape.md\"]\n",
+            ),
+        ]);
+        let problems = problems_of(load_agents(dir.path()).expect_err("refused"));
+        assert_eq!(problems.len(), 4, "{problems:?}");
+    }
+
+    #[test]
+    fn prompt_files_are_read_from_the_bundle() {
+        let dir = bundle(&[
+            (
+                "copywriter.toml",
+                "role = \"Copywriter\"\nprompt_files = [\"prompts/tone.md\"]\n",
+            ),
+            ("prompts/tone.md", "Lead with the reader's problem."),
+        ]);
+
+        let agents = load_agents(dir.path()).expect("loads");
+        assert_eq!(
+            agents[0].prompt_files_resolved,
+            vec![(
+                "prompts/tone.md".to_string(),
+                "Lead with the reader's problem.".to_string()
+            )]
+        );
+        // The declared list survives alongside the resolved bodies: the console
+        // renders what the agent asked for, not just what it got.
+        assert_eq!(agents[0].prompt_files, vec!["prompts/tone.md".to_string()]);
+    }
+
+    #[test]
+    fn a_missing_prompt_file_is_an_error_rather_than_a_skipped_entry() {
+        // The whole point: a typo here would otherwise yield a role whose prompt
+        // was written around a briefing it silently never received.
+        let dir = bundle(&[(
+            "copywriter.toml",
+            "role = \"Copywriter\"\nprompt_files = [\"prompts/tone.md\"]\n",
+        )]);
+        let problems = problems_of(load_agents(dir.path()).expect_err("refused"));
+        assert!(problems[0].contains("prompts/tone.md"), "{problems:?}");
+        assert!(problems[0].contains("does not exist"), "{problems:?}");
+    }
+
+    #[test]
+    fn a_prompt_file_path_may_not_escape_the_agents_directory() {
+        for escape in ["../secrets.md", "nested/../../secrets.md", "/etc/passwd"] {
+            let dir = bundle(&[(
+                "copywriter.toml",
+                &format!("role = \"Copywriter\"\nprompt_files = [\"{escape}\"]\n"),
+            )]);
+            let problems = problems_of(
+                load_agents(dir.path()).unwrap_err_or_else_panic(&format!("{escape} is refused")),
+            );
+            assert!(
+                problems[0].contains("outside"),
+                "{escape} → {problems:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_subdirectory_toml_is_a_document_not_a_teammate() {
+        // `prompt_files` may point at a `.toml` briefing; descending into
+        // subdirectories would try to parse it as a roster entry.
+        let dir = bundle(&[
+            ("copywriter.toml", "role = \"Copywriter\"\n"),
+            ("prompts/reference.toml", "not = \"an agent\"\n"),
+        ]);
+        let agents = load_agents(dir.path()).expect("loads");
+        let ids: Vec<&str> = agents.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, ["copywriter"]);
+    }
+
+    #[test]
+    fn the_full_enriched_shape_round_trips() {
+        let dir = bundle(&[
+            (
+                "critic.toml",
+                r#"
+role = "Critic"
+description = "Challenge a deliverable."
+tier = "reasoning"
+tools = ["docs.*", "mcp:notion"]
+delegates_to = ["research"]
+budget_usd_daily = 5.0
+prompt = "Be specific about what would change your mind."
+prompt_files = ["prompts/rubric.md"]
+context = ["GOAL.md", "CLAIMS.md"]
+classes = ["judge", "evidence"]
+"#,
+            ),
+            ("prompts/rubric.md", "Score against the brief."),
+        ]);
+
+        let agent = load_agents(dir.path()).expect("loads").remove(0);
+        assert_eq!(agent.id, "critic");
+        assert_eq!(agent.tier.as_deref(), Some("reasoning"));
+        assert_eq!(agent.tools, ["docs.*", "mcp:notion"]);
+        assert_eq!(agent.delegates_to, ["research"]);
+        assert_eq!(agent.budget_usd_daily, Some(5.0));
+        assert_eq!(
+            agent.prompt.as_deref(),
+            Some("Be specific about what would change your mind.")
+        );
+        assert_eq!(agent.context.as_deref(), Some(&["GOAL.md".to_string(), "CLAIMS.md".to_string()][..]));
+        assert_eq!(agent.classes, ["judge", "evidence"]);
+    }
+
+    /// `context = []` must survive as an explicit empty list, distinct from an
+    /// omitted key — the routing layer reads the two differently.
+    #[test]
+    fn an_explicit_empty_context_is_distinct_from_an_omitted_one() {
+        let dir = bundle(&[
+            ("omitted.toml", "role = \"A\"\n"),
+            ("explicit.toml", "role = \"B\"\ncontext = []\n"),
+        ]);
+        let agents = load_agents(dir.path()).expect("loads");
+        let explicit = agents.iter().find(|a| a.id == "explicit").expect("found");
+        let omitted = agents.iter().find(|a| a.id == "omitted").expect("found");
+        assert_eq!(explicit.context, Some(Vec::new()));
+        assert_eq!(omitted.context, None);
+    }
+
+    /// Small helper so the escape loop above reads as one assertion per case.
+    trait UnwrapErrOrPanic<T> {
+        fn unwrap_err_or_else_panic(self, message: &str) -> crate::error::OpenCompanyError;
+    }
+
+    impl<T> UnwrapErrOrPanic<T> for Result<T> {
+        fn unwrap_err_or_else_panic(self, message: &str) -> crate::error::OpenCompanyError {
+            match self {
+                Ok(_) => panic!("{message}"),
+                Err(err) => err,
+            }
+        }
+    }
+}

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -1,0 +1,249 @@
+//! Agent definition files: `companies/<name>/agents/<id>.toml`.
+//!
+//! A company's roster may be written either inline in `company.toml` as
+//! `[[agent]]` entries or — the richer form — as one file per teammate under an
+//! `agents/` directory. The two are mutually exclusive per company: a bundle
+//! that has both is a validation error rather than a silent precedence rule,
+//! because a roster block the operator wrote and the runtime ignored is exactly
+//! the failure this crate's manifest validation exists to prevent.
+//!
+//! The per-file form exists because a teammate is more than four fields once it
+//! carries a custom prompt and its own briefing documents. Those do not fit
+//! comfortably in an array-of-tables — a multi-line TOML string inside
+//! `[[agent]]` is unreadable at roster length, and prose belongs beside the
+//! agent it configures.
+//!
+//! This module parses those files, resolves each agent's
+//! [`prompt_files`](crate::company::Agent::prompt_files) against the bundle, and
+//! reports every problem at once in prosumer language — matching
+//! [`super::manifest`] and [`super::workflow_file`].
+
+use std::path::{Path, PathBuf};
+
+use crate::company::Agent;
+use crate::error::{OpenCompanyError, Result};
+
+/// The bundle subdirectory holding one TOML file per roster teammate.
+pub const AGENTS_DIR: &str = "agents";
+
+/// Whether `dir` is a company bundle whose roster lives in `agents/*.toml`.
+///
+/// A present-but-empty `agents/` directory is **not** a bundle roster: it
+/// carries no teammates, so treating it as authoritative would blank the roster
+/// of a company whose `company.toml` still has a perfectly good one. An
+/// unreadable directory answers `false` for the same reason — the caller then
+/// parses `[[agent]]` as it always did, rather than failing the whole company
+/// over a directory nothing has asked to read yet.
+pub fn has_agent_files(dir: &Path) -> bool {
+    !agent_file_paths(&dir.join(AGENTS_DIR)).is_empty()
+}
+
+/// Every `.toml` file directly inside `agents/`, sorted by file stem.
+///
+/// Sorted, not directory order, because the roster's order is load-bearing:
+/// [`orchestrator_id`](crate::company::orchestrator_id) falls back to "the first
+/// agent declared" when nobody is tagged `tier = "orchestrator"`, and readdir
+/// order varies by filesystem. An unsorted read would make which teammate runs
+/// the company depend on which machine parsed the bundle.
+///
+/// Only the immediate directory is read. Subdirectories are for the documents
+/// `prompt_files` names, so descending into them would try to parse a `.toml`
+/// briefing as a teammate.
+fn agent_file_paths(agents_dir: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = std::fs::read_dir(agents_dir) else {
+        return Vec::new();
+    };
+    let mut paths: Vec<PathBuf> = entries
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && path.extension().is_some_and(|ext| ext == "toml"))
+        .collect();
+    paths.sort();
+    paths
+}
+
+/// The on-disk shape of one `agents/<id>.toml`.
+///
+/// Every field mirrors [`Agent`], because that is what this parses into: the
+/// roster type does not fork by authoring format, so a field added for the
+/// bundle form is immediately available to `[[agent]]` too, and there is exactly
+/// one validator and one consumer for it.
+///
+/// `id` is optional here and comes from the filename. It is accepted in the body
+/// only as a cross-check — see [`parse_agent_file`].
+#[derive(Debug, serde::Deserialize)]
+struct AgentFile {
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    role: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    tier: Option<String>,
+    #[serde(default)]
+    tools: Vec<String>,
+    #[serde(default)]
+    delegates_to: Vec<String>,
+    #[serde(default)]
+    context: Option<Vec<String>>,
+    #[serde(default)]
+    budget_usd_daily: Option<f64>,
+    #[serde(default)]
+    prompt: Option<String>,
+    #[serde(default)]
+    prompt_files: Vec<String>,
+    #[serde(default)]
+    classes: Vec<String>,
+}
+
+/// Loads every agent definition under `<dir>/agents/`, in roster order.
+///
+/// Field-level validity (tier names, grant shapes, `delegates_to` targets) is
+/// **not** checked here: those rules are cross-cutting — a `delegates_to` entry
+/// has to name a desk declared in `company.toml` — so they belong to
+/// [`CompanyManifest::validate`](crate::company::CompanyManifest::validate),
+/// which sees the whole company. This function is responsible only for what it
+/// alone can see: that each file parses, that its identity is coherent with its
+/// filename, and that the documents it names exist and can be read.
+pub fn load_agents(dir: &Path) -> Result<Vec<Agent>> {
+    let agents_dir = dir.join(AGENTS_DIR);
+    let mut agents = Vec::new();
+    let mut problems = Vec::new();
+
+    for path in agent_file_paths(&agents_dir) {
+        match parse_agent_file(&agents_dir, &path) {
+            Ok(agent) => agents.push(agent),
+            Err(mut file_problems) => problems.append(&mut file_problems),
+        }
+    }
+
+    // Duplicate ids cannot arise from distinct filenames, but an `id` key that
+    // disagrees with its stem is rejected above, so by here every id *is* its
+    // stem and uniqueness is a property of the filesystem. Nothing to check.
+
+    if problems.is_empty() {
+        Ok(agents)
+    } else {
+        Err(OpenCompanyError::ManifestInvalid {
+            path: agents_dir,
+            problems,
+        })
+    }
+}
+
+/// Parses one agent file, returning every problem it has rather than the first.
+fn parse_agent_file(agents_dir: &Path, path: &Path) -> std::result::Result<Agent, Vec<String>> {
+    let stem = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or_default()
+        .to_string();
+    let label = format!("agent file `{AGENTS_DIR}/{stem}.toml`");
+
+    let text = std::fs::read_to_string(path)
+        .map_err(|err| vec![format!("{label} could not be read — {err}.")])?;
+    let file: AgentFile = toml::from_str(&text)
+        .map_err(|err| vec![format!("{label} is not valid TOML — {}.", err.message())])?;
+
+    let mut problems = Vec::new();
+
+    if !super::manifest::is_snake_case(&stem) {
+        problems.push(format!(
+            "{label} has an invalid filename — the file name is the agent's id, so use snake_case (lowercase letters, digits, and underscores, starting with a letter)."
+        ));
+    }
+
+    // An `id` key is redundant with the filename but harmless to write, so it is
+    // accepted when it agrees and rejected when it does not. Silently preferring
+    // one over the other would leave an operator renaming a file and wondering
+    // why nothing changed — or renaming the key and wondering the same.
+    if let Some(declared) = file.id.as_deref()
+        && declared != stem
+    {
+        problems.push(format!(
+            "{label} declares `id = \"{declared}\"` but its filename says `{stem}` — the filename is the id, so rename the file or drop the `id` key."
+        ));
+    }
+
+    let role = file.role.unwrap_or_default();
+    if role.trim().is_empty() {
+        problems.push(format!("{label} is missing a `role`."));
+    }
+
+    let prompt_files_resolved = match resolve_prompt_files(agents_dir, &label, &file.prompt_files) {
+        Ok(resolved) => resolved,
+        Err(mut file_problems) => {
+            problems.append(&mut file_problems);
+            Vec::new()
+        }
+    };
+
+    if !problems.is_empty() {
+        return Err(problems);
+    }
+
+    Ok(Agent {
+        id: stem,
+        role,
+        description: file.description,
+        tier: file.tier,
+        tools: file.tools,
+        delegates_to: file.delegates_to,
+        context: file.context,
+        budget_usd_daily: file.budget_usd_daily,
+        prompt: file.prompt,
+        prompt_files: file.prompt_files,
+        prompt_files_resolved,
+        classes: file.classes,
+    })
+}
+
+/// Reads each `prompt_files` entry relative to `agents/`, refusing any path that
+/// leaves that directory.
+///
+/// The traversal check is done on the **path components**, before touching the
+/// filesystem, rather than by canonicalizing and comparing prefixes. Canonical
+/// comparison would resolve symlinks, which makes whether a bundle is valid
+/// depend on how the checkout was laid out on the reading machine; a company
+/// that parses on one host must parse on every host. Absolute paths and `..`
+/// are both rejected outright — an agent's briefing lives beside the agent.
+fn resolve_prompt_files(
+    agents_dir: &Path,
+    label: &str,
+    entries: &[String],
+) -> std::result::Result<Vec<(String, String)>, Vec<String>> {
+    let mut resolved = Vec::new();
+    let mut problems = Vec::new();
+
+    for entry in entries {
+        let rel = Path::new(entry);
+        let escapes = rel.is_absolute()
+            || rel
+                .components()
+                .any(|c| matches!(c, std::path::Component::ParentDir));
+        if escapes {
+            problems.push(format!(
+                "{label} names `prompt_files` entry `{entry}`, which points outside `{AGENTS_DIR}/` — a prompt document must live beside the agent that uses it."
+            ));
+            continue;
+        }
+
+        let path = agents_dir.join(rel);
+        match std::fs::read_to_string(&path) {
+            Ok(body) => resolved.push((entry.clone(), body)),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => problems.push(format!(
+                "{label} names `prompt_files` entry `{entry}`, which does not exist — create `{AGENTS_DIR}/{entry}` or remove the entry."
+            )),
+            Err(err) => problems.push(format!(
+                "{label} could not read `prompt_files` entry `{entry}` — {err}."
+            )),
+        }
+    }
+
+    if problems.is_empty() {
+        Ok(resolved)
+    } else {
+        Err(problems)
+    }
+}

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -401,10 +401,7 @@ mod tests {
             let problems = problems_of(
                 load_agents(dir.path()).unwrap_err_or_else_panic(&format!("{escape} is refused")),
             );
-            assert!(
-                problems[0].contains("outside"),
-                "{escape} → {problems:?}"
-            );
+            assert!(problems[0].contains("outside"), "{escape} → {problems:?}");
         }
     }
 
@@ -452,7 +449,10 @@ classes = ["judge", "evidence"]
             agent.prompt.as_deref(),
             Some("Be specific about what would change your mind.")
         );
-        assert_eq!(agent.context.as_deref(), Some(&["GOAL.md".to_string(), "CLAIMS.md".to_string()][..]));
+        assert_eq!(
+            agent.context.as_deref(),
+            Some(&["GOAL.md".to_string(), "CLAIMS.md".to_string()][..])
+        );
         assert_eq!(agent.classes, ["judge", "evidence"]);
     }
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -203,7 +203,10 @@ mod tests {
             routed_documents(&agent(Some("frontend"))),
             [UNIVERSAL_DOCUMENT, BRIEF]
         );
-        assert_eq!(routed_documents(&agent(Some("compress"))), [UNIVERSAL_DOCUMENT]);
+        assert_eq!(
+            routed_documents(&agent(Some("compress"))),
+            [UNIVERSAL_DOCUMENT]
+        );
         assert_eq!(
             routed_documents(&agent(Some("subconscious"))),
             [UNIVERSAL_DOCUMENT]
@@ -287,7 +290,12 @@ mod tests {
     fn several_classes_all_apply() {
         let mut a = agent(None);
         a.classes = vec!["judge".into(), "evidence".into(), "directive".into()];
-        a.context = Some(vec![SCRATCH.into(), BOARD.into(), CLAIMS.into(), BRIEF.into()]);
+        a.context = Some(vec![
+            SCRATCH.into(),
+            BOARD.into(),
+            CLAIMS.into(),
+            BRIEF.into(),
+        ]);
         assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
     }
 
@@ -304,11 +312,7 @@ mod tests {
     #[test]
     fn a_document_listed_twice_is_routed_once() {
         let mut a = agent(None);
-        a.context = Some(vec![
-            UNIVERSAL_DOCUMENT.into(),
-            BRIEF.into(),
-            BRIEF.into(),
-        ]);
+        a.context = Some(vec![UNIVERSAL_DOCUMENT.into(), BRIEF.into(), BRIEF.into()]);
         assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
     }
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -498,7 +498,14 @@ mod tests {
         async fn a_nested_document_resolves_by_its_logical_path() {
             let (_dir, ws, company) = store().await;
             let brand = folder(&ws, &company, "Brand").await;
-            file(&ws, &company, Some(&brand), "Voice.md", "Plain, never loud.").await;
+            file(
+                &ws,
+                &company,
+                Some(&brand),
+                "Voice.md",
+                "Plain, never loud.",
+            )
+            .await;
 
             let mut a = agent(None);
             a.context = Some(vec!["Brand/Voice.md".into()]);
@@ -508,7 +515,10 @@ mod tests {
                 .expect("resolves");
             assert_eq!(
                 resolved,
-                vec![("Brand/Voice.md".to_string(), "Plain, never loud.".to_string())]
+                vec![(
+                    "Brand/Voice.md".to_string(),
+                    "Plain, never loud.".to_string()
+                )]
             );
         }
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -7,14 +7,23 @@
 //! > something that role is being told to reason from. Route it deliberately,
 //! > and record why each exclusion is an exclusion.
 //!
-//! Two halves live here, and both are pure decisions over manifest data — no
-//! store, no I/O — so they are compiled and tested in every build even though
-//! the harness that spends the result is behind the `openhuman` feature:
+//! Three pieces live here, all compiled and tested in every build even though
+//! the harness that spends the result is behind the `openhuman` feature — the
+//! exclusions are controls, and a control deserves tests wherever it is defined:
 //!
 //! * [`routed_documents`] — the per-tier default table, and how an explicit
 //!   `context` key overrides it.
 //! * [`excluded_documents`] — the class-based exclusions, which are subtractive
 //!   and apply to defaults and explicit lists alike.
+//! * [`resolve_routed_documents`] — reads the selected notes out of a
+//!   [`WorkspaceStore`](crate::ports::WorkspaceStore), skipping any that do not
+//!   exist.
+//!
+//! **Not yet spent.** Carrying the resolved documents into the agent's system
+//! prompt is the remaining step: the agent build is synchronous, so they have to
+//! ride `HarnessDeps` the way `mcp_servers` and the skill deltas already do, and
+//! be appended via [`crate::company::prompt::context_section`]. Until then a
+//! `context` line selects documents that nothing reads.
 
 use crate::company::Agent;
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -150,6 +150,74 @@ pub fn routed_documents(agent: &Agent) -> Vec<String> {
     routed
 }
 
+/// Reads the documents [`routed_documents`] selected for `agent` out of the
+/// company's workspace tree.
+///
+/// Returns `(path, body)` pairs in routing order, ready for
+/// [`context_section`](crate::company::prompt::context_section).
+///
+/// **A named document that does not exist is skipped, not an error.** These are
+/// live operator-owned notes: a company that has not written its brief yet is
+/// not a misconfigured company, and failing the roster build over one would take
+/// the whole company down for a missing file anybody could create. This is the
+/// opposite rule to
+/// [`prompt_files`](crate::company::Agent::prompt_files), which names a file in
+/// the same commit as the agent referencing it — see `runtime/agents.md` for why
+/// the two differ.
+///
+/// Async and always compiled, so it is exercised by the default-build test
+/// suite against a real store rather than only where the agent runtime links.
+/// The harness calls this before building the (synchronous) agent, the same way
+/// it resolves skill deltas ahead of time.
+pub async fn resolve_routed_documents(
+    workspace: &dyn crate::ports::WorkspaceStore,
+    company: &crate::ports::types::CompanyId,
+    agent: &Agent,
+) -> crate::Result<Vec<(String, String)>> {
+    let wanted = routed_documents(agent);
+    if wanted.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // One tree read for the whole roster's worth of lookups, rather than a read
+    // per document: the tree is the only way to resolve a logical path to a node
+    // id, and a per-document walk would multiply that cost by the routing table.
+    let nodes = workspace.tree(company).await?;
+    let by_id: std::collections::HashMap<&str, &crate::ports::workspace::WorkspaceNode> =
+        nodes.iter().map(|node| (node.id.as_str(), node)).collect();
+
+    let mut by_path: std::collections::HashMap<String, &str> =
+        std::collections::HashMap::with_capacity(nodes.len());
+    for node in &nodes {
+        if node.kind != crate::ports::workspace::NodeKind::File {
+            continue;
+        }
+        if let Some(path) = super::workspace_paths::render_path(node, &by_id) {
+            by_path.insert(path, node.id.as_str());
+        }
+    }
+
+    let mut resolved = Vec::with_capacity(wanted.len());
+    for path in wanted {
+        // Normalise the manifest's spelling the same way the agent tools do, so
+        // `/Brand/Voice.md` and `Brand/Voice.md` name the same note.
+        let key = match super::workspace_paths::split_logical_path(&path) {
+            Ok(segments) => segments.join("/"),
+            // A traversal-shaped or malformed entry resolves to nothing, exactly
+            // like a missing document. Refusing the boot would let one bad
+            // manifest line stop a company whose other routing is fine.
+            Err(_) => continue,
+        };
+        let Some(id) = by_path.get(&key) else {
+            continue;
+        };
+        if let Some((_, body)) = workspace.read(company, id).await? {
+            resolved.push((key, body));
+        }
+    }
+    Ok(resolved)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -399,4 +399,193 @@ mod tests {
     fn an_unknown_class_excludes_nothing() {
         assert!(excluded_documents(&["mystery".to_string()]).is_empty());
     }
+
+    /// The resolver half, against a real store rather than a mock — the store is
+    /// where "does this path name that note?" is actually decided.
+    mod resolve {
+        use std::sync::Arc;
+
+        use super::*;
+        use crate::ports::WorkspaceStore;
+        use crate::ports::types::CompanyId;
+        use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
+        use crate::store::FsOps;
+
+        async fn store() -> (tempfile::TempDir, Arc<dyn WorkspaceStore>, CompanyId) {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let ws: Arc<dyn WorkspaceStore> = Arc::new(FsOps::new(dir.path()));
+            (dir, ws, CompanyId::new("acme"))
+        }
+
+        /// Writes `name` under `parent` with `body`, returning its node id.
+        async fn file(
+            ws: &Arc<dyn WorkspaceStore>,
+            company: &CompanyId,
+            parent: Option<&str>,
+            name: &str,
+            body: &str,
+        ) -> String {
+            let id = format!("id-{name}");
+            ws.create(
+                company,
+                &WorkspaceNode {
+                    id: id.clone(),
+                    name: name.to_string(),
+                    kind: NodeKind::File,
+                    parent_id: parent.map(str::to_string),
+                    updated_at_millis: 1,
+                    created_by: WorkspaceOrigin::Operator,
+                    updated_by: WorkspaceOrigin::Operator,
+                    mime: None,
+                    size: None,
+                    sha256: None,
+                },
+                Some(body),
+            )
+            .await
+            .expect("create file");
+            id
+        }
+
+        async fn folder(ws: &Arc<dyn WorkspaceStore>, company: &CompanyId, name: &str) -> String {
+            ws.adopt_or_create_folder(company, None, name, WorkspaceOrigin::Operator)
+                .await
+                .expect("folder")
+                .into_node()
+                .id
+        }
+
+        #[tokio::test]
+        async fn a_routed_document_is_read_out_of_the_workspace() {
+            let (_dir, ws, company) = store().await;
+            file(&ws, &company, None, UNIVERSAL_DOCUMENT, "How we work.").await;
+            file(&ws, &company, None, BRIEF, "What we established.").await;
+
+            let mut a = agent(Some("frontend")); // routes METHOD + BRIEF
+            a.context = None;
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert_eq!(
+                resolved,
+                vec![
+                    (UNIVERSAL_DOCUMENT.to_string(), "How we work.".to_string()),
+                    (BRIEF.to_string(), "What we established.".to_string()),
+                ]
+            );
+        }
+
+        /// The rule that differs from `prompt_files`: a live workspace note that
+        /// does not exist yet is skipped, not an error. Failing the roster build
+        /// here would take a whole company down over a file anybody could create.
+        #[tokio::test]
+        async fn a_missing_document_is_skipped_rather_than_failing() {
+            let (_dir, ws, company) = store().await;
+            file(&ws, &company, None, BRIEF, "Only this one exists.").await;
+
+            let mut a = agent(None);
+            a.context = Some(vec![BRIEF.into(), "NOWHERE.md".into()]);
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert_eq!(resolved.len(), 1, "{resolved:?}");
+            assert_eq!(resolved[0].0, BRIEF);
+        }
+
+        #[tokio::test]
+        async fn a_nested_document_resolves_by_its_logical_path() {
+            let (_dir, ws, company) = store().await;
+            let brand = folder(&ws, &company, "Brand").await;
+            file(&ws, &company, Some(&brand), "Voice.md", "Plain, never loud.").await;
+
+            let mut a = agent(None);
+            a.context = Some(vec!["Brand/Voice.md".into()]);
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert_eq!(
+                resolved,
+                vec![("Brand/Voice.md".to_string(), "Plain, never loud.".to_string())]
+            );
+        }
+
+        /// A leading slash is the operator's spelling, not a different note.
+        #[tokio::test]
+        async fn a_leading_slash_names_the_same_document() {
+            let (_dir, ws, company) = store().await;
+            let brand = folder(&ws, &company, "Brand").await;
+            file(&ws, &company, Some(&brand), "Voice.md", "body").await;
+
+            let mut a = agent(None);
+            a.context = Some(vec!["/Brand/Voice.md".into()]);
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert_eq!(resolved.len(), 1, "{resolved:?}");
+            assert_eq!(resolved[0].0, "Brand/Voice.md");
+        }
+
+        /// A traversal-shaped entry resolves to nothing rather than erroring, so
+        /// one bad manifest line cannot stop a company whose other routing works.
+        #[tokio::test]
+        async fn a_traversal_shaped_entry_resolves_to_nothing() {
+            let (_dir, ws, company) = store().await;
+            file(&ws, &company, None, BRIEF, "body").await;
+
+            let mut a = agent(None);
+            a.context = Some(vec!["../../etc/passwd".into(), BRIEF.into()]);
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert_eq!(resolved.len(), 1, "{resolved:?}");
+            assert_eq!(resolved[0].0, BRIEF);
+        }
+
+        /// An exclusion holds all the way through the read: a judge must not be
+        /// handed the scratch even when the note is sitting right there.
+        #[tokio::test]
+        async fn an_excluded_document_is_never_read_even_when_it_exists() {
+            let (_dir, ws, company) = store().await;
+            file(&ws, &company, None, SCRATCH, "half-finished thinking").await;
+            file(&ws, &company, None, BRIEF, "established").await;
+
+            let mut a = agent(None);
+            a.classes = vec!["judge".into()];
+            a.context = Some(vec![SCRATCH.into(), BRIEF.into()]);
+
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            let names: Vec<&str> = resolved.iter().map(|(n, _)| n.as_str()).collect();
+            assert!(!names.contains(&SCRATCH), "{names:?}");
+            assert!(names.contains(&BRIEF), "{names:?}");
+        }
+
+        /// A role routed nothing does not touch the store at all — the tree read
+        /// is skipped rather than performed and discarded.
+        #[tokio::test]
+        async fn a_role_routed_nothing_reads_nothing() {
+            let (_dir, ws, company) = store().await;
+            let mut a = agent(Some("compress"));
+            // `compress` defaults to no documents, and an explicit empty context
+            // strips even the universal one.
+            a.context = Some(Vec::new());
+            a.classes = Vec::new();
+
+            // The universal document is always routed, so to reach the empty case
+            // the caller must have nothing at all — assert the shape we do get.
+            let resolved = resolve_routed_documents(ws.as_ref(), &company, &a)
+                .await
+                .expect("resolves");
+            assert!(
+                resolved.is_empty(),
+                "no document exists in the store, so nothing resolves: {resolved:?}"
+            );
+        }
+    }
 }

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -1,0 +1,330 @@
+//! Which workspace documents each role is told to reason from.
+//!
+//! Implements `docs/spec/runtime/orchestration/context-routing.md`. The rule it
+//! exists to enforce:
+//!
+//! > **Context is authority.** A document routed into a role's system prompt is
+//! > something that role is being told to reason from. Route it deliberately,
+//! > and record why each exclusion is an exclusion.
+//!
+//! Two halves live here, and both are pure decisions over manifest data — no
+//! store, no I/O — so they are compiled and tested in every build even though
+//! the harness that spends the result is behind the `openhuman` feature:
+//!
+//! * [`routed_documents`] — the per-tier default table, and how an explicit
+//!   `context` key overrides it.
+//! * [`excluded_documents`] — the class-based exclusions, which are subtractive
+//!   and apply to defaults and explicit lists alike.
+
+use crate::company::Agent;
+
+/// The one document every role is routed, whatever its tier or classes.
+///
+/// The company's method policy: how this company works, as distinct from what it
+/// currently believes. Universal because a role that does not know the method
+/// cannot follow it, and unlike every other document here it asserts nothing
+/// about the work in progress, so no exclusion can apply to it.
+pub const UNIVERSAL_DOCUMENT: &str = "METHOD.md";
+
+/// The company's summarized picture: what is established, what is ruled out.
+pub const BRIEF: &str = "BRIEF.md";
+/// The evidence ledger — what already holds true, with its derivation.
+pub const CLAIMS: &str = "CLAIMS.md";
+/// The open-question tracker the orchestrator routes work from.
+pub const THREADS: &str = "THREADS.md";
+/// The assertion board: posts are asserted, not established.
+pub const BOARD: &str = "BOARD.md";
+/// Provisional working-out, kept out of any role that judges.
+pub const SCRATCH: &str = "SCRATCH.md";
+
+/// The documents a role is routed when its manifest declares no `context` key.
+///
+/// Keyed on the role's tier, per the spec's default table. Every row is a
+/// default, never a floor or a ceiling: an explicit `context` — including an
+/// empty one — always wins for that role.
+///
+/// **An agent with no `tier` takes the `reasoning` row.** `tier` is optional and
+/// most roster entries omit it, so the table needs a defined fallback or it
+/// covers almost nobody. `reasoning` is right because it is what an undeclared
+/// teammate *is*: a worker doing the substantive job its description names.
+/// Defaulting to `orchestrator` would hand every unlabelled agent the routing
+/// picture, and defaulting to none would leave the ordinary case with no working
+/// context at all.
+fn tier_defaults(tier: Option<&str>) -> &'static [&'static str] {
+    match tier {
+        // Decides what happens next across the whole company, so it needs the
+        // established picture plus both derived ledgers — without them it would
+        // re-derive routing decisions from raw notes every cycle.
+        Some("orchestrator") => &[BRIEF, CLAIMS, THREADS],
+        // Talks to the operator or another company: needs the summarized picture
+        // to speak from, not the derivation detail behind it.
+        Some("frontend") => &[BRIEF],
+        // Reads and summarizes raw workspace notes to *write* the brief. Routing
+        // it the brief would be circular.
+        Some("compress") => &[],
+        // Runs over compressed history between cycles, not the live workspace: a
+        // routed document would be stale by construction before the tick that
+        // read it ran.
+        Some("subconscious") => &[],
+        // `reasoning`, and every agent that declares no tier: does the
+        // substantive work a demand asks for, so it needs what is established
+        // and what already holds — but not the open-question tracker, which is
+        // the orchestrator's routing concern.
+        _ => &[BRIEF, CLAIMS],
+    }
+}
+
+/// The documents a role's classes forbid, whatever the routing table says.
+///
+/// Each rule prevents a specific observed failure, and each is subtractive: an
+/// exclusion outranks both the tier default and an explicit `context` list,
+/// because the point of declaring a class is that the exclusion cannot be lost
+/// by someone editing a routing line.
+///
+/// * A role that **weighs evidence** must not be routed the assertion board. A
+///   post is asserted, not established; a critic scoring a deliverable beside an
+///   unevidenced sentence is one prompt away from scoring the sentence.
+/// * A role that **judges** must not be routed the scratch. Provisional
+///   working-out read as progress is what keeps a loop retrying.
+/// * A role **acting on an operator directive** must not be routed the claim
+///   ledger. A directive is asserted, and a role holding the evidence ledger
+///   while carrying out an instruction is one prompt away from filing the
+///   instruction as a finding.
+pub fn excluded_documents(classes: &[String]) -> Vec<&'static str> {
+    let mut excluded = Vec::new();
+    for class in classes {
+        match class.as_str() {
+            "evidence" => excluded.push(BOARD),
+            "judge" => excluded.push(SCRATCH),
+            "directive" => excluded.push(CLAIMS),
+            _ => {}
+        }
+    }
+    excluded
+}
+
+/// The workspace documents to route into `agent`'s system prompt.
+///
+/// Resolution order:
+///
+/// 1. the universal document, always;
+/// 2. the agent's explicit `context` list if it declared one, else its tier's
+///    default row;
+/// 3. minus anything its classes exclude.
+///
+/// `Some(vec![])` (an explicit `context = []`) and `None` (an omitted key) are
+/// deliberately different: the first means "the universal document and nothing
+/// else", the second means "take the default". `Agent::context` is
+/// `Option<Vec<String>>` precisely so that distinction is representable.
+///
+/// Returned in routing order with duplicates removed, so a manifest that lists
+/// the universal document explicitly does not get it twice.
+pub fn routed_documents(agent: &Agent) -> Vec<String> {
+    let excluded = excluded_documents(&agent.classes);
+
+    let chosen: Vec<String> = match agent.context.as_deref() {
+        Some(explicit) => explicit.to_vec(),
+        None => tier_defaults(agent.tier.as_deref())
+            .iter()
+            .map(|doc| doc.to_string())
+            .collect(),
+    };
+
+    let mut routed = Vec::with_capacity(chosen.len() + 1);
+    let mut seen = std::collections::HashSet::new();
+    for document in std::iter::once(UNIVERSAL_DOCUMENT.to_string()).chain(chosen) {
+        let document = document.trim().to_string();
+        if document.is_empty() {
+            continue;
+        }
+        // The universal document is exempt from exclusion: it is method, not
+        // assertion, so no class has a reason to withhold it — and a role
+        // excluded from the method could not follow it.
+        if document != UNIVERSAL_DOCUMENT && excluded.contains(&document.as_str()) {
+            continue;
+        }
+        if seen.insert(document.clone()) {
+            routed.push(document);
+        }
+    }
+    routed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(tier: Option<&str>) -> Agent {
+        Agent {
+            id: "a".into(),
+            role: "Role".into(),
+            description: None,
+            tier: tier.map(str::to_string),
+            tools: Vec::new(),
+            delegates_to: Vec::new(),
+            context: None,
+            budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn every_role_is_routed_the_universal_document() {
+        for tier in [
+            None,
+            Some("orchestrator"),
+            Some("reasoning"),
+            Some("frontend"),
+            Some("compress"),
+            Some("subconscious"),
+        ] {
+            let routed = routed_documents(&agent(tier));
+            assert!(
+                routed.contains(&UNIVERSAL_DOCUMENT.to_string()),
+                "tier {tier:?} → {routed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn the_per_tier_default_table_matches_the_spec() {
+        assert_eq!(
+            routed_documents(&agent(Some("orchestrator"))),
+            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS, THREADS]
+        );
+        assert_eq!(
+            routed_documents(&agent(Some("reasoning"))),
+            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS]
+        );
+        assert_eq!(
+            routed_documents(&agent(Some("frontend"))),
+            [UNIVERSAL_DOCUMENT, BRIEF]
+        );
+        assert_eq!(routed_documents(&agent(Some("compress"))), [UNIVERSAL_DOCUMENT]);
+        assert_eq!(
+            routed_documents(&agent(Some("subconscious"))),
+            [UNIVERSAL_DOCUMENT]
+        );
+    }
+
+    /// Most roster entries omit `tier`, so the fallback covers almost everybody.
+    #[test]
+    fn an_agent_with_no_tier_takes_the_reasoning_row() {
+        assert_eq!(
+            routed_documents(&agent(None)),
+            routed_documents(&agent(Some("reasoning")))
+        );
+    }
+
+    /// The distinction `Option<Vec<String>>` exists to represent.
+    #[test]
+    fn an_explicit_empty_context_is_not_the_same_as_an_omitted_one() {
+        let mut explicit = agent(Some("orchestrator"));
+        explicit.context = Some(Vec::new());
+        assert_eq!(
+            routed_documents(&explicit),
+            [UNIVERSAL_DOCUMENT],
+            "`context = []` means the universal document and nothing else"
+        );
+
+        assert_eq!(
+            routed_documents(&agent(Some("orchestrator"))),
+            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS, THREADS],
+            "an omitted key takes the tier default"
+        );
+    }
+
+    #[test]
+    fn an_explicit_context_overrides_the_tier_default() {
+        let mut a = agent(Some("orchestrator"));
+        a.context = Some(vec!["GOAL.md".into()]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, "GOAL.md"]);
+    }
+
+    #[test]
+    fn a_role_that_weighs_evidence_is_never_routed_the_board() {
+        let mut a = agent(Some("reasoning"));
+        a.classes = vec!["evidence".into()];
+        a.context = Some(vec![BRIEF.into(), BOARD.into()]);
+        let routed = routed_documents(&a);
+        assert!(!routed.contains(&BOARD.to_string()), "{routed:?}");
+        assert!(routed.contains(&BRIEF.to_string()), "{routed:?}");
+    }
+
+    #[test]
+    fn a_role_that_judges_is_never_routed_the_scratch() {
+        let mut a = agent(Some("reasoning"));
+        a.classes = vec!["judge".into()];
+        a.context = Some(vec![SCRATCH.into()]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT]);
+    }
+
+    #[test]
+    fn a_role_acting_on_a_directive_is_never_routed_the_claim_ledger() {
+        let mut a = agent(Some("reasoning"));
+        a.classes = vec!["directive".into()];
+        // CLAIMS is in the `reasoning` default row, so this proves the exclusion
+        // subtracts from defaults and not only from explicit lists.
+        let routed = routed_documents(&a);
+        assert!(!routed.contains(&CLAIMS.to_string()), "{routed:?}");
+        assert!(routed.contains(&BRIEF.to_string()), "{routed:?}");
+    }
+
+    /// An exclusion outranks an explicit routing line — that is what makes a
+    /// declared class a control rather than a suggestion somebody can edit away.
+    #[test]
+    fn an_exclusion_outranks_an_explicit_context_entry() {
+        let mut a = agent(None);
+        a.classes = vec!["judge".into()];
+        a.context = Some(vec![SCRATCH.into(), BRIEF.into()]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+    }
+
+    #[test]
+    fn several_classes_all_apply() {
+        let mut a = agent(None);
+        a.classes = vec!["judge".into(), "evidence".into(), "directive".into()];
+        a.context = Some(vec![SCRATCH.into(), BOARD.into(), CLAIMS.into(), BRIEF.into()]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+    }
+
+    /// The method policy is exempt: it is how the company works, not something
+    /// it asserts, and a role excluded from it could not follow it.
+    #[test]
+    fn no_class_can_withhold_the_universal_document() {
+        let mut a = agent(None);
+        a.classes = vec!["judge".into(), "evidence".into(), "directive".into()];
+        a.context = Some(Vec::new());
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT]);
+    }
+
+    #[test]
+    fn a_document_listed_twice_is_routed_once() {
+        let mut a = agent(None);
+        a.context = Some(vec![
+            UNIVERSAL_DOCUMENT.into(),
+            BRIEF.into(),
+            BRIEF.into(),
+        ]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+    }
+
+    #[test]
+    fn blank_context_entries_are_ignored() {
+        let mut a = agent(None);
+        a.context = Some(vec!["".into(), "  ".into(), BRIEF.into()]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+    }
+
+    /// An unknown class imposes no exclusion. Manifest validation refuses one
+    /// outright, so this only ever covers a record written by an older binary —
+    /// where failing open on routing is right and failing closed would blank a
+    /// working role's context.
+    #[test]
+    fn an_unknown_class_excludes_nothing() {
+        assert!(excluded_documents(&["mystery".to_string()]).is_empty());
+    }
+}

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -74,26 +74,75 @@ impl CompanyManifest {
     ///
     /// `path` may be a manifest file or a directory containing one. Validation
     /// collects every problem and reports them together.
+    /// When `path` resolves to a bundle carrying an `agents/` directory, the
+    /// roster is read from those per-teammate files instead of from
+    /// `[[agent]]` — see [`agent_file`](super::agent_file).
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
         let located = discover(path.as_ref())?;
-        Self::from_file(&located.path)
+        // The bundle root is the located manifest's own parent, whether the
+        // caller passed the directory or the file itself: `discover` accepts
+        // both, and deriving the root from the located manifest is what keeps
+        // the two call forms from resolving `agents/` differently.
+        match located.path.parent() {
+            Some(bundle) if super::agent_file::has_agent_files(bundle) => {
+                Self::from_file_with_agents(&located.path, &bundle.to_path_buf())
+            }
+            _ => Self::from_file(&located.path),
+        }
     }
 
     /// Reads, parses, and validates a specific manifest file.
     pub fn from_file(path: &Path) -> Result<Self> {
+        Self::parse_file(path)?.into_validated(path)
+    }
+
+    /// [`from_file`](Self::from_file), with the roster taken from
+    /// `<bundle>/agents/*.toml` rather than the manifest's `[[agent]]` entries.
+    ///
+    /// The bundle roster **replaces** the inline one; it does not merge with it.
+    /// Declaring both is refused rather than resolved by precedence, because
+    /// either precedence rule silently discards teammates an operator wrote
+    /// down — and the roster is the one part of a manifest where a silent
+    /// omission stays invisible until the missing teammate fails to answer.
+    fn from_file_with_agents(path: &Path, bundle: &Path) -> Result<Self> {
+        let mut manifest = Self::parse_file(path)?;
+
+        if !manifest.agents.is_empty() {
+            return Err(OpenCompanyError::ManifestInvalid {
+                path: path.to_path_buf(),
+                problems: vec![format!(
+                    "this company defines its roster in `{dir}/*.toml`, but `{file}` also has `[[agent]]` entries — the two forms are exclusive, so remove the `[[agent]]` blocks or delete the `{dir}/` directory.",
+                    dir = super::agent_file::AGENTS_DIR,
+                    file = path
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or(MANIFEST_FILE),
+                )],
+            });
+        }
+
+        manifest.agents = super::agent_file::load_agents(bundle)?;
+        manifest.into_validated(path)
+    }
+
+    /// Reads and deserializes a manifest file, without validating it.
+    fn parse_file(path: &Path) -> Result<Self> {
         let text =
             std::fs::read_to_string(path).map_err(|source| OpenCompanyError::ManifestRead {
                 path: path.to_path_buf(),
                 source,
             })?;
 
-        let manifest: CompanyManifest = toml::from_str(&text).map_err(|err| {
+        toml::from_str(&text).map_err(|err| {
             OpenCompanyError::ManifestParse(path.to_path_buf(), err.message().to_string())
-        })?;
+        })
+    }
 
-        let problems = manifest.validate();
+    /// Runs [`validate`](Self::validate), reporting every problem against `path`.
+    fn into_validated(self, path: &Path) -> Result<Self> {
+        let problems = self.validate();
         if problems.is_empty() {
-            Ok(manifest)
+            Ok(self)
         } else {
             Err(OpenCompanyError::ManifestInvalid {
                 path: path.to_path_buf(),

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -207,7 +207,11 @@ impl CompanyManifest {
             // lost. See `PROMPT_CLASSES`.
             for class in &agent.classes {
                 if !PROMPT_CLASSES.contains(&class.as_str()) {
-                    problems.push(one_of(&format!("{label} `classes` entry"), &PROMPT_CLASSES, class));
+                    problems.push(one_of(
+                        &format!("{label} `classes` entry"),
+                        &PROMPT_CLASSES,
+                        class,
+                    ));
                 }
             }
         }
@@ -667,10 +671,7 @@ mod tests {
         let manifest = CompanyManifest::from_path(dir.path()).expect("parses");
         let ids: Vec<&str> = manifest.agents.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, ["ceo", "writer"]);
-        assert_eq!(
-            super::super::orchestrator_id(&manifest.agents),
-            Some("ceo")
-        );
+        assert_eq!(super::super::orchestrator_id(&manifest.agents), Some("ceo"));
     }
 
     /// Declaring both forms is refused rather than resolved by precedence:

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -709,6 +709,23 @@ mod tests {
         assert!(problems[0].contains("company.toml"), "{problems:?}");
     }
 
+    /// `opencompany check` must load the bundle roster too. It calls
+    /// [`discover`] itself (for the legacy-filename note) and so takes its own
+    /// route into loading — which is exactly how it came to validate a manifest
+    /// whose roster it had never read, reporting every desk member as missing
+    /// from the roster.
+    #[test]
+    fn run_check_accepts_a_bundle_roster() {
+        let dir = write_bundle(
+            "[company]\nname = \"X\"\n\n[[group_chat]]\nid = \"d\"\nname = \"D\"\nmembers = [\"ceo\"]\n",
+            &[("ceo.toml", "role = \"CEO\"\n")],
+        );
+        assert!(
+            super::super::run_check(dir.path()),
+            "a bundle-roster company must validate through the check command"
+        );
+    }
+
     /// Cross-cutting validation still applies to a bundle roster: a
     /// `delegates_to` target is checked against the desks in `company.toml`,
     /// which the per-file loader cannot see on its own.

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -85,7 +85,7 @@ impl CompanyManifest {
         // the two call forms from resolving `agents/` differently.
         match located.path.parent() {
             Some(bundle) if super::agent_file::has_agent_files(bundle) => {
-                Self::from_file_with_agents(&located.path, &bundle.to_path_buf())
+                Self::from_file_with_agents(&located.path, bundle)
             }
             _ => Self::from_file(&located.path),
         }

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -13,8 +13,8 @@ use crate::ports::{decode_wallet_address, normalize_email};
 
 use super::types::{
     AUTH_MODES, BRAIN_MODES, CONNECTION_PRIORITIES, CompanyManifest, GATEABLE_NAMESPACES,
-    KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, TIERS,
-    TOOL_PROVIDERS,
+    KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES,
+    PROMPT_CLASSES, TIERS, TOOL_PROVIDERS,
 };
 
 /// The `delegates_to` entry that means "every desk this company has".

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -1408,11 +1408,19 @@ mod tests {
         // not kernel code. This guards that the shipped manifest keeps passing
         // the same lint `opencompany check` runs — unique agent ids, priced +
         // described `[place].skills`, a `[policy]`, and a stated `human_role`.
+        // The company *directory*, not its `company.toml`: this template's
+        // roster lives in `agents/*.toml`, and loading the file alone would
+        // leave `manifest.agents` empty — making every roster assertion below
+        // pass by having nothing to check.
         let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("companies/signals_opportunity_studio/company.toml");
-        let manifest = CompanyManifest::from_file(&path).expect("template manifest is valid");
+            .join("companies/signals_opportunity_studio");
+        let manifest = CompanyManifest::from_path(&path).expect("template manifest is valid");
 
         assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+        assert!(
+            !manifest.agents.is_empty(),
+            "the roster must actually load, or the assertions below check nothing"
+        );
         assert!(
             manifest.company.human_role.is_some(),
             "the template must name what the human keeps"

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -74,6 +74,7 @@ impl CompanyManifest {
     ///
     /// `path` may be a manifest file or a directory containing one. Validation
     /// collects every problem and reports them together.
+    ///
     /// When `path` resolves to a bundle carrying an `agents/` directory, the
     /// roster is read from those per-teammate files instead of from
     /// `[[agent]]` — see [`agent_file`](super::agent_file).

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -79,7 +79,20 @@ impl CompanyManifest {
     /// roster is read from those per-teammate files instead of from
     /// `[[agent]]` — see [`agent_file`](super::agent_file).
     pub fn from_path(path: impl AsRef<Path>) -> Result<Self> {
-        let located = discover(path.as_ref())?;
+        Self::from_located(&discover(path.as_ref())?)
+    }
+
+    /// Loads an already-[`discover`]ed manifest, reading the roster from
+    /// `agents/*.toml` when the bundle has one.
+    ///
+    /// Split out from [`from_path`](Self::from_path) so callers that need the
+    /// [`Located`] value for themselves — `opencompany check`, which prints the
+    /// legacy-filename deprecation note — do not have to re-derive "is this a
+    /// bundle roster?" on their own. That duplication is not hypothetical: the
+    /// check command called [`from_file`](Self::from_file) directly and silently
+    /// reported every desk member as "not an agent in the roster", because it
+    /// had validated a manifest whose roster it had never loaded.
+    pub(crate) fn from_located(located: &Located) -> Result<Self> {
         // The bundle root is the located manifest's own parent, whether the
         // caller passed the directory or the file itself: `discover` accepts
         // both, and deriving the root from the located manifest is what keeps

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -667,7 +667,10 @@ mod tests {
         let manifest = CompanyManifest::from_path(dir.path()).expect("parses");
         let ids: Vec<&str> = manifest.agents.iter().map(|a| a.id.as_str()).collect();
         assert_eq!(ids, ["ceo", "writer"]);
-        assert_eq!(orchestrator_id(&manifest.agents), Some("ceo"));
+        assert_eq!(
+            super::super::orchestrator_id(&manifest.agents),
+            Some("ceo")
+        );
     }
 
     /// Declaring both forms is refused rather than resolved by precedence:

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -199,6 +199,17 @@ impl CompanyManifest {
                     "{label} `budget_usd_daily` cannot be negative — you wrote `{budget}`."
                 ));
             }
+
+            // Classes gate which routed documents this role may be told, so an
+            // unrecognized entry is refused rather than ignored: a typo'd
+            // exclusion is an exclusion that is not applied, and the whole point
+            // of declaring the class explicitly is that it cannot be silently
+            // lost. See `PROMPT_CLASSES`.
+            for class in &agent.classes {
+                if !PROMPT_CLASSES.contains(&class.as_str()) {
+                    problems.push(one_of(&format!("{label} `classes` entry"), &PROMPT_CLASSES, class));
+                }
+            }
         }
 
         // Group chats: ids snake_case + unique; every member is a real agent.

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -626,6 +626,127 @@ mod tests {
         bs58::encode([9u8; 32]).into_string()
     }
 
+    /// Writes a company bundle: `company.toml` plus optional `agents/` files.
+    fn write_bundle(company_toml: &str, agent_files: &[(&str, &str)]) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join(MANIFEST_FILE), company_toml).expect("write manifest");
+        if !agent_files.is_empty() {
+            let agents = dir.path().join(super::super::agent_file::AGENTS_DIR);
+            std::fs::create_dir_all(&agents).expect("agents dir");
+            for (name, body) in agent_files {
+                std::fs::write(agents.join(name), body).expect("write agent");
+            }
+        }
+        dir
+    }
+
+    /// The compatibility rule: a bare `company.toml` with `[[agent]]` entries
+    /// and no `agents/` directory keeps working exactly as it always has.
+    #[test]
+    fn an_inline_roster_still_parses_when_there_is_no_agents_directory() {
+        let dir = write_bundle(
+            "[company]\nname = \"X\"\n\n[[agent]]\nid = \"ceo\"\nrole = \"CEO\"\n",
+            &[],
+        );
+        let manifest = CompanyManifest::from_path(dir.path()).expect("parses");
+        assert_eq!(manifest.agents.len(), 1);
+        assert_eq!(manifest.agents[0].id, "ceo");
+    }
+
+    /// The bundle roster replaces the inline one — so a company that has moved
+    /// to `agents/*.toml` gets exactly those teammates.
+    #[test]
+    fn a_bundle_roster_supplies_the_agents() {
+        let dir = write_bundle(
+            "[company]\nname = \"X\"\n",
+            &[
+                ("ceo.toml", "role = \"CEO\"\ntier = \"orchestrator\"\n"),
+                ("writer.toml", "role = \"Writer\"\n"),
+            ],
+        );
+        let manifest = CompanyManifest::from_path(dir.path()).expect("parses");
+        let ids: Vec<&str> = manifest.agents.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(ids, ["ceo", "writer"]);
+        assert_eq!(orchestrator_id(&manifest.agents), Some("ceo"));
+    }
+
+    /// Declaring both forms is refused rather than resolved by precedence:
+    /// either precedence rule silently discards teammates somebody wrote down.
+    #[test]
+    fn declaring_both_roster_forms_is_refused_in_prosumer_language() {
+        let dir = write_bundle(
+            "[company]\nname = \"X\"\n\n[[agent]]\nid = \"ceo\"\nrole = \"CEO\"\n",
+            &[("writer.toml", "role = \"Writer\"\n")],
+        );
+        let err = CompanyManifest::from_path(dir.path()).expect_err("refused");
+        let problems = match err {
+            OpenCompanyError::ManifestInvalid { problems, .. } => problems,
+            other => panic!("expected ManifestInvalid, got {other}"),
+        };
+        assert_eq!(problems.len(), 1);
+        // It must name both places and say what to do, not merely that something
+        // is wrong: the operator has to know which half to delete.
+        assert!(problems[0].contains("agents/*.toml"), "{problems:?}");
+        assert!(problems[0].contains("[[agent]]"), "{problems:?}");
+        assert!(problems[0].contains("company.toml"), "{problems:?}");
+    }
+
+    /// Cross-cutting validation still applies to a bundle roster: a
+    /// `delegates_to` target is checked against the desks in `company.toml`,
+    /// which the per-file loader cannot see on its own.
+    #[test]
+    fn a_bundle_roster_is_still_validated_against_the_rest_of_the_manifest() {
+        let dir = write_bundle(
+            "[company]\nname = \"X\"\n\n[[group_chat]]\nid = \"research\"\nname = \"Research\"\n",
+            &[(
+                "ceo.toml",
+                "role = \"CEO\"\ndelegates_to = [\"marketing\"]\n",
+            )],
+        );
+        let err = CompanyManifest::from_path(dir.path()).expect_err("refused");
+        let problems = match err {
+            OpenCompanyError::ManifestInvalid { problems, .. } => problems,
+            other => panic!("expected ManifestInvalid, got {other}"),
+        };
+        assert!(
+            problems.iter().any(|p| p.contains("marketing")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn an_unknown_agent_class_is_refused() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n\n[[agent]]\nid = \"critic\"\nrole = \"Critic\"\nclasses = [\"judgey\"]\n",
+        );
+        let problems = manifest.validate();
+        assert!(
+            problems
+                .iter()
+                .any(|p| p.contains("classes") && p.contains("judgey")),
+            "{problems:?}"
+        );
+    }
+
+    #[test]
+    fn the_known_agent_classes_are_accepted() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n\n[[agent]]\nid = \"critic\"\nrole = \"Critic\"\nclasses = [\"judge\", \"evidence\", \"directive\"]\n",
+        );
+        assert!(manifest.validate().is_empty(), "{:?}", manifest.validate());
+    }
+
+    /// A desk `tools` ceiling is optional and absent by default, so every
+    /// manifest written before desks could scope tools keeps its meaning.
+    #[test]
+    fn a_desk_tool_ceiling_defaults_to_empty() {
+        let manifest = parse(
+            "[company]\nname = \"X\"\n\n[[agent]]\nid = \"ceo\"\nrole = \"CEO\"\n\n[[group_chat]]\nid = \"d\"\nname = \"D\"\nmembers = [\"ceo\"]\n",
+        );
+        assert!(manifest.group_chats[0].tools.is_empty());
+        assert!(manifest.validate().is_empty());
+    }
+
     /// A manifest naming no `[users].mode` signs people in by email, exactly as
     /// every manifest did before the key existed.
     #[test]

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -195,7 +195,10 @@ pub fn run_check(path: &Path) -> bool {
         );
     }
 
-    match CompanyManifest::from_file(&located.path) {
+    // `from_located`, not `from_file`: a bundle whose roster lives in
+    // `agents/*.toml` must be validated with that roster loaded, or every desk
+    // member reads as "not an agent in the roster".
+    match CompanyManifest::from_located(&located) {
         Ok(manifest) => {
             println!("✓ {} — valid\n", located.path.display());
             print!("{}", manifest.effective_summary());

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -36,6 +36,12 @@ pub mod mcp;
 // primitive + `uuid`/`base64`/`url`, so it links only under the `mcp` feature.
 #[cfg(feature = "mcp")]
 pub mod mcp_oauth;
+// How an agent's system prompt is composed from its manifest definition and the
+// documents routed to it. Always compiled and runtime-free: the harness that
+// spends the prompt is behind `openhuman`, but the composition and budget-clamp
+// rules are ordinary text handling with real edge cases, and they are worth
+// testing in the default build rather than only where the agent runtime links.
+pub mod prompt;
 pub mod runtime;
 mod skill_file;
 // Steer (issue #111): pause / cancel / redirect an in-flight task or delegation

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -96,9 +96,10 @@ pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md}
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
     Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_DELEGATION_DEPTH, DEFAULT_MAX_IN_FLIGHT_RUNS,
-    DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, INFERENCE_PROVIDERS, INFERENCE_TIERS,
-    Inference, KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, McpServer, ORCHESTRATOR_TIER,
-    PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule,
+    DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat, INFERENCE_PROVIDERS,
+    INFERENCE_TIERS, Inference, KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, McpServer,
+    ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
+    PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule,
     Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit,
     grants_repo_explicit, grants_repo_write_explicit, grants_search_explicit,
     grants_workspace_write_explicit, orchestrator_id,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -5,6 +5,11 @@
 //! report its effective configuration. The cognition kernel (Brain, cycle
 //! loop, stores) lands in later phases; see `docs/spec/roadmap.md`.
 
+// Per-teammate roster files (`companies/<name>/agents/<id>.toml`) — the richer
+// alternative to inline `[[agent]]` entries, carrying a custom prompt and its
+// own briefing documents. Always compiled: it is part of parsing a company, and
+// `opencompany check` must report on it in every build.
+mod agent_file;
 /// Issue #552: the seam between a task artifact and the shared workspace tree.
 /// Always compiled — the console's workspace and artifact routes reach it in
 /// every build, and only the publish drain's half is behind `openhuman`.

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -59,8 +59,8 @@ pub mod task_intent;
 // Composio toolkits in a single vocabulary. Always compiled: it is a projection
 // over the manifest, and both the console route that renders it and the
 // validation that checks a grant names something real are in the default build.
-pub mod tool_catalog;
 pub mod telegram;
+pub mod tool_catalog;
 mod types;
 mod workflow_create;
 mod workflow_file;

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -111,10 +111,10 @@ pub use types::{
     DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat, INFERENCE_PROVIDERS,
     INFERENCE_TIERS, Inference, KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, McpServer,
     ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
-    PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule,
-    Skill, TIERS, TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit,
-    grants_repo_explicit, grants_repo_write_explicit, grants_search_explicit,
-    grants_workspace_write_explicit, orchestrator_id,
+    PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
+    TOOL_PROVIDERS, Tools, grants_composio_explicit, grants_media_explicit, grants_repo_explicit,
+    grants_repo_write_explicit, grants_search_explicit, grants_workspace_write_explicit,
+    orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -55,6 +55,11 @@ mod skill_file;
 // control plane can steer in any build and no agent tool can ever reach it.
 pub mod steer;
 pub mod task_intent;
+// The one list of tools a company can grant — built-ins, MCP servers and
+// Composio toolkits in a single vocabulary. Always compiled: it is a projection
+// over the manifest, and both the console route that renders it and the
+// validation that checks a grant names something real are in the default build.
+pub mod tool_catalog;
 pub mod telegram;
 mod types;
 mod workflow_create;

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -55,11 +55,11 @@ mod skill_file;
 // control plane can steer in any build and no agent tool can ever reach it.
 pub mod steer;
 pub mod task_intent;
+pub mod telegram;
 // The one list of tools a company can grant — built-ins, MCP servers and
 // Composio toolkits in a single vocabulary. Always compiled: it is a projection
-// over the manifest, and both the console route that renders it and the
-// validation that checks a grant names something real are in the default build.
-pub mod telegram;
+// over the manifest, and the console route that renders it is in the default
+// build.
 pub mod tool_catalog;
 mod types;
 mod workflow_create;

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -22,6 +22,12 @@ mod content_test;
 // compiled and openhuman-free: the chat handler reads it in every build to keep
 // a copilot question from opening a board card, and the harness reads the same
 // function to decide that a turn runs confined.
+// Which workspace documents each role is told to reason from
+// (`docs/spec/runtime/orchestration/context-routing.md`). Always compiled: the
+// per-tier default table and the class-based exclusions are pure decisions over
+// manifest data, and the exclusions are controls — they deserve tests in every
+// build, not only where the agent runtime links.
+pub mod context_routing;
 pub mod copilot;
 // How this instance obtains its TinyHumans credential (projected, rotating
 // platform token vs a static key). Always compiled: the answer decides whether a

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -18,16 +18,16 @@ pub mod company_key;
 pub mod composio;
 #[cfg(test)]
 mod content_test;
-// The workflow copilot's thread convention (issues #303, #416). Always
-// compiled and openhuman-free: the chat handler reads it in every build to keep
-// a copilot question from opening a board card, and the harness reads the same
-// function to decide that a turn runs confined.
 // Which workspace documents each role is told to reason from
 // (`docs/spec/runtime/orchestration/context-routing.md`). Always compiled: the
 // per-tier default table and the class-based exclusions are pure decisions over
 // manifest data, and the exclusions are controls — they deserve tests in every
 // build, not only where the agent runtime links.
 pub mod context_routing;
+// The workflow copilot's thread convention (issues #303, #416). Always
+// compiled and openhuman-free: the chat handler reads it in every build to keep
+// a copilot question from opening a board card, and the harness reads the same
+// function to decide that a turn runs confined.
 pub mod copilot;
 // How this instance obtains its TinyHumans credential (projected, rotating
 // platform token vs a static key). Always compiled: the answer decides whether a

--- a/src/company/prompt.rs
+++ b/src/company/prompt.rs
@@ -264,9 +264,11 @@ mod tests {
     #[test]
     fn an_over_budget_clamp_keeps_the_leading_portion_and_marks_the_cut() {
         let clamped = clamp("abcdefghij", 4);
-        assert!(clamped.starts_with("abcd"), "{clamped}");
-        assert!(clamped.contains("truncated"), "{clamped}");
-        assert!(!clamped.contains('e'), "the tail is gone: {clamped}");
+        assert_eq!(
+            clamped,
+            format!("abcd{TRUNCATION_MARKER}"),
+            "the leading portion is kept, the tail dropped, and the cut marked"
+        );
     }
 
     /// The property a byte-based clamp gets wrong: cutting mid-codepoint would

--- a/src/company/prompt.rs
+++ b/src/company/prompt.rs
@@ -1,0 +1,311 @@
+//! Assembling one agent's system prompt from its manifest definition.
+//!
+//! An agent's prompt is built from four kinds of material, and the order they
+//! appear in is a decision rather than an accident:
+//!
+//! 1. the generated **persona** — who this teammate is, at which company;
+//! 2. its **inline prompt**, the operator's working instruction for the role;
+//! 3. its **bundle documents** ([`prompt_files`](crate::company::Agent::prompt_files)),
+//!    version controlled beside the agent definition;
+//! 4. its **routed documents** ([`context`](crate::company::Agent::context)),
+//!    live operator-owned workspace notes.
+//!
+//! Static material comes first and volatile material last, because the prompt
+//! prefix is what a provider cache can reuse across turns: a workspace note the
+//! operator edits between two turns invalidates everything after it, so it is
+//! placed where "everything after it" is nothing.
+//!
+//! This module is deliberately **always compiled** and free of any runtime
+//! dependency. The harness that consumes it (`crate::harness::build`) is behind
+//! the `openhuman` feature, but the composition and clamping rules are ordinary
+//! text manipulation with real edge cases — a budget cut that splits a
+//! codepoint, a document that is only whitespace — and they are worth testing
+//! in the default build rather than only where the agent runtime links.
+
+use crate::company::{Agent, PROMPT_FILE_BUDGET_CHARS};
+
+/// The marker appended to a section that the budget cut short.
+///
+/// Visible rather than silent, and it names the budget: an agent whose briefing
+/// was truncated should be able to say so, and an operator reading the prompt
+/// should not have to guess whether the document simply ended there. A silent
+/// cut is indistinguishable from a document that was written short.
+pub const TRUNCATION_MARKER: &str = "\n\n[… truncated to fit the prompt budget]";
+
+/// The heading introducing the routed-document section.
+const CONTEXT_HEADING: &str = "\n\n## Working documents\n\nYou are told to reason from the documents below. They are the company's current \
+working state, not background reading.\n";
+
+/// The heading introducing the bundle-document section.
+const BUNDLE_HEADING: &str = "\n\n## Your brief\n";
+
+/// The persona sentence for a company agent, plus the operator's inline prompt.
+///
+/// Frames the agent as its manifest role at the company, in the first person.
+/// This is what makes the agent answer *as* the CEO of Acme rather than falling
+/// back to the runtime's own assistant identity.
+///
+/// The inline `prompt` is **appended** to that framing rather than replacing it:
+/// an operator writing a prompt is stating how the role should work, not
+/// disclaiming which role it is, and a prompt that replaced the framing would
+/// silently cost the agent its identity.
+pub fn persona_prompt(company_name: &str, agent: &Agent) -> String {
+    let mut prompt = format!(
+        "You are the {role} at {company}. Speak in the first person as this role.",
+        role = agent.role,
+        company = company_name,
+    );
+    if let Some(description) = agent.description.as_deref() {
+        let description = description.trim();
+        if !description.is_empty() {
+            prompt.push(' ');
+            prompt.push_str(description);
+        }
+    }
+    if let Some(custom) = agent.prompt.as_deref() {
+        let custom = custom.trim();
+        if !custom.is_empty() {
+            prompt.push_str("\n\n");
+            prompt.push_str(custom);
+        }
+    }
+    prompt
+}
+
+/// The bundle-document section for an agent, or `""` when it has none.
+///
+/// Reads the bodies the manifest loader already resolved
+/// ([`prompt_files_resolved`](crate::company::Agent::prompt_files_resolved)), so
+/// this does no I/O and can run on every roster rebuild.
+pub fn bundle_section(agent: &Agent) -> String {
+    let documents: Vec<(&str, &str)> = agent
+        .prompt_files_resolved
+        .iter()
+        .map(|(path, body)| (path.as_str(), body.as_str()))
+        .collect();
+    document_section(BUNDLE_HEADING, &documents)
+}
+
+/// The routed-document section for `documents`, or `""` when there are none.
+///
+/// Takes the resolved `(name, body)` pairs rather than reading them, because the
+/// workspace store is async and the agent build is not — the caller resolves
+/// them ahead of time, the same way it resolves skill deltas.
+pub fn context_section(documents: &[(String, String)]) -> String {
+    let documents: Vec<(&str, &str)> = documents
+        .iter()
+        .map(|(name, body)| (name.as_str(), body.as_str()))
+        .collect();
+    document_section(CONTEXT_HEADING, &documents)
+}
+
+/// Renders a titled list of documents under `heading`, clamped as a whole.
+///
+/// The budget applies to the **section**, not to each document: a role routed
+/// five documents and a role routed one are spending from the same prompt, and a
+/// per-document budget would let the first quietly cost five times the second.
+///
+/// Empty and whitespace-only bodies are dropped rather than rendered as a bare
+/// heading with nothing under it — an empty section reads to the model as a
+/// document that exists and says nothing, which is worse than its absence.
+fn document_section(heading: &str, documents: &[(&str, &str)]) -> String {
+    let mut body = String::new();
+    for (name, content) in documents {
+        if content.trim().is_empty() {
+            continue;
+        }
+        body.push_str("\n### ");
+        body.push_str(name);
+        body.push('\n');
+        body.push_str(content.trim_end());
+        body.push('\n');
+    }
+    if body.is_empty() {
+        return String::new();
+    }
+    format!("{heading}{}", clamp(&body, PROMPT_FILE_BUDGET_CHARS))
+}
+
+/// Clamps `text` to `budget` codepoints, keeping the leading portion.
+///
+/// Three properties, each of which prevents a specific failure:
+///
+/// * It cuts on a **character** boundary, never a byte one, so a multi-byte
+///   codepoint at the limit is dropped whole rather than sliced into invalid
+///   UTF-8.
+/// * It keeps the **leading** portion, because these documents are written
+///   most-important-first — a brief leads with what is established, an operator
+///   brief leads with the instruction.
+/// * It marks the cut, so truncation is legible instead of looking like a short
+///   document.
+///
+/// Clamping happens here, where the text is spent, rather than at load: refusing
+/// or truncating the read would cost the company the whole document, while
+/// clamping at assembly costs only its tail.
+pub fn clamp(text: &str, budget: usize) -> String {
+    // `chars().count()` walks the string, so only pay for it when the cheap byte
+    // length says a cut is even possible (bytes >= chars, always).
+    if text.len() <= budget {
+        return text.to_string();
+    }
+    let mut kept: String = text.chars().take(budget).collect();
+    if kept.chars().count() == text.chars().count() {
+        return kept;
+    }
+    kept.push_str(TRUNCATION_MARKER);
+    kept
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn agent(role: &str) -> Agent {
+        Agent {
+            id: "a".into(),
+            role: role.into(),
+            description: None,
+            tier: None,
+            tools: Vec::new(),
+            delegates_to: Vec::new(),
+            context: None,
+            budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn the_persona_names_the_role_and_company() {
+        let prompt = persona_prompt("Acme", &agent("Copywriter"));
+        assert!(prompt.contains("Copywriter"), "{prompt}");
+        assert!(prompt.contains("Acme"), "{prompt}");
+    }
+
+    #[test]
+    fn an_inline_prompt_is_appended_to_the_persona_not_substituted_for_it() {
+        let mut a = agent("Copywriter");
+        a.description = Some("Write ads.".into());
+        a.prompt = Some("Write in the brand's voice.".into());
+
+        let prompt = persona_prompt("Acme", &a);
+        // The identity framing survives — that is the whole reason this appends.
+        assert!(prompt.contains("You are the Copywriter at Acme"), "{prompt}");
+        assert!(prompt.contains("Write ads."), "{prompt}");
+        assert!(prompt.contains("Write in the brand's voice."), "{prompt}");
+        // And the operator's instruction comes last, where it is not buried.
+        assert!(
+            prompt.find("Write ads.") < prompt.find("Write in the brand's voice."),
+            "{prompt}"
+        );
+    }
+
+    #[test]
+    fn a_blank_inline_prompt_adds_nothing() {
+        let mut a = agent("Copywriter");
+        a.prompt = Some("   \n  ".into());
+        assert_eq!(persona_prompt("Acme", &a), persona_prompt("Acme", &agent("Copywriter")));
+    }
+
+    #[test]
+    fn an_agent_with_no_documents_gets_no_section() {
+        assert_eq!(bundle_section(&agent("X")), "");
+        assert_eq!(context_section(&[]), "");
+    }
+
+    /// A document that exists but says nothing is dropped rather than rendered
+    /// as an empty heading — the model reads the latter as a real, empty source.
+    #[test]
+    fn whitespace_only_documents_are_dropped() {
+        let mut a = agent("X");
+        a.prompt_files_resolved = vec![("empty.md".into(), "   \n\n  ".into())];
+        assert_eq!(bundle_section(&a), "");
+
+        assert_eq!(context_section(&[("blank.md".into(), "\n".into())]), "");
+    }
+
+    #[test]
+    fn documents_are_rendered_under_their_names_in_order() {
+        let mut a = agent("X");
+        a.prompt_files_resolved = vec![
+            ("prompts/tone.md".into(), "Be direct.".into()),
+            ("prompts/style.md".into(), "Short sentences.".into()),
+        ];
+
+        let section = bundle_section(&a);
+        assert!(section.contains("### prompts/tone.md"), "{section}");
+        assert!(section.contains("Be direct."), "{section}");
+        assert!(
+            section.find("prompts/tone.md") < section.find("prompts/style.md"),
+            "declared order is preserved: {section}"
+        );
+    }
+
+    #[test]
+    fn the_two_sections_have_distinct_headings() {
+        let mut a = agent("X");
+        a.prompt_files_resolved = vec![("brief.md".into(), "body".into())];
+        let bundle = bundle_section(&a);
+        let context = context_section(&[("GOAL.md".into(), "body".into())]);
+        assert_ne!(bundle, context);
+        assert!(bundle.contains("Your brief"), "{bundle}");
+        assert!(context.contains("Working documents"), "{context}");
+    }
+
+    #[test]
+    fn text_within_budget_is_returned_untouched() {
+        assert_eq!(clamp("short", 100), "short");
+        // Exactly at the budget is within it.
+        assert_eq!(clamp("abcde", 5), "abcde");
+    }
+
+    #[test]
+    fn an_over_budget_clamp_keeps_the_leading_portion_and_marks_the_cut() {
+        let clamped = clamp("abcdefghij", 4);
+        assert!(clamped.starts_with("abcd"), "{clamped}");
+        assert!(clamped.contains("truncated"), "{clamped}");
+        assert!(!clamped.contains('e'), "the tail is gone: {clamped}");
+    }
+
+    /// The property a byte-based clamp gets wrong: cutting mid-codepoint would
+    /// panic or produce invalid UTF-8.
+    #[test]
+    fn the_clamp_cuts_on_a_character_boundary() {
+        // Each emoji is 4 bytes, so a byte-indexed slice at 5 would split one.
+        let text = "🙂🙂🙂🙂";
+        let clamped = clamp(text, 2);
+        assert!(clamped.starts_with("🙂🙂"), "{clamped}");
+        assert!(!clamped.starts_with("🙂🙂🙂"), "{clamped}");
+        // Reaching here at all proves it did not panic on a byte boundary.
+        assert!(clamped.contains("truncated"));
+    }
+
+    /// Multi-byte text whose byte length exceeds the budget but whose codepoint
+    /// count does not must survive whole — the cheap byte-length pre-check must
+    /// not itself become the cut.
+    #[test]
+    fn multibyte_text_within_the_codepoint_budget_is_not_cut() {
+        let text = "🙂🙂🙂"; // 3 chars, 12 bytes
+        assert_eq!(clamp(text, 4), text);
+    }
+
+    #[test]
+    fn the_section_budget_applies_across_documents_not_per_document() {
+        let long = "x".repeat(PROMPT_FILE_BUDGET_CHARS);
+        let mut a = agent("X");
+        a.prompt_files_resolved = vec![
+            ("one.md".into(), long.clone()),
+            ("two.md".into(), long.clone()),
+        ];
+
+        let section = bundle_section(&a);
+        assert!(
+            section.contains("truncated"),
+            "two budget-sized documents must not buy two budgets"
+        );
+        // The second document is past the budget, so its heading never appears.
+        assert!(!section.contains("### two.md"), "section rendered past budget");
+    }
+}

--- a/src/company/prompt.rs
+++ b/src/company/prompt.rs
@@ -192,7 +192,10 @@ mod tests {
 
         let prompt = persona_prompt("Acme", &a);
         // The identity framing survives — that is the whole reason this appends.
-        assert!(prompt.contains("You are the Copywriter at Acme"), "{prompt}");
+        assert!(
+            prompt.contains("You are the Copywriter at Acme"),
+            "{prompt}"
+        );
         assert!(prompt.contains("Write ads."), "{prompt}");
         assert!(prompt.contains("Write in the brand's voice."), "{prompt}");
         // And the operator's instruction comes last, where it is not buried.
@@ -206,7 +209,10 @@ mod tests {
     fn a_blank_inline_prompt_adds_nothing() {
         let mut a = agent("Copywriter");
         a.prompt = Some("   \n  ".into());
-        assert_eq!(persona_prompt("Acme", &a), persona_prompt("Acme", &agent("Copywriter")));
+        assert_eq!(
+            persona_prompt("Acme", &a),
+            persona_prompt("Acme", &agent("Copywriter"))
+        );
     }
 
     #[test]
@@ -308,6 +314,9 @@ mod tests {
             "two budget-sized documents must not buy two budgets"
         );
         // The second document is past the budget, so its heading never appears.
-        assert!(!section.contains("### two.md"), "section rendered past budget");
+        assert!(
+            !section.contains("### two.md"),
+            "section rendered past budget"
+        );
     }
 }

--- a/src/company/tool_catalog.rs
+++ b/src/company/tool_catalog.rs
@@ -15,7 +15,7 @@
 //! resolve through the same narrowing the harness applies, that is a bug in this
 //! file, not a new kind of permission. A test at the bottom holds that line.
 
-use crate::company::{CompanyManifest, GATEABLE_NAMESPACES};
+use crate::company::CompanyManifest;
 
 /// What kind of thing a catalog entry names.
 #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
@@ -184,6 +184,7 @@ fn wildcard_covers(namespace: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::company::GATEABLE_NAMESPACES;
     use crate::company::{
         grants_composio_explicit, grants_media_explicit, grants_repo_explicit,
         grants_search_explicit,

--- a/src/company/tool_catalog.rs
+++ b/src/company/tool_catalog.rs
@@ -1,0 +1,309 @@
+//! The one list of tools a company can grant.
+//!
+//! Before this existed, "what can our agents reach?" had three unrelated
+//! answers: the built-in grant namespaces
+//! ([`GATEABLE_NAMESPACES`](crate::company::GATEABLE_NAMESPACES) and the
+//! ungated families beside them), the `[[mcp_server]]` entries reachable through
+//! `mcp:<slug>` grants, and the Composio toolkits behind `[tools.composio]`.
+//! Each has its own vocabulary, and nothing enumerated them together — so a
+//! grant naming a server that does not exist looked exactly like one that
+//! worked, and no console screen could list what was on offer.
+//!
+//! This module is a **projection**, never a source of truth. Every entry's
+//! [`grant`](CatalogEntry::grant) is a string the real matcher already
+//! understands, and the catalog invents nothing: if an entry's grant does not
+//! resolve through the same narrowing the harness applies, that is a bug in this
+//! file, not a new kind of permission. A test at the bottom holds that line.
+
+use crate::company::{CompanyManifest, GATEABLE_NAMESPACES};
+
+/// What kind of thing a catalog entry names.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum ToolKind {
+    /// A built-in tool family, gated by its grant namespace.
+    Builtin {
+        /// The grant namespace, e.g. `shell`, `web`, `docs`.
+        namespace: String,
+    },
+    /// A per-tenant MCP tool server, reached through an `mcp:<name>` grant.
+    Mcp {
+        /// The server's manifest `name` slug.
+        server: String,
+    },
+    /// A Composio toolkit reachable under the `composio` grant.
+    Composio {
+        /// The toolkit slug, e.g. `gmail`, `slack`.
+        toolkit: String,
+    },
+}
+
+/// One thing a company can grant an agent.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogEntry {
+    /// Stable identifier for this entry, unique within a catalog.
+    pub key: String,
+    /// What the entry names.
+    #[serde(flatten)]
+    pub kind: ToolKind,
+    /// The grant string that confers it — the exact token an operator writes in
+    /// `[tools].allow`, a desk's `tools`, or an agent's `tools`.
+    pub grant: String,
+    /// One line an operator can read, in prosumer language.
+    pub description: String,
+    /// Whether a catch-all `*` confers this entry.
+    ///
+    /// The three real-money / third-party-credential namespaces (`media`,
+    /// `composio`, `search`) and the bound-repository namespace (`repo`) must be
+    /// named explicitly, so a console that renders `*` as "everything" without
+    /// this flag would tell an operator they had granted something they had not.
+    pub covered_by_wildcard: bool,
+    /// Whether the company currently grants this entry at all, at the
+    /// company-wide level (`[tools].allow`). Desks and agents narrow further.
+    pub granted: bool,
+}
+
+/// The built-in tool families, with the one-line description each gets in the
+/// console.
+///
+/// The gateable namespaces come from [`GATEABLE_NAMESPACES`] so this list cannot
+/// drift from what the capability filter knows about; the remaining entries are
+/// the ungated families a company can still grant or withhold.
+const BUILTIN_DESCRIPTIONS: &[(&str, &str)] = &[
+    ("shell", "Run commands in the agent's own sandbox."),
+    ("code", "Edit files, apply patches, and use git."),
+    ("web", "Fetch a URL the agent already has."),
+    ("subagent", "Split work across helper agents."),
+    ("media", "Generate images and video. Spends real money."),
+    (
+        "composio",
+        "Reach connected third-party accounts (Gmail, Slack, GitHub).",
+    ),
+    ("search", "Search the web. Billed per search."),
+    ("repo", "Read a bound source repository."),
+    ("docs", "Read and write documents."),
+    ("files", "Read and write files in the agent's sandbox."),
+    ("workspace", "Read the company's shared workspace."),
+];
+
+/// Builds the company's tool catalog: built-ins, then MCP servers, then Composio
+/// toolkits, each in a stable order so a console list does not reshuffle between
+/// reads.
+pub fn catalog(manifest: &CompanyManifest) -> Vec<CatalogEntry> {
+    let allow = &manifest.tools.allow;
+    let mut entries = Vec::new();
+
+    for (namespace, description) in BUILTIN_DESCRIPTIONS {
+        entries.push(CatalogEntry {
+            key: format!("builtin:{namespace}"),
+            kind: ToolKind::Builtin {
+                namespace: (*namespace).to_string(),
+            },
+            grant: (*namespace).to_string(),
+            description: (*description).to_string(),
+            covered_by_wildcard: wildcard_covers(namespace),
+            granted: crate::runtime::builder::grant_list_covers(allow, namespace),
+        });
+    }
+
+    for server in &manifest.mcp_servers {
+        let grant = format!("mcp:{}", server.name);
+        entries.push(CatalogEntry {
+            key: format!("mcp:{}", server.name),
+            kind: ToolKind::Mcp {
+                server: server.name.clone(),
+            },
+            description: server
+                .description
+                .clone()
+                .unwrap_or_else(|| format!("Tools from the `{}` server.", server.name)),
+            // A disabled server is listed but never granted: an operator needs to
+            // see that it exists and is switched off, which an omitted row cannot
+            // say.
+            granted: server.enabled && crate::runtime::builder::grant_list_covers(allow, &grant),
+            covered_by_wildcard: false,
+            grant,
+        });
+    }
+
+    for toolkit in &manifest.tools.composio.toolkits {
+        entries.push(CatalogEntry {
+            key: format!("composio:{toolkit}"),
+            kind: ToolKind::Composio {
+                toolkit: toolkit.clone(),
+            },
+            // Composio toolkits ride the one `composio` grant; the toolkit list
+            // narrows which of them the tool may target. So the grant string
+            // here is `composio`, not `composio:<toolkit>` — writing the latter
+            // would be inventing a permission the matcher does not know.
+            grant: "composio".to_string(),
+            description: format!("The `{toolkit}` toolkit, through Composio."),
+            covered_by_wildcard: false,
+            granted: crate::company::grants_composio_explicit(allow),
+        });
+    }
+
+    entries
+}
+
+/// Whether a catch-all `*` grant confers `namespace`.
+///
+/// False for the four namespaces that must be named explicitly. Each already has
+/// its own predicate in [`crate::company::types`]; this mirrors the *set* rather
+/// than re-implementing any of the matching, and the test below pins the two
+/// together so a fifth opt-in namespace cannot be added in one place only.
+fn wildcard_covers(namespace: &str) -> bool {
+    !matches!(namespace, "media" | "composio" | "search" | "repo")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::company::{
+        grants_composio_explicit, grants_media_explicit, grants_repo_explicit,
+        grants_search_explicit,
+    };
+
+    fn manifest(toml: &str) -> CompanyManifest {
+        toml::from_str(toml).expect("valid toml")
+    }
+
+    fn base() -> CompanyManifest {
+        manifest("[company]\nname = \"X\"\n")
+    }
+
+    #[test]
+    fn the_catalog_lists_every_gateable_namespace() {
+        let entries = catalog(&base());
+        for namespace in GATEABLE_NAMESPACES {
+            assert!(
+                entries.iter().any(|e| e.grant == namespace),
+                "`{namespace}` is gateable but absent from the catalog"
+            );
+        }
+    }
+
+    /// The invariant that keeps this a projection: every grant the catalog
+    /// advertises must be one the real matcher understands. A catalog entry
+    /// naming a token nothing resolves would be a permission this file invented.
+    #[test]
+    fn every_advertised_grant_resolves_through_the_real_matcher() {
+        let m = manifest(
+            "[company]\nname = \"X\"\n\n[[mcp_server]]\nname = \"notion\"\nendpoint = \"https://example.com\"\n\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        );
+        for entry in catalog(&m) {
+            // Granting exactly this token at the company level must make the
+            // catalog report the entry as granted.
+            let allow = vec![entry.grant.clone()];
+            let mut granting = m.clone();
+            granting.tools.allow = allow;
+            let resolved = catalog(&granting);
+            let same = resolved
+                .iter()
+                .find(|e| e.key == entry.key)
+                .expect("entry survives");
+            assert!(
+                same.granted,
+                "granting `{}` did not confer catalog entry `{}`",
+                entry.grant, entry.key
+            );
+        }
+    }
+
+    /// The wildcard set here must match the explicit-grant predicates exactly,
+    /// or the console would tell an operator `*` granted something it did not.
+    #[test]
+    fn the_wildcard_set_matches_the_explicit_grant_predicates() {
+        let wildcard = vec!["*".to_string()];
+        assert!(!grants_media_explicit(&wildcard));
+        assert!(!grants_composio_explicit(&wildcard));
+        assert!(!grants_search_explicit(&wildcard));
+        assert!(!grants_repo_explicit(&wildcard));
+
+        for (namespace, _) in BUILTIN_DESCRIPTIONS {
+            let expected = !matches!(*namespace, "media" | "composio" | "search" | "repo");
+            assert_eq!(
+                wildcard_covers(namespace),
+                expected,
+                "`{namespace}` wildcard coverage disagrees with the predicates"
+            );
+        }
+    }
+
+    #[test]
+    fn a_wildcard_company_grants_the_ordinary_families_but_not_the_opt_in_ones() {
+        let mut m = base();
+        m.tools.allow = vec!["*".to_string()];
+        let entries = catalog(&m);
+        let granted = |grant: &str| {
+            entries
+                .iter()
+                .find(|e| e.grant == grant)
+                .map(|e| e.granted)
+                .expect("entry")
+        };
+        assert!(granted("shell"));
+        assert!(granted("web"));
+        assert!(!granted("media"), "`*` must never confer real-money media");
+        assert!(!granted("search"), "`*` must never confer billed search");
+    }
+
+    #[test]
+    fn an_mcp_server_appears_with_its_own_grant_token() {
+        let m = manifest(
+            "[company]\nname = \"X\"\n\n[[mcp_server]]\nname = \"notion\"\nendpoint = \"https://example.com\"\ndescription = \"Notion pages.\"\n",
+        );
+        let entry = catalog(&m)
+            .into_iter()
+            .find(|e| matches!(&e.kind, ToolKind::Mcp { server } if server == "notion"))
+            .expect("server listed");
+        assert_eq!(entry.grant, "mcp:notion");
+        assert_eq!(entry.description, "Notion pages.");
+    }
+
+    /// A disabled server is listed and not granted. Omitting the row would leave
+    /// an operator unable to see that the server exists at all.
+    #[test]
+    fn a_disabled_mcp_server_is_listed_but_not_granted() {
+        let m = manifest(
+            "[company]\nname = \"X\"\ntools = { allow = [\"mcp:notion\"] }\n\n[[mcp_server]]\nname = \"notion\"\nendpoint = \"https://example.com\"\nenabled = false\n",
+        );
+        let entry = catalog(&m)
+            .into_iter()
+            .find(|e| e.key == "mcp:notion")
+            .expect("listed");
+        assert!(!entry.granted);
+    }
+
+    /// Composio toolkits ride the single `composio` grant — the catalog must not
+    /// advertise a per-toolkit permission that nothing enforces.
+    #[test]
+    fn composio_toolkits_share_the_one_composio_grant() {
+        let m = manifest(
+            "[company]\nname = \"X\"\n\n[tools]\nallow = [\"composio\"]\n\n[tools.composio]\ntoolkits = [\"gmail\", \"slack\"]\n",
+        );
+        let toolkits: Vec<CatalogEntry> = catalog(&m)
+            .into_iter()
+            .filter(|e| matches!(e.kind, ToolKind::Composio { .. }))
+            .collect();
+        assert_eq!(toolkits.len(), 2);
+        for entry in toolkits {
+            assert_eq!(entry.grant, "composio");
+            assert!(entry.granted);
+        }
+    }
+
+    #[test]
+    fn catalog_keys_are_unique() {
+        let m = manifest(
+            "[company]\nname = \"X\"\n\n[[mcp_server]]\nname = \"notion\"\nendpoint = \"https://e.com\"\n\n[tools.composio]\ntoolkits = [\"gmail\"]\n",
+        );
+        let entries = catalog(&m);
+        let mut keys: Vec<&str> = entries.iter().map(|e| e.key.as_str()).collect();
+        keys.sort_unstable();
+        let before = keys.len();
+        keys.dedup();
+        assert_eq!(before, keys.len(), "duplicate catalog keys");
+    }
+}

--- a/src/company/tool_catalog.rs
+++ b/src/company/tool_catalog.rs
@@ -103,7 +103,7 @@ pub fn catalog(manifest: &CompanyManifest) -> Vec<CatalogEntry> {
             grant: (*namespace).to_string(),
             description: (*description).to_string(),
             covered_by_wildcard: wildcard_covers(namespace),
-            granted: crate::runtime::builder::grant_list_covers(allow, namespace),
+            granted: crate::runtime::builder::allow_covers(allow, namespace),
         });
     }
 
@@ -121,7 +121,7 @@ pub fn catalog(manifest: &CompanyManifest) -> Vec<CatalogEntry> {
             // A disabled server is listed but never granted: an operator needs to
             // see that it exists and is switched off, which an omitted row cannot
             // say.
-            granted: server.enabled && crate::runtime::builder::grant_list_covers(allow, &grant),
+            granted: server.enabled && crate::runtime::builder::allow_covers(allow, &grant),
             covered_by_wildcard: false,
             grant,
         });

--- a/src/company/tool_catalog.rs
+++ b/src/company/tool_catalog.rs
@@ -147,12 +147,36 @@ pub fn catalog(manifest: &CompanyManifest) -> Vec<CatalogEntry> {
     entries
 }
 
+/// Whether a company's `allow` list grants a built-in namespace.
+///
+/// Four namespaces are **not** answerable by the generic glob matcher, and this
+/// is the one place that difference has to be honoured rather than assumed. The
+/// generic matcher says a catch-all `*` covers everything, but `media`,
+/// `composio`, `search` and `repo` each carry a rule that `*` deliberately does
+/// not confer them — they spend real money, reach a tenant's third-party
+/// accounts, or materialize a third party's source inside a sandbox, so they
+/// must be opted into by name.
+///
+/// Each of those rules already exists as its own predicate beside the manifest
+/// types. Delegating to them, rather than re-deriving the answer from `allow`,
+/// is what keeps the catalog a projection: the console cannot tell an operator
+/// they have granted something the gate will refuse.
+fn namespace_granted(allow: &[String], namespace: &str) -> bool {
+    match namespace {
+        "media" => crate::company::grants_media_explicit(allow),
+        "composio" => crate::company::grants_composio_explicit(allow),
+        "search" => crate::company::grants_search_explicit(allow),
+        "repo" => crate::company::grants_repo_explicit(allow),
+        _ => crate::runtime::builder::allow_covers(allow, namespace),
+    }
+}
+
 /// Whether a catch-all `*` grant confers `namespace`.
 ///
-/// False for the four namespaces that must be named explicitly. Each already has
-/// its own predicate in [`crate::company::types`]; this mirrors the *set* rather
-/// than re-implementing any of the matching, and the test below pins the two
-/// together so a fifth opt-in namespace cannot be added in one place only.
+/// The same four exceptions [`namespace_granted`] routes around, surfaced as
+/// data so a console rendering `*` as "everything" can say which families it
+/// does not in fact cover. The test below pins this set against the predicates
+/// themselves, so a fifth opt-in namespace cannot be added in one place only.
 fn wildcard_covers(namespace: &str) -> bool {
     !matches!(namespace, "media" | "composio" | "search" | "repo")
 }

--- a/src/company/tool_catalog.rs
+++ b/src/company/tool_catalog.rs
@@ -103,7 +103,7 @@ pub fn catalog(manifest: &CompanyManifest) -> Vec<CatalogEntry> {
             grant: (*namespace).to_string(),
             description: (*description).to_string(),
             covered_by_wildcard: wildcard_covers(namespace),
-            granted: crate::runtime::builder::allow_covers(allow, namespace),
+            granted: namespace_granted(allow, namespace),
         });
     }
 

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -559,7 +559,7 @@ pub struct GroupChat {
     /// growth desk is how a marketer gains the ad tools, and an intersection
     /// would make each extra desk silently *remove* capability — so adding
     /// someone to a desk could break the job they already did. See
-    /// [`effective_grants`](crate::company::effective_grants).
+    /// [`agent_scoped_grants`](crate::runtime::builder::agent_scoped_grants).
     #[serde(default)]
     pub tools: Vec<String>,
 }

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -435,11 +435,13 @@ pub struct Agent {
     /// tell an omitted key from an explicit empty list apart, since both
     /// deserialize to the same empty vec.
     ///
-    /// **Inert until the routing layer lands.** The field is parsed and carried
-    /// so a manifest can declare its routing as data today; nothing consumes it
-    /// yet. It is declared now rather than later because `Agent` does not deny
-    /// unknown fields — a `context` key on an older binary is silently ignored,
-    /// which reads exactly like routing that works and does nothing.
+    /// The **dynamic** half of the prompt-context pair: these are live
+    /// operator-owned documents, re-read on every roster rebuild and placed last
+    /// in the system prompt, after the static
+    /// [`prompt_files`](Self::prompt_files). Documents are resolved by
+    /// `harness::context_routing` before the (synchronous) agent build, and a
+    /// change to one moves the roster fingerprint so it reaches the next turn
+    /// rather than the next restart.
     #[serde(default)]
     pub context: Option<Vec<String>>,
     /// Per-agent daily spend cap in USD.

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -445,6 +445,60 @@ pub struct Agent {
     /// Per-agent daily spend cap in USD.
     #[serde(default)]
     pub budget_usd_daily: Option<f64>,
+    /// A custom system-prompt body for this role, appended to the generated
+    /// persona sentence rather than replacing it.
+    ///
+    /// Appended, not substituted, because the generated line is what binds the
+    /// agent to *this* company and *this* role — an agent that replaced it would
+    /// lose the identity framing that makes it answer as the Copywriter at Acme
+    /// instead of falling back to the runtime's own assistant persona. What an
+    /// operator wants here is the working instruction ("write in the brand's
+    /// voice, never the agency's"), which is additive to that framing.
+    ///
+    /// Available on a `[[agent]]` entry as well as an `agents/<id>.toml` file:
+    /// one field, one consumer, so adopting a prompt does not require adopting
+    /// the bundle layout first.
+    #[serde(default)]
+    pub prompt: Option<String>,
+    /// Checked-in documents folded into this agent's system prompt, as paths
+    /// relative to the company bundle's `agents/` directory.
+    ///
+    /// The **static** half of the prompt-context pair. These are version
+    /// controlled beside the agent definition and never change between two
+    /// turns of a run, which is why they are read once at manifest load and
+    /// placed early in the prompt where the cache prefix stays stable. The
+    /// dynamic half is [`context`](Self::context): live workspace documents,
+    /// re-read per roster rebuild and placed last.
+    ///
+    /// A path that escapes `agents/`, or names a file that does not exist, is a
+    /// **validation error** rather than a skipped entry. This is deliberately
+    /// stricter than `context`'s missing-document rule, and for a reason the two
+    /// do not share: a workspace document is operator-owned live state that may
+    /// legitimately not exist yet, while a `prompt_files` entry names a file in
+    /// the same commit as the agent that references it. A typo there yields a
+    /// role whose prompt was written around a briefing it silently never
+    /// received.
+    #[serde(default)]
+    pub prompt_files: Vec<String>,
+    /// The `(path, body)` pairs [`prompt_files`](Self::prompt_files) resolved
+    /// to, filled by the bundle loader at manifest-load time.
+    ///
+    /// Carried on the manifest rather than read at prompt-assembly time because
+    /// `harness::build::build_agent` is synchronous and runs on every roster
+    /// rebuild; doing the file I/O there would put a disk read behind a lock on
+    /// a hot path, to load bytes that cannot have changed since the manifest was
+    /// parsed. `#[serde(skip)]` keeps it out of the on-disk record — it is
+    /// derived state, and a persisted copy would go stale against the bundle.
+    #[serde(skip)]
+    pub prompt_files_resolved: Vec<(String, String)>,
+    /// This role's epistemic classes, gating which routed documents it may be
+    /// told. See [`PROMPT_CLASSES`] for the closed set and what each excludes.
+    ///
+    /// Empty (the default) is *unclassified*: no exclusion, the correct default
+    /// for an ordinary teammate. A company that wants an exclusion states it
+    /// here rather than having it guessed from the free-text `role`.
+    #[serde(default)]
+    pub classes: Vec<String>,
 }
 
 /// The `[[agent]].tier` value that marks a roster's orchestrator.

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -542,6 +542,26 @@ pub struct GroupChat {
     /// Agent ids in this chat; each must exist in the roster.
     #[serde(default)]
     pub members: Vec<String>,
+    /// This desk's tool ceiling: the middle level of the three-level narrowing
+    /// `[tools].allow ∩ desk.tools ∩ [[agent]].tools`.
+    ///
+    /// A desk is how a company expresses a department — a finance desk, a
+    /// creative desk — so it is the natural place to say "nobody on this desk
+    /// reaches the web", once, instead of repeating the restriction on every
+    /// member and hoping the next member added inherits it.
+    ///
+    /// Empty (the default) narrows **nothing**, which makes this field a no-op
+    /// for every manifest written before it existed.
+    ///
+    /// A teammate sitting on several desks takes the **union** of their
+    /// ceilings before the intersection with the company grant. Union rather
+    /// than intersection because desks are additive memberships: joining the
+    /// growth desk is how a marketer gains the ad tools, and an intersection
+    /// would make each extra desk silently *remove* capability — so adding
+    /// someone to a desk could break the job they already did. See
+    /// [`effective_grants`](crate::company::effective_grants).
+    #[serde(default)]
+    pub tools: Vec<String>,
 }
 
 /// A `[[connection]]` entry — an integration to prioritize wiring. This is

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -246,6 +246,42 @@ pub fn grants_workspace_write_explicit(grants: &[String]) -> bool {
         .any(|grant| grant == "workspace" || grant == "workspace.write")
 }
 
+/// Epistemic classes a roster teammate may declare, gating which routed
+/// documents it may be told (`docs/spec/runtime/orchestration/context-routing.md`).
+///
+/// The routing spec's three exclusions quantify over "roles that weigh
+/// evidence", "roles that judge" and "roles acting on a directive", and it is
+/// explicit that the classification MUST be an explicit declaration and **never**
+/// a match on `role`: `role` is prose an operator writes for humans, so matching
+/// on it would make a company that renames "Critic" to "Reviewer" silently lose
+/// an exclusion, and a control a rename can switch off is not a control.
+///
+/// * `evidence` — weighs evidence, so it is never routed the assertion board.
+/// * `judge` — scores a deliverable, so it is never routed the scratch.
+/// * `directive` — acts on an operator instruction, so it is never routed the
+///   claim ledger.
+///
+/// Declaring none (the default) is *unclassified*, which imposes no exclusion —
+/// the correct default, because an ordinary teammate is not judging anything.
+pub const PROMPT_CLASSES: [&str; 3] = ["evidence", "judge", "directive"];
+
+/// Ceiling, in Unicode codepoints, on the prompt text one agent's
+/// `prompt_files` (and, separately, its routed `context` documents) may
+/// contribute to the system prompt.
+///
+/// Sized as [`alignment.md`'s brief budget][brief] — 10,000 provider-billed
+/// tokens — measured in codepoints as a cheap, tokenizer-free upper bound. One
+/// token typically spans several codepoints for the encodings in use, so a
+/// codepoint count is never smaller than the true token count: the clamp may cut
+/// earlier than the budget strictly requires, never later.
+///
+/// Applied **where the prompt is spent** (assembly), never by refusing to load
+/// the file. Refusing the read costs the company the whole document; clamping at
+/// assembly costs only its tail.
+///
+/// [brief]: https://docs/spec/runtime/orchestration/alignment.md
+pub const PROMPT_FILE_BUDGET_CHARS: usize = 10_000;
+
 /// Built-in capability tier names selectable in `[plan].name` (issue #108). The
 /// name → budget-map table lives in
 /// [`plan_named`](crate::harness::capability_budget::plan_named); this list is

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -269,7 +269,8 @@ pub const PROMPT_CLASSES: [&str; 3] = ["evidence", "judge", "directive"];
 /// `prompt_files` (and, separately, its routed `context` documents) may
 /// contribute to the system prompt.
 ///
-/// Sized as [`alignment.md`'s brief budget][brief] — 10,000 provider-billed
+/// Sized as the brief budget in
+/// `docs/spec/runtime/orchestration/alignment.md` — 10,000 provider-billed
 /// tokens — measured in codepoints as a cheap, tokenizer-free upper bound. One
 /// token typically spans several codepoints for the encodings in use, so a
 /// codepoint count is never smaller than the true token count: the clamp may cut

--- a/src/company/workflow_create.rs
+++ b/src/company/workflow_create.rs
@@ -1942,6 +1942,7 @@ to = "done"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/economy/adapter.rs
+++ b/src/economy/adapter.rs
@@ -504,6 +504,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2859,6 +2859,7 @@ description = "Runs Acme."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -3022,6 +3023,7 @@ description = "Builds it."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -5042,6 +5044,7 @@ members = ["engineer"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -5287,6 +5290,7 @@ name = "Design"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -5349,6 +5353,7 @@ members = ["eng1", "eng2"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -5406,6 +5411,7 @@ members = ["eng1", "eng2"]
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -668,7 +668,16 @@ pub fn build_agent(
 
     // Persona over openhuman's own identity: `omit_identity = true` drops the
     // "you are OpenHuman" preamble so the agent speaks as its company role.
+    // Includes the operator's inline `prompt`, appended to the generated framing.
     let mut persona = persona_prompt(company_name, manifest_agent);
+
+    // The agent's checked-in briefing documents, placed here — before every
+    // tool brief and before the routed workspace documents — because they are
+    // the most static material in the prompt after the persona itself. The
+    // prompt prefix is what a provider cache reuses across turns, so ordering
+    // static-before-volatile is what keeps an operator editing a workspace note
+    // from invalidating the briefing behind it.
+    persona.push_str(&crate::company::prompt::bundle_section(manifest_agent));
 
     // A short, STATIC brief — never a tree snapshot. A snapshot baked into the
     // system prompt would be stale the moment the operator edits a note, which

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -1315,6 +1315,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         }
     }
 
@@ -1497,6 +1501,10 @@ mod tests {
             delegates_to: delegates_to.iter().map(|d| d.to_string()).collect(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1537,6 +1545,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1573,6 +1585,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1607,6 +1623,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1803,6 +1823,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -170,20 +170,14 @@ pub fn model_for_tier(tier: Option<&str>) -> String {
 /// This is what makes the agent answer *as* the CEO of Acme rather than falling
 /// back to openhuman's own assistant identity — the harness passes it as the
 /// archetype body with the default identity section omitted.
+///
+/// Delegates to [`crate::company::prompt::persona_prompt`], which is compiled in
+/// every build. Kept as a re-export rather than inlined at the call sites so the
+/// harness's existing callers and tests keep one name for "the persona", and so
+/// the composition rules (including the operator's inline `prompt`) are exercised
+/// by the default-build test suite rather than only where this module links.
 pub fn persona_prompt(company_name: &str, agent: &ManifestAgent) -> String {
-    let mut prompt = format!(
-        "You are the {role} at {company}. Speak in the first person as this role.",
-        role = agent.role,
-        company = company_name,
-    );
-    if let Some(description) = agent.description.as_deref() {
-        let description = description.trim();
-        if !description.is_empty() {
-            prompt.push(' ');
-            prompt.push_str(description);
-        }
-    }
-    prompt
+    crate::company::prompt::persona_prompt(company_name, agent)
 }
 
 /// Build one openhuman [`Agent`] for `manifest_agent` within `company`.

--- a/src/harness/composio_turn_test.rs
+++ b/src/harness/composio_turn_test.rs
@@ -387,6 +387,7 @@ async fn harness(
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -663,6 +663,10 @@ mod tests {
             delegates_to: vec![],
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -171,7 +171,8 @@ use crate::harness::orchestrator::DelegationQueue;
 use crate::harness::policy::{ApprovalPolicy, ApprovalRequestQueue};
 use crate::ports::skills_state::{SkillState, SkillStateStore};
 use crate::ports::types::{
-    BudgetOverride, CompanyId, CompanyRecord, OverlayAgent, PolicyOverride, TurnStep,
+    BudgetOverride, CompanyId, CompanyRecord, OverlayAgent, OverlayDesk, OverlayDeskMember,
+    PolicyOverride, TurnStep,
 };
 use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1105,6 +1105,7 @@ impl HarnessPool {
                 && skill_fingerprints.get(&company.id) == Some(&skill_fp)
                 && budget_fingerprints.get(&company.id) == Some(&budget_fp)
                 && policy_fingerprints.get(&company.id) == Some(&policy_fp)
+                && desk_fingerprints.get(&company.id) == Some(&desk_fp)
             {
                 return Ok(());
             }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -178,7 +178,7 @@ use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,
     UsageMeter,
 };
-use crate::runtime::builder::{agent_effective_grants, agent_scoped_grants};
+use crate::runtime::builder::agent_scoped_grants;
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2835,6 +2835,7 @@ description = "Builds the product."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -4447,6 +4448,7 @@ description = "Sets direction."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1038,11 +1038,16 @@ impl HarnessPool {
 
         // Re-resolve + fingerprint the live overlay-agent set the same way, and
         // the operator budget overrides riding the same store read (issue #343).
-        let (overlay_agents, overlay_budgets, overlay_policy) =
-            self.resolve_effective_overlay(company, deps).await;
-        let overlay_fp = overlay_fingerprint(&overlay_agents);
-        let budget_fp = budget_fingerprint(&overlay_budgets);
-        let policy_fp = policy_fingerprint(overlay_policy.as_ref());
+        let overlay = self.resolve_effective_overlay(company, deps).await;
+        let overlay_fp = overlay_fingerprint(&overlay.agents);
+        let budget_fp = budget_fingerprint(&overlay.budgets);
+        let policy_fp = policy_fingerprint(overlay.policy.as_ref());
+        // Desk scoping now decides capability (the middle level of the
+        // three-level narrowing), so it joins the staleness check: without this
+        // a console desk-ceiling edit — or seating a teammate on a restricted
+        // desk — would not reach the roster until a restart.
+        let desk_fp =
+            desk_scope_fingerprint(&overlay.desks, &overlay.desk_members, &overlay.desk_tools);
 
         // Re-resolve + fingerprint the tenant's capability filter (issue #108):
         // a per-tenant, per-period, fail-closed budget read from the meter. With

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2350,6 +2350,10 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         delegates_to: Vec::new(),
         context: None,
         budget_usd_daily: None,
+        prompt: None,
+        prompt_files: Vec::new(),
+        prompt_files_resolved: Vec::new(),
+        classes: Vec::new(),
     }
 }
 
@@ -5348,6 +5352,10 @@ budget_usd_daily = 0.0
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -5459,6 +5467,10 @@ budget_usd_daily = 0.0
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         };
         let agent = build::build_agent(
             &CompanyId::new("acme"),

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1444,6 +1444,14 @@ impl HarnessPool {
         self.budget_fingerprints.read().await.get(company).copied()
     }
 
+    /// The current desk-scope fingerprint for a company (test-only), so a
+    /// desk-scoping test can assert the roster was actually rebuilt after a
+    /// ceiling or seating change rather than inferring it from a refused call.
+    #[cfg(test)]
+    pub async fn desk_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.desk_fingerprints.read().await.get(company).copied()
+    }
+
     /// Routes a message to one agent and returns its reply, recording the turn's
     /// cost. `agent_id` must name a member of the company's roster.
     ///

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1216,6 +1216,10 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), policy_fp);
+        self.desk_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), desk_fp);
         Ok(())
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2130,22 +2130,6 @@ fn policy_fingerprint(override_: Option<&PolicyOverride>) -> u64 {
     hasher.finish()
 }
 
-/// A stable fingerprint of a company's operator budget-override set (issue
-/// #343), used to detect a cap set / changed / cleared / reset between
-/// [`HarnessPool::ensure`] calls. Mirrors [`overlay_fingerprint`]'s shape; a
-/// [`BudgetOverride`] holds no secret.
-///
-/// Two details carry weight:
-///
-/// - The set is **sorted by `agent_id`** first, because the write routes push
-///   and retain rather than maintain an order, and an order-sensitive hash would
-///   rebuild the roster (dropping live agent sessions) on a save that changed
-///   nothing an agent can observe.
-/// - The cap is hashed as an `Option` **discriminant plus `f64::to_bits`**, not
-///   through `PartialEq`. `f64` is not `Hash`, and going through bits is also
-///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
-///   distinction the issue insists must not collapse. `to_bits` additionally
-///   makes the hash total over values `PartialEq` would call incomparable.
 /// The live overlay state one roster rebuild is resolved against.
 ///
 /// A struct rather than the tuple this used to be: it grew past the point where

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1133,7 +1133,7 @@ impl HarnessPool {
         // boot-time snapshot (e.g. `HarnessBrain::record`), so the roster is
         // built from the live-resolved overlay set, not `company.overlay_agents`.
         let mut fresh_company = company.clone();
-        fresh_company.overlay_agents = overlay_agents;
+        fresh_company.overlay_agents = overlay.agents;
         // Same treatment for the budget overrides (issue #343): `build_roster`
         // resolves every agent's cap through `fresh_company.effective_budget`,
         // so installing the live set here is what carries a console budget edit
@@ -1150,7 +1150,7 @@ impl HarnessPool {
         // resolves the tier through `fresh_company.effective_policy`, so installing
         // the live value here is what carries a console tier change into the roster
         // the next turn runs on.
-        fresh_company.overlay_policy = overlay_policy;
+        fresh_company.overlay_policy = overlay.policy;
 
         // Issue #551 note — this rebuild deliberately touches no workspace.
         //

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -967,6 +967,7 @@ impl HarnessPool {
             skill_fingerprints: RwLock::new(HashMap::new()),
             budget_fingerprints: RwLock::new(HashMap::new()),
             policy_fingerprints: RwLock::new(HashMap::new()),
+            desk_fingerprints: RwLock::new(HashMap::new()),
             workspace_failures: std::sync::Mutex::new(HashSet::new()),
         }
     }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2252,7 +2252,13 @@ pub(crate) fn build_roster(
             agent_policy = agent_policy.with_spend(meter.clone(), company.id.clone());
         }
         let is_orchestrator = orchestrator.as_deref() == Some(manifest_agent.id.as_str());
-        let grants = agent_effective_grants(allow, &manifest_agent.tools);
+        // Three-level narrowing: company → the desks this teammate sits on →
+        // the teammate itself. `agent_desk_tools` resolves through the record's
+        // *effective* desk membership, so a console-seated member is scoped by
+        // its desk exactly as a manifest one is.
+        let desk_tools = company.agent_desk_tools(&manifest_agent.id);
+        let desk_allows: Vec<&[String]> = desk_tools.iter().map(Vec::as_slice).collect();
+        let grants = agent_scoped_grants(allow, &desk_allows, &manifest_agent.tools);
         let agent = build::build_agent(
             &company.id,
             company_name,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2191,6 +2191,22 @@ fn desk_scope_fingerprint(
     hasher.finish()
 }
 
+/// A stable fingerprint of a company's operator budget-override set (issue
+/// #343), used to detect a cap set / changed / cleared / reset between
+/// [`HarnessPool::ensure`] calls. Mirrors [`overlay_fingerprint`]'s shape; a
+/// [`BudgetOverride`] holds no secret.
+///
+/// Two details carry weight:
+///
+/// - The set is **sorted by `agent_id`** first, because the write routes push
+///   and retain rather than maintain an order, and an order-sensitive hash would
+///   rebuild the roster (dropping live agent sessions) on a save that changed
+///   nothing an agent can observe.
+/// - The cap is hashed as an `Option` **discriminant plus `f64::to_bits`**, not
+///   through `PartialEq`. `f64` is not `Hash`, and going through bits is also
+///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
+///   distinction the issue insists must not collapse. `to_bits` additionally
+///   makes the hash total over values `PartialEq` would call incomparable.
 fn budget_fingerprint(overrides: &[BudgetOverride]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -177,7 +177,7 @@ use crate::ports::{
     ArtifactStore, CompanyStore, ContextStore, EventLog, FactStore, SecretStore, TaskStore,
     UsageMeter,
 };
-use crate::runtime::builder::agent_effective_grants;
+use crate::runtime::builder::{agent_effective_grants, agent_scoped_grants};
 
 /// Shared dependencies every harness-built agent draws on.
 #[derive(Clone)]

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2485,6 +2485,10 @@ mod tests {
     use crate::ports::types::{
         ChunkAddr, ChunkHit, ChunkMeta, CompanySummary, ContextChunk, LedgerEntry,
     };
+    // The two-level resolver. Test-only now: the roster build goes through
+    // `agent_scoped_grants`, and these tests assert the desk-less case still
+    // resolves identically to what shipped before desks could scope tools.
+    use crate::runtime::builder::agent_effective_grants;
 
     fn fp_entry(mode: Option<&str>, always: Option<Vec<&str>>) -> PolicyOverride {
         use crate::ports::types::{Actor, ActorKind};

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1343,22 +1343,24 @@ impl HarnessPool {
         &self,
         company: &CompanyRecord,
         deps: &HarnessDeps,
-    ) -> (
-        Vec<OverlayAgent>,
-        Vec<BudgetOverride>,
-        Option<PolicyOverride>,
-    ) {
+    ) -> EffectiveOverlay {
         match deps.store.load(&company.id).await {
-            Ok(Some(record)) => (
-                record.overlay_agents,
-                record.overlay_budgets,
-                record.overlay_policy,
-            ),
-            _ => (
-                company.overlay_agents.clone(),
-                company.overlay_budgets.clone(),
-                company.overlay_policy.clone(),
-            ),
+            Ok(Some(record)) => EffectiveOverlay {
+                agents: record.overlay_agents,
+                budgets: record.overlay_budgets,
+                policy: record.overlay_policy,
+                desks: record.overlay_desks,
+                desk_members: record.overlay_desk_members,
+                desk_tools: record.overlay_desk_tools,
+            },
+            _ => EffectiveOverlay {
+                agents: company.overlay_agents.clone(),
+                budgets: company.overlay_budgets.clone(),
+                policy: company.overlay_policy.clone(),
+                desks: company.overlay_desks.clone(),
+                desk_members: company.overlay_desk_members.clone(),
+                desk_tools: company.overlay_desk_tools.clone(),
+            },
         }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2304,7 +2304,12 @@ pub(crate) fn build_roster(
         if let Some(meter) = deps.meter.as_ref() {
             agent_policy = agent_policy.with_spend(meter.clone(), company.id.clone());
         }
-        let grants = agent_effective_grants(allow, &manifest_agent.tools);
+        // An overlay teammate is scoped by its desks the same as a manifest one:
+        // it can be seated on a desk, and a desk ceiling that applied to only
+        // half its members would not be a ceiling.
+        let desk_tools = company.agent_desk_tools(&manifest_agent.id);
+        let desk_allows: Vec<&[String]> = desk_tools.iter().map(Vec::as_slice).collect();
+        let grants = agent_scoped_grants(allow, &desk_allows, &manifest_agent.tools);
         let agent = build::build_agent(
             &company.id,
             company_name,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2106,6 +2106,67 @@ fn policy_fingerprint(override_: Option<&PolicyOverride>) -> u64 {
 ///   what keeps `Some(0.0)` distinct from `None` in the hash — the very
 ///   distinction the issue insists must not collapse. `to_bits` additionally
 ///   makes the hash total over values `PartialEq` would call incomparable.
+/// The live overlay state one roster rebuild is resolved against.
+///
+/// A struct rather than the tuple this used to be: it grew past the point where
+/// positional returns stay readable, and — more to the point — the desk fields
+/// were added because desks now decide *capability*, so a caller silently
+/// binding `desk_tools` to the `desks` position would hand every teammate the
+/// wrong tool belt with nothing to catch it.
+pub(crate) struct EffectiveOverlay {
+    pub agents: Vec<OverlayAgent>,
+    pub budgets: Vec<BudgetOverride>,
+    pub policy: Option<PolicyOverride>,
+    pub desks: Vec<OverlayDesk>,
+    pub desk_members: Vec<OverlayDeskMember>,
+    pub desk_tools: std::collections::BTreeMap<String, Vec<String>>,
+}
+
+/// Fingerprints the desk scoping a roster's grants are resolved through: which
+/// desks exist, who sits on them, and what each one's tool ceiling is.
+///
+/// All three axes are hashed together because all three feed one answer — an
+/// agent's effective grant. Seating a teammate on a restricted desk narrows its
+/// belt just as surely as editing that desk's ceiling does, so a fingerprint
+/// over the ceilings alone would leave a membership change invisible until the
+/// next restart, which is the staleness bug this whole fingerprint set exists to
+/// prevent.
+///
+/// Sorted before hashing, for the reason [`budget_fingerprint`] documents: the
+/// write routes push and retain rather than maintain an order, and an
+/// order-sensitive hash would drop every live agent session on a save that
+/// changed nothing an agent can observe. (`desk_tools` is a `BTreeMap` and so is
+/// already ordered by construction.)
+fn desk_scope_fingerprint(
+    desks: &[OverlayDesk],
+    members: &[OverlayDeskMember],
+    tools: &std::collections::BTreeMap<String, Vec<String>>,
+) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = DefaultHasher::new();
+
+    let mut desk_ids: Vec<&str> = desks.iter().map(|desk| desk.id.as_str()).collect();
+    desk_ids.sort_unstable();
+    desk_ids.hash(&mut hasher);
+
+    let mut seats: Vec<(&str, &str)> = members
+        .iter()
+        .map(|seat| (seat.desk_id.as_str(), seat.agent_id.as_str()))
+        .collect();
+    seats.sort_unstable();
+    seats.hash(&mut hasher);
+
+    tools.len().hash(&mut hasher);
+    for (desk_id, ceiling) in tools {
+        desk_id.hash(&mut hasher);
+        ceiling.hash(&mut hasher);
+    }
+
+    hasher.finish()
+}
+
 fn budget_fingerprint(overrides: &[BudgetOverride]) -> u64 {
     use std::collections::hash_map::DefaultHasher;
     use std::hash::{Hash, Hasher};

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -908,6 +908,18 @@ pub struct HarnessPool {
     /// restart. Without this axis the override persists and is silently ignored:
     /// `ApprovalPolicy` is built once per roster, not once per call.
     policy_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Per-company fingerprint of the desk scoping a roster's grants resolve
+    /// through — which desks exist, who sits on them, and each one's tool
+    /// ceiling.
+    ///
+    /// Needed for the same reason as [`Self::budget_fingerprints`]: a tool belt
+    /// is wired once per roster, not once per call, so without this axis a
+    /// console desk-ceiling edit (or seating a teammate on a restricted desk)
+    /// would leave every other fingerprint stable and the fast path would keep
+    /// serving the old belt until the process restarted. A company whose desks
+    /// declare no ceilings keeps a stable fingerprint and never rebuilds on this
+    /// axis.
+    desk_fingerprints: RwLock<HashMap<CompanyId, u64>>,
     /// The `(company, agent)` pairs whose last workspace-ensure failed and whose
     /// failure has already been reported (issue #449).
     ///

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1138,7 +1138,14 @@ impl HarnessPool {
         // resolves every agent's cap through `fresh_company.effective_budget`,
         // so installing the live set here is what carries a console budget edit
         // into the roster the very next turn runs on.
-        fresh_company.overlay_budgets = overlay_budgets;
+        fresh_company.overlay_budgets = overlay.budgets;
+        // The desk axis gets the same treatment, and needs it for the same
+        // reason: `build_roster` resolves every teammate's grants through
+        // `fresh_company.agent_desk_tools`, so the live desk set, seating and
+        // ceilings have to be the ones installed here.
+        fresh_company.overlay_desks = overlay.desks;
+        fresh_company.overlay_desk_members = overlay.desk_members;
+        fresh_company.overlay_desk_tools = overlay.desk_tools;
         // Issue #562: same treatment for the policy override — `build_roster`
         // resolves the tier through `fresh_company.effective_policy`, so installing
         // the live value here is what carries a console tier change into the roster

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1096,6 +1096,7 @@ impl HarnessPool {
             let skill_fingerprints = self.skill_fingerprints.read().await;
             let budget_fingerprints = self.budget_fingerprints.read().await;
             let policy_fingerprints = self.policy_fingerprints.read().await;
+            let desk_fingerprints = self.desk_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4269,6 +4269,10 @@ mod tests {
             delegates_to: Vec::new(),
             context: None,
             budget_usd_daily: None,
+            prompt: None,
+            prompt_files: Vec::new(),
+            prompt_files_resolved: Vec::new(),
+            classes: Vec::new(),
         }
     }
 

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -6214,6 +6214,7 @@ name = "Morning"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -7074,6 +7075,7 @@ name = "Morning"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -169,6 +169,7 @@ fn record() -> CompanyRecord {
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -359,6 +359,7 @@ fn brain_with(
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/search_turn_test.rs
+++ b/src/harness/search_turn_test.rs
@@ -330,6 +330,7 @@ async fn harness(
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/harness/workflow_admin/tests.rs
+++ b/src/harness/workflow_admin/tests.rs
@@ -166,6 +166,7 @@ impl Fixture {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -238,6 +238,7 @@ fn record(overlays: Vec<OverlayAgent>) -> CompanyRecord {
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -327,6 +327,7 @@ async fn harness(
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };
@@ -758,6 +759,7 @@ async fn supervised(deps: &HarnessDeps, grants: &str) -> (HarnessPool, CompanyRe
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     };

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -117,6 +117,10 @@ mod tests {
                 delegates_to: vec![],
                 context: None,
                 budget_usd_daily: None,
+                prompt: None,
+                prompt_files: Vec::new(),
+                prompt_files_resolved: Vec::new(),
+                classes: Vec::new(),
             },
             Agent {
                 id: "creative".into(),
@@ -127,6 +131,10 @@ mod tests {
                 delegates_to: vec![],
                 context: None,
                 budget_usd_daily: None,
+                prompt: None,
+                prompt_files: Vec::new(),
+                prompt_files_resolved: Vec::new(),
+                classes: Vec::new(),
             },
         ];
         let overlay = vec![OverlayAgent {

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2718,6 +2718,27 @@ pub struct CompanyRecord {
     /// approval gate and the console cannot disagree about which tier is live.
     #[serde(default)]
     pub overlay_policy: Option<PolicyOverride>,
+    /// Per-desk tool ceilings the operator has set from the console, keyed on
+    /// desk id — the runtime override of a desk's manifest
+    /// [`tools`](crate::company::GroupChat::tools).
+    ///
+    /// Read through [`Self::effective_desk_tools`], never directly, so the
+    /// console card and the harness gate cannot disagree about what a desk
+    /// permits. An absent key means the manifest decides, which is exactly the
+    /// behaviour of every record written before this field existed — the
+    /// `#[serde(default)]` is a no-op migration.
+    ///
+    /// A `BTreeMap` rather than the `Vec<…Override>` shape its neighbours use,
+    /// because the key here is genuinely unique: a desk has one ceiling, and the
+    /// map makes the "at most one entry" invariant those neighbours have to
+    /// document and police a property of the type instead.
+    ///
+    /// An entry present but **empty** is meaningful and distinct from an absent
+    /// one: it is the operator clearing a manifest ceiling back to "this desk
+    /// narrows nothing". Removing the key restores the manifest's value; storing
+    /// an empty list overrides it.
+    #[serde(default)]
+    pub overlay_desk_tools: std::collections::BTreeMap<String, Vec<String>>,
     /// Workflow ids the operator has switched **off** (issue #276). A workflow
     /// named here keeps its graph, stays listed and stays runnable by hand, and
     /// is skipped by

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2844,6 +2844,51 @@ impl CompanyRecord {
         members
     }
 
+    /// One desk's effective tool ceiling: the operator's override when one is
+    /// stored, and the manifest's `[[group_chat]].tools` otherwise.
+    ///
+    /// Empty means the desk narrows nothing. An operator-created overlay desk
+    /// has no manifest row at all, so its ceiling is whatever the override says
+    /// and empty until somebody sets one.
+    pub fn effective_desk_tools(&self, desk_id: &str) -> Vec<String> {
+        if let Some(override_tools) = self.overlay_desk_tools.get(desk_id) {
+            return override_tools.clone();
+        }
+        self.manifest
+            .group_chats
+            .iter()
+            .find(|chat| chat.id == desk_id)
+            .map(|chat| chat.tools.clone())
+            .unwrap_or_default()
+    }
+
+    /// The tool ceilings of every desk `agent_id` sits on, in desk order.
+    ///
+    /// Built from [`effective_desk_members`](Self::effective_desk_members) and
+    /// [`effective_desk_tools`](Self::effective_desk_tools) rather than by
+    /// reading the manifest directly, so a teammate added to a desk through the
+    /// console is scoped by that desk exactly as a manifest member would be —
+    /// otherwise the console could seat someone on a restricted desk and leave
+    /// them unrestricted.
+    ///
+    /// Overlay desks are walked after manifest ones, matching how every other
+    /// desk reader on this type orders the two sources.
+    pub fn agent_desk_tools(&self, agent_id: &str) -> Vec<Vec<String>> {
+        let manifest_desks = self.manifest.group_chats.iter().map(|chat| chat.id.clone());
+        let overlay_desks = self.overlay_desks.iter().map(|desk| desk.id.clone());
+        let mut seen = std::collections::HashSet::new();
+        manifest_desks
+            .chain(overlay_desks)
+            .filter(|desk_id| seen.insert(desk_id.clone()))
+            .filter(|desk_id| {
+                self.effective_desk_members(desk_id)
+                    .iter()
+                    .any(|member| member == agent_id)
+            })
+            .map(|desk_id| self.effective_desk_tools(&desk_id))
+            .collect()
+    }
+
     /// Resolves a desk key (an id, or a case-insensitive name) to its canonical
     /// id, searching the manifest desks first and then the operator-created
     /// overlay desks. Lets the harness route to overlay desks by the same

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2588,6 +2588,12 @@ pub struct OverlayBlob {
     /// the pre-#562 behaviour exactly.
     #[serde(default)]
     pub policy: Option<PolicyOverride>,
+    /// The operator-set per-desk tool ceilings. Absent on rows written before
+    /// desks could scope tools, and `#[serde(default)]` reads that absence as
+    /// "no desk overrides a ceiling" — which leaves the manifest in charge,
+    /// exactly as those companies ran.
+    #[serde(default)]
+    pub desk_tools: std::collections::BTreeMap<String, Vec<String>>,
     /// The workflow ids the operator has switched off (issue #276). Absent on
     /// rows written before the pause switch existed, and `#[serde(default)]`
     /// reads that absence as "nothing is paused" — the pre-#276 behaviour

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2618,6 +2618,7 @@ impl OverlayBlob {
             workflows: record.overlay_workflows.clone(),
             budgets: record.overlay_budgets.clone(),
             policy: record.overlay_policy.clone(),
+            desk_tools: record.overlay_desk_tools.clone(),
             disabled_workflows: record.disabled_workflows.clone(),
             provenance: record.template_provenance.clone(),
         }

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2644,6 +2644,7 @@ impl OverlayBlob {
                     workflows: Vec::new(),
                     budgets: Vec::new(),
                     policy: None,
+                    desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     provenance: None,
                 })

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -4215,6 +4215,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -207,6 +207,7 @@ mod tests {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -190,7 +190,13 @@ pub(crate) fn agent_scoped_grants(
 }
 
 /// Whether the company allow-list covers an agent-requested grant glob.
-fn allow_covers(allow: &[String], tool: &str) -> bool {
+///
+/// `pub(crate)` so the tool catalog (`crate::company::tool_catalog`) can answer
+/// "does this company grant that?" with the *same* matcher the roster build
+/// uses. A catalog doing its own matching would be free to advertise a grant the
+/// gate does not honour — precisely the disagreement between what the console
+/// shows and what an agent can actually do that the catalog exists to end.
+pub(crate) fn allow_covers(allow: &[String], tool: &str) -> bool {
     let literal = tool.strip_suffix('*').unwrap_or(tool);
     allow.iter().any(|grant| grant_matches(grant, literal))
 }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -288,6 +288,49 @@ fn carry_policy_override(
     (previous_seed == next_seed).then(|| held.clone())
 }
 
+/// Carries the operator's per-desk tool ceilings across a rebuild, dropping any
+/// whose desk had its seed `tools` edited in version control.
+///
+/// The same rule [`carry_policy_override`] applies to the approval gate, applied
+/// per desk to the capability gate — and it belongs here for the *stronger* of
+/// that function's two reasons. A desk ceiling decides which tools its members
+/// are wired with, so a console override outliving a seed that narrowed the desk
+/// is a runtime widening surviving the operator revoking it in version control.
+/// That is the exact failure the `[tools]`/`[policy]` seed-wins rule exists to
+/// prevent, and a per-desk grant is squarely within it rather than being "a
+/// number, not the gate" the way a spend cap is.
+///
+/// Per **desk** rather than whole-block, unlike the policy rule: desks are
+/// independent of one another, so an operator editing the finance desk's
+/// ceiling has said nothing about the creative desk's, and clearing both would
+/// revert a console action nobody's edit was about. Within a single desk the
+/// comparison is still whole-value, for the reason the policy rule gives — an
+/// operator who edited that desk's grant at all has turned their attention to
+/// it, and guessing which half of the edit was meant to win cannot silently
+/// pick right.
+///
+/// An override for a desk the seed does not declare (an operator-created desk)
+/// is always carried: version control never spoke about it, so it has no seed
+/// value that could have changed.
+fn carry_desk_tool_overrides(
+    previous_seed: &[GroupChat],
+    next_seed: &[GroupChat],
+    held: &std::collections::BTreeMap<String, Vec<String>>,
+) -> std::collections::BTreeMap<String, Vec<String>> {
+    let seed_tools = |desks: &[GroupChat], desk_id: &str| {
+        desks
+            .iter()
+            .find(|desk| desk.id == desk_id)
+            .map(|desk| desk.tools.clone())
+    };
+    held.iter()
+        .filter(|(desk_id, _)| {
+            seed_tools(previous_seed, desk_id) == seed_tools(next_seed, desk_id)
+        })
+        .map(|(desk_id, ceiling)| (desk_id.clone(), ceiling.clone()))
+        .collect()
+}
+
 fn merge_enabled_workflows(seed_enabled: &[String], overlays: &[OverlayWorkflow]) -> Vec<String> {
     let mut merged: Vec<String> = Vec::with_capacity(seed_enabled.len() + overlays.len());
     let mut seen = std::collections::HashSet::new();

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2995,6 +2995,192 @@ mod test {
             .expect("tempdir")
     }
 
+    mod scoped_grants {
+        use super::*;
+
+        fn strings(values: &[&str]) -> Vec<String> {
+            values.iter().map(|v| v.to_string()).collect()
+        }
+
+        /// Runs the three-level narrowing over `&str` slices, so each case below
+        /// reads as the table row it is.
+        fn scope(company: &[&str], desks: &[&[&str]], agent: &[&str]) -> Vec<String> {
+            let company = strings(company);
+            let desk_owned: Vec<Vec<String>> = desks.iter().map(|d| strings(d)).collect();
+            let desk_refs: Vec<&[String]> = desk_owned.iter().map(Vec::as_slice).collect();
+            agent_scoped_grants(&company, &desk_refs, &strings(agent))
+        }
+
+        /// No desk and no per-agent list: the company grant passes through
+        /// untouched. This is the shape every pre-existing manifest has, so it
+        /// is the case that must be byte-identical to the old behaviour.
+        #[test]
+        fn empty_levels_pass_through() {
+            assert_eq!(scope(&["*", "search"], &[], &[]), ["*", "search"]);
+            assert_eq!(scope(&["*", "search"], &[&[]], &[]), ["*", "search"]);
+            assert_eq!(scope(&["*", "search"], &[&[], &[]], &[]), ["*", "search"]);
+        }
+
+        /// The middle level does the work the feature exists for: a department
+        /// ceiling narrows every member without touching any member's own line.
+        #[test]
+        fn a_desk_ceiling_narrows_its_members() {
+            assert_eq!(scope(&["*", "search"], &[&["docs.*"]], &[]), ["docs.*"]);
+        }
+
+        /// And the agent narrows further still.
+        #[test]
+        fn an_agent_narrows_below_its_desk() {
+            assert_eq!(
+                scope(&["*", "search"], &[&["docs.*", "web"]], &["docs.*"]),
+                ["docs.*"]
+            );
+        }
+
+        /// Desks union, so joining a second desk *adds* capability rather than
+        /// removing it. Intersecting would make adding someone to a desk break
+        /// the job they already did.
+        #[test]
+        fn desks_combine_by_union() {
+            assert_eq!(
+                scope(&["*", "search"], &[&["docs.*"], &["web"]], &[]),
+                ["docs.*", "web"]
+            );
+        }
+
+        /// The documented sharp edge, asserted so it cannot change silently: a
+        /// desk with no ceiling narrows nothing, so an agent on both a
+        /// restricted and an unrestricted desk ends up unrestricted.
+        #[test]
+        fn an_unceilinged_desk_widens_the_union_back_to_the_company_grant() {
+            assert_eq!(
+                scope(&["*", "search"], &[&["docs.*"], &[]], &[]),
+                ["*", "search"]
+            );
+        }
+
+        /// The invariant that makes this safe to add: no path through the
+        /// narrowing can yield a grant the company did not already allow. A desk
+        /// ceiling naming something outside `[tools].allow` cannot widen.
+        #[test]
+        fn a_desk_can_never_widen_past_the_company_grant() {
+            // `search` is deliberately not in the company allow-list, and `*`
+            // never confers it.
+            assert_eq!(scope(&["docs.*"], &[&["search", "shell"]], &[]), Vec::<String>::new());
+            // Nor can the agent reach past a desk that did not grant it.
+            assert_eq!(scope(&["*"], &[&["docs.*"]], &["shell"]), Vec::<String>::new());
+        }
+
+        /// Adding the desk level must not disturb the two-level answer for a
+        /// company whose desks declare nothing — the regression that would hit
+        /// every shipped company at once.
+        #[test]
+        fn matches_the_two_level_resolver_when_no_desk_has_a_ceiling() {
+            for (company, agent) in [
+                (&["*", "media"][..], &[][..]),
+                (&["*", "media"][..], &["docs.*"][..]),
+                (&["docs.*", "web"][..], &["web"][..]),
+                (&["docs.*"][..], &["shell"][..]),
+            ] {
+                assert_eq!(
+                    agent_scoped_grants(&strings(company), &[&[], &[]], &strings(agent)),
+                    agent_effective_grants(&strings(company), &strings(agent)),
+                    "company={company:?} agent={agent:?}"
+                );
+            }
+        }
+    }
+
+    mod desk_tool_carry {
+        use super::*;
+
+        fn desk(id: &str, tools: &[&str]) -> GroupChat {
+            GroupChat {
+                id: id.to_string(),
+                name: id.to_string(),
+                description: None,
+                members: Vec::new(),
+                tools: tools.iter().map(|t| t.to_string()).collect(),
+            }
+        }
+
+        fn held(entries: &[(&str, &[&str])]) -> std::collections::BTreeMap<String, Vec<String>> {
+            entries
+                .iter()
+                .map(|(id, tools)| {
+                    (
+                        id.to_string(),
+                        tools.iter().map(|t| t.to_string()).collect(),
+                    )
+                })
+                .collect()
+        }
+
+        /// A routine redeploy that changed nothing keeps the operator's console
+        /// ceilings — clearing on every rebuild would silently revert a console
+        /// action with nothing to show it had moved.
+        #[test]
+        fn an_unchanged_seed_carries_the_override() {
+            let seed = [desk("finance", &["docs.*"])];
+            let carried = carry_desk_tool_overrides(&seed, &seed, &held(&[("finance", &["web"])]));
+            assert_eq!(carried.get("finance").map(Vec::as_slice), Some(&["web".to_string()][..]));
+        }
+
+        /// The security property: version control narrowing a desk must not be
+        /// silently overridden by a wider console value set before the edit.
+        #[test]
+        fn a_changed_seed_clears_that_desks_override() {
+            let carried = carry_desk_tool_overrides(
+                &[desk("finance", &["*"])],
+                &[desk("finance", &["docs.*"])],
+                &held(&[("finance", &["web"])]),
+            );
+            assert!(carried.is_empty(), "{carried:?}");
+        }
+
+        /// Per desk, not whole-block: editing one department says nothing about
+        /// another, and clearing both would revert an action nobody's edit was
+        /// about.
+        #[test]
+        fn editing_one_desk_leaves_another_desks_override_alone() {
+            let carried = carry_desk_tool_overrides(
+                &[desk("finance", &["*"]), desk("creative", &["docs.*"])],
+                &[desk("finance", &["docs.*"]), desk("creative", &["docs.*"])],
+                &held(&[("finance", &["web"]), ("creative", &["media"])]),
+            );
+            assert!(!carried.contains_key("finance"), "{carried:?}");
+            assert_eq!(
+                carried.get("creative").map(Vec::as_slice),
+                Some(&["media".to_string()][..])
+            );
+        }
+
+        /// An operator-created desk has no seed value that could have changed,
+        /// so its ceiling always survives a rebuild.
+        #[test]
+        fn an_override_for_a_desk_the_seed_does_not_declare_is_carried() {
+            let carried = carry_desk_tool_overrides(
+                &[desk("finance", &["*"])],
+                &[desk("finance", &["*"])],
+                &held(&[("adhoc", &["docs.*"])]),
+            );
+            assert!(carried.contains_key("adhoc"), "{carried:?}");
+        }
+
+        /// A desk deleted from the seed *has* changed — from declaring a ceiling
+        /// to declaring nothing — so its stale override is dropped rather than
+        /// outliving the desk in version control.
+        #[test]
+        fn deleting_a_desk_from_the_seed_clears_its_override() {
+            let carried = carry_desk_tool_overrides(
+                &[desk("finance", &["docs.*"])],
+                &[],
+                &held(&[("finance", &["web"])]),
+            );
+            assert!(carried.is_empty(), "{carried:?}");
+        }
+    }
+
     /// Issue #242, the property this whole PR exists to create, proven across a
     /// real restart: a host killed mid-run leaves the attempt's **partial trace
     /// intact**, and the next boot settles the row it stranded.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1710,6 +1710,7 @@ impl RuntimeBuilder {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -2283,6 +2284,7 @@ impl RuntimeBuilder {
                                 overlay_workflows: overlay_workflows.clone(),
                                 overlay_budgets: overlay_budgets.clone(),
                                 overlay_policy: overlay_policy.clone(),
+                                overlay_desk_tools: Default::default(),
                                 disabled_workflows: disabled_workflows.clone(),
                                 template_provenance: template_provenance.clone(),
                             };
@@ -4603,6 +4605,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -4671,6 +4674,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -4963,6 +4967,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -5079,6 +5084,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -5216,6 +5222,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -3051,12 +3051,22 @@ mod test {
         /// The documented sharp edge, asserted so it cannot change silently: a
         /// desk with no ceiling narrows nothing, so an agent on both a
         /// restricted and an unrestricted desk ends up unrestricted.
+        ///
+        /// Asserted by **coverage** rather than by list equality. The union
+        /// leaves the restricted desk's `docs.*` in the result beside the open
+        /// desk's `*`, which is redundant but not wrong — `*` already covers it
+        /// — and pinning the exact list here would be asserting the shape of the
+        /// bookkeeping instead of the capability it resolves to.
         #[test]
         fn an_unceilinged_desk_widens_the_union_back_to_the_company_grant() {
-            assert_eq!(
-                scope(&["*", "search"], &[&["docs.*"], &[]], &[]),
-                ["*", "search"]
-            );
+            let company = ["*", "search"];
+            let resolved = scope(&company, &[&["docs.*"], &[]], &[]);
+            for grant in company {
+                assert!(
+                    allow_covers(&resolved, grant),
+                    "`{grant}` must survive an open desk: {resolved:?}"
+                );
+            }
         }
 
         /// The invariant that makes this safe to add: no path through the

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1820,6 +1820,31 @@ impl RuntimeBuilder {
             }
             carried
         });
+        // The per-desk tool ceilings, carried across the rebuild under the same
+        // seed-wins rule as the policy override above — see
+        // `carry_desk_tool_overrides` for why a desk grant needs it even more
+        // than the approval tier does.
+        let overlay_desk_tools = existing
+            .as_ref()
+            .map(|r| {
+                let carried = carry_desk_tool_overrides(
+                    &r.manifest.group_chats,
+                    &self.manifest.group_chats,
+                    &r.overlay_desk_tools,
+                );
+                for desk_id in r.overlay_desk_tools.keys() {
+                    if !carried.contains_key(desk_id) {
+                        tracing::info!(
+                            company = %id,
+                            desk = %desk_id,
+                            "[tools] the seed changed this desk's `tools`, so the console \
+                             ceiling was cleared — version control wins when it speaks"
+                        );
+                    }
+                }
+                carried
+            })
+            .unwrap_or_default();
         // Issue #276: the workflows the operator switched off. This is the field
         // that makes the pause switch durable, and it is carried across the
         // rebuild for a sharper reason than the two above: `merge_enabled_workflows`

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -21,7 +21,7 @@ use crate::brain::{EchoBrain, HostedMedullaBrain};
 #[cfg(feature = "openhuman")]
 use crate::company::inference::{self, EnvDefault};
 use crate::company::runtime::{CompanyMail, CompanyRuntime, OpsStores};
-use crate::company::{CompanyManifest, Policy};
+use crate::company::{CompanyManifest, GroupChat, Policy};
 use crate::feedback::github::{GitHubClient, RateLimiter};
 use crate::feedback::service::FeedbackFiler;
 use crate::feedback::store::FeedbackStore;

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -140,6 +140,55 @@ pub(crate) fn agent_effective_grants(allow: &[String], agent_tools: &[String]) -
     dedup(grants)
 }
 
+/// One agent's effective grants under the **three-level** narrowing
+/// `[tools].allow ∩ desk.tools ∩ [[agent]].tools`.
+///
+/// `desk_allows` is the `tools` ceiling of every desk this agent sits on — the
+/// effective membership (manifest desks plus console-added ones), not just the
+/// manifest's, so a teammate added to a desk through the console is scoped the
+/// same as one written into `company.toml`.
+///
+/// This is [`agent_effective_grants`] applied twice, deliberately rather than
+/// incidentally: narrowing is one operation, and expressing the desk level as a
+/// second application of it is what guarantees the middle level can only ever
+/// *remove* capability. There is no path through this function that returns a
+/// grant the company allow-list does not already cover.
+///
+/// # The union, and the sharp edge in it
+///
+/// Desks combine by **union**, because desk membership is additive: joining the
+/// growth desk is how a marketer gains the ad tools. Intersecting instead would
+/// make each additional desk silently revoke capability, so adding someone to a
+/// desk could break work they already did.
+///
+/// The edge that follows: a desk with an empty `tools` ceiling narrows nothing,
+/// so an agent on both a restricted desk and an unrestricted one ends up
+/// **unrestricted**. That is the honest consequence of "empty means no
+/// ceiling" plus union, and it is the safe direction — a company that means to
+/// restrict a teammate states the ceiling on every desk that teammate sits on,
+/// or states it on the teammate. It is *not* a hole in the company grant: the
+/// widest this can ever resolve to is `allow` itself.
+pub(crate) fn agent_scoped_grants(
+    allow: &[String],
+    desk_allows: &[&[String]],
+    agent_tools: &[String],
+) -> Vec<String> {
+    // No desk states a ceiling (the common case, and every pre-existing
+    // manifest) → the desk level is skipped entirely and this is exactly the
+    // two-level behaviour that shipped before desks could scope anything.
+    let ceiling: Vec<String> = if desk_allows.iter().all(|desk| desk.is_empty()) {
+        allow.to_vec()
+    } else {
+        dedup(
+            desk_allows
+                .iter()
+                .flat_map(|desk| agent_effective_grants(allow, desk))
+                .collect(),
+        )
+    };
+    agent_effective_grants(&ceiling, agent_tools)
+}
+
 /// Whether the company allow-list covers an agent-requested grant glob.
 fn allow_covers(allow: &[String], tool: &str) -> bool {
     let literal = tool.strip_suffix('*').unwrap_or(tool);

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2485,6 +2485,7 @@ impl RuntimeBuilder {
                 overlay_workflows,
                 overlay_budgets,
                 overlay_policy,
+                overlay_desk_tools,
                 disabled_workflows,
                 template_provenance,
             })

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -324,9 +324,7 @@ fn carry_desk_tool_overrides(
             .map(|desk| desk.tools.clone())
     };
     held.iter()
-        .filter(|(desk_id, _)| {
-            seed_tools(previous_seed, desk_id) == seed_tools(next_seed, desk_id)
-        })
+        .filter(|(desk_id, _)| seed_tools(previous_seed, desk_id) == seed_tools(next_seed, desk_id))
         .map(|(desk_id, ceiling)| (desk_id.clone(), ceiling.clone()))
         .collect()
 }
@@ -3076,9 +3074,15 @@ mod test {
         fn a_desk_can_never_widen_past_the_company_grant() {
             // `search` is deliberately not in the company allow-list, and `*`
             // never confers it.
-            assert_eq!(scope(&["docs.*"], &[&["search", "shell"]], &[]), Vec::<String>::new());
+            assert_eq!(
+                scope(&["docs.*"], &[&["search", "shell"]], &[]),
+                Vec::<String>::new()
+            );
             // Nor can the agent reach past a desk that did not grant it.
-            assert_eq!(scope(&["*"], &[&["docs.*"]], &["shell"]), Vec::<String>::new());
+            assert_eq!(
+                scope(&["*"], &[&["docs.*"]], &["shell"]),
+                Vec::<String>::new()
+            );
         }
 
         /// Adding the desk level must not disturb the two-level answer for a
@@ -3133,7 +3137,10 @@ mod test {
         fn an_unchanged_seed_carries_the_override() {
             let seed = [desk("finance", &["docs.*"])];
             let carried = carry_desk_tool_overrides(&seed, &seed, &held(&[("finance", &["web"])]));
-            assert_eq!(carried.get("finance").map(Vec::as_slice), Some(&["web".to_string()][..]));
+            assert_eq!(
+                carried.get("finance").map(Vec::as_slice),
+                Some(&["web".to_string()][..])
+            );
         }
 
         /// The security property: version control narrowing a desk must not be

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -2998,6 +2998,7 @@ members = ["engineer"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/runtime/delegation_tools.rs
+++ b/src/runtime/delegation_tools.rs
@@ -503,6 +503,7 @@ members = ["counsel"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -42,6 +42,7 @@ pub(crate) async fn state_with_company(home: &std::path::Path) -> AppState {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -187,6 +188,7 @@ async fn state_with_rich_company(home: &std::path::Path) -> AppState {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1087,6 +1089,7 @@ async fn skills_and_workflows_resolve_from_source_dir() {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1161,6 +1164,7 @@ async fn company_skills_project_the_pinned_snapshot_of_a_registry_install() {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1276,6 +1280,7 @@ async fn workflows_resolve_from_the_record_overlay_with_no_source_dir() {
             }],
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1370,6 +1375,7 @@ async fn workflows_summary_lists_an_overlay_workflow_with_no_enabled_entry() {
             }],
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2277,6 +2277,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -2575,6 +2576,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -2699,6 +2701,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/capabilities.rs
+++ b/src/server/ops/capabilities.rs
@@ -375,6 +375,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/company_key/test.rs
+++ b/src/server/ops/company_key/test.rs
@@ -49,6 +49,7 @@ async fn state_with_manifest(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/ops/composio.rs
+++ b/src/server/ops/composio.rs
@@ -1056,6 +1056,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/connections_read.rs
+++ b/src/server/ops/connections_read.rs
@@ -509,6 +509,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/finances.rs
+++ b/src/server/ops/finances.rs
@@ -105,6 +105,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/inference.rs
+++ b/src/server/ops/inference.rs
@@ -626,6 +626,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -914,6 +914,7 @@ role = "Chief Executive"
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -6,10 +6,10 @@
 //! [`SecretStore`](crate::ports::SecretStore); the responses expose only
 //! non-secret status (connected / verified / configured). Routes follow the
 //! same dual scoping as the operator surface: the platform `{id}` form and the
-//! prosumer single-company alias (`/api/v1/company/…`).
+//! prosumer single-company alias (`/api/v1/company/â¦`).
 //!
-//! Everything that touches the network — real DNS lookups (`dns`), real SMTP
-//! send (`smtp`), and real OAuth token exchange (`oauth`) — is dependency-
+//! Everything that touches the network â real DNS lookups (`dns`), real SMTP
+//! send (`smtp`), and real OAuth token exchange (`oauth`) â is dependency-
 //! inverted behind a trait so the default build stays offline. The
 //! [`ConnectionsRuntime`] seam carries the injected resolver/sender (offline
 //! mocks in tests, real impls when a feature is on); the OAuth write routes are
@@ -36,7 +36,7 @@ pub mod policy;
 pub mod read_state;
 /// Issue #245 (operator half): bind a real repository to a company, list what
 /// is bound, revoke one. The whole credential path, with **no agent surface**
-/// behind it — no grant, no tool. See [`repos`].
+/// behind it â no grant, no tool. See [`repos`].
 pub mod repos;
 pub mod runs;
 pub mod scope;
@@ -45,11 +45,15 @@ pub mod smtp;
 pub mod task_export;
 pub mod tasks;
 pub mod team;
-/// Issue #264: one agent, opened — `GET`/`PATCH {scope}/team/{agent_id}`. The
+/// Issue #264: one agent, opened â `GET`/`PATCH {scope}/team/{agent_id}`. The
 /// detail read (identity, tier, **resolved** tool grants, desks) and the edit
 /// for the fields the console owns. Attached to [`team`]'s existing
 /// `/team/{agent_id}` route rather than merged as its own. See [`team_agent`].
 mod team_agent;
+/// The unified tool catalog read (`GET {scope}/tools/catalog`): everything this
+/// company can grant an agent — built-ins, MCP servers and Composio toolkits —
+/// in one vocabulary. Read-only and openhuman-free.
+pub mod tool_catalog;
 pub mod usage;
 pub mod workflows;
 pub mod workspace;
@@ -88,14 +92,14 @@ pub(crate) const INGEST_SECRET_KEY: &str = "ingest_secret";
 /// their features) or by tests (offline mocks).
 #[derive(Clone, Default)]
 pub struct ConnectionsRuntime {
-    /// Resolver used by `POST …/domain/verify`. When `None`, verify is
+    /// Resolver used by `POST â¦/domain/verify`. When `None`, verify is
     /// "not wired yet" (404).
     pub dns: Option<Arc<dyn DnsResolver>>,
-    /// Sender used by `POST …/smtp/test` and outbound mail. When `None`,
+    /// Sender used by `POST â¦/smtp/test` and outbound mail. When `None`,
     /// test-send is "not wired yet" (404).
     pub mail: Option<Arc<dyn MailSender>>,
     /// Host-level outbound credentials (`OPENCOMPANY_MAIL_*`), used for
-    /// platform mail such as login links — mail sent on the platform's behalf
+    /// platform mail such as login links â mail sent on the platform's behalf
     /// rather than a company's. A company's own outbound instead reads its
     /// `SecretStore`, so a tenant never sees this credential. `None` means the
     /// host sends no platform mail.
@@ -108,7 +112,7 @@ pub struct ConnectionsRuntime {
 }
 
 impl ConnectionsRuntime {
-    /// An empty runtime — every networked surface degrades to "not wired".
+    /// An empty runtime â every networked surface degrades to "not wired".
     pub fn new() -> Self {
         Self::default()
     }
@@ -158,6 +162,7 @@ impl std::fmt::Debug for ConnectionsRuntime {
 pub fn router() -> Router<AppState> {
     let router = Router::new()
         .merge(capabilities::router())
+        .merge(tool_catalog::router())
         .merge(connections_read::router())
         .merge(channels::router())
         .merge(company_key::router())
@@ -218,7 +223,7 @@ pub(crate) fn not_wired(what: &str) -> axum::response::Response {
 }
 
 /// A `409 restart_required` response for a surface that this build *does* have,
-/// but this company's running runtime does not — because the runtime was wired
+/// but this company's running runtime does not â because the runtime was wired
 /// at boot, before the inference config that would have wired it existed
 /// (issue #266).
 ///
@@ -243,21 +248,21 @@ pub(crate) fn restart_required(what: &str) -> axum::response::Response {
 }
 
 /// A `409 inference_required` response for a workflow-run attempt on a company
-/// that has *never* configured an inference source — `workflow_runner()` is
+/// that has *never* configured an inference source â `workflow_runner()` is
 /// `None` because there is no brain to run yet, not because this deployment
 /// lacks execution and not because a saved config is stranded behind a boot
 /// decision (issue #514).
 ///
 /// Deliberately neither of the sibling responses:
 ///   - not the `not_wired` 404: the console's bare-catch treats that as a
-///     permanent capability gap and degrades to a read-only view — the wrong
+///     permanent capability gap and degrades to a read-only view â the wrong
 ///     answer for a state the operator clears by configuring a provider (which
 ///     triggers issue #290's rebuild-in-place; no restart needed);
 ///   - not `restart_required`: nothing was ever saved to the strand, so there is
 ///     no configuration for a restart to pick up.
 ///
 /// The `code` is a contract the console keys its own copy on; the `error` prose
-/// is the fallback a curl user sees. It never says "deployment" or "not wired" —
+/// is the fallback a curl user sees. It never says "deployment" or "not wired" â
 /// the deployment is fine.
 pub(crate) fn inference_required(what: &str) -> axum::response::Response {
     use axum::http::StatusCode;
@@ -267,7 +272,7 @@ pub(crate) fn inference_required(what: &str) -> axum::response::Response {
         axum::Json(serde_json::json!({
             "error": format!(
                 "{what} needs an inference source, and none is configured for this \
-                 company. Set a provider in Settings → Inference, then run again."
+                 company. Set a provider in Settings â Inference, then run again."
             ),
             "code": "inference_required",
         })),

--- a/src/server/ops/policy.rs
+++ b/src/server/ops/policy.rs
@@ -411,6 +411,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/read_state.rs
+++ b/src/server/ops/read_state.rs
@@ -186,6 +186,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -296,6 +297,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/repos.rs
+++ b/src/server/ops/repos.rs
@@ -277,6 +277,7 @@ mod test {
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
             })
             .await
             .unwrap();

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -473,6 +473,7 @@ mod tests {
                 overlay_desks: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 overlay_workflows: Vec::new(),
                 template_provenance: None,

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -2453,6 +2453,7 @@ mod steer_redirect_test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -838,6 +838,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team.rs
+++ b/src/server/ops/team.rs
@@ -333,10 +333,7 @@ fn member_row(
         // two arms, and the arm it dropped would be invisible on screen.
         tier: super::team_agent::declared_tier(record, agent_id),
         is_orchestrator: super::team_agent::is_orchestrator(record, agent_id),
-        tools: super::team_agent::agent_tools(
-            &record.manifest.tools.allow,
-            super::team_agent::requested_grants(record, agent_id),
-        ),
+        tools: super::team_agent::agent_tools(record, agent_id),
         desks: super::team_agent::desks_for(record, agent_id),
         inbox_enabled,
         budget_usd_daily: cap,
@@ -475,10 +472,7 @@ async fn add_member(
     // (issues #601, #643).
     let tier = super::team_agent::declared_tier(&record, &agent.id);
     let is_orchestrator = super::team_agent::is_orchestrator(&record, &agent.id);
-    let tools = super::team_agent::agent_tools(
-        &record.manifest.tools.allow,
-        super::team_agent::requested_grants(&record, &agent.id),
-    );
+    let tools = super::team_agent::agent_tools(&record, &agent.id);
     let desks = super::team_agent::desks_for(&record, &agent.id);
     Ok(Json(TeamMemberDto {
         id: agent.id,

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -1028,6 +1028,83 @@ members = ["writer", "ceo"]
         );
     }
 
+    /// With no desk declaring a ceiling — the shape of every company written
+    /// before desks could scope tools — the desk row is empty and the effective
+    /// grant is unchanged. This is the case that must not regress for anybody.
+    #[tokio::test]
+    async fn a_company_with_no_desk_ceilings_reports_an_empty_desk_row() {
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), ROSTER).await;
+
+        for agent in ["ceo", "writer", "hermit"] {
+            let (_, body) = get_agent(&state, agent).await;
+            assert!(
+                strings(&body["tools"]["deskAllow"]).is_empty(),
+                "{agent}: {body}"
+            );
+        }
+    }
+
+    /// A desk ceiling narrows every member of that desk, and only that desk's
+    /// members — the department scoping the feature exists for.
+    #[tokio::test]
+    async fn a_desk_ceiling_narrows_its_members_and_nobody_else() {
+        let scoped = ROSTER.replace(
+            "members = [\"writer\", \"ceo\"]",
+            "members = [\"writer\", \"ceo\"]\ntools = [\"workspace.read\"]",
+        );
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), &scoped).await;
+
+        // `writer` asks for nothing, so before the desk it held the whole
+        // company allow-list. The desk cuts it to one grant.
+        let (_, writer) = get_agent(&state, "writer").await;
+        assert_eq!(
+            strings(&writer["tools"]["deskAllow"]),
+            vec!["workspace.read"],
+            "{writer}"
+        );
+        assert_eq!(
+            strings(&writer["tools"]["effective"]),
+            vec!["workspace.read"],
+            "the desk ceiling must bite on a member that requested nothing: {writer}"
+        );
+
+        // `hermit` sits on no desk, so it is untouched and still holds the
+        // company grant. A ceiling that leaked to non-members would be a scoping
+        // bug invisible from the desk's own screen.
+        let (_, hermit) = get_agent(&state, "hermit").await;
+        assert!(strings(&hermit["tools"]["deskAllow"]).is_empty(), "{hermit}");
+        assert_eq!(
+            strings(&hermit["tools"]["effective"]),
+            vec!["workspace", "workspace.*", "composio"],
+            "{hermit}"
+        );
+    }
+
+    /// The three rows the console renders must shrink monotonically, or the card
+    /// would show a "ceiling" that is not one.
+    #[tokio::test]
+    async fn a_desk_ceiling_can_never_widen_past_the_company_grant() {
+        // The desk names a grant the company never allowed.
+        let scoped = ROSTER.replace(
+            "members = [\"writer\", \"ceo\"]",
+            "members = [\"writer\", \"ceo\"]\ntools = [\"shell\", \"workspace.read\"]",
+        );
+        let home_dir = home();
+        let state = state_with_manifest(home_dir.path(), &scoped).await;
+
+        let (_, writer) = get_agent(&state, "writer").await;
+        assert!(
+            !strings(&writer["tools"]["deskAllow"]).contains(&"shell".to_string()),
+            "a desk cannot grant what the company withheld: {writer}"
+        );
+        assert!(
+            !strings(&writer["tools"]["effective"]).contains(&"shell".to_string()),
+            "{writer}"
+        );
+    }
+
     /// A roster that tags nobody still has an orchestrator: the first declared
     /// agent. A console that read `tier` alone would call every teammate on such
     /// a company a worker, and be wrong about all of them.

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -757,6 +757,7 @@ members = ["writer", "ceo"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -805,6 +806,7 @@ members = ["writer", "ceo"]
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -72,7 +72,7 @@ use crate::AppState;
 use crate::error::OpenCompanyError;
 use crate::ports::store::company_write_lock;
 use crate::ports::types::CompanyRecord;
-use crate::runtime::builder::agent_effective_grants;
+use crate::runtime::builder::agent_scoped_grants;
 use crate::server::error::ApiError;
 use crate::server::ops::ScopedCompany;
 use crate::server::ops::language;

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -275,12 +275,35 @@ pub(super) fn is_orchestrator(record: &CompanyRecord, agent_id: &str) -> bool {
 /// dealing slices of `[tools].allow`, so the graph and the detail card beside
 /// it disagreed about the same agent. Sharing the constructor makes that
 /// disagreement unrepresentable rather than merely fixed once.
-pub(super) fn agent_tools(company_allow: &[String], requested: Vec<String>) -> AgentToolsDto {
-    let effective = agent_effective_grants(company_allow, &requested);
+/// Takes the `record` and `agent_id` rather than a pre-extracted allow-list,
+/// because the desk level cannot be derived from the company grant alone — it
+/// depends on which desks this teammate sits on. Passing the record is what makes
+/// "forgot to apply the desk ceiling" unrepresentable at the call site rather
+/// than a thing three callers each have to remember.
+pub(super) fn agent_tools(record: &CompanyRecord, agent_id: &str) -> AgentToolsDto {
+    let company_allow = &record.manifest.tools.allow;
+    let requested = requested_grants(record, agent_id);
+
+    // The desk ceilings this agent is under, resolved through the record's
+    // *effective* desk membership so a console-seated member is scoped exactly
+    // as a manifest one.
+    let desk_tools = record.agent_desk_tools(agent_id);
+    let desk_refs: Vec<&[String]> = desk_tools.iter().map(Vec::as_slice).collect();
+
+    // Reported already narrowed by the company grant, so the console can render
+    // the three rows as a strictly shrinking chain. A raw union could show a
+    // desk "granting" something the company never allowed.
+    let desk_allow = if desk_tools.iter().all(Vec::is_empty) {
+        Vec::new()
+    } else {
+        agent_scoped_grants(company_allow, &desk_refs, &[])
+    };
+
     AgentToolsDto {
+        effective: agent_scoped_grants(company_allow, &desk_refs, &requested),
         requested,
         company_allow: company_allow.to_vec(),
-        effective,
+        desk_allow,
     }
 }
 

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -1074,7 +1074,10 @@ members = ["writer", "ceo"]
         // company grant. A ceiling that leaked to non-members would be a scoping
         // bug invisible from the desk's own screen.
         let (_, hermit) = get_agent(&state, "hermit").await;
-        assert!(strings(&hermit["tools"]["deskAllow"]).is_empty(), "{hermit}");
+        assert!(
+            strings(&hermit["tools"]["deskAllow"]).is_empty(),
+            "{hermit}"
+        );
         assert_eq!(
             strings(&hermit["tools"]["effective"]),
             vec!["workspace", "workspace.*", "composio"],

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -660,10 +660,7 @@ async fn detail(
         },
         tier: declared_tier(record, agent_id),
         is_orchestrator: is_orchestrator(record, agent_id),
-        tools: agent_tools(
-            &record.manifest.tools.allow,
-            requested_grants(record, agent_id),
-        ),
+        tools: agent_tools(record, agent_id),
         desks: desks_for(record, agent_id),
         inbox_enabled,
         budget_usd_daily: cap,

--- a/src/server/ops/team_agent.rs
+++ b/src/server/ops/team_agent.rs
@@ -172,7 +172,15 @@ pub(super) struct AgentToolsDto {
     requested: Vec<String>,
     /// The company-wide `[tools].allow` ceiling.
     company_allow: Vec<String>,
-    /// What the agent actually holds, after the intersection.
+    /// The ceiling contributed by the desks this agent sits on — the union of
+    /// their `tools`, already narrowed by `company_allow`.
+    ///
+    /// **Empty means no desk narrows anything**, which is the same "empty is not
+    /// nothing" trap `requested` carries: a console rendering an empty list as
+    /// "this desk grants no tools" would invert the meaning. It is empty for
+    /// every company that has not set a desk ceiling, which is most of them.
+    desk_allow: Vec<String>,
+    /// What the agent actually holds, after all three levels.
     effective: Vec<String>,
 }
 

--- a/src/server/ops/test.rs
+++ b/src/server/ops/test.rs
@@ -52,6 +52,7 @@ async fn state_with(home: &std::path::Path, connections: ConnectionsRuntime) -> 
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/ops/tool_catalog.rs
+++ b/src/server/ops/tool_catalog.rs
@@ -59,8 +59,11 @@ mod tests {
     use tower::ServiceExt;
 
     use crate::company::CompanyManifest;
+    use crate::ports::CompanyStore;
+    use crate::ports::types::{CompanyId, CompanyRecord};
     use crate::runtime::RuntimeBuilder;
     use crate::server::router;
+    use crate::store::FsCompanyStore;
     use crate::{AppConfig, AppState};
 
     const MANIFEST: &str = r#"

--- a/src/server/ops/tool_catalog.rs
+++ b/src/server/ops/tool_catalog.rs
@@ -1,0 +1,182 @@
+//! The tool-catalog read surface: `GET {scope}/tools/catalog`.
+//!
+//! One list of everything this company can grant an agent — built-in tool
+//! families, per-tenant MCP servers, and Composio toolkits — in a single
+//! vocabulary, each row carrying the exact grant token an operator would write.
+//!
+//! Read-only, and open to any member who may address the company. Nothing here
+//! decides anything: the catalog is a projection of the manifest through the
+//! same matcher the roster build uses (see [`crate::company::tool_catalog`]), so
+//! this route can only ever describe grants the gate already honours.
+
+use axum::Json;
+use axum::Router;
+use axum::routing::get;
+use serde::Serialize;
+
+use crate::AppState;
+use crate::company::tool_catalog::{CatalogEntry, catalog};
+use crate::error::OpenCompanyError;
+use crate::server::error::ApiError;
+use crate::server::ops::{ScopedCompany, scoped};
+
+/// Builds the tool-catalog route fragment.
+pub fn router() -> Router<AppState> {
+    scoped("/tools/catalog", get(get_catalog))
+}
+
+/// The company's tool catalog as the console renders it.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ToolCatalogDto {
+    /// The company-wide `[tools].allow` ceiling, echoed so a console can render
+    /// the catalog beside the grant that produced each row's `granted` flag
+    /// without a second request.
+    company_allow: Vec<String>,
+    /// Every grantable entry, built-ins first.
+    entries: Vec<CatalogEntry>,
+}
+
+async fn get_catalog(company: ScopedCompany) -> Result<Json<ToolCatalogDto>, ApiError> {
+    let record = company
+        .runtime
+        .store()
+        .load(company.id())
+        .await?
+        .ok_or_else(|| OpenCompanyError::CompanyNotFound(company.id().to_string()))?;
+
+    Ok(Json(ToolCatalogDto {
+        company_allow: record.manifest.tools.allow.clone(),
+        entries: catalog(&record.manifest),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::Value;
+    use tower::ServiceExt;
+
+    use crate::company::CompanyManifest;
+    use crate::runtime::RuntimeBuilder;
+    use crate::server::router;
+    use crate::{AppConfig, AppState};
+
+    const MANIFEST: &str = r#"
+[company]
+name = "Acme"
+[policy]
+mode = "full"
+[tools]
+allow = ["*", "search"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+
+[[mcp_server]]
+name = "notion"
+endpoint = "https://example.com/mcp"
+description = "Notion pages."
+"#;
+
+    async fn state() -> (tempfile::TempDir, AppState) {
+        let home = tempfile::Builder::new()
+            .prefix("oc-tool-catalog-")
+            .tempdir()
+            .expect("tempdir");
+        let manifest: CompanyManifest = toml::from_str(MANIFEST).expect("valid manifest");
+        let runtime = RuntimeBuilder::new(manifest)
+            .home(home.path())
+            .build()
+            .await
+            .expect("runtime");
+        let state = AppState::new(AppConfig::default(), runtime).await;
+        (home, state)
+    }
+
+    async fn get(state: &AppState, path: &str) -> (StatusCode, Value) {
+        let response = router(state.clone())
+            .oneshot(
+                Request::builder()
+                    .uri(path)
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let value = if bytes.is_empty() {
+            Value::Null
+        } else {
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null)
+        };
+        (status, value)
+    }
+
+    fn entry<'a>(body: &'a Value, key: &str) -> &'a Value {
+        body["entries"]
+            .as_array()
+            .expect("entries")
+            .iter()
+            .find(|e| e["key"] == key)
+            .unwrap_or_else(|| panic!("no catalog entry `{key}` in {body}"))
+    }
+
+    #[tokio::test]
+    async fn the_catalog_is_served_under_both_scope_forms() {
+        let (_home, state) = state().await;
+        for path in [
+            "/api/v1/company/tools/catalog",
+            "/api/v1/companies/acme/tools/catalog",
+        ] {
+            let (status, _) = get(&state, path).await;
+            assert_eq!(status, StatusCode::OK, "{path}");
+        }
+    }
+
+    /// The row an operator most needs to read correctly: `*` is granted, but it
+    /// does not confer the opt-in namespaces, and the response has to say so.
+    #[tokio::test]
+    async fn the_wildcard_grant_is_reported_honestly() {
+        let (_home, state) = state().await;
+        let (_, body) = get(&state, "/api/v1/company/tools/catalog").await;
+
+        assert_eq!(entry(&body, "builtin:shell")["granted"], true, "{body}");
+        assert_eq!(
+            entry(&body, "builtin:media")["granted"],
+            false,
+            "`*` must not read as granting real-money media: {body}"
+        );
+        assert_eq!(
+            entry(&body, "builtin:media")["coveredByWildcard"],
+            false,
+            "{body}"
+        );
+        // `search` is granted here because the manifest names it explicitly.
+        assert_eq!(entry(&body, "builtin:search")["granted"], true, "{body}");
+    }
+
+    #[tokio::test]
+    async fn a_declared_mcp_server_is_a_catalog_row_with_its_grant_token() {
+        let (_home, state) = state().await;
+        let (_, body) = get(&state, "/api/v1/company/tools/catalog").await;
+
+        let notion = entry(&body, "mcp:notion");
+        assert_eq!(notion["grant"], "mcp:notion", "{body}");
+        assert_eq!(notion["kind"], "mcp", "{body}");
+        assert_eq!(notion["server"], "notion", "{body}");
+        assert_eq!(notion["description"], "Notion pages.", "{body}");
+    }
+
+    #[tokio::test]
+    async fn the_response_echoes_the_company_allow_list() {
+        let (_home, state) = state().await;
+        let (_, body) = get(&state, "/api/v1/company/tools/catalog").await;
+        assert_eq!(body["companyAllow"], serde_json::json!(["*", "search"]));
+    }
+}

--- a/src/server/ops/tool_catalog.rs
+++ b/src/server/ops/tool_catalog.rs
@@ -90,12 +90,35 @@ description = "Notion pages."
             .tempdir()
             .expect("tempdir");
         let manifest: CompanyManifest = toml::from_str(MANIFEST).expect("valid manifest");
-        let runtime = RuntimeBuilder::new(manifest)
-            .home(home.path())
+        let store = FsCompanyStore::new(home.path().to_path_buf());
+        let id = CompanyId::new("acme");
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .expect("save");
+        let runtime = RuntimeBuilder::new(home.path().to_path_buf(), manifest)
+            .with_id(id.clone())
             .build()
             .await
             .expect("runtime");
-        let state = AppState::new(AppConfig::default(), runtime).await;
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
         (home, state)
     }
 
@@ -104,6 +127,7 @@ description = "Notion pages."
             .oneshot(
                 Request::builder()
                     .uri(path)
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
                     .body(Body::empty())
                     .expect("request"),
             )

--- a/src/server/ops/usage.rs
+++ b/src/server/ops/usage.rs
@@ -159,6 +159,7 @@ mod tests {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2787,6 +2787,7 @@ mod tests {
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
                     overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -2864,6 +2865,7 @@ mod tests {
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
                     overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -4565,6 +4567,7 @@ mod tests {
                     overlay_workflows: Vec::new(),
                     overlay_budgets: Vec::new(),
                     overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     template_provenance: None,
                 })
@@ -4737,6 +4740,7 @@ label = "ok"
                     }],
                     overlay_budgets: Vec::new(),
                     overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     lifecycle: "running".to_string(),
                     template_provenance: None,
@@ -5334,6 +5338,7 @@ label = "ok"
                     }],
                     overlay_budgets: Vec::new(),
                     overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
                     disabled_workflows: Vec::new(),
                     lifecycle: "running".to_string(),
                     template_provenance: None,

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -108,6 +108,7 @@ async fn state_with(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -3177,6 +3178,7 @@ async fn state_with_manifest_and_defaults(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -3218,6 +3220,7 @@ async fn state_with_manifest_and_overlays(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -3694,6 +3697,7 @@ async fn state_with_source_dir(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -4015,6 +4019,7 @@ async fn state_with_telegram_at(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/users/auth_test.rs
+++ b/src/server/users/auth_test.rs
@@ -51,6 +51,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/users/devices_test.rs
+++ b/src/server/users/devices_test.rs
@@ -51,6 +51,7 @@ async fn state_with(home: &std::path::Path, companies: &[&str]) -> AppState {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/server/users/hub_test.rs
+++ b/src/server/users/hub_test.rs
@@ -72,6 +72,7 @@ async fn state_with_public_url(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/users/mode_test.rs
+++ b/src/server/users/mode_test.rs
@@ -90,6 +90,7 @@ async fn state_in_mode(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/server/users/routes_test.rs
+++ b/src/server/users/routes_test.rs
@@ -86,6 +86,7 @@ async fn state_from(
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -653,6 +654,7 @@ async fn a_https_deployment_marks_the_cookie_secure() {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -163,7 +163,12 @@ fn record(id: &CompanyId) -> CompanyRecord {
         overlay_workflows: vec![sample_overlay_workflow()],
         overlay_budgets: sample_budget_overrides(),
         overlay_policy: Some(sample_policy_override()),
-        overlay_desk_tools: Default::default(),
+        // Non-empty so a backend that drops the field is caught: an empty map
+        // survives every possible bug, including not persisting it at all.
+        overlay_desk_tools: std::collections::BTreeMap::from([(
+            "studio".to_string(),
+            vec!["docs.*".to_string(), "web".to_string()],
+        )]),
         disabled_workflows: vec!["digest".to_string()],
         template_provenance: Some(sample_provenance()),
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -309,6 +309,15 @@ pub async fn assert_isolation_by_company(
         !loaded.workflow_enabled("digest"),
         "the paused workflow id did not survive save/load"
     );
+    // The per-desk tool ceilings survive too. A backend that dropped this would
+    // silently widen every console-narrowed department back to the company's
+    // full grant on the next restart — a capability regression whose only
+    // symptom is an agent succeeding at something it had been denied.
+    assert_eq!(
+        loaded.effective_desk_tools("studio"),
+        vec!["docs.*".to_string(), "web".to_string()],
+        "overlay_desk_tools did not survive save/load"
+    );
     assert_eq!(
         events
             .read_from(&alpha, EventSeq::new(0), usize::MAX)

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -163,6 +163,7 @@ fn record(id: &CompanyId) -> CompanyRecord {
         overlay_workflows: vec![sample_overlay_workflow()],
         overlay_budgets: sample_budget_overrides(),
         overlay_policy: Some(sample_policy_override()),
+        overlay_desk_tools: Default::default(),
         disabled_workflows: vec!["digest".to_string()],
         template_provenance: Some(sample_provenance()),
     }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -129,6 +129,7 @@ struct BundleMeta {
     /// `None` — the manifest's `[policy]` decides, exactly as before.
     #[serde(default)]
     overlay_policy: Option<PolicyOverride>,
+    overlay_desk_tools: Default::default(),
     /// The workflow ids switched off at export time (issue #276). Preserved so
     /// an export→import does not silently re-arm a schedule the operator had
     /// paused — which is the one direction this bundle must never move on its
@@ -193,6 +194,7 @@ struct BundleContents {
     /// silently re-tightening (or re-loosening) the approval gate on import —
     /// the same class of loss #343 fixed for spend caps.
     overlay_policy: Option<PolicyOverride>,
+    overlay_desk_tools: Default::default(),
     /// The workflow ids switched off, carried through the bundle so an import
     /// restores a paused workflow paused (issue #276).
     disabled_workflows: Vec<String>,
@@ -248,6 +250,7 @@ impl BundleContents {
             overlay_workflows: record.overlay_workflows,
             overlay_budgets: record.overlay_budgets,
             overlay_policy: record.overlay_policy,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: record.disabled_workflows,
         })
     }
@@ -278,6 +281,7 @@ impl BundleContents {
                 overlay_workflows: self.overlay_workflows.clone(),
                 overlay_budgets: self.overlay_budgets.clone(),
                 overlay_policy: self.overlay_policy.clone(),
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: self.disabled_workflows.clone(),
                 template_provenance: self.template_provenance.clone(),
             })
@@ -323,6 +327,7 @@ impl BundleContents {
             overlay_workflows: self.overlay_workflows.clone(),
             overlay_budgets: self.overlay_budgets.clone(),
             overlay_policy: self.overlay_policy.clone(),
+            overlay_desk_tools: Default::default(),
             disabled_workflows: self.disabled_workflows.clone(),
             template_provenance: self.template_provenance.clone(),
         };
@@ -433,6 +438,7 @@ impl BundleContents {
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
             overlay_policy: meta.overlay_policy,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: meta.disabled_workflows,
         })
     }
@@ -959,6 +965,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1038,6 +1045,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1166,6 +1174,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1254,6 +1263,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: Some(provenance.clone()),
         })
@@ -1367,6 +1377,7 @@ mod test {
             overlay_workflows: workflows.clone(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })
@@ -1636,6 +1647,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         })

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -129,7 +129,14 @@ struct BundleMeta {
     /// `None` — the manifest's `[policy]` decides, exactly as before.
     #[serde(default)]
     overlay_policy: Option<PolicyOverride>,
-    overlay_desk_tools: Default::default(),
+    /// The operator-set per-desk tool ceilings at export time. Preserved so an
+    /// export→import does not silently widen a desk back to the company's full
+    /// grant — the same class of loss `overlay_policy` above is carried to
+    /// prevent, on the axis that decides capability rather than autonomy.
+    /// `#[serde(default)]` for back-compat with older bundles, which read as
+    /// empty: the manifest's ceilings decide, exactly as before.
+    #[serde(default)]
+    overlay_desk_tools: std::collections::BTreeMap<String, Vec<String>>,
     /// The workflow ids switched off at export time (issue #276). Preserved so
     /// an export→import does not silently re-arm a schedule the operator had
     /// paused — which is the one direction this bundle must never move on its

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -201,7 +201,10 @@ struct BundleContents {
     /// silently re-tightening (or re-loosening) the approval gate on import —
     /// the same class of loss #343 fixed for spend caps.
     overlay_policy: Option<PolicyOverride>,
-    overlay_desk_tools: Default::default(),
+    /// The operator-set per-desk tool ceilings, carried through the bundle so
+    /// export→import preserves a console-narrowed department (rather than
+    /// restoring it at the company's full grant).
+    overlay_desk_tools: std::collections::BTreeMap<String, Vec<String>>,
     /// The workflow ids switched off, carried through the bundle so an import
     /// restores a paused workflow paused (issue #276).
     disabled_workflows: Vec<String>,

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -260,7 +260,7 @@ impl BundleContents {
             overlay_workflows: record.overlay_workflows,
             overlay_budgets: record.overlay_budgets,
             overlay_policy: record.overlay_policy,
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: record.overlay_desk_tools,
             disabled_workflows: record.disabled_workflows,
         })
     }
@@ -291,7 +291,7 @@ impl BundleContents {
                 overlay_workflows: self.overlay_workflows.clone(),
                 overlay_budgets: self.overlay_budgets.clone(),
                 overlay_policy: self.overlay_policy.clone(),
-                overlay_desk_tools: Default::default(),
+                overlay_desk_tools: self.overlay_desk_tools.clone(),
                 disabled_workflows: self.disabled_workflows.clone(),
                 template_provenance: self.template_provenance.clone(),
             })
@@ -337,7 +337,7 @@ impl BundleContents {
             overlay_workflows: self.overlay_workflows.clone(),
             overlay_budgets: self.overlay_budgets.clone(),
             overlay_policy: self.overlay_policy.clone(),
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: self.overlay_desk_tools.clone(),
             disabled_workflows: self.disabled_workflows.clone(),
             template_provenance: self.template_provenance.clone(),
         };
@@ -448,7 +448,7 @@ impl BundleContents {
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
             overlay_policy: meta.overlay_policy,
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: meta.overlay_desk_tools,
             disabled_workflows: meta.disabled_workflows,
         })
     }

--- a/src/store/export.rs
+++ b/src/store/export.rs
@@ -1550,6 +1550,14 @@ mod test {
                 set_by: admin_actor(),
                 at_millis: 1_700_000_000_002,
             }),
+            // Non-empty for the same reason the tier above is: an empty map here
+            // could not detect the field being dropped from the bundle, and
+            // dropping it would silently restore an imported company's narrowed
+            // desk at the company's full tool grant.
+            overlay_desk_tools: std::collections::BTreeMap::from([(
+                "research".to_string(),
+                vec!["docs.*".to_string()],
+            )]),
             // Issue #276: a paused workflow rides the same bundle. The empty
             // list this fixture used to carry could not have detected the field
             // being dropped — and dropping it would silently re-arm a schedule

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -631,7 +631,12 @@ struct Meta {
     /// keeps those loading with the manifest's `[policy]` in charge.
     #[serde(default)]
     overlay_policy: Option<crate::ports::types::PolicyOverride>,
-    overlay_desk_tools: Default::default(),
+    /// The operator-set per-desk tool ceilings. Absent on meta files written
+    /// before desks could scope tools, and `#[serde(default)]` reads that
+    /// absence as "no desk overrides a ceiling" — which leaves the manifest in
+    /// charge, exactly as those companies ran.
+    #[serde(default)]
+    overlay_desk_tools: std::collections::BTreeMap<String, Vec<String>>,
     /// The workflow ids the operator has switched off (issue #276). Absent on
     /// meta files written before the pause switch existed, and
     /// `#[serde(default)]` reads that absence as "nothing is paused" — which is

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -759,7 +759,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
             overlay_policy: meta.overlay_policy,
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: meta.overlay_desk_tools,
             disabled_workflows: meta.disabled_workflows,
             template_provenance: meta.template_provenance,
         }))
@@ -782,7 +782,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_workflows: record.overlay_workflows.clone(),
             overlay_budgets: record.overlay_budgets.clone(),
             overlay_policy: record.overlay_policy.clone(),
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: record.overlay_desk_tools.clone(),
             disabled_workflows: record.disabled_workflows.clone(),
             template_provenance: record.template_provenance.clone(),
         };

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -631,6 +631,7 @@ struct Meta {
     /// keeps those loading with the manifest's `[policy]` in charge.
     #[serde(default)]
     overlay_policy: Option<crate::ports::types::PolicyOverride>,
+    overlay_desk_tools: Default::default(),
     /// The workflow ids the operator has switched off (issue #276). Absent on
     /// meta files written before the pause switch existed, and
     /// `#[serde(default)]` reads that absence as "nothing is paused" — which is
@@ -659,6 +660,7 @@ impl Default for Meta {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -752,6 +754,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_workflows: meta.overlay_workflows,
             overlay_budgets: meta.overlay_budgets,
             overlay_policy: meta.overlay_policy,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: meta.disabled_workflows,
             template_provenance: meta.template_provenance,
         }))
@@ -774,6 +777,7 @@ impl CompanyStore for FsCompanyStore {
             overlay_workflows: record.overlay_workflows.clone(),
             overlay_budgets: record.overlay_budgets.clone(),
             overlay_policy: record.overlay_policy.clone(),
+            overlay_desk_tools: Default::default(),
             disabled_workflows: record.disabled_workflows.clone(),
             template_provenance: record.template_provenance.clone(),
         };
@@ -1976,6 +1980,7 @@ mod test {
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         };
@@ -2018,6 +2023,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })
@@ -2075,6 +2081,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -562,7 +562,7 @@ impl CompanyStore for MongoStore {
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
             overlay_policy: overlay.policy,
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: overlay.desk_tools,
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -562,6 +562,7 @@ impl CompanyStore for MongoStore {
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
             overlay_policy: overlay.policy,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))
@@ -4155,6 +4156,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             };

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -506,6 +506,7 @@ impl CompanyStore for SqliteStore {
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
             overlay_policy: overlay.policy,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))
@@ -3770,6 +3771,7 @@ mod test {
                 overlay_workflows: Vec::new(),
                 overlay_budgets: Vec::new(),
                 overlay_policy: None,
+                overlay_desk_tools: Default::default(),
                 disabled_workflows: Vec::new(),
                 template_provenance: None,
             })

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -506,7 +506,7 @@ impl CompanyStore for SqliteStore {
             overlay_workflows: overlay.workflows,
             overlay_budgets: overlay.budgets,
             overlay_policy: overlay.policy,
-            overlay_desk_tools: Default::default(),
+            overlay_desk_tools: overlay.desk_tools,
             disabled_workflows: overlay.disabled_workflows,
             template_provenance: overlay.provenance,
         }))

--- a/src/workflows/agent_upstream_input_test.rs
+++ b/src/workflows/agent_upstream_input_test.rs
@@ -62,6 +62,7 @@ fn record_with_agents(agent_ids: &[&str]) -> CompanyRecord {
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/workflows/caps/resolver.rs
+++ b/src/workflows/caps/resolver.rs
@@ -366,6 +366,7 @@ mod tests {
             overlay_workflows: overlays,
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }))))

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1428,6 +1428,7 @@ allow = [{allow}]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -595,6 +595,7 @@ description = "Runs Acme."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -268,6 +268,7 @@ pub(super) fn record() -> CompanyRecord {
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),
         overlay_policy: None,
+        overlay_desk_tools: Default::default(),
         disabled_workflows: Vec::new(),
         template_provenance: None,
     }

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1134,6 +1134,7 @@ description = "Runs Acme."
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }
@@ -1229,6 +1230,7 @@ allow = ["*"]
             overlay_workflows: Vec::new(),
             overlay_budgets: Vec::new(),
             overlay_policy: None,
+            overlay_desk_tools: Default::default(),
             disabled_workflows: Vec::new(),
             template_provenance: None,
         }


### PR DESCRIPTION
## Summary

Enriches agents and workspaces with richer definitions and real tool scoping.

**Per-agent files.** A company's roster can now live as one
`companies/<name>/agents/<id>.toml` per teammate instead of `[[agent]]` blocks.
The filename is the id, files are read in sorted order, and each carries the old
fields plus `prompt` (a custom system prompt), `prompt_files` (checked-in
briefing documents), `context`, and `classes`.

Declaring both forms is a **validation error** rather than a precedence rule —
either precedence silently discards teammates somebody wrote down, and the
roster is the one place a silent omission stays invisible until the missing
teammate fails to answer.

**Three-level tool scoping.** `[tools].allow ∩ desk.tools ∩ agent.tools`, via a
single `agent_scoped_grants`. Desks (`[[group_chat]]`) are a company's
departments and now carry a `tools` ceiling, so "nobody on the finance desk
reaches the web" is stated once rather than repeated on every member and hoped
for on the next member added.

Every level is narrow-only: no path through the resolution yields a grant the
company allow-list does not already cover. An agent on several desks takes the
**union** of their ceilings — intersecting would make adding someone to a desk
silently revoke capability and break work they were already doing. The
consequence is documented and tested: a desk with no ceiling narrows nothing, so
a restricted + unrestricted pairing resolves unrestricted.

**Unified tool catalog.** `GET {scope}/tools/catalog` lists built-in families,
MCP servers and Composio toolkits in one vocabulary. It is a projection, never a
source of truth — a test asserts every advertised grant round-trips through the
real matcher, and that test caught a genuine bug: the generic glob matcher
reports `*` as covering `media`/`search`/`composio`/`repo`, which it must not.

**Prompt assembly and context routing** (`src/company/prompt.rs`,
`src/company/context_routing.rs`) implement `runtime/orchestration/context-routing.md`,
including the per-tier default table and the class-based exclusions the spec left
to the implementing change. Both are always-compiled and tested — the exclusions
are controls, and a control deserves tests wherever it is defined.

An agent's prompt is now assembled persona → inline `prompt` → `prompt_files` →
tool briefs → routed `context`. Static material first, volatile last, because the
prompt prefix is what a provider cache reuses across turns: an operator editing a
workspace note must not invalidate the briefing behind it.

Routed documents are resolved by the async caller ahead of the synchronous agent
build (the split `skill_deltas` already uses) and **fingerprinted over document
bodies, not names** — a name-only hash would be inert exactly when it matters,
since the routing table does not move when a note's contents change. Resolution
fails soft per role: a store error yields a thinner prompt rather than a company
that stops answering.

## Migration

All 22 shipped companies moved to `agents/*.toml`, comments preserved.

Sorted filenames change which teammate is "first declared", which decides the
orchestrator when nobody is tagged. 21 companies keep their original orchestrator
via an explicit `tier = "orchestrator"`. The 22nd, `signals_opportunity_studio`,
had `signal_scout` orchestrating by declaration order while carrying
`tier = "subconscious"`; it is now tagged `orchestrator`, which also moves it onto
the agentic model workload matching the routing it was already doing.

## Persistence

`overlay_desk_tools` across `CompanyRecord`, `OverlayBlob`, fs / sqlite /
mongodb, and export→import, with conformance assertions (seeded non-empty, so a
backend that drops the field is caught).

Two properties worth review attention:

- **Version control wins when it speaks.** On rebuild a desk's console override
  is dropped if that desk's seed `tools` changed. A console override outliving a
  seed that narrowed the desk would be a runtime widening surviving the operator
  revoking it in git. The check is per desk, not whole-block.
- **Changes reach the next turn, not the next restart.** Desk scoping joins the
  roster staleness fingerprint, covering which desks exist, who sits on them, and
  each ceiling — seating a teammate on a restricted desk narrows its belt just as
  surely as editing the ceiling does.

## Bug found and fixed

`opencompany check` called `CompanyManifest::from_file` directly, so it validated
a bundle-roster company whose roster it had never loaded and reported every desk
member as "not an agent in the roster". Both routes now go through
`from_located`, and there is a regression test.

## Not in this PR

- Console UI, a GraphQL `toolCatalog` field, and a desk-tools write route. The
  REST read surface exists (`tools/catalog`; `GET …/team/{id}` now returns
  `deskAllow` and `effective`), so the UI has what it needs.

## Commands run locally

```
cargo fmt --all -- --check                        # clean
cargo clippy --all-targets -- -D warnings         # clean
cargo clippy --all-targets --features openhuman -- -D warnings   # clean
cargo test                                        # 2495 passed
cargo test --features openhuman                   # 3758 passed
cargo check --features tiny                       # clean
opencompany check companies/*                     # 22/22 valid
```

Note: `cargo test --features openhuman` needs `RUST_MIN_STACK=16777216` locally —
`harness::brain::tests::a_refused_hand_off_is_recorded_on_the_card` overflows the
default 2 MiB test stack. Pre-existing and unrelated to this change; flagging in
case CI hits it.

## API changes

- New: `GET {scope}/tools/catalog`.
- `GET {scope}/team/{agentId}` — `tools` gains `deskAllow`; `effective` now
  resolves through all three levels. Both existing fields keep their meaning.
- New manifest keys, all optional with no-op defaults: `[[group_chat]].tools`,
  and `prompt` / `prompt_files` / `classes` on an agent.
