### PR TITLE
console: open external markdown links in a new tab

### DIFF
--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -4,6 +4,22 @@ import remarkGfm from "remark-gfm";
 import { cn } from "@/lib/utils";
 
 /**
+ * Is `href` a link that leaves the console?
+ *
+ * Absolute `http://`, `https://` and protocol-relative `//host/…` targets are
+ * external. Everything else — `#/chat`, `/workspace`, `./note.md`, `mailto:`,
+ * and an empty or missing href — is not, and must keep opening in place:
+ * in-app navigation in a new tab would be worse, not better.
+ *
+ * Exported for the unit suite: the decision is a pure string function, so it
+ * is checked there rather than through a rendered document.
+ */
+export function isExternalHref(href?: string): boolean {
+  const target = (href ?? "").trim();
+  return /^(https?:)?\/\//i.test(target);
+}
+
+/**
  * Shared markdown renderer used across chat, memory, workspace, and workflow
  * surfaces so `**bold**`, lists, links, and inline code render consistently
  * instead of leaking literal markup. Wraps `react-markdown` + `remark-gfm` in a
@@ -11,6 +27,13 @@ import { cn } from "@/lib/utils";
  *
  * Mirrors the recipe already used by WorkspaceView (NoteMarkdown) and
  * WorkflowsView so every surface shares one renderer and one look.
+ *
+ * External links open in a new tab. This renderer is shared by chat, memory,
+ * workspace and workflows, and in all four the surrounding view is a working
+ * context with state that is expensive to lose: following a citation used to
+ * navigate the console away mid-conversation, and coming back meant a reload
+ * and a scroll hunt. `rel="noreferrer noopener"` goes with it — without
+ * `noopener` the opened page can reach this one through `window.opener`.
  */
 export function Markdown({
   children,
@@ -21,7 +44,22 @@ export function Markdown({
 }) {
   return (
     <div className={cn("prose prose-sm max-w-none dark:prose-invert", className)}>
-      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          a: ({ href, children: content, ...rest }) => (
+            <a
+              href={href}
+              {...(isExternalHref(href) ? { target: "_blank", rel: "noreferrer noopener" } : {})}
+              {...rest}
+            >
+              {content}
+            </a>
+          ),
+        }}
+      >
+        {children}
+      </ReactMarkdown>
     </div>
   );
 }

--- a/frontend/test/unit/markdown-links.test.ts
+++ b/frontend/test/unit/markdown-links.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isExternalHref } from "@/components/markdown";
+
+/**
+ * Which links leave the console, and which stay in it.
+ *
+ * `components/markdown.tsx` is one renderer behind chat, memory, workspace and
+ * workflows. An external link that takes over the tab costs the operator the
+ * view they were reading — and in chat, the scroll position in a long thread.
+ * An *internal* link that opens a tab is the same mistake in the other
+ * direction, which is why this is a decision and not a blanket `target`.
+ */
+describe("isExternalHref", () => {
+  it("treats absolute web URLs as external", () => {
+    expect(isExternalHref("https://example.com/docs")).toBe(true);
+    expect(isExternalHref("http://example.com")).toBe(true);
+    expect(isExternalHref("HTTPS://EXAMPLE.COM")).toBe(true);
+    // Protocol-relative: the browser resolves it to http(s), so it leaves too.
+    expect(isExternalHref("//example.com/asset.png")).toBe(true);
+    expect(isExternalHref("  https://example.com  ")).toBe(true);
+  });
+
+  it("keeps in-app navigation in the same tab", () => {
+    expect(isExternalHref("#/chat/ceo")).toBe(false);
+    expect(isExternalHref("/workspace")).toBe(false);
+    expect(isExternalHref("./note.md")).toBe(false);
+    expect(isExternalHref("note.md")).toBe(false);
+  });
+
+  it("leaves non-web schemes alone", () => {
+    // A new tab for a mail client is a blank tab left behind.
+    expect(isExternalHref("mailto:team@example.com")).toBe(false);
+    expect(isExternalHref("tel:+3110000000")).toBe(false);
+  });
+
+  it("is safe on a link the markdown left without a target", () => {
+    expect(isExternalHref(undefined)).toBe(false);
+    expect(isExternalHref("")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- open absolute HTTP(S) and protocol-relative markdown links in a new tab
- keep in-app, relative, `mailto:`, and `tel:` links in the current browsing context
- add focused unit coverage for the link classification

## Problem and root cause

The shared markdown renderer currently lets `react-markdown` emit bare anchors.
Clicking an external citation therefore navigates the operator console away from
chat, memory, workspace, or workflow state.

This adds a small anchor override to the shared renderer. External targets
receive `target="_blank"` and `rel="noreferrer noopener"`; internal navigation
retains the existing behavior.

## Impact

There is no API or data-model change. Operators keep their place in the console
when opening an external markdown link, while internal and non-web links
continue to behave as before.

## Validation

- `npx vitest run test/unit/markdown-links.test.ts` — 4 tests passed
- `npm test` — 78 files, 819 tests passed
- `npx tsc -p tsconfig.app.json --noEmit`
- `npx tsc -p tsconfig.unit.json --noEmit`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * External HTTP(S) and protocol-relative links in Markdown now open in a new tab.
  * External links use enhanced security protections when opened.

* **Bug Fixes**
  * Internal links, email links, empty links, and missing destinations continue to open with their default behavior.

* **Tests**
  * Added coverage for external link detection and link behavior across supported URL types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->