### PR TITLE
docs: organize Discussions around what operators are doing

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/agents-and-runs.yml
+++ b/.github/DISCUSSION_TEMPLATE/agents-and-runs.yml
@@ -1,0 +1,47 @@
+title: ""
+labels: ["agents"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        What an agent did, why a run stalled, how work gets steered or approved,
+        and the seams into the OpenHuman launcher and TinyAgents.
+
+        A run has a journal. It is nearly always the answer, so bring it.
+  - type: textarea
+    id: expected
+    attributes:
+      label: What should the agent have done?
+      validations:
+        required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: What did it do instead?
+    validations:
+      required: true
+  - type: dropdown
+    id: surface
+    attributes:
+      label: Where does this happen?
+      options:
+        - A task's runs
+        - Planning
+        - Approvals
+        - Workflows
+        - The OpenHuman launcher
+        - TinyAgents (tiny feature)
+        - Not sure
+    validations:
+      required: true
+  - type: textarea
+    id: journal
+    attributes:
+      label: Timeline or journal excerpt
+      description: The entries around the moment it went wrong. Redact anything the agent read that you would not post publicly.
+      render: text
+  - type: input
+    id: model
+    attributes:
+      label: Model and provider
+      description: Which model was driving the run.

--- a/.github/DISCUSSION_TEMPLATE/agents-and-runs.yml
+++ b/.github/DISCUSSION_TEMPLATE/agents-and-runs.yml
@@ -12,8 +12,8 @@ body:
     id: expected
     attributes:
       label: What should the agent have done?
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: actual
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/q-a.yml
+++ b/.github/DISCUSSION_TEMPLATE/q-a.yml
@@ -1,0 +1,48 @@
+title: ""
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Questions about running a company on OpenCompany. Mark an answer when
+        you get one — an answered thread is the next person's documentation.
+
+        Reporting behavior that should change? Open an issue instead.
+  - type: textarea
+    id: question
+    attributes:
+      label: What are you trying to do?
+      description: The goal, not just the error. Most answers here change the approach, not the flag.
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What have you already tried?
+      description: Commands run, config changed, docs read. Saves the first three replies.
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of `opencompany --version`, or the commit you are on.
+    validations:
+      required: true
+  - type: dropdown
+    id: how
+    attributes:
+      label: How are you running it?
+      options:
+        - cargo run / local build
+        - Docker
+        - Hosted (opencompany-manager)
+        - Something else
+    validations:
+      required: true
+  - type: textarea
+    id: manifest
+    attributes:
+      label: Relevant company.toml
+      description: The section that matters, with secrets removed.
+      render: toml

--- a/.github/DISCUSSION_TEMPLATE/rfcs.yml
+++ b/.github/DISCUSSION_TEMPLATE/rfcs.yml
@@ -1,0 +1,49 @@
+title: "RFC: "
+labels: ["rfc"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A change big enough that finding out after the PR is too late: a new
+        surface, a change to the journal or the storage ports, anything that
+        breaks an existing company's manifest or data.
+
+        Small changes do not need an RFC. Open the PR.
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: Who hits it, how often, and what they do today instead.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: The proposal
+      description: What you want to build. Concrete enough to disagree with.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What else you considered
+      description: Including doing nothing, and why that loses.
+    validations:
+      required: true
+  - type: textarea
+    id: blast
+    attributes:
+      label: What this breaks
+      description: |
+        Existing manifests, stored data, the HTTP surface, exports and bundles,
+        the hosted deployment. Say "nothing" only after you have checked each.
+    validations:
+      required: true
+  - type: checkboxes
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - label: This changes data that is already on someone's disk.
+        - label: This changes a public HTTP route or its response shape.
+        - label: This needs a matching change in OpenHuman.

--- a/.github/DISCUSSION_TEMPLATE/self-hosting.yml
+++ b/.github/DISCUSSION_TEMPLATE/self-hosting.yml
@@ -1,0 +1,42 @@
+title: ""
+labels: ["self-hosting"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Getting an instance up and keeping it up: Docker, the entrypoint, data
+        directories, reverse proxies, TLS, wake-on-request.
+
+        Most threads here are settled by two things — the container log and the
+        environment the container actually got. Paste both.
+  - type: textarea
+    id: what
+    attributes:
+      label: What is happening?
+      description: What you expected the instance to do, and what it does instead.
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: |
+        Host OS and architecture, Docker version, and how the container is
+        started. Include the OPENCOMPANY_* variables you set, with values
+        redacted where they are secrets.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Container log
+      description: From boot to the failure. `/healthz` behavior matters — the proxy blocks on it.
+      render: text
+    validations:
+      required: true
+  - type: input
+    id: data-dir
+    attributes:
+      label: Data directory
+      description: The value of OPENCOMPANY_DATA_DIR, and whether that path is writable in the container.

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -13,8 +13,8 @@ body:
     id: what
     attributes:
       label: What does the company do?
-      validations:
-        required: true
+    validations:
+      required: true
   - type: textarea
     id: shape
     attributes:

--- a/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
+++ b/.github/DISCUSSION_TEMPLATE/show-and-tell.yml
@@ -1,0 +1,34 @@
+title: ""
+labels: ["show and tell"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        A company you are running on OpenCompany. What it does, what you handed
+        to agents, and what you kept for yourself.
+
+        The useful posts here are specific: which functions run unattended, what
+        you approve by hand, and what went wrong before it worked.
+  - type: textarea
+    id: what
+    attributes:
+      label: What does the company do?
+      validations:
+        required: true
+  - type: textarea
+    id: shape
+    attributes:
+      label: How is it set up?
+      description: Roles, the approvals you require, the workflows on a schedule. A trimmed company.toml is welcome.
+    validations:
+      required: true
+  - type: textarea
+    id: learned
+    attributes:
+      label: What you would do differently
+      description: The part everyone else is here to read.
+  - type: input
+    id: running-since
+    attributes:
+      label: Running since
+      description: Roughly how long it has been live.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,17 @@
 blank_issues_enabled: true
+contact_links:
+  - name: Ask a question
+    url: https://github.com/tinyhumansai/opencompany/discussions/categories/q-a
+    about: "How do I…? Answers get marked, so the thread becomes the documentation."
+  - name: Self-hosting help
+    url: https://github.com/tinyhumansai/opencompany/discussions/categories/self-hosting
+    about: Docker, data directories, reverse proxies, an instance that will not boot.
+  - name: Propose a large change (RFC)
+    url: https://github.com/tinyhumansai/opencompany/discussions/categories/rfcs
+    about: New surfaces, storage or journal changes, anything that breaks an existing company.
+  - name: Show your company
+    url: https://github.com/tinyhumansai/opencompany/discussions/categories/show-and-tell
+    about: What you are running on OpenCompany, and what you learned running it.
+  - name: Report a security issue
+    url: https://github.com/tinyhumansai/opencompany/security/policy
+    about: Never in a public issue or discussion.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,19 @@
 # Contributing
 
+## Before You Open Anything
+
+Questions, self-hosting trouble, and a run that misbehaved go to
+[Discussions](https://github.com/tinyhumansai/opencompany/discussions);
+reproducible behavior that should change goes to an issue.
+[SUPPORT.md](SUPPORT.md) has the full routing table, and
+[docs/community/discussions.md](docs/community/discussions.md) explains how
+threads are triaged.
+
+A change big enough to break an existing company — the manifest, stored data, a
+public route — starts as an
+[RFC](https://github.com/tinyhumansai/opencompany/discussions/categories/rfcs),
+not as a pull request.
+
 ## Local Checks
 
 Run these before opening a pull request:

--- a/README.md
+++ b/README.md
@@ -259,6 +259,14 @@ and the [tiny.place economy](gitbooks/overview/tiny-place.md). Builders should
 start with the [developer section](gitbooks/developers/README.md) — build,
 CLI, architecture, authoring companies, deployment, and configuration.
 
+## Community
+
+[Discussions](https://github.com/tinyhumansai/opencompany/discussions) is where
+questions get answered and large changes get argued out before they are built —
+sorted by what you are doing (running a company, agents and runs, storage and
+tenancy, self-hosting, RFCs) rather than by post type.
+[SUPPORT.md](SUPPORT.md) says which channel takes what.
+
 ## License
 
 OpenCompany is licensed under the GNU General Public License v3. See

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,33 @@
 # Support
 
-Use GitHub issues for bug reports and feature requests. Include reproduction
-steps, expected behavior, actual behavior, and the output of relevant local
-commands.
+Pick the channel by what you have, not by how urgent it feels.
+
+| You have | Go to |
+| --- | --- |
+| A question about how to do something | [Q&A](https://github.com/tinyhumansai/opencompany/discussions/categories/q-a) |
+| An instance that will not start, or will not stay up | [Self-hosting](https://github.com/tinyhumansai/opencompany/discussions/categories/self-hosting) |
+| An agent or a run that did the wrong thing | [Agents & runs](https://github.com/tinyhumansai/opencompany/discussions/categories/agents-and-runs) |
+| Reproducible behavior that should change | [A bug report](https://github.com/tinyhumansai/opencompany/issues/new?template=bug_report.yml) |
+| A small, well-shaped feature request | [A feature request](https://github.com/tinyhumansai/opencompany/issues/new?template=feature_request.yml) |
+| A change big enough to break someone | [RFCs](https://github.com/tinyhumansai/opencompany/discussions/categories/rfcs) |
+| A company you are running on this | [Show your company](https://github.com/tinyhumansai/opencompany/discussions/categories/show-and-tell) |
+| A vulnerability | [The security policy](SECURITY.md) — never a public thread |
+
+## What to bring
+
+Every category has a form, and the form asks for the thing that usually settles
+the thread: your version, how you are running it, the container log, the run's
+journal. Filling it in is faster than the three replies that ask for it.
+
+Redact secrets before you paste. A discussion is public, it is indexed, and
+editing it later does not un-publish a key — you have to rotate it.
+
+## What to expect
+
+Maintainers work a triage queue, not an inbox. A thread with community replies
+but no maintainer reply gets the `awaiting maintainer` label and is worked
+oldest-first; see [docs/community/discussions.md](docs/community/discussions.md)
+for how that queue runs and who can move a thread through it.
+
+If a question turns out to be a bug, a maintainer opens the issue and links it.
+You do not need to file it twice.

--- a/docs/community/discussions.md
+++ b/docs/community/discussions.md
@@ -1,0 +1,87 @@
+# Discussions
+
+How this repository's Discussions are organized, and how a thread moves through
+them. Written for maintainers doing triage; contributors only need
+[SUPPORT.md](../../SUPPORT.md).
+
+## Why not the default six
+
+GitHub ships every repository the same categories — Announcements, General,
+Ideas, Polls, Q&A, Show and tell. They sort posts by *what kind of speech act*
+a post is, which is a distinction nobody needs when they are stuck: the person
+whose container will not boot and the person whose agent looped are both "Q&A",
+and both land in the same undifferentiated pile.
+
+Categories here sort by **what the poster is doing**, because that is what
+decides who can answer and what evidence is required. General stays as the
+catch-all; Ideas and Polls are retired into RFCs and Announcements.
+
+## Categories
+
+| Category | Slug | Answerable | For |
+| --- | --- | --- | --- |
+| Announcements | `announcements` | no | Releases, breaking changes, anything a running company must act on. Maintainers post; anyone comments. |
+| Running a company | `running-a-company` | yes | `company.toml`, roles, approvals, workflows — using the product rather than operating the server. |
+| Agents & runs | `agents-and-runs` | yes | A run that stalled, steering, planning, the OpenHuman launcher, TinyAgents. |
+| Storage & tenancy | `storage-and-tenancy` | yes | Backends, data directories, db-per-tenant and shared-single-DB, exports and bundles. |
+| Self-hosting | `self-hosting` | yes | Docker, the entrypoint, reverse proxies, TLS, `/healthz`, wake-on-request. |
+| RFCs | `rfcs` | no | Changes big enough that finding out at PR review is too late. |
+| Q&A | `q-a` | yes | Everything else someone is stuck on. |
+| Show your company | `show-and-tell` | no | What people are running on this. |
+| General | `general` | no | The catch-all. Triage moves posts out of it. |
+
+Five of these have a form under
+[`.github/DISCUSSION_TEMPLATE/`](../../.github/DISCUSSION_TEMPLATE). **The file
+name must equal the category slug** — a template whose slug does not match a
+real category is silently ignored, which is the failure mode to check first if a
+form stops appearing.
+
+## Labels
+
+Discussion labels are the repository's issue labels; these are the ones triage
+depends on.
+
+| Label | Meaning | Who sets it |
+| --- | --- | --- |
+| `awaiting maintainer` | Has replies, none from a maintainer. The triage queue. | Triage |
+| `needs repro` | Cannot be acted on until someone reproduces it. | Anyone |
+| `needs logs` | The container log or run journal is missing. | Anyone |
+| `breaking` | Describes or proposes a change that breaks existing companies. | Maintainer |
+| `good first issue` | A newcomer could close this. Mirrors the issue label. | Maintainer |
+| `promoted` | An issue was opened from this thread; the issue is linked. | Maintainer |
+
+## Triage
+
+Run over the queue rather than the feed. In order:
+
+1. **Wrong category** — move it. A misfiled thread is answered by nobody.
+2. **`awaiting maintainer`, oldest first.** A thread with four community replies
+   and no maintainer is the failure this queue exists to catch; "unanswered"
+   does not show it, because those replies count as answers.
+3. **Answerable and answered** — mark the answer. An unmarked answer means the
+   next person with the same problem posts again.
+4. **A bug** — open the issue, link both ways, label the thread `promoted`, and
+   leave the thread open until the fix ships. Do not ask the reporter to file it
+   again.
+5. **An RFC that is settled** — record the decision as a comment and mark it the
+   answer, then close. A decision nobody can find gets relitigated.
+
+Threads are not closed for being old. A stale answered thread is documentation;
+a stale unanswered one is a queue item that was missed.
+
+## Cross-posting with OpenHuman
+
+OpenHuman is the runtime inside OpenCompany, so a real question often belongs to
+both repositories: the launcher, the agent journal, the workspace root.
+
+Post it where the person is running into it, and link the counterpart rather
+than closing it as a duplicate — the two repositories have different maintainers
+and a link keeps both able to answer. When the fix lands in the other
+repository, say so in the thread and mark it answered here.
+
+## Changing this setup
+
+Categories cannot be created from the API — there is no GraphQL mutation for
+them, so they are made in **Settings → Discussions** by someone with admin on
+the repository. Anything added there needs a row in the table above, and a form
+under `.github/DISCUSSION_TEMPLATE/` if the category expects evidence.


### PR DESCRIPTION
Sets this repository's Discussions up for the traffic a busy open-source project actually gets, instead of leaving it on GitHub's six default categories (Announcements / General / Ideas / Polls / Q&A / Show and tell). Those sort posts by *what kind of speech act* a post is — the one distinction that does not help when someone is stuck. A container that will not boot and an agent that looped are both "Q&A", need different evidence, and are answered by different people.

Categories here sort by **what the poster is doing**, because that decides who can answer and what evidence is required.

## What's in the diff

- **`.github/DISCUSSION_TEMPLATE/`** — forms for `q-a`, `self-hosting`, `agents-and-runs`, `rfcs`, `show-and-tell`. Each asks for the thing that usually settles the thread on the first reply: version, how it is being run, the container log, the run journal, the trimmed `company.toml`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — contact links routing "how do I…", self-hosting trouble, RFCs and security reports away from the issue tracker.
- **`SUPPORT.md`** — a routing table replacing "use GitHub issues for everything", plus what to bring and what to expect.
- **`docs/community/discussions.md`** — the maintainer runbook: the category table with slugs, the triage labels, and the order to work the queue in.
- **`README.md` / `CONTRIBUTING.md`** — pointers, and the rule that a breaking change starts as an RFC rather than a PR.

## Manual steps for an admin (this PR cannot do them)

GitHub has no API for discussion categories — there is no `createDiscussionCategory` mutation — so these are **Settings → Discussions** by hand. Until they exist, the matching templates sit inert; the file name must equal the category slug.

Create, marking Q&A-style categories answerable:

| Name | Slug | Answerable |
| --- | --- | --- |
| Running a company | `running-a-company` | yes |
| Agents & runs | `agents-and-runs` | yes |
| Storage & tenancy | `storage-and-tenancy` | yes |
| Self-hosting | `self-hosting` | yes |
| RFCs | `rfcs` | no |

Keep Announcements, Q&A, Show and tell, General. Ideas and Polls retire into RFCs and Announcements.

Labels triage depends on: `awaiting maintainer`, `needs repro`, `needs logs`, `breaking`, `promoted`.

## Why `awaiting maintainer` matters

GitHub's built-in filter is "unanswered", which cannot see the failure that actually loses contributors: a thread with four community replies and no maintainer reply. Those replies count as answers. The label makes that queue visible and workable oldest-first.

## Verification

All six YAML files parse, and every non-markdown block was checked for an `id`, a `label`, dropdown `options`, and `validations` at block level rather than nested under `attributes` (three had it nested — GitHub would have silently dropped the required flag).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added community guidance for questions, support requests, bug reports, feature proposals, RFCs, security concerns, and project showcases.
  * Added discussion templates to collect relevant context for troubleshooting, self-hosting, agent behavior, Q&A, RFCs, and show-and-tell posts.
  * Documented discussion categories, labels, triage workflows, and contribution routing.
  * Added reminders to redact secrets and provide versions, deployment details, logs, and journals when requesting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->