### PR TITLE
fix(console): name teammates on the coverage lines, not their ids (#931)

### DIFF
--- a/frontend/src/api/repos.ts
+++ b/frontend/src/api/repos.ts
@@ -13,6 +13,7 @@
 
 import type { OpenCompanyClient } from "./client";
 import { expectList } from "./mcp";
+import type { RosterAgent } from "./types";
 
 /** One bound repository, as the host reports it. Never carries a credential. */
 export interface Repo {
@@ -54,8 +55,10 @@ export interface RepoList {
    * and nobody is allowed to open them, which is a silent misconfiguration the
    * card names rather than leaves for an operator to discover by asking an
    * agent.
+   *
+   * Render {@link RosterAgent.name}, never the id (issue #931).
    */
-  grantedAgents: string[];
+  grantedAgents: RosterAgent[];
 }
 
 /** A mutating route's body. `repo` is absent on revoke. */
@@ -91,7 +94,7 @@ export async function listRepos(
     // An older host that predates the field sends nothing, and "nobody" is the
     // safe reading: it prompts an operator to check the grant rather than
     // reassuring them that somebody can read the code.
-    grantedAgents: expectList<string>(record.grantedAgents ?? [], "granted agent list"),
+    grantedAgents: expectList<RosterAgent>(record.grantedAgents ?? [], "granted agent list"),
   };
 }
 

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -871,6 +871,23 @@ export interface McpHealth {
 }
 
 /**
+ * One roster agent named on a console coverage line — {@link
+ * McpServer.reachableBy} ("Reachable by") and the repositories card's
+ * `grantedAgents` ("Readable by"), both computed from one roster walk on the
+ * host.
+ *
+ * `name` is the display label the rest of the console uses for that teammate (a
+ * manifest teammate's role, an operator-added teammate's name) and is the only
+ * thing worth showing a reader: an operator-added teammate's `id` is a minted
+ * internal string, which both lines used to print raw (issue #931). The id is
+ * still carried so a client can key or link on it.
+ */
+export interface RosterAgent {
+  id: string;
+  name: string;
+}
+
+/**
  * One effective MCP tool server (issue #50), as `.../mcp/servers` returns it.
  * The credential is never present — only the non-secret `authConfigured` flag
  * and the last (scrubbed) probe `health`.
@@ -888,16 +905,18 @@ export interface McpServer {
   /** Whether an outbound credential is stored — never the credential itself. */
   authConfigured: boolean;
   /**
-   * Ids of the company's agents whose effective tool grants cover this server —
-   * who can actually call it (issue #568). On an **enabled** server an empty
-   * array means no teammate can reach it, a probable misconfiguration the
-   * console flags loudly. A **disabled** server is always empty (the harness
-   * hands out no tool for it whatever the grants say), so the console reads the
-   * empty case against `enabled` and stays quiet there. Optional only for
-   * forward-compat with an older backend that does not send the field;
-   * `undefined` (unknown) is treated differently from `[]` (known-empty).
+   * The company's agents whose effective tool grants cover this server — who can
+   * actually call it (issue #568). On an **enabled** server an empty array means
+   * no teammate can reach it, a probable misconfiguration the console flags
+   * loudly. A **disabled** server is always empty (the harness hands out no tool
+   * for it whatever the grants say), so the console reads the empty case against
+   * `enabled` and stays quiet there. Optional only for forward-compat with an
+   * older backend that does not send the field; `undefined` (unknown) is treated
+   * differently from `[]` (known-empty).
+   *
+   * Render {@link RosterAgent.name}, never the id (issue #931).
    */
-  reachableBy?: string[];
+  reachableBy?: RosterAgent[];
   /** The last recorded (scrubbed) probe outcome, when the server has been probed. */
   health?: McpHealth;
 }

--- a/frontend/src/lib/repos.ts
+++ b/frontend/src/lib/repos.ts
@@ -8,6 +8,7 @@
 // operator their setup is fine when no agent can read a line of code.
 
 import type { Repo } from "@/api/repos";
+import type { RosterAgent } from "@/api/types";
 
 /** What the card should tell the operator about their setup. */
 export type RepoNotice =
@@ -23,7 +24,7 @@ export interface RepoCoverageInput {
   /** The bindings the host returned. */
   repos: Repo[];
   /** The roster agents whose effective grants include `repo`. */
-  grantedAgents: string[];
+  grantedAgents: RosterAgent[];
   /**
    * Whether the company manifest explicitly grants `repo`.
    *
@@ -39,8 +40,12 @@ export interface RepoCoverageInput {
 export interface RepoCoverage {
   /** Which mismatch to name, if any. */
   notice: RepoNotice;
-  /** Who can open a checkout. Empty when nobody can. */
-  readableBy: string[];
+  /**
+   * Who can open a checkout. Empty when nobody can.
+   *
+   * Print each one's `name`, never its id (issue #931).
+   */
+  readableBy: RosterAgent[];
 }
 
 /**

--- a/frontend/src/views/connections/McpServersSection.tsx
+++ b/frontend/src/views/connections/McpServersSection.tsx
@@ -548,7 +548,10 @@ export function McpServersSection({ client, company, canManage, chrome = "inline
                           <p data-testid="mcp-reachability" className="text-xs text-muted-foreground">
                             Reachable by:{" "}
                             <span className="font-medium text-foreground">
-                              {server.reachableBy.join(", ")}
+                              {/* Names, not ids (issue #931): an operator-added teammate's
+                                  id is a minted internal string and tells the reader
+                                  nothing about who can reach the server. */}
+                              {server.reachableBy.map((agent) => agent.name).join(", ")}
                             </span>
                           </p>
                         ))}

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -508,7 +508,10 @@ function McpBody({
             ) : (
               <span>
                 Reachable by:{" "}
-                <span className="font-medium text-foreground">{server.reachableBy.join(", ")}</span>
+                {/* Names, not ids (issue #931) — see `McpServersSection`. */}
+                <span className="font-medium text-foreground">
+                  {server.reachableBy.map((agent) => agent.name).join(", ")}
+                </span>
               </span>
             )}
           </p>

--- a/frontend/src/views/connections/RepositoriesCard.tsx
+++ b/frontend/src/views/connections/RepositoriesCard.tsx
@@ -4,7 +4,7 @@ import { toast } from "sonner";
 
 import type { OpenCompanyClient } from "@/api/client";
 import { bindRepo, listRepos, revokeRepo, type Repo } from "@/api/repos";
-import { ApiError } from "@/api/types";
+import { ApiError, type RosterAgent } from "@/api/types";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -58,7 +58,7 @@ export function RepositoriesCard({ client, company, canManage }: Props) {
   const [load, setLoad] = useState<Load>("loading");
   const [repos, setRepos] = useState<Repo[]>([]);
   const [diffsAvailable, setDiffsAvailable] = useState(false);
-  const [grantedAgents, setGrantedAgents] = useState<string[]>([]);
+  const [grantedAgents, setGrantedAgents] = useState<RosterAgent[]>([]);
   const [repoGranted, setRepoGranted] = useState<boolean | undefined>(undefined);
   const [url, setUrl] = useState("");
   const [token, setToken] = useState("");
@@ -260,13 +260,15 @@ export function RepositoriesCard({ client, company, canManage }: Props) {
             </ul>
           )}
 
-          {/* Who can actually open them. The names are the roster ids the host
-              resolved through the same grant walk the harness builds agents
-              with, so this says what is wired rather than what the manifest
-              looks like it should wire. */}
+          {/* Who can actually open them, from the same grant walk the harness
+              builds agents with — so this says what is wired rather than what
+              the manifest looks like it should wire. Each teammate's display
+              name, never its id (issue #931): an operator-added teammate's id
+              is a minted internal string. */}
           {load === "ready" && readableBy.length > 0 && (
             <p className="text-xs text-muted-foreground">
-              Readable by {readableBy.join(", ")}. A checkout lands in that teammate&apos;s own
+              Readable by {readableBy.map((agent) => agent.name).join(", ")}. A checkout lands in
+              that teammate&apos;s own
               workspace, is disconnected from this host&apos;s copy, and is deleted when the task
               ends.
             </p>

--- a/frontend/test/unit/provider-detail-render.test.ts
+++ b/frontend/test/unit/provider-detail-render.test.ts
@@ -380,8 +380,19 @@ describe("the same panel, opened on a remote MCP server (#821)", () => {
     // usage above it is history, not evidence that it is reachable now.
     await openMcp(mcpServer({ reachableBy: [] }));
     expect(text()).toContain("No agent can reach this server");
-    await openMcp(mcpServer({ reachableBy: ["ceo", "engineer"] }));
-    expect(text()).toContain("ceo, engineer");
+    // #931: the line prints each teammate's display name. An operator-added
+    // teammate's id is a minted internal string, and printing it told a reader
+    // nothing about who can reach the server — which is the line's whole point.
+    await openMcp(
+      mcpServer({
+        reachableBy: [
+          { id: "ceo", name: "Chief" },
+          { id: "019fa75dbc9b-000000000001", name: "Jamie" },
+        ],
+      }),
+    );
+    expect(text()).toContain("Chief, Jamie");
+    expect(text()).not.toContain("019fa75dbc9b");
   });
 });
 

--- a/frontend/test/unit/repo-tier.test.ts
+++ b/frontend/test/unit/repo-tier.test.ts
@@ -72,9 +72,12 @@ describe("what a repository approval says", () => {
 
 describe("which half of the repository setup is missing", () => {
   it("says nothing when bound repositories have a reader", () => {
-    expect(repoCoverage({ repos: [BOUND], grantedAgents: ["ceo"], repoGranted: true })).toEqual({
+    // The reader is carried as id + display label (issue #931): the card prints
+    // the label, because an operator-added teammate's id is minted internally.
+    const ceo = { id: "ceo", name: "Chief" };
+    expect(repoCoverage({ repos: [BOUND], grantedAgents: [ceo], repoGranted: true })).toEqual({
       notice: null,
-      readableBy: ["ceo"],
+      readableBy: [ceo],
     });
   });
 

--- a/src/server/ops/mcp.rs
+++ b/src/server/ops/mcp.rs
@@ -29,6 +29,7 @@ use crate::company::mcp::{
 };
 use crate::company::runtime::CompanyRuntime;
 use crate::error::OpenCompanyError;
+use crate::metering::roster_display_names;
 use crate::ports::types::CompanyRecord;
 use crate::runtime::builder::agent_effective_grants;
 use crate::runtime::tools::grants_cover_server;
@@ -74,22 +75,43 @@ struct McpServerDto {
     timeout_secs: u64,
     /// Whether an outbound credential is stored — never the credential itself.
     auth_configured: bool,
-    /// The ids of the company's agents whose effective tool grants cover this
-    /// server — who can actually call it (issue #568). Computed over the same
-    /// roster the harness builds (manifest agents + promoted overlay teammates),
-    /// through the shared
-    /// [`grants_cover_server`](crate::runtime::tools::grants_cover_server), so the
-    /// console cannot disagree with the harness about reachability. **An empty
-    /// list is meaningful**: an *enabled*, healthy server no teammate can reach
-    /// is almost always a misconfiguration, and the console flags it rather than
-    /// showing an empty list silently. A **disabled** server is always empty —
-    /// the harness hands out no tool for it whatever the grants say — so the
+    /// The company's agents whose effective tool grants cover this server — who
+    /// can actually call it (issue #568). Computed over the same roster the
+    /// harness builds (manifest agents + promoted overlay teammates), through the
+    /// shared [`grants_cover_server`](crate::runtime::tools::grants_cover_server),
+    /// so the console cannot disagree with the harness about reachability. **An
+    /// empty list is meaningful**: an *enabled*, healthy server no teammate can
+    /// reach is almost always a misconfiguration, and the console flags it rather
+    /// than showing an empty list silently. A **disabled** server is always empty
+    /// — the harness hands out no tool for it whatever the grants say — so the
     /// console reads the empty case against `enabled` and stays quiet there.
     /// Always serialized (even when empty).
-    reachable_by: Vec<String>,
+    reachable_by: Vec<RosterAgentDto>,
     /// The last recorded probe outcome (scrubbed), or `None` when never probed.
     #[serde(skip_serializing_if = "Option::is_none")]
     health: Option<McpHealth>,
+}
+
+/// One roster agent named on a coverage line, carried as an id **and** the label
+/// the console prints (issue #931).
+///
+/// The id alone was the whole payload until #931: readable for a manifest agent,
+/// whose id is an authored slug, but a minted `{millis}-{counter}` string for an
+/// operator-added overlay teammate — so the console's "Reachable by" line printed
+/// blueprint slugs next to raw internal ids. `name` is the same display label the
+/// Team page and the usage buckets use ([`roster_display_names`]: a manifest
+/// agent's `role`, an overlay teammate's `name`); the id stays so a client can
+/// still key or link on it.
+///
+/// `pub(super)` and named for the roster rather than for MCP because it rides
+/// out of [`roster_grants`], which the repositories surface reads too (issue
+/// #245) — its "Readable by" line is the same sentence about a different
+/// namespace and printed the same raw ids.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct RosterAgentDto {
+    pub(super) id: String,
+    pub(super) name: String,
 }
 
 /// A mutating response: the resulting server, the rebuild reminder, the live
@@ -240,7 +262,7 @@ async fn manifest_servers(runtime: &CompanyRuntime) -> Result<Vec<McpServer>, Ap
 /// can reach it (issue #568), and attaching the last (scrubbed) probe health.
 fn dto_from_decl(
     decl: &mcp::McpServerDecl,
-    reachable_by: Vec<String>,
+    reachable_by: Vec<RosterAgentDto>,
     health: Option<McpHealth>,
 ) -> McpServerDto {
     McpServerDto {
@@ -259,7 +281,7 @@ fn dto_from_decl(
 }
 
 /// Every roster agent's *effective* tool grants (issue #568), as
-/// `(agent_id, grants)`.
+/// `(agent, grants)`.
 ///
 /// `pub(super)` since issue #245: the repositories surface answers the same
 /// question about a different namespace ("who can read this?"), and a second
@@ -272,15 +294,26 @@ fn dto_from_decl(
 /// `overlay_agent_to_manifest` gives it. An overlay id already claimed by a
 /// manifest agent is skipped, both mirroring the harness so console
 /// reachability equals what an agent is actually granted.
-pub(super) fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)> {
+///
+/// Each agent carries its display label alongside its id (issue #931), resolved
+/// through [`roster_display_names`] — the same map the Team page and the usage
+/// buckets read, so one teammate is named identically everywhere in the console.
+/// An id absent from that map (it cannot be, over this roster) falls back to the
+/// id, matching `bucket_usage`.
+pub(super) fn roster_grants(record: &CompanyRecord) -> Vec<(RosterAgentDto, Vec<String>)> {
     let allow = &record.manifest.tools.allow;
-    let mut grants: Vec<(String, Vec<String>)> = record
+    let names = roster_display_names(&record.manifest.agents, &record.overlay_agents);
+    let roster_agent = |id: &str| RosterAgentDto {
+        id: id.to_string(),
+        name: names.get(id).cloned().unwrap_or_else(|| id.to_string()),
+    };
+    let mut grants: Vec<(RosterAgentDto, Vec<String>)> = record
         .manifest
         .agents
         .iter()
         .map(|agent| {
             (
-                agent.id.clone(),
+                roster_agent(&agent.id),
                 agent_effective_grants(allow, &agent.tools),
             )
         })
@@ -307,30 +340,33 @@ pub(super) fn roster_grants(record: &CompanyRecord) -> Vec<(String, Vec<String>)
         // server, and the console asserted a connection the harness does not
         // grant.
         grants.push((
-            overlay.id.clone(),
+            roster_agent(&overlay.id),
             agent_effective_grants(allow, &overlay.tools),
         ));
     }
     grants
 }
 
-/// The ids of the agents whose effective `grants` reach `decl` (issue #568),
-/// read through the shared [`grants_cover_server`] so this agrees with the
-/// harness registry. Empty ⇒ no teammate can reach the server.
+/// The agents whose effective `grants` reach `decl` (issue #568), read through
+/// the shared [`grants_cover_server`] so this agrees with the harness registry.
+/// Empty ⇒ no teammate can reach the server.
 ///
 /// A **disabled** server reaches nobody regardless of grants: `registry_for_agent`
 /// filters on `decl.enabled && grants_cover_server(..)`, so an agent granted
 /// `mcp:<slug>` still gets no such tool while the server is off. Mirroring both
 /// halves of that filter here is what keeps the console from claiming a
 /// reachability the harness does not hand out.
-fn reachers_of(roster_grants: &[(String, Vec<String>)], decl: &mcp::McpServerDecl) -> Vec<String> {
+fn reachers_of(
+    roster_grants: &[(RosterAgentDto, Vec<String>)],
+    decl: &mcp::McpServerDecl,
+) -> Vec<RosterAgentDto> {
     if !decl.enabled {
         return Vec::new();
     }
     roster_grants
         .iter()
         .filter(|(_, grants)| grants_cover_server(grants, &decl.name))
-        .map(|(id, _)| id.clone())
+        .map(|(agent, _)| agent.clone())
         .collect()
 }
 
@@ -944,7 +980,7 @@ role = "Chief Executive"
         let grants = roster_grants(&scoped);
         let jamie = grants
             .iter()
-            .find(|(id, _)| id == "jamie")
+            .find(|(agent, _)| agent.id == "jamie")
             .expect("the overlay teammate is on the roster");
         assert_eq!(
             jamie.1,
@@ -956,11 +992,42 @@ role = "Chief Executive"
         // the narrowing above is the teammate's own and not a company change.
         let ceo = grants
             .iter()
-            .find(|(id, _)| id == "ceo")
+            .find(|(agent, _)| agent.id == "ceo")
             .expect("on roster");
         assert_eq!(
             ceo.1,
             vec!["mcp:notion".to_string(), "mcp:linear".to_string()]
+        );
+    }
+
+    /// Issue #931: every roster entry carries a printable label, so no console
+    /// coverage line has to fall back to the id.
+    ///
+    /// The id is the wrong thing to print for exactly the teammates an operator
+    /// created: `POST …/team` mints `{millis:012x}-{counter:012x}`, which is
+    /// what "Reachable by" and "Readable by" showed. The two halves resolve
+    /// differently and both are asserted — a manifest agent has no name of its
+    /// own, so its label is its `role`; an overlay teammate's is its `name`.
+    #[test]
+    fn every_roster_entry_carries_a_printable_label() {
+        let minted = "019fa75dbc9b-000000000001";
+        let mut teammate = teammate(minted, Vec::new());
+        teammate.name = "Jamie".to_string();
+        let grants = roster_grants(&record(vec![teammate]));
+        let label = |id: &str| {
+            grants
+                .iter()
+                .find(|(agent, _)| agent.id == id)
+                .unwrap_or_else(|| panic!("`{id}` is on the roster"))
+                .0
+                .name
+                .clone()
+        };
+        assert_eq!(label(minted), "Jamie", "an overlay teammate's own name");
+        assert_eq!(
+            label("ceo"),
+            "Chief Executive",
+            "a manifest agent has no name of its own, so its role is the label"
         );
     }
 
@@ -970,7 +1037,10 @@ role = "Chief Executive"
     #[test]
     fn an_unscoped_overlay_teammate_still_inherits_the_company_grant() {
         let grants = roster_grants(&record(vec![teammate("jamie", Vec::new())]));
-        let jamie = grants.iter().find(|(id, _)| id == "jamie").expect("roster");
+        let jamie = grants
+            .iter()
+            .find(|(agent, _)| agent.id == "jamie")
+            .expect("roster");
         assert_eq!(
             jamie.1,
             vec!["mcp:notion".to_string(), "mcp:linear".to_string()]

--- a/src/server/ops/repos.rs
+++ b/src/server/ops/repos.rs
@@ -38,6 +38,7 @@ use crate::company::runtime::CompanyRuntime;
 use crate::runtime::RepoManager;
 use crate::runtime::repo_manager::types::{BindRequest, RepoBinding};
 use crate::server::error::ApiError;
+use crate::server::ops::mcp::RosterAgentDto;
 use crate::server::ops::{AdminScopedCompany, ScopedCompany, scoped};
 
 /// Builds the repository binding route fragment.
@@ -65,7 +66,10 @@ struct RepoList {
     /// per-binding copy of one list would imply a per-repository control that
     /// does not exist. Empty is the misconfiguration the card names: a company
     /// that bound repositories nobody is allowed to read.
-    granted_agents: Vec<String>,
+    ///
+    /// Each entry carries the label to print as well as the id (issue #931) —
+    /// see [`RosterAgentDto`].
+    granted_agents: Vec<RosterAgentDto>,
 }
 
 /// The reminder attached to every mutating response.
@@ -172,18 +176,24 @@ async fn list_repos(company: ScopedCompany) -> Result<Json<RepoList>, Response> 
 /// reach is what `build_agent` actually wires, rather than a second answer
 /// derived from the manifest by hand.
 ///
+/// Each agent carries the label the card prints alongside its id (issue #931).
+/// The id alone is readable only for a manifest agent; an operator-added
+/// teammate's is minted, so "Readable by" named half a company's teammates in
+/// internal strings — the same defect the MCP surface's "Reachable by" line had,
+/// which sharing one roster walk with it makes a single fix.
+///
 /// A store error degrades to an empty list rather than failing the read: the
 /// bindings are what this route is for, and losing the coverage annotation is a
 /// smaller loss than losing the page. Empty then reads as "nobody", which is the
 /// safe direction — it prompts an operator to check rather than reassuring them.
-async fn granted_agents(runtime: &CompanyRuntime) -> Vec<String> {
+async fn granted_agents(runtime: &CompanyRuntime) -> Vec<RosterAgentDto> {
     let Ok(Some(record)) = runtime.store().load(runtime.id()).await else {
         return Vec::new();
     };
     super::mcp::roster_grants(&record)
         .into_iter()
         .filter(|(_, grants)| crate::company::grants_repo_explicit(grants))
-        .map(|(id, _)| id)
+        .map(|(agent, _)| agent)
         .collect()
 }
 
@@ -501,13 +511,19 @@ mod test {
                 can_push: None,
             }],
             pull_requests_available: false,
-            granted_agents: vec!["ceo".to_string()],
+            granted_agents: vec![RosterAgentDto {
+                id: "ceo".to_string(),
+                name: "Chief".to_string(),
+            }],
         };
         let json = serde_json::to_string(&list).unwrap();
         assert!(!json.contains("SENTINEL"), "{json}");
         assert!(json.contains("tokenFingerprint"), "{json}");
         assert!(json.contains("pullRequestsAvailable"), "{json}");
         assert!(json.contains("grantedAgents"), "{json}");
+        // Issue #931: the card has a label to print, not only an id — for an
+        // operator-added teammate the id is a minted internal string.
+        assert!(json.contains(r#""name":"Chief""#), "{json}");
     }
 
     #[test]

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -3373,8 +3373,8 @@ async fn mcp_manifest_server_cannot_be_deleted_but_can_be_overridden() {
     );
 }
 
-/// Issue #568: each listed server carries the ids of the agents whose *effective*
-/// grants reach it — over the full runtime roster, manifest agents plus overlay
+/// Issue #568: each listed server carries the agents whose *effective* grants
+/// reach it — over the full runtime roster, manifest agents plus overlay
 /// teammates. With a company `allow = ["*"]`, an agent that declares no `tools`
 /// (and every overlay teammate, which has no tools row) inherits the wildcard and
 /// reaches everything; an agent that narrows itself to `mcp:notion` reaches only
@@ -3391,8 +3391,10 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
     .unwrap();
     let home_dir = home();
     let home = home_dir.path().to_path_buf();
+    // A minted id, exactly as `POST …/team` gives an operator-added teammate —
+    // the shape that used to reach the console's "Reachable by" line raw (#931).
     let overlay = crate::ports::types::OverlayAgent {
-        id: "helper".to_string(),
+        id: "019fa75dbc9b-000000000001".to_string(),
         name: "Helper".to_string(),
         role: "Assistant".to_string(),
         description: None,
@@ -3402,29 +3404,48 @@ async fn mcp_reachability_lists_reaching_agents_including_overlay() {
 
     let (status, list) = send(&state, "GET", "/api/v1/company/mcp/servers", None).await;
     assert_eq!(status, StatusCode::OK);
-    let reach = |name: &str| -> Vec<String> {
+    let reach = |name: &str| -> Vec<(String, String)> {
         let row = list
             .as_array()
             .unwrap()
             .iter()
             .find(|s| s["name"] == name)
             .unwrap_or_else(|| panic!("server `{name}` is listed"));
-        let mut ids: Vec<String> = row["reachableBy"]
+        let mut agents: Vec<(String, String)> = row["reachableBy"]
             .as_array()
             .expect("reachableBy serializes as an array")
             .iter()
-            .map(|v| v.as_str().unwrap().to_string())
+            .map(|v| {
+                (
+                    v["id"].as_str().unwrap().to_string(),
+                    v["name"].as_str().unwrap().to_string(),
+                )
+            })
             .collect();
-        ids.sort();
-        ids
+        agents.sort();
+        agents
     };
+    let pair = |id: &str, name: &str| (id.to_string(), name.to_string());
 
     // notion: the narrowed ceo, the wildcard-inheriting eng, and the overlay.
-    assert_eq!(reach("notion"), vec!["ceo", "eng", "helper"]);
+    // Issue #931: every row carries the display label the rest of the console
+    // uses — a manifest agent's role, an overlay teammate's name — so the minted
+    // overlay id is never what a reader sees.
+    assert_eq!(
+        reach("notion"),
+        vec![
+            pair("019fa75dbc9b-000000000001", "Helper"),
+            pair("ceo", "Chief"),
+            pair("eng", "Engineer"),
+        ]
+    );
     // linear: only the wildcard holders — ceo scoped itself out of it.
     assert_eq!(
         reach("linear"),
-        vec!["eng", "helper"],
+        vec![
+            pair("019fa75dbc9b-000000000001", "Helper"),
+            pair("eng", "Engineer"),
+        ],
         "ceo narrowed to mcp:notion, so it cannot reach linear"
     );
 }
@@ -3461,9 +3482,9 @@ async fn mcp_reachability_flags_a_server_no_agent_can_reach() {
             .as_array()
             .unwrap()
             .iter()
-            .map(|v| v.as_str().unwrap())
+            .map(|v| (v["id"].as_str().unwrap(), v["name"].as_str().unwrap()))
             .collect::<Vec<_>>(),
-        vec!["ceo"],
+        vec![("ceo", "Chief")],
         "the company allow covers mcp:docs for the one agent"
     );
     assert!(
@@ -3495,7 +3516,7 @@ async fn mcp_reachability_is_empty_for_a_disabled_server() {
             .as_array()
             .expect("reachableBy serializes as an array")
             .iter()
-            .map(|v| v.as_str().unwrap().to_string())
+            .map(|v| v["id"].as_str().unwrap().to_string())
             .collect()
     };
 


### PR DESCRIPTION
Fixes #931.

## Summary

`Reachable by` (Connections, MCP Servers, and the provider detail panel) and `Readable by` (the repositories card) printed roster **ids**. A manifest agent's id is an authored slug, so it passes for a name; an operator-added teammate's is minted by `generate_id` as `{millis:012x}-{counter:012x}`. A company with teammates added through Company → New teammate therefore got a list of blueprint slugs followed by internal strings — telling the reader nothing about who can reach the server, which is the entire point of the line.

Both lines come from one roster walk, `mcp::roster_grants`, shared with the repositories surface since #245. It now carries each agent's display label alongside its id, resolved through `metering::roster_display_names` — the same map the Team page and the usage buckets read, so a teammate is named identically everywhere in the console.

## Root cause

- `reachers_of` mapped matching roster entries to `(id, _) => id.clone()`.
- `roster_grants` builds that roster from two sources with two kinds of id: manifest agents (`company.toml`, human-authored slug) and overlay teammates (`server/ops/team.rs` → `ports/ids.rs::generate_id`).
- The display name for overlay teammates (`OverlayAgent::name`) was simply never carried on these routes, though `metering::roster_display_names` already existed for exactly this.

The reported ids are not ULIDs — the leading segment is a hex millisecond clock, which is why they look like one.

**Why it was never caught:** the covering test gave its overlay teammate the id `"helper"`, a readable slug no production path can mint.

## Behaviour / API changes

- `reachableBy` (`GET …/mcp/servers`) and `grantedAgents` (`GET …/repos`) change element shape from `string` to `{ id, name }`. The id stays on the wire so a client can key or link on it; only rendering changes. Both are console-facing reads with in-repo consumers only.
- Manifest agents now render as their role (`Backend engineer`) rather than their slug (`backend_engineer`), matching the Team and Usage pages.
- Reachability itself is untouched: `grants_cover_server` and the enabled/disabled filter still decide who is listed.

## Scope note

The issue named Connections and MCP Servers. Changing the shared helper forced the repositories call site too, and a sweep found `ProviderDetail.tsx` carrying a second copy of the same line. Both are fixed here — `.join(", ")` over an array of objects is valid TypeScript, so leaving either would have silently rendered `[object Object]` rather than failing the build.

## Tests

- `write_test.rs`'s overlay teammate now uses a real minted id (`019fa75dbc9b-000000000001`) instead of the readable slug that let this through, and asserts the labels.
- New `every_roster_entry_carries_a_printable_label` unit test pins both label paths (manifest → `role`, overlay → `name`) at the helper.
- `provider-detail-render.test.ts` asserts the minted id does **not** appear in the rendered text.
- `repo-tier.test.ts` and the `RepoList` serialization test updated for the new shape.

## Commands run locally

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings` (exit 0)
- `cargo test --lib` — 2616 passed, 0 failed
- `npm run typecheck:unit`
- `npm run test` — 797 passed
- `npm run build`