### PR TITLE
fix(console): wait for a channel's history before calling it empty (#934)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -71,7 +71,10 @@ import {
   channelIdForThread,
   deskFromDto,
   dmChannelId,
+  HISTORY_UNSTARTED,
   type DecidedApproval,
+  type HistoryHydration,
+  type HistoryStatus,
   type Transcripts,
 } from "@/views/chat/model";
 import { Conversation } from "@/views/Conversation";
@@ -292,6 +295,11 @@ export function AppShell({
   // mounts and unmounts `ChatView` per route, so component-local state there
   // would be discarded on every trip away from Chat and back.
   const [transcripts, setTranscripts] = useState<Transcripts>({});
+  // How far each channel's history rehydration has got. Kept beside
+  // `transcripts` rather than inside it because an empty transcript is a
+  // legitimate final answer, and the timeline has to tell that apart from not
+  // having asked yet before it prints "this is the start of…" (issue #934).
+  const [hydration, setHydration] = useState<HistoryHydration>(HISTORY_UNSTARTED);
   // Host thread id → chat channel id, for every channel this company has.
   // Resolved by the desks/roster effect below, which already works the pairing
   // out to hydrate each channel and used to throw it away — leaving the shell
@@ -481,6 +489,10 @@ export function AppShell({
     // channels that no longer exist, and start the unread floor again so the
     // incoming company's rehydrated history isn't counted as news.
     setChatChannelByThread({});
+    // Another company's channels are another namespace here too, and a status
+    // carried over would let the incoming company's channels claim to be
+    // settled before anything has asked about them.
+    setHydration(HISTORY_UNSTARTED);
     setFirstDeskChannelId(null);
     setLastViewedChannel({});
     setUnreadSince(Date.now());
@@ -536,20 +548,35 @@ export function AppShell({
     // untouched), but not for a DM: the channel id is the console-local
     // `dmChannelId`, while the thread id `getChatHistory`/`chat` read is the
     // roster agent id (see `ChatView`'s `send`) — so this takes both.
+    const markHistory = (channelId: string, status: HistoryStatus) =>
+      setHydration((h) => ({ ...h, byChannel: { ...h.byChannel, [channelId]: status } }));
+
     const hydrateChannel = (channelId: string, threadId: string) => {
+      // Marked before the request, not after: the gap between "this channel
+      // exists" and "its history is in flight" is precisely the window the
+      // timeline used to fill with the empty-channel copy.
+      markHistory(channelId, "loading");
       client
         .getChatHistory(threadId, company)
         .then((entries) => {
-          if (cancelled || entries.length === 0) return;
+          if (cancelled) return;
+          if (entries.length === 0) {
+            // An empty answer is still an answer, and the only thing that ever
+            // makes the "start of your direct message" copy true.
+            markHistory(channelId, "ready");
+            return;
+          }
           const hydrated = fromHistory(entries);
           setTranscripts((t) => {
             const known = new Set((t[channelId] ?? []).map((m) => m.id));
             const fresh = hydrated.filter((m) => !known.has(m.id));
             return fresh.length === 0 ? t : { ...t, [channelId]: [...fresh, ...(t[channelId] ?? [])] };
           });
+          markHistory(channelId, "ready");
         })
         .catch(() => {
           /* host without `/chat/history`, or offline — channel stays empty */
+          if (!cancelled) markHistory(channelId, "ready");
         });
     };
 
@@ -586,6 +613,9 @@ export function AppShell({
         setFirstDeskChannelId(chatDesks[0]?.id ?? null);
         chatDesks.forEach((d) => hydrateChannel(d.id, d.id));
         roster.forEach((m) => hydrateChannel(dmChannelId(m), m.id));
+        // Every channel this pass will hydrate now has a status, so a channel
+        // with none is one nothing is coming for.
+        setHydration((h) => ({ ...h, discovered: true }));
       })
       .catch(() => {
         // Host without `/desks`, or offline — keep the static default
@@ -596,6 +626,7 @@ export function AppShell({
         setChatChannelByThread(channelMap(fallbackDesks, []));
         setFirstDeskChannelId(fallbackDesks[0]?.id ?? null);
         fallbackDesks.forEach((d) => hydrateChannel(d.id, d.id));
+        if (!cancelled) setHydration((h) => ({ ...h, discovered: true }));
       });
 
     return () => {
@@ -1198,6 +1229,7 @@ export function AppShell({
               onReply={() => void feed.refresh()}
               transcripts={transcripts}
               setTranscripts={setTranscripts}
+              hydration={hydration}
               onSendStart={onSendStart}
               onSendEnd={onSendEnd}
               liveStepsByThread={liveStepsByThread}

--- a/frontend/src/views/ChatView.tsx
+++ b/frontend/src/views/ChatView.tsx
@@ -55,10 +55,13 @@ import {
   dmChannelId,
   findChannel,
   firstChannel,
+  historyReady,
+  HISTORY_UNTRACKED,
   offersDeliverableChoice,
   resolveDmChannelId,
   toggleReaction,
   type DecidedApproval,
+  type HistoryHydration,
   type Transcripts,
 } from "./chat/model";
 
@@ -79,6 +82,14 @@ interface Props {
    */
   transcripts: Transcripts;
   setTranscripts: Dispatch<SetStateAction<Transcripts>>;
+  /**
+   * How far the shell's rehydration of each channel's history has got, so the
+   * timeline can hold a loading state instead of claiming a channel is empty
+   * while its history is still on the wire (issue #934). Optional, and absent
+   * means "nothing is pending" — a mount with no shell behind it renders as it
+   * always did rather than spinning forever.
+   */
+  hydration?: HistoryHydration;
   /**
    * Called around the awaited chat POST with the **host thread id** it was sent
    * on, so the shell can suppress the SSE echo of our own turn while it is in
@@ -158,6 +169,7 @@ export function ChatView({
   onReply,
   transcripts,
   setTranscripts,
+  hydration = HISTORY_UNTRACKED,
   onSendStart,
   onSendEnd,
   liveStepsByThread,
@@ -437,6 +449,18 @@ export function ChatView({
   }, [inChannel, members]);
 
   const messages = channel ? (transcripts[channel.id] ?? []) : [];
+  /**
+   * Whether this channel's history is still on the wire.
+   *
+   * `messages` cannot tell you — the `?? []` above collapses "never fetched"
+   * into "empty", which is why the timeline could claim a reloaded DM was brand
+   * new (issue #934). The roster is part of the answer too: a DM's channel only
+   * exists once `members` lands, and until then nothing has even asked the shell
+   * to hydrate it.
+   */
+  const historyPending = channel
+    ? loadingTeam || !historyReady(hydration, channel.id)
+    : false;
   const entries = useMemo(
     () => (channel ? buildTimeline(messages, channel) : []),
     [messages, channel],
@@ -828,6 +852,7 @@ export function ChatView({
             <MessageTimeline
               channel={channel}
               items={items}
+              historyPending={historyPending}
               openThreadId={openThreadId}
               typing={sending && !openThreadId}
               liveSteps={openThreadId ? undefined : liveSteps}

--- a/frontend/src/views/chat/MessageTimeline.tsx
+++ b/frontend/src/views/chat/MessageTimeline.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import type { ApprovalSummary, GrantScope, TurnStep, Verdict } from "@/api/types";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import { ApprovalRow } from "./ApprovalRow";
 import { Avatar } from "./Avatar";
@@ -17,6 +18,11 @@ interface Props {
    * message — see {@link TimelineItem}.
    */
   items: TimelineItem[];
+  /**
+   * This channel's persisted history has not arrived yet, so the absence of
+   * rows is not evidence of anything (issue #934).
+   */
+  historyPending?: boolean;
   /** The message whose thread is open, if any — that row stays highlighted. */
   openThreadId: string | null;
   /** Someone on the company side is composing a reply. */
@@ -72,6 +78,7 @@ const BOTTOM_SLACK_PX = 32;
 export function MessageTimeline({
   channel,
   items,
+  historyPending = false,
   openThreadId,
   typing,
   liveSteps,
@@ -85,6 +92,10 @@ export function MessageTimeline({
 }: Props) {
   const scroller = useRef<HTMLDivElement>(null);
   const liveStepCount = liveSteps?.length ?? 0;
+  // Rows that arrived locally — a message sent before hydration landed — are
+  // still worth showing while the rest of the history is in flight. It is only
+  // the *claim of emptiness* that has to wait.
+  const loading = historyPending && items.length === 0;
   /**
    * Is the view parked at the bottom, and therefore still following?
    *
@@ -139,7 +150,11 @@ export function MessageTimeline({
   return (
     <div ref={scroller} onScroll={trackFollowing} className="flex-1 overflow-y-auto">
       <div className="flex min-h-full flex-col justify-end pb-4">
-        <ChannelIntro channel={channel} empty={items.length === 0} />
+        {/* `empty` only drives the top padding, and the skeleton fills the
+            same space real rows will — so a loading channel is spaced like a
+            full one and the intro does not jump down and back up. */}
+        <ChannelIntro channel={channel} empty={items.length === 0 && !loading} loading={loading} />
+        {loading && <HistorySkeleton />}
         {items.map((item) =>
           item.kind === "message" ? (
             <div key={item.key}>
@@ -228,7 +243,15 @@ function DayDivider({ label }: { label: string }) {
  * above the first message rather than only showing when the channel is empty —
  * scrolling to the beginning of a channel should tell you where you are.
  */
-function ChannelIntro({ channel, empty }: { channel: Channel; empty: boolean }) {
+function ChannelIntro({
+  channel,
+  empty,
+  loading,
+}: {
+  channel: Channel;
+  empty: boolean;
+  loading: boolean;
+}) {
   return (
     <div className={cn("px-4 pb-3", empty ? "pt-16" : "pt-6")}>
       <Avatar
@@ -238,11 +261,44 @@ function ChannelIntro({ channel, empty }: { channel: Channel; empty: boolean }) 
         className="mb-3 size-12 rounded-lg text-base"
       />
       <h2 className="text-xl font-semibold tracking-tight">{channelTitle(channel)}</h2>
+      {/* Both of these sentences are positive claims that the channel has no
+          history — "the start of", "the very beginning of". Neither may render
+          until the host has answered, or a reload of a busy DM reads as lost
+          conversation (issue #934). The identity block above is not a claim
+          and stays either way, so the pane still says where you are. */}
       <p className="mt-1 max-w-prose text-sm text-muted-foreground">
-        {channel.kind === "dm"
-          ? `This is the start of your direct message with ${channel.name} — ${lower(channel.purpose)}.`
-          : `This is the very beginning of ${channelTitle(channel)}. ${sentence(channel.purpose)}`}
+        {loading
+          ? sentence(channel.purpose)
+          : channel.kind === "dm"
+            ? `This is the start of your direct message with ${channel.name} — ${lower(channel.purpose)}.`
+            : `This is the very beginning of ${channelTitle(channel)}. ${sentence(channel.purpose)}`}
       </p>
+    </div>
+  );
+}
+
+/**
+ * Placeholder rows while a channel's history is on the wire.
+ *
+ * Shaped like the message rows it stands in for — avatar gutter, a name line,
+ * two lines of body — so the pane does not jump when the real transcript
+ * replaces it. `role="status"` is what makes the wait legible to a screen
+ * reader, which cannot see that anything is pulsing.
+ */
+function HistorySkeleton() {
+  return (
+    <div role="status" aria-busy="true" className="space-y-1">
+      <span className="sr-only">Loading messages…</span>
+      {[0, 1, 2].map((row) => (
+        <div key={row} className="flex items-start gap-2.5 px-4 py-1">
+          <Skeleton className="size-9 shrink-0 rounded-full" />
+          <div className="min-w-0 flex-1 space-y-2 py-1">
+            <Skeleton className="h-3 w-28" />
+            <Skeleton className="h-3 w-full max-w-prose" />
+            <Skeleton className={cn("h-3", row === 1 ? "w-1/2" : "w-3/4")} />
+          </div>
+        </div>
+      ))}
     </div>
   );
 }

--- a/frontend/src/views/chat/README.md
+++ b/frontend/src/views/chat/README.md
@@ -45,7 +45,7 @@ backend, and there is no per-channel routing on the host.
 
 | | |
 |---|---|
-| Transcripts | Journaled by the host and rehydrated from `GET {scope}/chat/history` on load. This has been true since #65 — the "per-session memory" this file used to claim was already out of date. |
+| Transcripts | Journaled by the host and rehydrated from `GET {scope}/chat/history` on load. This has been true since #65 — the "per-session memory" this file used to claim was already out of date. The rehydration is *not* instant, and the timeline has to say so: see [Empty, or not answered yet](#empty-or-not-answered-yet). |
 | Channel scoping | Every message carries the desk it was sent to, and the host filters server-side. Two people in two channels are not in the same room, and have not been since #53/#65. |
 | Threads | A reply posts its `parent` — the parent message's own id — and comes back under it. Both halves of the exchange hang off the row the thread opened from. |
 | Reactions | One durable row per person per emoji, so a chip says who reacted and whether one of them was you. `POST {scope}/chat/messages/{seq}/reactions` with an explicit `on`, which makes a retry idempotent. |
@@ -67,6 +67,37 @@ no reactions, which is the truth about it. History journaled under the old
 counter-minted `member-N` teammate ids stays orphaned — there is no honest
 mapping from `member-3` to a person, and inventing one would be worse than the
 loss.
+
+## Empty, or not answered yet
+
+`Transcripts` is `Record<string, ChatMessage[]>`, and the timeline reads it as
+`transcripts[channel.id] ?? []`. That `??` collapses two different facts into
+one: *nobody has asked the host about this channel* and *the host says this
+channel has nothing*. The channel intro then printed the second — "This is the
+start of your direct message with …" — while the first was true, so reloading a
+DM with months of history rendered it as brand new for as long as the fetch took
+(issue #934). Nothing was lost; it just read exactly like it had been.
+
+`HistoryHydration` in `model.ts` is the missing fact, and `historyReady()` is
+the one place that reads it:
+
+| State | May the intro claim "this is the start"? |
+|---|---|
+| `byChannel[id] === "loading"` | No — the request is in flight. |
+| `byChannel[id] === "ready"` | Yes. Settled, including a host that answered with nothing or failed outright. |
+| No entry, `discovered === false` | No. The shell's pass has not reached this channel yet — `ChatView` resolves its own desk list independently, so it can paint a channel a moment before the shell marks it. |
+| No entry, `discovered === true` | Yes. The pass ran and did not claim it, so nothing is coming — a console-only teammate, or a host with no `chat/history`. Holding a spinner forever would be a worse lie than the one this prevents. |
+
+`AppShell` owns the map because it owns the fetches. A channel is marked
+`loading` *before* its request goes out, never after — the gap between "this
+channel exists" and "its history is in flight" is precisely the window the bug
+lived in.
+
+While a channel is pending and has no rows, `MessageTimeline` renders skeleton
+rows in place of the claim. The avatar and title above them still render: those
+state where you are, which is not a claim about history. Rows that arrived
+locally — a message sent before hydration landed — render immediately; only the
+assertion of emptiness waits.
 
 ## Membership
 
@@ -115,7 +146,7 @@ chart's desk level, since no desk can name a parent desk. See
 | `model.ts` | Channels, senders, timeline grouping, formatting. All pure. |
 | `ChannelRail.tsx` | The channel/DM list, with collapsible sections. |
 | `ChatHeader.tsx` | The bar above the timeline. |
-| `MessageTimeline.tsx` | The scroll body: day dividers, channel intro, typing row. |
+| `MessageTimeline.tsx` | The scroll body: day dividers, channel intro, loading skeleton, typing row. |
 | `MessageRow.tsx` | One line — avatar gutter, author, body, reactions, hover action bar. |
 | `MessageComposer.tsx` | The composer dock; also used compact in the thread panel. |
 | `ThreadPanel.tsx` | Replies to one message, with their own composer. |

--- a/frontend/src/views/chat/model.ts
+++ b/frontend/src/views/chat/model.ts
@@ -37,6 +37,60 @@ export function deskFromDto(d: DeskDto): Desk {
  */
 export type Transcripts = Record<string, ChatMessage[]>;
 
+/**
+ * How far a channel's persisted history has got, per channel.
+ *
+ * {@link Transcripts} cannot answer this on its own: an absent key and a key
+ * holding `[]` both read as "no messages", and the timeline coerces the two
+ * together the moment it does `transcripts[id] ?? []`. So "nobody has asked the
+ * host yet" is indistinguishable from "the host says this channel is empty",
+ * and the timeline printed the second while the first was true — the reload
+ * flash issue #934 describes.
+ */
+export type HistoryStatus = "loading" | "ready";
+
+export interface HistoryHydration {
+  /**
+   * Whether the desks/roster pass has finished marking every channel it is
+   * going to hydrate.
+   *
+   * Needed because `ChatView` resolves its own desk list independently of the
+   * shell's, and can therefore render a channel before the shell's pass has
+   * reached it. Without this, that window has no entry in `byChannel` and looks
+   * exactly like a channel nothing will ever hydrate.
+   */
+  discovered: boolean;
+  /** Channel id → whether its `chat/history` request has settled. */
+  byChannel: Record<string, HistoryStatus>;
+}
+
+/** Before a company's rehydration pass has begun: everything is still pending. */
+export const HISTORY_UNSTARTED: HistoryHydration = { discovered: false, byChannel: {} };
+
+/**
+ * No rehydration is happening or ever will — for a `ChatView` mounted without a
+ * shell behind it. The distinction from {@link HISTORY_UNSTARTED} is the whole
+ * point: this one resolves every channel to "ready", so a caller that does not
+ * track hydration renders exactly as it did before, rather than spinning on a
+ * pass that is never coming.
+ */
+export const HISTORY_UNTRACKED: HistoryHydration = { discovered: true, byChannel: {} };
+
+/**
+ * Whether we know enough about `channelId` to state that it is empty.
+ *
+ * The three cases, and why the last one is `discovered` rather than `false`: a
+ * channel with a status answers for itself; a channel with none *after* the
+ * pass has run is one nothing will hydrate (a console-only teammate, a host
+ * with no `chat/history`), and holding a spinner on it forever is worse than
+ * the wrong claim this exists to prevent.
+ */
+export function historyReady(hydration: HistoryHydration, channelId: string): boolean {
+  const status = hydration.byChannel[channelId];
+  if (status) return status === "ready";
+  return hydration.discovered;
+}
+
 export type ChannelKind = "channel" | "dm";
 
 export interface Channel {

--- a/frontend/test/e2e/chat-channel-membership.spec.ts
+++ b/frontend/test/e2e/chat-channel-membership.spec.ts
@@ -226,9 +226,11 @@ test("#370 an unknown channel opens the first one and says so", async ({ page })
   await mockApi(page, () => "ok");
   await openChannel(page, "does-not-exist");
 
-  const notice = page.getByRole("status");
+  // Scoped to the notice rather than "the page's one status region": the
+  // timeline raises a second one while a channel's history is still loading
+  // (issue #934), and an unqualified `getByRole("status")` matches both.
+  const notice = page.getByRole("status").filter({ hasText: /isn't a channel here/ });
   await expect(notice).toContainText("#does-not-exist");
-  await expect(notice).toContainText("isn't a channel here");
   await expect(notice).toContainText("#engineering");
   // The hash is left alone deliberately — rewriting it needs replace-semantics
   // the shell does not thread through yet, and a push would fight the back
@@ -237,7 +239,7 @@ test("#370 an unknown channel opens the first one and says so", async ({ page })
 
   // It is derived from the hash, so navigating clears it with no dismiss.
   await page.getByRole("complementary").first().getByRole("button", { name: /content/i }).click();
-  await expect(page.getByRole("status")).toHaveCount(0);
+  await expect(notice).toHaveCount(0);
 });
 
 test("#370 a broken /desks is a retryable error, not invented channels", async ({ page }) => {

--- a/frontend/test/e2e/chat-history-loading.spec.ts
+++ b/frontend/test/e2e/chat-history-loading.spec.ts
@@ -1,0 +1,157 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * End-to-end proof for issue #934 — a channel never claims to be empty before
+ * the host has said so.
+ *
+ * Reloading a DM that had history rendered "This is the start of your direct
+ * message with …" and no messages, for as long as `chat/history` took to
+ * answer. Nothing was lost — switching away and back showed the full thread —
+ * but the copy is a positive claim about an empty channel, and an operator has
+ * no way to tell a false one from real data loss.
+ *
+ * # Why this is an e2e spec and not a unit test
+ *
+ * `historyReady()` — the decision itself — *is* unit-tested, in
+ * `test/unit/chat-history-hydration.test.ts`. What cannot be tested there is
+ * the thing that actually broke: two independent fetches (`ChatView`'s own desk
+ * list, `AppShell`'s hydration pass) racing to paint a pane. That race only
+ * exists in a browser with a real host behind it, and the bug lived precisely
+ * in the window between them.
+ *
+ * # Why the host's history is delayed rather than merely slow
+ *
+ * The defect is a timing window, and a timing window observed by luck is a
+ * flaky test in both directions — it passes on a fast loopback host whether or
+ * not the fix is present. So the DM's `chat/history` is held open on a latch
+ * the test opens by hand: the loading state is asserted while the request is
+ * provably still in flight, and the settled state after it provably is not.
+ * Every other channel's history is left completely alone, which also proves the
+ * hold is per channel and not a pane-wide freeze.
+ *
+ * Like the rest of `test/e2e` this drives a running host — see
+ * `playwright.config.ts`.
+ */
+
+/** The harness roster's agent ids double as their DM thread ids. */
+const TEAMMATE = "engineer";
+/** …and a DM's console-local channel id is `dm:<teammate id>` (issue #364). */
+const DM_CHANNEL = `dm:${TEAMMATE}`;
+
+/** The claim under test. It must not appear until the host has justified it. */
+const EMPTY_CLAIM = /This is the start of your direct message/;
+
+/**
+ * The first-run product tour renders a modal over the console and swallows
+ * every click beneath it. Answer "already skipped" for whatever company id the
+ * host resolves to rather than hard-coding the harness's.
+ */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+/**
+ * Hold this one teammate's `chat/history` open, and answer it with `messages`
+ * only when the returned latch is called.
+ *
+ * Matching on the `desk` query parameter is what keeps the hold surgical: the
+ * shell fires one of these per channel on load, and delaying all of them would
+ * prove nothing about which pane was waiting for which answer.
+ */
+async function holdHistory(page: Page, threadId: string, messages: unknown[]) {
+  let release!: () => void;
+  const latch = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  let seen = false;
+  await page.route(
+    (url) =>
+      url.pathname.endsWith("/chat/history") &&
+      url.searchParams.get("desk") === threadId,
+    async (route) => {
+      seen = true;
+      await latch;
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(messages),
+      });
+    },
+  );
+  return {
+    /** Resolves once the console has actually asked for this channel's history. */
+    requested: async () => {
+      await expect.poll(() => seen, { timeout: 30_000 }).toBe(true);
+    },
+    release: () => release(),
+  };
+}
+
+/** One journaled line, in the shape `GET .../chat/history` returns. */
+function line(seq: number, from: "operator" | "agent", text: string) {
+  return {
+    seq,
+    id: String(seq),
+    role: from === "operator" ? "user" : "assistant",
+    author: from === "operator" ? "operator" : TEAMMATE,
+    text,
+    at: "2026-08-17T09:00:00Z",
+    desk: TEAMMATE,
+  };
+}
+
+test("a reloaded DM waits for its history instead of calling itself new", async ({ page }) => {
+  const history = await holdHistory(page, TEAMMATE, [
+    line(1, "operator", "Where did we land on the migration?"),
+    line(2, "agent", "Behind the flag, shipping Thursday."),
+  ]);
+
+  await page.goto(`/#/chat/${DM_CHANNEL}`);
+
+  // The pane is up — composer rendered, channel resolved — and the history it
+  // is going to render is still on the wire. This is the exact moment the bug
+  // was visible.
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+  await history.requested();
+
+  // The whole issue, in one assertion.
+  await expect(page.getByText(EMPTY_CLAIM)).toHaveCount(0);
+  // And something says so, rather than the pane just sitting blank.
+  await expect(page.getByRole("status").filter({ hasText: /Loading messages/ })).toBeVisible();
+
+  history.release();
+
+  await expect(page.getByText("Behind the flag, shipping Thursday.")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(page.getByText("Where did we land on the migration?")).toBeVisible();
+  await expect(page.getByRole("status").filter({ hasText: /Loading messages/ })).toHaveCount(0);
+  // The intro line DOES come back here, and that is correct: it sits above the
+  // first message as the top of the scroll — see `ChannelIntro`. Standing over
+  // a rendered thread it reads as "you are at the beginning", which is true.
+  // What made it a lie was standing alone over nothing, which is the assertion
+  // before the release above.
+  await expect(page.getByText(EMPTY_CLAIM)).toBeVisible();
+});
+
+test("a DM the host reports empty does say it is the start", async ({ page }) => {
+  // The other half of the fix, and the one a naive "just never show the copy"
+  // would break: an empty answer is still an answer. Without this, the guard
+  // could regress into a spinner that never resolves and no test would notice.
+  const history = await holdHistory(page, TEAMMATE, []);
+
+  await page.goto(`/#/chat/${DM_CHANNEL}`);
+  await expect(page.getByPlaceholder(/^Message /)).toBeVisible({ timeout: 30_000 });
+  await history.requested();
+  await expect(page.getByText(EMPTY_CLAIM)).toHaveCount(0);
+
+  history.release();
+
+  await expect(page.getByText(EMPTY_CLAIM)).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole("status").filter({ hasText: /Loading messages/ })).toHaveCount(0);
+});

--- a/frontend/test/unit/chat-history-hydration.test.ts
+++ b/frontend/test/unit/chat-history-hydration.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  HISTORY_UNSTARTED,
+  HISTORY_UNTRACKED,
+  historyReady,
+  type HistoryHydration,
+} from "@/views/chat/model";
+
+/**
+ * The question issue #934 was filed over: may the timeline say this channel is
+ * empty?
+ *
+ * The bug was not a rendering mistake — it was that nothing could answer this.
+ * `Transcripts` maps a channel to `ChatMessage[]`, and `transcripts[id] ?? []`
+ * turns "nobody has asked the host yet" into "the host says there is nothing",
+ * so a reloaded DM with months of history rendered the copy that only belongs
+ * on a channel that has never been used.
+ *
+ * These cases are the whole contract. Each is a state the console genuinely
+ * reaches, and getting any of them wrong costs the operator something specific:
+ * a false claim of emptiness (which reads as data loss) or a spinner that never
+ * resolves (which reads as a hang).
+ */
+
+function hydration(over: Partial<HistoryHydration> = {}): HistoryHydration {
+  return { discovered: false, byChannel: {}, ...over };
+}
+
+describe("whether a channel may be called empty", () => {
+  it("holds while the channel's history request is in flight", () => {
+    const h = hydration({ discovered: true, byChannel: { "dm:pm": "loading" } });
+    expect(historyReady(h, "dm:pm")).toBe(false);
+  });
+
+  it("releases once the request has settled", () => {
+    const h = hydration({ discovered: true, byChannel: { "dm:pm": "ready" } });
+    expect(historyReady(h, "dm:pm")).toBe(true);
+  });
+
+  it("holds before the rehydration pass has reached the channel", () => {
+    // The window that made the bug reachable at all: `ChatView` resolves its
+    // own desk list independently of the shell's, so it can paint a channel
+    // the shell's pass has not marked yet. No entry here does NOT mean
+    // "nothing is coming" — it means "ask again in a moment".
+    expect(historyReady(hydration({ byChannel: { other: "ready" } }), "dm:pm")).toBe(false);
+  });
+
+  it("releases an unknown channel once the pass has finished marking", () => {
+    // A console-only teammate, or a host whose roster never named this channel:
+    // the pass ran and did not claim it, so nothing will ever hydrate it.
+    // Waiting forever would be a worse lie than the one this prevents.
+    const h = hydration({ discovered: true, byChannel: { other: "ready" } });
+    expect(historyReady(h, "dm:ghost")).toBe(true);
+  });
+
+  it("holds every channel before a company's pass begins", () => {
+    expect(historyReady(HISTORY_UNSTARTED, "dm:pm")).toBe(false);
+    expect(historyReady(HISTORY_UNSTARTED, "main")).toBe(false);
+  });
+
+  it("releases every channel when nothing is tracking hydration", () => {
+    // A `ChatView` mounted without the shell behind it: there is no pass to
+    // wait for, so it must render exactly as it did before this existed.
+    expect(historyReady(HISTORY_UNTRACKED, "dm:pm")).toBe(true);
+    expect(historyReady(HISTORY_UNTRACKED, "main")).toBe(true);
+  });
+
+  it("keeps a settled channel settled while a sibling is still loading", () => {
+    // Per channel, not per pass — the operator should not wait on #general for
+    // a DM that already answered.
+    const h = hydration({
+      discovered: true,
+      byChannel: { main: "ready", "dm:pm": "loading" },
+    });
+    expect(historyReady(h, "main")).toBe(true);
+    expect(historyReady(h, "dm:pm")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #934 — reloading a DM with history rendered "This is the start of your direct message with …" and no messages until `chat/history` answered. Nothing was lost, but the copy is a positive claim that the thread is empty, and an operator has no way to tell a false one from real data loss.

## Root cause

The console could not tell the two states apart. `Transcripts` is `Record<string, ChatMessage[]>`, and the timeline reads it as:

```ts
const messages = channel ? (transcripts[channel.id] ?? []) : [];
```

That `??` collapses *nobody has asked the host yet* into *the host says this channel is empty*. `ChannelIntro` then renders the claim off `items.length === 0`, so it printed the second while the first was true.

The window is wide enough to notice because DM history is three round-trips deep on a cold load — `listDesks` → `await listTeam` → one `getChatHistory` per channel — while `ChatView` gates its render on `desks` only, and knows nothing about hydration happening in the shell above it. Switching away and back "fixed" it only because hydration had completed in the background; the shell never unmounts, so the return trip renders state that had already arrived.

An empty answer is a legitimate final state, so this cannot be derived from the transcripts alone. It needs a fact that was not being recorded.

## The fix

`HistoryHydration` + `historyReady()` in `views/chat/model.ts` — per-channel status, owned by `AppShell` because `AppShell` owns the fetches. A channel is marked `loading` **before** its request goes out, and `ready` on every settle path: a normal answer, the `entries.length === 0` early return, and the `.catch`.

| State | May the intro claim "this is the start"? |
|---|---|
| `loading` | No — the request is in flight. |
| `ready` | Yes. Settled, including an empty answer or an outright failure. |
| No entry, pass unfinished | No. `ChatView` resolves its own desk list independently of the shell's, so it can paint a channel a moment before the shell marks it. |
| No entry, pass finished | Yes. Nothing will hydrate it — a console-only teammate, or a host with no `chat/history`. A permanent spinner would be a worse lie than the one this prevents. |

While a channel is pending with no rows, `MessageTimeline` renders skeleton rows under `role="status"` and drops the claim sentence. The avatar and title stay — those say *where you are*, which is not an assertion about history. Locally-sent rows still render immediately; only the claim of emptiness waits.

The `hydration` prop is optional and defaults to "untracked", so a `ChatView` mounted without a shell behind it renders exactly as before rather than spinning on a pass that is never coming.

## Commands run locally

- `npm run typecheck` / `typecheck:unit` / `typecheck:e2e` — clean
- `npx vitest run` — 804 passed
- `npx playwright test` against a host built from this branch — **104 passed, 14 skipped, 0 failed** (the whole suite, not only the chat specs)

**The new e2e specs were confirmed load-bearing**: with the fix disabled, both fail; restored, both pass. A timing bug observed by luck passes whether or not it is fixed, so the DM's `chat/history` is held open on a hand-released latch rather than merely being slow — the loading state is asserted while the request is provably in flight, and the settled state after it provably is not. Every other channel's history is left alone, which also proves the hold is per channel and not a pane-wide freeze.

## Tests

- `frontend/test/unit/chat-history-hydration.test.ts` — 7 cases over `historyReady()`, one per state the console actually reaches.
- `frontend/test/e2e/chat-history-loading.spec.ts` — the race itself, which only exists in a browser with a real host behind it. The second spec covers the inverse: a genuinely empty DM **does** get the copy once the host answers, so the fix cannot regress into a spinner that never resolves without a test noticing.

## One regression this caught, and fixed

The full run surfaced a real break in `chat-channel-membership.spec.ts`: the skeleton is a second `role="status"` region, so the spec's unqualified `getByRole("status")` started resolving to two elements and failed on strict mode.

That locator meant *the unknown-channel notice* and only worked because the notice happened to be the sole live region on the page. It now says so — including the closing `toHaveCount(0)`, which asserted the notice was gone and would otherwise have started asserting the skeleton was gone too. Second commit, kept separate from the fix.

## Behaviour changes

None to any API. One deliberate rendering change: the intro's claim sentence is replaced by the channel's plain purpose line while history is pending. The intro still renders above a full thread as it always has — standing over rendered messages it reads as "you are at the beginning", which is true; what made it a lie was standing alone over nothing.

## Notes

Docs updated in `frontend/src/views/chat/README.md` (new "Empty, or not answered yet" section).

One adjacent bug with the same root — `ChatView` gates on `desks` but not on its own roster load, so a `#/chat/dm:…` deep link can briefly compute `unknownChannel` truthy before `members` lands — is deliberately **not** included here, since it is a different symptom from what #934 reports. Happy to file it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
