### PR TITLE
fix(tasks): let a card settled by a chat turn carry an output link (#806)

### DIFF
--- a/docs/spec/runtime/ports-runs.md
+++ b/docs/spec/runtime/ports-runs.md
@@ -133,6 +133,17 @@ Old `RunRecord`s are never synthesised from historical `AgentReply` events:
 fabricating identity for attempts nobody recorded would be worse than a
 pre-existing card honestly showing zero of them.
 
+Nor is one synthesised for an **operator chat turn** (issue #806). A turn that
+produces something from chat — authoring a workflow inline with
+`create_workflow`, say — has no attempt behind it, and minting a run row so its
+card could carry a `TaskOutput` would make the Attempts tab claim work was
+attempted. Run records stay reserved for actual work attempts, so the Attempts
+list shows turns that did something (epic #183 §4). `TaskOutput` instead names
+*what produced it* as a closed set — `TaskOutputSource::Run` or
+`TaskOutputSource::ChatTurn` — which keeps the board's "every card in Done links
+to what it produced" (#339) true without weakening what a run means. See
+[ports-state.md](ports-state.md) for the task record itself.
+
 ## Reading runs back
 
 Three surfaces, all in `src/server/ops/runs.rs`, under both scope forms:

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -48,29 +48,54 @@ export interface TaskOutputWorkflow {
 }
 
 /**
+ * What produced a {@link TaskOutput} — and what its link of last resort points
+ * at (issue #806).
+ *
+ * A run is *an* addressable producer, not the only one. An operator chat turn
+ * produces things too, and run records stay reserved for actual work attempts,
+ * so such a turn has no run to name. This is a union rather than an optional
+ * `runId` so the console can label what is at the other end instead of calling
+ * a conversation an attempt.
+ *
+ * Discriminate with `"runId" in source` — the host flattens these keys onto the
+ * output, so a run-sourced record is byte-identical to what this type carried
+ * before the union existed.
+ */
+export type TaskOutputSource =
+  | {
+      /** The attempt that produced it. */
+      runId: string;
+      /** Its 1-based ordinal, for the label. Absent if unreadable. */
+      attempt?: number;
+    }
+  | {
+      /** The conversation whose turn produced it. */
+      chatId: string;
+    };
+
+/**
  * What a card's latest **successful** attempt produced (issue #339, epic #183
  * §6) — the link that turns a finished card into something you can open.
  *
- * `runId` is unconditional, and that is the whole design: an output with no
- * artifacts and no workflows is not an absence, it is the *trace case*. Plenty
- * of tasks produce no file — a message sent, a record updated, a question
- * answered — and for those the attempt's trace **is** the deliverable. It is
- * also the fallback when an artifact is later deleted.
+ * **A last-resort link is unconditional, and that is the whole design**: an
+ * output with no artifacts and no workflows is not an absence, it is the *trace
+ * case*. Plenty of tasks produce no file — a message sent, a record updated, a
+ * question answered — and for those the producer's own record **is** the
+ * deliverable. It is also the fallback when an artifact is later deleted.
+ *
+ * The guarantee is "there is always something to open", not "there is always a
+ * `runId`" (issue #806) — see {@link TaskOutputSource}.
  *
  * Absent entirely on a card that has never succeeded, one moved to Done by
  * hand, and every card settled before this shipped. Those link to the card
  * itself rather than to a synthesized output.
  */
-export interface TaskOutput {
-  /** The attempt that produced it — always present. */
-  runId: string;
-  /** That attempt's 1-based ordinal, for the label. Absent if unreadable. */
-  attempt?: number;
+export type TaskOutput = TaskOutputSource & {
   /** Epoch-millis the stamp was written. */
   atMillis: number;
   artifacts?: TaskOutputArtifact[];
   workflows?: TaskOutputWorkflow[];
-}
+};
 
 /**
  * What surface a plan's prerequisite is checked against (issue #337).

--- a/frontend/src/lib/task-output.ts
+++ b/frontend/src/lib/task-output.ts
@@ -98,17 +98,37 @@ function linksFor(taskId: string, output: TaskOutput): TaskLink[] {
           : "Opens the workflow this task built. It has not been run yet.",
     });
   }
-  // Always last, and always present: the attempt is the deliverable when
+  // Always last, and always present: the producer is the deliverable when
   // nothing else is, and the fallback when a published artifact is later
   // deleted. This is what stops "no artifact" degrading into "no link".
-  links.push({
-    kind: "trace",
-    href: traceHref(taskId, output.runId),
-    label: output.attempt
-      ? `View run trace · attempt ${output.attempt}`
-      : "View run trace",
-    hint: "Opens what this attempt actually did, step by step.",
-  });
+  //
+  // Which producer is a closed set (issue #806). A run has a trace to open; an
+  // operator chat turn has no run row and never gets a synthetic one, so it
+  // falls back to the card and says why. Labelling a conversation "attempt 1"
+  // would be the lie the union exists to prevent.
+  if ("runId" in output) {
+    links.push({
+      kind: "trace",
+      href: traceHref(taskId, output.runId),
+      label: output.attempt
+        ? `View run trace · attempt ${output.attempt}`
+        : "View run trace",
+      hint: "Opens what this attempt actually did, step by step.",
+    });
+  } else {
+    // `#/conversation/<id>` is deliberately NOT used here: `conversation` is a
+    // view in the hash router but the active thread is component state, so no
+    // such address resolves today. The card is where the conversation is
+    // reachable from ("Opened from a conversation", issue #246), so this points
+    // there and says so rather than minting a link that would silently land on
+    // the wrong thread. Deep-linking the thread is its own change.
+    links.push({
+      kind: "card",
+      href: cardHref(taskId),
+      label: "Open this task",
+      hint: "This was settled by a chat turn rather than a run, so there is no attempt to open — the conversation it came from is linked on the card.",
+    });
+  }
   return links;
 }
 

--- a/frontend/test/unit/task-links.test.ts
+++ b/frontend/test/unit/task-links.test.ts
@@ -74,6 +74,39 @@ describe("primaryLink", () => {
     expect(link.href).toBe("#/tasks/t-1");
   });
 
+  // --- issue #806: an output whose producer is a chat turn, not a run --------
+
+  it("opens the workflow a chat turn authored, with no run in the address", () => {
+    // The case #806 exists for: the card is settled by an operator chat turn,
+    // so there is no attempt — but there IS a deliverable, and the board's
+    // contract is written in terms of links. The workflow href must carry no
+    // `?run=`, because naming one would address an attempt that never happened.
+    const link = primaryLink(
+      task({
+        output: {
+          chatId: "chat-42",
+          atMillis: 0,
+          workflows: [{ workflowId: "w-1", action: "created" }],
+        },
+      }),
+    );
+    expect(link.kind).toBe("workflow");
+    expect(link.href).toBe("#/workflows/w-1");
+  });
+
+  it("never labels a chat turn as a run trace", () => {
+    // The last-resort arm. A chat-sourced output with nothing else to show must
+    // not reach `traceHref` — `#/tasks/t-1?run=undefined` is the shape of the
+    // bug this union prevents.
+    const link = primaryLink(
+      task({ output: { chatId: "chat-42", atMillis: 0 } }),
+    );
+    expect(link.kind).toBe("card");
+    expect(link.href).toBe("#/tasks/t-1");
+    expect(link.href).not.toContain("run=");
+    expect(link.label).not.toContain("attempt");
+  });
+
   it("escapes a task id that would otherwise break the address", () => {
     const link = primaryLink(task({ id: "t/1 2" }));
     expect(link.href).toBe("#/tasks/t%2F1%202");

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -64,7 +64,7 @@ use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
 use crate::ports::runs::{RunOutcome, RunStatus};
-use crate::ports::tasks::{COLUMN_IN_REVIEW, TaskOutput, TaskOutputArtifact};
+use crate::ports::tasks::{COLUMN_IN_REVIEW, TaskOutput, TaskOutputArtifact, TaskOutputSource};
 use crate::ports::types::{
     CompanyEvent, CompanyRecord, CompressedTrace, CycleRequest, CycleResult, OutboundMessage,
     TokenUsage, TurnStep, TurnStepKind, TurnStepStatus, Verdict,
@@ -1171,8 +1171,10 @@ impl HarnessBrain {
         // failed retry cannot erase the link to the success before it.
         if succeeded && let Some(sink) = sink.as_ref() {
             card.output = Some(TaskOutput {
-                run_id: sink.run_id().to_string(),
-                attempt: self.attempt_ordinal(sink.run_id()).await,
+                source: TaskOutputSource::Run {
+                    run_id: sink.run_id().to_string(),
+                    attempt: self.attempt_ordinal(sink.run_id()).await,
+                },
                 at_millis: now_millis(),
                 artifacts: recorded,
                 workflows: staged_workflows,

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -1252,12 +1252,14 @@ async fn a_plan_fills_a_blank_assignee_but_never_reassigns_one() {
 /// silence that has to keep being true.
 #[tokio::test]
 async fn a_re_plan_does_not_erase_what_an_earlier_attempt_produced() {
-    use crate::ports::tasks::TaskOutput;
+    use crate::ports::tasks::{TaskOutput, TaskOutputSource};
 
     let (_home, runtime) = runtime_with(ScriptedModel::replying(CLEAN_PLAN)).await;
     let produced = TaskOutput {
-        run_id: "run-7".to_string(),
-        attempt: Some(2),
+        source: TaskOutputSource::Run {
+            run_id: "run-7".to_string(),
+            attempt: Some(2),
+        },
         at_millis: 1_000,
         artifacts: Vec::new(),
         workflows: Vec::new(),

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -909,8 +909,12 @@ async fn a_published_card_links_to_the_version_its_run_wrote() {
         .await
         .output
         .expect("a successful run stamps its card");
-    assert_eq!(output.run_id, "run-1");
-    assert_eq!(output.attempt, Some(1), "the first attempt at this card");
+    assert_eq!(output.source.run_id(), Some("run-1"));
+    assert_eq!(
+        output.source.attempt(),
+        Some(1),
+        "the first attempt at this card"
+    );
     assert_eq!(output.artifacts.len(), 1, "got {:?}", output.artifacts);
 
     let linked = &output.artifacts[0];
@@ -958,7 +962,7 @@ async fn a_task_that_produced_no_file_still_links_to_its_trace() {
         .await
         .output
         .expect("no artifact must not mean no link");
-    assert_eq!(output.run_id, "run-1");
+    assert_eq!(output.source.run_id(), Some("run-1"));
     assert!(output.artifacts.is_empty());
     assert!(output.workflows.is_empty());
 }
@@ -1006,8 +1010,8 @@ async fn a_re_run_repins_the_link_to_the_attempt_that_last_succeeded() {
         .expect("run 2");
 
     let second = card_after(&ops, "t-1").await.output.expect("re-stamped");
-    assert_eq!(second.run_id, "run-2");
-    assert_eq!(second.attempt, Some(2));
+    assert_eq!(second.source.run_id(), Some("run-2"));
+    assert_eq!(second.source.attempt(), Some(2));
     assert_eq!(second.artifacts.len(), 1, "one path, one record, one link");
     assert_eq!(
         second.artifacts[0].version, 2,
@@ -1018,7 +1022,7 @@ async fn a_re_run_repins_the_link_to_the_attempt_that_last_succeeded() {
         "republishing one path extends one record"
     );
     // The earlier attempt is not erased — it is still reachable as its own run.
-    assert_ne!(second.run_id, first.run_id);
+    assert_ne!(second.source.run_id(), first.source.run_id());
 }
 
 /// *"A retried task links to the successful one."* The failing half: a later
@@ -1069,7 +1073,7 @@ async fn a_failed_retry_does_not_erase_the_link_to_the_success_before_it() {
     let still = after
         .output
         .expect("the success's link survives the failure");
-    assert_eq!(still.run_id, succeeded.run_id);
+    assert_eq!(still.source.run_id(), succeeded.source.run_id());
     assert_eq!(still.artifacts, succeeded.artifacts);
 }
 

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -531,15 +531,27 @@ where
 /// of a task was a chat message: prose in a conversation, with no durable thing
 /// to open, share, or hand to somebody else. This is that thing.
 ///
-/// # `run_id` is unconditional, and that is the whole design
+/// # A last-resort link is unconditional, and that is the whole design
 ///
 /// An output with **no** artifacts and **no** workflows is not an absence — it
 /// is the *trace case*, and it is the common one. Plenty of tasks produce no
 /// file (a message sent, a record updated, a question answered), and for those
-/// the attempt's trace **is** the deliverable. Making `run_id` mandatory is what
-/// stops "no artifact" degrading into "no link", which is the failure epic #183
-/// §6 exists to close. It is also the fallback when an artifact is later
-/// deleted: the pinned artifact link dangles, the trace does not.
+/// the producer's own record **is** the deliverable. A mandatory last-resort
+/// link is what stops "no artifact" degrading into "no link", which is the
+/// failure epic #183 §6 exists to close. It is also the fallback when an
+/// artifact is later deleted: the pinned artifact link dangles, the producer
+/// does not.
+///
+/// **The invariant is "there is always something to open", not "there is always
+/// a `run_id`"** (issue #806). Until that issue this field *was* a bare
+/// `run_id: String`, and its own docs argued the mandatory run was the design —
+/// conflating the guarantee with the single mechanism that happened to provide
+/// it. A run is *an* addressable producer; it is not the only one. An operator
+/// chat turn produces things too, and run records stay deliberately reserved for
+/// actual work attempts (#183 §4), so such a turn has no run to name and a card
+/// it settled could carry no output at all. [`TaskOutputSource`] is that
+/// distinction made explicit: the guarantee is unchanged and now type-level,
+/// while what satisfies it is a closed set the console matches on.
 ///
 /// # Which attempt, and why nothing has to choose
 ///
@@ -567,17 +579,14 @@ where
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TaskOutput {
-    /// The attempt that produced it — always present, and the link of last
-    /// resort (see the type's docs).
-    pub run_id: String,
-    /// That attempt's 1-based ordinal, for the operator-facing label
-    /// (*"attempt 2"*).
+    /// What produced it — and the link of last resort (see the type's docs).
     ///
-    /// `None` when the run row could not be read at stamp time. The ordinal is
-    /// a label, never an identity: `run_id` addresses the attempt either way, so
-    /// a failed read costs a nicety and never a link.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub attempt: Option<u32>,
+    /// Flattened, so a [`Run`](TaskOutputSource::Run) source is *byte-identical*
+    /// on the wire to the `runId` + `attempt` pair this struct carried before
+    /// [`TaskOutputSource`] existed. That is what makes this need no migration:
+    /// every stored card deserializes into the variant it always meant.
+    #[serde(flatten)]
+    pub source: TaskOutputSource,
     /// Epoch-millis the stamp was written (the moment the attempt settled).
     pub at_millis: u64,
     /// Every artifact the attempt published, pinned at the version it wrote.
@@ -594,6 +603,89 @@ pub struct TaskOutput {
     /// correlation, not of the record.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub workflows: Vec<TaskOutputWorkflow>,
+}
+
+/// What produced a [`TaskOutput`] — and, when nothing else survives, what the
+/// card's link of last resort points at (issue #806).
+///
+/// # Why this is a sum and not an optional `run_id`
+///
+/// Making `run_id` optional would have been honest about the absence and silent
+/// about what is actually there, leaving every reader to re-derive "then what do
+/// I link to?" and the console's trace arm to degrade to the card even for a
+/// turn that demonstrably produced a workflow. Synthesising a run row for a chat
+/// turn was the other candidate and is worse: it would reopen #183 §4 on purpose
+/// — *"run records stay reserved for actual work attempts, so the Attempts list
+/// shows turns that did something"* — and put an id that addresses nothing real
+/// behind a type that promises it does.
+///
+/// A closed set keeps the guarantee the type has always made (there is always
+/// one more link) while saying which kind of thing is at the other end, so the
+/// console can label it correctly instead of calling a conversation an attempt.
+///
+/// # Wire compatibility
+///
+/// `#[serde(untagged)]` plus the `#[serde(flatten)]` on
+/// [`TaskOutput::source`] means [`Run`](Self::Run) reads and writes exactly the
+/// `runId` / `attempt` keys the struct used before this type existed. Stored
+/// cards need no migration and no dual-read: they deserialize into `Run`, which
+/// is what they always were. A `ChatTurn` is new keys on a new record only.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+// `rename_all` on an enum renames the VARIANTS, not their fields, and an
+// untagged enum never writes a variant name — so it would have silently done
+// nothing here while the fields went out as `run_id`/`chat_id` and broke every
+// stored card. `rename_all_fields` is the attribute that reaches them.
+#[serde(untagged, rename_all_fields = "camelCase")]
+pub enum TaskOutputSource {
+    /// A work attempt — the original and still overwhelmingly common case.
+    Run {
+        /// The attempt that produced it.
+        run_id: String,
+        /// That attempt's 1-based ordinal, for the operator-facing label
+        /// (*"attempt 2"*).
+        ///
+        /// `None` when the run row could not be read at stamp time. The ordinal
+        /// is a label, never an identity: `run_id` addresses the attempt either
+        /// way, so a failed read costs a nicety and never a link.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        attempt: Option<u32>,
+    },
+    /// An operator chat turn that produced something without a work attempt
+    /// behind it — a turn that authored a workflow inline with `create_workflow`
+    /// being the case that forced this (PR #805, issue #678).
+    ///
+    /// Carries the conversation, which is the durable, addressable record of
+    /// what the operator asked for and what came back. It is deliberately **not**
+    /// a run: minting one would make the Attempts list claim work was attempted.
+    ChatTurn {
+        /// The conversation the turn belongs to — [`TaskRecord::origin_chat_id`]
+        /// for the card this settles.
+        chat_id: String,
+    },
+}
+
+impl TaskOutputSource {
+    /// The run that produced this, when one did.
+    ///
+    /// The accessor exists so the many readers that only ever wanted "which run,
+    /// if any" do not each grow a `match`. A chat turn answers `None`, which is
+    /// the truthful answer to a question about runs — never an absence of a
+    /// *link*, which [`TaskOutput`] still always has.
+    pub fn run_id(&self) -> Option<&str> {
+        match self {
+            Self::Run { run_id, .. } => Some(run_id.as_str()),
+            Self::ChatTurn { .. } => None,
+        }
+    }
+
+    /// That attempt's 1-based ordinal, when there is an attempt and it was
+    /// readable.
+    pub fn attempt(&self) -> Option<u32> {
+        match self {
+            Self::Run { attempt, .. } => *attempt,
+            Self::ChatTurn { .. } => None,
+        }
+    }
 }
 
 /// One published deliverable, pinned to the exact revision this attempt wrote.
@@ -1379,8 +1471,10 @@ mod test {
     fn an_output_stamp_round_trips_and_is_absent_on_a_legacy_card() {
         let mut card = plain_card();
         card.output = Some(TaskOutput {
-            run_id: "run-2".to_string(),
-            attempt: Some(2),
+            source: TaskOutputSource::Run {
+                run_id: "run-2".to_string(),
+                attempt: Some(2),
+            },
             at_millis: 99,
             artifacts: vec![TaskOutputArtifact {
                 artifact_id: "a-1".to_string(),
@@ -1429,8 +1523,10 @@ mod test {
     fn a_task_that_produced_no_file_still_carries_a_link() {
         let mut card = plain_card();
         card.output = Some(TaskOutput {
-            run_id: "run-1".to_string(),
-            attempt: Some(1),
+            source: TaskOutputSource::Run {
+                run_id: "run-1".to_string(),
+                attempt: Some(1),
+            },
             at_millis: 5,
             artifacts: Vec::new(),
             workflows: Vec::new(),
@@ -1443,7 +1539,7 @@ mod test {
 
         let back: TaskRecord = serde_json::from_str(&json).expect("round trip");
         let output = back.output.expect("the stamp survives with no deliverable");
-        assert_eq!(output.run_id, "run-1");
+        assert_eq!(output.source.run_id(), Some("run-1"));
         assert!(output.artifacts.is_empty());
         assert!(output.workflows.is_empty());
     }
@@ -1453,8 +1549,10 @@ mod test {
     #[test]
     fn an_unknown_attempt_ordinal_still_leaves_an_addressable_link() {
         let output = TaskOutput {
-            run_id: "run-9".to_string(),
-            attempt: None,
+            source: TaskOutputSource::Run {
+                run_id: "run-9".to_string(),
+                attempt: None,
+            },
             at_millis: 5,
             artifacts: Vec::new(),
             workflows: Vec::new(),
@@ -1462,8 +1560,93 @@ mod test {
         let json = serde_json::to_string(&output).expect("serialize");
         assert!(!json.contains("attempt"), "{json}");
         let back: TaskOutput = serde_json::from_str(&json).expect("round trip");
-        assert_eq!(back.run_id, "run-9");
-        assert_eq!(back.attempt, None);
+        assert_eq!(back.source.run_id(), Some("run-9"));
+        assert_eq!(back.source.attempt(), None);
+    }
+
+    // --- issue #806: an output whose producer is not a run --------------------
+
+    /// **The migration guarantee.** Every card written before `TaskOutputSource`
+    /// existed carries a bare `runId` + `attempt` pair, and there is no dual-read
+    /// anywhere — so if this stops deserializing into `Run`, every stamped card
+    /// in every store silently loses its link.
+    ///
+    /// The literal here is deliberately hand-written rather than produced by
+    /// serializing the current type: a test that round-trips today's shape would
+    /// still pass if both halves drifted together, which is exactly the failure
+    /// it is supposed to catch.
+    #[test]
+    fn a_stamp_written_before_the_source_union_still_reads_as_a_run() {
+        let stored = r#"{"runId":"run-7","attempt":2,"atMillis":1234}"#;
+        let output: TaskOutput =
+            serde_json::from_str(stored).expect("a pre-#806 stamp must still load");
+        assert_eq!(output.source.run_id(), Some("run-7"));
+        assert_eq!(output.source.attempt(), Some(2));
+        assert_eq!(output.at_millis, 1234);
+    }
+
+    /// And the other direction: a `Run` source must still *write* those exact
+    /// keys, so a card stamped by this build is readable by anything that has
+    /// not been updated — and by the console's `"runId" in output` discriminator.
+    #[test]
+    fn a_run_source_serializes_to_the_keys_it_always_did() {
+        let output = TaskOutput {
+            source: TaskOutputSource::Run {
+                run_id: "run-7".to_string(),
+                attempt: Some(2),
+            },
+            at_millis: 1234,
+            artifacts: Vec::new(),
+            workflows: Vec::new(),
+        };
+        let json = serde_json::to_string(&output).expect("serialize");
+        assert!(json.contains(r#""runId":"run-7""#), "{json}");
+        assert!(json.contains(r#""attempt":2"#), "{json}");
+        assert!(
+            !json.contains("chatId") && !json.contains("source"),
+            "the union must be flattened, not nested or tagged: {json}"
+        );
+    }
+
+    /// A chat turn's stamp carries the conversation and **no** run — the whole
+    /// point of #806. `run_id()` answering `None` is the truthful answer to a
+    /// question about runs, and is what stops a reader labelling a conversation
+    /// as an attempt.
+    #[test]
+    fn a_chat_turn_stamp_carries_a_conversation_and_no_run() {
+        let output = TaskOutput {
+            source: TaskOutputSource::ChatTurn {
+                chat_id: "chat-3".to_string(),
+            },
+            at_millis: 9,
+            artifacts: Vec::new(),
+            workflows: vec![TaskOutputWorkflow {
+                workflow_id: "wf-1".to_string(),
+                run_id: None,
+                action: TaskOutputAction::Created,
+            }],
+        };
+        let json = serde_json::to_string(&output).expect("serialize");
+        assert!(json.contains(r#""chatId":"chat-3""#), "{json}");
+        assert!(
+            !json.contains("runId\":\"chat"),
+            "a chat turn must never be written as a run: {json}"
+        );
+
+        let back: TaskOutput = serde_json::from_str(&json).expect("round trip");
+        assert_eq!(back.source.run_id(), None);
+        assert_eq!(back.source.attempt(), None);
+        assert_eq!(
+            back.source,
+            TaskOutputSource::ChatTurn {
+                chat_id: "chat-3".to_string()
+            }
+        );
+        assert_eq!(
+            back.workflows.len(),
+            1,
+            "the deliverable it produced is what makes the link worth having"
+        );
     }
 
     // --- The plan → workflow bridge (issue #580) -----------------------------

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -31,7 +31,10 @@ use crate::harness::orchestrator::{self, Delegation, DelegationQueue};
 use crate::harness::policy::ApprovalRequestQueue;
 use crate::harness::run_trace::RunTraceSink;
 use crate::harness::workflow_refs::WorkflowRefQueue;
-use crate::ports::tasks::{COLUMN_PLANNING, COLUMN_TODO, TaskOutputAction, TaskOutputWorkflow};
+use crate::ports::tasks::{
+    COLUMN_PLANNING, COLUMN_TODO, TaskOutput, TaskOutputAction, TaskOutputSource,
+    TaskOutputWorkflow,
+};
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
@@ -870,12 +873,11 @@ impl<'a> DelegationRunner<'a> {
         // settles from `pending_publishes`, which `create_workflow` never
         // populates. The operator got the workflow; the card lagged (issue #678).
         //
-        // The drain below closes that. What it does NOT do is give the card an
-        // output link: `TaskOutput.run_id` is required and an operator chat turn
-        // has no run row, so a card settled here names its workflows in the note
-        // and carries no `TaskOutput`. Output-without-a-run remains unbuilt — it
-        // was #183's territory and #183 closed without it — so the note is the
-        // record until it exists.
+        // The drain below closes that, and since #806 the settled card also
+        // carries a real output link: a `TaskOutput` whose source is the
+        // conversation rather than a run row, naming the workflows the turn
+        // authored. Run records stay reserved for actual work attempts (#183
+        // §4), so this turn mints none — see `TaskOutputSource`.
         let handler_card = match carded_by_handler {
             true => self.chat_handler_card(message).await?,
             false => None,
@@ -1041,6 +1043,7 @@ impl<'a> DelegationRunner<'a> {
                     responder,
                     parked,
                     &authored,
+                    chat_id,
                 )
                 .await;
             }
@@ -1065,17 +1068,24 @@ impl<'a> DelegationRunner<'a> {
     /// mode of this function is exactly the bug it fixes — never something
     /// worse.
     ///
-    /// # No `TaskOutput`
+    /// # The output link (issue #806)
     ///
-    /// The card names its workflows in the note and gets no output link.
-    /// `TaskOutput.run_id` is required and an operator chat turn has no run row;
-    /// see the note at the adoption site.
+    /// The card is stamped with a [`TaskOutput`] whose source is
+    /// [`TaskOutputSource::ChatTurn`] — the conversation this turn happened in,
+    /// which is `chat_id`, not the card's `origin_chat_id` (always `None` on an
+    /// adopted handler card) — carrying the workflows this turn authored.
+    /// The note stays — it is prose a person reads — but the *link* is what the
+    /// board's contract is written in terms of (#339), and until #806 this card
+    /// could not have one: `TaskOutput` required a `run_id` and an operator chat
+    /// turn has no run row. Minting one was rejected deliberately; see
+    /// [`TaskOutputSource`].
     async fn settle_authored_workflow_card(
         &self,
         handler_card: Option<&str>,
         responder: &str,
         parked: usize,
         authored: &[TaskOutputWorkflow],
+        chat_id: Option<&str>,
     ) {
         let Some(task_id) = handler_card else {
             // The turn authored a workflow with no card in scope to record it
@@ -1126,6 +1136,41 @@ impl<'a> DelegationRunner<'a> {
             );
             return;
         };
+        // Issue #806: the link, stamped before the settle writes the card so one
+        // store round-trip carries both.
+        //
+        // The source is the conversation, not a run: this turn made no work
+        // attempt, and #183 §4 keeps run records meaning exactly that. Written
+        // wholesale like every other stamp, so a card the orchestrator later
+        // works for real overwrites this with the run that did it — a chat turn
+        // is the weakest producer, never one that outranks an attempt.
+        //
+        // The TURN's own `chat_id` is what addresses it — deliberately not the
+        // card's `origin_chat_id`, which is always `None` here by construction:
+        // `chat_handler_card` only adopts a card whose `origin_chat_id.is_none()`,
+        // so the #463 handler card this settles can never carry one. A turn with
+        // no thread at all (a dispatched path) keeps the note-only behaviour
+        // rather than getting a stamp pointing nowhere.
+        match chat_id {
+            Some(chat_id) => {
+                card.output = Some(TaskOutput {
+                    source: TaskOutputSource::ChatTurn {
+                        chat_id: chat_id.to_string(),
+                    },
+                    at_millis: now_millis(),
+                    artifacts: Vec::new(),
+                    workflows: authored.to_vec(),
+                });
+            }
+            None => {
+                tracing::debug!(
+                    company = %self.company,
+                    task_id = %task_id,
+                    "[delegation] this turn has no chat thread to address, so its card is \
+                     recorded in the note without an output link"
+                );
+            }
+        }
         if let Err(err) = self
             .settle_work_card(&mut card, responder, TaskRunEnd::Completed, parked, &body)
             .await
@@ -2618,6 +2663,7 @@ mod tests {
     use crate::ports::TaskStore;
     use crate::ports::tasks::{
         COLUMN_DONE, COLUMN_IN_PROGRESS, COLUMN_IN_REVIEW, COLUMN_PAUSED, COLUMN_TODO,
+        TaskOutputSource,
     };
     use crate::ports::types::LedgerEntry;
     use crate::store::FsOps;
@@ -3965,12 +4011,126 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let note = cards[0].note.clone().unwrap_or_default();
         assert!(
             note.contains("nightly-digest"),
-            "the note is the record of what was authored (there is no TaskOutput              without a run row): {note}"
+            "the note is the prose record of what was authored: {note}"
         );
         assert_eq!(
             fx.workflow_refs.queued(),
             0,
             "the drain empties the queue, or the next turn inherits this turn's workflows"
+        );
+    }
+
+    /// The other side of the stamp: a turn with **no** chat thread to address
+    /// gets the note and no output link. There is no conversation to point at,
+    /// and a stamp pointing nowhere is worse than none — the same reason
+    /// `primaryLink` falls back to the card rather than synthesising a target.
+    #[tokio::test]
+    async fn a_turn_with_no_chat_thread_settles_without_an_output_link() {
+        let imperative = "create a workflow named nightly digest";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        let handler = handler_card_in(title, COLUMN_TODO);
+        TaskStore::upsert(&*fx.tasks, &fx.record.id, &handler)
+            .await
+            .expect("seed the handler card");
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::authoring(
+                "authored it",
+                vec![authored("nightly-digest")],
+            )],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(
+            cards[0].column,
+            lifecycle::settled_landing_column(TaskRunEnd::Completed, 0),
+            "the settle itself does not depend on having a thread"
+        );
+        assert!(
+            cards[0]
+                .note
+                .clone()
+                .unwrap_or_default()
+                .contains("nightly-digest"),
+            "the note still records what was authored"
+        );
+        assert!(
+            cards[0].output.is_none(),
+            "no thread to address, so no link is written"
+        );
+    }
+
+    /// Issue #806: the settled card carries a real **output link**, not just a
+    /// note. `TaskOutput` used to require a `run_id` and an operator chat turn
+    /// has no run row, so this card could carry no output at all — the board's
+    /// contract (#339, *"Done carries a link to what it produced"*) is written
+    /// in terms of links, and prose is not one.
+    ///
+    /// The source is the conversation. Asserting `run_id()` is `None` is half
+    /// the point: minting a run for a turn that attempted no work would make the
+    /// Attempts tab lie, which #183 §4 settled deliberately.
+    #[tokio::test]
+    async fn a_workflow_authored_in_a_chat_turn_gives_its_card_an_output_link() {
+        let imperative = "create a workflow named nightly digest";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        // NOTE: no `origin_chat_id` on the seeded card, and that is not an
+        // oversight — `chat_handler_card` only adopts a card whose
+        // `origin_chat_id.is_none()`, so setting one here makes the card
+        // unadoptable and nothing settles at all. The conversation the stamp
+        // addresses is the TURN's, passed to `handle_operator_message` below.
+        let handler = handler_card_in(title, COLUMN_TODO);
+        TaskStore::upsert(&*fx.tasks, &fx.record.id, &handler)
+            .await
+            .expect("seed the handler card");
+        let turns = ScriptedTurns::new(
+            &fx,
+            vec![Turn::authoring(
+                "authored it",
+                vec![authored("nightly-digest")],
+            )],
+        );
+        fx.runner(&turns)
+            .handle_operator_message("chief", imperative, Some("general"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        let output = cards[0]
+            .output
+            .clone()
+            .expect("a settled chat turn stamps an output link");
+        assert_eq!(
+            output.source,
+            TaskOutputSource::ChatTurn {
+                chat_id: "general".to_string()
+            },
+            "the producer is the conversation this turn happened in"
+        );
+        assert_eq!(
+            output.source.run_id(),
+            None,
+            "an operator chat turn attempted no work, so it mints no run"
+        );
+        assert_eq!(
+            output
+                .workflows
+                .iter()
+                .map(|w| w.workflow_id.as_str())
+                .collect::<Vec<_>>(),
+            vec!["nightly-digest"],
+            "the link points at what the turn actually produced"
+        );
+        assert!(
+            output.artifacts.is_empty(),
+            "this turn published no file — the workflow is the deliverable"
         );
     }
 

--- a/src/server/ops/tasks.rs
+++ b/src/server/ops/tasks.rs
@@ -25,7 +25,8 @@ use crate::company::{WorkflowGraphSpec, create_company_workflow, raw_workflow_fr
 use crate::error::OpenCompanyError;
 use crate::ports::tasks::{
     BOARD_COLUMNS, COLUMN_DONE, COLUMN_TODO, TaskDeliverable, TaskOutput, TaskOutputAction,
-    TaskOutputWorkflow, TaskRecord, TaskWorkflowProposal, cap_discussion, is_board_column,
+    TaskOutputSource, TaskOutputWorkflow, TaskRecord, TaskWorkflowProposal, cap_discussion,
+    is_board_column,
 };
 use crate::ports::types::CompanyEvent;
 use crate::ports::{generate_id, now_millis};
@@ -606,8 +607,10 @@ async fn apply_workflow_proposal(
         .flatten()
         .map(|run| run.attempt);
     record.output = Some(TaskOutput {
-        run_id: proposal.run_id.clone(),
-        attempt,
+        source: TaskOutputSource::Run {
+            run_id: proposal.run_id.clone(),
+            attempt,
+        },
         at_millis: now_millis(),
         artifacts: Vec::new(),
         workflows: vec![TaskOutputWorkflow {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -565,7 +565,7 @@ async fn a_task_created_from_a_thread_remembers_and_reads_back_that_thread() {
 async fn a_stamped_card_hands_its_output_link_to_both_reads() {
     use crate::ports::artifacts::ArtifactKind;
     use crate::ports::tasks::{
-        TaskOutput, TaskOutputAction, TaskOutputArtifact, TaskOutputWorkflow,
+        TaskOutput, TaskOutputAction, TaskOutputArtifact, TaskOutputSource, TaskOutputWorkflow,
     };
 
     let home_dir = home();
@@ -598,8 +598,10 @@ async fn a_stamped_card_hands_its_output_link_to_both_reads() {
         .find(|t| t.id == id)
         .expect("card");
     card.output = Some(TaskOutput {
-        run_id: "run-2".to_string(),
-        attempt: Some(2),
+        source: TaskOutputSource::Run {
+            run_id: "run-2".to_string(),
+            attempt: Some(2),
+        },
         at_millis: 42,
         artifacts: vec![TaskOutputArtifact {
             artifact_id: "a-1".to_string(),


### PR DESCRIPTION
## Summary

A card settled by an operator chat turn could carry no output link at all. `TaskOutput.run_id` was a required `String`, an operator chat turn has no run row, and PR #805 therefore settles the #463 handler card with its workflows named in the **note** and no `TaskOutput` — so the console shows no output link on a card whose work is demonstrably finished. The board's own contract (#339) is written in terms of links, and prose is not one.

### The distinction this rests on

`ports/tasks.rs` argued the case for a mandatory `run_id` under the heading *"`run_id` is unconditional, and that is the whole design"*. **That conflates the guarantee with the single mechanism that happened to provide it.** The invariant the type protects is *"there is always something to open"* — `run_id` is one way to satisfy it, not the thing itself. A run is *an* addressable producer; it is not the only one. `TaskRecord::origin_chat_id` has existed since #151, and `TaskDetailView` already renders "Opened from a conversation".

A reviewer reading that heading will otherwise think this PR broke a deliberate design. It did not — it separates the two and keeps the guarantee, now enforced by the type rather than by a comment.

So `TaskOutput` names **what produced it** as a closed set:

```rust
#[serde(untagged, rename_all_fields = "camelCase")]
pub enum TaskOutputSource {
    Run { run_id: String, attempt: Option<u32> },
    ChatTurn { chat_id: String },
}
```

`settle_authored_workflow_card` now stamps the card with the workflows it was **already holding** — `authored: &[TaskOutputWorkflow]` was in scope the whole time; `run_id` was the only thing stopping it.

### The two rejected alternatives, and why

- **Synthesise a run row for the turn.** Rejected: it reopens #183 §4 on purpose — *"run records stay reserved for actual work attempts, so the Attempts list shows turns that did something"* — and puts an id that addresses nothing real behind a type that promises it does. `docs/spec/runtime/ports-runs.md` already says old `RunRecord`s are never synthesised because *"fabricating identity for attempts nobody recorded would be worse"*; this is the same rule one case further on.
- **Make `run_id` optional.** Rejected: honest about the absence, silent about what *is* there. Every reader would re-derive "then what do I link to?", and the console's trace arm would degrade to the card even for a turn that demonstrably produced a workflow — a wrong link traded for no link.

## API Or Behavior Changes

- `TaskOutput.run_id` / `.attempt` are replaced by `TaskOutput.source`. Readers that only wanted "which run, if any" use `source.run_id() -> Option<&str>` and `source.attempt() -> Option<u32>` rather than each growing a `match`.
- **No wire change and no migration.** `#[serde(untagged)]` + `#[serde(flatten)]` means a `Run` source reads and writes exactly the `runId` / `attempt` keys the struct always had. Stored cards deserialize into `Run`, which is what they always were. A `ChatTurn` is new keys on new records only.
- A card settled by an operator chat turn now carries a `TaskOutput` where it previously carried none, so the console shows its workflow link instead of "Open this task". A card with **no** `origin_chat_id` keeps the note-only behaviour — there is no conversation to address, and a stamp pointing nowhere would be worse than none.
- Console: `primaryLink`'s precedence (artifact → workflow → last resort) is unchanged. The last-resort arm branches on the source; a chat turn resolves to the card, never to `#/tasks/<id>?run=undefined`.

## Tests

Backend (`src/ports/tasks.rs`):

- `a_stamp_written_before_the_source_union_still_reads_as_a_run` — **the migration guarantee.** The legacy JSON is a hand-written literal, deliberately *not* produced by serializing the current type: a symmetric round-trip would still pass if both halves drifted together, which is precisely the failure it exists to catch. It did catch one — see below.
- `a_run_source_serializes_to_the_keys_it_always_did` — the other direction, and it pins that the union is flattened rather than nested or tagged.
- `a_chat_turn_stamp_carries_a_conversation_and_no_run`.

`src/runtime/delegation.rs`:

- `a_workflow_authored_in_a_chat_turn_gives_its_card_an_output_link` — the regression: the settled card carries the link, sourced from the conversation, with `run_id()` `None`.
- The existing sibling test gained an assertion that a card with no `origin_chat_id` still gets no stamp.

Console (`frontend/test/unit/task-links.test.ts`): 15 pass. **Honestly, 1 of the 2 new ones has teeth** — `never labels a chat turn as a run trace` fails when the last-resort arm is reverted; `opens the workflow a chat turn authored` passes reverted, because workflow precedence never reaches the trace arm, so it is a type-level guard rather than a runtime one. Stating that rather than claiming two.

> **A real bug this caught.** The first cut used `#[serde(rename_all = "camelCase")]` on the enum. On an **untagged** enum that renames the *variants* — which are never written — and does nothing to their fields, so it emitted `run_id` / `chat_id` in snake_case and **every stored card's output would have failed to deserialize.** `rename_all_fields` is the attribute that reaches them. Only the hand-authored legacy literal caught it.

⚠️ **`runtime::delegation` is behind `#[cfg(feature = "openhuman")]`** — `cargo test --lib runtime::delegation` runs 0 tests and exits 0. The gated lane below is the only one that runs it.

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean. Mirrors CI; a local `--all-targets` without `--no-deps` drowns in vendored lints CI never sees.
- [x] `cargo build --all-targets` — N/A as written; the `--all-targets` clippy and test compiles above build the same targets under the feature set that actually compiles these modules.
- [x] `cargo test --locked --features openhuman,tinycortex --lib` (with `RUST_MIN_STACK=16777216`, as CI sets) — green. Plus `npx vitest run test/unit/task-links.test.ts` — 15 passed.

## Documentation

- `TaskOutput`'s doc heading rewritten from *"`run_id` is unconditional"* to the invariant it actually protects, with the mechanism/guarantee distinction spelled out.
- `TaskOutputSource` carries the rejected alternatives and the wire-compatibility reasoning at the type.
- `docs/spec/runtime/ports-runs.md` gains the chat-turn case beside the existing "never synthesised" rule, so #183 §4's statement about what a run record means still agrees with the code — the acceptance criterion in the issue.
- `src/runtime/delegation.rs`'s two stale comments ("there is no `TaskOutput` without a run row") corrected.

## Known gap, deliberately excluded

The chat last-resort link points at the **card**, not the conversation. `conversation` is a view in the hash router, but the active thread is component state (`activeThreadId`) and nothing reads a thread id out of the hash — so `#/conversation/<id>` resolves nowhere today. Minting that href would look right and silently land on the wrong thread. The card is where the conversation is already reachable from ("Opened from a conversation", #246). Deep-linking a thread is its own change.

This does not weaken the fix: `settle_authored_workflow_card` is called under `if !authored.is_empty()`, so a chat-settled card always has at least one workflow and `primaryLink` returns the **workflow** link. The chat arm is defensive, not the main path.

Closes #806
