### PR TITLE
fix(tests): repair the #900 x #902 fixture break that red-lit main

### DIFF
--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -3706,6 +3706,12 @@ mod tests {
                         cancelled: false,
                         notices: Vec::new(),
                         board: Vec::new(),
+                        // Added by #881/#880 after this fixture was written. A
+                        // failed run parks nothing and blocks nothing, so both
+                        // are empty here — see `Settled::from`'s Err arm, which
+                        // makes the same choice for the same reason.
+                        approvals: Vec::new(),
+                        blocked_nodes: Vec::new(),
                     },
                 )
                 .await

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -128,6 +128,10 @@ fn record() -> CompanyRecord {
         overlay_agents: Vec::new(),
         overlay_desk_members: Vec::new(),
         overlay_desk_order: Vec::new(),
+        // Added by #902's desk-level tool ceiling after this fixture was
+        // written. Empty means no desk narrows anything, which is what this
+        // test's manifest already describes.
+        overlay_desk_tools: Default::default(),
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),
         overlay_budgets: Vec::new(),


### PR DESCRIPTION
## Summary

`main` does not compile its test suite. `cargo build` succeeds and `cargo test` fails, which is why the staging-deploy lane is green on `d681a665` while `CI` is red on the same commit.

Two fixtures, both a union break — each was correct against a `main` that lacked the other, and the two landed about an hour apart:

```
error[E0063]: missing fields `approvals` and `blocked_nodes` in initializer of `CompanyEvent`
    --> src/server/ops/workflows.rs:3699

error[E0063]: missing field `overlay_desk_tools` in initializer of `CompanyRecord`
   --> src/workflows/blocked_node_test.rs:123
```

- `ops/workflows.rs` is a fixture from **#902** that builds `WorkflowRunFinished` without the two fields **#900** added.
- `blocked_node_test.rs` is a fixture from **#900** that builds `CompanyRecord` without the field **#902** added.

Neither author could have seen it: GitHub reports MERGEABLE on a clean text merge, and each branch's CI only ever ran against a base without the other's change.

## API Or Behavior Changes

None. Test fixtures only — no production code is touched.

## Tests

`cargo fmt --all -- --check` clean. `cargo test --locked --features openhuman,tinycortex` → **3874 passed, 0 failed** (plus 10 + 1 + 11 + 2 across the other targets). Verified the break first on a pristine checkout of `d681a665`, so the fix is pinned to the actual failure rather than to a guess.

Both fields get the empty value their surrounding case already implies — a failed run parks nothing and blocks nothing (the same choice `Settled::from`'s `Err` arm makes), and the blocked-node test's manifest describes no desk-level narrowing. Each carries a comment naming the PR that introduced the field, so the next reader does not have to bisect for it.

## Documentation

None needed.

## Notes for the reviewer

Worth landing ahead of #876, which currently inherits this break through its own merge of `main` and cannot prove itself against a base that does not build.

The structural point, offered rather than pressed: a clean text merge is not a compiling merge, and nothing in the current setup tests the union of two approved PRs before both are in. This is the second main-red incident today after the vendor bump in #905 — different cause, same shape, in that `main` broke through a path no single PR's CI could see.
