### PR TITLE
fix(chat): run the operator chat turn off the request future

### DIFF
--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -25,6 +25,7 @@ use axum::{Json, Router};
 use futures::StreamExt;
 use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
+use tokio::task::JoinHandle;
 
 use crate::AppState;
 use crate::company::runtime::CompanyRuntime;
@@ -1357,11 +1358,108 @@ async fn chat_and_emit(
         Some(raw) => Some(parse_message_id(raw)?),
         None => None,
     };
-    let (mut report, feedback_note) = run_chat(runtime.clone(), message, by, parent).await?;
+    // The turn runs on its own task, and the replies are journaled there too
+    // (issue #882). Both used to sit in this handler's future, which hyper drops
+    // the moment the peer goes away — and a reverse proxy in front of a hosted
+    // tenant goes away the moment it decides the upstream is too slow. A turn
+    // slower than that timeout was therefore cancelled mid-flight: tokens spent,
+    // side effects half-applied, and no `AgentReply` ever appended, so the
+    // operator's DM history held their question and no answer and the turn could
+    // neither be read back nor resumed.
+    //
+    // Awaiting the handle is drop-safe — dropping it abandons the *waiting*, not
+    // the work — so this answers exactly as it did before and needs no wire
+    // change to survive the disconnect. Same shape as the approval path
+    // (`CompanyRuntime::resolve_approval_spawned`, issue #380 defect 3) and the
+    // workflow runner (`WorkflowSpawn::spawn_admitted`), which is why a 504'd
+    // workflow run kept executing while a 504'd chat turn did not.
+    let (report, feedback_note) = join_chat_turn(spawn_chat_turn(ChatTurn {
+        runtime,
+        company: id.clone(),
+        desk,
+        message,
+        by,
+        parent,
+    }))
+    .await?;
     emit_cycle_webhooks(state, id, &report).await;
     if let Some(note) = feedback_note {
         emit_feedback_webhook(state, id, &note).await;
     }
+    Ok(Json(ChatResponse {
+        // The operator's own message is the cycle's single input event, so its
+        // sequence is the first the cycle journaled (issue #364).
+        message_id: report.input_seqs.first().map(|seq| seq.value().to_string()),
+        responses: report.responses,
+        // A chat turn is nobody's sign-off, so this stays absent here.
+        still_awaiting: None,
+    }))
+}
+
+/// Everything a chat turn needs once it is off the request's future.
+///
+/// A struct rather than six positional arguments because the spawn boundary is
+/// exactly where a mis-ordered pair of `String`s would compile and then journal
+/// replies against the wrong desk.
+struct ChatTurn {
+    runtime: Arc<CompanyRuntime>,
+    company: CompanyId,
+    desk: String,
+    message: ChatMessage,
+    by: Option<Actor>,
+    parent: Option<EventSeq>,
+}
+
+/// Runs a chat turn and journals its replies on a task of its own (issue #882).
+///
+/// The journal write belongs on this side of the spawn, not back in the handler.
+/// Spawning only the cycle would still lose the answer: the turn would finish,
+/// and the `AgentReply` append that makes it readable — and that the `agent_reply`
+/// SSE frame is derived from — would die with the dropped handler future. The
+/// work is not recorded until it is journaled, so both halves move together.
+fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<String>), ApiError>> {
+    tokio::spawn(async move {
+        let ChatTurn {
+            runtime,
+            company,
+            desk,
+            message,
+            by,
+            parent,
+        } = turn;
+        let (mut report, feedback_note) =
+            run_chat(Arc::clone(&runtime), message, by, parent).await?;
+        journal_chat_replies(&runtime, &company, &desk, parent, &mut report).await;
+        Ok((report, feedback_note))
+    })
+}
+
+/// Awaits a spawned chat turn, turning a task that never finished into an error.
+///
+/// Mirrors [`crate::company::runtime::join_follow_up`]: a panicked or aborted
+/// task is a background-task failure rather than a silent empty reply.
+async fn join_chat_turn(
+    turn: JoinHandle<Result<(CycleReport, Option<String>), ApiError>>,
+) -> Result<(CycleReport, Option<String>), ApiError> {
+    match turn.await {
+        Ok(result) => result,
+        Err(err) => Err(ApiError(OpenCompanyError::BackgroundTask(format!(
+            "the chat turn did not finish: {err}"
+        )))),
+    }
+}
+
+/// Journals each reply against the addressed desk.
+///
+/// Runs inside the spawned turn (issue #882) so the record survives a client or
+/// proxy that gave up waiting.
+async fn journal_chat_replies(
+    runtime: &Arc<CompanyRuntime>,
+    id: &CompanyId,
+    desk: &str,
+    parent: Option<EventSeq>,
+    report: &mut CycleReport,
+) {
     // Journal each reply against the addressed desk so desk history can be read
     // back (GraphQL `Chat.history`, WS2c). Single-responder in v1.
     //
@@ -1389,7 +1487,7 @@ async fn chat_and_emit(
                     // which is the lineage an operator wants and costs no
                     // schema change.
                     task_id: response.task_id.clone(),
-                    chat_id: desk.clone(),
+                    chat_id: desk.to_string(),
                     agent_id: response.channel.clone(),
                     text: response.text.clone(),
                     // Persist the per-bubble timeline so a history reload
@@ -1410,14 +1508,6 @@ async fn chat_and_emit(
             ),
         }
     }
-    Ok(Json(ChatResponse {
-        // The operator's own message is the cycle's single input event, so its
-        // sequence is the first the cycle journaled (issue #364).
-        message_id: report.input_seqs.first().map(|seq| seq.value().to_string()),
-        responses: report.responses,
-        // A chat turn is nobody's sign-off, so this stays absent here.
-        still_awaiting: None,
-    }))
 }
 
 /// Parses a message id from the wire into the sequence position it names.
@@ -4808,6 +4898,138 @@ mod test {
             c.runtime.grants.live_count(),
             1,
             "the continuation minted no second grant"
+        );
+    }
+
+    /// The reply a stalled chat turn produces once released.
+    const SLOW_TURN_REPLY: &str = "the slow turn's answer";
+
+    /// A brain that stalls on the operator's **first** turn — the chat lane,
+    /// rather than the approval follow-up `StalledContinuationBrain` stalls on.
+    struct StalledChatBrain {
+        /// Fires once the turn is under way, which is the moment the field
+        /// report's proxy gave up and closed the connection.
+        entered: Arc<tokio::sync::Notify>,
+        /// The test's permission for that turn to finish.
+        release: Arc<tokio::sync::Notify>,
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::brain::Brain for StalledChatBrain {
+        async fn run_cycle(
+            &self,
+            req: crate::ports::types::CycleRequest,
+            _host: &dyn crate::ports::brain::CycleHost,
+        ) -> crate::Result<crate::ports::types::CycleResult> {
+            let mut channel_responses = Vec::new();
+            for event in &req.events {
+                if matches!(event, CompanyEvent::OperatorMessage { .. }) {
+                    self.entered.notify_one();
+                    self.release.notified().await;
+                    channel_responses.push(crate::ports::types::OutboundMessage {
+                        message_id: None,
+                        task_id: None,
+                        channel: "operator".into(),
+                        text: SLOW_TURN_REPLY.into(),
+                        steps: Vec::new(),
+                        reply_to: None,
+                    });
+                }
+            }
+            Ok(crate::ports::types::CycleResult {
+                channel_responses,
+                new_traces: vec![crate::ports::types::CompressedTrace::now(
+                    &req.cycle_id,
+                    "stalled chat",
+                )],
+                ledger_deltas: Vec::new(),
+                token_usage: crate::ports::types::TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Whether the turn's answer reached the durable journal.
+    async fn reply_journaled(runtime: &Arc<CompanyRuntime>) -> bool {
+        runtime
+            .events()
+            .read_from(runtime.id(), EventSeq::new(0), 10_000)
+            .await
+            .unwrap()
+            .iter()
+            .any(|stored| {
+                matches!(
+                    &stored.event,
+                    CompanyEvent::AgentReply { text, .. } if text == SLOW_TURN_REPLY
+                )
+            })
+    }
+
+    /// Waits for the released turn to journal its reply.
+    async fn await_reply_journaled(runtime: &Arc<CompanyRuntime>) -> bool {
+        tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while !reply_journaled(runtime).await {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok()
+    }
+
+    /// **Issue #882.** A chat turn whose caller walks away mid-flight must still
+    /// finish and still journal its answer.
+    ///
+    /// This is the chat-lane twin of
+    /// `a_dropped_connection_does_not_cancel_the_follow_up_cycle`. Both the
+    /// cycle and the `AgentReply` append used to live inside the request future,
+    /// so a turn slower than nginx's read timeout was cancelled mid-flight and
+    /// the answer was never written. The operator's DM history then held their
+    /// question and nothing else — the turn could not be read back on reload and
+    /// could not be resumed, which is what #882 reported. Workflow runs survived
+    /// the identical 504 precisely because they are spawned.
+    ///
+    /// `Router::oneshot` reproduces the cancellation by the same mechanism hyper
+    /// uses: the handler future is owned by the future the caller polls, so
+    /// dropping the latter drops the former.
+    #[tokio::test]
+    async fn a_dropped_connection_does_not_lose_the_chat_turns_work() {
+        let home_dir = home();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let release = Arc::new(tokio::sync::Notify::new());
+        let state = build_state_with_brain(
+            home_dir.path(),
+            "running",
+            AppConfig::default(),
+            Some(Arc::new(StalledChatBrain {
+                entered: entered.clone(),
+                release: release.clone(),
+            })),
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let app = router(state);
+
+        // Send the turn, then let the connection die once it is under way —
+        // exactly what the proxy does when it decides the upstream is too slow.
+        let mut chatting = Box::pin(app.clone().oneshot(chat_request("run the seo audit")));
+        tokio::select! {
+            _ = &mut chatting => panic!("the chat answered before the turn began"),
+            _ = entered.notified() => {}
+        }
+        drop(chatting);
+
+        // Nothing is journaled yet: the turn is still stalled inside the brain.
+        assert!(
+            !reply_journaled(&runtime).await,
+            "the reply was journaled before the turn was released"
+        );
+
+        // The work must survive the caller giving up.
+        release.notify_one();
+        assert!(
+            await_reply_journaled(&runtime).await,
+            "the chat turn died with the dropped connection: the operator's \
+             message is journaled, the answer is not, and the turn can neither \
+             be read back nor resumed (issue #882)"
         );
     }
 


### PR DESCRIPTION
## Summary

A long chat turn returned a raw nginx `504` **and lost the turn's work**. After the timeout the
operator's DM history held their question and no reply: nothing was persisted, so the turn could
neither be read back on reload nor resumed. That is the half that corrupts state — the board and the
journal disagree with reality.

The cause is not a timeout value. It is **cancellation**. The chat turn ran inline inside the request
handler future (`run_chat` → `runtime.run_cycle(...).await`), and hyper drops a handler future the
moment the peer closes — which is exactly what a reverse proxy does when it decides the upstream is
too slow. Tokens spent, side effects half-applied, nothing journaled.

The issue's own evidence points straight at this: a `feature_pipeline` run **also** 504'd and kept
executing server-side, nodes completing normally. Workflow runs are `tokio::spawn`ed
(`WorkflowSpawn::spawn_admitted`); the operator chat turn was the remaining inline path. Same proxy,
same 504, opposite outcome — a cancellation signature, not a timeout signature.

**No timeout is touched here.** Raising one moves the cliff without removing it.

### Why this diff is +232 and not +20

The non-obvious half: **the journal write had to cross the spawn boundary too.**

Spawning only the cycle would still have lost the answer. The `AgentReply` append did not live in the
cycle — it sat back in the handler, *after* `run_chat` returned (`operator.rs:1373-1412` before this
change). So a spawned cycle would have completed correctly and the append that makes a reply readable
would still have died with the dropped handler future. That same append is what the `agent_reply` SSE
frame is derived from, so the live stream would have stayed silent as well. The work is not recorded
until it is journaled, so both halves move together — which is what the new `spawn_chat_turn` /
`journal_chat_replies` split is for.

### Precedent, not a new pattern

This is the shape the repo already prescribes for exactly this failure, applied to the one lane that
had not received it. `CompanyRuntime::resolve_approval_spawned` (`src/company/runtime.rs:1130-1152`)
documents the reasoning verbatim:

> hyper drops a handler's future the moment the peer closes the connection, and a reverse proxy in
> front of a hosted tenant closes it the moment it decides the upstream is too slow […] Awaiting a
> `JoinHandle` is drop-safe: dropping the handle abandons the *waiting*, not the work. So every caller
> — including the one that just awaits it and answers exactly as before — survives a disconnect, with
> no wire change required to get that.

That is precisely what this does for chat.

### Context: the unfinished half of #380

#380 ("a slow approval times out at the proxy, then reports the decision as failed when it was
recorded") named four defects. PR #394 closed it, **frontend-only** — its checklist reads
`cargo — N/A: no Rust file is touched`. Defects 3 and 4 were never done:

> **3.** Decouple the response from the follow-up cycle […] Raising the proxy timeout is a mitigation,
> not a fix.
> **4.** Confirm and fix whether a dropped client connection cancels the in-flight cycle.

The approval lane later got that treatment. Chat did not. This is that work, in the chat lane.

## API Or Behavior Changes

**No wire change.** The handler awaits the spawned turn's `JoinHandle`, so `POST {scope}/chat` answers
with the same `ChatResponse`, the same status, and the same `message_id`/`responses` bytes as before.
No route, DTO, schema or timeout is altered.

The behaviour that changes is what survives a dropped connection: the turn now runs to completion and
its replies are journaled, so the answer is readable from `chat/history` on reload and is emitted on
the `agent_reply` SSE frame. Previously both were lost.

A task that panics or is aborted now surfaces as `OpenCompanyError::BackgroundTask` rather than a
silent empty reply, mirroring `join_follow_up`.

**Ordering note:** replies are now journaled *before* `emit_cycle_webhooks` rather than after. Durable
first is the right order for this bug, and no reader depends on the previous interleaving.

### Known limitation, stated deliberately

`emit_cycle_webhooks` still runs in the handler, so a dropped connection still skips the webhook
fan-out. This mirrors the approval route's **synchronous** arm, which has the same property; only its
`detach` arm spawns the fan-out. Journal state is now drop-safe, outbound notification is not. Left
out of scope rather than silently widened — worth its own follow-up.

### The 504 itself is not fixed here

Reported rather than changed, because the premise it would rest on does not hold:

* **It is a proxy limit.** `frontend/nginx/default.conf.template` sets **no `proxy_read_timeout`** for
  `location /api/`, so nginx's default **60s** applies. `grep` finds no `proxy_read_timeout` anywhere
  in the repo.
* **There is no server deadline.** The router carries one `.layer()` (auth); no `TimeoutLayer`
  anywhere. The only turn deadline in the tree is `BUILD_TIMEOUT = 120s`
  (`src/harness/workflow_build.rs:96`), scoped to the workflow-copilot build turn.
* **The turn is unbounded server-side.**
* **There is no existing 600s deadline to align with.** No such constant exists; the only 600s is the
  unrelated `OAUTH_PENDING_TTL` (`src/app/types.rs:878`).

So a 504 fix would *create* a policy rather than align with one — either a `202` + SSE shape for chat
(the detach arm approvals already has) or a server-side turn deadline returning a real error envelope
instead of an nginx page. Both are larger and both are product calls, so they belong in their own
issue referencing #380 defect 3. This PR fixes the half that loses data.

*UNVERIFIED:* the reported 504 came from a hosted tenant whose ingress nginx is not in this repo. Only
the in-repo template was inspected; no live staging check was made (browser automation unavailable).

## Tests

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs it:
  `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
  exit 0. `--no-deps` mirrors the `Clippy (openhuman, tinycortex)` lane, where it is load-bearing;
  an unscoped run hard-fails on vendored lints CI never sees.
- [x] `cargo build --all-targets` — `cargo build --locked --features openhuman,tinycortex
  --all-targets`, exit 0.
- [x] `cargo test` — two lanes:
  * `cargo test --locked --features openhuman,tinycortex --tests` → **4105 passed, 0 failed, 3
    ignored** across 5 targets (the gated lane; default features skip roughly a third of the code).
  * `cargo test --lib` → **2722 passed, 0 failed, 1 ignored**.

### The new test was verified to gate

`a_dropped_connection_does_not_lose_the_chat_turns_work` (`src/server/operator.rs`) is the chat-lane
twin of the existing `a_dropped_connection_does_not_cancel_the_follow_up_cycle`. A `StalledChatBrain`
holds the turn open; the test drops the request future mid-turn, releases the brain, and asserts the
reply reached the durable journal.

`Router::oneshot` reproduces the cancellation by the same mechanism hyper uses rather than by analogy:
the handler future is owned by the future the caller polls, so dropping the latter drops the former.
This is the method the existing keystone test already relies on.

**Reverting the fix fails it.** Restoring the pre-#882 inline shape (cycle and journal both in the
handler) and re-running produces the field symptom exactly:

```
test server::operator::test::a_dropped_connection_does_not_lose_the_chat_turns_work ... FAILED
panicked at src/server/operator.rs:
  the chat turn died with the dropped connection: the operator's message is journaled,
  the answer is not, and the turn can neither be read back nor resumed (issue #882)
```

Restoring the fix returns it to green. The test also asserts that **nothing** is journaled before the
brain is released, so it cannot pass vacuously against a fix that journals eagerly.

## Documentation

No spec doc changes. `docs/spec/runtime/api.md:48-52` already states the drop-safety contract for the
resolve/run paths ("it is no longer cancelled when a client or a reverse proxy gives up mid-turn");
this brings chat into line with that documented behaviour rather than changing it. The reasoning
specific to the chat lane — and why the journal write must sit on the spawned side — is recorded in
the doc comments on `spawn_chat_turn` and `journal_chat_replies`.

Closes #882
