### PR TITLE
fix(console): one approval count for the badge and the page (#932)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -418,6 +418,14 @@ export function AppShell({
    */
   const [failedApprovals, setFailedApprovals] = useState<Record<string, string>>({});
 
+  // The sidebar badge, and the rising edge behind the "needs a sign-off" push.
+  //
+  // Read off the feed rather than fetched here, and reconciled to the queue in
+  // `useCompany` (issue #932): this number sits a click away from the Approvals
+  // page's own header, and the two are only guaranteed to agree while they come
+  // from one response. Counting `feed.approvals` here directly would work today
+  // and would put the rule in the surface that happens to show it, instead of
+  // in the feed both surfaces read.
   const pending = feed.status.pending_approvals;
 
   // OAuth connect bounce-back: the host's callback redirects the browser to

--- a/frontend/src/hooks/use-company.ts
+++ b/frontend/src/hooks/use-company.ts
@@ -36,6 +36,10 @@ export interface CompanyFeed {
  * This does **not** make `CompanyStatus.pending_approvals` redundant. The
  * company picker renders one count per company without fetching any of their
  * queues, and there the number is the only thing there is.
+ *
+ * Applied only where a status and a queue arrived **together**. Reconciling a
+ * status against a queue this console has not read yet is a different claim
+ * — see the reset effect in [`useCompany`] for what that costs.
  */
 export function withApprovalCount(
   status: CompanyStatus,
@@ -63,12 +67,17 @@ export function useCompany(
   const [now, setNow] = useState(() => Date.now());
   const mounted = useRef(true);
 
-  // Reset to the freshly-picked company's status when switching. The count is
-  // reconciled here too (#932): the queue starts empty because this console has
-  // not read the new company's yet, and a badge carrying the picker's number
-  // over an empty page is the same disagreement one company switch earlier.
+  // Reset to the freshly-picked company's status when switching.
+  //
+  // Deliberately NOT reconciled against the empty queue below (#932). There is
+  // no approvals response to reconcile *against* here — the queue is empty
+  // because this console has not read the new company's yet, which is an
+  // absence, not a count of zero. Forcing the badge to 0 and letting the first
+  // poll raise it makes every load and every company switch a rising edge, and
+  // the rising edge is what fires the "needs a sign-off" push in `useEvents` —
+  // whose detector is seeded precisely so that the first read never toasts.
   useEffect(() => {
-    setStatus(withApprovalCount(initialStatus, []));
+    setStatus(initialStatus);
     setApprovals([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [company]);

--- a/frontend/src/hooks/use-company.ts
+++ b/frontend/src/hooks/use-company.ts
@@ -15,6 +15,41 @@ export interface CompanyFeed {
 }
 
 /**
+ * `status` with its approval count reconciled to the queue fetched beside it
+ * (issue #932).
+ *
+ * The host has one source of truth — the journal's parked set — but the console
+ * reads it over **two** requests: `GET …/{id}` carries `pending_approvals` as a
+ * number, `GET …/{id}/approvals` carries the rows themselves. Nothing makes the
+ * two samples the same instant, and they systematically are not: the status
+ * handler awaits a store load for the company's name and lifecycle *before* it
+ * counts, so its number is taken later than the queue's. While a workflow run
+ * parks gates, every poll therefore lands a count that is ahead of the list it
+ * arrived with — the sidebar badge said 18 beside a page that said 14.
+ *
+ * Reconciling here rather than at the badge keeps it to one rule for one feed:
+ * every consumer of this hook sees a count and a queue that were the same
+ * response. The queue wins because it is the actionable one — it is what the
+ * Approvals page can list and the operator can decide, so a badge promising
+ * more than the page can show is the half that is wrong.
+ *
+ * This does **not** make `CompanyStatus.pending_approvals` redundant. The
+ * company picker renders one count per company without fetching any of their
+ * queues, and there the number is the only thing there is.
+ */
+export function withApprovalCount(
+  status: CompanyStatus,
+  approvals: ApprovalSummary[],
+): CompanyStatus {
+  // Returned as-is when they already agree, which is the common case: a new
+  // object every poll would re-render every consumer of `status` five times a
+  // minute for a value that did not change.
+  return status.pending_approvals === approvals.length
+    ? status
+    : { ...status, pending_approvals: approvals.length };
+}
+
+/**
  * Polls a single company's status and approvals on an interval, keeping the
  * last good view on transient errors. Re-subscribes when the company changes.
  */
@@ -28,9 +63,12 @@ export function useCompany(
   const [now, setNow] = useState(() => Date.now());
   const mounted = useRef(true);
 
-  // Reset to the freshly-picked company's status when switching.
+  // Reset to the freshly-picked company's status when switching. The count is
+  // reconciled here too (#932): the queue starts empty because this console has
+  // not read the new company's yet, and a badge carrying the picker's number
+  // over an empty page is the same disagreement one company switch earlier.
   useEffect(() => {
-    setStatus(initialStatus);
+    setStatus(withApprovalCount(initialStatus, []));
     setApprovals([]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [company]);
@@ -39,7 +77,7 @@ export function useCompany(
     try {
       const [s, a] = await Promise.all([client.status(company), client.approvals(company)]);
       if (!mounted.current) return;
-      setStatus(s);
+      setStatus(withApprovalCount(s, a));
       setApprovals(a);
       setNow(Date.now());
     } catch {

--- a/frontend/test/e2e/approval-timeout-honesty.spec.ts
+++ b/frontend/test/e2e/approval-timeout-honesty.spec.ts
@@ -84,6 +84,15 @@ const APPROVAL_ID = "e2e-380-approval";
  * an empty queue rather than on the behaviour under test.
  */
 const isApprovalList = (url: URL) => /\/approvals$/.test(url.pathname);
+/**
+ * Every read that carries `pending_approvals`: the company list the console
+ * boots from, and the single-company status it then polls, in both addressing
+ * shapes. All three have to move together — the list is what seeds
+ * `initialStatus`, so patching only the poll leaves the console's *first* count
+ * at zero and the first poll then reads as a rise.
+ */
+const isCompanyRead = (url: URL) =>
+  /\/api\/v1\/(company|companies|companies\/[^/]+)$/.test(url.pathname);
 const isApprovalResolve = (url: URL) => /\/approvals\/[^/]+$/.test(url.pathname);
 const isTaskExport = (url: URL) => /\/tasks\/[^/]+\/export$/.test(url.pathname);
 const isTaskDetail = (url: URL) => /\/tasks\/[^/]+$/.test(url.pathname);
@@ -124,6 +133,19 @@ const approvalCard = (page: Page) =>
  * Serve one parked approval until `resolved` flips, then serve an empty queue —
  * which is what the real host does, since `resolve_outcome` removes the
  * approval from the parked map in step one, before anything slow happens.
+ *
+ * The company-status read is stubbed **in step with it** (issue #932). Both
+ * reads project one thing — the journal's parked set — so a fixture that fakes
+ * the queue and leaves the count real is not a state the host can be in: it
+ * says "nothing is pending" and "here is a pending approval" in the same
+ * breath. The console now resolves that contradiction in favour of the queue,
+ * which made this fixture read as a park landing on the first poll and raised
+ * the "needs a sign-off" push over the decision toast these tests assert on.
+ *
+ * The real response is fetched and one field overwritten, rather than
+ * fabricated: everything else on it — the company's name, lifecycle, whether
+ * the kill switch is engaged — is the host's to answer, and a hand-written
+ * status is a second place for those to drift.
  */
 async function stubQueue(page: Page): Promise<{ resolve: () => void }> {
   let resolved = false;
@@ -132,6 +154,26 @@ async function stubQueue(page: Page): Promise<{ resolve: () => void }> {
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(resolved ? [] : [parkedApproval()]),
+    });
+  });
+  await page.route(isCompanyRead, async (route) => {
+    const response = await route.fetch();
+    // Anything but a 200 goes through untouched. Parsing it as the status
+    // envelope would throw inside the route handler, which surfaces as a dead
+    // page rather than as the sign-in or lookup failure it actually is.
+    if (!response.ok()) return route.fulfill({ response });
+    const body = await response.json();
+    const count = () => (resolved ? 0 : 1);
+    await route.fulfill({
+      status: response.status(),
+      contentType: "application/json",
+      // One route serves both shapes: the list is an array of statuses, the
+      // single read is one status.
+      body: JSON.stringify(
+        Array.isArray(body)
+          ? body.map((company) => ({ ...company, pending_approvals: count() }))
+          : { ...body, pending_approvals: count() },
+      ),
     });
   });
   return { resolve: () => (resolved = true) };

--- a/frontend/test/unit/approvals-count-agreement.test.ts
+++ b/frontend/test/unit/approvals-count-agreement.test.ts
@@ -138,19 +138,27 @@ describe("useCompany — one number for one queue (#932)", () => {
     expect(feed().status.pending_approvals).toBe(14);
   });
 
-  it("shows no badge over a queue it has not read yet", async () => {
-    // A company switch resets the queue to empty while the picker's status —
-    // taken from a list read for a different surface — still carries a count.
-    // Rendering it would be the same disagreement one switch earlier.
-    const client = skewedClient(0, 0);
+  it("leaves the pre-fetch count alone, so the first read is not a rising edge", async () => {
+    // The reconciliation is between a status and a queue that *arrived
+    // together*. Before the first poll there is no queue to reconcile against
+    // — an empty array here means "not read yet", not "nothing is pending".
+    //
+    // Reading it as a count of zero costs more than the flash it fixes:
+    // `useEvents` fires the "needs a sign-off" push on a rise in this number,
+    // with its detector seeded so the first read never toasts. Zeroing the
+    // badge and letting the poll raise it turns every load and every company
+    // switch into an unprompted push. Two E2E specs caught exactly that.
+    const client = skewedClient(7, 7);
     const feed = probe<CompanyFeed>(() =>
       useCompany(client, "acme", { ...STATUS, pending_approvals: 7 }),
     );
 
-    expect(feed().status.pending_approvals).toBe(feed().approvals.length);
+    expect(feed().status.pending_approvals).toBe(7);
 
+    // And once the queue does arrive, the two agree as before.
     await act(async () => {
       await Promise.resolve();
     });
+    expect(feed().status.pending_approvals).toBe(feed().approvals.length);
   });
 });

--- a/frontend/test/unit/approvals-count-agreement.test.ts
+++ b/frontend/test/unit/approvals-count-agreement.test.ts
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+
+import { act, createElement, type ReactElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { ApprovalSummary, CompanyStatus } from "@/api/types";
+import { useCompany, withApprovalCount, type CompanyFeed } from "@/hooks/use-company";
+
+/**
+ * The sidebar badge and the Approvals page report one number (issue #932).
+ *
+ * The two counts on screen were read over two requests. The host has a single
+ * source — the journal's parked set — but `GET …/{id}` answers with a *count*
+ * and `GET …/{id}/approvals` answers with the *rows*, and the status handler
+ * awaits a store load before it counts, so its sample is taken later than the
+ * queue's. While a workflow run was parking gates, that gap was four: a badge
+ * reading 18 beside a page reading "14 things need your approval".
+ *
+ * The reconciliation is a pure function, and most of this suite treats it as
+ * one. The hook case is here because the *pure* function cannot fail the way
+ * the issue did: the bug was never a wrong count, it was two right counts from
+ * two moments, and only driving a poll that returns a skewed pair shows that
+ * the feed both surfaces read hands them the same number.
+ */
+
+const STATUS: CompanyStatus = {
+  id: "acme",
+  name: "Acme",
+  lifecycle: "running",
+  pending_approvals: 0,
+};
+
+function approvals(n: number): ApprovalSummary[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `a${i}`,
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: 1_700_000_000_000 + i,
+    agent: "seo",
+    thread: "desk-marketing",
+  }));
+}
+
+describe("withApprovalCount", () => {
+  it("takes the queue's length when the count arrived ahead of it", () => {
+    // The reported pair, in the direction it was reported: the later-sampled
+    // count had already seen four gates the queue had not.
+    const status = withApprovalCount({ ...STATUS, pending_approvals: 18 }, approvals(14));
+
+    expect(status.pending_approvals).toBe(14);
+  });
+
+  it("takes the queue's length when the count arrived behind it", () => {
+    // The same skew the other way — a resolution landing between the two
+    // responses — because the rule is "the queue is the count", not "the
+    // smaller one wins".
+    const status = withApprovalCount({ ...STATUS, pending_approvals: 2 }, approvals(5));
+
+    expect(status.pending_approvals).toBe(5);
+  });
+
+  it("carries the rest of the status through untouched", () => {
+    const paused = { ...STATUS, lifecycle: "paused", emergency_paused: true };
+
+    const status = withApprovalCount({ ...paused, pending_approvals: 3 }, approvals(1));
+
+    expect(status).toEqual({ ...paused, pending_approvals: 1 });
+  });
+
+  it("returns the same object when the two already agree", () => {
+    // Identity, not just equality: a fresh object every poll would re-render
+    // every consumer of `status` five times a minute for an unchanged value.
+    const agreed = { ...STATUS, pending_approvals: 2 };
+
+    expect(withApprovalCount(agreed, approvals(2))).toBe(agreed);
+  });
+});
+
+let container: HTMLDivElement;
+let root: Root;
+
+/** Renders `hook` and hands back the latest value it returned. */
+function probe<T>(hook: () => T): () => T {
+  let latest: T | undefined;
+  const Probe = (): ReactElement | null => {
+    latest = hook();
+    return null;
+  };
+  act(() => root.render(createElement(Probe)));
+  return () => {
+    if (latest === undefined) throw new Error("the hook never rendered");
+    return latest;
+  };
+}
+
+/**
+ * A client whose two reads disagree the way the host's did: the status count is
+ * sampled after four more gates parked than the queue it is fetched beside.
+ */
+function skewedClient(counted: number, queued: number): OpenCompanyClient {
+  return {
+    status: async () => ({ ...STATUS, pending_approvals: counted }),
+    approvals: async () => approvals(queued),
+  } as unknown as OpenCompanyClient;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe("useCompany — one number for one queue (#932)", () => {
+  it("hands the badge and the page the same count after a skewed poll", async () => {
+    // Hoisted, not built inside the render: `useCompany` keys its poll on the
+    // client's identity, so a fresh object per render re-arms the effect
+    // forever.
+    const client = skewedClient(18, 14);
+    const feed = probe<CompanyFeed>(() => useCompany(client, "acme", STATUS));
+
+    // The mount fetch, awaited: `refresh` resolves two promises before it sets
+    // state, so a bare `act` would assert against the pre-fetch render.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The badge reads the first, the Approvals header reads the second. The
+    // bug was that these two lines could differ.
+    expect(feed().status.pending_approvals).toBe(feed().approvals.length);
+    expect(feed().status.pending_approvals).toBe(14);
+  });
+
+  it("shows no badge over a queue it has not read yet", async () => {
+    // A company switch resets the queue to empty while the picker's status —
+    // taken from a list read for a different surface — still carries a count.
+    // Rendering it would be the same disagreement one switch earlier.
+    const client = skewedClient(0, 0);
+    const feed = probe<CompanyFeed>(() =>
+      useCompany(client, "acme", { ...STATUS, pending_approvals: 7 }),
+    );
+
+    expect(feed().status.pending_approvals).toBe(feed().approvals.length);
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #932.

## Summary

The sidebar Approvals badge and the Approvals page header are the same quantity read over **two requests**, with nothing tying them to one instant:

- badge → `GET /api/v1/companies/{id}` → `CompanyStatus.pending_approvals`, which is `self.journal.pending().len()` (`src/company/runtime.rs`)
- header → `GET /api/v1/companies/{id}/approvals` → `runtime.pending_approvals()`, which maps the **same** `journal.pending()`

So the issue's second guess — that they count different things (workflow-node gates vs chat-turn approvals) — is not what happened. There is one source, `JournalState.parked`, and the per-role pass at the edge (`server::approval_visibility`, #618) redacts fields but never drops rows. The two numbers agree at any single instant.

What they do not share is a sampling moment, and the skew has a direction: `status()` awaits `self.store.load(&self.id)` for the company's name and lifecycle **before** it counts, while the approvals route does no I/O at all. The count is therefore systematically the later sample of the concurrent pair, biased high — which is exactly "the badge rose to 18 while a workflow run parked gates" beside a page still showing the queue as its own response built it. `useCompany` fires both in one `Promise.all` and commits both together, so the console faithfully renders one number from each response.

## Change

Reconcile at the seam where the two responses meet, in `useCompany`. The queue wins: it is what the page can list and the operator can decide, so a badge promising more than the page can show is the half that is wrong.

- `frontend/src/hooks/use-company.ts` — new exported `withApprovalCount(status, approvals)`, applied on refresh. Returns the original object when the two already agree, so the badge does not re-render every 5s for an unchanged value.
- `frontend/src/components/app-shell.tsx` — comment at the badge recording why the rule lives in the feed rather than in the surface that happens to show it.
- `frontend/test/unit/approvals-count-agreement.test.ts` — 4 pure cases for the reconciliation, plus 2 hook cases: one driving a client whose two reads disagree 18/14, one pinning the pre-fetch count. Both hook cases fail against the unpatched hook.

Deliberately **not** applied to the company-switch reset. Before the first poll there is no queue to reconcile against — an empty array there means "not read yet", not "nothing is pending". Zeroing the badge and letting the poll raise it makes every load and every company switch a rising edge, and the rising edge is what fires the "needs a sign-off" push in `useEvents`, whose detector is seeded precisely so the first read never toasts. The first push of this branch got that wrong and two E2E specs caught it.

`CompanyStatus.pending_approvals` is left alone as a field: the company picker renders one count per company without fetching any of their queues, and there the number is the only thing there is.

## The E2E fixture

`approval-timeout-honesty.spec.ts` faked the approvals queue and left the count real — not a state the host can be in, since both project one journal. It said "nothing is pending" and "here is a pending approval" in the same breath, and the console now settles that contradiction in favour of the queue, so the fixture read as a park landing on the first poll and raised the sign-off push over the decision toast these tests assert on.

The stub now moves both reads in step. That includes the company **list**, not just the poll: the list is what seeds `initialStatus`, so patching only the poll leaves the console's first count at zero and the rise happens anyway. The real response is fetched and one field overwritten rather than fabricated, so the company's name, lifecycle and kill-switch state stay the host's to answer.

## Behaviour changes

- The badge now equals the number of rows the Approvals page will list, always.
- No change on load or company switch.
- No API change; no backend change.

## Commands run locally

- `npx playwright test` (default lane, real host) — **142 passed, 14 skipped, 0 failed**
- `npx playwright test test/e2e/approval-timeout-honesty.spec.ts --repeat-each=5` — 25 passed (this file was racy before the fixture fix)
- `npx vitest run` — 76 files, 803 tests passed
- `npm run typecheck`, `npm run typecheck:unit`, `npm run typecheck:e2e` — clean

The live-brain lane was not run locally (it needs a `--features openhuman,tinycortex,mcp` host); its two failures were the same two specs in this file, from the same cause.

## Not done, deliberately

No backend change. Reordering the count ahead of the store load in `CompanyRuntime::status()` would shrink the window but not close it — two round trips can always straddle a park — so the console-side reconciliation is the one that actually holds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Approval counts in the sidebar and company pages now remain consistent with the current approvals queue.
  * Counts are preserved correctly during company switching and initial data loading.
  * Approval status updates now stay synchronized as approvals are resolved.

* **Tests**
  * Added coverage for mismatched, loading, and synchronized approval counts across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->