### PR TITLE
Reuse OpenHuman's TinyAgents checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,9 +163,8 @@ jobs:
       # `Report vendored openhuman drift` step's `git -C vendor/openhuman
       # rev-parse|fetch|merge-base|rev-list` — a different command that belongs
       # inline — nor `deploy-staging.yml`'s root-level `git submodule update
-      # --init --recursive`, which is a different shape fetching a different set
-      # (it also takes `vendor/tinyagents`, and runs against a `submodules:
-      # false` checkout).
+      # --init`, which is a different shape fetching the top-level OpenHuman
+      # checkout before the shared helper fills its nested vendor tree.
       - name: Vendored submodule init is not inlined
         run: |
           set -euo pipefail
@@ -675,9 +674,9 @@ jobs:
       # `--no-deps` is LOAD-BEARING — do not "simplify" it away. Cargo treats the
       # vendored `[patch]` crates as local packages, so an unscoped `-D warnings`
       # hard-fails on lints this repo neither owns nor can fix here (today:
-      # `large_enum_variant` in `vendor/tinyagents`), and the gate would never
-      # reach first-party code. Scoping to the primary package is what makes it
-      # meaningful.
+      # `large_enum_variant` in OpenHuman's nested `vendor/tinyagents`), and the
+      # gate would never reach first-party code. Scoping to the primary package
+      # is what makes it meaningful.
       - name: Clippy (openhuman, tinycortex)
         run: cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -85,7 +85,9 @@ jobs:
       # desktop-only submodules (tauri-cef is a heavy CEF checkout) that no
       # server build compiles.
       - name: Fetch build vendor submodules
-        run: git submodule update --init --recursive vendor/openhuman vendor/tinyagents
+        run: |
+          git submodule update --init vendor/openhuman
+          scripts/ci/init-vendored-submodules.sh
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/tinyagents"]
-	path = vendor/tinyagents
-	url = https://github.com/tinyhumansai/tinyagents.git
 [submodule "vendor/openhuman"]
 	path = vendor/openhuman
 	url = https://github.com/tinyhumansai/openhuman.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,10 +17,8 @@ are data-only definitions under `companies/` (a `company.toml` manifest plus a
 `frontend/`. Design notes and module specifications live in `docs/`, with
 `docs/spec/README.md` as the top-level architecture reference and
 `docs/modules/` holding per-surface design docs.
-Vendored runtime sources live under `vendor/` as Git submodules:
-
-- `vendor/openhuman/`
-- `vendor/tinyagents/`
+The vendored runtime source is the `vendor/openhuman/` Git submodule. TinyAgents
+is inherited from OpenHuman at `vendor/openhuman/vendor/tinyagents/`.
 
 Prefer small modules with focused responsibilities. Keep core type definitions
 in a dedicated `types.rs` file and package-local tests in the module file or a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,8 +33,9 @@ dedicated `test.rs` file when they grow.
 - `cargo test`: run the full test suite.
 - `cargo run --bin opencompany`: run the CLI.
 - `cargo run --bin opencompany -- serve`: run the Axum HTTP server on `127.0.0.1:8080`.
-- `git submodule update --init --recursive`: initialize OpenHuman and TinyAgents.
-- `cargo check --features tiny`: compile against vendored TinyAgents.
+- `git submodule update --init vendor/openhuman`: initialize OpenHuman.
+- `scripts/ci/init-vendored-submodules.sh`: initialize its vendored crates.
+- `cargo check --features tiny`: compile against OpenHuman's TinyAgents pin.
 
 Run commands from the repository root unless a future workspace layout changes
 the module location.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ fs2 = "0.4"
 # and `axum`, so this is a direct-use declaration, not new compilation.
 tower = { version = "0.5", features = ["util"] }
 
-tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"] }
+tinyagents = { path = "vendor/openhuman/vendor/tinyagents", optional = true, features = ["sqlite"] }
 
 # WS4: openhuman embedded as a library (the harness). Only links under the
 # `openhuman` feature; the default build pulls none of this enormous native
@@ -103,10 +103,8 @@ tinyagents = { path = "vendor/tinyagents", optional = true, features = ["sqlite"
 # OpenHuman's own skill *read* tools (`list_workflows` / `describe_workflow` /
 # `read_workflow_resource`), which live in the gated `openhuman::skills`
 # domain. The feature carries no extra deps (`skills = []` upstream) — it only
-# recompiles the skills domain modules. Keep `vendor/tinyagents` on the
-# same commit openhuman's own `vendor/tinyagents` pins: the two are a
-# lockstep pair, and a skew fails to compile (only under this feature, which
-# CI does not build).
+# recompiles the skills domain modules. TinyAgents is consumed from OpenHuman's
+# own pin so both crates always share one trait identity and cannot drift.
 openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false, features = ["skills", "mcp"] }
 # The openhuman `Provider`/`Memory` traits return `anyhow::Result` and log via
 # the `log` facade; both only link under the `openhuman` feature.
@@ -140,7 +138,7 @@ url = "2"
 # replaces the crate's SOURCE, not the version requirement it has to satisfy, so
 # a stale `0.5` fails resolution outright rather than quietly building the old
 # copy. Its `tinyagents` requirement resolves to the already-vendored
-# `vendor/tinyagents`, so this adds no new lockstep.
+# `vendor/openhuman/vendor/tinyagents`, so this adds no second copy.
 # We deliberately do NOT enable openhuman's own `flows` feature: that drags in
 # rhai + the builder tools, defeating the point of running tinyflows directly.
 tinyflows = { version = "0.8", optional = true }
@@ -407,10 +405,9 @@ telegram = ["dep:reqwest"]
 oauth = ["dep:reqwest"]
 
 [patch.crates-io]
-# opencompany's own vendored tinyagents (2.1.0). Satisfies openhuman's `^2.1`.
-# Kept on the exact commit openhuman's own `vendor/tinyagents` pins — see the
-# lockstep note on `openhuman_core` above.
-tinyagents = { path = "vendor/tinyagents" }
+# Reuse OpenHuman's own TinyAgents pin (2.1.0). This satisfies OpenHuman's
+# `^2.1` requirement while keeping a single checkout and crate identity.
+tinyagents = { path = "vendor/openhuman/vendor/tinyagents" }
 # WS4: openhuman's own Cargo.toml `[patch.crates-io]` is ignored when it is a
 # path dependency, so its vendored-submodule patches must be replicated here
 # (paths rebased onto `vendor/openhuman/vendor/...`). These entries are inert in

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # The whole workspace is copied (examples/*/Cargo.toml load the workspace;
-# vendor/tinyagents backs the [patch.crates-io] entry). vendor/openhuman,
-# target/, and node_modules are trimmed via .dockerignore.
+# vendor/openhuman/vendor/tinyagents backs the [patch.crates-io] entry).
+# vendor/openhuman, target/, and node_modules are trimmed via .dockerignore.
 COPY . .
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \

--- a/README.md
+++ b/README.md
@@ -280,7 +280,8 @@ frontend/               Company-agnostic operator console (Vite + React)
 docs/spec/              Architecture reference
 docs/modules/           Per-package design docs
 vendor/openhuman/       OpenHuman git submodule
-vendor/tinyagents/      TinyAgents git submodule
+vendor/openhuman/vendor/tinyagents/
+                        TinyAgents inherited from OpenHuman
 ```
 
 Package surfaces: **`app`** (config + shared state), **`company`** (manifest

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,7 +39,7 @@ doctl apps update <APP_ID> --spec .do/app.yaml   # after editing OPENCOMPANY_COM
 ```
 
 Point `github.repo`/`branch` at your fork first. Submodules are cloned by the
-builder, so the `vendor/tinyagents` patch resolves.
+builder, so the nested `vendor/openhuman/vendor/tinyagents` patch resolves.
 
 ### DigitalOcean — plain Droplet
 

--- a/docs/spec/integrations/README.md
+++ b/docs/spec/integrations/README.md
@@ -27,14 +27,12 @@ being *required*.
 
 ## Vendoring and versioning
 
-- `vendor/openhuman` and `vendor/tinyagents` are git submodules
-  (`git submodule update --init --recursive`); OpenHuman nests its own
-  submodules including TinyCortex and the tiny.place SDK.
-- Published crates are preferred where they exist: `tinyagents = "1.8"`
-  (path-patched to the submodule via `[patch.crates-io]`), `tinyplace =
-  "2.0"`.
-- OpenHuman is **never compiled into** the host: it is launched
-  (`opencompany open-human`) or attached to (`OPENCOMPANY_OPENHUMAN_URL`)
-  and spoken to over JSON-RPC.
+- `vendor/openhuman` is a git submodule; OpenHuman nests TinyAgents, TinyCortex,
+  and the tiny.place SDK as its own submodules.
+- Published crates are preferred where they exist: `tinyagents = "2.1"`
+  (path-patched to OpenHuman's nested submodule via `[patch.crates-io]`),
+  `tinyplace = "2.0"`.
+- OpenHuman is embedded behind the `openhuman` feature for the agent harness;
+  the desktop launcher remains available through `opencompany open-human`.
 - Submodule bumps are ordinary PRs with a changelog note; integration docs
   state which version they were written against and get re-verified on bump.

--- a/docs/spec/integrations/tinyagents.md
+++ b/docs/spec/integrations/tinyagents.md
@@ -1,7 +1,8 @@
 # TinyAgents
 
-TinyAgents (vendored at `vendor/tinyagents`, crate `tinyagents = "1.8"`,
-Rust 2024) is the recursive language-model harness: durable typed state
+TinyAgents (inherited from OpenHuman at
+`vendor/openhuman/vendor/tinyagents`, crate `tinyagents = "2.1"`, Rust 2024)
+is the recursive language-model harness: durable typed state
 graphs (checkpoints, interrupts, `Send` fan-out, subgraphs), a
 provider-neutral model harness (typed tools, middleware, structured output,
 streaming, usage/cost), a capability registry, the `.rag`/`.ragsh` surfaces,

--- a/gitbooks/developers/architecture.md
+++ b/gitbooks/developers/architecture.md
@@ -53,7 +53,8 @@ src/bin/opencompany.rs  CLI entrypoint
 companies/              Business definitions (a company.toml + docs each)
 frontend/               Company-agnostic operator console (Vite + React)
 vendor/openhuman/       OpenHuman git submodule
-vendor/tinyagents/      TinyAgents git submodule
+vendor/openhuman/vendor/tinyagents/
+                        TinyAgents inherited from OpenHuman
 ```
 
 ## Design goals

--- a/src/company/workflow_file.rs
+++ b/src/company/workflow_file.rs
@@ -1358,8 +1358,9 @@ pub(crate) fn required_config_problems(
         }
         // `field` OR `expression` both satisfy a switch — the tinyflows engine
         // reads `config.expression` first and falls back to `config.field`
-        // (`vendor/tinyagents` `switch.rs`), so either is honoured downstream and
-        // requiring only that ONE is present matches the runtime.
+        // (`vendor/openhuman/vendor/tinyflows/.../switch.rs`), so either is
+        // honoured downstream and requiring only that ONE is present matches the
+        // runtime.
         WorkflowNodeKind::Switch if !non_empty("field") && !non_empty("expression") => {
             problems.push(format!(
                 "{label} is a switch node but names no discriminant — set `config.field` or \

--- a/src/tiny/status.rs
+++ b/src/tiny/status.rs
@@ -21,7 +21,7 @@ impl RuntimeModuleStatus {
                 name: "tinyagents",
                 enabled: cfg!(feature = "tinyagents"),
                 role: "agent harness, graphs, registry, and RLM runtime",
-                path: "vendor/tinyagents",
+                path: "vendor/openhuman/vendor/tinyagents",
             },
             Self {
                 name: "openhuman",
@@ -39,11 +39,10 @@ mod tests {
 
     #[test]
     fn all_known_modules_are_reported() {
-        let names: Vec<_> = RuntimeModuleStatus::all()
-            .into_iter()
-            .map(|module| module.name)
-            .collect();
+        let modules = RuntimeModuleStatus::all();
+        let names: Vec<_> = modules.iter().map(|module| module.name).collect();
 
         assert_eq!(names, vec!["tinyagents", "openhuman"]);
+        assert_eq!(modules[0].path, "vendor/openhuman/vendor/tinyagents");
     }
 }


### PR DESCRIPTION
## Summary

- remove OpenCompany’s duplicate top-level TinyAgents submodule
- resolve the direct dependency and crates.io patch through OpenHuman’s nested TinyAgents checkout
- align runtime status, deployment initialization, CI commentary, and documentation with the single-checkout layout

## Why

OpenHuman already owns a mature, wired TinyAgents pin. Reusing it prevents the two checkouts from drifting and guarantees one TinyAgents trait identity across OpenCompany, OpenHuman, TinyCortex, and TinyMemory.

## Validation

- cargo test --locked --features tiny tiny::status::tests::all_known_modules_are_reported --lib
- cargo check --locked --features openhuman --lib
- cargo fmt --all -- --check
- git diff --check
- scripts/ci/assert-md-line-cap.sh
- scripts/ci/init-vendored-submodules.sh

No public API changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project and deployment documentation to reflect the consolidated TinyAgents location and OpenHuman integration.
  - Documented TinyAgents version 2.1 and clarified available integration options.

- **Maintenance**
  - Consolidated vendored TinyAgents under OpenHuman, simplifying dependency management.
  - Updated build and staging setup to use the consolidated dependency layout.

- **Tests**
  - Updated validation to confirm the new vendored dependency path.

- **No user-facing behavior changes**; existing runtime functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->