### PR TITLE
fix(console): stop a toast being pinned open forever (#933)

### DIFF
--- a/frontend/ARCHITECTURE.md
+++ b/frontend/ARCHITECTURE.md
@@ -285,6 +285,15 @@ feature-gated off.
 - **Graceful 404:** until an endpoint exists it should 404; the console already
   treats that as "not wired yet" and shows the sample/notice — so partial
   rollout is safe.
+- **Toast lifetime:** the one `<Toaster>` is mounted at the app root, outside the
+  routed tree, so a toast outlives the view that raised it and nothing about
+  changing view clears one. `sonner`'s auto-dismiss is a timer it *pauses* — on
+  hover, on a pointer interaction, on a hidden tab — and two of those latch with
+  no way back (issue #933). `src/lib/toast-lifetime.ts` is the ceiling that makes
+  a stuck toast impossible: it accumulates each toast's *visible* time and
+  dismisses one whose duration plus a grace period is spent. Hovering to read, a
+  backgrounded tab, and an explicit `duration: Infinity` are all still honoured,
+  so callers keep raising plain `toast.*` calls and need not think about it.
 
 ## Implementation order (delivered)
 

--- a/frontend/src/components/ui/sonner.tsx
+++ b/frontend/src/components/ui/sonner.tsx
@@ -1,9 +1,66 @@
+import { useEffect, useRef } from "react"
 import { useTheme } from "next-themes"
-import { Toaster as Sonner, type ToasterProps } from "sonner"
+import { Toaster as Sonner, toast, useSonner, type ToasterProps } from "sonner"
 import { CircleCheckIcon, InfoIcon, TriangleAlertIcon, OctagonXIcon, Loader2Icon } from "lucide-react"
+
+import { reconcileTracked, sweepToasts, type TrackedToast } from "@/lib/toast-lifetime"
+
+/** How often the dismissal guard re-checks the toasts that are up. */
+const SWEEP_INTERVAL_MS = 500
+
+/** Is the pointer genuinely over the toaster, whatever sonner's state believes? */
+function toasterHovered(): boolean {
+  return Array.from(document.querySelectorAll("[data-sonner-toaster]")).some((el) =>
+    el.matches(":hover"),
+  )
+}
+
+/**
+ * The ceiling on a toast's life that sonner does not provide (issue #933).
+ *
+ * sonner's auto-dismiss is a *pausable* timer, and two of the things that pause
+ * it can latch with no way back — see `lib/toast-lifetime.ts` for which, and
+ * why. The reported symptom was the "Starting the product tour." toast sitting
+ * over every view for nine minutes with a working × and nothing else that
+ * cleared it. This sweep is what makes that impossible: a toast nobody is
+ * hovering, in a tab the operator is looking at, goes away once its own duration
+ * plus a grace period has passed, whatever sonner thinks its timer is doing.
+ *
+ * Deliberately additive. Every intentional pause still holds: hover to read,
+ * hidden tab, and an explicit `duration: Infinity` are all left alone.
+ */
+function useToastDismissalCeiling(): void {
+  const { toasts } = useSonner()
+  const tracked = useRef<TrackedToast[]>([])
+
+  useEffect(() => {
+    tracked.current = reconcileTracked(
+      tracked.current,
+      toasts.map((t) => ({ id: t.id, duration: t.duration })),
+    )
+  }, [toasts])
+
+  // Only while something is on screen: the console is a long-lived dashboard, and
+  // a timer that ticks all day to find nothing is a timer that keeps the tab
+  // awake for no reason.
+  const anyToasts = toasts.length > 0
+  useEffect(() => {
+    if (!anyToasts) return
+    const timer = window.setInterval(() => {
+      const { next, overdue } = sweepToasts(tracked.current, SWEEP_INTERVAL_MS, {
+        hovered: toasterHovered(),
+        documentHidden: document.hidden,
+      })
+      tracked.current = next
+      for (const id of overdue) toast.dismiss(id)
+    }, SWEEP_INTERVAL_MS)
+    return () => window.clearInterval(timer)
+  }, [anyToasts])
+}
 
 const Toaster = ({ ...props }: ToasterProps) => {
   const { theme = "system" } = useTheme()
+  useToastDismissalCeiling()
 
   return (
     <Sonner

--- a/frontend/src/lib/toast-lifetime.ts
+++ b/frontend/src/lib/toast-lifetime.ts
@@ -1,0 +1,122 @@
+// A wall-clock ceiling on how long one toast may stay on screen.
+//
+// Issue #933. `sonner`'s auto-dismiss is not a deadline — it is a timer the
+// library *pauses*, and it pauses on three conditions held in `Toaster` state:
+// the toaster being `expanded`, a pointer `interacting` with it, and the
+// document being hidden. Two of those have no path back on their own:
+//
+//   * `expanded` is set by `mouseenter`/`mousemove` **and by sonner's built-in
+//     Alt+T hotkey**, which also focuses the toast list. It is cleared only by a
+//     `mouseleave`, by Escape while focus is inside the list, or by the toast
+//     array changing. Expand it with the hotkey while the pointer is elsewhere
+//     and no `mouseleave` can ever arrive: with a single toast up, nothing
+//     changes the array either, so the timer stays paused indefinitely.
+//   * `interacting` is set on `pointerdown` and cleared on `pointerup` *on the
+//     toaster*. Pointer capture covers the ordinary drag, but not a toast that
+//     opted out of dismissal, where sonner skips the capture and keeps the flag.
+//
+// A latched toast then rides over every view until someone clicks its ×, which
+// is what #933 reported: nine minutes and four navigations of "Starting the
+// product tour.".
+//
+// So the console does not rely on that timer alone. This module is the pure
+// half of the guard in `components/ui/sonner.tsx`: it accumulates each toast's
+// *visible* time and names the ones that have outstayed their duration. The two
+// intentional pauses are preserved — a toast under the pointer is being read,
+// and a toast in a hidden tab has not been seen yet — so the ceiling only ever
+// removes a toast nobody is looking at.
+
+/** sonner's own default lifetime (`TOAST_LIFETIME`), which the console does not override. */
+export const DEFAULT_TOAST_DURATION_MS = 4000;
+
+/**
+ * How far past its duration a toast may go before the guard steps in.
+ *
+ * sonner's timer should be what dismisses a toast in the normal case; this is a
+ * backstop, and firing it early would race the exit animation and swallow
+ * `onAutoClose`. Long enough to lose that race, short enough that a wedged
+ * toast is a blip rather than a fixture.
+ */
+export const DISMISSAL_GRACE_MS = 2000;
+
+/** One toast the guard is watching, with the visible time it has accumulated. */
+export interface TrackedToast {
+  id: string | number;
+  /** Milliseconds this toast has been on screen *while the tab was visible*. */
+  visibleMs: number;
+  /** The toast's own duration, when it set one. */
+  duration?: number;
+}
+
+/** What the guard can observe about the moment it is deciding in. */
+export interface ToastEnvironment {
+  /** Is the pointer actually over the toaster? Not what sonner believes — what is true. */
+  hovered: boolean;
+  /** Is the tab hidden, so the operator has not seen these toasts yet? */
+  documentHidden: boolean;
+}
+
+export interface SweepOptions {
+  defaultDurationMs?: number;
+  graceMs?: number;
+}
+
+export interface SweepResult {
+  /** The tracked set advanced by this tick. */
+  next: TrackedToast[];
+  /** Ids to dismiss, because their time is up and nobody is reading them. */
+  overdue: (string | number)[];
+}
+
+/**
+ * Advance the guard by one tick and say which toasts are overdue.
+ *
+ * The clock only runs while the tab is visible, so a toast raised against a
+ * backgrounded console still gets its full life once the operator returns —
+ * and a throttled background interval can only under-count, never over-count.
+ */
+export function sweepToasts(
+  tracked: TrackedToast[],
+  tickMs: number,
+  env: ToastEnvironment,
+  options: SweepOptions = {},
+): SweepResult {
+  const defaultDuration = options.defaultDurationMs ?? DEFAULT_TOAST_DURATION_MS;
+  const grace = options.graceMs ?? DISMISSAL_GRACE_MS;
+
+  // A hidden tab stops the clock rather than pausing the decision: resuming from
+  // a half-spent life would dismiss a toast the operator has only just seen.
+  if (env.documentHidden) return { next: tracked, overdue: [] };
+
+  const next = tracked.map((t) => ({ ...t, visibleMs: t.visibleMs + tickMs }));
+
+  // Hovering is the one pause the console keeps: the pointer being there is the
+  // operator reading the toast, and yanking it mid-read is the opposite of the
+  // fix. The ceiling applies the moment they move away.
+  if (env.hovered) return { next, overdue: [] };
+
+  const overdue = next
+    .filter((t) => t.duration !== Number.POSITIVE_INFINITY)
+    .filter((t) => t.visibleMs >= (t.duration ?? defaultDuration) + grace)
+    .map((t) => t.id);
+
+  return { next, overdue };
+}
+
+/**
+ * Reconcile the tracked set against what is actually on screen.
+ *
+ * Accumulated visible time survives — a toast whose content is updated in place
+ * keeps its age, so an updater cannot keep it alive by refreshing it.
+ */
+export function reconcileTracked(
+  tracked: TrackedToast[],
+  live: { id: string | number; duration?: number }[],
+): TrackedToast[] {
+  const seen = new Map(tracked.map((t) => [t.id, t]));
+  return live.map((t) => ({
+    id: t.id,
+    visibleMs: seen.get(t.id)?.visibleMs ?? 0,
+    duration: t.duration,
+  }));
+}

--- a/frontend/test/e2e/toast-dismissal.spec.ts
+++ b/frontend/test/e2e/toast-dismissal.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #933 — the "Starting the product tour." toast that never dismissed.
+ *
+ * Only a browser can hold this. sonner's auto-dismiss is a timer it *pauses* on
+ * three pieces of its own state, and the latch that produced the report is
+ * reachable only through real input: sonner ships an Alt+T hotkey that expands
+ * the toaster and focuses the toast list, and `expanded` is cleared only by a
+ * `mouseleave` — which a pointer that was never over the toaster cannot deliver.
+ * With one toast up nothing changes the toast array either, so the timer stayed
+ * paused. The reporter saw it survive nine minutes and four navigations with a
+ * working × and nothing else that cleared it.
+ *
+ * The decision the console's guard makes is pinned fast in
+ * `test/unit/toast-lifetime.test.ts`. What is only true here is that the latch
+ * is real, that the guard beats it, and that it does not cost us the one pause
+ * worth keeping — hovering to read.
+ */
+
+type Page = import("@playwright/test").Page;
+
+/** The bottom-right toast, whichever view it is riding over. */
+const TOAST = "[data-sonner-toast]";
+
+/**
+ * Land on Settings with no tour running, and no welcome dialog in the way.
+ *
+ * The dialog is not cosmetic here: it is a Radix dialog, so while it is open
+ * every element under it is `aria-hidden` and invisible to `getByRole` — the
+ * "Replay tour" button included. A first run always offers it.
+ */
+async function settings(page: Page): Promise<void> {
+  await page.goto("/#/settings");
+  const skip = page.getByRole("button", { name: "Skip for now" });
+  await expect(skip).toBeVisible();
+  await skip.click();
+  await expect(page.getByRole("button", { name: "Replay tour" })).toBeVisible();
+}
+
+/** Raise the toast the issue is about, and park the pointer far from it. */
+async function replayTour(page: Page): Promise<void> {
+  await page.getByRole("button", { name: "Replay tour" }).click();
+  await expect(page.locator(TOAST)).toBeVisible();
+  await page.mouse.move(20, 20);
+}
+
+test("the tour toast dismisses itself", async ({ page }) => {
+  await settings(page);
+  await replayTour(page);
+  // Generous: sonner's own 4s timer should do this, and the console's ceiling is
+  // a second line at 6s. Either way it must not need a click.
+  await expect(page.locator(TOAST)).toHaveCount(0, { timeout: 15_000 });
+});
+
+test("a toast cannot be pinned open by sonner's expand hotkey", async ({ page }) => {
+  await settings(page);
+  await replayTour(page);
+
+  // The latch. Before the fix this toast stayed up indefinitely — verified at
+  // twenty seconds, and the report had it at nine minutes.
+  await page.keyboard.press("Alt+KeyT");
+  await page.mouse.move(20, 20);
+
+  await expect(page.locator(TOAST)).toHaveCount(0, { timeout: 20_000 });
+});
+
+test("a toast does not follow the operator across views", async ({ page }) => {
+  await settings(page);
+  await replayTour(page);
+  await page.keyboard.press("Alt+KeyT");
+
+  // The shape of the report: raise it, then walk the console. The toaster is
+  // mounted at the app root, outside the routed tree, so nothing about changing
+  // view clears a toast — the ceiling is the only reason this ends.
+  await page.mouse.move(20, 20);
+  await page.goto("/#/overview");
+  await page.goto("/#/approvals");
+
+  await expect(page.locator(TOAST)).toHaveCount(0, { timeout: 20_000 });
+});
+
+test("hovering a toast still holds it open to be read", async ({ page }) => {
+  await settings(page);
+  await page.getByRole("button", { name: "Replay tour" }).click();
+  const toast = page.locator(TOAST);
+  await expect(toast).toBeVisible();
+
+  // The pause the fix must not take away: a toast under the pointer is one
+  // somebody is reading.
+  await toast.hover();
+  await page.waitForTimeout(9_000);
+  await expect(toast).toBeVisible();
+
+  // ...and it goes as soon as they look away, without a click.
+  await page.mouse.move(20, 20);
+  await expect(toast).toHaveCount(0, { timeout: 10_000 });
+});

--- a/frontend/test/unit/toast-lifetime.test.ts
+++ b/frontend/test/unit/toast-lifetime.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_TOAST_DURATION_MS,
+  DISMISSAL_GRACE_MS,
+  reconcileTracked,
+  sweepToasts,
+  type ToastEnvironment,
+  type TrackedToast,
+} from "@/lib/toast-lifetime";
+
+/**
+ * The console's ceiling on a toast's life (issue #933).
+ *
+ * The bug was a toast that never left: sonner's auto-dismiss is a timer it
+ * *pauses* on `expanded` / `interacting` / hidden-document, and the first two can
+ * latch with no way back — sonner's Alt+T hotkey expands the toaster and focuses
+ * it, and `expanded` then waits for a `mouseleave` that a pointer which was
+ * never there cannot deliver. The reported toast sat over four views for nine
+ * minutes with only its × working.
+ *
+ * These tests pin the guard's decision, which is the whole of the fix worth
+ * pinning fast: *when* a toast is overdue, and — just as important — the three
+ * cases where it must be left alone. The browser half (the real hotkey, a real
+ * hover) is `test/e2e/toast-dismissal.spec.ts`.
+ */
+
+const AWAKE: ToastEnvironment = { hovered: false, documentHidden: false };
+const TICK = 500;
+
+/** Run the guard until it reports something overdue, or give up. */
+function runUntilOverdue(
+  tracked: TrackedToast[],
+  env: ToastEnvironment,
+  maxMs = 60_000,
+): { elapsed: number; overdue: (string | number)[] } {
+  let current = tracked;
+  for (let elapsed = TICK; elapsed <= maxMs; elapsed += TICK) {
+    const { next, overdue } = sweepToasts(current, TICK, env);
+    current = next;
+    if (overdue.length > 0) return { elapsed, overdue };
+  }
+  return { elapsed: maxMs, overdue: [] };
+}
+
+describe("sweepToasts", () => {
+  it("dismisses a toast once its duration plus the grace period is up", () => {
+    const { elapsed, overdue } = runUntilOverdue([{ id: "a", visibleMs: 0 }], AWAKE);
+    expect(overdue).toEqual(["a"]);
+    expect(elapsed).toBe(DEFAULT_TOAST_DURATION_MS + DISMISSAL_GRACE_MS);
+  });
+
+  it("leaves a toast alone until then, so sonner's own timer is what normally fires", () => {
+    // The guard is a backstop. Reporting overdue before the grace has elapsed
+    // would race sonner's exit animation and swallow its `onAutoClose`.
+    const { overdue } = sweepToasts(
+      [{ id: "a", visibleMs: DEFAULT_TOAST_DURATION_MS }],
+      TICK,
+      AWAKE,
+    );
+    expect(overdue).toEqual([]);
+  });
+
+  it("honours a toast's own longer duration", () => {
+    const { elapsed } = runUntilOverdue([{ id: "a", visibleMs: 0, duration: 20_000 }], AWAKE);
+    expect(elapsed).toBe(20_000 + DISMISSAL_GRACE_MS);
+  });
+
+  it("never dismisses a toast that asked to be permanent", () => {
+    const { overdue } = runUntilOverdue(
+      [{ id: "a", visibleMs: 0, duration: Number.POSITIVE_INFINITY }],
+      AWAKE,
+    );
+    expect(overdue).toEqual([]);
+  });
+
+  it("holds a hovered toast for as long as the pointer is on it", () => {
+    // The one pause the console keeps: the pointer being there is somebody
+    // reading, and this fix must not yank a toast out from under them.
+    const hovered = { hovered: true, documentHidden: false };
+    const { overdue } = runUntilOverdue([{ id: "a", visibleMs: 0 }], hovered);
+    expect(overdue).toEqual([]);
+  });
+
+  it("still ages a hovered toast, so it goes the moment the pointer leaves", () => {
+    const hovered = { hovered: true, documentHidden: false };
+    let tracked: TrackedToast[] = [{ id: "a", visibleMs: 0 }];
+    for (let i = 0; i < 40; i++) tracked = sweepToasts(tracked, TICK, hovered).next;
+    // 20s of hovering: nothing dismissed, but the clock ran.
+    expect(tracked[0].visibleMs).toBe(20_000);
+    expect(sweepToasts(tracked, TICK, AWAKE).overdue).toEqual(["a"]);
+  });
+
+  it("stops the clock while the tab is hidden, so an unseen toast keeps its full life", () => {
+    let tracked: TrackedToast[] = [{ id: "a", visibleMs: 0 }];
+    const hidden = { hovered: false, documentHidden: true };
+    for (let i = 0; i < 200; i++) tracked = sweepToasts(tracked, TICK, hidden).next;
+    expect(tracked[0].visibleMs).toBe(0);
+
+    // Back in the foreground it gets the whole window, not the remainder of one
+    // it spent in a tab nobody was looking at.
+    const { elapsed } = runUntilOverdue(tracked, AWAKE);
+    expect(elapsed).toBe(DEFAULT_TOAST_DURATION_MS + DISMISSAL_GRACE_MS);
+  });
+
+  it("reports every overdue toast, not just the front one", () => {
+    const overdue = sweepToasts(
+      [
+        { id: "old", visibleMs: 30_000 },
+        { id: "older", visibleMs: 90_000 },
+        { id: "fresh", visibleMs: 0 },
+      ],
+      TICK,
+      AWAKE,
+    ).overdue;
+    expect(overdue).toEqual(["old", "older"]);
+  });
+});
+
+describe("reconcileTracked", () => {
+  it("starts new toasts at zero and forgets ones that have left", () => {
+    const tracked = reconcileTracked([{ id: "gone", visibleMs: 3000 }], [{ id: "new" }]);
+    expect(tracked).toEqual([{ id: "new", visibleMs: 0, duration: undefined }]);
+  });
+
+  it("keeps the accumulated age of a toast that is updated in place", () => {
+    // sonner's update path replaces the toast object for the same id. If that
+    // reset the age, anything refreshing a toast would keep it alive forever —
+    // the very shape of bug this guard exists to close.
+    const tracked = reconcileTracked(
+      [{ id: "a", visibleMs: 3500 }],
+      [{ id: "a", duration: 8000 }],
+    );
+    expect(tracked).toEqual([{ id: "a", visibleMs: 3500, duration: 8000 }]);
+  });
+});


### PR DESCRIPTION
## Summary

The "Starting the product tour." toast could stay on screen indefinitely (#933).
`toast.success` relies on sonner's 4s default, and that default is not a deadline
— it is a timer sonner *pauses* on three pieces of `Toaster` state: `expanded`,
`interacting`, and a hidden document. Two of them latch with no path back:

- `expanded` is set by `mouseenter`/`mousemove` **and by sonner's built-in Alt+T
  hotkey**, which also focuses the toast list. It clears only on a `mouseleave`,
  on Escape while focus is inside the list, or when the toast array changes.
  Expand it with the hotkey while the pointer is elsewhere and no `mouseleave`
  can arrive; with one toast up nothing changes the array either.
- `interacting` is set on `pointerdown` and cleared on `pointerup` *on the
  toaster*. Pointer capture covers the ordinary drag, but sonner skips the
  capture for a toast that opted out of dismissal.

The single `<Toaster>` is mounted at the app root, outside the routed tree, so a
latched toast then rides over every view until someone clicks its ×. That is the
report: nine minutes, four navigations, only the × working.

sonner 2.0.8 (latest) has identical logic, so there is nothing to upgrade to.

## What this does

Adds the ceiling sonner does not give, at the console's one choke point:
`src/lib/toast-lifetime.ts` accumulates each toast's *visible* time and names the
ones whose duration plus a 2s grace is spent; `components/ui/sonner.tsx` sweeps
every 500ms and dismisses them. It reads the *real* hover state
(`[data-sonner-toaster]:matches(":hover")`) rather than sonner's belief about it.

All three intentional pauses still hold, so no caller has to change:

- hovering to read holds a toast for as long as the pointer is on it;
- a hidden tab stops the clock, so an unseen toast keeps its full life;
- an explicit `duration: Infinity` is never touched.

The sweep only runs while a toast is on screen — the console is a long-lived
dashboard and a timer ticking all day to find nothing keeps the tab awake.

Deliberately **not** included: clearing toasts on route change (the other half of
the issue's Expected). It is in direct tension with this very toast — the tour
navigates to Overview immediately after raising it, so a blanket
dismiss-on-view-change would flash it away, and it would silently affect every
other raise-then-navigate pair in the console. The ceiling gives the guarantee
the report actually wanted without that cost.

## Behaviour changes

No API change. Any toast is now guaranteed to leave on its own; previously none
were. A toast held open by hover is unaffected.

## Commands run locally

```
npm run typecheck            # tsc -b --noEmit
npm run typecheck:e2e
npm test                     # 807 unit tests, incl. 10 new
npm run e2e                  # 146 passed, 14 skipped, 0 failed
```

The two latch specs in `test/e2e/toast-dismissal.spec.ts` were **seen failing**
with the sweep disabled, while the two that pin existing behaviour (plain
dismissal, hover-to-read) kept passing — so the new specs assert something.

## Untested edge cases

`interacting` latching via a non-dismissible toast is described in
`toast-lifetime.ts` but not covered by a spec: no console toast sets
`dismissible: false` or uses `toast.loading`, so there is no way to reach it from
the app today. The ceiling covers it regardless, since it does not consult
sonner's state.

Closes #933

🤖 Generated with [Claude Code](https://claude.com/claude-code)
