### PR TITLE
fix(console): a paused card names the approvals blocking it, and Resume stops re-running them (#883)

### DIFF
--- a/frontend/src/components/app-shell.tsx
+++ b/frontend/src/components/app-shell.tsx
@@ -1250,6 +1250,12 @@ export function AppShell({
               // counter the chat's in-flight strip reads, so a card opened from
               // chat lands on the board without a reload.
               taskEventTick={taskEventTick}
+              // Issue #883: a paused card is blocked until every approval its
+              // turn parked is decided, and the board's own read carries none
+              // of them. This is the feed the sidebar badge already polls, so
+              // the card says what it is waiting on without a second request.
+              approvals={feed.approvals}
+              now={feed.now}
               // Issue #246: the card → chat half of the round trip. A card
               // opened from a conversation remembers which one, so its detail
               // screen can put the operator back in that thread.
@@ -1257,6 +1263,11 @@ export function AppShell({
                 setActiveThreadId(threadId);
                 setView("conversation");
               }}
+              // Issue #883: "Review" on a blocked card opens the queue narrowed
+              // to that card. Through `navigate` rather than `setView` so the
+              // filter lands in the hash and survives a refresh and the Back
+              // button, like every other sub-page.
+              onReviewApprovals={(taskId) => navigate("approvals", encodeURIComponent(taskId))}
             />
           )}
           {view === "ledgers" && (
@@ -1317,6 +1328,13 @@ export function AppShell({
               client={client}
               company={company}
               feed={feed}
+              // Issue #883: `#/approvals/<taskId>` narrows the queue to one
+              // card, so "Review" on a blocked card lands on its approvals
+              // rather than on a page the operator has to search. Same
+              // unvalidated second segment every other sub-page gets — only
+              // this view knows whether the id matches anything parked, so it
+              // does that check itself and says so when it does not.
+              sub={sub}
               onResolved={noteSystem}
               onGoToConversation={() => setView("chat")}
             />

--- a/frontend/src/lib/task-approvals.ts
+++ b/frontend/src/lib/task-approvals.ts
@@ -1,4 +1,5 @@
 import type { TaskApproval } from "@/api/tasks";
+import type { ApprovalSummary } from "@/api/types";
 
 /**
  * What the task card says about approvals (issue #468).
@@ -51,4 +52,74 @@ export function pendingApprovalWait(
   }
   if (count === 0) return null;
   return { count, since, waited: Math.max(0, now - since) };
+}
+
+/**
+ * The parked approvals the board's own poll says belong to one card (#883).
+ *
+ * The board reads `…/tasks`, whose card projection carries no approvals, and
+ * opening every card to find out would be N reads per 4s poll — the cost
+ * `TaskCard::output` is documented as existing to avoid. So the join happens
+ * here instead, against the approvals feed the shell **already** polls for the
+ * sidebar badge. No new request, no new wire field, and the board and the
+ * Approvals page are reading one list rather than two that can disagree.
+ *
+ * `GET …/approvals` returns the parked queue and nothing else, so every entry is
+ * pending by construction — unlike {@link pendingApprovalWait}, which filters a
+ * task-detail projection that includes resolutions.
+ *
+ * **Only `{link: "task"}` matches, and that is the whole ownership rule here.**
+ * `CycleHostImpl::park` stamps the link on every park path, so a card-dispatched
+ * approval always carries it. The host's own `approval_owner` has a first rule
+ * this cannot reach — the attempt-level `run_id`, which separates two *runs of
+ * the same card* — but that distinction does not change the answer to "is this
+ * card blocked", which is the only question asked here. `{link: "unlinked"}`
+ * (a workflow delivery, an operator-chat turn, a scheduler tick) and an absent
+ * link (a park predating #333) both belong to no card and are skipped rather
+ * than guessed at: the host keeps a run-window heuristic for the ambiguous case
+ * and the board has no window to apply it against.
+ */
+export function approvalsForTask(
+  approvals: readonly ApprovalSummary[],
+  taskId: string,
+): ApprovalSummary[] {
+  return approvals.filter((a) => a.task?.link === "task" && a.task.id === taskId);
+}
+
+/** Why a card is stopped — read by its board card and by its Resume button (#883). */
+export interface TaskApprovalBlock {
+  /** The still-parked approvals for this card, oldest park first. */
+  approvals: ApprovalSummary[];
+  /** How many there are — the number the card reports. */
+  count: number;
+  /** Epoch-millis the *oldest* of them parked — what the card measures from. */
+  since: number;
+}
+
+/**
+ * What is blocking one card right now — `null` when nothing is (#883).
+ *
+ * This is the derivation behind both halves of the fix, and it is one function
+ * rather than two so they cannot disagree: the line that says *why* the card is
+ * stopped and the `disabled` that stops Resume re-running it read the same
+ * result. A card that said "blocked on 4 approvals" beside a Resume button that
+ * dispatched anyway would be a worse surface than the silent one it replaces.
+ *
+ * Ordered oldest-first, and `since` is the oldest park — same reasoning as
+ * {@link pendingApprovalWait}: it is how long the card has really been stopped,
+ * and taking the newest would reset a clock that should be climbing every time
+ * a second effect parks behind the first.
+ *
+ * No `waited` counterpart, unlike {@link pendingApprovalWait}: this block's only
+ * reader renders the span through `timeAgo`, which takes the instant and clamps
+ * its own negative — so a second copy of that arithmetic here would be a field
+ * with no consumer to keep it honest.
+ */
+export function taskApprovalBlock(
+  approvals: readonly ApprovalSummary[],
+  taskId: string,
+): TaskApprovalBlock | null {
+  const mine = approvalsForTask(approvals, taskId).sort((a, b) => a.at_millis - b.at_millis);
+  if (mine.length === 0) return null;
+  return { approvals: mine, count: mine.length, since: mine[0].at_millis };
 }

--- a/frontend/src/views/ApprovalsView.tsx
+++ b/frontend/src/views/ApprovalsView.tsx
@@ -24,6 +24,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import type { CompanyFeed } from "@/hooks/use-company";
 import { approvedByRuntimeLine, approvedLine } from "@/lib/approval-wording";
 import { approvalSummary, grantHeadline, timeAgo, toolAction } from "@/lib/language";
+import { approvalsForTask } from "@/lib/task-approvals";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { isRecord, parseNodeMessages } from "@/views/workflows/run-output";
 
@@ -76,12 +77,30 @@ interface Props {
   client: OpenCompanyClient;
   company: string | null;
   feed: CompanyFeed;
+  /**
+   * `#/approvals/<taskId>` — narrow the queue to one board card (issue #883).
+   *
+   * Arrives unvalidated, as every hash sub-page does. An id matching nothing
+   * parked is a legitimate state rather than an error: the operator followed a
+   * blocked card's Review link and the last of its approvals was decided on the
+   * way, which is the flow working. It renders as "this card is clear" with a
+   * way back to the whole queue, never as the generic "nothing needs you" —
+   * those are different facts and only one of them is about the whole company.
+   */
+  sub?: string | null;
   onResolved: (systemLine: string) => void;
   onGoToConversation: () => void;
 }
 
 /** The approvals inbox: the few things the company parked for the operator. */
-export function ApprovalsView({ client, company, feed, onResolved, onGoToConversation }: Props) {
+export function ApprovalsView({
+  client,
+  company,
+  feed,
+  sub,
+  onResolved,
+  onGoToConversation,
+}: Props) {
   // Issue #373: in-flight state is per approval, not a single module-wide slot.
   //
   // Approving is not a quick write — the host mints a grant and re-dispatches
@@ -96,6 +115,32 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
   // is doing it" vs "recorded"), and the card says which one it is waiting on.
   const [inFlight, setInFlight] = useState<ReadonlyMap<string, Verdict>>(() => new Map());
   const { approvals, now } = feed;
+  /**
+   * The card the queue is narrowed to, or `null` for the whole queue (#883).
+   *
+   * Decoded because the shell percent-encodes the id into the hash; a malformed
+   * escape throws `URIError`, and a broken link must fall back to the full queue
+   * rather than blank the page.
+   */
+  const focusTaskId = useMemo(() => {
+    if (!sub) return null;
+    try {
+      return decodeURIComponent(sub);
+    } catch {
+      return null;
+    }
+  }, [sub]);
+  /**
+   * The rows on screen. Every other derivation below — the batch totals, the
+   * asker names, the decide path — deliberately stays on the **full** queue:
+   * a batch's "1 of 3 from this turn" counts what the turn parked, and filtering
+   * the count with the view would turn a batch of three into a batch of one and
+   * tell the operator the opposite of the truth.
+   */
+  const visible = useMemo(
+    () => (focusTaskId === null ? approvals : approvalsForTask(approvals, focusTaskId)),
+    [approvals, focusTaskId],
+  );
   const askerNames = useAskerNames(client, company, approvals);
   const { grants, granterNames, refreshGrants } = useStandingGrants(client, company);
   /**
@@ -217,19 +262,39 @@ export function ApprovalsView({ client, company, feed, onResolved, onGoToConvers
   return (
     <div className="flex-1 overflow-y-auto">
       <div className="mx-auto w-full max-w-3xl px-4 py-6">
-        {approvals.length === 0 ? (
-          <EmptyApprovals onGoToConversation={onGoToConversation} />
+        {/* Issue #883: the filter says so, and offers the way out of itself.
+            A narrowed queue that looked identical to the whole one would make a
+            decided-elsewhere approval look like it had vanished. */}
+        {focusTaskId !== null && (
+          <div className="mb-4 flex items-center justify-between gap-3 rounded-lg border bg-muted/40 px-3 py-2 text-xs">
+            <span className="min-w-0 text-muted-foreground">
+              Showing only what one board card is waiting on.
+            </span>
+            <a
+              href="#/approvals"
+              className="shrink-0 font-medium underline-offset-2 hover:underline"
+            >
+              Show all
+            </a>
+          </div>
+        )}
+        {visible.length === 0 ? (
+          focusTaskId !== null ? (
+            <ClearedForTask />
+          ) : (
+            <EmptyApprovals onGoToConversation={onGoToConversation} />
+          )
         ) : (
           <>
             <div className="mb-4 flex items-baseline justify-between">
               <h2 className="text-sm font-medium text-muted-foreground">
-                {approvals.length === 1
+                {visible.length === 1
                   ? "1 thing needs your approval"
-                  : `${approvals.length} things need your approval`}
+                  : `${visible.length} things need your approval`}
               </h2>
             </div>
             <div className="flex flex-col gap-3">
-              {approvals.map((a) => (
+              {visible.map((a) => (
                 <ApprovalCard
                   key={a.id}
                   approval={a}
@@ -651,6 +716,32 @@ function WorkflowContentReview({ approval }: { approval: ApprovalSummary }) {
           )}
         </div>
       ))}
+    </div>
+  );
+}
+
+/**
+ * A filtered queue with nothing left in it (issue #883).
+ *
+ * Deliberately not {@link EmptyApprovals}. That one says "nothing is waiting on
+ * you", which is a claim about the *whole company* — and here it would be said
+ * while other cards' approvals sit one click away, unread. The two states also
+ * mean opposite things to the operator who arrived from a blocked card: this
+ * one says the card is free to resume, which is the answer they came for.
+ */
+function ClearedForTask() {
+  return (
+    <div className="mt-16 flex flex-col items-center gap-3 text-center">
+      <div className="flex size-12 items-center justify-center rounded-2xl bg-status-done-soft text-status-done-text">
+        <ShieldCheck className="size-6" />
+      </div>
+      <div className="space-y-1">
+        <p className="font-medium">This card is clear</p>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          Nothing it parked is still waiting on you. Other cards may still have
+          approvals of their own — use <span className="font-medium">Show all</span> to see them.
+        </p>
+      </div>
     </div>
   );
 }

--- a/frontend/src/views/TaskDetailView.tsx
+++ b/frontend/src/views/TaskDetailView.tsx
@@ -78,6 +78,7 @@ import {
   AWAITING_APPROVAL_LABEL,
   ApiError,
   STEP_FAILURE_LABEL,
+  type ApprovalSummary,
 } from "@/api/types";
 import type { OpenCompanyClient } from "@/api/client";
 import { hasFocus, type TaskFocus } from "@/lib/task-output";
@@ -110,7 +111,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
-import { effectDone } from "@/lib/language";
+import { approvalAction, effectDone } from "@/lib/language";
 
 import { labelFor, PRIORITY_STYLES, type TaskColumn } from "@/lib/board-columns";
 import { useBoardColumns } from "@/hooks/use-board-columns";
@@ -204,6 +205,13 @@ export function waitingBandHeight(millis: number): number {
   return Math.round(Math.min(112, Math.max(12, raw)));
 }
 
+/**
+ * A stable empty default for the `parked` prop (issue #883). A `[]` literal in
+ * the parameter list is a new array every render, which would re-run the memo
+ * that reads it on a screen with a 1s clock.
+ */
+const EMPTY_PARKED: readonly ApprovalSummary[] = [];
+
 /** `1h 04m 09s` / `4m 09s` / `9s`. */
 function formatDuration(millis: number): string {
   const s = Math.floor(millis / 1000);
@@ -265,6 +273,7 @@ export function TaskDetailView({
   company,
   taskId,
   focus,
+  parked = EMPTY_PARKED,
   onBack,
   onNavigate,
   onOpenThread,
@@ -274,6 +283,12 @@ export function TaskDetailView({
   client: OpenCompanyClient;
   company: string | null;
   taskId: string;
+  /**
+   * The company's parked approvals, for naming what this card is waiting on
+   * (issue #883). Optional and defaulting to empty, which renders the pre-#883
+   * row — this screen's own read is what decides *whether* it is waiting.
+   */
+  parked?: readonly ApprovalSummary[];
   /**
    * What the address asked this screen to open (issue #339): a pinned artifact
    * or an attempt's trace. Empty — the ordinary "open the card" navigation —
@@ -491,7 +506,12 @@ export function TaskDetailView({
               columns={columns}
             />
 
-            <AwaitingApprovalRow approvals={detail.approvals} now={now} />
+            <AwaitingApprovalRow
+              approvals={detail.approvals}
+              parked={parked}
+              taskId={detail.task.id}
+              now={now}
+            />
 
             {/* Issue #580: the built workflow awaiting approval, shown only while
                 the card sits In Review with a proposal. Apply creates the
@@ -1836,22 +1856,58 @@ function RunDrawer({
  * Renders nothing when nothing is pending — an always-present "no approvals"
  * line is the clutter the tab was removed for.
  */
-function AwaitingApprovalRow({ approvals, now }: { approvals: TaskApproval[]; now: number }) {
+function AwaitingApprovalRow({
+  approvals,
+  parked,
+  taskId,
+  now,
+}: {
+  approvals: TaskApproval[];
+  /**
+   * The company's parked queue, for naming (issue #883). Deliberately **not**
+   * the source of truth for whether the card is waiting: `approvals` is, because
+   * the host computed it with an ownership rule (`approval_owner`) that has an
+   * attempt-level key this side cannot see. These rows are matched into it by
+   * id, so an approval the host counts and the feed has not caught up on is
+   * still counted — it just goes unnamed for one poll rather than disappearing.
+   */
+  parked: readonly ApprovalSummary[];
+  taskId: string;
+  now: number;
+}) {
   const pending = pendingApprovalWait(approvals, now);
+  const named = useMemo(() => {
+    if (!pending) return null;
+    const ids = new Set(approvals.filter((a) => a.status === "pending").map((a) => a.id));
+    const hits = parked.filter((p) => ids.has(p.id));
+    // Only when *every* pending row is named, and there is exactly one. Naming
+    // "the" blocked call while a second one the feed has not delivered sits
+    // beside it would tell the operator one decision clears the card when two
+    // do — the precise mistake issue #883 is about.
+    return hits.length === 1 && pending.count === 1 ? hits[0] : null;
+  }, [approvals, parked, pending]);
   if (!pending) return null;
   const { waited } = pending;
+  const href = `#/approvals/${encodeURIComponent(taskId)}`;
 
   return (
     <div className="flex items-center gap-2 rounded-lg border border-status-blocked/30 bg-status-blocked-soft px-3 py-2 text-xs">
       <Hourglass className="size-3.5 shrink-0 text-status-blocked-text" />
       <span className="min-w-0 flex-1 text-status-blocked-text">
-        {pending.count === 1
-          ? "Waiting on an approval"
-          : `Waiting on ${pending.count} approvals`}{" "}
+        {/* Issue #883: name the call, not the mechanism. "Waiting on an
+            approval" is true of every one of these rows and therefore answers
+            nothing — the same complaint #372 made of the chat card and #846 of
+            the workflow one. `approvalAction` is the function both of those were
+            fixed with, so all three surfaces say one thing about one approval. */}
+        {named
+          ? `Waiting on your approval — ${approvalAction(named).toLowerCase()}`
+          : pending.count === 1
+            ? "Waiting on an approval"
+            : `Waiting on ${pending.count} approvals`}{" "}
         <span className="tabular-nums">for {formatDuration(waited)}</span>
       </span>
       <a
-        href="#/approvals"
+        href={href}
         className="shrink-0 font-medium text-status-blocked-text underline-offset-2 hover:underline"
         aria-label={
           pending.count === 1

--- a/frontend/src/views/TasksView.tsx
+++ b/frontend/src/views/TasksView.tsx
@@ -32,6 +32,7 @@ import {
   CircleHelp,
   ClipboardList,
   FileText,
+  Hourglass,
   ListTree,
   Paperclip,
   Play,
@@ -47,12 +48,15 @@ import {
   type TaskPlan,
 } from "@/api/tasks";
 import type { OpenCompanyClient } from "@/api/client";
+import type { ApprovalSummary } from "@/api/types";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { startVisiblePolling } from "@/lib/visible-poll";
 import { labelFor, PRIORITY_STYLES } from "@/lib/board-columns";
+import { approvalAction, timeAgo } from "@/lib/language";
+import { taskApprovalBlock, type TaskApprovalBlock } from "@/lib/task-approvals";
 import { useBoardColumns } from "@/hooks/use-board-columns";
 import {
   extraOutputCount,
@@ -94,6 +98,14 @@ function readTaskDetailId(): string | null {
  */
 const POLL_MS = 4000;
 
+/**
+ * A stable empty default for {@link TasksView}'s `approvals` prop.
+ *
+ * A `[]` literal in the parameter list is a new array identity on every render.
+ * Hoisting it keeps the default stable for anything downstream that compares by
+ * reference, on a screen that re-renders on a 4s poll.
+ */
+const EMPTY_APPROVALS: readonly ApprovalSummary[] = [];
 
 function priorityStyle(priority: string): string {
   return PRIORITY_STYLES[priority as keyof typeof PRIORITY_STYLES] ?? PRIORITY_STYLES.low;
@@ -110,7 +122,10 @@ export function TasksView({
   client,
   company,
   taskEventTick,
+  approvals = EMPTY_APPROVALS,
+  now,
   onOpenThread,
+  onReviewApprovals,
 }: {
   client: OpenCompanyClient;
   company: string | null;
@@ -122,11 +137,28 @@ export function TasksView({
    * reload.
    */
   taskEventTick?: number;
+  /**
+   * The company's parked approvals (issue #883), from the shell's existing feed
+   * poll. A paused card is blocked until every approval its turn parked has
+   * been decided, and the board's own `…/tasks` read carries none of them — so
+   * without this a paused card can only show a Resume button and no reason.
+   * Defaults to empty, which renders exactly the pre-#883 card.
+   */
+  approvals?: readonly ApprovalSummary[];
+  /** The feed's clock, for "blocked for 4m". Falls back to the browser's. */
+  now?: number;
   /** Opens the chat thread a card came from (issue #246). */
   onOpenThread?: (threadId: string) => void;
+  /** Opens the Approvals page filtered to one card (issue #883). */
+  onReviewApprovals?: (taskId: string) => void;
 }) {
   // The board's shape, from the host. Nothing here declares a column.
   const columns = useBoardColumns(client, company);
+  // The clock the "blocked since" labels measure against (issue #883). The
+  // feed's is preferred because it is stamped at the same read the approvals
+  // came from, so a card cannot report a wait longer than the data behind it;
+  // the browser's is the fallback for a caller that passes approvals without one.
+  const clock = now ?? Date.now();
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -254,6 +286,12 @@ export function TasksView({
 
   // Re-dispatch a paused card (issue #111): a Resume moves it back into
   // "In progress", which is what hands it to its assignee again.
+  //
+  // Issue #883: this is not reached while the card is blocked on its own
+  // undecided approvals — `TaskItem` disables the button from the same
+  // `taskApprovalBlock` read, which is deliberately the *only* place the rule
+  // lives. A second copy of it here would be a branch nothing can execute, and
+  // therefore a branch nothing keeps true.
   async function resume(task: Task) {
     setTasks((ts) => ts.map((t) => (t.id === task.id ? { ...t, column: "in_progress" } : t)));
     try {
@@ -276,6 +314,10 @@ export function TasksView({
         company={company}
         taskId={detailId}
         focus={focus}
+        // Issue #883: so the detail row can name the blocked call rather than
+        // only counting it. The screen's own read still decides whether the
+        // card is waiting; this only supplies the words.
+        parked={approvals}
         onBack={closeDetail}
         onNavigate={openDetail}
         onOpenThread={onOpenThread}
@@ -327,8 +369,14 @@ export function TasksView({
             <TaskItem
               task={task}
               dragging={dragging}
+              // Issue #883: what this card is stopped behind, derived from the
+              // shell's approvals feed. `null` for every card that is not
+              // blocked, which is what keeps the pre-#883 card unchanged.
+              block={taskApprovalBlock(approvals, task.id)}
+              now={clock}
               onOpen={() => openCard(task)}
               onResume={() => void resume(task)}
+              onReview={onReviewApprovals ? () => onReviewApprovals(task.id) : undefined}
             />
           )}
         />
@@ -356,17 +404,33 @@ export function TasksView({
  * what a *task* looks like. That split is what lets one board serve both this
  * and a ledger a company declared — see that module's docs for why the card is
  * a slot rather than something built from field roles.
+ *
+ * Exported for `test/unit/task-blocked-card.test.ts` (issue #883). The
+ * paused card's central claim — Resume is *disabled* while the card's own
+ * approvals are undecided, because pressing it re-runs work that parks again —
+ * exists only at the rendered button, so a pure test of the derivation cannot
+ * reach it. Same exception `approval-batch-card.test.ts` earns, on the same
+ * grounds: the thing under test is what reaches the operator's hand.
  */
-function TaskItem({
+export function TaskItem({
   task,
   dragging,
+  block,
+  now,
   onOpen,
   onResume,
+  onReview,
 }: {
   task: Task;
   dragging: boolean;
+  /** What this card is stopped behind, or `null` when nothing (issue #883). */
+  block: TaskApprovalBlock | null;
+  /** The clock `block` was derived against, for its relative label. */
+  now: number;
   onOpen: () => void;
   onResume: () => void;
+  /** Opens the Approvals page filtered to this card (issue #883). */
+  onReview?: () => void;
 }) {
   return (
     <div
@@ -416,20 +480,93 @@ function TaskItem({
       {task.plan && <PlanBadgeRow plan={task.plan} />}
       {SHOWS_OUTPUT_LINK.has(task.column) && <OutputLinkRow task={task} />}
       {task.column === "paused" && (
-        <Button
-          variant="outline"
-          size="sm"
-          className="mt-3 h-7 w-full"
-          onClick={(e) => {
-            // Don't let the click bubble to the card's open handler.
-            e.stopPropagation();
-            onResume();
-          }}
-        >
-          <Play className="mr-1.5 size-3.5" />
-          Resume
-        </Button>
+        <>
+          {block && <BlockedRow block={block} now={now} onReview={onReview} />}
+          <Button
+            variant="outline"
+            size="sm"
+            className={cn("h-7 w-full", block ? "mt-2" : "mt-3")}
+            // Issue #883: the button is disabled rather than hidden while the
+            // card is blocked. Hiding it would leave the card looking like it
+            // had no next action at all, which is the ambiguity being fixed —
+            // the operator has to be able to see that Resume is the wrong click
+            // right now, not wonder where it went. `title` carries the reason
+            // for a pointer; the row above carries it for everyone else.
+            disabled={block !== null}
+            title={
+              block
+                ? "Blocked — decide its approvals first; resuming re-runs the work from the start."
+                : undefined
+            }
+            onClick={(e) => {
+              // Don't let the click bubble to the card's open handler.
+              e.stopPropagation();
+              onResume();
+            }}
+          >
+            <Play className="mr-1.5 size-3.5" />
+            Resume
+          </Button>
+        </>
       )}
+    </div>
+  );
+}
+
+/**
+ * Why a paused card is stopped, on the card itself (issue #883).
+ *
+ * The card used to carry a Resume button and nothing else, so "decided one of
+ * five, still waiting on four" and "wedged" were the same pixels — and Resume
+ * was the natural next click from both. It is the wrong click from the first:
+ * the turn continues on its own when the last decision lands (#469), so
+ * re-dispatching only re-runs the work and parks the same calls again.
+ *
+ * Names the calls, not the mechanism. One blocked call is quoted in full —
+ * through {@link approvalAction}, the same function the Approvals page and the
+ * chat card label their rows with, so all three say "Fetch a web page" rather
+ * than three different things about one approval. Several are counted instead,
+ * because five tool names is not something to read on a Kanban card; the count
+ * plus the Review link is, and the page it links to lists them.
+ */
+function BlockedRow({
+  block,
+  now,
+  onReview,
+}: {
+  block: TaskApprovalBlock;
+  /** The same clock the block was derived against. */
+  now: number;
+  onReview?: () => void;
+}) {
+  const only = block.count === 1 ? block.approvals[0] : null;
+  return (
+    <div className="mt-2 rounded-md border border-status-blocked/30 bg-status-blocked-soft px-2 py-1.5">
+      <div className="flex items-center gap-1.5 text-2xs font-medium text-status-blocked-text">
+        <Hourglass className="size-3 shrink-0" />
+        <span className="min-w-0 truncate">
+          {only ? approvalAction(only) : `Blocked on ${block.count} approvals`}
+        </span>
+      </div>
+      <div className="mt-0.5 flex items-center justify-between gap-2 text-2xs text-muted-foreground">
+        <span className="truncate">
+          Waiting for your approval · {timeAgo(block.since, now)}
+        </span>
+        {onReview && (
+          <button
+            type="button"
+            className="shrink-0 font-medium text-status-blocked-text underline-offset-2 hover:underline"
+            onClick={(e) => {
+              // The card's own click handler opens task detail; this goes
+              // somewhere else, so it must not also do that.
+              e.stopPropagation();
+              onReview();
+            }}
+          >
+            Review
+          </button>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/test/unit/task-approval-block.test.ts
+++ b/frontend/test/unit/task-approval-block.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApprovalSummary } from "@/api/types";
+import { approvalsForTask, taskApprovalBlock } from "@/lib/task-approvals";
+
+/**
+ * What a paused card is blocked on (issue #883).
+ *
+ * The board reads `…/tasks`, whose card projection carries no approvals, so
+ * before this a paused card could only show a Resume button and no reason —
+ * and Resume is the wrong click from that state: the turn continues on its own
+ * when the last decision it parked lands (#469), so re-dispatching re-runs the
+ * work and parks the same calls again.
+ *
+ * These pin the join the card is derived from. Each case below is a way the
+ * card could look completely normal while saying something false, which is why
+ * they are here rather than left to the rendered board.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+
+function approval(
+  id: string,
+  at: number,
+  task: ApprovalSummary["task"],
+): ApprovalSummary {
+  return {
+    id,
+    kind: "web_fetch",
+    amount_usd: null,
+    at_millis: at,
+    agent: "seo",
+    task,
+    payload: { url: `https://example.com/${id}` },
+  };
+}
+
+const MINE = (id: string, at: number) => approval(id, at, { link: "task", id: "task-1" });
+const THEIRS = (id: string, at: number) => approval(id, at, { link: "task", id: "task-2" });
+
+describe("approvalsForTask", () => {
+  it("takes only the approvals whose park named this card", () => {
+    const feed = [MINE("a1", T0), THEIRS("b1", T0), MINE("a2", T0 + 1_000)];
+    expect(approvalsForTask(feed, "task-1").map((a) => a.id)).toEqual(["a1", "a2"]);
+  });
+
+  /**
+   * `{link: "unlinked"}` is a park the runtime performed for no card — a
+   * workflow delivery, an operator-chat turn, a scheduler tick. Counting one
+   * would put "blocked on 1 approval" on a card that is not blocked at all, and
+   * then disable its Resume button forever, since deciding that approval would
+   * never be something the operator connects to this card.
+   */
+  it("ignores an approval that belongs to no card", () => {
+    const feed = [approval("u1", T0, { link: "unlinked" }), MINE("a1", T0)];
+    expect(approvalsForTask(feed, "task-1").map((a) => a.id)).toEqual(["a1"]);
+  });
+
+  /**
+   * An absent link is a park written before #333 stamped one. The host keeps a
+   * run-window heuristic for exactly this case; the board has no window to
+   * apply it against, so it must skip rather than guess — attributing an
+   * unrecorded park to whichever card happened to be read would block a card
+   * for a reason that is not its own.
+   */
+  it("ignores an approval whose park recorded no link at all", () => {
+    const feed = [approval("old", T0, undefined), MINE("a1", T0)];
+    expect(approvalsForTask(feed, "task-1").map((a) => a.id)).toEqual(["a1"]);
+  });
+});
+
+describe("taskApprovalBlock", () => {
+  it("is null when nothing in the queue names this card", () => {
+    expect(taskApprovalBlock([THEIRS("b1", T0)], "task-1")).toBeNull();
+    expect(taskApprovalBlock([], "task-1")).toBeNull();
+  });
+
+  it("counts every approval parked for this card", () => {
+    const feed = [MINE("a1", T0), THEIRS("b1", T0), MINE("a2", T0), MINE("a3", T0)];
+    expect(taskApprovalBlock(feed, "task-1")?.count).toBe(3);
+  });
+
+  /**
+   * The oldest park, not the newest — the thing the card reports is how long it
+   * has really been stopped. Taking the newest would reset a climbing clock
+   * every time a second effect parked behind the first, so a card wedged for an
+   * hour would read as freshly blocked and nothing about it would look wrong.
+   */
+  it("anchors the wait to the oldest park, whatever order the feed is in", () => {
+    const feed = [MINE("late", T0 + 600_000), MINE("early", T0), MINE("mid", T0 + 60_000)];
+    expect(taskApprovalBlock(feed, "task-1")?.since).toBe(T0);
+  });
+
+  /**
+   * Oldest first, because the card names the *first* blocked call when there is
+   * only one to name and the detail row reads the same list. An order that
+   * varied with the host's response order would make the card's sentence change
+   * between two polls that carry identical facts.
+   */
+  it("orders the approvals oldest park first", () => {
+    const feed = [MINE("late", T0 + 600_000), MINE("early", T0), MINE("mid", T0 + 60_000)];
+    expect(taskApprovalBlock(feed, "task-1")?.approvals.map((a) => a.id)).toEqual([
+      "early",
+      "mid",
+      "late",
+    ]);
+  });
+});

--- a/frontend/test/unit/task-blocked-card.test.ts
+++ b/frontend/test/unit/task-blocked-card.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { Task } from "@/api/tasks";
+import type { ApprovalSummary } from "@/api/types";
+import { taskApprovalBlock } from "@/lib/task-approvals";
+import { TaskItem } from "@/views/TasksView";
+
+/**
+ * The paused card says what it is waiting on, and does not offer Resume as the
+ * way out of it (issue #883).
+ *
+ * This suite is normally for pure functions — see `vitest.config.ts` — and the
+ * exception is earned exactly as `approval-batch-card.test.ts` earns it: the
+ * claim under test only exists at the rendered card. The issue's reproduction
+ * is a loop, and the loop is a click:
+ *
+ *   1. a turn parks five approvals;
+ *   2. the operator decides one, nothing visibly happens — the turn continues
+ *      only when the *last* of them lands (#469);
+ *   3. so Resume is the natural next click, and it re-dispatches: the agent
+ *      re-runs from the top, parks the same calls again, the queue grows.
+ *
+ * `taskApprovalBlock` is unit-tested next door and decides *whether* the card is
+ * blocked. What it cannot reach is whether the button the operator's hand lands
+ * on is actually stopped, which is the half that breaks the loop.
+ */
+
+const T0 = new Date("2026-03-02T10:00:00Z").getTime();
+const NOW = T0 + 240_000;
+
+function card(): Task {
+  return {
+    id: "task-1",
+    title: "Triage the release blockers",
+    column: "paused",
+    priority: "high",
+    assignee: "qa",
+    updatedAt: T0,
+  } as Task;
+}
+
+function parked(id: string, kind: string, at = T0): ApprovalSummary {
+  return {
+    id,
+    kind,
+    amount_usd: null,
+    at_millis: at,
+    agent: "qa",
+    task: { link: "task", id: "task-1" },
+    payload: { url: "https://example.com/a" },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+let resumes: number;
+
+async function render(approvals: ApprovalSummary[]) {
+  resumes = 0;
+  await act(async () => {
+    root.render(
+      createElement(TaskItem, {
+        task: card(),
+        dragging: false,
+        block: taskApprovalBlock(approvals, "task-1"),
+        now: NOW,
+        onOpen: () => {},
+        onResume: () => {
+          resumes += 1;
+        },
+        onReview: () => {},
+      }),
+    );
+  });
+}
+
+function resumeButton(): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll("button")).find((b) =>
+    b.textContent?.includes("Resume"),
+  );
+  if (!button) throw new Error(`no Resume button in:\n${container.innerHTML}`);
+  return button as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+describe("a paused card with approvals outstanding", () => {
+  it("names the one call it is blocked on, rather than the mechanism", async () => {
+    await render([parked("a1", "web_fetch")]);
+    // `approvalAction`'s words — the same function the Approvals page and the
+    // chat card label their rows with, so all three say one thing about one
+    // approval instead of three different things.
+    expect(container.textContent).toContain("Fetch a web page");
+    expect(container.textContent).toContain("Waiting for your approval");
+  });
+
+  it("counts them when there is more than one, instead of quoting a list", async () => {
+    await render([
+      parked("a1", "shell"),
+      parked("a2", "shell", T0 + 1_000),
+      parked("a3", "shell", T0 + 2_000),
+      parked("a4", "publish_artifact", T0 + 3_000),
+    ]);
+    expect(container.textContent).toContain("Blocked on 4 approvals");
+  });
+
+  /**
+   * The behaviour the issue is actually about. Step 3 of its reproduction is an
+   * operator pressing Resume on a card that is waiting, and the card getting
+   * worse for it.
+   */
+  it("disables Resume, so the re-dispatch loop cannot be started from here", async () => {
+    await render([parked("a1", "web_fetch")]);
+    const button = resumeButton();
+    expect(button.disabled).toBe(true);
+    await act(async () => {
+      button.click();
+    });
+    expect(resumes).toBe(0);
+  });
+
+  /**
+   * Disabled, not hidden. A card with no visible next action is the ambiguity
+   * being fixed — the operator has to see that Resume is the wrong click now,
+   * not wonder where it went.
+   */
+  it("still shows the Resume button, with the reason on it", async () => {
+    await render([parked("a1", "web_fetch")]);
+    expect(resumeButton().getAttribute("title")).toContain("decide its approvals first");
+  });
+});
+
+describe("a paused card with nothing outstanding", () => {
+  it("renders no blocked row and an enabled Resume", async () => {
+    await render([]);
+    expect(container.textContent).not.toContain("Waiting for your approval");
+    const button = resumeButton();
+    expect(button.disabled).toBe(false);
+    await act(async () => {
+      button.click();
+    });
+    expect(resumes).toBe(1);
+  });
+
+  it("is not blocked by another card's approvals", async () => {
+    await render([
+      { ...parked("b1", "web_fetch"), task: { link: "task", id: "task-2" } },
+    ]);
+    expect(resumeButton().disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

A paused card carried a **Resume** button and nothing about *why* it was paused. The card is blocked
until every approval its turn parked has been decided — the #469 continuation rule: a turn is
continued once, when the last decision it was blocked on lands. Neither the count nor the identity of
those approvals reached the card.

That makes two different states look identical:

| the operator has | the card shows |
|---|---|
| decided 1 of 5, still waiting on 4 | a Resume button |
| a genuinely wedged card | a Resume button |

Resume is the natural next click from both, and it is the wrong click from the first: it
re-dispatches, the agent re-runs from the top, parks the same calls again, and the queue grows. The
issue's own reproduction is that loop.

> **Branched off `9dc9971a`** — the #941 ledger-board merge, which landed the same day. This is
> written against the **new** board (`LedgerBoard` + `TasksView`'s `renderCard`), not the one the
> issue was filed against. A reviewer comparing to the issue text will find the card component has
> moved underneath it.

### 1. The card names the blocked call — through the function every other surface already uses

This is the part worth reading closely, because it is a **cross-surface consistency** change rather
than "the card now shows some text".

`approvalAction` in `frontend/src/lib/language.ts` is the one place that answers *"what is this
approval asking for"*. It is what #372/#375 fixed the **chat card** with when it was showing raw
runtime identifiers ("Glob", "Shell"), and what **PR #854** extended when the **workflow card** was
labelled `Continue a paused workflow` — true of every one of those cards and therefore an answer to
nothing. The board card was the third surface with the same defect and no fix.

So the blocked row calls the same function. All three now say **"Fetch a web page"** about the same
approval, instead of three different things — and a glossary entry added for one of them lands on all
three. Nothing new was written here; the wording layer is reused as-is.

- **One** blocked call is quoted in full.
- **Several** are counted (`Blocked on 4 approvals`), because five tool names is not something to
  read on a Kanban card. The count plus a **Review** link is, and the page it links to lists them.

### 2. Resume is disabled, not hidden — with the reason on it

Stated explicitly because it is a deliberate choice a reviewer will otherwise ask about.

**Hiding the button would re-create the bug.** The ambiguity being fixed is a card that gives the
operator no way to tell "blocked, and here is on what" from "stuck". A card whose only action
silently disappeared answers neither — it just moves the confusion from *which click* to *where did
the button go*. The operator has to be able to see that Resume exists and is the wrong click **right
now**.

So the button stays, `disabled`, carrying its reason in `title`
(*"Blocked — decide its approvals first; resuming re-runs the work from the start"*) for a pointer,
with the blocked row above it carrying the same reason for everyone else.

The rule lives in **exactly one place** — `taskApprovalBlock` — read by the button's `disabled` and
by the row that explains it, so the card cannot say "blocked on 4 approvals" beside a button that
dispatches anyway. There is deliberately **no second guard inside `resume()`**: `onResume` is wired
only to that button, so a copy of the rule there would be a branch nothing can execute and therefore
a branch nothing keeps true.

### 3. The queue can be narrowed to one card

`#/approvals/<taskId>`, using the unvalidated second hash segment every other view already takes
(`#/workflows/<id>`, `#/team/<agentId>`). Linkable, survives a refresh, honours Back.

A filtered queue with nothing left in it renders **"This card is clear"**, deliberately *not* the
existing "Nothing is waiting on you" — that one is a claim about the **whole company**, and it would
be said here while other cards' approvals sit one click away unread. It is also the wrong answer to
the question the operator arrived with.

### 4. The detail row names the call too

`AwaitingApprovalRow` already said *that* the card was waiting and for how long (#468). It now also
says **what**, which is what the MVP spec asks for: *"clicking the task shows what approval is
needed."*

Its **source of truth is unchanged**: `detail.approvals`, the host's own read, still decides *whether*
the card is waiting — because `approval_owner` resolves ownership with an attempt-level `run_id` key
this side cannot see. The feed only supplies the words, matched in **by approval id**. An approval the
host counts and the feed has not caught up on is still counted; it goes unnamed for one poll rather
than disappearing. It also only names the call when there is exactly one *and* every pending row was
matched — naming "the" blocked call while a second sits beside it would say one decision clears the
card when two do, which is the precise mistake this issue is about.

### Where the data comes from — and why there is no new wire field

The board reads `…/tasks`, whose card projection carries no approvals, and opening every card to find
out would be N reads per 4s poll — the cost `TaskCard::output`'s own docs record as the reason it
rides the board read.

Neither was needed. **The shell already polls `GET …/approvals` every 5s** for the sidebar badge, and
since #333 every entry carries `task: {link: "task", id}`. `CycleHostImpl::park` stamps that link on
**every** park path, so a card-dispatched approval always has it. The board joins against the feed it
was already paying for.

The consequence worth noting: the board and the Approvals page now read **one list**, not two that can
disagree.

Two states are skipped rather than guessed at, and both are deliberate:

- `{link: "unlinked"}` — a workflow delivery, an operator-chat turn, a scheduler tick. Counting one
  would put "blocked on 1 approval" on a card that is not blocked, then disable its Resume forever,
  since deciding that approval is not something the operator would ever connect to this card.
- **absent** — a park predating #333. The host keeps a run-window heuristic for exactly this case;
  the board has no window to apply it against, so it skips.

`approval_owner`'s first rule — the attempt-level `run_id` — is unreachable from here. It separates
two *runs of the same card*, which does not change the answer to "is this card blocked", the only
question the board asks.

## What this does **not** fix — stated rather than left implicit

**Resume still re-runs.** This stops the operator walking into the loop; it does not make a resume
resumable. That is engine work in the vendored pause primitive, and it is already filed twice:

| issue | the gap | why it is not here |
|---|---|---|
| **#899** | an agent node's internal call has no replay path | `NodeControl::Interrupt` discards the activation's state update, so the node re-runs from the top; `finish_agent_run` already refuses with *"resuming a paused agent is not supported yet"*. #846's `PAYLOAD_PERFORMED` ledger keys on a `tool_call` node's **static** slug and args, and an agent's internal calls are chosen mid-turn, so there is nothing to key against. |
| **#850** | `shell` / `curl` / `git_operations` still repeat | all three are `EffectGroup::Other`, which is useless as a replay predicate — the host cannot tell a `git log` from a `git push`. #846 refused to fold it in on the grounds that replaying on a guess is a bigger behavioural change than the bug. |

So: the issue's two halves land in different places. **"A paused card never says which approvals block
it"** is fixed here, completely. **"Resume re-parks it"** is *contained* here — the operator can no
longer start it from a blocked card — and *fixed* in #899 / #850, neither of which this touches.

A card sitting in Paused with **no** approvals outstanding — one moved there by hand, or a
`RunStatus::Paused` "resumed, not approved" card whose approvals have since been decided — keeps its
enabled Resume and its existing behaviour exactly.

Also untouched by design: batching (#842 / PR #848) — nothing here groups or consolidates cards — and
`approval-card.tsx`, which PR #854 deliberately stayed out of for the same reason.

## API Or Behavior Changes

**None on the wire.** No route, no HTTP/GraphQL type, no Rust file, no `Cargo.lock` line. Every new
prop is optional and defaults to the pre-#883 render, so a console built from this against an older
host behaves exactly as before.

**Behaviour:**

1. A paused card with approvals outstanding shows what it is waiting on, how many, and how long.
2. Its Resume button is disabled while they are undecided, and says why.
3. **Review** opens `#/approvals/<taskId>`, the queue narrowed to that card, with **Show all** back.
4. The task-detail awaiting row names the call and links to the same filtered queue.
5. A paused card with nothing outstanding is unchanged.

## Tests

- [x] `cargo fmt --all -- --check` — N/A: no Rust file is touched. `git diff --name-only
      upstream/main` is seven paths, all under `frontend/`.
- [x] `cargo clippy --all-targets -- -D warnings` — N/A: no Rust file is touched, and no feature
      gate is involved, so neither the default nor the `openhuman,tinycortex` lane has anything to
      lint here.
- [x] `cargo build --all-targets` — N/A: no Rust file is touched; `git diff --stat Cargo.lock` is
      empty.
- [x] `cargo test` — N/A as above. **Ran instead, as the console's CI lane does:**
  - `npm run typecheck` (`tsc -b --noEmit`) — clean
  - `npm run typecheck:unit` — clean
  - `npm run typecheck:e2e` — clean
  - `npm run build` — clean
  - `npx vitest run` — **828 passed, 79 files, 0 failed.** No pre-existing failures in this repo;
    13 of those tests are new.

  Not run: `prettier`. CI does not run it, and untouched files (`src/views/InboxView.tsx`,
  `src/hooks/use-company.ts`) fail `prettier --check` on `main` — so running it would have produced
  reformatting noise across files this change has nothing to do with.

### Every new test was proven to fail with its fix reverted — 12 of 13

Each fix reverted individually, the suite re-run, the named test observed failing:

| reverted | test that failed |
|---|---|
| `since` takes the newest park instead of the oldest | `anchors the wait to the oldest park, whatever order the feed is in` |
| the oldest-first `sort` is dropped | `anchors the wait to the oldest park…`, `orders the approvals oldest park first` |
| `approvalsForTask` stops filtering on the task link | all 3 `approvalsForTask` cases, both `taskApprovalBlock` ownership cases, `is not blocked by another card's approvals` (6 in total) |
| `BlockedRow` is not rendered | `names the one call it is blocked on…`, `counts them when there is more than one…` |
| the row names the mechanism instead of the call | the same two |
| `disabled={block !== null}` → `disabled={false}` | `disables Resume, so the re-dispatch loop cannot be started from here` |
| the `title` reason is removed | `still shows the Resume button, with the reason on it` |

**The 13th is a control case** — `renders no blocked row and an enabled Resume`, the unblocked path —
and has no meaningful revert: any change that makes it fail also fails one of the tests above.
Recorded rather than counted as coverage.

**One test file earns an exception to `vitest.config.ts`'s pure-functions rule**, on the same grounds
`approval-batch-card.test.ts` earns it: the claim under test is *"Resume is disabled"*, which exists
only at the rendered button. `taskApprovalBlock` is unit-tested next door and decides *whether* the
card is blocked; it cannot reach whether the button the operator's hand lands on is actually stopped,
and that is the half that breaks the loop. `TaskItem` is exported for it, with the reason recorded at
the export.

### What is NOT proven, stated rather than claimed as coverage

- **No live check.** Browser automation was unavailable for this session, so nothing here was driven
  against the `marketing` staging tenant. The claims are from the code and the suite.
- **The Approvals filter's markup has no component test.** Its predicate — `approvalsForTask`, the
  same one the board uses, deliberately not a second copy — is unit-tested and revert-proven, but the
  filter banner, the **Show all** link and the `ClearedForTask` state are JSX with no component-test
  harness in this repo for that view. Same gap PR #854 recorded for `RunHistoryPanel`'s branch.
- **No test drives an approval end-to-end from park to blocked card.** That needs the e2e lane
  (a live host plus the mock brain), which this change did not add a spec to.

## Documentation

No spec doc changes. The reasoning lives at the code it governs: `frontend/src/lib/task-approvals.ts`
carries the ownership rule, why the two skipped link states are skipped, and why the host's
attempt-level key is out of reach; `TasksView`'s `BlockedRow` carries the disabled-not-hidden
argument and the `approvalAction` reuse.

Closes #883
