### PR TITLE
docs(readme): add a setup path for people without a software background

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,48 @@ OpenCompany is the open host that points your companies at it.
 > Grab your key and request Medulla access at
 > **[tinyhumans.ai](https://tinyhumans.ai)**.
 
+## New to this?
+
+You do not need a software background to run a company. Three things, and
+about fifteen minutes.
+
+1. **[Docker Desktop](https://www.docker.com/products/docker-desktop/)**, a
+   free app that runs OpenCompany in a self-contained box so it cannot make a
+   mess of your machine.
+2. **A TinyHumans API key** from [tinyhumans.ai](https://tinyhumans.ai). This
+   is what lets the agents think and act. Skip it at first if you like: without
+   a key you can still launch a company and look around, the agents just will
+   not do real work.
+3. **A terminal.** On a Mac that is the app called Terminal, on Linux you
+   already know, and on Windows install
+   [WSL](https://learn.microsoft.com/windows/wsl/install) or Git Bash first,
+   because these commands expect a Unix-style shell.
+
+Then three lines. Copy one, press enter, wait for it to finish, and move to the
+next:
+
+```sh
+git clone --recurse-submodules https://github.com/tinyhumansai/opencompany.git
+cd opencompany
+./scripts/launch-demo.sh marketing up
+```
+
+The first run takes a few minutes while it downloads and builds. When it
+settles, open **http://localhost:5173**: that is the console, where you watch
+your agents work and answer anything waiting on you. Run
+`./scripts/list-demos.sh` to see the other businesses you can launch in place
+of `marketing`, and `./scripts/launch-demo.sh marketing down` when you are
+finished.
+
+Making it yours means editing `companies/<name>/company.toml`, a plain text
+file naming the roles, what each one owns, and where you want to be asked
+before anything happens. It is written to be read by people, and changing a
+role is editing a few lines rather than programming.
+[Your first company](gitbooks/get-started/your-first-company.md) walks through
+it.
+
+The rest of this section is the from-source path, for changing the host itself.
+
 ## Start your company
 
 ```sh


### PR DESCRIPTION
The README currently opens its setup with `git submodule update --init --recursive` and a `cargo run` invocation. That is the right instruction for someone who intends to change the host, and the wrong first instruction for the much larger group who just want to see a company running: it assumes a Rust toolchain, assumes you know what a submodule is, and gives no clue that Docker gets you there without either.

This adds a **New to this?** section immediately before it, and leaves everything after it untouched.

## What it covers

- **Three prerequisites**, each explained rather than named: Docker Desktop (described as what it does, with a download link), a TinyHumans API key, and a terminal. The key is explicitly marked skippable at first, since you can launch a company and look around without one and only the agents' real work is gated on it.
- **A Windows caveat.** `scripts/launch-demo.sh` is a shell script, so Windows readers are pointed at WSL or Git Bash before they hit a confusing failure.
- **Three copy-paste commands**, each with a sentence saying what it does, plus the note that the first run is slow because it is building.
- **The console URL**, `http://localhost:5173`, and what they will see there. This was reachable from the existing Docker section but never stated as the thing to open once setup finishes.
- **`list-demos.sh` and the `down` command**, so the reader can pick a different business and shut the stack down cleanly.
- **What `company.toml` is**, in one paragraph: a plain text file naming roles and sign-off points, readable by people, where editing a role is not programming. Hands off to `gitbooks/get-started/your-first-company.md`.

It closes by saying the rest of the section is the from-source path, so the two routes read as a sequence rather than as competing instructions.

## Notes

Every command was checked against the repository: `scripts/launch-demo.sh` and `scripts/list-demos.sh` both exist, the friendly name `marketing` and the `:5173` console port match the existing Docker section, and `gitbooks/get-started/your-first-company.md` is a real path.

Docs only. No code, no behavior change.