### PR TITLE
fix(credentials): report the platform-credential gap at boot

### DIFF
--- a/docs/spec/runtime/credentials.md
+++ b/docs/spec/runtime/credentials.md
@@ -217,3 +217,20 @@ is `managed`, and even then they are the same value for different reasons.
 - **Two companies pasting the same key share one entity.** That cannot be
   prevented client-side; it is a deployment caveat, the same one the BYO Composio
   token already carries.
+- **Media generation does not read the projected tier.** `web_search`, chat
+  inference and embeddings all resolve through `TinyhumansTokenSource`, so a
+  hosted tenant's rotating pod token reaches them. `media_backend_from_env` does
+  not: it reads `OPENCOMPANY_MEDIA_KEY`, else a static `TINYHUMANS_API_KEY`, and
+  a projected token file alone leaves media unwired. This is a migration miss
+  from #189 rather than a decision, but it cannot be closed here — the upstream
+  media client takes a `String` bearer for the life of the process, so flattening
+  a 600-second projected token into it would trade "never works" for "works for
+  ten minutes". Fixing it properly means giving that client a resolvable
+  credential upstream, the same shape `SearchBackend` already has. Until then a
+  hosted deployment that wants media must also carry a **non-projected** key, and
+  `PlatformCredentialStatus::boot_warning` says so at boot (#879). That key
+  should be `OPENCOMPANY_MEDIA_KEY`, the supported per-surface override. A static
+  `TINYHUMANS_API_KEY` would also work, but it is the `docker compose` credential
+  and the explicitly unsupported self-host hatch; reaching for it here would make
+  that hatch load-bearing on the hosted path, which is a decision for whoever
+  closes the upstream gap rather than a workaround to settle by default.

--- a/src/bin/opencompany.rs
+++ b/src/bin/opencompany.rs
@@ -572,8 +572,18 @@ fn attach_harness(builder: RuntimeBuilder) -> RuntimeBuilder {
     use opencompany::app::config::ProcessEnv;
     use opencompany::harness::HarnessPool;
     use opencompany::harness::provider::{
-        harness_inference_from_env, media_backend_from_env, search_backend_from_env,
+        PlatformCredentialStatus, harness_inference_from_env, media_backend_from_env,
+        search_backend_from_env,
     };
+
+    // Issue #879: every managed surface below fails closed and says nothing at
+    // boot, so a tenant provisioned without its platform token comes up looking
+    // healthy and only reveals the gap when an agent is built or a workflow node
+    // 500s. Say it once, here, where an operator reading the pod's first lines
+    // will see it.
+    if let Some(warning) = PlatformCredentialStatus::resolve(&ProcessEnv).boot_warning() {
+        tracing::warn!("[boot] {warning}");
+    }
 
     let builder = builder.with_harness(Arc::new(HarnessPool::new()));
     // Issue #109: the MANAGED media-generation backend, resolved from the

--- a/src/harness/provider.rs
+++ b/src/harness/provider.rs
@@ -226,6 +226,116 @@ pub fn search_backend_from_env(env: &dyn EnvSource) -> Option<super::search::Sea
     ))
 }
 
+/// Which managed-platform surfaces resolved a credential at boot (issue #879).
+///
+/// Every surface below fails **closed** and independently: a tenant with no
+/// platform credential still boots, still serves, and still builds agents — it
+/// simply never wires `web_search`, never wires the media tools, and falls back
+/// to whatever brain its manifest names. That is the right runtime behaviour and
+/// the wrong operator experience: the only trace today is one `tracing::warn`
+/// per agent at roster build, which nobody reads until a workflow 500s.
+///
+/// This is the boot-time summary of the same resolvers the rest of the module
+/// exposes, so there is one place that answers "did this deployment come up with
+/// a platform identity" and it cannot drift from what actually got wired.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlatformCredentialStatus {
+    /// A platform identity resolved at all — [`TinyhumansTokenSource::from_env`]
+    /// found a projected file or a static key.
+    pub platform_identity: bool,
+    /// That identity is the **projected-file** tier rather than a static key.
+    pub projected_tier: bool,
+    /// Managed chat inference and embeddings resolved
+    /// ([`hosted_endpoint_from_env`]).
+    pub inference: bool,
+    /// Managed web search resolved ([`search_backend_from_env`]).
+    pub search: bool,
+    /// Managed media generation resolved ([`media_backend_from_env`]).
+    pub media: bool,
+}
+
+impl PlatformCredentialStatus {
+    /// Resolves every managed surface against one environment read.
+    pub fn resolve(env: &dyn EnvSource) -> Self {
+        let source = TinyhumansTokenSource::from_env(env);
+        let projected_tier = source
+            .as_ref()
+            .is_some_and(|s| s.tier() == crate::company::credentials::TokenTier::ProjectedFile);
+        Self {
+            platform_identity: source.is_some(),
+            projected_tier,
+            inference: hosted_endpoint_from_env(env).is_some(),
+            search: search_backend_from_env(env).is_some(),
+            media: media_backend_from_env(env).is_some(),
+        }
+    }
+
+    /// Every managed surface has a credential.
+    pub fn all_wired(&self) -> bool {
+        self.inference && self.search && self.media
+    }
+
+    /// The one line an operator needs at boot, or `None` when nothing is
+    /// missing.
+    ///
+    /// Two shapes, because they call for two different actions:
+    ///
+    /// * **No platform identity at all** — the hosted tenant was provisioned
+    ///   without its projected token volume. Names both tiers, since the fix
+    ///   differs between a cluster tenant and `docker compose`.
+    /// * **A projected identity that media cannot use** — the deployment *does*
+    ///   have a platform token and search/inference are live, but
+    ///   [`media_backend_from_env`] reads only the static tier
+    ///   ([`API_KEY_ENV`](crate::company::credentials::API_KEY_ENV)), never the
+    ///   projected file. Without this arm an operator who has just fixed a
+    ///   missing-token incident sees media still reporting "Awaiting credential"
+    ///   with nothing anywhere saying why. The underlying asymmetry is not
+    ///   fixable here — the upstream media client takes a `String` bearer for
+    ///   the life of the process, so flattening a 600-second projected token
+    ///   into it would trade "never works" for "works for ten minutes" — so the
+    ///   deployment is told, precisely, what to set instead.
+    pub fn boot_warning(&self) -> Option<String> {
+        use crate::company::credentials::{API_KEY_ENV, TOKEN_FILE_ENV};
+
+        if !self.platform_identity && !self.inference && !self.media {
+            return Some(format!(
+                "no platform credential resolved: managed inference, embeddings, web_search and \
+                 media generation are ALL unwired for every company on this deployment \
+                 (fail-closed). A hosted tenant expects the platform-projected token volume named \
+                 by {TOKEN_FILE_ENV}; a local or self-hosted instance expects a static \
+                 {API_KEY_ENV}."
+            ));
+        }
+
+        if self.projected_tier && !self.media {
+            return Some(format!(
+                "the platform identity is a projected token file ({TOKEN_FILE_ENV}), which media \
+                 generation does not read: media tools stay unwired even for a company that grants \
+                 `media`. Set OPENCOMPANY_MEDIA_KEY (or a static {API_KEY_ENV}) to wire them."
+            ));
+        }
+
+        let mut unwired: Vec<&str> = Vec::new();
+        if !self.inference {
+            unwired.push("managed inference/embeddings");
+        }
+        if !self.search {
+            unwired.push("web_search");
+        }
+        if !self.media {
+            unwired.push("media generation");
+        }
+        if unwired.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "platform credential is only partly configured: {} unwired (fail-closed). See \
+             {TOKEN_FILE_ENV} / {API_KEY_ENV}.",
+            unwired.join(", ")
+        ))
+    }
+}
+
 /// Flatten a tinyagents request's messages into the OpenAI-compatible wire
 /// `[{role, content, …}]` array.
 ///
@@ -1184,6 +1294,127 @@ mod tests {
             ("OPENCOMPANY_SEARCH_KEY", "search-specific"),
         ]);
         assert!(search_backend_from_env(&env).is_none());
+    }
+
+    // ---- boot-time platform credential status (issue #879) -----------------
+
+    /// Writes a projected-token file and returns `(dir, path-as-string)`. The
+    /// `TempDir` must stay alive: `TinyhumansTokenSource` selects the projected
+    /// tier only when the path **exists**.
+    fn projected_token_file() -> (tempfile::TempDir, String) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-cred-")
+            .tempdir()
+            .expect("tempdir");
+        let path = dir.path().join("token");
+        std::fs::write(&path, "projected-token").unwrap();
+        let rendered = path.display().to_string();
+        (dir, rendered)
+    }
+
+    /// The #879 tenant: nothing at all is set. One warning must name every
+    /// surface that silently failed closed, and both tiers, because the fix
+    /// differs between a cluster tenant and `docker compose`.
+    #[test]
+    fn no_platform_credential_warns_about_every_managed_surface() {
+        let status = PlatformCredentialStatus::resolve(&MapEnv::default());
+        assert!(!status.platform_identity);
+        assert!(!status.all_wired());
+
+        let warning = status.boot_warning().expect("a warning");
+        assert!(warning.contains("no platform credential"), "{warning}");
+        for expected in [
+            "inference",
+            "web_search",
+            "media",
+            crate::company::credentials::TOKEN_FILE_ENV,
+            crate::company::credentials::API_KEY_ENV,
+        ] {
+            assert!(warning.contains(expected), "{expected} missing: {warning}");
+        }
+    }
+
+    /// The trap this check exists for. A hosted tenant given the projected token
+    /// volume — the documented hosted mechanism, and the fix for #879 — resolves
+    /// inference and search but **not** media, because
+    /// [`media_backend_from_env`] reads only the static tier. Staying silent
+    /// here is what leaves an operator who has just supplied the credential
+    /// staring at a console that still says "Awaiting credential".
+    #[test]
+    fn projected_token_alone_warns_that_media_cannot_use_it() {
+        let (_dir, token_path) = projected_token_file();
+        let env = MapEnv::new([(crate::company::credentials::TOKEN_FILE_ENV, token_path)]);
+
+        let status = PlatformCredentialStatus::resolve(&env);
+        assert!(status.platform_identity);
+        assert!(status.projected_tier);
+        assert!(status.inference, "inference reads the projected tier");
+        assert!(status.search, "search reads the projected tier");
+        assert!(!status.media, "media reads only the static tier");
+        assert!(!status.all_wired());
+
+        let warning = status.boot_warning().expect("a warning");
+        assert!(warning.contains("media"), "{warning}");
+        assert!(
+            warning.contains("OPENCOMPANY_MEDIA_KEY"),
+            "the warning must name the variable that fixes it: {warning}"
+        );
+    }
+
+    /// A projected token plus a media key wires everything, so boot says
+    /// nothing. Guards the check against crying wolf on a healthy deployment.
+    #[test]
+    fn projected_token_with_a_media_key_is_silent() {
+        let (_dir, token_path) = projected_token_file();
+        let env = MapEnv::new([
+            (
+                crate::company::credentials::TOKEN_FILE_ENV.to_string(),
+                token_path,
+            ),
+            (
+                "OPENCOMPANY_MEDIA_KEY".to_string(),
+                "media-specific".to_string(),
+            ),
+        ]);
+
+        let status = PlatformCredentialStatus::resolve(&env);
+        assert!(status.all_wired());
+        assert_eq!(status.boot_warning(), None);
+    }
+
+    /// The `docker compose` / self-host shape: one static key feeds all three
+    /// surfaces, so boot is silent there too.
+    #[test]
+    fn a_static_key_wires_every_surface_and_is_silent() {
+        let env = MapEnv::new([(crate::company::credentials::API_KEY_ENV, "th-static")]);
+        let status = PlatformCredentialStatus::resolve(&env);
+
+        assert!(status.platform_identity);
+        assert!(!status.projected_tier);
+        assert!(status.all_wired());
+        assert_eq!(status.boot_warning(), None);
+    }
+
+    /// A media key on its own is not a platform identity: it wires media and
+    /// leaves inference and search closed, which the partial arm must report by
+    /// name rather than collapsing into "no credential".
+    #[test]
+    fn a_media_key_alone_warns_about_the_surfaces_it_does_not_cover() {
+        let env = MapEnv::new([("OPENCOMPANY_MEDIA_KEY", "media-specific")]);
+        let status = PlatformCredentialStatus::resolve(&env);
+
+        assert!(!status.platform_identity);
+        assert!(status.media);
+        assert!(!status.inference);
+        assert!(!status.search);
+
+        let warning = status.boot_warning().expect("a warning");
+        assert!(warning.contains("partly configured"), "{warning}");
+        assert!(warning.contains("web_search"), "{warning}");
+        assert!(
+            !warning.contains("no platform credential"),
+            "a partial deployment is not a bare one: {warning}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Closes tinyhumansai/opencompany#879.

A tenant provisioned without a platform token boots clean, serves `/healthz`, and builds
agents. Managed inference, `web_search` and media generation each fail closed
independently and say nothing at startup; the only trace is one `tracing::warn` per agent
at roster build, which nobody reads until a workflow node 500s with
`tool_call 'web_search' is granted, but no managed search backend is configured`.

This PR makes that state legible at boot. It does **not** — and cannot — provision the
token; see the boundary section below.

### What the platform token actually is

Worth stating up front, because the intuitive reading of #879 leads to the wrong fix. The
hosted credential is **not a secret somebody forgot to paste**. Per
`src/company/credentials.rs`:

> A hosted tenant holds **no** static secret. The platform gives its pod a short-lived,
> audience-bound token in a file that the kubelet rewrites **in place** (roughly every 8
> minutes) … The platform mounts it read-only as `/var/run/secrets/tinyhumans.ai/token`
> with a 600-second expiry; the env var carries the **path**, never a token value.

So `TINYHUMANS_TOKEN_FILE` is a **kubelet-projected, audience-bound ServiceAccount token
volume** whose variable holds a path. The correct fix is a pod-spec change that mounts the
volume, not a value pasted into an env var. `TINYHUMANS_API_KEY` is the second tier, and
the module documents it as the `docker compose` credential and the "explicitly
**unsupported**" self-host escape hatch.

### Why the marketing tenant has none: a missing provisioning step

Not a stale image, not a bad pin, not a code path that fails to read it — the read path is
fine. **Nothing anywhere sets either variable for a hosted tenant.** Three in-repo
confirmations:

1. `CLAUDE.md` enumerates exactly what the manager injects into every tenant container:
   `OPENCOMPANY_COMPANY`, `OPENCOMPANY_BIND`, `OPENCOMPANY_DATA_DIR`,
   `OPENCOMPANY_PUBLIC_URL`, `OPENCOMPANY_ADMIN_EMAIL`, `OPENCOMPANY_STORAGE` /
   `OPENCOMPANY_MONGODB_*`, `OPENCOMPANY_TENANT_ID`. No `TINYHUMANS_*`.
2. `.github/workflows/patch-tenant-env.yml` says the manager "patches the StatefulSet with
   server-side apply and only owns the fields it sets (image, `OPENCOMPANY_*`, mongo/mail
   creds)", and describes itself as the knob for "env the manager does **NOT** own".
3. `grep TINYHUMANS` across `deploy/` and `.github/workflows/` returns prose mentions only
   — no manifest, no workflow, no entrypoint sets either variable.

This is therefore not specific to `marketing`; every hosted tenant is in this state.

### Code / platform boundary

| | Where it lives | In this PR |
| --- | --- | --- |
| Project the SA token volume into tenant pods, set `TINYHUMANS_TOKEN_FILE` | `tinyhumansai/opencompany-microservices` (the manager control plane) | **No** — cross-repo, cannot be done here |
| Unblock the existing `marketing` tenant | `patch-tenant-env.yml` (operational, disruptive, human decision) | **No** — recommendation only, see below |
| Give media a resolvable credential | upstream `openhuman` (`IntegrationClient`) | **No** — see the known limit |
| Make the missing credential visible at boot | this repo | **Yes** |

No deploy workflow was run while preparing this. `refresh_all_tenants` is self-described
as disruptive and is a human decision; if the conclusion is that the tenant needs a
redeploy, that is a recommendation for an operator, not something this PR performs.

### The trap this exists to catch

`media_backend_from_env` reads `OPENCOMPANY_MEDIA_KEY`, else a static `TINYHUMANS_API_KEY`
— it never consults `TINYHUMANS_TOKEN_FILE`. Chat inference, embeddings and `web_search`
all resolve through `TinyhumansTokenSource` and do. `git log` shows why: #189 moved
inference and Composio onto the token source and did not touch media, which predates it
from #109. It is a migration miss, not a decision.

The consequence is what makes it worth a boot check rather than a comment: **doing the
correct hosted fix restores inference, embeddings and search, and leaves media dead**, with
the console still reporting "Awaiting credential" to an operator who has just supplied the
credential. `PlatformCredentialStatus` reports that case separately and names the variable
that resolves it.

**A decision this surfaces rather than settles.** The projected-tier warning points at
`OPENCOMPANY_MEDIA_KEY`, the supported per-surface override. A static `TINYHUMANS_API_KEY`
would also wire media, but adopting it on the hosted path would make the explicitly
unsupported self-host hatch load-bearing for hosted tenants. The docs note says so in as
many words and leaves the call to whoever closes the upstream gap.

### Not fixed here, recorded

`tinyhumans_api_key` can be set in `config.toml` and reaches `RuntimeConfig` and `doctor`,
but reaches none of the resolvers — they read `ProcessEnv` directly and nothing re-exports
the config layer (no `set_var` outside tests). A self-hoster who sets it in TOML gets
`doctor` reporting `cycles: available` while all three managed surfaces are unwired. Out of
scope for #879; happy to file it.

## API Or Behavior Changes

New public API: `opencompany::harness::provider::PlatformCredentialStatus` (behind the
existing `openhuman` feature) with `resolve`, `all_wired`, `boot_warning`.

Behaviour: one additional `tracing::warn` at startup when a managed surface has no
credential. Nothing is gated, refused, or wired differently — every fail-closed path
behaves exactly as before. A deployment with a complete credential is silent.

## Tests

Run from a clean clone at `upstream/main`, with the vendored submodules initialised.

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — ran CI's form,
      `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
      exit 0. `--no-deps` mirrors `ci.yml`; a bare `--all-targets` drowns in vendored lints
      CI never compiles.
- [x] `cargo build --all-targets` — ran
      `cargo build --locked --features openhuman,tinycortex --all-targets`, exit 0. The
      changed code is behind the `openhuman` feature, so the default build does not compile
      it; the default-feature suite below covers the untouched half.
- [x] `cargo test` — both halves. Default features: `cargo test --locked`, exit 0. Gated
      lane: `RUST_MIN_STACK=16777216 cargo test --locked --features openhuman,tinycortex --tests`,
      **4109 passed / 0 failed**. `RUST_MIN_STACK` matches `ci.yml`; without it an unrelated
      `harness::brain` test overflows the stack locally.

Five new tests in `harness::provider::tests`. `feature-lanes.txt` needs no new row: they sit
behind `openhuman`, already classified `tested` on `openhuman,tinycortex`, and
`scripts/ci/assert-feature-lanes.sh` passes.

**Revert proof.** I replaced `boot_warning` with the plausible naive body — warn only when
no platform identity resolves at all — and re-ran:

```
test projected_token_alone_warns_that_media_cannot_use_it ... FAILED
test a_media_key_alone_warns_about_the_surfaces_it_does_not_cover ... FAILED
test result: FAILED. 34 passed; 2 failed
```

Restored, both pass. Being straight about the other three: `no_platform_credential_…`,
`projected_token_with_a_media_key_is_silent` and `a_static_key_wires_every_surface_and_is_silent`
pass under the naive body too. They are regression guards — the last two exist so the check
cannot cry wolf on a healthy deployment — not discriminating tests, and I am not claiming
them as such.

**Not verified.** I have no cluster access, so I did not read the live pod spec or the
tenant's actual environment; the reasoning above is from the repo. The only live check made
was `GET /healthz` on the marketing tenant, which returns 200. Browser automation was not
attempted.

## Documentation

`docs/spec/runtime/credentials.md` — a `Known limits, recorded deliberately` entry for the
media/projected-tier asymmetry: what it is, why it is a migration miss rather than a
decision, why it cannot be closed in this repo, and why `OPENCOMPANY_MEDIA_KEY` rather than
the unsupported static hatch is the answer until it is. File stays under the 500-line limit
(236).
