### PR TITLE
fix(workflows): settle a run from history when its stream dies (#921)

### DIFF
--- a/frontend/src/views/WorkflowsView.tsx
+++ b/frontend/src/views/WorkflowsView.tsx
@@ -1115,9 +1115,25 @@ export function WorkflowsView({
     };
   }, [runs, runsFor, selectedId]);
 
+  // Issue #921: the runs the HOST reports as no longer in flight. This is the
+  // only authority that survives a dead stream — the `workflow_run_finished`
+  // frame the fold would otherwise wait on is precisely the one that goes
+  // missing when the console stops updating mid-run.
+  //
+  // Scoped to the selected workflow's own history for the same reason
+  // `inFlightSeed` is: a run id is unique, but a list read for another workflow
+  // cannot contain this run anyway, and pairing the two guards keeps one rule
+  // rather than two.
+  const settledRunIds = useMemo(() => {
+    if (!selectedId || runsFor !== selectedId) return undefined;
+    const ids = new Set<string>();
+    for (const r of runs) if (r.runId && !r.running) ids.add(r.runId);
+    return ids;
+  }, [runs, runsFor, selectedId]);
+
   const liveRun = useMemo(
-    () => foldLiveRun(runEvents, selectedId, graph, inFlightSeed),
-    [runEvents, selectedId, graph, inFlightSeed],
+    () => foldLiveRun(runEvents, selectedId, graph, inFlightSeed, settledRunIds),
+    [runEvents, selectedId, graph, inFlightSeed, settledRunIds],
   );
 
   // The optimistic frontier is only for the gap before the first frame. Once
@@ -1181,11 +1197,25 @@ export function WorkflowsView({
   // Polling stops on its own: the effect above clears `activeRunId` the moment
   // a settled row lands, and that unmounts this interval. With a working stream
   // the live fold clears it first, so at most one extra fetch is spent.
+  //
+  // Issue #921: it polls while the CANVAS believes a run is walking too, not
+  // only while `activeRunId` is set. Those are different states, and the gap
+  // between them is this bug: `activeRunId` is only ever adopted for a run this
+  // console STARTED (the `starting` guard above), so a run being watched — a
+  // cron fire, a run started from chat, a run adopted from history after a
+  // reload — polled nothing. When its stream then died mid-run there was no
+  // frame to settle the fold and no poll to correct it, so the canvas kept a
+  // node pulsing and the header kept reading "running" until someone reloaded.
+  //
+  // Same self-limiting shape as before: `settledRunIds` clears `liveRun.active`
+  // on the first settled row, which unmounts this interval. With a working
+  // stream the finish frame gets there first and this costs at most one fetch.
+  const watchingRun = Boolean(activeRunId) || Boolean(liveRun?.active);
   useEffect(() => {
-    if (!activeRunId || !historySupported) return;
+    if (!watchingRun || !historySupported) return;
     const timer = window.setInterval(() => setRunsTick((n) => n + 1), 2_000);
     return () => window.clearInterval(timer);
-  }, [activeRunId, historySupported]);
+  }, [watchingRun, historySupported]);
 
   // Switching workflow (or company) clears the canvas: another graph's node ids
   // are meaningless here, and a stale mark on a same-named node would be a lie.

--- a/frontend/src/views/workflows/graph.ts
+++ b/frontend/src/views/workflows/graph.ts
@@ -74,12 +74,27 @@ export interface InFlightRun {
  * not a partial trail, nothing — for the whole run, because the fold's only
  * way to learn a run's id was a `workflow_run_started` frame it had missed.
  * The window still wins when it has a start of its own: a live start is newer
- * than any history read, and a rerun must supersede the run before it. */
+ * than any history read, and a rerun must supersede the run before it.
+ *
+ * Issue #921: `settledRunIds` is the one thing the window does NOT get to win.
+ * A run is active here only while NO `workflow_run_finished` frame for it has
+ * arrived — so a stream that dies mid-run leaves the fold reporting `active`
+ * forever, with the node it was on stuck pulsing and the header still reading
+ * "running" three minutes after the host finished. The frame that would clear
+ * it is exactly the one that did not arrive, so waiting for it is waiting for
+ * the thing that broke.
+ *
+ * The host's run history is the authority on *settled*, and it is reachable by
+ * polling rather than by a frame: a run the host lists as no longer `running`
+ * IS finished, whatever the window still shows. The reported ok/error marks
+ * survive — `settle` only clears the orphaned `running` ones — so the canvas
+ * keeps its honest "how far did it get?" answer rather than blanking. */
 export function foldLiveRun(
   events: CompanyStreamEvent[],
   selectedId: string | null,
   graph: WorkflowGraph | null,
   inFlight?: InFlightRun | null,
+  settledRunIds?: ReadonlySet<string>,
 ): LiveRun | null {
   if (!selectedId || !graph) return null;
 
@@ -93,7 +108,9 @@ export function foldLiveRun(
     }
   }
   if (startIndex === -1)
-    return inFlight ? foldFromHistory(events, graph, inFlight) : null;
+    return inFlight
+      ? foldFromHistory(events, graph, inFlight, settledRunIds)
+      : null;
   const started = events[startIndex];
   if (started.type !== "workflow_run_started") return null;
 
@@ -104,14 +121,9 @@ export function foldLiveRun(
   // host from here (#382), not derived.
   const states = initialRunState(graph);
   const elapsed: Record<string, number> = {};
-  const active = applyFrames(
-    events,
-    startIndex + 1,
-    runId,
-    selectedId,
-    states,
-    elapsed,
-  );
+  const active =
+    applyFrames(events, startIndex + 1, runId, selectedId, states, elapsed) &&
+    !settledRunIds?.has(runId);
 
   settle(states, active);
   return { runId, states, elapsed, active, scheduled };
@@ -131,6 +143,7 @@ function foldFromHistory(
   events: CompanyStreamEvent[],
   graph: WorkflowGraph,
   inFlight: InFlightRun,
+  settledRunIds?: ReadonlySet<string>,
 ): LiveRun {
   const states = { ...initialRunState(graph), ...inFlight.states };
   const elapsed = { ...inFlight.elapsed };
@@ -139,7 +152,9 @@ function foldFromHistory(
   // (no run id) is deliberately NOT honoured here — with no start frame to pair
   // it with, "the run on screen" is a guess, and guessing a run settled would
   // clear a live node on a console that is watching it correctly.
-  const active = applyFrames(events, 0, inFlight.runId, null, states, elapsed);
+  const active =
+    applyFrames(events, 0, inFlight.runId, null, states, elapsed) &&
+    !settledRunIds?.has(inFlight.runId);
 
   settle(states, active);
   return {

--- a/frontend/test/unit/workflow-live-run.test.ts
+++ b/frontend/test/unit/workflow-live-run.test.ts
@@ -273,3 +273,89 @@ describe("workflow_node_started routing", () => {
     expect(subs.onWorkspaceEvent).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * Issue #921: a finished run still reads as running.
+ *
+ * The fold clears `active` on one signal only — a `workflow_run_finished` frame
+ * for the run it is following. When the stream dies mid-run that frame never
+ * arrives, so the canvas keeps a node pulsing and the header keeps saying
+ * "running" long after the host is done; three QA reports were filed as engine
+ * hangs on the strength of it, and only a reload ever corrected the view.
+ *
+ * The host's run history is the authority that survives a dead stream: a run it
+ * no longer lists as `running` IS settled, whatever the frame window shows. The
+ * console polls that list, so this is reachable without the broken stream.
+ */
+describe("a run settles from the host's history when its stream dies", () => {
+  /** The window a dropped stream leaves behind: the run started, the agent node
+   * started, and then nothing — no finish for the node, none for the run. */
+  const truncated: Ev[] = [start("r1"), nodeStarted("r1", "ceo")];
+
+  it("stays active on the frames alone — the state the bug reports", () => {
+    const live = foldLiveRun(truncated, "greet", GRAPH);
+    expect(live?.active).toBe(true);
+    expect(live?.states.ceo).toBe("running");
+  });
+
+  it("settles once the host lists the run as no longer running", () => {
+    const live = foldLiveRun(truncated, "greet", GRAPH, null, new Set(["r1"]));
+    expect(live?.active).toBe(false);
+  });
+
+  it("clears the orphaned running mark but keeps what was reported", () => {
+    const window: Ev[] = [
+      start("r1"),
+      nodeStarted("r1", "ceo"),
+      nodeFinished("r1", "ceo", "ok"),
+      nodeStarted("r1", "done"),
+    ];
+    const live = foldLiveRun(window, "greet", GRAPH, null, new Set(["r1"]));
+    expect(live?.active).toBe(false);
+    // The node the run died on stops pulsing…
+    expect(live?.states.done).toBeUndefined();
+    // …and the honest "how far did it get?" answer survives.
+    expect(live?.states.ceo).toBe("ok");
+  });
+
+  it("a run the host still lists as running is left alone", () => {
+    const live = foldLiveRun(truncated, "greet", GRAPH, null, new Set(["other"]));
+    expect(live?.active).toBe(true);
+    expect(live?.states.ceo).toBe("running");
+  });
+
+  // The dispatch's other half: a fix that repairs "finished" but not "failed"
+  // is half a fix. The host settles a run the same way whatever became of it —
+  // failed, cancelled or denied all stop being `running` — so the reconciliation
+  // must not be keyed on a successful outcome.
+  it("settles a run that ended badly, not only a clean one", () => {
+    const failed: Ev[] = [
+      start("r1"),
+      nodeStarted("r1", "ceo"),
+      nodeFinished("r1", "ceo", "error"),
+      nodeStarted("r1", "done"),
+    ];
+    const live = foldLiveRun(failed, "greet", GRAPH, null, new Set(["r1"]));
+    expect(live?.active).toBe(false);
+    expect(live?.states.ceo).toBe("error");
+    expect(live?.states.done).toBeUndefined();
+  });
+
+  it("settles a run adopted from history rather than from a start frame", () => {
+    // No start frame in the window at all (issue #863's path) — a console that
+    // joined mid-run and then lost the stream is the worst case, because it has
+    // neither a start frame nor a finish one.
+    const seed = {
+      runId: "r1",
+      states: { ceo: "ok" as const },
+      elapsed: { ceo: 5 },
+      scheduled: false,
+    };
+    const stillRunning = foldLiveRun([], "greet", GRAPH, seed);
+    expect(stillRunning?.active).toBe(true);
+
+    const live = foldLiveRun([], "greet", GRAPH, seed, new Set(["r1"]));
+    expect(live?.active).toBe(false);
+    expect(live?.states.ceo).toBe("ok");
+  });
+});


### PR DESCRIPTION
## Summary

A workflow run completes on the server and the console never learns it finished: the header keeps
reading `Manual run running`, the canvas keeps half-filled badges, and only a reload reconciles it.
Three QA reports were filed as engine hangs on the strength of this. The engine was fine each time.

**This is entirely console-side.** The backend was cleared before anything was changed: `runner.rs`
journals all four run events, `project_event` in `src/server/operator.rs` projects
`workflow_run_finished` including its `error` and `cancelled` arms, and the SSE endpoint sets a 15s
keep-alive so a proxy idle timeout does not kill the stream.

### Why it happens, in two halves

**1. The fold clears `active` on exactly one signal** — a `workflow_run_finished` frame for the run it
is following. If the stream drops mid-run that frame never arrives, so `foldLiveRun` reports the run
active forever: the node it was on keeps pulsing, and the header keeps saying "running".

Waiting for `workflow_run_finished` is waiting for the thing that broke.

**2. Nothing re-reads the history to correct it.** The history refetch fires on `runsTick` /
`runEventTick`. `runEventTick` bumps *only* on a `workflow_run_finished` frame — the same missing
frame. And `runsTick`'s 2s poll was gated on `activeRunId`, which is only ever adopted for a run
**this console started** (the `starting` guard in the #528 effect). So a run merely being *watched* —
a cron fire, a run started from chat, a run adopted from history after a reload — polled nothing at
all. This half is easy to miss, and without it the first half cannot recover.

### The detail that pins the diagnosis

**A reload fixes it because a fresh mount has an empty frame window.** With no frames, `foldLiveRun`
falls to `startIndex === -1` and re-seeds the canvas from the run history (#863's path) — which is
exactly the reconciliation route the live console had locked itself out of. The view was never
missing the data; it was refusing to go and read it.

### The fix

`foldLiveRun` now takes the set of run ids the host no longer lists as `running` and settles on that.
The host's run history is the authority on *settled*, and it is reachable by polling rather than by a
frame, which is what makes it survive a dead stream. The reported ok/error marks survive — `settle`
only clears the orphaned `running` ones — so the canvas keeps its honest "how far did it get?" answer
rather than blanking.

The poll that feeds it now runs while the canvas believes a run is walking, not only while
`activeRunId` is set, and stops the moment a settled row lands.

Settling is keyed on the host's `running` flag rather than on a successful outcome, so **a run that
failed, was cancelled, or was denied reconciles by the same path as a clean one** — there is a test
for that specifically, because a fix that repaired "finished" but not "failed" would be half a fix.

Closes #921

## API Or Behavior Changes

- `foldLiveRun` gains a fifth optional parameter, `settledRunIds?: ReadonlySet<string>`. Optional and
  additive: every existing call site and test compiles unchanged, and omitting it preserves the old
  behaviour exactly.
- The Workflows view now polls `…/workflows/runs` every 2s while the canvas shows a run walking, where
  it previously polled only for a run this console started. **Accepted cost:** a cron or chat-started
  run being watched now polls where it did not before. Bounded by the run's duration and self-limiting
  — the first settled row clears `liveRun.active` and unmounts the interval. With a working stream the
  finish frame still gets there first, so it usually costs at most one extra fetch.
- No API surface, route, or wire shape changed. No Rust changed.

## Tests

Frontend-only change, so the four Rust commands below are genuinely not applicable — this PR touches
zero `.rs` files. What was actually run, from `frontend/`:

- `pnpm test` — **821 passed (77 files)**, including 6 new cases
- `pnpm typecheck` (`tsc -b --noEmit`) — exit 0
- `npx prettier --check` on the changed files

**Revert check (fleet standard):** with the reconciliation reverted but the signature kept, **4 of the
6 new tests fail**. The other two pass either way *by design* and are not counted as coverage — one
pins the bug's precondition (a truncated window stays `active`), the other guards against a false
positive (a run the host still lists as running is left alone). Naming them here rather than implying
6/6.

The 4 that fail on revert cover: settling from the host's settled set with no finish frame; clearing
the orphaned `running` mark while keeping reported marks; settling a run that ended in `error`; and
settling a run adopted from history rather than from a start frame.

**Limitation, stated plainly:** browser automation was unavailable, so **I did not drive the staging
console**. This diagnosis and fix come from reading the code and from the reproduction detail in the
issue. The reload behaviour described above is derived from the code path, not observed by me on
staging.

- [x] `cargo fmt --all -- --check` — N/A, frontend-only change; no `.rs` file is touched.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A, frontend-only change; no `.rs` file is touched.
- [x] `cargo build --all-targets` — N/A, frontend-only change; no `.rs` file is touched.
- [x] `cargo test` — N/A, frontend-only change; no `.rs` file is touched. Frontend suite run instead: `pnpm test`, 821 passed.

## Documentation

No doc change needed: this restores the behaviour `docs/spec/runtime/hub-console.md` already
describes (the console reconciling off the run-events stream), rather than changing it. The reasoning
lives next to the code it constrains — the `foldLiveRun` doc comment and the two call-site comments
in `WorkflowsView.tsx` both name issue #921 and say why the host outranks the frame window.

### Two adjacent defects found and deliberately left out of scope

Both are real and neither is fixed here; each wants its own issue.

1. **Silent SSE frame loss.** `Err(broadcast::error::RecvError::Lagged(_)) => continue` in all three
   stores (`src/store/sqlite.rs`, `fs.rs`, `mongodb.rs`) drops frames with no signal to either end.
   That is a plausible *source* of the missing finish frame. This PR makes the console recover
   whatever the cause; it does not make the drop visible.
2. **`running: true` can be permanent server-side.** Per the note at `src/server/ops/workflows.rs`
   (`a_dropped_connection_does_not_cancel_a_synchronous_run`), if `WorkflowRunFinished` is never
   journaled the runs fold reports `running: true` forever and `sweep_interrupted_runs` is boot-only.
   This fix cannot help there — the history itself would be wrong.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflow runs now correctly transition to an inactive state when history confirms completion, even if a completion event is unavailable.
  * Active run status is updated for locally started, scheduled, and externally started workflows.
  * Completed and failed node states are preserved while stale running indicators are cleared.

* **Tests**
  * Added coverage for truncated, completed, failed, and history-adopted workflow runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->