### PR TITLE
docker: preserve Rust cache across non-code changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,10 +22,20 @@ RUN apt-get update \
        libx11-dev libxi-dev libxtst-dev libxrandr-dev libxcb1-dev libxkbcommon-dev \
     && rm -rf /var/lib/apt/lists/*
 
-# The whole workspace is copied (examples/*/Cargo.toml load the workspace;
-# vendor/openhuman/vendor/tinyagents backs the [patch.crates-io] entry).
-# vendor/openhuman, target/, and node_modules are trimmed via .dockerignore.
-COPY . .
+# Copy only inputs read by the Rust build, rather than the whole checkout.
+# Keeping frontend, docs, scripts, and deployment files out of this layer lets
+# their changes reuse the compiled Cargo cache.
+#
+# `build.rs` embeds the shipped company agents and `src/desktop.rs` embeds each
+# preset manifest, so the complete companies tree remains a real build input.
+# `vendor/` backs the path dependencies and Cargo patch table.
+COPY Cargo.toml Cargo.lock rust-toolchain.toml build.rs ./
+COPY src ./src
+COPY benches ./benches
+COPY tests ./tests
+COPY examples ./examples
+COPY vendor ./vendor
+COPY companies ./companies
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry \
     --mount=type=cache,target=/build/target \


### PR DESCRIPTION
## Summary

- copy only Cargo inputs into the Docker builder stage
- keep frontend, documentation, scripts, and deployment files out of the Rust cache key
- include the current `build.rs` and complete `companies/` tree because they embed company manifests and agent files

## Why

The builder currently uses `COPY . .`. Any unrelated console, documentation, or deployment change therefore invalidates the release compilation layer. Splitting the copy inputs lets those changes reuse the existing Cargo build cache without changing the produced binary or runtime image.

## Validation

- `git diff --check`
- verified every copied source path exists on current upstream `main`
- initialized the complete vendored submodule graph
- `docker build --target builder .` reached compilation of the `opencompany` crate, proving the isolated context contains the current Cargo graph and generated-agent inputs; the local ARM Docker VM was killed during final release codegen by its memory limit, including with one Cargo job, so the full builder result is left to upstream CI

No runtime behavior, Cargo feature, dependency, or build parallelism setting changes.