### PR TITLE
fix(console): the theme switch renders invisibly in dark mode

### DIFF
--- a/frontend/src/components/theme-toggle.tsx
+++ b/frontend/src/components/theme-toggle.tsx
@@ -9,13 +9,27 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-/** Light / dark / system switch, following the OS by default. */
+/**
+ * Light / dark / system switch, following the OS by default.
+ *
+ * The two icons are stacked and cross-faded by the `dark:` variant rather than
+ * swapped in JS, so the glyph is correct on the first paint — `useTheme()` has
+ * no resolved theme until after mount, and branching on it flashes the wrong
+ * icon. That puts the Moon in `absolute`, which makes `relative` on the trigger
+ * load-bearing: `Button` is `position: static`, so without it the Moon resolves
+ * against whatever positioned ancestor happens to be up the tree. On Settings
+ * that is `SidebarInset`, *outside* the view's own `overflow-y-auto` scroller —
+ * so the glyph did not scroll with its button and drifted down the page by
+ * exactly `scrollTop`, leaving an empty 32x32 hit target behind (issue #922).
+ */
 export function ThemeToggle() {
   const { setTheme } = useTheme();
   return (
     <DropdownMenu>
       <DropdownMenuTrigger
-        render={<Button variant="ghost" size="icon" className="size-8" aria-label="Change theme" />}
+        render={
+          <Button variant="ghost" size="icon" className="relative" aria-label="Change theme" />
+        }
       >
         <Sun className="size-4 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
         <Moon className="absolute size-4 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />

--- a/frontend/src/views/SettingsView.tsx
+++ b/frontend/src/views/SettingsView.tsx
@@ -18,6 +18,7 @@ import {
 import { Button } from "@/components/ui/button";
 import {
   Card,
+  CardAction,
   CardContent,
   CardDescription,
   CardHeader,
@@ -115,38 +116,44 @@ export function SettingsView({ client, company, feed, onFlag }: Props) {
         {/* Domain & email */}
         <DomainSettings company={company} />
 
-        {/* Appearance */}
+        {/* Appearance.
+
+            The trailing control goes in `CardAction`, not a bare child:
+            `CardHeader` is a grid, so `flex-row justify-between` on it is inert
+            and the control drops onto a row of its own below the description.
+            `CardAction` is what switches the header to `grid-cols-[1fr_auto]`
+            and parks the control at the top right. */}
         <Card>
-          <CardHeader className="flex-row items-center justify-between space-y-0">
-            <div className="space-y-1">
-              <CardTitle className="text-base">Appearance</CardTitle>
-              <CardDescription>Switch between light, dark, and system themes.</CardDescription>
-            </div>
-            <ThemeToggle />
+          <CardHeader>
+            <CardTitle className="text-base">Appearance</CardTitle>
+            <CardDescription>Switch between light, dark, and system themes.</CardDescription>
+            <CardAction>
+              <ThemeToggle />
+            </CardAction>
           </CardHeader>
         </Card>
 
         {/* Product tour */}
         <Card>
-          <CardHeader className="flex-row items-center justify-between space-y-0">
-            <div className="space-y-1">
-              <CardTitle className="text-base">Product tour</CardTitle>
-              <CardDescription>Replay the guided walkthrough of the console.</CardDescription>
-            </div>
-            <Button
-              variant="outline"
-              // The tour's code is lazily loaded, so without this the download
-              // starts on the click and the button appears to do nothing until
-              // it lands. Pointing at it is intent enough to fetch.
-              onPointerEnter={preloadTour}
-              onFocus={preloadTour}
-              onClick={() => {
-                restartTour(scope);
-                toast.success("Starting the product tour.");
-              }}
-            >
-              <Compass className="size-4" /> Replay tour
-            </Button>
+          <CardHeader>
+            <CardTitle className="text-base">Product tour</CardTitle>
+            <CardDescription>Replay the guided walkthrough of the console.</CardDescription>
+            <CardAction>
+              <Button
+                variant="outline"
+                // The tour's code is lazily loaded, so without this the download
+                // starts on the click and the button appears to do nothing until
+                // it lands. Pointing at it is intent enough to fetch.
+                onPointerEnter={preloadTour}
+                onFocus={preloadTour}
+                onClick={() => {
+                  restartTour(scope);
+                  toast.success("Starting the product tour.");
+                }}
+              >
+                <Compass className="size-4" /> Replay tour
+              </Button>
+            </CardAction>
           </CardHeader>
         </Card>
 

--- a/frontend/test/e2e/theme-toggle-visible.spec.ts
+++ b/frontend/test/e2e/theme-toggle-visible.spec.ts
@@ -1,0 +1,153 @@
+import { expect, test, type Page } from "@playwright/test";
+
+/**
+ * Regression proof for #922 — the theme switch must render a visible glyph
+ * inside its own button, in both themes, however far down Settings is scrolled.
+ *
+ * `ThemeToggle` stacks a Sun and a Moon and cross-fades them with the `dark:`
+ * variant, so the correct glyph is on screen at the first paint rather than
+ * after `useTheme()` resolves. Stacking puts the Moon in `position: absolute`,
+ * and `Button` is `position: static` — so the Moon resolved against the nearest
+ * positioned ancestor instead of its button. On Settings that ancestor is
+ * `SidebarInset`, which sits *outside* the view's own `overflow-y-auto`
+ * scroller, and an absolutely-positioned box does not scroll with a container
+ * that is not its containing block. The Moon therefore stayed pinned where the
+ * unscrolled layout had put it while its button scrolled away, drifting down
+ * the page by exactly `scrollTop`. In dark mode the Sun is `scale-0`, so what
+ * was left behind was an empty 32x32 hit target: a card reading "Switch between
+ * light, dark, and system themes" with no visible control, and a stray moon
+ * glyph roughly 1300px further down the document.
+ *
+ * The assertion is deliberately geometric rather than a class check. `relative`
+ * on the trigger is today's fix, but the contract is "the glyph is inside the
+ * button", and any future restyle that breaks it — a different stacking trick,
+ * a `transform` moved onto an ancestor — should fail here too.
+ *
+ * Scrolling is the load-bearing step. At `scrollTop: 0` the drift is zero and
+ * the bug is invisible, which is how it shipped twice: the Appearance card is
+ * near the bottom of Settings, so nobody reaches it without scrolling, and
+ * nobody testing it at the top of the page sees anything wrong.
+ *
+ * `ThemeToggle` also renders in the company picker and on Login, where it sits
+ * in a header at the top of a document-scrolled page. Both are latent cases of
+ * the same fault rather than separate bugs, and the fix is in the shared
+ * component, so this spec exercises the one call site that actually reproduced.
+ */
+
+/** The first-run tour opens a modal over a fresh console and eats every click. */
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    const real = Storage.prototype.getItem;
+    Storage.prototype.getItem = function getItem(key: string) {
+      return key.startsWith("oc-tour:") ? '{"skipped":true}' : real.call(this, key);
+    };
+  });
+});
+
+const trigger = (page: Page) => page.getByRole("button", { name: "Change theme" });
+
+/** Pin the theme before the app boots, so the first paint is the one under test. */
+async function openSettings(page: Page, theme: "dark" | "light") {
+  await page.addInitScript((value) => {
+    window.localStorage.setItem("theme", value);
+  }, theme);
+  await page.goto("/#/settings");
+  await expect(trigger(page)).toBeVisible();
+  await expect(page.locator("html")).toHaveClass(new RegExp(`\\b${theme}\\b`));
+}
+
+/**
+ * Geometry of the trigger and of whichever glyph is currently on screen.
+ *
+ * "On screen" is the whole point: the hidden icon is `scale-0` and collapses to
+ * a 0x0 box, so a non-empty box is what distinguishes the painted glyph from
+ * its counterpart without hard-coding which of the two a given theme shows.
+ */
+async function glyphGeometry(page: Page) {
+  return page.evaluate(() => {
+    const button = document.querySelector('button[aria-label="Change theme"]');
+    if (!button) throw new Error("theme trigger not in the document");
+    const box = button.getBoundingClientRect();
+    const painted = [...button.querySelectorAll("svg")]
+      .map((svg) => {
+        const rect = svg.getBoundingClientRect();
+        return {
+          icon: svg.getAttribute("class")?.includes("lucide-sun") ? "sun" : "moon",
+          x: rect.x,
+          y: rect.y,
+          width: rect.width,
+          height: rect.height,
+        };
+      })
+      .filter((glyph) => glyph.width > 0 && glyph.height > 0);
+    return {
+      button: { x: box.x, y: box.y, width: box.width, height: box.height },
+      painted,
+    };
+  });
+}
+
+/** Scroll Settings until the Appearance card is on screen, and report by how much. */
+async function scrollToAppearance(page: Page) {
+  const scrolled = await page.evaluate(() => {
+    const button = document.querySelector('button[aria-label="Change theme"]');
+    button?.scrollIntoView({ block: "center" });
+    let node = button?.parentElement ?? null;
+    while (node) {
+      if (node.scrollTop > 0) return node.scrollTop;
+      node = node.parentElement;
+    }
+    return window.scrollY;
+  });
+  // A drift bug that only appears past the fold proves nothing if the card was
+  // already in view, so fail loudly rather than passing on an untested page.
+  expect(scrolled, "Appearance should sit below the fold on Settings").toBeGreaterThan(0);
+  return scrolled;
+}
+
+for (const theme of ["dark", "light"] as const) {
+  test(`theme switch shows a glyph inside its button on scrolled Settings (${theme})`, async ({
+    page,
+  }) => {
+    await openSettings(page, theme);
+    await scrollToAppearance(page);
+
+    const { button, painted } = await glyphGeometry(page);
+
+    // Exactly one of the stacked icons is painted; the other is `scale-0`.
+    expect(painted).toHaveLength(1);
+    expect(painted[0].icon).toBe(theme === "dark" ? "moon" : "sun");
+
+    // And it is inside the button it belongs to — the assertion that failed on
+    // `main`, where the moon landed ~1300px below its own trigger.
+    const glyph = painted[0];
+    expect(glyph.x).toBeGreaterThanOrEqual(button.x);
+    expect(glyph.y).toBeGreaterThanOrEqual(button.y);
+    expect(glyph.x + glyph.width).toBeLessThanOrEqual(button.x + button.width);
+    expect(glyph.y + glyph.height).toBeLessThanOrEqual(button.y + button.height);
+  });
+}
+
+test("the theme menu opens over the trigger and switches the theme", async ({ page }) => {
+  await openSettings(page, "dark");
+  await scrollToAppearance(page);
+
+  // Clicking the control the card advertises, not blank space next to it.
+  await trigger(page).click();
+  const menu = page.locator('[data-slot="dropdown-menu-content"]');
+  await expect(menu).toBeVisible();
+
+  // The popup must be opaque: it overlaps the cards beneath it, and a
+  // see-through menu is unreadable against them.
+  await expect(menu).not.toHaveCSS("background-color", "rgba(0, 0, 0, 0)");
+
+  await menu.getByRole("menuitem", { name: "Light" }).click();
+  await expect(page.locator("html")).toHaveClass(/\blight\b/);
+
+  // The glyph swaps with the theme rather than going blank.
+  const { button, painted } = await glyphGeometry(page);
+  expect(painted).toHaveLength(1);
+  expect(painted[0].icon).toBe("sun");
+  expect(painted[0].y).toBeGreaterThanOrEqual(button.y);
+  expect(painted[0].y + painted[0].height).toBeLessThanOrEqual(button.y + button.height);
+});


### PR DESCRIPTION
## Summary

Fixes #922 — `Settings → Appearance` shows a title, a description, and nothing else in dark mode.

**Root cause.** `ThemeToggle` stacks a Sun and a Moon and cross-fades them with the `dark:` variant, so the correct glyph is painted on the first frame (`useTheme()` has no resolved theme until after mount). Stacking requires the Moon to be `position: absolute` — and `buttonVariants` has no `relative`, so the Moon resolved its containing block against the nearest *positioned* ancestor. On Settings that is `SidebarInset`, which sits **outside** the view's own `overflow-y-auto` scroller.

An absolutely-positioned box does not scroll with a container that isn't its containing block, so the Moon stayed pinned where the unscrolled layout put it while its button scrolled away. Measured in an isolated harness mirroring the real DOM: **the drift equals `scrollTop`, to the pixel.** In dark mode the Sun is `scale-0` (a 0×0 box), so what remained at the card was an empty 32×32 hit target, plus a stray moon far down the document.

Two properties explain why this shipped twice: it only reproduces **below the fold** (drift is zero at `scrollTop: 0`), and only in **dark** mode (in light the painted glyph is the Sun, which is in normal flow).

A separate defect made the card look worse: `CardHeader` is a grid, so `flex-row items-center justify-between space-y-0` on it was entirely inert and the controls were dropping onto a row of their own below the description instead of the card's top right. Second commit moves both Settings cards to `CardAction`.

## Behaviour changes

- Theme switch is visible in both themes at any scroll position, in all three call sites (Settings, company picker, Login — the latter two were latent cases of the same fault).
- Appearance and Product tour render their control at the card's top right.
- No API or token changes.

## Tests

`frontend/test/e2e/theme-toggle-visible.spec.ts` asserts **geometrically** — the painted glyph's box sits inside its button after scrolling — rather than checking for the `relative` class, so a future restyle that breaks the same contract fails too. It also fails loudly if the Appearance card is *not* below the fold, since that's the condition the bug needs.

Confirmed to fail without the fix: glyph bottom at `1096` vs button bottom `376`.

## Commands run locally

```
npm run typecheck && npm run typecheck:e2e     # clean
npm test                                        # 377 passed
npx playwright test theme-toggle-visible.spec.ts alert-dialog-confirm.spec.ts   # 5 passed
```

`alert-dialog-confirm.spec.ts` is included because it is the other spec covering `SettingsView`.

⚠️ The e2e runs used a **stale local host binary** — the current `companies/e2e_harness` manifest fails to parse on it. The console bundle under test was built from this branch; the host acted only as a backend. Worth a clean CI run.

## Not changed

The issue also reports the dropdown having "a transparent background". It doesn't. Sampling composited pixels across the popup's edge where it overlaps a card in dark mode:

| sample | rgb |
|---|---|
| popup fill | `23,23,29` |
| popup edge (ring) | `38,38,42` |
| card behind, clear of the popup | `19,19,24` |
| a card's own edge against the page | `23,23,29` vs page `12,12,15` |

The popup is opaque and its outline is a 19-level step — nearly twice the contrast of the card edges the design already relies on. The obvious "fix" (lifting dark `--popover` from `oklch(0.205)` to `oklch(0.24)`) measurably weakens the hover affordance, since items highlight with `focus:bg-accent` at `oklch(0.269)`. `--popover` sharing a value with `--card` is the shadcn dark palette's design, not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
