### PR TITLE
fix(build): set the fields main's own literals are missing

### DIFF
--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -3706,6 +3706,8 @@ mod tests {
                         cancelled: false,
                         notices: Vec::new(),
                         board: Vec::new(),
+                        blocked_nodes: Vec::new(),
+                        approvals: Vec::new(),
                     },
                 )
                 .await

--- a/src/workflows/blocked_node_test.rs
+++ b/src/workflows/blocked_node_test.rs
@@ -127,6 +127,7 @@ fn record() -> CompanyRecord {
         lifecycle: "running".to_string(),
         overlay_agents: Vec::new(),
         overlay_desk_members: Vec::new(),
+        overlay_desk_tools: std::collections::BTreeMap::new(),
         overlay_desk_order: Vec::new(),
         overlay_desks: Vec::new(),
         overlay_workflows: Vec::new(),


### PR DESCRIPTION
## Summary

`main` has not built under `openhuman,tinycortex` since #881/#880 and the desk-tools overlay landed. Two literals were left behind by shapes that changed under them:

```
error[E0063]: missing fields `approvals` and `blocked_nodes` in initializer of `ports::types::CompanyEvent`
   --> src/server/ops/workflows.rs:3699

error[E0063]: missing field `overlay_desk_tools` in initializer of `ports::types::CompanyRecord`
   --> src/workflows/blocked_node_test.rs:123
```

Two lines. Empty values throughout — the first is a legacy-error journal append and the second a test fixture, and neither has blocked nodes, approvals or per-desk tool overrides to record.

## Problem

The fourth union break in this repository in about a day, and the same shape every time: a struct gains a field on one branch while another branch adds or keeps a literal of it. The two never conflict textually, so GitHub reports `MERGEABLE`, both are green individually, and the merge is red.

What makes this one worse than the earlier three is where it landed. Neither file is reachable from the default feature set, so the `Rust` lane stays green and only `Rust (openhuman, tinycortex)` reports it. `main` therefore merged red and **stayed** red — [run 32001078448](https://github.com/tinyhumansai/opencompany/actions/runs/32001078448) on tip `d681a665` — while looking healthy to anything reading the default lane.

Every open pull request that merges `main` inherits it. It is currently the only red lane on #851, in files that PR never touches.

## Solution

Set the fields.

## Submission Checklist

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --locked --features openhuman,tinycortex --all-targets` — the lane that was failing
- [ ] Full gated test run — deferred to CI here; the failure was a build error, and the build is what this fixes.

## Impact

Unblocks the gated lane for `main` and for every open pull request. No runtime behaviour changes: one journal append gains two empty collections, one test fixture gains an empty map.

## Related

Surfaced while resolving conflicts on #851, whose gated lane fails on exactly these two errors in files it does not touch.

Worth considering separately: four breaks of this shape in a day is a process gap rather than four coincidences. A merge queue, or requiring the gated lane on `main`, would catch the class — `MERGEABLE` demonstrably does not mean "compiles".