### PR TITLE
Report a missing path as not-found, not as a missing app

### DIFF
--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -67,6 +67,7 @@ export type TurnStepFailure =
   | "unauthorized"
   | "missing_permission"
   | "missing_app"
+  | "not_found"
   | "timeout"
   | "unavailable"
   | "failed";
@@ -115,6 +116,7 @@ export const STEP_FAILURE_LABEL: Record<TurnStepFailure, string> = {
   unauthorized: "Unauthorized",
   missing_permission: "Missing permission",
   missing_app: "App unavailable",
+  not_found: "Not found",
   timeout: "Timed out",
   unavailable: "Service unavailable",
   failed: "Failed",

--- a/src/harness/steps.rs
+++ b/src/harness/steps.rs
@@ -65,6 +65,14 @@
 //! * **Result on failure** is the classifier's plain-language
 //!   [`cause_plain`](oh::tools::status::ClassifiedFailure::cause_plain), or an
 //!   intrinsic tool's own message — never the remote error text.
+//! * **One upstream verdict is re-read** (issue #924). `ENOENT` is the same
+//!   operating-system error whether a binary is not installed or a file is not
+//!   there, and upstream classifies on message text alone, so it calls both
+//!   [`MissingApp`](oh::tools::status::ToolFailureClass::MissingApp) — telling a
+//!   server operator to "install or open the app" when a note is simply absent.
+//!   For a tool that resolves a path in this process there is no app to install,
+//!   so [`PATH_ONLY_TOOLS`] names those and [`refine_missing_app`] reports
+//!   [`TurnStepFailure::NotFound`] instead. Nothing else is re-classified.
 //!
 //! The unit test `planted_secret_never_reaches_serialized_steps` proves it end
 //! to end: a secret planted in a tool's output, its nested arguments, and its
@@ -667,11 +675,13 @@ fn complete(
         None => oh::tools::status::classify(output, false),
     };
 
+    let (failure, cause_override) = refine_missing_app(tool_name, &classified);
+
     Completed {
         status: TurnStepStatus::Error,
         detail,
-        result: failure_result(tool_name, output, &classified),
-        failure: Some(failure_of(classified.class)),
+        result: failure_result(tool_name, output, &classified, cause_override),
+        failure: Some(failure),
         truncated: false,
     }
 }
@@ -694,6 +704,70 @@ fn failure_of(class: ToolFailureClass) -> TurnStepFailure {
         }
         ToolFailureClass::Unknown => TurnStepFailure::Failed,
     }
+}
+
+/// Tools that resolve a caller-supplied path **in this process** and can never
+/// invoke an external program.
+///
+/// The list exists because one operating-system error means two different
+/// things. `ENOENT` — "No such file or directory (os error 2)" — is what the
+/// kernel says both when a binary you tried to spawn is not installed and when
+/// a file you tried to read is not there. Upstream's classifier sees only the
+/// message text, so it routes every `ENOENT` to
+/// [`ToolFailureClass::MissingApp`], whose remediation copy is "Install or open
+/// the app, then try again."
+///
+/// For a tool on this list there is no app to install: it opens a path and
+/// returns bytes. So its `ENOENT` is re-read as
+/// [`TurnStepFailure::NotFound`] here (issue #924, where `grep` on a company
+/// note path and `read_skill_resource` on an absent `references/` file both
+/// rendered as "App unavailable" on a server tenant with nothing installable).
+///
+/// **Keyed on the tool, not on the message.** Six of upstream's seven
+/// `MissingApp` needles ("command not found", "executable not found", …) name a
+/// program unambiguously; only the bare `ENOENT` string is shared. But sniffing
+/// for those needles cannot separate the cases either, because
+/// `Command::new(program)` on a missing binary yields the bare `ENOENT` with
+/// none of them — a genuinely missing `git` would then be relabelled a missing
+/// file. Which tool ran is the signal that actually distinguishes them.
+///
+/// **Under-inclusive by design.** A path tool missing from this list keeps
+/// today's behaviour rather than gaining a new wrong one, so the failure mode of
+/// drift is a stale label, never a false `NotFound` on a real missing program.
+/// [`every_path_tool_on_the_belt_is_listed`] fails when the belt grows one this
+/// list does not name.
+const PATH_ONLY_TOOLS: &[&str] = &[
+    "file_read",
+    "file_write",
+    "edit",
+    "list",
+    "glob",
+    "grep",
+    crate::harness::skills::READ_SKILL_RESOURCE_TOOL,
+];
+
+/// Whether `tool_name` reads a path in-process, per [`PATH_ONLY_TOOLS`].
+fn is_path_only_tool(tool_name: &str) -> bool {
+    PATH_ONLY_TOOLS.contains(&tool_name)
+}
+
+/// Re-read a `MissingApp` verdict that came from a path tool as `NotFound`.
+///
+/// Returns the class to report and the plain-language cause to show, so the
+/// label and the sentence beside it can never disagree. Every other verdict is
+/// returned untouched — this narrows one misrouted class, it does not
+/// re-classify.
+fn refine_missing_app<'a>(
+    tool_name: &str,
+    classified: &'a ClassifiedFailure,
+) -> (TurnStepFailure, Option<&'a str>) {
+    if matches!(classified.class, ToolFailureClass::MissingApp) && is_path_only_tool(tool_name) {
+        return (
+            TurnStepFailure::NotFound,
+            Some("The file or folder this action asked for does not exist."),
+        );
+    }
+    (failure_of(classified.class), None)
 }
 
 /// Whether the model was handed OpenHuman's *approval-required* refusal by
@@ -721,12 +795,24 @@ fn output_was_truncated(output: &str) -> bool {
 /// problem ("a workflow needs exactly one trigger"), where the classifier can
 /// only offer a category. Everything else gets the classifier's `cause_plain`,
 /// never the raw output.
-fn failure_result(tool_name: &str, output: &str, classified: &ClassifiedFailure) -> Option<String> {
+///
+/// `cause_override` replaces `cause_plain` when this crate re-read the upstream
+/// verdict ([`refine_missing_app`]); it ranks below an intrinsic tool's own
+/// message for the same reason `cause_plain` does.
+fn failure_result(
+    tool_name: &str,
+    output: &str,
+    classified: &ClassifiedFailure,
+    cause_override: Option<&str>,
+) -> Option<String> {
     if INTRINSIC_TOOLS.contains(&tool_name) {
         let message = output.trim();
         if !message.is_empty() {
             return Some(truncate(message, RESULT_MAX));
         }
+    }
+    if let Some(cause) = cause_override {
+        return Some(cause.to_string());
     }
     let cause = classified.cause_plain.trim();
     (!cause.is_empty()).then(|| cause.to_string())
@@ -964,10 +1050,10 @@ mod tests {
                       failed (store_io).";
         let classified = oh::tools::status::classify(output, false);
 
-        let intrinsic = failure_result("workspace_read", output, &classified);
+        let intrinsic = failure_result("workspace_read", output, &classified, None);
         assert_eq!(intrinsic.as_deref(), Some(output));
 
-        let remote = failure_result("mcp_call_tool", output, &classified);
+        let remote = failure_result("mcp_call_tool", output, &classified, None);
         assert_eq!(remote.as_deref(), Some(classified.cause_plain.trim()));
         assert_ne!(
             remote.as_deref(),
@@ -1287,6 +1373,140 @@ mod tests {
         ] {
             assert_eq!(failure_of(class), expected, "class {class:?}");
         }
+    }
+
+    // -----------------------------------------------------------------------
+    // #924: a missing path is not a missing app
+    // -----------------------------------------------------------------------
+
+    /// The bare operating-system `ENOENT` string, which is what both tools in
+    /// issue #924 actually returned. Upstream's classifier routes this to
+    /// `MissingApp` on text alone.
+    const ENOENT: &str = "No such file or directory (os error 2)";
+
+    /// **The two failures issue #924 reports**, verbatim in the shape their
+    /// producers emit, driven end to end through the fold.
+    ///
+    /// `grep`'s comes from openhuman's `validate_path`, which joins the
+    /// caller's sub-path onto the agent's *own* workspace and canonicalizes it —
+    /// so a company note path like `Agents/…`, which the sandboxed file tools
+    /// cannot see, fails here rather than anywhere more informative.
+    /// `read_skill_resource`'s comes from its `symlink_metadata` pre-check on a
+    /// `references/` file that the skill does not bundle.
+    ///
+    /// Neither host has an app to install, which is what made "App unavailable"
+    /// unactionable on a server tenant.
+    #[test]
+    fn a_path_tools_missing_file_is_not_reported_as_a_missing_app() {
+        for (tool, output) in [
+            (
+                "grep",
+                format!("Failed to resolve path 'Agents/Product Manager/notes': {ENOENT}"),
+            ),
+            (
+                crate::harness::skills::READ_SKILL_RESOURCE_TOOL,
+                format!(
+                    "read_skill_resource: failed to stat resource \
+                     /data/companies/acme/skills/feature-spec/references/spec.md: {ENOENT}"
+                ),
+            ),
+        ] {
+            // Precondition: upstream really does call this a missing app, so
+            // this test is exercising the re-read and not a changed upstream.
+            assert!(
+                matches!(
+                    oh::tools::status::classify(&output, false).class,
+                    ToolFailureClass::MissingApp
+                ),
+                "upstream no longer calls `{tool}`'s ENOENT a missing app; \
+                 the re-read in `refine_missing_app` may be obsolete"
+            );
+
+            let step = one(tool, false, &output, None);
+            assert_eq!(
+                step.failure,
+                Some(TurnStepFailure::NotFound),
+                "`{tool}` reads a path in this process; there is nothing to install: {step:?}"
+            );
+            let result = step.result.expect("a failed step states its cause");
+            assert!(
+                result.contains("does not exist"),
+                "the cause must name the real problem: {result:?}"
+            );
+            assert!(
+                !result.to_lowercase().contains("install"),
+                "a server operator cannot install anything to fix a missing note: {result:?}"
+            );
+        }
+    }
+
+    /// The other half of the same `ENOENT`, and the reason this is keyed on the
+    /// tool rather than the message: `Command::new` on a binary that is not
+    /// installed yields the *same* string with none of upstream's
+    /// program-specific needles. `shell` can genuinely be missing an app, so its
+    /// verdict must survive untouched.
+    #[test]
+    fn a_missing_program_is_still_a_missing_app() {
+        for tool in ["shell", "git_operations", "apply_patch"] {
+            let step = one(
+                tool,
+                false,
+                &format!("failed to spawn `git`: {ENOENT}"),
+                None,
+            );
+            assert_eq!(
+                step.failure,
+                Some(TurnStepFailure::MissingApp),
+                "`{tool}` can invoke an external program, so its ENOENT may well \
+                 be a missing app and must not be relabelled: {step:?}"
+            );
+        }
+    }
+
+    /// The wire value the console keys on.
+    ///
+    /// `STEP_FAILURE_LABEL` in `frontend/src/api/types.ts` is a
+    /// `Record<TurnStepFailure, string>`, so TypeScript fails its own build if
+    /// the label is missing — but nothing checks that the *string* on each side
+    /// is the same one. This pins this side of that seam.
+    #[test]
+    fn not_found_serializes_as_the_snake_case_the_console_indexes_on() {
+        assert_eq!(
+            serde_json::to_value(TurnStepFailure::NotFound).expect("serializes"),
+            serde_json::json!("not_found")
+        );
+    }
+
+    /// **The drift guard.** [`PATH_ONLY_TOOLS`] is a `const`, so it is memory;
+    /// this derives the truth from the same constructor the belt uses
+    /// ([`crate::harness::build::file_tools`]) and fails when the belt grows a
+    /// path tool the list does not name.
+    ///
+    /// Without it the list rots silently: a new sandboxed file tool would go on
+    /// reporting "App unavailable" for a missing file and nothing would say so.
+    #[test]
+    fn every_path_tool_on_the_belt_is_listed() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let missing: Vec<String> = crate::harness::build::file_tools(dir.path())
+            .iter()
+            .map(|t| t.name().to_string())
+            .filter(|name| !PATH_ONLY_TOOLS.contains(&name.as_str()))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "these sandboxed file tools resolve a path in this process but are not in \
+             `PATH_ONLY_TOOLS`, so a missing file from them still renders as \
+             \"App unavailable\": {missing:?}"
+        );
+        // Vacuity guard: an empty belt would satisfy the filter above.
+        assert!(
+            PATH_ONLY_TOOLS.contains(&"grep"),
+            "`grep` is one of the two tools #924 is about"
+        );
+        assert!(
+            PATH_ONLY_TOOLS.contains(&crate::harness::skills::READ_SKILL_RESOURCE_TOOL),
+            "`read_skill_resource` is the other"
+        );
     }
 
     /// An unauthorized call reads as unauthorized end to end — through the fold,

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -2279,7 +2279,20 @@ pub enum TurnStepFailure {
     /// The host lacks an operating-system permission the call needed.
     MissingPermission,
     /// A program or application the call needed is not available.
+    ///
+    /// Only ever claimed for a call that could actually invoke an external
+    /// program. A path-reading tool that runs in this process has no app to
+    /// install, so its "not there" is [`NotFound`](Self::NotFound) — see
+    /// [`crate::harness::steps`] (issue #924).
     MissingApp,
+    /// The file, folder, or bundled resource the call named does not exist.
+    ///
+    /// Distinct from [`MissingApp`](Self::MissingApp) because the remedy is
+    /// different in kind: a missing path is fixed by naming a different path,
+    /// not by installing software. Both arrive as one `ENOENT` from the
+    /// operating system, and telling a server operator to "install or open the
+    /// app" when a note is simply absent is unactionable (issue #924).
+    NotFound,
     /// The call ran past its deadline and was stopped.
     Timeout,
     /// A service the call depends on — an upstream API, or the model provider —


### PR DESCRIPTION
## Summary

**The title invites the wrong fix.** Nothing here is unwired, and nothing needed wiring.

`grep` and `read_skill_resource` are both **on the belt**, both **declared in
`policy::consequence`**, and both **refused correctly**. Only the *verdict* on their refusal was
wrong. A reviewer arriving expecting a wiring change will not find one.

### What actually happens

`ENOENT` is the same operating-system error whether a binary is not installed or a file is not
there. `src/openhuman/tools/status/ops.rs`'s `classify()` keys on message text alone, and **rule 5
carries a bare `"no such file or directory (os error 2)"` needle alongside six needles that name a
program** (`"command not found"`, `"executable not found"`, …). So every `ENOENT` — file or binary —
lands on `ToolFailureClass::MissingApp`, and `describe()` renders it:

> The app or program needed for this action isn't available. **Install or open the app, then try again.**

On a server tenant there is nothing to install. That misclassification, at
`ops.rs:137-151`, is the defect.

The two reported calls reach it from different directions and both were behaving correctly:

1. **`grep` with `path=Agents/…`.** `Agents/` is the **company note tree** — a *different surface*,
   served by `workspace_read` / `workspace_search`, scoped by the store rather than the filesystem.
   The `files`/`docs` tools are sandboxed `workspace_only` to the agent's **own** workspace
   (`build.rs:1131` `file_tools`, `build.rs:1118` `workspace_security`), so they genuinely cannot see
   it. `validate_path` joins the sub-path onto that sandbox, `canonicalize` fails, and the tool
   returns `Failed to resolve path 'Agents/…': No such file or directory (os error 2)`. **Refusing a
   path it cannot see is the correct behaviour** — the sandbox is the point.

2. **`read_skill_resource(feature-spec, references/spec.md)`.** Its `symlink_metadata` pre-check
   returns the same `ENOENT`. `companies/agentic_software_company/skills/feature-spec/` ships
   **only `SKILL.md`**; no bundled skill in this repo has a `references/` directory at all. The file
   does not exist, so refusing is correct here too.

### Two corrections to the issue's premises

- **Not hosted-specific.** It reproduces wherever the path is absent, which is why the regression
  test below is a plain unit test and needs no tenant.
- **"An agent running the Feature Spec skill cannot read that skill's own reference material"**
  overstates it: that skill has no reference material. The tool was not denied a file it should have
  had.

### On the read-only-prefix hypothesis

Raised while triaging, and it **does not apply** — recording it because the premise looked right.
The concern was that `consequence.rs`'s read-only prefixes cover `list`/`read` but not
`describe`/`grep`, so an undeclared local read can park for approval. Both tools here are
**explicitly declared** — `d("grep", …)` at `consequence.rs:415`, `d("read_skill_resource", …)` at
`:587` — and an explicit declaration means the prefix rule is never consulted. The prefix comments at
`:407` and `:571-578` are earlier fixes for exactly that hazard. Neither tool parks; both fail in
1–2 ms.

## API Or Behavior Changes

**New `TurnStepFailure` variant: `NotFound`** (`"not_found"` on the wire), rendered
**"Not found"** in the console.

A failed step from a tool that resolves a path *in this process* and cannot spawn a program now
reports `not_found` with the cause *"The file or folder this action asked for does not exist."*,
where it previously reported `missing_app` with *"The app or program needed for this action isn't
available."* No other verdict changes.

`refine_missing_app` returns the class and the cause **together**, so the chip and the sentence beside
it cannot disagree.

**Keyed on the tool, not on the message — deliberately.** Sniffing for the six program-specific
needles cannot separate the two cases, because `Command::new(program)` on a missing binary yields the
*bare* `ENOENT` with none of them (`install_tool.rs:198`; `workspace_state.rs:203` spawning `git`).
A text-based rule would relabel a genuinely missing `git` as a missing file. Which tool ran is the
signal that actually distinguishes them.

**`PATH_ONLY_TOOLS` is under-inclusive by design.** A path tool absent from it keeps today's
behaviour rather than gaining a new wrong one, so the failure mode of drift is a stale label, never a
false `not_found` on a real missing program.

## Does this belong on #874, and would a coverage test have caught it?

**No, and no — plainly:**

**A test asserting "every advertised slug resolves" would have passed today and would not have caught
this.** Both tools resolve. `every_registered_tool_is_declared`
(`src/harness/mod.rs:6160`) already enforces declaration coverage exhaustively against the live belt,
and both tools satisfy it. Neither an advertisement check nor a declaration check can see a bug whose
entire content is *which failure class a correct refusal is reported as*.

What would have caught it is an invariant one level down, and this PR adds it:
`every_path_tool_on_the_belt_is_listed` derives the set from the same constructor the belt uses
(`build::file_tools`) rather than transcribing names, and fails when the belt grows a path tool
`PATH_ONLY_TOOLS` does not name — the "exhaustive by construction rather than by memory" shape
`every_registered_tool_is_declared` documents.

**This partly undercuts #874's premise as applied here.** #874 is about grants-vs-deployment-wiring
on `GET …/workflows/tool-slugs`, where a granted-but-unwired tool really is advertised and really
cannot run. That is a genuine bug and this PR does not address it. But #924 was filed under the same
"advertised then fails" heading and is **not** an instance of it: nothing was unwired, so the
wiring-aware set #874 proposes would have listed both of these tools too. #924 is narrower and shares
no code with it — different surface, different fix.

## Tests

Run locally, on the lane that actually builds this code:

- [x] `cargo fmt --all -- --check` — PASS
- [x] `cargo clippy --all-targets -- -D warnings` — ran as CI's gated form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`.
      PASS. `--no-deps` mirrors `ci.yml:679`; an unscoped run drowns in vendored `tinyagents` lints CI
      never sees.
- [x] `cargo build --all-targets` — covered by the clippy and test runs above at
      `--features openhuman,tinycortex --all-targets`.
- [x] `cargo test` — **4084 passed / 0 failed** at `--features openhuman,tinycortex --lib`, and
      **2721 passed / 0 failed** at default features. Needs
      `RUST_MIN_STACK=16777216` (pre-existing; a `harness::brain` test overflows without it, which is
      why `ci.yml:626` sets it).

Frontend: `npm run typecheck` — PASS.

### Each new test proven to fail with the fix reverted

- **`a_path_tools_missing_file_is_not_reported_as_a_missing_app`** — the two reported failures,
  verbatim in the shape their producers emit, driven end to end through the fold. Reverting
  `refine_missing_app` to a pass-through fails it, reproducing the bug exactly:
  `result: Some("The app or program needed for this action isn't available."), failure: Some(MissingApp)`
  for `grep`. It also asserts upstream still calls this `MissingApp`, so the test reports an obsolete
  re-read rather than silently passing if upstream is fixed.
- **`every_path_tool_on_the_belt_is_listed`** — dropping `"grep"` from `PATH_ONLY_TOOLS` fails it:
  `these sandboxed file tools … are not in PATH_ONLY_TOOLS …: ["grep"]`.
- **`not_found_serializes_as_the_snake_case_the_console_indexes_on`** — pins the wire string the
  console keys on.
- Frontend: removing `not_found` from `STEP_FAILURE_LABEL` fails the build with
  `error TS2741: Property 'not_found' is missing … but required in type 'Record<TurnStepFailure, string>'`.

**One test is a guard, not coverage — stating it rather than counting it:**
`a_missing_program_is_still_a_missing_app` **passes with the fix reverted**. It exists to prove the
change does not over-reach — that `shell` / `git_operations` / `apply_patch` keep `missing_app` for
the same `ENOENT` — so it is a non-regression assertion, not evidence the fix works.

### Known gap, not addressed here

**Nothing ties the Rust `TurnStepFailure` to the TypeScript union.** `Record<TurnStepFailure, string>`
forces a *label* to exist, and the serde test pins this variant's string, but no check asserts the two
lists hold the same members. Both sides are updated here; the seam itself stays unguarded.

## Documentation

`src/harness/steps.rs`'s module header gains a bullet for the one re-read verdict, alongside the
existing statements about what a step may carry — the taxonomy is documented there, so a class this
crate reinterprets belongs in the same list. `PATH_ONLY_TOOLS` and `refine_missing_app` carry the
reasoning inline, including why the discriminator is the tool and not the message. Both
`TurnStepFailure` variants document how they differ and why.

No `docs/` change: this alters no route, no launcher behavior, and no `tiny*` integration.

Closes tinyhumansai/opencompany#924
