### PR TITLE
Add operator-only workspace secrets

### DIFF
--- a/docs/modules/runtime/README.md
+++ b/docs/modules/runtime/README.md
@@ -161,6 +161,10 @@ an unmanaged root is never inspected, deduplicated, warned about or removed.
 The builder threads that same `WorkspaceStore` handle onto `HarnessDeps`
 (`workspace`), so agents read and write the shared note tree through the tools
 in `harness::workspace_tools` (issues #237, #551) rather than being blind to it.
+Boot also provisions lowercase `secrets/README.md`; agent workspace tools omit
+that whole subtree while console and operator APIs keep ordinary access. It is
+for operator-only workspace notes, not credentials consumed by providers or
+tools, which remain in the dedicated secret/connection stores.
 One handle, three writers — console REST, GraphQL, and a granted agent — so an
 operator edit is what the next turn reads, with no rebuild, and an agent's note
 is in the tab the operator is already looking at. Each write records its author

--- a/docs/spec/runtime/manifest.md
+++ b/docs/spec/runtime/manifest.md
@@ -420,13 +420,19 @@ prompt = "Weekly review and operator digest"
     which reaches further than own-folder lifecycle does. Renaming or deleting
     anything elsewhere in the tree stays operator-only.
 
-    Agent writes are **unconfined**: an agent may create or edit anywhere in its
-    company's tree. Confining creation while leaving overwrite free would
+    Agent writes are broad: an agent may create or edit ordinary shared content
+    anywhere in its company's tree. The reserved lowercase `secrets/` subtree
+    is the exception: boot creates it with an explanatory `README.md`, and
+    agent workspace list/read/search/write/create tools omit or refuse the
+    entire subtree while operator workspace APIs retain full access. This is a
+    model-visibility boundary, not the application credential store; provider
+    and tool credentials still belong in Connections/inference settings.
+    Confining other creation while leaving overwrite free would
     protect nothing. What keeps the tree navigable instead is steering plus
     attribution — the persona brief names the agent's own reserved folder
     `Agents/<agent-id>/` (minted the first time that agent puts something in it;
-    boot only scaffolds the empty `Agents/` root, and since issue #645 `Desks/`
-    is minted on first use rather than scaffolded) as the default
+    boot scaffolds the empty `Agents/` root plus `secrets/README.md`, and since
+    issue #645 `Desks/` is minted on first use rather than scaffolded) as the default
     home for what it produces and marks shared
     guidance as something to edit only on purpose, and every node records who
     created it and who last wrote it (issue #326), which the console shows. Both

--- a/docs/spec/runtime/ports-console.md
+++ b/docs/spec/runtime/ports-console.md
@@ -330,15 +330,16 @@ Backends persist the node as opaque JSON and both fields are
 round-trip, the write stamp, and the rename non-stamp across all three
 backends.
 
-**`Agents/` and `Desks/` (#551, #645).** `company::workspace_scaffold` owns the
-workspace's two reserved system roots and the folders beneath them, on two
-different schedules:
+**System workspace roots.** `company::workspace_scaffold` owns `Agents/`,
+`Desks/`, and the operator-only `secrets/` subtree on different schedules:
 
 * `ensure_workspace_scaffold` adopt-or-creates the roots listed in
-  `SYSTEM_ROOTS` — `Agents` alone — **empty**, from one seam:
+  `SYSTEM_ROOTS` — `Agents` and lowercase `secrets` — from one seam:
   `RuntimeBuilder::build` (boot). It takes no roster (a company with no agents
-  still gets it), so an existing company picks it up on its next boot.
-  Idempotent; one tree read.
+  still gets them), so an existing company picks them up on its next boot.
+  `Agents/` stays empty; `secrets/README.md` explains that every agent workspace
+  tool omits or refuses this subtree while operator APIs retain normal access.
+  Idempotent.
 * `ensure_agent_folder` / `ensure_desk_folder` adopt-or-create
   `Agents/<agent-id>/` and `Desks/<desk-id>/` **on demand**, returning the node
   id, called when that agent or desk first produces something. A folder means
@@ -358,8 +359,9 @@ Both are fail-closed: a name collision (a *file* of that name, or several nodes
 sharing it) is never resolved by creating a duplicate that would make the path
 permanently ambiguous. The scaffold warns and skips, since nothing waits on its
 result; a minter returns the collision as an error, since its caller needs the
-id. The folder is an organizational and attribution unit only; agents may
-create and write **anywhere** in their company's tree.
+id. The agent/desks folders are organizational and attribution units only;
+agents may create and write ordinary shared content anywhere. `secrets/` is
+the operator-only exception on the workspace tool surface.
 
 ### FactStore
 

--- a/src/brain/hosted/test.rs
+++ b/src/brain/hosted/test.rs
@@ -498,11 +498,9 @@ fn manifest(policy_mode: &str) -> CompanyManifest {
 /// finishes booting (issue #327).
 ///
 /// Boot lays down the reserved workspace roots, and since #327 the workspace
-/// store announces its own writes — so one `WorkspaceChanged` per root is
-/// journalled before any operator message arrives. Derived from `SYSTEM_ROOTS`
-/// rather than written as a literal, so adding a root cannot silently
-/// desynchronise the scripted cycle id below from the one the runtime computes.
-const BOOT_JOURNAL_EVENTS: u64 = crate::company::workspace_scaffold::SYSTEM_ROOTS.len() as u64;
+/// store announces its own writes — one `WorkspaceChanged` per root, plus the
+/// explanatory `secrets/README.md`, is journalled before any operator message.
+const BOOT_JOURNAL_EVENTS: u64 = crate::company::workspace_scaffold::SYSTEM_ROOTS.len() as u64 + 1;
 
 /// The deterministic first-cycle id a real runtime for `Acme` produces: the
 /// company id slugs to `acme`, and the first *cycle* event lands at the first

--- a/src/company/workspace_scaffold.rs
+++ b/src/company/workspace_scaffold.rs
@@ -1,6 +1,5 @@
-//! The workspace's system roots — `Agents/` and `Desks/` — and the folders
-//! minted beneath them the first time somebody actually produces something
-//! (issue #551).
+//! The workspace's system roots — `Agents/`, `Desks/`, and `secrets/` — and the
+//! content the runtime owns beneath them.
 //!
 //! Before this module an agent had nowhere in the shared tree that was
 //! recognisably *its own*: everything it produced landed in its private
@@ -31,6 +30,8 @@
 //!   folder per roster member, one level up. It is therefore minted *whole* —
 //!   root and member folder in one call — by [`ensure_desk_folder`], so it
 //!   appears exactly when a desk first has something to put in it.
+//! * `secrets/` is operator-only scaffolding. It is laid down eagerly with a
+//!   `README.md` explaining that agent workspace tools omit the entire subtree.
 //! * A **member folder** was never scaffolding either; it is a container for
 //!   something. `Agents/<agent-id>/` and `Desks/<desk-id>/` are minted on demand
 //!   — by [`ensure_agent_folder`] / [`ensure_desk_folder`], at the moment that
@@ -85,6 +86,7 @@ use crate::Result;
 use crate::error::OpenCompanyError;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceOrigin, WorkspaceStore};
+use crate::ports::{generate_id, now_millis};
 
 /// The reserved root folder holding one subfolder per agent that has produced
 /// something.
@@ -100,6 +102,17 @@ pub const AGENTS_ROOT: &str = "Agents";
 /// Not scaffolded at boot — see [`SYSTEM_ROOTS`] and [`ensure_desk_folder`].
 pub const DESKS_ROOT: &str = "Desks";
 
+/// The operator-only workspace subtree.
+///
+/// Agents never receive this root or anything beneath it through their
+/// workspace list, read, search, or write tools. The operator surfaces still
+/// use the full workspace store, so notes here remain ordinarily browsable and
+/// editable in the console.
+pub const SECRETS_ROOT: &str = "secrets";
+
+/// The note provisioned inside [`SECRETS_ROOT`] on first boot.
+pub const SECRETS_README: &str = "# Workspace secrets\n\nStore private operator notes and secret values in this folder. Everything under `secrets/` is hidden from agent workspace tools, including listing, reading, searching, and writing. Operators can still browse and edit these notes in the Workspace view.\n\nDo not treat this folder as an application credential store: use the Connections and inference settings for credentials that OpenCompany must inject into tools or providers.\n";
+
 /// The system roots the runtime lays down eagerly, on every boot.
 ///
 /// Deliberately *not* derived from the manifest: `Agents/` exists because a
@@ -114,19 +127,35 @@ pub const DESKS_ROOT: &str = "Desks";
 /// apart from content — the re-seed tests, a future console filter — can ask
 /// rather than hard-code the names, and so promoting a root back to eager stays
 /// a one-line change.
-pub const SYSTEM_ROOTS: [&str; 1] = [AGENTS_ROOT];
+pub const SYSTEM_ROOTS: [&str; 2] = [AGENTS_ROOT, SECRETS_ROOT];
+
+/// Whether a logical workspace path belongs to the operator-only subtree.
+///
+/// This is case-insensitive on the root segment so a colliding `Secrets` node
+/// cannot become an accidental agent-visible twin. Descendants are tested by
+/// segments rather than string prefix, so `secrets-old/` remains ordinary
+/// shared workspace content.
+pub fn is_agent_hidden_path(path: &str) -> bool {
+    path.trim()
+        .trim_start_matches('/')
+        .split('/')
+        .next()
+        .is_some_and(|root| root.eq_ignore_ascii_case(SECRETS_ROOT))
+}
 
 /// Adopt-or-create the eagerly-scaffolded roots ([`SYSTEM_ROOTS`]) for
 /// `company`.
 ///
-/// One `tree()` read, then only the creates that are actually missing. Safe to
+/// Two `tree()` reads (the second resolves the README parent), then only the
+/// creates that are actually missing. Safe to
 /// call on every boot: it depends on nothing but the company id, so an existing
 /// company picks the roots up the next time it starts.
 ///
 /// What it creates is stamped [`WorkspaceOrigin::Seed`] — scaffolding the
-/// runtime lays down, authored by no operator and no agent. Nothing is created
-/// *inside* a root here; see [`ensure_agent_folder`]. `Desks/` is not created
-/// here at all, and an existing one is never even looked at: this walks
+/// runtime lays down, authored by no operator and no agent. `secrets/` receives
+/// one explanatory `README.md`; member folders beneath `Agents/` remain lazy
+/// (see [`ensure_agent_folder`]). `Desks/` is not created here at all, and an
+/// existing one is never even looked at: this walks
 /// [`SYSTEM_ROOTS`] by name, so a legacy company's `Desks/` (from before issue
 /// #645, or hand-made by an operator) is left exactly as it stands, contents
 /// and authorship included.
@@ -163,6 +192,52 @@ pub async fn ensure_workspace_scaffold(
                         company = %company,
                         error = %e,
                         "[workspace] could not create the `{root}` root; will retry on the next boot"
+                    );
+                }
+            }
+        }
+    }
+
+    // `secrets/` is useful before an operator has put anything in it, and the
+    // note explains the boundary at the place they encounter it. Refresh the
+    // tree after claiming roots so a newly-created root has an id to parent the
+    // note beneath. As with the roots, collisions fail closed and retry later.
+    let nodes = store.tree(company).await?;
+    let secret_root = match find(&nodes, None, SECRETS_ROOT) {
+        Found::Folder(id) => Some(id),
+        Found::Collision(why) => {
+            tracing::warn!(
+                company = %company,
+                "[workspace] {why}; not provisioning `{SECRETS_ROOT}/README.md`"
+            );
+            None
+        }
+        Found::Free => None,
+    };
+    if let Some(root_id) = secret_root {
+        match find(&nodes, Some(root_id.as_str()), "README.md") {
+            Found::Folder(_) | Found::Collision(_) => tracing::warn!(
+                company = %company,
+                "[workspace] `{SECRETS_ROOT}/README.md` is not one unambiguous note; leaving it untouched"
+            ),
+            Found::Free => {
+                let readme = WorkspaceNode {
+                    id: generate_id(),
+                    name: "README.md".to_string(),
+                    kind: NodeKind::File,
+                    parent_id: Some(root_id),
+                    updated_at_millis: now_millis(),
+                    created_by: WorkspaceOrigin::Seed,
+                    updated_by: WorkspaceOrigin::Seed,
+                    mime: None,
+                    size: None,
+                    sha256: None,
+                };
+                if let Err(error) = store.create(company, &readme, Some(SECRETS_README)).await {
+                    tracing::warn!(
+                        company = %company,
+                        %error,
+                        "[workspace] could not create `{SECRETS_ROOT}/README.md`; will retry on the next boot"
                     );
                 }
             }
@@ -440,11 +515,13 @@ mod tests {
         paths(&ws.tree(company).await.unwrap())
     }
 
-    /// The scaffold is exactly one empty root — and, crucially, nothing else.
-    /// A folder per roster member is what this feature stopped doing: a member
-    /// folder means "this teammate produced something", so an empty one is a
-    /// claim the tree has no business making. Issue #645 applied the same rule
-    /// to `Desks/` itself, which had no producer at all.
+    fn scaffold_paths() -> Vec<&'static str> {
+        vec!["Agents", "secrets", "secrets/README.md"]
+    }
+
+    /// The scaffold has an empty agent root plus the operator-only secrets
+    /// folder and its explanatory note. It never creates roster member folders
+    /// or the unused `Desks/` root.
     #[tokio::test]
     async fn it_provisions_one_empty_system_root() {
         let (_dir, ws) = store().await;
@@ -457,11 +534,10 @@ mod tests {
         let nodes = ws.tree(&company).await.unwrap();
         assert_eq!(
             paths(&nodes),
-            vec!["Agents"],
+            scaffold_paths(),
             "`Desks/` has no producer, so boot must not lay it down"
         );
-        for node in &nodes {
-            assert_eq!(node.kind, NodeKind::Folder, "{} is not a folder", node.name);
+        for node in nodes.iter().filter(|node| node.kind == NodeKind::Folder) {
             assert_eq!(
                 node.created_by,
                 WorkspaceOrigin::Seed,
@@ -469,6 +545,9 @@ mod tests {
                 node.name
             );
         }
+        let readme = nodes.iter().find(|node| node.name == "README.md").unwrap();
+        let (_, body) = ws.read(&company, &readme.id).await.unwrap().unwrap();
+        assert_eq!(body, SECRETS_README);
     }
 
     /// The scaffold takes no roster and asks for none: a company with no agents
@@ -484,7 +563,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents"]);
+        assert_eq!(tree_paths(&ws, &company).await, scaffold_paths());
     }
 
     /// The property that lets this run on every boot.
@@ -499,7 +578,7 @@ mod tests {
                 .unwrap();
         }
 
-        assert_eq!(tree_paths(&ws, &company).await, vec!["Agents"]);
+        assert_eq!(tree_paths(&ws, &company).await, scaffold_paths());
     }
 
     /// An operator-made `Agents/` folder is adopted as-is rather than
@@ -533,7 +612,7 @@ mod tests {
             .unwrap();
 
         let nodes = ws.tree(&company).await.unwrap();
-        assert_eq!(paths(&nodes), vec!["Agents"]);
+        assert_eq!(paths(&nodes), scaffold_paths());
         let root = nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap();
         assert_eq!(root.id, "hand-made", "the operator's folder must be reused");
         assert_eq!(
@@ -577,8 +656,8 @@ mod tests {
         let nodes = ws.tree(&company).await.unwrap();
         assert_eq!(
             paths(&nodes),
-            vec!["Agents"],
-            "the collision must not be worked around by creating anything else"
+            scaffold_paths(),
+            "the collision must not be shadowed; unrelated scaffold still provisions"
         );
         assert_eq!(
             nodes.iter().find(|n| n.name == AGENTS_ROOT).unwrap().kind,
@@ -605,7 +684,11 @@ mod tests {
             2,
             "an ambiguous root must not gain a third candidate"
         );
-        assert_eq!(nodes.len(), 2, "nothing else was created either");
+        assert_eq!(
+            paths(&nodes),
+            vec!["Agents", "Agents", "secrets", "secrets/README.md"],
+            "only the unrelated secrets scaffold may be created beside the collision"
+        );
     }
 
     /// The tree is company-scoped: scaffolding one company leaves another's
@@ -644,7 +727,7 @@ mod tests {
         assert_eq!(first, second, "a second call minted a rival folder");
         assert_eq!(
             tree_paths(&ws, &company).await,
-            vec!["Agents", "Agents/ceo"]
+            vec!["Agents", "Agents/ceo", "secrets", "secrets/README.md"]
         );
         let nodes = ws.tree(&company).await.unwrap();
         let ceo = nodes.iter().find(|n| n.name == "ceo").unwrap();
@@ -668,7 +751,7 @@ mod tests {
 
         assert_eq!(
             tree_paths(&ws, &company).await,
-            vec!["Agents", "Agents/cmo"]
+            vec!["Agents", "Agents/cmo", "secrets", "secrets/README.md"]
         );
     }
 
@@ -892,7 +975,7 @@ mod tests {
         let nodes = ws.tree(&company).await.unwrap();
         assert_eq!(
             paths(&nodes),
-            vec!["Agents", "Desks"],
+            vec!["Agents", "Desks", "secrets", "secrets/README.md"],
             "dropping `Desks/` from the scaffold must not delete an existing one"
         );
         let desks = nodes.iter().find(|n| n.name == DESKS_ROOT).unwrap();

--- a/src/company/workspace_search.rs
+++ b/src/company/workspace_search.rs
@@ -57,6 +57,7 @@ use std::num::NonZeroUsize;
 
 use crate::Result;
 use crate::company::workspace_paths::{render_path, split_logical_path};
+use crate::company::workspace_scaffold::is_agent_hidden_path;
 use crate::error::OpenCompanyError;
 use crate::ports::types::CompanyId;
 use crate::ports::workspace::{NodeKind, WorkspaceNode, WorkspaceStore};
@@ -179,6 +180,36 @@ pub async fn search_workspace(
     prefix: Option<&str>,
     limit: NonZeroUsize,
 ) -> Result<SearchOutcome> {
+    search_workspace_with_visibility(store, company, query, prefix, limit, |_| true).await
+}
+
+/// Search the workspace subset exposed to agents.
+///
+/// Operator REST and GraphQL search use [`search_workspace`] and retain the
+/// complete tree. Agent tools use this function so the operator-only
+/// `secrets/` subtree is discarded before either names or note bodies are
+/// considered.
+pub async fn search_workspace_for_agent(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    query: &str,
+    prefix: Option<&str>,
+    limit: NonZeroUsize,
+) -> Result<SearchOutcome> {
+    search_workspace_with_visibility(store, company, query, prefix, limit, |path| {
+        !is_agent_hidden_path(path)
+    })
+    .await
+}
+
+async fn search_workspace_with_visibility(
+    store: &dyn WorkspaceStore,
+    company: &CompanyId,
+    query: &str,
+    prefix: Option<&str>,
+    limit: NonZeroUsize,
+    visible: impl Fn(&str) -> bool,
+) -> Result<SearchOutcome> {
     let needle = query.trim();
     if needle.is_empty() {
         return Err(OpenCompanyError::InvalidRequest(
@@ -214,6 +245,9 @@ pub async fn search_workspace(
         let Some(path) = render_path(node, &by_id) else {
             continue;
         };
+        if !visible(&path) {
+            continue;
+        }
         if let Some(scope) = &scope
             && !(path == *scope || path.starts_with(&format!("{scope}/")))
         {

--- a/src/company/workspace_sweep.rs
+++ b/src/company/workspace_sweep.rs
@@ -367,7 +367,7 @@ mod tests {
         assert_eq!(swept_names(&removed), vec!["ceo", "cto"]);
         assert_eq!(
             names(&ws, &company).await,
-            vec!["Agents", "cmo", "task-1"],
+            vec!["Agents", "README.md", "cmo", "secrets", "task-1"],
             "a folder holding anything at all must survive"
         );
     }
@@ -399,7 +399,10 @@ mod tests {
             .unwrap();
 
         assert_eq!(swept_names(&removed), vec!["ceo"]);
-        assert_eq!(names(&ws, &company).await, vec!["Agents", "README.md"]);
+        assert_eq!(
+            names(&ws, &company).await,
+            vec!["Agents", "README.md", "README.md", "secrets"]
+        );
     }
 
     /// Acceptance criterion: running it twice is a no-op the second time. The
@@ -519,9 +522,11 @@ mod tests {
                 "Agents",
                 "Archive",
                 "Desks",
+                "README.md",
                 "ceo",
                 "creative_studio",
-                "drafts"
+                "drafts",
+                "secrets"
             ],
         );
     }
@@ -614,8 +619,14 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(names(&ws, &acme).await, vec!["Agents"]);
-        assert_eq!(names(&ws, &other).await, vec!["Agents", "ceo"]);
+        assert_eq!(
+            names(&ws, &acme).await,
+            vec!["Agents", "README.md", "secrets"]
+        );
+        assert_eq!(
+            names(&ws, &other).await,
+            vec!["Agents", "README.md", "ceo", "secrets"]
+        );
     }
 
     // -- the predicate, on shapes no backend here would create ---------------

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -32,10 +32,16 @@
 //! session cache, so a note edited in the console between two turns changes
 //! what the agent quotes on the next turn with no agent rebuild.
 //!
-//! # Agents write unconfined — and why that is the right call (issue #551)
+//! # Agents write broadly, except for operator-only secrets
 //!
-//! There is no prefix gate here. An agent may create and overwrite anywhere in
-//! the company's tree, exactly as `workspace_write` always could. Confining
+//! Ordinary shared content has no prefix gate: an agent may create and
+//! overwrite anywhere in the company's tree, exactly as `workspace_write`
+//! always could. The one confidentiality boundary is `secrets/`: that subtree
+//! is omitted from the agent path index and search before names or bodies are
+//! returned, and create refuses the root case-insensitively. Console and
+//! operator APIs continue to use the complete store.
+//!
+//! Confining
 //! *create* to `Agents/<id>/` while leaving *overwrite* free would protect
 //! nothing — overwriting an existing standard is the strictly more destructive
 //! of the two operations — so the confinement would be theatre with a
@@ -184,11 +190,11 @@ use crate::company::artifact_mirror::{MirrorOutcome, mirror_node_edit};
 // with `workspace_search` so search can never offer a node this module's
 // `PathIndex` would then refuse to resolve.
 use crate::company::workspace_paths::{render_path, split_logical_path};
-use crate::company::workspace_scaffold::AGENTS_ROOT;
+use crate::company::workspace_scaffold::{AGENTS_ROOT, is_agent_hidden_path};
 // The one definition of a workspace match, shared with the REST route and the
 // GraphQL resolver so no two surfaces can answer the same query differently.
 use crate::company::workspace_search::{
-    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_RESULTS, search_workspace,
+    DEFAULT_SEARCH_LIMIT, MAX_SEARCH_RESULTS, search_workspace_for_agent,
 };
 use crate::harness::build::TOOL_RESULT_BUDGET_BYTES;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactStore};
@@ -377,7 +383,7 @@ impl CompanyWorkspace {
     /// The single company-scoped read every tool funnels through.
     async fn index(&self) -> crate::Result<PathIndex> {
         let nodes = self.store.tree(&self.company).await?;
-        Ok(PathIndex::build(nodes))
+        Ok(PathIndex::build_for_agent(nodes))
     }
 
     /// Whether `segments` spell exactly this agent's own home folder,
@@ -477,7 +483,21 @@ struct PathIndex {
 }
 
 impl PathIndex {
+    #[cfg(test)]
     fn build(nodes: Vec<WorkspaceNode>) -> Self {
+        Self::build_with_visibility(nodes, |_| true)
+    }
+
+    /// Build the index exposed through agent workspace tools.
+    ///
+    /// Hidden nodes remain in `child_count`, so lifecycle safety still sees a
+    /// folder as non-empty when its only child is operator-only, but they are
+    /// absent from both address maps and therefore unreachable by path or id.
+    fn build_for_agent(nodes: Vec<WorkspaceNode>) -> Self {
+        Self::build_with_visibility(nodes, |path| !is_agent_hidden_path(path))
+    }
+
+    fn build_with_visibility(nodes: Vec<WorkspaceNode>, visible: impl Fn(&str) -> bool) -> Self {
         let by_id_raw: HashMap<&str, &WorkspaceNode> =
             nodes.iter().map(|n| (n.id.as_str(), n)).collect();
 
@@ -492,7 +512,7 @@ impl PathIndex {
         }
         for node in &nodes {
             match render_path(node, &by_id_raw) {
-                Some(path) => {
+                Some(path) if visible(&path) => {
                     let entry = Entry {
                         path: path.clone(),
                         node: node.clone(),
@@ -500,6 +520,7 @@ impl PathIndex {
                     index.by_id.insert(node.id.clone(), entry.clone());
                     index.by_path.entry(path).or_default().push(entry);
                 }
+                Some(_) => {}
                 None => index.unaddressable += 1,
             }
         }
@@ -1141,7 +1162,7 @@ impl Tool for WorkspaceReadTool {
 ///
 /// This is the one tool that does not build a [`PathIndex`], and the containment
 /// argument is unchanged rather than merely similar:
-/// [`search_workspace`](crate::company::workspace_search::search_workspace) is
+/// [`search_workspace_for_agent`](crate::company::workspace_search::search_workspace_for_agent) is
 /// handed `self.workspace.company` — fixed at agent-build time, never read from
 /// an argument — and derives its entire reachable set from one
 /// `store.tree(company)` call, reading bodies only by ids that came out of that
@@ -1252,7 +1273,7 @@ impl Tool for WorkspaceSearchTool {
         };
         let limit = NonZeroUsize::new(limit).unwrap_or(NonZeroUsize::MIN);
 
-        let outcome = match search_workspace(
+        let outcome = match search_workspace_for_agent(
             self.workspace.store.as_ref(),
             &self.workspace.company,
             query,
@@ -1789,6 +1810,11 @@ impl Tool for WorkspaceCreateTool {
             Err(why) => return Ok(ToolResult::error(format!("Invalid `path`: {why}."))),
         };
         let normalized = segments.join("/");
+        if is_agent_hidden_path(&normalized) {
+            return Ok(ToolResult::error(
+                "Refused: this workspace path is not available to agents.".to_string(),
+            ));
+        }
         let (parent_segments, name) = segments.split_at(segments.len() - 1);
         let name = name[0];
 
@@ -2069,6 +2095,120 @@ mod tests {
         assert_eq!(index.by_id["b"].path, "Standards/Engineering standards.md");
         assert_eq!(index.by_id["c"].path, "README.md");
         assert_eq!(index.unaddressable, 0);
+    }
+
+    #[test]
+    fn the_agent_index_omits_the_secrets_subtree_by_path_and_id() {
+        let nodes = vec![
+            folder("secret-root", "secrets", None),
+            file("secret-note", "token.md", Some("secret-root")),
+            file("public-note", "secrets-old.md", None),
+        ];
+
+        let index = PathIndex::build_for_agent(nodes);
+
+        assert!(!index.by_id.contains_key("secret-root"));
+        assert!(!index.by_id.contains_key("secret-note"));
+        assert_eq!(index.by_id["public-note"].path, "secrets-old.md");
+        assert_eq!(index.unaddressable, 0, "hidden is not malformed");
+    }
+
+    #[tokio::test]
+    async fn secrets_are_operator_visible_but_absent_from_every_agent_workspace_tool() {
+        let (_dir, store) = seeded("acme").await;
+        let company = CompanyId::new("acme");
+        store
+            .create(&company, &folder("secret-root", "secrets", None), None)
+            .await
+            .unwrap();
+        store
+            .create(
+                &company,
+                &file("secret-note", "keys.md", Some("secret-root")),
+                Some("launch-codeword-umbra"),
+            )
+            .await
+            .unwrap();
+        let workspace = ws(store.clone(), company.clone());
+
+        let listed = text(
+            &WorkspaceListTool::new(workspace.clone())
+                .execute(json!({}))
+                .await
+                .unwrap(),
+        );
+        assert!(!listed.contains("secrets"), "{listed}");
+        assert!(!listed.contains("secret-note"), "{listed}");
+
+        for args in [
+            json!({"path": "secrets/keys.md"}),
+            json!({"id": "secret-note"}),
+        ] {
+            let result = WorkspaceReadTool::new(workspace.clone())
+                .execute(args)
+                .await
+                .unwrap();
+            assert!(result.is_error, "{}", text(&result));
+            assert!(!text(&result).contains("launch-codeword-umbra"));
+        }
+
+        let searched = text(
+            &WorkspaceSearchTool::new(workspace.clone())
+                .execute(json!({"query": "launch-codeword-umbra"}))
+                .await
+                .unwrap(),
+        );
+        assert!(searched.contains("No workspace notes match"), "{searched}");
+        assert!(!searched.contains("secret-note"), "{searched}");
+
+        let write = WorkspaceWriteTool::new(workspace.clone())
+            .execute(json!({
+                "id": "secret-note",
+                "content": "overwritten",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(write.is_error, "{}", text(&write));
+
+        let rename = WorkspaceRenameTool::new(workspace.clone())
+            .execute(json!({"id": "secret-note", "new_name": "public.md"}))
+            .await
+            .unwrap();
+        assert!(rename.is_error, "{}", text(&rename));
+
+        let delete = WorkspaceDeleteTool::new(workspace.clone())
+            .execute(json!({
+                "id": "secret-note",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(delete.is_error, "{}", text(&delete));
+
+        let create = WorkspaceCreateTool::new(workspace)
+            .execute(json!({
+                "path": "Secrets/new.md",
+                "kind": "file",
+                "content": "agent value",
+            }))
+            .await
+            .unwrap();
+        assert!(create.is_error, "{}", text(&create));
+
+        // Operator-facing helpers deliberately retain the complete tree.
+        let operator = crate::company::workspace_search::search_workspace(
+            store.as_ref(),
+            &company,
+            "launch-codeword-umbra",
+            None,
+            NonZeroUsize::MIN,
+        )
+        .await
+        .unwrap();
+        assert_eq!(operator.hits[0].path, "secrets/keys.md");
+        let (_, body) = store.read(&company, "secret-note").await.unwrap().unwrap();
+        assert_eq!(body, "launch-codeword-umbra");
     }
 
     /// A child excluded from the path maps must still be counted against its

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -4135,18 +4135,24 @@ mod test {
             .build()
             .await
             .unwrap();
-        // Seeded: README.md, Brand/, Brand/voice.md — plus the system roots
-        // boot always scaffolds beside them (issue #551), which are not seeded
-        // content and so are not what the re-seed gate is about. Filtering by
-        // `SYSTEM_ROOTS` rather than by name keeps this honest as that set
-        // changes (issue #645 took `Desks/` out of it).
+        // Seeded: README.md, Brand/, Brand/voice.md — plus runtime scaffold
+        // (`Agents/` and `secrets/README.md`) which is not what the re-seed
+        // gate is about.
         let seeded = |tree: &[crate::ports::WorkspaceNode]| {
+            let secrets = tree
+                .iter()
+                .find(|node| {
+                    node.parent_id.is_none()
+                        && node.name == crate::company::workspace_scaffold::SECRETS_ROOT
+                })
+                .map(|node| node.id.as_str());
             let mut names: Vec<String> = tree
                 .iter()
-                .map(|n| n.name.clone())
-                .filter(|name| {
-                    !crate::company::workspace_scaffold::SYSTEM_ROOTS.contains(&name.as_str())
+                .filter(|node| {
+                    !crate::company::workspace_scaffold::SYSTEM_ROOTS.contains(&node.name.as_str())
+                        && node.parent_id.as_deref() != secrets
                 })
+                .map(|node| node.name.clone())
                 .collect();
             names.sort();
             names
@@ -4176,9 +4182,8 @@ mod test {
         assert!(runtime.store().load(&id).await.unwrap().is_some());
     }
 
-    /// Issue #551: boot lays down the workspace's system roots — and nothing
-    /// inside them. Since issue #645 that is `Agents/` alone: `Desks/` had no
-    /// producer, so it is minted on first use instead of standing empty here.
+    /// Boot lays down `Agents/` and operator-only `secrets/README.md`. `Desks/`
+    /// has no producer, so it is minted on first use instead of standing empty.
     ///
     /// The per-agent folder is deliberately absent: it is minted the first time
     /// that agent produces something, so a roster of teammates who have done
@@ -4190,7 +4195,7 @@ mod test {
     /// an existing company picks the root up.
     #[tokio::test]
     async fn boot_provisions_the_system_roots_and_nothing_inside_them() {
-        use crate::company::workspace_scaffold::AGENTS_ROOT;
+        use crate::company::workspace_scaffold::{AGENTS_ROOT, SECRETS_ROOT};
         use crate::ports::workspace::{NodeKind, WorkspaceOrigin};
 
         let home_dir = tmp_home("oc-agents-");
@@ -4215,15 +4220,19 @@ mod test {
         names.sort_unstable();
         assert_eq!(
             names,
-            vec![AGENTS_ROOT],
-            "boot provisions the managed root with no seed dir — no `Desks/`, and no \
+            vec![AGENTS_ROOT, "README.md", SECRETS_ROOT],
+            "boot provisions the managed roots with no seed dir — no `Desks/`, and no \
              folder for a teammate that has produced nothing"
         );
         for node in &tree {
-            assert!(node.parent_id.is_none());
-            assert_eq!(node.kind, NodeKind::Folder);
             assert_eq!(node.created_by, WorkspaceOrigin::Seed);
         }
+        assert_eq!(
+            tree.iter()
+                .filter(|node| node.parent_id.is_none() && node.kind == NodeKind::Folder)
+                .count(),
+            2
+        );
 
         // An existing, non-empty workspace: an `is_empty` gate would have
         // skipped this boot entirely, and a company that predates the feature
@@ -4265,7 +4274,13 @@ mod test {
         names.sort_unstable();
         assert_eq!(
             names,
-            vec![AGENTS_ROOT, "Desks", "creative_studio"],
+            vec![
+                AGENTS_ROOT,
+                "Desks",
+                "README.md",
+                "creative_studio",
+                SECRETS_ROOT,
+            ],
             "the deleted root was re-provisioned, and the unmanaged `Desks/` left as it stood"
         );
     }
@@ -4274,7 +4289,7 @@ mod test {
     /// roster: a company with no agents at all still gets it.
     #[tokio::test]
     async fn boot_provisions_the_roots_for_a_company_with_no_agents() {
-        use crate::company::workspace_scaffold::AGENTS_ROOT;
+        use crate::company::workspace_scaffold::{AGENTS_ROOT, SECRETS_ROOT};
 
         let home_dir = tmp_home("oc-noagents-");
         let id = CompanyId::new("acme");
@@ -4290,7 +4305,7 @@ mod test {
         let tree = runtime.workspace().tree(&id).await.unwrap();
         let mut names: Vec<&str> = tree.iter().map(|n| n.name.as_str()).collect();
         names.sort_unstable();
-        assert_eq!(names, vec![AGENTS_ROOT]);
+        assert_eq!(names, vec![AGENTS_ROOT, "README.md", SECRETS_ROOT]);
     }
 
     /// Issue #85: the launch path's template provenance is stamped onto the

--- a/src/server/graphql/test.rs
+++ b/src/server/graphql/test.rs
@@ -893,7 +893,7 @@ async fn empty_surfaces_resolve_to_empty_lists() {
         .map(|node| node["name"].as_str().unwrap())
         .collect();
     names.sort_unstable();
-    assert_eq!(names, vec!["Agents", "maya"]);
+    assert_eq!(names, vec!["Agents", "README.md", "maya", "secrets"]);
     let root = tree
         .iter()
         .find(|node| node["name"] == serde_json::json!("Agents"))

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -1333,7 +1333,7 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
 
     // A workspace with nothing seeded into it reads as a real tree, not a 404
     // and not a fixture. It is not *empty*, though: boot scaffolds the reserved
-    // `Agents/` root (issue #551). The manifest here has an agent and it gets
+    // `Agents/` root and operator-only `secrets/README.md`. The manifest here has an agent and it gets
     // no folder — a member folder is minted on first use, not on joining the
     // roster. `Desks/` is absent for the same reason since issue #645: nothing
     // writes into it, so it is minted on first use rather than scaffolded.
@@ -1341,8 +1341,8 @@ async fn workspace_tree_and_file_reads_reflect_writes() {
     assert_eq!(status, StatusCode::OK);
     assert_eq!(
         provisioned_names(&tree),
-        vec!["Agents"],
-        "a fresh company starts with the one system root and nothing else"
+        vec!["Agents", "README.md", "secrets"],
+        "a fresh company starts with its system scaffold and nothing else"
     );
     let provisioned = tree.as_array().unwrap().len();
 
@@ -1548,7 +1548,10 @@ async fn workspace_reads_are_isolated_between_companies() {
     )
     .await;
     assert_eq!(status, StatusCode::OK);
-    assert_eq!(provisioned_names(&tree_b), vec!["Agents"]);
+    assert_eq!(
+        provisioned_names(&tree_b),
+        vec!["Agents", "README.md", "secrets"]
+    );
 
     // Even naming A's node id explicitly, B's scope does not resolve it.
     let (status, _) = send_auth(
@@ -1826,8 +1829,10 @@ async fn workspace_sweep_previews_then_removes_only_the_empty_agent_folders() {
         vec![
             "Agents".to_string(),
             "README.md".to_string(),
+            "README.md".to_string(),
             "cmo".to_string(),
             "launch-brief.md".to_string(),
+            "secrets".to_string(),
         ],
         "the folder holding a deliverable, the operator's note and the root all stay"
     );


### PR DESCRIPTION
## Summary

- provision a lowercase secrets folder with an explanatory README for every company workspace
- keep the full subtree visible to operators while excluding it from every agent workspace tool by path and node ID
- preserve operator REST and GraphQL search behavior and document the visibility boundary

## Behavior

Agents cannot list, read, search, overwrite, rename, delete, or create content under secrets/. Operators retain normal workspace browse, edit, and search access. This folder is for operator-only workspace notes; application credentials still belong in Connections and inference settings.

## Validation

- cargo fmt --all -- --check
- scripts/ci/assert-md-line-cap.sh
- cargo test --quiet
- RUST_MIN_STACK=8388608 cargo test --quiet --features openhuman -- --test-threads=1
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-targets --features openhuman -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an operator-only `secrets/` workspace area with a starter README.
  - Agent workspace tools now exclude the `secrets/` subtree from listing, searching, reading, editing, and creation.
  - Operators retain full access to protected workspace content.
  - Workspace setup now creates `Agents/` and `secrets/` automatically, while `Desks/` remains created on demand.

- **Documentation**
  - Updated runtime and workspace documentation to describe protected secrets, workspace access rules, and boot-time scaffolding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->