### PR TITLE
feat(agents): carry routed workspace documents into agent prompts

### DIFF
--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -22,11 +22,8 @@ not specific enough to ship.
 # fails silently and confidently.
 prompt_files = ["prompts/house-style.md"]
 
-# Live workspace documents, placed last in the prompt once the harness carries
-# them. Unlike `prompt_files` these are operator-owned and may not exist yet, so
-# a missing one is skipped rather than refused.
-#
-# Selection and reading are implemented; the harness wiring that spends them is
-# not yet, so this line is declarative today. See
-# docs/spec/runtime/orchestration/context-routing.md.
+# Live workspace documents, placed last in the prompt — after every tool brief —
+# because they are the most volatile thing in it. Unlike `prompt_files` these are
+# operator-owned and may not exist yet, so a missing one is skipped rather than
+# refused. Editing either note reaches the next turn without a restart.
 context = ["Brand/Brand voice.md", "Playbooks/Campaign checklist.md"]

--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -95,12 +95,10 @@ Static material first, volatile last. The prompt prefix is what a provider cache
 reuses across turns, so a workspace note the operator edits between two turns
 must not invalidate the briefing behind it.
 
-> **Step 5 is not yet wired into the harness.** The selection
-> (`routed_documents`), the workspace read (`resolve_routed_documents`) and the
-> rendering (`context_section`) are implemented and tested; carrying the result
-> through `HarnessDeps` into `build::build_agent` is the remaining step. See
-> [context-routing.md](orchestration/context-routing.md#the-rule). Steps 1–4
-> are live.
+Step 5 is resolved by the async caller before the (synchronous) agent build and
+fingerprinted over document **bodies**, so editing a routed note reaches the next
+turn rather than the next restart. See
+[context-routing.md](orchestration/context-routing.md).
 
 **`prompt` is appended, never substituted.** The generated line is what binds the
 agent to *this* role at *this* company; a prompt that replaced it would silently

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -76,17 +76,26 @@ the distinction above at all.
 **Implemented** in `src/company/context_routing.rs`, always compiled and tested:
 `routed_documents` carries the table above and the exclusions below;
 `resolve_routed_documents` reads the selected notes out of a `WorkspaceStore`,
-skipping any that do not exist. Rendering into a prompt section is
+skipping any that do not exist. Rendering is
 `crate::company::prompt::context_section`.
 
-**Not yet wired into the harness.** The agent build is synchronous, so the
-resolved documents have to be fetched ahead of it and carried on `HarnessDeps`
-— the pattern `mcp_servers`, `composio` and the skill deltas already follow in
-`Harness::ensure_roster` — and folded into the persona last, after the static
-`prompt_files`. Until that lands, `context` selects documents that nothing
-spends. The remaining work is: resolve per roster member in `ensure_roster`,
-install on `fresh_deps`, fingerprint the result so an edited note rebuilds the
-roster, and append `context_section` in `build::build_agent`.
+**Wired into the harness.** `Harness::resolve_routed_context` resolves every
+roster member's documents ahead of the (synchronous) agent build — the same
+async-caller split the skill deltas use — and `build::build_agent` appends them
+**last**, after every tool brief, because they are the most volatile thing in the
+prompt and the prefix is what a provider cache reuses.
+
+Two properties, each closing a specific failure:
+
+- **An edit reaches the next turn, not the next restart.** The routed documents
+  join the roster staleness fingerprint, hashed over their **bodies** rather
+  than their names. A name-only hash would be inert exactly when it matters: the
+  routing table is manifest data and does not move when an operator edits a note.
+- **Resolution fails soft, per role.** A store error yields no documents for that
+  role rather than failing the rebuild. Routing enriches a prompt; a company
+  whose workspace read hiccuped should answer from a thinner prompt rather than
+  stop answering. An unwired store resolves to nothing, which is the pre-routing
+  behaviour exactly.
 
 ## Exclusions are load-bearing
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -19,11 +19,9 @@
 //!   [`WorkspaceStore`](crate::ports::WorkspaceStore), skipping any that do not
 //!   exist.
 //!
-//! **Not yet spent.** Carrying the resolved documents into the agent's system
-//! prompt is the remaining step: the agent build is synchronous, so they have to
-//! ride `HarnessDeps` the way `mcp_servers` and the skill deltas already do, and
-//! be appended via [`crate::company::prompt::context_section`]. Until then a
-//! `context` line selects documents that nothing reads.
+//! The harness resolves these ahead of the (synchronous) agent build — see
+//! `Harness::resolve_routed_context` — and appends them to the persona last, via
+//! [`crate::company::prompt::context_section`].
 
 use crate::company::Agent;
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -187,6 +187,12 @@ pub fn persona_prompt(company_name: &str, agent: &ManifestAgent) -> String {
 /// and/or a source directory), the agent's effective skill set is materialized
 /// and surfaced as three read tools plus a persona-prompt catalogue.
 ///
+/// `routed_context` are this agent's workspace documents, already selected by
+/// [`context_routing`](crate::company::context_routing) and read out of the
+/// store by the async caller. Passed in rather than fetched here for the same
+/// reason `skill_deltas` is: this function is synchronous and runs on every
+/// roster rebuild, while the `WorkspaceStore` is async.
+///
 /// `is_orchestrator` marks the company's orchestrator agent (issue #53): it
 /// additionally receives the delegating-orchestrator persona brief and the
 /// `query_company` / `spawn_task` / `delegate_to_desk` tools.

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -1533,6 +1533,7 @@ mod tests {
             &deps,
             &grants,
             &[],
+            &[],
             is_orchestrator,
         )
         .expect("agent builds");
@@ -1577,6 +1578,7 @@ mod tests {
             &deps,
             &grants,
             &[],
+            &[],
             false,
         )
         .expect("agent builds");
@@ -1617,6 +1619,7 @@ mod tests {
             &deps,
             &grants,
             &[],
+            &[],
             false,
         )
         .expect("agent builds");
@@ -1654,6 +1657,7 @@ mod tests {
             policy,
             &deps,
             &grants,
+            &[],
             &[],
             false,
         )
@@ -1854,6 +1858,7 @@ mod tests {
             policy,
             &deps,
             &grants,
+            &[],
             &[],
             false,
         )

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -842,6 +842,13 @@ pub fn build_agent(
         ));
     }
 
+    // The routed workspace documents go LAST, after every tool brief. They are
+    // the most volatile thing in the prompt — an operator editing a note between
+    // two turns moves them — and the prompt prefix is what a provider cache
+    // reuses across turns, so putting them anywhere earlier would invalidate
+    // every brief behind them on an edit that changed none of those briefs.
+    persona.push_str(&crate::company::prompt::context_section(routed_context));
+
     let prompt_builder = SystemPromptBuilder::for_subagent(
         persona, /* omit_identity */ true, /* omit_safety_preamble */ false,
         /* omit_skills_catalog */ true,

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -209,6 +209,7 @@ pub fn build_agent(
     deps: &HarnessDeps,
     grants: &[String],
     skill_deltas: &[SkillState],
+    routed_context: &[(String, String)],
     is_orchestrator: bool,
 ) -> crate::Result<Agent> {
     let memory: Arc<dyn Memory> = Arc::new(OcMemory::new(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2312,10 +2312,18 @@ fn repo_binding_fingerprint(bindings: &[crate::runtime::repo_manager::types::Rep
 ///
 /// `skill_deltas` are the company's operator skill overrides (fetched once by
 /// the async caller); every agent folds them into its effective skill set.
+///
+/// `routed_context` maps an agent id to the workspace documents routed into its
+/// system prompt, resolved by the async caller for the same reason
+/// `skill_deltas` is — this function is synchronous and the `WorkspaceStore` is
+/// not. An agent absent from the map gets no routed documents, which is the
+/// correct reading for a company with no workspace store wired: fail closed to
+/// the pre-routing prompt rather than to a half-populated one.
 pub(crate) fn build_roster(
     company: &CompanyRecord,
     deps: &HarnessDeps,
     skill_deltas: &[SkillState],
+    routed_context: &HashMap<String, Vec<(String, String)>>,
 ) -> crate::Result<Vec<Arc<CompanyAgent>>> {
     // Issue #562: the policy in force, not the one the manifest shipped with —
     // the same relationship `effective_budget` (issue #343) has to the manifest

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3149,7 +3149,7 @@ description = "Builds the product."
             tools: Vec::new(),
         });
 
-        let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
+        let roster = build_roster(&rec, &fx.deps, &[], &HashMap::new()).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(ids, vec!["ceo", "engineer", "growth"], "got {ids:?}");
         let overlay_agent = roster
@@ -3173,7 +3173,7 @@ description = "Builds the product."
             tools: Vec::new(),
         });
 
-        let roster = build_roster(&rec, &fx.deps, &[]).expect("roster builds");
+        let roster = build_roster(&rec, &fx.deps, &[], &HashMap::new()).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(
             ids,
@@ -3249,7 +3249,7 @@ description = "Builds the product."
         let saved = store.load(&company).await.unwrap().expect("record");
         assert_eq!(saved.overlay_agents[0].id, "engineer_2");
 
-        let roster = build_roster(&saved, &fx.deps, &[]).expect("roster builds");
+        let roster = build_roster(&saved, &fx.deps, &[], &HashMap::new()).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(
             ids,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1554,6 +1554,14 @@ impl HarnessPool {
         self.desk_fingerprints.read().await.get(company).copied()
     }
 
+    /// The current routed-context fingerprint for a company (test-only), so a
+    /// routing test can assert that editing a routed workspace note actually
+    /// rebuilt the roster rather than inferring it from a reply.
+    #[cfg(test)]
+    pub async fn context_fingerprint_of(&self, company: &CompanyId) -> Option<u64> {
+        self.context_fingerprints.read().await.get(company).copied()
+    }
+
     /// Routes a message to one agent and returns its reply, recording the turn's
     /// cost. `agent_id` must name a member of the company's roster.
     ///

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -921,6 +921,19 @@ pub struct HarnessPool {
     /// declare no ceilings keeps a stable fingerprint and never rebuilds on this
     /// axis.
     desk_fingerprints: RwLock<HashMap<CompanyId, u64>>,
+    /// Per-company fingerprint of the routed workspace documents — hashed over
+    /// their **bodies**, not merely their names.
+    ///
+    /// A persona is assembled once per roster, so without this axis an operator
+    /// editing a routed note would leave every other fingerprint stable and the
+    /// fast path would keep serving a prompt quoting the old text until the
+    /// process restarted. Hashing the names alone would have exactly that bug,
+    /// since the routing table does not move when a document's contents do —
+    /// which is the whole reason the routing layer is worth having.
+    ///
+    /// A company with no workspace store wired, or whose roles route nothing,
+    /// keeps a stable fingerprint and never rebuilds on this axis.
+    context_fingerprints: RwLock<HashMap<CompanyId, u64>>,
     /// The `(company, agent)` pairs whose last workspace-ensure failed and whose
     /// failure has already been reported (issue #449).
     ///

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1100,6 +1100,18 @@ impl HarnessPool {
         };
         let skill_fp = skill_delta_fingerprint(&skill_deltas);
 
+        // Resolve the routed workspace documents (context routing) before the
+        // fast-path check, and fingerprint their *content*. Both halves matter:
+        // resolving here is what lets the synchronous `build_agent` fold them
+        // into a persona at all, and hashing the bodies rather than the file
+        // names is what makes an operator's edit to a routed note rebuild the
+        // roster. A name-only hash would leave an edited note invisible until a
+        // restart — the same staleness bug `skill_fp` above exists to close.
+        let routed_context = self
+            .resolve_routed_context(company, deps, &overlay.agents)
+            .await;
+        let context_fp = routed_context_fingerprint(&routed_context);
+
         {
             let agents = self.agents.read().await;
             let mcp_fingerprints = self.mcp_fingerprints.read().await;

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3053,7 +3053,7 @@ description = "Builds the product."
     #[tokio::test]
     async fn roster_builds_every_manifest_agent() {
         let fx = fixture();
-        let roster = build_roster(&record(), &fx.deps, &[]).expect("roster builds");
+        let roster = build_roster(&record(), &fx.deps, &[], &HashMap::new()).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(ids, vec!["ceo", "engineer"]);
         assert_eq!(roster[0].role, "Chief Executive");
@@ -3119,7 +3119,7 @@ description = "Builds the product."
             checkouts: crate::harness::repo::CheckoutLedger::default(),
         };
 
-        let roster = build_roster(&record(), &deps, &[]).expect("roster builds with skills");
+        let roster = build_roster(&record(), &deps, &[], &HashMap::new()).expect("roster builds with skills");
         assert_eq!(roster.len(), 2);
         // The scratch skill tree was materialized for the first roster agent.
         assert!(
@@ -3804,7 +3804,7 @@ description = "Builds the product."
             repo_bindings: Vec::new(),
             checkouts: crate::harness::repo::CheckoutLedger::default(),
         };
-        let roster = build_roster(&record(), &deps, &[]).expect("roster");
+        let roster = build_roster(&record(), &deps, &[], &HashMap::new()).expect("roster");
         // Keep the tempdir alive for the agent's workspace by leaking it into the
         // test's lifetime — the process ends the test anyway.
         std::mem::forget(dir);

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2519,7 +2519,10 @@ pub(crate) fn build_roster(
             deps,
             &grants,
             skill_deltas,
-            routed_context.get(&manifest_agent.id).map(Vec::as_slice).unwrap_or(&[]),
+            routed_context
+                .get(&manifest_agent.id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
             is_orchestrator,
         )?;
         roster.push(Arc::new(CompanyAgent {
@@ -2571,7 +2574,10 @@ pub(crate) fn build_roster(
             deps,
             &grants,
             skill_deltas,
-            routed_context.get(&manifest_agent.id).map(Vec::as_slice).unwrap_or(&[]),
+            routed_context
+                .get(&manifest_agent.id)
+                .map(Vec::as_slice)
+                .unwrap_or(&[]),
             /* is_orchestrator */ false,
         )?;
         roster.push(Arc::new(CompanyAgent {
@@ -3061,7 +3067,8 @@ description = "Builds the product."
     #[tokio::test]
     async fn roster_builds_every_manifest_agent() {
         let fx = fixture();
-        let roster = build_roster(&record(), &fx.deps, &[], &HashMap::new()).expect("roster builds");
+        let roster =
+            build_roster(&record(), &fx.deps, &[], &HashMap::new()).expect("roster builds");
         let ids: Vec<_> = roster.iter().map(|a| a.agent_id.as_str()).collect();
         assert_eq!(ids, vec!["ceo", "engineer"]);
         assert_eq!(roster[0].role, "Chief Executive");
@@ -3136,9 +3143,7 @@ description = "Builds the product."
             assert!(fx.deps.workspace.is_none(), "fixture has no store wired");
 
             let pool = HarnessPool::new();
-            let routed = pool
-                .resolve_routed_context(&record(), &fx.deps, &[])
-                .await;
+            let routed = pool.resolve_routed_context(&record(), &fx.deps, &[]).await;
             assert!(routed.is_empty(), "{routed:?}");
             assert_eq!(
                 routed_context_fingerprint(&routed),
@@ -3178,9 +3183,7 @@ description = "Builds the product."
             fx.deps.workspace = Some(ws);
 
             let pool = HarnessPool::new();
-            let routed = pool
-                .resolve_routed_context(&record(), &fx.deps, &[])
-                .await;
+            let routed = pool.resolve_routed_context(&record(), &fx.deps, &[]).await;
 
             // Both fixture agents default to the `reasoning` row, which routes
             // BRIEF — so both resolve it, and neither invents the notes that do
@@ -3261,7 +3264,8 @@ description = "Builds the product."
             checkouts: crate::harness::repo::CheckoutLedger::default(),
         };
 
-        let roster = build_roster(&record(), &deps, &[], &HashMap::new()).expect("roster builds with skills");
+        let roster = build_roster(&record(), &deps, &[], &HashMap::new())
+            .expect("roster builds with skills");
         assert_eq!(roster.len(), 2);
         // The scratch skill tree was materialized for the first roster agent.
         assert!(

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2247,6 +2247,38 @@ pub(crate) struct EffectiveOverlay {
     pub desk_tools: std::collections::BTreeMap<String, Vec<String>>,
 }
 
+/// Fingerprints the routed workspace documents a roster's personas are built
+/// from — **over their bodies**, not their names.
+///
+/// Hashing the content is the whole point. The routing table is manifest data
+/// and does not move when an operator edits a note, so a name-only hash would
+/// leave the edit invisible: the persona is assembled once per roster, and the
+/// fast path would keep serving a prompt quoting the old text until the process
+/// restarted. That is precisely the staleness the routing layer exists to avoid.
+///
+/// Sorted by agent id before hashing, for the reason [`budget_fingerprint`]
+/// documents — a `HashMap` has no order, and an order-sensitive hash would drop
+/// every live agent session on a rebuild that changed nothing.
+fn routed_context_fingerprint(routed: &HashMap<String, Vec<(String, String)>>) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let mut ordered: Vec<(&String, &Vec<(String, String)>)> = routed.iter().collect();
+    ordered.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut hasher = DefaultHasher::new();
+    ordered.len().hash(&mut hasher);
+    for (agent_id, documents) in ordered {
+        agent_id.hash(&mut hasher);
+        documents.len().hash(&mut hasher);
+        for (path, body) in documents {
+            path.hash(&mut hasher);
+            body.hash(&mut hasher);
+        }
+    }
+    hasher.finish()
+}
+
 /// Fingerprints the desk scoping a roster's grants are resolved through: which
 /// desks exist, who sits on them, and what each one's tool ceiling is.
 ///

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1123,6 +1123,7 @@ impl HarnessPool {
             let budget_fingerprints = self.budget_fingerprints.read().await;
             let policy_fingerprints = self.policy_fingerprints.read().await;
             let desk_fingerprints = self.desk_fingerprints.read().await;
+            let context_fingerprints = self.context_fingerprints.read().await;
             if agents.contains_key(&company.id)
                 && mcp_fingerprints.get(&company.id) == Some(&mcp_fp)
                 && overlay_fingerprints.get(&company.id) == Some(&overlay_fp)

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -5630,6 +5630,7 @@ budget_usd_daily = 0.0
             &deps,
             &grants,
             &[],
+            &[],
             is_orchestrator,
         )
         .expect("agent builds");
@@ -5742,6 +5743,7 @@ budget_usd_daily = 0.0
             ApprovalPolicy::new(&Policy::default(), None),
             &deps,
             &["*".to_string()],
+            &[],
             &[],
             true,
         )

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1403,6 +1403,75 @@ impl HarnessPool {
     /// The two collections share **one** store round-trip deliberately: they
     /// come off the same record, and splitting them would double the per-turn
     /// read for no gain.
+    /// Resolves every roster member's routed workspace documents, keyed by agent
+    /// id (`docs/spec/runtime/orchestration/context-routing.md`).
+    ///
+    /// Runs here, in the async caller, because `build_roster` is synchronous and
+    /// the [`WorkspaceStore`](crate::ports::WorkspaceStore) is not — the same
+    /// split as the skill deltas beside it.
+    ///
+    /// **Fails soft, per agent.** A store error yields no documents for that
+    /// role rather than failing the rebuild: routing enriches a prompt, and a
+    /// company whose workspace read hiccuped should answer from a thinner prompt
+    /// rather than stop answering. An unwired store (`None`) resolves to an
+    /// empty map, which is the pre-routing behaviour exactly.
+    ///
+    /// Overlay teammates are included: they are real roster agents that
+    /// [`build_roster`] builds the same way, so leaving them out would give a
+    /// console-added teammate a silently different prompt from a manifest one.
+    async fn resolve_routed_context(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+        overlay_agents: &[OverlayAgent],
+    ) -> HashMap<String, Vec<(String, String)>> {
+        let Some(workspace) = deps.workspace.as_ref() else {
+            return HashMap::new();
+        };
+
+        // A manifest agent wins an id collision, exactly as `build_roster`
+        // resolves one, so the overlay half skips any id already claimed.
+        let manifest_ids: HashSet<&str> = company
+            .manifest
+            .agents
+            .iter()
+            .map(|a| a.id.as_str())
+            .collect();
+        let overlay_as_manifest: Vec<ManifestAgent> = overlay_agents
+            .iter()
+            .filter(|overlay| !manifest_ids.contains(overlay.id.as_str()))
+            .map(overlay_agent_to_manifest)
+            .collect();
+
+        let mut routed = HashMap::new();
+        for agent in company.manifest.agents.iter().chain(&overlay_as_manifest) {
+            match crate::company::context_routing::resolve_routed_documents(
+                workspace.as_ref(),
+                &company.id,
+                agent,
+            )
+            .await
+            {
+                // An agent that resolved nothing is left out of the map rather
+                // than stored as an empty vec: `build_roster` reads an absent id
+                // as "no routed documents", so the two are the same answer and
+                // the map stays the size of what actually routed.
+                Ok(documents) if documents.is_empty() => {}
+                Ok(documents) => {
+                    routed.insert(agent.id.clone(), documents);
+                }
+                Err(err) => tracing::warn!(
+                    company = %company.id,
+                    agent = %agent.id,
+                    error = %err,
+                    "[context] could not read this role's routed documents; its prompt \
+                     goes out without them"
+                ),
+            }
+        }
+        routed
+    }
+
     async fn resolve_effective_overlay(
         &self,
         company: &CompanyRecord,

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -982,6 +982,7 @@ impl HarnessPool {
             budget_fingerprints: RwLock::new(HashMap::new()),
             policy_fingerprints: RwLock::new(HashMap::new()),
             desk_fingerprints: RwLock::new(HashMap::new()),
+            context_fingerprints: RwLock::new(HashMap::new()),
             workspace_failures: std::sync::Mutex::new(HashSet::new()),
         }
     }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1134,6 +1134,7 @@ impl HarnessPool {
                 && budget_fingerprints.get(&company.id) == Some(&budget_fp)
                 && policy_fingerprints.get(&company.id) == Some(&policy_fp)
                 && desk_fingerprints.get(&company.id) == Some(&desk_fp)
+                && context_fingerprints.get(&company.id) == Some(&context_fp)
             {
                 return Ok(());
             }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -1195,7 +1195,7 @@ impl HarnessPool {
         // repair path if boot's create ever fail-softed, since the minter
         // creates the root it needs. A rebuild-time call would now be a tree
         // read that can only ever find its work already done.
-        let roster = build_roster(&fresh_company, &fresh_deps, &skill_deltas)?;
+        let roster = build_roster(&fresh_company, &fresh_deps, &skill_deltas, &routed_context)?;
 
         let mut agents = self.agents.write().await;
         agents.insert(company.id.clone(), roster);
@@ -1235,6 +1235,10 @@ impl HarnessPool {
             .write()
             .await
             .insert(company.id.clone(), desk_fp);
+        self.context_fingerprints
+            .write()
+            .await
+            .insert(company.id.clone(), context_fp);
         Ok(())
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -3067,6 +3067,140 @@ description = "Builds the product."
         assert_eq!(roster[0].role, "Chief Executive");
     }
 
+    /// Context routing: the resolution that feeds a persona, and the fingerprint
+    /// that decides whether an edit reaches the next turn.
+    mod routed_context {
+        use super::*;
+        use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin};
+
+        fn docs(entries: &[(&str, &[(&str, &str)])]) -> HashMap<String, Vec<(String, String)>> {
+            entries
+                .iter()
+                .map(|(agent, documents)| {
+                    (
+                        (*agent).to_string(),
+                        documents
+                            .iter()
+                            .map(|(p, b)| ((*p).to_string(), (*b).to_string()))
+                            .collect(),
+                    )
+                })
+                .collect()
+        }
+
+        /// The property the whole axis exists for. The routing table is manifest
+        /// data and does not move when an operator edits a note, so a
+        /// name-only hash would leave the edit invisible until a restart.
+        #[test]
+        fn the_fingerprint_moves_when_a_documents_body_changes() {
+            let before = routed_context_fingerprint(&docs(&[("ceo", &[("BRIEF.md", "old")])]));
+            let after = routed_context_fingerprint(&docs(&[("ceo", &[("BRIEF.md", "new")])]));
+            assert_ne!(
+                before, after,
+                "an edited routed note must rebuild the roster"
+            );
+        }
+
+        /// A `HashMap` has no order, so an order-sensitive hash would drop every
+        /// live agent session on a rebuild that changed nothing.
+        #[test]
+        fn the_fingerprint_is_stable_across_map_iteration_order() {
+            let one = docs(&[
+                ("ceo", &[("BRIEF.md", "b")]),
+                ("engineer", &[("CLAIMS.md", "c")]),
+            ]);
+            let two = docs(&[
+                ("engineer", &[("CLAIMS.md", "c")]),
+                ("ceo", &[("BRIEF.md", "b")]),
+            ]);
+            assert_eq!(
+                routed_context_fingerprint(&one),
+                routed_context_fingerprint(&two)
+            );
+        }
+
+        /// Renaming a document is a real change even when its text is identical:
+        /// the persona quotes the path as the section heading.
+        #[test]
+        fn the_fingerprint_moves_when_a_document_is_renamed() {
+            let before = routed_context_fingerprint(&docs(&[("ceo", &[("BRIEF.md", "same")])]));
+            let after = routed_context_fingerprint(&docs(&[("ceo", &[("GOAL.md", "same")])]));
+            assert_ne!(before, after);
+        }
+
+        /// A company with no workspace store keeps a stable fingerprint and never
+        /// rebuilds on this axis — the pre-routing behaviour exactly.
+        #[tokio::test]
+        async fn no_workspace_store_resolves_to_nothing() {
+            let fx = fixture();
+            assert!(fx.deps.workspace.is_none(), "fixture has no store wired");
+
+            let pool = HarnessPool::new();
+            let routed = pool
+                .resolve_routed_context(&record(), &fx.deps, &[])
+                .await;
+            assert!(routed.is_empty(), "{routed:?}");
+            assert_eq!(
+                routed_context_fingerprint(&routed),
+                routed_context_fingerprint(&HashMap::new()),
+                "a company that routes nothing must not rebuild on this axis"
+            );
+        }
+
+        /// The real path: a routed document that exists in the tree is read and
+        /// keyed to the agent whose manifest asked for it.
+        #[tokio::test]
+        async fn a_routed_document_is_resolved_per_agent() {
+            let dir = tempfile::tempdir().expect("tempdir");
+            let ws: Arc<dyn crate::ports::WorkspaceStore> =
+                Arc::new(crate::store::FsOps::new(dir.path()));
+            let company = CompanyId::new("acme");
+            ws.create(
+                &company,
+                &WorkspaceNode {
+                    id: "n-brief".to_string(),
+                    name: "BRIEF.md".to_string(),
+                    kind: NodeKind::File,
+                    parent_id: None,
+                    updated_at_millis: 1,
+                    created_by: WorkspaceOrigin::Operator,
+                    updated_by: WorkspaceOrigin::Operator,
+                    mime: None,
+                    size: None,
+                    sha256: None,
+                },
+                Some("What the company established."),
+            )
+            .await
+            .expect("create");
+
+            let mut fx = fixture();
+            fx.deps.workspace = Some(ws);
+
+            let pool = HarnessPool::new();
+            let routed = pool
+                .resolve_routed_context(&record(), &fx.deps, &[])
+                .await;
+
+            // Both fixture agents default to the `reasoning` row, which routes
+            // BRIEF — so both resolve it, and neither invents the notes that do
+            // not exist in the tree.
+            for agent in ["ceo", "engineer"] {
+                let documents = routed
+                    .get(agent)
+                    .unwrap_or_else(|| panic!("no routed documents for {agent}: {routed:?}"));
+                assert_eq!(
+                    documents,
+                    &vec![(
+                        "BRIEF.md".to_string(),
+                        "What the company established.".to_string()
+                    )],
+                    "{agent}"
+                );
+            }
+        }
+    }
+
     /// The roster builds end-to-end with the skill read surface wired: the
     /// effective set materializes, the read tools build, and the catalogue folds
     /// into the persona — all without error — and the scratch tree lands under

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2378,6 +2378,7 @@ pub(crate) fn build_roster(
             deps,
             &grants,
             skill_deltas,
+            routed_context.get(&manifest_agent.id).map(Vec::as_slice).unwrap_or(&[]),
             is_orchestrator,
         )?;
         roster.push(Arc::new(CompanyAgent {
@@ -2429,6 +2430,7 @@ pub(crate) fn build_roster(
             deps,
             &grants,
             skill_deltas,
+            routed_context.get(&manifest_agent.id).map(Vec::as_slice).unwrap_or(&[]),
             /* is_orchestrator */ false,
         )?;
         roster.push(Arc::new(CompanyAgent {


### PR DESCRIPTION
Follow-up to #911, which landed the routing *decision* but not the wiring that
spends it. Until this, a `context` line selected documents nothing read.

## What this does

Carries each role's routed workspace documents into its system prompt.

`Harness::resolve_routed_context` resolves every roster member's documents ahead
of the (synchronous) agent build — the same async-caller split `skill_deltas`
already uses, since the `WorkspaceStore` is async and `build_roster` is not — and
`build::build_agent` appends them **last**, after every tool brief.

Prompt order is now: persona → inline `prompt` → `prompt_files` → tool briefs →
routed `context`. Static material first, volatile last, because the prompt prefix
is what a provider cache reuses across turns; an operator editing a workspace note
must not invalidate the briefing behind it.

## Two properties worth review attention

**The fingerprint hashes document bodies, not names.** A persona is assembled once
per roster, so the routed documents have to join the roster staleness fingerprint
or an edit would not reach an agent until the process restarted. Hashing only the
names would be inert *exactly* when it matters: the routing table is manifest data
and does not move when a note's contents change. Three tests pin this — body
change moves it, rename moves it, map iteration order does not.

**Resolution fails soft, per role.** A store error yields no documents for that
role rather than failing the rebuild, and logs which role and why. Routing
enriches a prompt; a company whose workspace read hiccuped should answer from a
thinner prompt rather than stop answering. An unwired store resolves to an empty
map — the pre-routing behaviour exactly, and a stable fingerprint, so such a
company never rebuilds on this axis.

Overlay (console-added) teammates are included, resolved through the same
`overlay_agent_to_manifest` shape `build_roster` uses, so a console-added teammate
does not get a silently different prompt from a manifest one. Manifest agents win
an id collision, matching `build_roster`.

## Signature changes

`build_roster` and `build_agent` take the routed documents as a parameter rather
than a `HarnessDeps` field — following `skill_deltas`, which is per-rebuild
resolved data for the same reason. That kept the change to ~10 call sites instead
of the 39 `HarnessDeps` construction sites.

## Tests

Five new, in `harness::tests::routed_context`: the three fingerprint properties
above, the no-store case, and per-agent resolution against a real `FsOps` store.
The selection table, the exclusions and the section rendering were already covered
in #911.

## Commands run locally

```
cargo fmt --all -- --check                                       clean
cargo clippy --all-targets -- -D warnings                        clean
cargo clippy --all-targets --features openhuman -- -D warnings   clean
cargo test                                                       2495 passed
cargo test --features openhuman                                  3770 passed
cargo check --features tiny                                      clean
opencompany check companies/*                                    22/22 valid
```

Note: `cargo test --features openhuman` needs `RUST_MIN_STACK=16777216` locally —
`harness::brain::tests::a_refused_hand_off_is_recorded_on_the_card` overflows the
default 2 MiB test stack. Pre-existing and unrelated; flagging again in case CI
hits it.

## Docs

`context-routing.md`, `agents.md` and the `copywriter.toml` example lose their
"not yet wired" caveats, which were accurate when #911 merged and are not now.

## Still not in scope

Console UI, a GraphQL `toolCatalog` field, and a desk-tools write route — as noted
in #911.
