### PR TITLE
Per-agent context write scope, ledger grants, and AGENTS.md routing

### DIFF
--- a/companies/agentic_accounting_firm/AGENTS.md
+++ b/companies/agentic_accounting_firm/AGENTS.md
@@ -32,3 +32,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `bookkeeper` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Books/Q2 close.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `bookkeeper` (unconfined) to change.
+

--- a/companies/agentic_accounting_firm/AGENTS.md
+++ b/companies/agentic_accounting_firm/AGENTS.md
@@ -1,0 +1,34 @@
+# Agentic Accounting Firm — working agreement
+
+> An accounting firm of agents that keeps books, prepares taxes and payroll, forecasts, and readies audits — a human signs off on filings.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `audit_prep` | Audit Preparer |  | Assemble documentation for audits. |
+| `bookkeeper` | Bookkeeper | orchestrator | Record transactions and reconcile accounts. |
+| `forecaster` | Forecaster |  | Build financial forecasts and budgets. |
+| `payroll_agent` | Payroll Agent |  | Run payroll and related filings. |
+| `tax_preparer` | Tax Preparer |  | Prepare tax filings. |
+
+`bookkeeper` (Bookkeeper) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **sign-off on filings**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `bookkeeper` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_accounting_firm/AGENTS.md
+++ b/companies/agentic_accounting_firm/AGENTS.md
@@ -6,13 +6,13 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `audit_prep` | Audit Preparer |  | Assemble documentation for audits. |
-| `bookkeeper` | Bookkeeper | orchestrator | Record transactions and reconcile accounts. |
-| `forecaster` | Forecaster |  | Build financial forecasts and budgets. |
-| `payroll_agent` | Payroll Agent |  | Run payroll and related filings. |
-| `tax_preparer` | Tax Preparer |  | Prepare tax filings. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `audit_prep` | Audit Preparer | Assemble documentation for audits. |
+| `bookkeeper` | Bookkeeper (orchestrator) | Record transactions and reconcile accounts. |
+| `forecaster` | Forecaster | Build financial forecasts and budgets. |
+| `payroll_agent` | Payroll Agent | Run payroll and related filings. |
+| `tax_preparer` | Tax Preparer | Prepare tax filings. |
 
 `bookkeeper` (Bookkeeper) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_accounting_firm/agents/audit_prep.toml
+++ b/companies/agentic_accounting_firm/agents/audit_prep.toml
@@ -1,2 +1,11 @@
 role = "Audit Preparer"
 description = "Assemble documentation for audits."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_accounting_firm/agents/audit_prep.toml
+++ b/companies/agentic_accounting_firm/agents/audit_prep.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Books/Q2 close.md", access = "write" },
+]

--- a/companies/agentic_accounting_firm/agents/forecaster.toml
+++ b/companies/agentic_accounting_firm/agents/forecaster.toml
@@ -1,2 +1,11 @@
 role = "Forecaster"
 description = "Build financial forecasts and budgets."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_accounting_firm/agents/forecaster.toml
+++ b/companies/agentic_accounting_firm/agents/forecaster.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Books/Q2 close.md", access = "write" },
+]

--- a/companies/agentic_accounting_firm/agents/payroll_agent.toml
+++ b/companies/agentic_accounting_firm/agents/payroll_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Books/Q2 close.md", access = "write" },
+]

--- a/companies/agentic_accounting_firm/agents/payroll_agent.toml
+++ b/companies/agentic_accounting_firm/agents/payroll_agent.toml
@@ -1,2 +1,11 @@
 role = "Payroll Agent"
 description = "Run payroll and related filings."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_accounting_firm/agents/tax_preparer.toml
+++ b/companies/agentic_accounting_firm/agents/tax_preparer.toml
@@ -1,2 +1,11 @@
 role = "Tax Preparer"
 description = "Prepare tax filings."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_accounting_firm/agents/tax_preparer.toml
+++ b/companies/agentic_accounting_firm/agents/tax_preparer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Books/Q2 close.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/AGENTS.md
+++ b/companies/agentic_consultation_firm/AGENTS.md
@@ -6,15 +6,15 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `deck_builder` | Deck Builder |  | Produce client-ready presentations. |
-| `financial_modeler` | Financial Modeler |  | Build the supporting financial models. |
-| `implementation_planner` | Implementation Planner |  | Turn strategy into an execution roadmap. |
-| `industry_analyst` | Industry Analyst |  | Industry, market, and competitive analysis. |
-| `interviewer` | Interviewer |  | Conduct and synthesize stakeholder interviews. |
-| `researcher` | Researcher | orchestrator | Desk research and evidence gathering. |
-| `strategist` | Strategist |  | Synthesize findings into strategy recommendations. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `deck_builder` | Deck Builder | Produce client-ready presentations. |
+| `financial_modeler` | Financial Modeler | Build the supporting financial models. |
+| `implementation_planner` | Implementation Planner | Turn strategy into an execution roadmap. |
+| `industry_analyst` | Industry Analyst | Industry, market, and competitive analysis. |
+| `interviewer` | Interviewer | Conduct and synthesize stakeholder interviews. |
+| `researcher` | Researcher (orchestrator) | Desk research and evidence gathering. |
+| `strategist` | Strategist | Synthesize findings into strategy recommendations. |
 
 `researcher` (Researcher) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_consultation_firm/AGENTS.md
+++ b/companies/agentic_consultation_firm/AGENTS.md
@@ -34,3 +34,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `researcher` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Engagements/Retail growth strategy.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `researcher` (unconfined) to change.
+

--- a/companies/agentic_consultation_firm/AGENTS.md
+++ b/companies/agentic_consultation_firm/AGENTS.md
@@ -1,0 +1,36 @@
+# Agentic Consulting Firm — working agreement
+
+> A McKinsey-shaped firm of agents: research, analysis, modeling, and deck-building that produces strategy and implementation plans humans present in executive workshops.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `deck_builder` | Deck Builder |  | Produce client-ready presentations. |
+| `financial_modeler` | Financial Modeler |  | Build the supporting financial models. |
+| `implementation_planner` | Implementation Planner |  | Turn strategy into an execution roadmap. |
+| `industry_analyst` | Industry Analyst |  | Industry, market, and competitive analysis. |
+| `interviewer` | Interviewer |  | Conduct and synthesize stakeholder interviews. |
+| `researcher` | Researcher | orchestrator | Desk research and evidence gathering. |
+| `strategist` | Strategist |  | Synthesize findings into strategy recommendations. |
+
+`researcher` (Researcher) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **executive workshops**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `researcher` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_consultation_firm/agents/deck_builder.toml
+++ b/companies/agentic_consultation_firm/agents/deck_builder.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/agents/deck_builder.toml
+++ b/companies/agentic_consultation_firm/agents/deck_builder.toml
@@ -1,2 +1,11 @@
 role = "Deck Builder"
 description = "Produce client-ready presentations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/financial_modeler.toml
+++ b/companies/agentic_consultation_firm/agents/financial_modeler.toml
@@ -1,2 +1,11 @@
 role = "Financial Modeler"
 description = "Build the supporting financial models."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/financial_modeler.toml
+++ b/companies/agentic_consultation_firm/agents/financial_modeler.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/agents/implementation_planner.toml
+++ b/companies/agentic_consultation_firm/agents/implementation_planner.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/agents/implementation_planner.toml
+++ b/companies/agentic_consultation_firm/agents/implementation_planner.toml
@@ -1,2 +1,11 @@
 role = "Implementation Planner"
 description = "Turn strategy into an execution roadmap."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/industry_analyst.toml
+++ b/companies/agentic_consultation_firm/agents/industry_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/agents/industry_analyst.toml
+++ b/companies/agentic_consultation_firm/agents/industry_analyst.toml
@@ -1,2 +1,11 @@
 role = "Industry Analyst"
 description = "Industry, market, and competitive analysis."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/interviewer.toml
+++ b/companies/agentic_consultation_firm/agents/interviewer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_consultation_firm/agents/interviewer.toml
+++ b/companies/agentic_consultation_firm/agents/interviewer.toml
@@ -1,2 +1,11 @@
 role = "Interviewer"
 description = "Conduct and synthesize stakeholder interviews."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/strategist.toml
+++ b/companies/agentic_consultation_firm/agents/strategist.toml
@@ -1,2 +1,11 @@
 role = "Strategist"
 description = "Synthesize findings into strategy recommendations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_consultation_firm/agents/strategist.toml
+++ b/companies/agentic_consultation_firm/agents/strategist.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Engagements/Retail growth strategy.md", access = "write" },
+]

--- a/companies/agentic_customer_support/AGENTS.md
+++ b/companies/agentic_customer_support/AGENTS.md
@@ -1,0 +1,34 @@
+# Agentic Customer Support Company — working agreement
+
+> A support org of agents that resolves tickets, writes docs, files bug reports, escalates hard cases, and handles refunds — humans own escalation and policy.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `bug_reporter` | Bug Reporter |  | File actionable bug reports. |
+| `docs_writer` | Docs Writer |  | Write and maintain help docs. |
+| `escalation_manager` | Escalation Manager |  | Route and manage escalations. |
+| `refund_handler` | Refund Handler |  | Process refunds within policy. |
+| `support_agent` | Support Agent | orchestrator | Resolve inbound customer tickets. |
+
+`support_agent` (Support Agent) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **escalation and policy**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `support_agent` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_customer_support/AGENTS.md
+++ b/companies/agentic_customer_support/AGENTS.md
@@ -6,13 +6,13 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `bug_reporter` | Bug Reporter |  | File actionable bug reports. |
-| `docs_writer` | Docs Writer |  | Write and maintain help docs. |
-| `escalation_manager` | Escalation Manager |  | Route and manage escalations. |
-| `refund_handler` | Refund Handler |  | Process refunds within policy. |
-| `support_agent` | Support Agent | orchestrator | Resolve inbound customer tickets. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `bug_reporter` | Bug Reporter | File actionable bug reports. |
+| `docs_writer` | Docs Writer | Write and maintain help docs. |
+| `escalation_manager` | Escalation Manager | Route and manage escalations. |
+| `refund_handler` | Refund Handler | Process refunds within policy. |
+| `support_agent` | Support Agent (orchestrator) | Resolve inbound customer tickets. |
 
 `support_agent` (Support Agent) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_customer_support/AGENTS.md
+++ b/companies/agentic_customer_support/AGENTS.md
@@ -32,3 +32,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `support_agent` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Tickets/Login outage.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `support_agent` (unconfined) to change.
+

--- a/companies/agentic_customer_support/agents/bug_reporter.toml
+++ b/companies/agentic_customer_support/agents/bug_reporter.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Tickets/Login outage.md", access = "write" },
+]

--- a/companies/agentic_customer_support/agents/bug_reporter.toml
+++ b/companies/agentic_customer_support/agents/bug_reporter.toml
@@ -1,2 +1,11 @@
 role = "Bug Reporter"
 description = "File actionable bug reports."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_customer_support/agents/docs_writer.toml
+++ b/companies/agentic_customer_support/agents/docs_writer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Tickets/Login outage.md", access = "write" },
+]

--- a/companies/agentic_customer_support/agents/docs_writer.toml
+++ b/companies/agentic_customer_support/agents/docs_writer.toml
@@ -1,2 +1,11 @@
 role = "Docs Writer"
 description = "Write and maintain help docs."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_customer_support/agents/escalation_manager.toml
+++ b/companies/agentic_customer_support/agents/escalation_manager.toml
@@ -1,2 +1,11 @@
 role = "Escalation Manager"
 description = "Route and manage escalations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_customer_support/agents/escalation_manager.toml
+++ b/companies/agentic_customer_support/agents/escalation_manager.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Tickets/Login outage.md", access = "write" },
+]

--- a/companies/agentic_customer_support/agents/refund_handler.toml
+++ b/companies/agentic_customer_support/agents/refund_handler.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Tickets/Login outage.md", access = "write" },
+]

--- a/companies/agentic_customer_support/agents/refund_handler.toml
+++ b/companies/agentic_customer_support/agents/refund_handler.toml
@@ -1,2 +1,11 @@
 role = "Refund Handler"
 description = "Process refunds within policy."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_design_studio/AGENTS.md
+++ b/companies/agentic_design_studio/AGENTS.md
@@ -6,13 +6,13 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `brand_designer` | Brand Designer | orchestrator | Identity systems, logos, and guidelines. |
-| `illustrator` | Illustrator |  | Custom illustration and iconography. |
-| `motion_designer` | Motion Designer |  | Animation and motion graphics. |
-| `ui_designer` | UI Designer |  | Product UI and design systems. |
-| `user_researcher` | User Researcher |  | User testing and design validation. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `brand_designer` | Brand Designer (orchestrator) | Identity systems, logos, and guidelines. |
+| `illustrator` | Illustrator | Custom illustration and iconography. |
+| `motion_designer` | Motion Designer | Animation and motion graphics. |
+| `ui_designer` | UI Designer | Product UI and design systems. |
+| `user_researcher` | User Researcher | User testing and design validation. |
 
 `brand_designer` (Brand Designer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_design_studio/AGENTS.md
+++ b/companies/agentic_design_studio/AGENTS.md
@@ -32,3 +32,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `brand_designer` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Projects/Fintech rebrand.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `brand_designer` (unconfined) to change.
+

--- a/companies/agentic_design_studio/AGENTS.md
+++ b/companies/agentic_design_studio/AGENTS.md
@@ -1,0 +1,34 @@
+# Agentic Design Studio — working agreement
+
+> A design studio of agents delivering branding, UI, motion, and illustration — validated with user testing, signed off by a human creative director.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `brand_designer` | Brand Designer | orchestrator | Identity systems, logos, and guidelines. |
+| `illustrator` | Illustrator |  | Custom illustration and iconography. |
+| `motion_designer` | Motion Designer |  | Animation and motion graphics. |
+| `ui_designer` | UI Designer |  | Product UI and design systems. |
+| `user_researcher` | User Researcher |  | User testing and design validation. |
+
+`brand_designer` (Brand Designer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **creative direction sign-off**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `brand_designer` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_design_studio/agents/illustrator.toml
+++ b/companies/agentic_design_studio/agents/illustrator.toml
@@ -1,2 +1,11 @@
 role = "Illustrator"
 description = "Custom illustration and iconography."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_design_studio/agents/illustrator.toml
+++ b/companies/agentic_design_studio/agents/illustrator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Projects/Fintech rebrand.md", access = "write" },
+]

--- a/companies/agentic_design_studio/agents/motion_designer.toml
+++ b/companies/agentic_design_studio/agents/motion_designer.toml
@@ -1,2 +1,11 @@
 role = "Motion Designer"
 description = "Animation and motion graphics."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_design_studio/agents/motion_designer.toml
+++ b/companies/agentic_design_studio/agents/motion_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Projects/Fintech rebrand.md", access = "write" },
+]

--- a/companies/agentic_design_studio/agents/ui_designer.toml
+++ b/companies/agentic_design_studio/agents/ui_designer.toml
@@ -1,2 +1,11 @@
 role = "UI Designer"
 description = "Product UI and design systems."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_design_studio/agents/ui_designer.toml
+++ b/companies/agentic_design_studio/agents/ui_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Projects/Fintech rebrand.md", access = "write" },
+]

--- a/companies/agentic_design_studio/agents/user_researcher.toml
+++ b/companies/agentic_design_studio/agents/user_researcher.toml
@@ -1,2 +1,11 @@
 role = "User Researcher"
 description = "User testing and design validation."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_design_studio/agents/user_researcher.toml
+++ b/companies/agentic_design_studio/agents/user_researcher.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Projects/Fintech rebrand.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/AGENTS.md
+++ b/companies/agentic_enterprise_sales/AGENTS.md
@@ -1,0 +1,35 @@
+# Agentic Enterprise Sales Organization — working agreement
+
+> A sales org of agents that generates leads, personalizes outreach, keeps the CRM clean, writes proposals and contracts, and follows up — humans close strategic accounts.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `contract_generator` | Contract Generator |  | Generate contracts from templates. |
+| `crm_updater` | CRM Updater |  | Keep CRM records accurate and current. |
+| `follow_up_agent` | Follow-up Agent |  | Nurture and follow up on pipeline. |
+| `lead_gen` | Lead Generation | orchestrator | Generate and qualify leads. |
+| `outreach_personalizer` | Outreach Personalizer |  | Craft personalized outreach at scale. |
+| `proposal_writer` | Proposal Writer |  | Write tailored proposals. |
+
+`lead_gen` (Lead Generation) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **closing strategic accounts**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `lead_gen` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_enterprise_sales/AGENTS.md
+++ b/companies/agentic_enterprise_sales/AGENTS.md
@@ -6,14 +6,14 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `contract_generator` | Contract Generator |  | Generate contracts from templates. |
-| `crm_updater` | CRM Updater |  | Keep CRM records accurate and current. |
-| `follow_up_agent` | Follow-up Agent |  | Nurture and follow up on pipeline. |
-| `lead_gen` | Lead Generation | orchestrator | Generate and qualify leads. |
-| `outreach_personalizer` | Outreach Personalizer |  | Craft personalized outreach at scale. |
-| `proposal_writer` | Proposal Writer |  | Write tailored proposals. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `contract_generator` | Contract Generator | Generate contracts from templates. |
+| `crm_updater` | CRM Updater | Keep CRM records accurate and current. |
+| `follow_up_agent` | Follow-up Agent | Nurture and follow up on pipeline. |
+| `lead_gen` | Lead Generation (orchestrator) | Generate and qualify leads. |
+| `outreach_personalizer` | Outreach Personalizer | Craft personalized outreach at scale. |
+| `proposal_writer` | Proposal Writer | Write tailored proposals. |
 
 `lead_gen` (Lead Generation) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_enterprise_sales/AGENTS.md
+++ b/companies/agentic_enterprise_sales/AGENTS.md
@@ -33,3 +33,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `lead_gen` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Accounts/Globex expansion.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `lead_gen` (unconfined) to change.
+

--- a/companies/agentic_enterprise_sales/agents/contract_generator.toml
+++ b/companies/agentic_enterprise_sales/agents/contract_generator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Accounts/Globex expansion.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/agents/contract_generator.toml
+++ b/companies/agentic_enterprise_sales/agents/contract_generator.toml
@@ -1,2 +1,11 @@
 role = "Contract Generator"
 description = "Generate contracts from templates."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_enterprise_sales/agents/crm_updater.toml
+++ b/companies/agentic_enterprise_sales/agents/crm_updater.toml
@@ -1,2 +1,11 @@
 role = "CRM Updater"
 description = "Keep CRM records accurate and current."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_enterprise_sales/agents/crm_updater.toml
+++ b/companies/agentic_enterprise_sales/agents/crm_updater.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Accounts/Globex expansion.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
+++ b/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Accounts/Globex expansion.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
+++ b/companies/agentic_enterprise_sales/agents/follow_up_agent.toml
@@ -1,2 +1,11 @@
 role = "Follow-up Agent"
 description = "Nurture and follow up on pipeline."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
+++ b/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Accounts/Globex expansion.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
+++ b/companies/agentic_enterprise_sales/agents/outreach_personalizer.toml
@@ -1,2 +1,11 @@
 role = "Outreach Personalizer"
 description = "Craft personalized outreach at scale."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_enterprise_sales/agents/proposal_writer.toml
+++ b/companies/agentic_enterprise_sales/agents/proposal_writer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Accounts/Globex expansion.md", access = "write" },
+]

--- a/companies/agentic_enterprise_sales/agents/proposal_writer.toml
+++ b/companies/agentic_enterprise_sales/agents/proposal_writer.toml
@@ -1,2 +1,11 @@
 role = "Proposal Writer"
 description = "Write tailored proposals."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/AGENTS.md
+++ b/companies/agentic_game_business/AGENTS.md
@@ -34,3 +34,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `user_acquisition` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Events/Summer festival.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `user_acquisition` (unconfined) to change.
+

--- a/companies/agentic_game_business/AGENTS.md
+++ b/companies/agentic_game_business/AGENTS.md
@@ -6,15 +6,15 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `analytics_analyst` | Analytics Analyst |  | Track KPIs, LTV, retention, and cohorts. |
-| `community_manager` | Community Manager |  | Grow and moderate the player community. |
-| `liveops_manager` | LiveOps Manager |  | Plan and run events and content updates. |
-| `monetization_designer` | Monetization Designer |  | Design offers, pricing, and the in-game economy. |
-| `player_support` | Player Support |  | Resolve player issues and refunds. |
-| `store_optimizer` | Store Optimizer |  | App-store optimization and conversion. |
-| `user_acquisition` | User Acquisition | orchestrator | Run paid and organic UA campaigns. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst | Track KPIs, LTV, retention, and cohorts. |
+| `community_manager` | Community Manager | Grow and moderate the player community. |
+| `liveops_manager` | LiveOps Manager | Plan and run events and content updates. |
+| `monetization_designer` | Monetization Designer | Design offers, pricing, and the in-game economy. |
+| `player_support` | Player Support | Resolve player issues and refunds. |
+| `store_optimizer` | Store Optimizer | App-store optimization and conversion. |
+| `user_acquisition` | User Acquisition (orchestrator) | Run paid and organic UA campaigns. |
 
 `user_acquisition` (User Acquisition) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_game_business/AGENTS.md
+++ b/companies/agentic_game_business/AGENTS.md
@@ -1,0 +1,36 @@
+# Agentic Game Business — working agreement
+
+> The business layer around a live game: user acquisition, monetization design, LiveOps events, community, store optimization, and player support.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst |  | Track KPIs, LTV, retention, and cohorts. |
+| `community_manager` | Community Manager |  | Grow and moderate the player community. |
+| `liveops_manager` | LiveOps Manager |  | Plan and run events and content updates. |
+| `monetization_designer` | Monetization Designer |  | Design offers, pricing, and the in-game economy. |
+| `player_support` | Player Support |  | Resolve player issues and refunds. |
+| `store_optimizer` | Store Optimizer |  | App-store optimization and conversion. |
+| `user_acquisition` | User Acquisition | orchestrator | Run paid and organic UA campaigns. |
+
+`user_acquisition` (User Acquisition) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **monetization and growth strategy**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `user_acquisition` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_game_business/agents/analytics_analyst.toml
+++ b/companies/agentic_game_business/agents/analytics_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_business/agents/analytics_analyst.toml
+++ b/companies/agentic_game_business/agents/analytics_analyst.toml
@@ -1,2 +1,11 @@
 role = "Analytics Analyst"
 description = "Track KPIs, LTV, retention, and cohorts."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/community_manager.toml
+++ b/companies/agentic_game_business/agents/community_manager.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_business/agents/community_manager.toml
+++ b/companies/agentic_game_business/agents/community_manager.toml
@@ -1,2 +1,11 @@
 role = "Community Manager"
 description = "Grow and moderate the player community."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/liveops_manager.toml
+++ b/companies/agentic_game_business/agents/liveops_manager.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_business/agents/liveops_manager.toml
+++ b/companies/agentic_game_business/agents/liveops_manager.toml
@@ -1,2 +1,11 @@
 role = "LiveOps Manager"
 description = "Plan and run events and content updates."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/monetization_designer.toml
+++ b/companies/agentic_game_business/agents/monetization_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_business/agents/monetization_designer.toml
+++ b/companies/agentic_game_business/agents/monetization_designer.toml
@@ -1,2 +1,11 @@
 role = "Monetization Designer"
 description = "Design offers, pricing, and the in-game economy."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/player_support.toml
+++ b/companies/agentic_game_business/agents/player_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_business/agents/player_support.toml
+++ b/companies/agentic_game_business/agents/player_support.toml
@@ -1,2 +1,11 @@
 role = "Player Support"
 description = "Resolve player issues and refunds."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/store_optimizer.toml
+++ b/companies/agentic_game_business/agents/store_optimizer.toml
@@ -1,2 +1,11 @@
 role = "Store Optimizer"
 description = "App-store optimization and conversion."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_business/agents/store_optimizer.toml
+++ b/companies/agentic_game_business/agents/store_optimizer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Events/Summer festival.md", access = "write" },
+]

--- a/companies/agentic_game_studio/AGENTS.md
+++ b/companies/agentic_game_studio/AGENTS.md
@@ -1,0 +1,36 @@
+# Agentic Game Studio — working agreement
+
+> A studio of agents that designs worlds and stories, writes code, generates assets, tests, and balances — shipping games under human creative direction.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `asset_generator` | Asset Generator |  | Generate art, audio, and 3D assets. |
+| `balance_designer` | Balance Designer |  | Tune difficulty and game balance. |
+| `gameplay_engineer` | Gameplay Engineer |  | Implement gameplay systems and code. |
+| `marketer` | Marketer |  | Market and promote the launch. |
+| `narrative_designer` | Narrative Designer |  | Story, characters, and dialogue. |
+| `qa_tester` | QA Tester |  | Find and report bugs. |
+| `world_builder` | World Builder | orchestrator | Design worlds, lore, and settings. |
+
+`world_builder` (World Builder) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **creative and design direction**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `world_builder` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_game_studio/AGENTS.md
+++ b/companies/agentic_game_studio/AGENTS.md
@@ -6,15 +6,15 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `asset_generator` | Asset Generator |  | Generate art, audio, and 3D assets. |
-| `balance_designer` | Balance Designer |  | Tune difficulty and game balance. |
-| `gameplay_engineer` | Gameplay Engineer |  | Implement gameplay systems and code. |
-| `marketer` | Marketer |  | Market and promote the launch. |
-| `narrative_designer` | Narrative Designer |  | Story, characters, and dialogue. |
-| `qa_tester` | QA Tester |  | Find and report bugs. |
-| `world_builder` | World Builder | orchestrator | Design worlds, lore, and settings. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `asset_generator` | Asset Generator | Generate art, audio, and 3D assets. |
+| `balance_designer` | Balance Designer | Tune difficulty and game balance. |
+| `gameplay_engineer` | Gameplay Engineer | Implement gameplay systems and code. |
+| `marketer` | Marketer | Market and promote the launch. |
+| `narrative_designer` | Narrative Designer | Story, characters, and dialogue. |
+| `qa_tester` | QA Tester | Find and report bugs. |
+| `world_builder` | World Builder (orchestrator) | Design worlds, lore, and settings. |
 
 `world_builder` (World Builder) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_game_studio/AGENTS.md
+++ b/companies/agentic_game_studio/AGENTS.md
@@ -34,3 +34,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `world_builder` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Games/Skyward.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `world_builder` (unconfined) to change.
+

--- a/companies/agentic_game_studio/agents/asset_generator.toml
+++ b/companies/agentic_game_studio/agents/asset_generator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/asset_generator.toml
+++ b/companies/agentic_game_studio/agents/asset_generator.toml
@@ -1,2 +1,11 @@
 role = "Asset Generator"
 description = "Generate art, audio, and 3D assets."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_studio/agents/balance_designer.toml
+++ b/companies/agentic_game_studio/agents/balance_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/balance_designer.toml
+++ b/companies/agentic_game_studio/agents/balance_designer.toml
@@ -1,2 +1,11 @@
 role = "Balance Designer"
 description = "Tune difficulty and game balance."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_studio/agents/gameplay_engineer.toml
+++ b/companies/agentic_game_studio/agents/gameplay_engineer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/gameplay_engineer.toml
+++ b/companies/agentic_game_studio/agents/gameplay_engineer.toml
@@ -1,2 +1,11 @@
 role = "Gameplay Engineer"
 description = "Implement gameplay systems and code."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_studio/agents/marketer.toml
+++ b/companies/agentic_game_studio/agents/marketer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/marketer.toml
+++ b/companies/agentic_game_studio/agents/marketer.toml
@@ -1,2 +1,11 @@
 role = "Marketer"
 description = "Market and promote the launch."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_studio/agents/narrative_designer.toml
+++ b/companies/agentic_game_studio/agents/narrative_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/narrative_designer.toml
+++ b/companies/agentic_game_studio/agents/narrative_designer.toml
@@ -1,2 +1,11 @@
 role = "Narrative Designer"
 description = "Story, characters, and dialogue."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_game_studio/agents/qa_tester.toml
+++ b/companies/agentic_game_studio/agents/qa_tester.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Games/Skyward.md", access = "write" },
+]

--- a/companies/agentic_game_studio/agents/qa_tester.toml
+++ b/companies/agentic_game_studio/agents/qa_tester.toml
@@ -1,2 +1,11 @@
 role = "QA Tester"
 description = "Find and report bugs."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/AGENTS.md
+++ b/companies/agentic_influencer_business/AGENTS.md
@@ -6,16 +6,16 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `analytics_analyst` | Analytics Analyst |  | Analyze performance and advise. |
-| `community_manager` | Community Manager |  | Engage and moderate the community. |
-| `publisher` | Publisher |  | Schedule and post content. |
-| `scriptwriter` | Scriptwriter | orchestrator | Write video and post scripts. |
-| `sponsorship_outreach` | Sponsorship Outreach |  | Source and negotiate sponsorships. |
-| `thumbnail_designer` | Thumbnail Designer |  | Generate thumbnails and cover art. |
-| `trend_scout` | Trend Scout |  | Detect trends and content opportunities. |
-| `video_editor` | Video Editor |  | Edit video content. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst | Analyze performance and advise. |
+| `community_manager` | Community Manager | Engage and moderate the community. |
+| `publisher` | Publisher | Schedule and post content. |
+| `scriptwriter` | Scriptwriter (orchestrator) | Write video and post scripts. |
+| `sponsorship_outreach` | Sponsorship Outreach | Source and negotiate sponsorships. |
+| `thumbnail_designer` | Thumbnail Designer | Generate thumbnails and cover art. |
+| `trend_scout` | Trend Scout | Detect trends and content opportunities. |
+| `video_editor` | Video Editor | Edit video content. |
 
 `scriptwriter` (Scriptwriter) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_influencer_business/AGENTS.md
+++ b/companies/agentic_influencer_business/AGENTS.md
@@ -35,3 +35,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `scriptwriter` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Series/Beginner cooking series.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `scriptwriter` (unconfined) to change.
+

--- a/companies/agentic_influencer_business/AGENTS.md
+++ b/companies/agentic_influencer_business/AGENTS.md
@@ -1,0 +1,37 @@
+# Agentic Influencer Business — working agreement
+
+> Operates a creator brand around the clock — scripting, editing, thumbnails, posting, analytics, community, and sponsorships — with the human appearing occasionally or via an avatar.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst |  | Analyze performance and advise. |
+| `community_manager` | Community Manager |  | Engage and moderate the community. |
+| `publisher` | Publisher |  | Schedule and post content. |
+| `scriptwriter` | Scriptwriter | orchestrator | Write video and post scripts. |
+| `sponsorship_outreach` | Sponsorship Outreach |  | Source and negotiate sponsorships. |
+| `thumbnail_designer` | Thumbnail Designer |  | Generate thumbnails and cover art. |
+| `trend_scout` | Trend Scout |  | Detect trends and content opportunities. |
+| `video_editor` | Video Editor |  | Edit video content. |
+
+`scriptwriter` (Scriptwriter) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **occasional appearance or ai avatar**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `scriptwriter` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_influencer_business/agents/analytics_analyst.toml
+++ b/companies/agentic_influencer_business/agents/analytics_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/analytics_analyst.toml
+++ b/companies/agentic_influencer_business/agents/analytics_analyst.toml
@@ -1,2 +1,11 @@
 role = "Analytics Analyst"
 description = "Analyze performance and advise."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/community_manager.toml
+++ b/companies/agentic_influencer_business/agents/community_manager.toml
@@ -1,2 +1,11 @@
 role = "Community Manager"
 description = "Engage and moderate the community."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/community_manager.toml
+++ b/companies/agentic_influencer_business/agents/community_manager.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/publisher.toml
+++ b/companies/agentic_influencer_business/agents/publisher.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/publisher.toml
+++ b/companies/agentic_influencer_business/agents/publisher.toml
@@ -1,2 +1,11 @@
 role = "Publisher"
 description = "Schedule and post content."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
+++ b/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
@@ -1,2 +1,11 @@
 role = "Sponsorship Outreach"
 description = "Source and negotiate sponsorships."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
+++ b/companies/agentic_influencer_business/agents/sponsorship_outreach.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/thumbnail_designer.toml
+++ b/companies/agentic_influencer_business/agents/thumbnail_designer.toml
@@ -1,2 +1,11 @@
 role = "Thumbnail Designer"
 description = "Generate thumbnails and cover art."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/thumbnail_designer.toml
+++ b/companies/agentic_influencer_business/agents/thumbnail_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/trend_scout.toml
+++ b/companies/agentic_influencer_business/agents/trend_scout.toml
@@ -1,2 +1,11 @@
 role = "Trend Scout"
 description = "Detect trends and content opportunities."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/trend_scout.toml
+++ b/companies/agentic_influencer_business/agents/trend_scout.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_influencer_business/agents/video_editor.toml
+++ b/companies/agentic_influencer_business/agents/video_editor.toml
@@ -1,2 +1,11 @@
 role = "Video Editor"
 description = "Edit video content."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_influencer_business/agents/video_editor.toml
+++ b/companies/agentic_influencer_business/agents/video_editor.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Series/Beginner cooking series.md", access = "write" },
+]

--- a/companies/agentic_law_firm/AGENTS.md
+++ b/companies/agentic_law_firm/AGENTS.md
@@ -6,13 +6,13 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `compliance_agent` | Compliance Agent |  | Check regulatory compliance. |
-| `contract_drafter` | Contract Drafter |  | Draft contracts and legal documents. |
-| `discovery_agent` | Discovery Agent |  | Run and review document discovery. |
-| `legal_researcher` | Legal Researcher | orchestrator | Case law and legal research. |
-| `litigation_support` | Litigation Support |  | Prepare materials for litigation. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `compliance_agent` | Compliance Agent | Check regulatory compliance. |
+| `contract_drafter` | Contract Drafter | Draft contracts and legal documents. |
+| `discovery_agent` | Discovery Agent | Run and review document discovery. |
+| `legal_researcher` | Legal Researcher (orchestrator) | Case law and legal research. |
+| `litigation_support` | Litigation Support | Prepare materials for litigation. |
 
 `legal_researcher` (Legal Researcher) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_law_firm/AGENTS.md
+++ b/companies/agentic_law_firm/AGENTS.md
@@ -32,3 +32,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `legal_researcher` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Matters/Acme services agreement.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `legal_researcher` (unconfined) to change.
+

--- a/companies/agentic_law_firm/AGENTS.md
+++ b/companies/agentic_law_firm/AGENTS.md
@@ -1,0 +1,34 @@
+# Agentic Law Firm — working agreement
+
+> Within regulatory limits, a firm of agents does legal research, drafts contracts, supports litigation, runs discovery, and checks compliance — a licensed human approves filings.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `compliance_agent` | Compliance Agent |  | Check regulatory compliance. |
+| `contract_drafter` | Contract Drafter |  | Draft contracts and legal documents. |
+| `discovery_agent` | Discovery Agent |  | Run and review document discovery. |
+| `legal_researcher` | Legal Researcher | orchestrator | Case law and legal research. |
+| `litigation_support` | Litigation Support |  | Prepare materials for litigation. |
+
+`legal_researcher` (Legal Researcher) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **approving filings**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `legal_researcher` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_law_firm/agents/compliance_agent.toml
+++ b/companies/agentic_law_firm/agents/compliance_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Matters/Acme services agreement.md", access = "write" },
+]

--- a/companies/agentic_law_firm/agents/compliance_agent.toml
+++ b/companies/agentic_law_firm/agents/compliance_agent.toml
@@ -1,2 +1,11 @@
 role = "Compliance Agent"
 description = "Check regulatory compliance."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_law_firm/agents/contract_drafter.toml
+++ b/companies/agentic_law_firm/agents/contract_drafter.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Matters/Acme services agreement.md", access = "write" },
+]

--- a/companies/agentic_law_firm/agents/contract_drafter.toml
+++ b/companies/agentic_law_firm/agents/contract_drafter.toml
@@ -1,2 +1,11 @@
 role = "Contract Drafter"
 description = "Draft contracts and legal documents."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_law_firm/agents/discovery_agent.toml
+++ b/companies/agentic_law_firm/agents/discovery_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Matters/Acme services agreement.md", access = "write" },
+]

--- a/companies/agentic_law_firm/agents/discovery_agent.toml
+++ b/companies/agentic_law_firm/agents/discovery_agent.toml
@@ -1,2 +1,11 @@
 role = "Discovery Agent"
 description = "Run and review document discovery."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_law_firm/agents/litigation_support.toml
+++ b/companies/agentic_law_firm/agents/litigation_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Matters/Acme services agreement.md", access = "write" },
+]

--- a/companies/agentic_law_firm/agents/litigation_support.toml
+++ b/companies/agentic_law_firm/agents/litigation_support.toml
@@ -1,2 +1,11 @@
 role = "Litigation Support"
 description = "Prepare materials for litigation."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/AGENTS.md
+++ b/companies/agentic_marketing_agency/AGENTS.md
@@ -35,3 +35,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `creative_director` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Campaigns/Spring launch.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `creative_director` (unconfined) to change.
+

--- a/companies/agentic_marketing_agency/AGENTS.md
+++ b/companies/agentic_marketing_agency/AGENTS.md
@@ -1,0 +1,37 @@
+# Agentic Marketing Agency — working agreement
+
+> A full-service agency of agents producing creative, copy, SEO, paid, email, and landing pages — with a human reviewing campaigns before they ship.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst |  | Measure performance and report. |
+| `brand_strategist` | Brand Strategist |  | Positioning and brand strategy. |
+| `copywriter` | Copywriter |  | Write ads, pages, and campaign copy. |
+| `creative_director` | Creative Director | orchestrator | Own creative concept and direction. |
+| `email_marketer` | Email Marketer |  | Design and send lifecycle email. |
+| `landing_page_builder` | Landing Page Builder |  | Build and test conversion pages. |
+| `paid_ads_manager` | Paid Ads Manager |  | Plan and run paid-acquisition campaigns. |
+| `seo_specialist` | SEO Specialist |  | Organic search strategy and optimization. |
+
+`creative_director` (Creative Director) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **campaign review and sign-off**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `creative_director` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_marketing_agency/AGENTS.md
+++ b/companies/agentic_marketing_agency/AGENTS.md
@@ -6,16 +6,16 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `analytics_analyst` | Analytics Analyst |  | Measure performance and report. |
-| `brand_strategist` | Brand Strategist |  | Positioning and brand strategy. |
-| `copywriter` | Copywriter |  | Write ads, pages, and campaign copy. |
-| `creative_director` | Creative Director | orchestrator | Own creative concept and direction. |
-| `email_marketer` | Email Marketer |  | Design and send lifecycle email. |
-| `landing_page_builder` | Landing Page Builder |  | Build and test conversion pages. |
-| `paid_ads_manager` | Paid Ads Manager |  | Plan and run paid-acquisition campaigns. |
-| `seo_specialist` | SEO Specialist |  | Organic search strategy and optimization. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `analytics_analyst` | Analytics Analyst | Measure performance and report. |
+| `brand_strategist` | Brand Strategist | Positioning and brand strategy. |
+| `copywriter` | Copywriter | Write ads, pages, and campaign copy. |
+| `creative_director` | Creative Director (orchestrator) | Own creative concept and direction. |
+| `email_marketer` | Email Marketer | Design and send lifecycle email. |
+| `landing_page_builder` | Landing Page Builder | Build and test conversion pages. |
+| `paid_ads_manager` | Paid Ads Manager | Plan and run paid-acquisition campaigns. |
+| `seo_specialist` | SEO Specialist | Organic search strategy and optimization. |
 
 `creative_director` (Creative Director) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_marketing_agency/agents/analytics_analyst.toml
+++ b/companies/agentic_marketing_agency/agents/analytics_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/analytics_analyst.toml
+++ b/companies/agentic_marketing_agency/agents/analytics_analyst.toml
@@ -1,2 +1,11 @@
 role = "Analytics Analyst"
 description = "Measure performance and report."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/brand_strategist.toml
+++ b/companies/agentic_marketing_agency/agents/brand_strategist.toml
@@ -14,3 +14,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/brand_strategist.toml
+++ b/companies/agentic_marketing_agency/agents/brand_strategist.toml
@@ -5,3 +5,12 @@ description = "Positioning and brand strategy."
 # `delegate_to_teammate`, instead of declining work addressed to a specialist.
 # Naming its own desk is the enable switch; depth stays capped at 2.
 delegates_to = ["strategy"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/copywriter.toml
+++ b/companies/agentic_marketing_agency/agents/copywriter.toml
@@ -27,3 +27,12 @@ prompt_files = ["prompts/house-style.md"]
 # operator-owned and may not exist yet, so a missing one is skipped rather than
 # refused. Editing either note reaches the next turn without a restart.
 context = ["Brand/Brand voice.md", "Playbooks/Campaign checklist.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/email_marketer.toml
+++ b/companies/agentic_marketing_agency/agents/email_marketer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/email_marketer.toml
+++ b/companies/agentic_marketing_agency/agents/email_marketer.toml
@@ -1,2 +1,11 @@
 role = "Email Marketer"
 description = "Design and send lifecycle email."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/landing_page_builder.toml
+++ b/companies/agentic_marketing_agency/agents/landing_page_builder.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/landing_page_builder.toml
+++ b/companies/agentic_marketing_agency/agents/landing_page_builder.toml
@@ -1,2 +1,11 @@
 role = "Landing Page Builder"
 description = "Build and test conversion pages."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
+++ b/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
@@ -5,3 +5,12 @@ description = "Plan and run paid-acquisition campaigns."
 # `delegate_to_teammate`, instead of declining work addressed to a specialist.
 # Naming its own desk is the enable switch; depth stays capped at 2.
 delegates_to = ["growth"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
+++ b/companies/agentic_marketing_agency/agents/paid_ads_manager.toml
@@ -14,3 +14,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/seo_specialist.toml
+++ b/companies/agentic_marketing_agency/agents/seo_specialist.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Campaigns/Spring launch.md", access = "write" },
+]

--- a/companies/agentic_marketing_agency/agents/seo_specialist.toml
+++ b/companies/agentic_marketing_agency/agents/seo_specialist.toml
@@ -1,2 +1,11 @@
 role = "SEO Specialist"
 description = "Organic search strategy and optimization."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/AGENTS.md
+++ b/companies/agentic_media_company/AGENTS.md
@@ -1,0 +1,37 @@
+# Agentic Media Company — working agreement
+
+> A BuzzFeed-shaped newsroom of agents that finds stories, verifies sources, writes, illustrates, translates, and distributes — under human editorial standards.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `illustrator` | Illustrator |  | Create article illustrations. |
+| `publisher` | Publisher |  | Publish to the CMS. |
+| `seo_optimizer` | SEO Optimizer |  | Optimize articles for search. |
+| `social_distributor` | Social Distributor |  | Distribute across social channels. |
+| `source_verifier` | Source Verifier |  | Verify sources and fact-check. |
+| `story_scout` | Story Scout | orchestrator | Find and pitch story ideas. |
+| `translator` | Translator |  | Localize stories across languages. |
+| `writer` | Writer |  | Write and edit articles. |
+
+`story_scout` (Story Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **editorial standards**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `story_scout` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_media_company/AGENTS.md
+++ b/companies/agentic_media_company/AGENTS.md
@@ -6,16 +6,16 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `illustrator` | Illustrator |  | Create article illustrations. |
-| `publisher` | Publisher |  | Publish to the CMS. |
-| `seo_optimizer` | SEO Optimizer |  | Optimize articles for search. |
-| `social_distributor` | Social Distributor |  | Distribute across social channels. |
-| `source_verifier` | Source Verifier |  | Verify sources and fact-check. |
-| `story_scout` | Story Scout | orchestrator | Find and pitch story ideas. |
-| `translator` | Translator |  | Localize stories across languages. |
-| `writer` | Writer |  | Write and edit articles. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `illustrator` | Illustrator | Create article illustrations. |
+| `publisher` | Publisher | Publish to the CMS. |
+| `seo_optimizer` | SEO Optimizer | Optimize articles for search. |
+| `social_distributor` | Social Distributor | Distribute across social channels. |
+| `source_verifier` | Source Verifier | Verify sources and fact-check. |
+| `story_scout` | Story Scout (orchestrator) | Find and pitch story ideas. |
+| `translator` | Translator | Localize stories across languages. |
+| `writer` | Writer | Write and edit articles. |
 
 `story_scout` (Story Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_media_company/AGENTS.md
+++ b/companies/agentic_media_company/AGENTS.md
@@ -35,3 +35,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `story_scout` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Stories/Water rights investigation.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `story_scout` (unconfined) to change.
+

--- a/companies/agentic_media_company/agents/illustrator.toml
+++ b/companies/agentic_media_company/agents/illustrator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/illustrator.toml
+++ b/companies/agentic_media_company/agents/illustrator.toml
@@ -1,2 +1,11 @@
 role = "Illustrator"
 description = "Create article illustrations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/publisher.toml
+++ b/companies/agentic_media_company/agents/publisher.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/publisher.toml
+++ b/companies/agentic_media_company/agents/publisher.toml
@@ -1,2 +1,11 @@
 role = "Publisher"
 description = "Publish to the CMS."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/seo_optimizer.toml
+++ b/companies/agentic_media_company/agents/seo_optimizer.toml
@@ -1,2 +1,11 @@
 role = "SEO Optimizer"
 description = "Optimize articles for search."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/seo_optimizer.toml
+++ b/companies/agentic_media_company/agents/seo_optimizer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/social_distributor.toml
+++ b/companies/agentic_media_company/agents/social_distributor.toml
@@ -1,2 +1,11 @@
 role = "Social Distributor"
 description = "Distribute across social channels."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/social_distributor.toml
+++ b/companies/agentic_media_company/agents/social_distributor.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/source_verifier.toml
+++ b/companies/agentic_media_company/agents/source_verifier.toml
@@ -1,2 +1,11 @@
 role = "Source Verifier"
 description = "Verify sources and fact-check."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/source_verifier.toml
+++ b/companies/agentic_media_company/agents/source_verifier.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/translator.toml
+++ b/companies/agentic_media_company/agents/translator.toml
@@ -1,2 +1,11 @@
 role = "Translator"
 description = "Localize stories across languages."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/translator.toml
+++ b/companies/agentic_media_company/agents/translator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_media_company/agents/writer.toml
+++ b/companies/agentic_media_company/agents/writer.toml
@@ -1,2 +1,11 @@
 role = "Writer"
 description = "Write and edit articles."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_media_company/agents/writer.toml
+++ b/companies/agentic_media_company/agents/writer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Stories/Water rights investigation.md", access = "write" },
+]

--- a/companies/agentic_pharma_startup/AGENTS.md
+++ b/companies/agentic_pharma_startup/AGENTS.md
@@ -6,12 +6,12 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `literature_reviewer` | Literature Reviewer | orchestrator | Review and synthesize scientific literature. |
-| `molecule_discovery` | Molecule Discovery |  | Propose candidate molecules. |
-| `simulation_agent` | Simulation Agent |  | Run in-silico simulations and screening. |
-| `trial_planner` | Trial Planner |  | Design and plan clinical trials. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `literature_reviewer` | Literature Reviewer (orchestrator) | Review and synthesize scientific literature. |
+| `molecule_discovery` | Molecule Discovery | Propose candidate molecules. |
+| `simulation_agent` | Simulation Agent | Run in-silico simulations and screening. |
+| `trial_planner` | Trial Planner | Design and plan clinical trials. |
 
 `literature_reviewer` (Literature Reviewer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_pharma_startup/AGENTS.md
+++ b/companies/agentic_pharma_startup/AGENTS.md
@@ -1,0 +1,33 @@
+# Agentic Pharma Startup — working agreement
+
+> A drug-discovery startup of agents that reviews literature, proposes molecules, runs simulations, and plans trials — humans perform the laboratory work.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `literature_reviewer` | Literature Reviewer | orchestrator | Review and synthesize scientific literature. |
+| `molecule_discovery` | Molecule Discovery |  | Propose candidate molecules. |
+| `simulation_agent` | Simulation Agent |  | Run in-silico simulations and screening. |
+| `trial_planner` | Trial Planner |  | Design and plan clinical trials. |
+
+`literature_reviewer` (Literature Reviewer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **laboratory work**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `literature_reviewer` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_pharma_startup/AGENTS.md
+++ b/companies/agentic_pharma_startup/AGENTS.md
@@ -31,3 +31,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `literature_reviewer` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Programs/Kinase inhibitor program.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `literature_reviewer` (unconfined) to change.
+

--- a/companies/agentic_pharma_startup/agents/molecule_discovery.toml
+++ b/companies/agentic_pharma_startup/agents/molecule_discovery.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Programs/Kinase inhibitor program.md", access = "write" },
+]

--- a/companies/agentic_pharma_startup/agents/molecule_discovery.toml
+++ b/companies/agentic_pharma_startup/agents/molecule_discovery.toml
@@ -1,2 +1,11 @@
 role = "Molecule Discovery"
 description = "Propose candidate molecules."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_pharma_startup/agents/simulation_agent.toml
+++ b/companies/agentic_pharma_startup/agents/simulation_agent.toml
@@ -1,2 +1,11 @@
 role = "Simulation Agent"
 description = "Run in-silico simulations and screening."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_pharma_startup/agents/simulation_agent.toml
+++ b/companies/agentic_pharma_startup/agents/simulation_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Programs/Kinase inhibitor program.md", access = "write" },
+]

--- a/companies/agentic_pharma_startup/agents/trial_planner.toml
+++ b/companies/agentic_pharma_startup/agents/trial_planner.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Programs/Kinase inhibitor program.md", access = "write" },
+]

--- a/companies/agentic_pharma_startup/agents/trial_planner.toml
+++ b/companies/agentic_pharma_startup/agents/trial_planner.toml
@@ -1,2 +1,11 @@
 role = "Trial Planner"
 description = "Design and plan clinical trials."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_realestate_company/AGENTS.md
+++ b/companies/agentic_realestate_company/AGENTS.md
@@ -1,0 +1,34 @@
+# Agentic Real Estate Company — working agreement
+
+> A real-estate operator of agents that finds properties, analyzes neighborhoods, underwrites deals, coordinates contractors, and manages tenants — humans approve purchases.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `contractor_coordinator` | Contractor Coordinator |  | Coordinate contractors and renovations. |
+| `deal_underwriter` | Deal Underwriter |  | Underwrite deals and model returns. |
+| `neighborhood_analyst` | Neighborhood Analyst |  | Analyze neighborhoods, comps, and trends. |
+| `property_scout` | Property Scout | orchestrator | Find and screen candidate properties. |
+| `tenant_manager` | Tenant Manager |  | Manage tenants and property operations. |
+
+`property_scout` (Property Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **purchase approvals**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `property_scout` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_realestate_company/AGENTS.md
+++ b/companies/agentic_realestate_company/AGENTS.md
@@ -6,13 +6,13 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `contractor_coordinator` | Contractor Coordinator |  | Coordinate contractors and renovations. |
-| `deal_underwriter` | Deal Underwriter |  | Underwrite deals and model returns. |
-| `neighborhood_analyst` | Neighborhood Analyst |  | Analyze neighborhoods, comps, and trends. |
-| `property_scout` | Property Scout | orchestrator | Find and screen candidate properties. |
-| `tenant_manager` | Tenant Manager |  | Manage tenants and property operations. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `contractor_coordinator` | Contractor Coordinator | Coordinate contractors and renovations. |
+| `deal_underwriter` | Deal Underwriter | Underwrite deals and model returns. |
+| `neighborhood_analyst` | Neighborhood Analyst | Analyze neighborhoods, comps, and trends. |
+| `property_scout` | Property Scout (orchestrator) | Find and screen candidate properties. |
+| `tenant_manager` | Tenant Manager | Manage tenants and property operations. |
 
 `property_scout` (Property Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_realestate_company/AGENTS.md
+++ b/companies/agentic_realestate_company/AGENTS.md
@@ -32,3 +32,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `property_scout` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Deals/Maple St duplex.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `property_scout` (unconfined) to change.
+

--- a/companies/agentic_realestate_company/agents/contractor_coordinator.toml
+++ b/companies/agentic_realestate_company/agents/contractor_coordinator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Maple St duplex.md", access = "write" },
+]

--- a/companies/agentic_realestate_company/agents/contractor_coordinator.toml
+++ b/companies/agentic_realestate_company/agents/contractor_coordinator.toml
@@ -1,2 +1,11 @@
 role = "Contractor Coordinator"
 description = "Coordinate contractors and renovations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_realestate_company/agents/deal_underwriter.toml
+++ b/companies/agentic_realestate_company/agents/deal_underwriter.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Maple St duplex.md", access = "write" },
+]

--- a/companies/agentic_realestate_company/agents/deal_underwriter.toml
+++ b/companies/agentic_realestate_company/agents/deal_underwriter.toml
@@ -1,2 +1,11 @@
 role = "Deal Underwriter"
 description = "Underwrite deals and model returns."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
+++ b/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Maple St duplex.md", access = "write" },
+]

--- a/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
+++ b/companies/agentic_realestate_company/agents/neighborhood_analyst.toml
@@ -1,2 +1,11 @@
 role = "Neighborhood Analyst"
 description = "Analyze neighborhoods, comps, and trends."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_realestate_company/agents/tenant_manager.toml
+++ b/companies/agentic_realestate_company/agents/tenant_manager.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Maple St duplex.md", access = "write" },
+]

--- a/companies/agentic_realestate_company/agents/tenant_manager.toml
+++ b/companies/agentic_realestate_company/agents/tenant_manager.toml
@@ -1,2 +1,11 @@
 role = "Tenant Manager"
 description = "Manage tenants and property operations."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/AGENTS.md
+++ b/companies/agentic_recruiting_company/AGENTS.md
@@ -6,14 +6,14 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `candidate_sourcer` | Candidate Sourcer | orchestrator | Source candidates for open roles. |
-| `interviewer` | Interviewer |  | Conduct first-round interviews. |
-| `offer_generator` | Offer Generator |  | Draft and generate offers. |
-| `outreach_agent` | Outreach Agent |  | Run personalized candidate outreach. |
-| `resume_analyst` | Resume Analyst |  | Screen and rank resumes against the spec. |
-| `scheduler` | Scheduler |  | Coordinate interview scheduling. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `candidate_sourcer` | Candidate Sourcer (orchestrator) | Source candidates for open roles. |
+| `interviewer` | Interviewer | Conduct first-round interviews. |
+| `offer_generator` | Offer Generator | Draft and generate offers. |
+| `outreach_agent` | Outreach Agent | Run personalized candidate outreach. |
+| `resume_analyst` | Resume Analyst | Screen and rank resumes against the spec. |
+| `scheduler` | Scheduler | Coordinate interview scheduling. |
 
 `candidate_sourcer` (Candidate Sourcer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_recruiting_company/AGENTS.md
+++ b/companies/agentic_recruiting_company/AGENTS.md
@@ -1,0 +1,35 @@
+# Agentic Recruiting Company — working agreement
+
+> A recruiting firm of agents that sources, reaches out, screens resumes, runs first-round interviews, schedules, and generates offers — humans make the final call.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `candidate_sourcer` | Candidate Sourcer | orchestrator | Source candidates for open roles. |
+| `interviewer` | Interviewer |  | Conduct first-round interviews. |
+| `offer_generator` | Offer Generator |  | Draft and generate offers. |
+| `outreach_agent` | Outreach Agent |  | Run personalized candidate outreach. |
+| `resume_analyst` | Resume Analyst |  | Screen and rank resumes against the spec. |
+| `scheduler` | Scheduler |  | Coordinate interview scheduling. |
+
+`candidate_sourcer` (Candidate Sourcer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **final hiring decisions**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `candidate_sourcer` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_recruiting_company/AGENTS.md
+++ b/companies/agentic_recruiting_company/AGENTS.md
@@ -33,3 +33,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `candidate_sourcer` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Roles/Senior engineer search.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `candidate_sourcer` (unconfined) to change.
+

--- a/companies/agentic_recruiting_company/agents/interviewer.toml
+++ b/companies/agentic_recruiting_company/agents/interviewer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Roles/Senior engineer search.md", access = "write" },
+]

--- a/companies/agentic_recruiting_company/agents/interviewer.toml
+++ b/companies/agentic_recruiting_company/agents/interviewer.toml
@@ -1,2 +1,11 @@
 role = "Interviewer"
 description = "Conduct first-round interviews."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/agents/offer_generator.toml
+++ b/companies/agentic_recruiting_company/agents/offer_generator.toml
@@ -1,2 +1,11 @@
 role = "Offer Generator"
 description = "Draft and generate offers."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/agents/offer_generator.toml
+++ b/companies/agentic_recruiting_company/agents/offer_generator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Roles/Senior engineer search.md", access = "write" },
+]

--- a/companies/agentic_recruiting_company/agents/outreach_agent.toml
+++ b/companies/agentic_recruiting_company/agents/outreach_agent.toml
@@ -1,2 +1,11 @@
 role = "Outreach Agent"
 description = "Run personalized candidate outreach."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/agents/outreach_agent.toml
+++ b/companies/agentic_recruiting_company/agents/outreach_agent.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Roles/Senior engineer search.md", access = "write" },
+]

--- a/companies/agentic_recruiting_company/agents/resume_analyst.toml
+++ b/companies/agentic_recruiting_company/agents/resume_analyst.toml
@@ -1,2 +1,11 @@
 role = "Resume Analyst"
 description = "Screen and rank resumes against the spec."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/agents/resume_analyst.toml
+++ b/companies/agentic_recruiting_company/agents/resume_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Roles/Senior engineer search.md", access = "write" },
+]

--- a/companies/agentic_recruiting_company/agents/scheduler.toml
+++ b/companies/agentic_recruiting_company/agents/scheduler.toml
@@ -1,2 +1,11 @@
 role = "Scheduler"
 description = "Coordinate interview scheduling."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_recruiting_company/agents/scheduler.toml
+++ b/companies/agentic_recruiting_company/agents/scheduler.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Roles/Senior engineer search.md", access = "write" },
+]

--- a/companies/agentic_research_lab/AGENTS.md
+++ b/companies/agentic_research_lab/AGENTS.md
@@ -6,16 +6,16 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `analyst` | Analyst |  | Compute, model, and check the numbers a claim rests on. |
-| `critic` | Critic |  | Attack the lab's own conclusions before the operator sees them. |
-| `curator` | Curator |  | Owns the brief: one current statement of what the lab knows. |
-| `inventor` | Inventor |  | Propose a different angle when the current line stalls. |
-| `librarian` | Librarian |  | Find and download primary sources. Never reads them. |
-| `orchestrator` | Research Lead | orchestrator | Break the question into lines of inquiry, delegate, combine. |
-| `scholar` | Scholar |  | Read what was gathered; record what it establishes. Never fetches. |
-| `tool_builder` | Tool Builder |  | Write and run the programs, and keep the shared library. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `analyst` | Analyst | Compute, model, and check the numbers a claim rests on. |
+| `critic` | Critic | Attack the lab's own conclusions before the operator sees them. |
+| `curator` | Curator | Owns the brief: one current statement of what the lab knows. |
+| `inventor` | Inventor | Propose a different angle when the current line stalls. |
+| `librarian` | Librarian | Find and download primary sources. Never reads them. |
+| `orchestrator` | Research Lead (orchestrator) | Break the question into lines of inquiry, delegate, combine. |
+| `scholar` | Scholar | Read what was gathered; record what it establishes. Never fetches. |
+| `tool_builder` | Tool Builder | Write and run the programs, and keep the shared library. |
 
 `orchestrator` (Research Lead) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_research_lab/AGENTS.md
+++ b/companies/agentic_research_lab/AGENTS.md
@@ -1,0 +1,35 @@
+# Agentic Research Lab — working agreement
+
+> A research lab of agents that investigates a question with primary sources,
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `analyst` | Analyst |  | Compute, model, and check the numbers a claim rests on. |
+| `critic` | Critic |  | Attack the lab's own conclusions before the operator sees them. |
+| `curator` | Curator |  | Owns the brief: one current statement of what the lab knows. |
+| `inventor` | Inventor |  | Propose a different angle when the current line stalls. |
+| `librarian` | Librarian |  | Find and download primary sources. Never reads them. |
+| `orchestrator` | Research Lead | orchestrator | Break the question into lines of inquiry, delegate, combine. |
+| `scholar` | Scholar |  | Read what was gathered; record what it establishes. Never fetches. |
+| `tool_builder` | Tool Builder |  | Write and run the programs, and keep the shared library. |
+
+`orchestrator` (Research Lead) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `orchestrator` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_research_lab/AGENTS.md
+++ b/companies/agentic_research_lab/AGENTS.md
@@ -33,3 +33,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+No agent here declares a write-scoped `context` entry — the seeded workspace has no single shared active-work document to confine to, so every teammate keeps the unconfined `workspace_write`/`workspace_create` default.
+

--- a/companies/agentic_research_lab/AGENTS.md
+++ b/companies/agentic_research_lab/AGENTS.md
@@ -1,6 +1,6 @@
 # Agentic Research Lab — working agreement
 
-> A research lab of agents that investigates a question with primary sources,
+> A research lab of agents that investigates a question with primary sources, computes what it can, argues with its own conclusions, and reports only what it can defend — with a human setting the question and accepting the findings.
 
 This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
 

--- a/companies/agentic_research_lab/agents/analyst.toml
+++ b/companies/agentic_research_lab/agents/analyst.toml
@@ -2,3 +2,12 @@ role = "Analyst"
 description = "Compute, model, and check numbers against the claims on record."
 # Gets the code index so the second program does not rebuild the first.
 context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "INDEX.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/critic.toml
+++ b/companies/agentic_research_lab/agents/critic.toml
@@ -6,3 +6,12 @@ description = "Attack the lab's own conclusions before the operator sees them."
 # what it believes, and a critic given it argues with the summary rather than
 # with the evidence.
 context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/curator.toml
+++ b/companies/agentic_research_lab/agents/curator.toml
@@ -3,3 +3,12 @@ description = "Owns the brief. Keeps one current statement of what the lab knows
 # The single writer of BRIEF.md, and the one role that sees everything, because
 # its whole job is compressing everything into the document the others read.
 context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md", "INDEX.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/inventor.toml
+++ b/companies/agentic_research_lab/agents/inventor.toml
@@ -3,3 +3,12 @@ description = "Propose a different line of attack when the current one stalls."
 # Must see what has already been tried and closed, or it re-proposes it — the
 # one thing this role exists not to do.
 context = ["GOAL.md", "BRIEF.md", "THREADS.md", "CLAIMS.md", "BOARD.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/librarian.toml
+++ b/companies/agentic_research_lab/agents/librarian.toml
@@ -4,3 +4,12 @@ description = "Find and download primary sources. Never reads them."
 # does not re-download what the lab has. Not given the brief's conclusions: a
 # fetcher that knows what the lab wants to be true searches for it.
 context = ["GOAL.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/scholar.toml
+++ b/companies/agentic_research_lab/agents/scholar.toml
@@ -3,3 +3,12 @@ description = "Read what the librarian gathered and record what each source actu
 # Draws the evidence edges, so it must see the existing claims to know what is
 # already established and what a new source contradicts.
 context = ["GOAL.md", "BRIEF.md", "CLAIMS.md", "THREADS.md", "DEMANDS.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_research_lab/agents/tool_builder.toml
+++ b/companies/agentic_research_lab/agents/tool_builder.toml
@@ -1,3 +1,12 @@
 role = "Tool Builder"
 description = "Write and run the programs the analyst needs, and keep the shared library."
 context = ["GOAL.md", "CLAIMS.md", "INDEX.md"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/AGENTS.md
+++ b/companies/agentic_software_company/AGENTS.md
@@ -6,17 +6,17 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `backend_engineer` | Backend Engineer |  | Build and operate the backend and services. |
-| `customer_support` | Customer Support |  | Resolve customer issues and feed insight back. |
-| `designer` | Designer |  | Product and UX design. |
-| `devrel` | Developer Relations |  | Engage developers with demos, content, and community. |
-| `docs_writer` | Documentation Writer |  | Write and maintain product documentation. |
-| `frontend_engineer` | Frontend Engineer |  | Build the user-facing frontend. |
-| `product_manager` | Product Manager | orchestrator | Own the roadmap, specs, and prioritization. |
-| `qa_engineer` | QA Engineer |  | Test features and catch regressions. |
-| `security_engineer` | Security Engineer |  | Security review, hardening, and response. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `backend_engineer` | Backend Engineer | Build and operate the backend and services. |
+| `customer_support` | Customer Support | Resolve customer issues and feed insight back. |
+| `designer` | Designer | Product and UX design. |
+| `devrel` | Developer Relations | Engage developers with demos, content, and community. |
+| `docs_writer` | Documentation Writer | Write and maintain product documentation. |
+| `frontend_engineer` | Frontend Engineer | Build the user-facing frontend. |
+| `product_manager` | Product Manager (orchestrator) | Own the roadmap, specs, and prioritization. |
+| `qa_engineer` | QA Engineer | Test features and catch regressions. |
+| `security_engineer` | Security Engineer | Security review, hardening, and response. |
 
 `product_manager` (Product Manager) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_software_company/AGENTS.md
+++ b/companies/agentic_software_company/AGENTS.md
@@ -36,3 +36,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `product_manager` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Product/Billing v2.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `product_manager` (unconfined) to change.
+

--- a/companies/agentic_software_company/AGENTS.md
+++ b/companies/agentic_software_company/AGENTS.md
@@ -1,0 +1,38 @@
+# Agentic Software Company — working agreement
+
+> A software company of agents that designs, builds, ships, and supports an entire SaaS product — with a human owning product direction.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `backend_engineer` | Backend Engineer |  | Build and operate the backend and services. |
+| `customer_support` | Customer Support |  | Resolve customer issues and feed insight back. |
+| `designer` | Designer |  | Product and UX design. |
+| `devrel` | Developer Relations |  | Engage developers with demos, content, and community. |
+| `docs_writer` | Documentation Writer |  | Write and maintain product documentation. |
+| `frontend_engineer` | Frontend Engineer |  | Build the user-facing frontend. |
+| `product_manager` | Product Manager | orchestrator | Own the roadmap, specs, and prioritization. |
+| `qa_engineer` | QA Engineer |  | Test features and catch regressions. |
+| `security_engineer` | Security Engineer |  | Security review, hardening, and response. |
+
+`product_manager` (Product Manager) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **product direction**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `product_manager` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_software_company/agents/backend_engineer.toml
+++ b/companies/agentic_software_company/agents/backend_engineer.toml
@@ -14,3 +14,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/backend_engineer.toml
+++ b/companies/agentic_software_company/agents/backend_engineer.toml
@@ -5,3 +5,12 @@ description = "Build and operate the backend and services."
 # `delegate_to_teammate`, instead of declining work addressed to a specialist.
 # Naming its own desk is the enable switch; depth stays capped at 2.
 delegates_to = ["engineering"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/customer_support.toml
+++ b/companies/agentic_software_company/agents/customer_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/customer_support.toml
+++ b/companies/agentic_software_company/agents/customer_support.toml
@@ -1,2 +1,11 @@
 role = "Customer Support"
 description = "Resolve customer issues and feed insight back."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/designer.toml
+++ b/companies/agentic_software_company/agents/designer.toml
@@ -1,2 +1,11 @@
 role = "Designer"
 description = "Product and UX design."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/designer.toml
+++ b/companies/agentic_software_company/agents/designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/devrel.toml
+++ b/companies/agentic_software_company/agents/devrel.toml
@@ -5,3 +5,12 @@ description = "Engage developers with demos, content, and community."
 # `delegate_to_teammate`, instead of declining work addressed to a specialist.
 # Naming its own desk is the enable switch; depth stays capped at 2.
 delegates_to = ["go_to_market"]
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/devrel.toml
+++ b/companies/agentic_software_company/agents/devrel.toml
@@ -14,3 +14,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/docs_writer.toml
+++ b/companies/agentic_software_company/agents/docs_writer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/docs_writer.toml
+++ b/companies/agentic_software_company/agents/docs_writer.toml
@@ -1,2 +1,11 @@
 role = "Documentation Writer"
 description = "Write and maintain product documentation."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/frontend_engineer.toml
+++ b/companies/agentic_software_company/agents/frontend_engineer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/frontend_engineer.toml
+++ b/companies/agentic_software_company/agents/frontend_engineer.toml
@@ -1,2 +1,11 @@
 role = "Frontend Engineer"
 description = "Build the user-facing frontend."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/qa_engineer.toml
+++ b/companies/agentic_software_company/agents/qa_engineer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/qa_engineer.toml
+++ b/companies/agentic_software_company/agents/qa_engineer.toml
@@ -1,2 +1,11 @@
 role = "QA Engineer"
 description = "Test features and catch regressions."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_software_company/agents/security_engineer.toml
+++ b/companies/agentic_software_company/agents/security_engineer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Product/Billing v2.md", access = "write" },
+]

--- a/companies/agentic_software_company/agents/security_engineer.toml
+++ b/companies/agentic_software_company/agents/security_engineer.toml
@@ -1,2 +1,11 @@
 role = "Security Engineer"
 description = "Security review, hardening, and response."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_capital/AGENTS.md
+++ b/companies/agentic_venture_capital/AGENTS.md
@@ -1,0 +1,35 @@
+# Agentic Venture Capital Firm — working agreement
+
+> Sources founders, evaluates opportunities, and supports portfolio companies — leaving the actual investment decision to human partners.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `code_analyst` | Code Analyst |  | Analyze codebases, product, and technical traction. |
+| `deck_evaluator` | Deck Evaluator |  | Evaluate pitch decks and business models. |
+| `founder_sourcer` | Founder Sourcer | orchestrator | Source founders and deal flow. |
+| `market_sizer` | Market Sizer |  | Size markets and model opportunity. |
+| `portfolio_support` | Portfolio Support |  | Support portfolio companies post-investment. |
+| `reference_checker` | Reference Checker |  | Run founder and customer reference checks. |
+
+`founder_sourcer` (Founder Sourcer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **investment decisions**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `founder_sourcer` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_venture_capital/AGENTS.md
+++ b/companies/agentic_venture_capital/AGENTS.md
@@ -33,3 +33,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `founder_sourcer` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Deals/Devtools seed round.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `founder_sourcer` (unconfined) to change.
+

--- a/companies/agentic_venture_capital/AGENTS.md
+++ b/companies/agentic_venture_capital/AGENTS.md
@@ -6,14 +6,14 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `code_analyst` | Code Analyst |  | Analyze codebases, product, and technical traction. |
-| `deck_evaluator` | Deck Evaluator |  | Evaluate pitch decks and business models. |
-| `founder_sourcer` | Founder Sourcer | orchestrator | Source founders and deal flow. |
-| `market_sizer` | Market Sizer |  | Size markets and model opportunity. |
-| `portfolio_support` | Portfolio Support |  | Support portfolio companies post-investment. |
-| `reference_checker` | Reference Checker |  | Run founder and customer reference checks. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `code_analyst` | Code Analyst | Analyze codebases, product, and technical traction. |
+| `deck_evaluator` | Deck Evaluator | Evaluate pitch decks and business models. |
+| `founder_sourcer` | Founder Sourcer (orchestrator) | Source founders and deal flow. |
+| `market_sizer` | Market Sizer | Size markets and model opportunity. |
+| `portfolio_support` | Portfolio Support | Support portfolio companies post-investment. |
+| `reference_checker` | Reference Checker | Run founder and customer reference checks. |
 
 `founder_sourcer` (Founder Sourcer) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_venture_capital/agents/code_analyst.toml
+++ b/companies/agentic_venture_capital/agents/code_analyst.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Devtools seed round.md", access = "write" },
+]

--- a/companies/agentic_venture_capital/agents/code_analyst.toml
+++ b/companies/agentic_venture_capital/agents/code_analyst.toml
@@ -1,2 +1,11 @@
 role = "Code Analyst"
 description = "Analyze codebases, product, and technical traction."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_capital/agents/deck_evaluator.toml
+++ b/companies/agentic_venture_capital/agents/deck_evaluator.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Devtools seed round.md", access = "write" },
+]

--- a/companies/agentic_venture_capital/agents/deck_evaluator.toml
+++ b/companies/agentic_venture_capital/agents/deck_evaluator.toml
@@ -1,2 +1,11 @@
 role = "Deck Evaluator"
 description = "Evaluate pitch decks and business models."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_capital/agents/market_sizer.toml
+++ b/companies/agentic_venture_capital/agents/market_sizer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Devtools seed round.md", access = "write" },
+]

--- a/companies/agentic_venture_capital/agents/market_sizer.toml
+++ b/companies/agentic_venture_capital/agents/market_sizer.toml
@@ -1,2 +1,11 @@
 role = "Market Sizer"
 description = "Size markets and model opportunity."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_capital/agents/portfolio_support.toml
+++ b/companies/agentic_venture_capital/agents/portfolio_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Devtools seed round.md", access = "write" },
+]

--- a/companies/agentic_venture_capital/agents/portfolio_support.toml
+++ b/companies/agentic_venture_capital/agents/portfolio_support.toml
@@ -1,2 +1,11 @@
 role = "Portfolio Support"
 description = "Support portfolio companies post-investment."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_capital/agents/reference_checker.toml
+++ b/companies/agentic_venture_capital/agents/reference_checker.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Deals/Devtools seed round.md", access = "write" },
+]

--- a/companies/agentic_venture_capital/agents/reference_checker.toml
+++ b/companies/agentic_venture_capital/agents/reference_checker.toml
@@ -1,2 +1,11 @@
 role = "Reference Checker"
 description = "Run founder and customer reference checks."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/AGENTS.md
+++ b/companies/agentic_venture_studio/AGENTS.md
@@ -36,3 +36,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `opportunity_scout` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Ventures/Local services marketplace.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `opportunity_scout` (unconfined) to change.
+

--- a/companies/agentic_venture_studio/AGENTS.md
+++ b/companies/agentic_venture_studio/AGENTS.md
@@ -6,17 +6,17 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `customer_support` | Customer Support |  | Resolve customer issues and feed insight back to product. |
-| `designer` | Designer |  | Own product and brand design. |
-| `engineer` | Engineer |  | Build and ship the product. |
-| `finance` | Finance |  | Financial modeling, runway, and reporting. |
-| `founder` | Founder |  | Turn a thesis into a company: vision, roadmap, and priorities. |
-| `lawyer` | Lawyer |  | Incorporation, contracts, and compliance. |
-| `marketer` | Marketer |  | Positioning, demand generation, and launches. |
-| `opportunity_scout` | Opportunity Scout | orchestrator | Surface and score market opportunities and startup theses. |
-| `recruiter` | Recruiter |  | Source and staff each venture with agents or humans. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `customer_support` | Customer Support | Resolve customer issues and feed insight back to product. |
+| `designer` | Designer | Own product and brand design. |
+| `engineer` | Engineer | Build and ship the product. |
+| `finance` | Finance | Financial modeling, runway, and reporting. |
+| `founder` | Founder | Turn a thesis into a company: vision, roadmap, and priorities. |
+| `lawyer` | Lawyer | Incorporation, contracts, and compliance. |
+| `marketer` | Marketer | Positioning, demand generation, and launches. |
+| `opportunity_scout` | Opportunity Scout (orchestrator) | Surface and score market opportunities and startup theses. |
+| `recruiter` | Recruiter | Source and staff each venture with agents or humans. |
 
 `opportunity_scout` (Opportunity Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/agentic_venture_studio/AGENTS.md
+++ b/companies/agentic_venture_studio/AGENTS.md
@@ -1,0 +1,38 @@
+# Agentic Venture Studio — working agreement
+
+> A studio that conceives, builds, launches, and operates a portfolio of startups — with humans holding only capital and major strategy.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `customer_support` | Customer Support |  | Resolve customer issues and feed insight back to product. |
+| `designer` | Designer |  | Own product and brand design. |
+| `engineer` | Engineer |  | Build and ship the product. |
+| `finance` | Finance |  | Financial modeling, runway, and reporting. |
+| `founder` | Founder |  | Turn a thesis into a company: vision, roadmap, and priorities. |
+| `lawyer` | Lawyer |  | Incorporation, contracts, and compliance. |
+| `marketer` | Marketer |  | Positioning, demand generation, and launches. |
+| `opportunity_scout` | Opportunity Scout | orchestrator | Surface and score market opportunities and startup theses. |
+| `recruiter` | Recruiter |  | Source and staff each venture with agents or humans. |
+
+`opportunity_scout` (Opportunity Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **capital allocation and major strategic decisions**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `opportunity_scout` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/agentic_venture_studio/agents/customer_support.toml
+++ b/companies/agentic_venture_studio/agents/customer_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/customer_support.toml
+++ b/companies/agentic_venture_studio/agents/customer_support.toml
@@ -1,2 +1,11 @@
 role = "Customer Support"
 description = "Resolve customer issues and feed insight back to product."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/designer.toml
+++ b/companies/agentic_venture_studio/agents/designer.toml
@@ -1,2 +1,11 @@
 role = "Designer"
 description = "Own product and brand design."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/designer.toml
+++ b/companies/agentic_venture_studio/agents/designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/engineer.toml
+++ b/companies/agentic_venture_studio/agents/engineer.toml
@@ -1,2 +1,11 @@
 role = "Engineer"
 description = "Build and ship the product."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/engineer.toml
+++ b/companies/agentic_venture_studio/agents/engineer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/finance.toml
+++ b/companies/agentic_venture_studio/agents/finance.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/finance.toml
+++ b/companies/agentic_venture_studio/agents/finance.toml
@@ -1,2 +1,11 @@
 role = "Finance"
 description = "Financial modeling, runway, and reporting."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/founder.toml
+++ b/companies/agentic_venture_studio/agents/founder.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/founder.toml
+++ b/companies/agentic_venture_studio/agents/founder.toml
@@ -1,2 +1,11 @@
 role = "Founder"
 description = "Turn a thesis into a company: vision, roadmap, and priorities."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/lawyer.toml
+++ b/companies/agentic_venture_studio/agents/lawyer.toml
@@ -1,2 +1,11 @@
 role = "Lawyer"
 description = "Incorporation, contracts, and compliance."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/lawyer.toml
+++ b/companies/agentic_venture_studio/agents/lawyer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/marketer.toml
+++ b/companies/agentic_venture_studio/agents/marketer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/marketer.toml
+++ b/companies/agentic_venture_studio/agents/marketer.toml
@@ -1,2 +1,11 @@
 role = "Marketer"
 description = "Positioning, demand generation, and launches."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/agentic_venture_studio/agents/recruiter.toml
+++ b/companies/agentic_venture_studio/agents/recruiter.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Ventures/Local services marketplace.md", access = "write" },
+]

--- a/companies/agentic_venture_studio/agents/recruiter.toml
+++ b/companies/agentic_venture_studio/agents/recruiter.toml
@@ -1,2 +1,11 @@
 role = "Recruiter"
 description = "Source and staff each venture with agents or humans."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/AGENTS.md
+++ b/companies/startup_accelerator/AGENTS.md
@@ -35,3 +35,7 @@ This company keeps the three built-in ledgers — `tasks` (the task board), `goa
 - Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
 - Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
 
+## Write scope
+
+Every specialist but `startup_scout` declares an explicit `context` confining `workspace_write`/`workspace_create` to `Cohorts/Spring cohort.md` — this company's one shared active-work document — plus its own `Agents/<id>/` home, which stays writable regardless. `Standards/` and `Playbooks/` are left out of that grant: governance documents, read by everyone but reserved for the operator and `startup_scout` (unconfined) to change.
+

--- a/companies/startup_accelerator/AGENTS.md
+++ b/companies/startup_accelerator/AGENTS.md
@@ -6,16 +6,16 @@ This file is routed into every teammate's system prompt alongside `METHOD.md` (`
 
 ## Roster
 
-| Agent id | Role | Desk lead | Responsibility |
-| --- | --- | --- | --- |
-| `application_screener` | Application Screener |  | Score and shortlist applications against the thesis. |
-| `curriculum_designer` | Curriculum Designer |  | Design and schedule the program curriculum. |
-| `demo_day_producer` | Demo Day Producer |  | Prepare pitches and stage demo day. |
-| `investor_liaison` | Investor Liaison |  | Make warm, targeted investor introductions. |
-| `mentor_matcher` | Mentor Matcher |  | Pair startups with the right mentors and resources. |
-| `portfolio_support` | Portfolio Support |  | Support alumni after the program. |
-| `progress_coach` | Progress Coach |  | Track weekly milestones and unblock founders. |
-| `startup_scout` | Startup Scout | orchestrator | Source promising founders and startups into the pipeline. |
+| Agent id | Role | Responsibility |
+| --- | --- | --- |
+| `application_screener` | Application Screener | Score and shortlist applications against the thesis. |
+| `curriculum_designer` | Curriculum Designer | Design and schedule the program curriculum. |
+| `demo_day_producer` | Demo Day Producer | Prepare pitches and stage demo day. |
+| `investor_liaison` | Investor Liaison | Make warm, targeted investor introductions. |
+| `mentor_matcher` | Mentor Matcher | Pair startups with the right mentors and resources. |
+| `portfolio_support` | Portfolio Support | Support alumni after the program. |
+| `progress_coach` | Progress Coach | Track weekly milestones and unblock founders. |
+| `startup_scout` | Startup Scout (orchestrator) | Source promising founders and startups into the pipeline. |
 
 `startup_scout` (Startup Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
 

--- a/companies/startup_accelerator/AGENTS.md
+++ b/companies/startup_accelerator/AGENTS.md
@@ -1,0 +1,37 @@
+# Startup Accelerator — working agreement
+
+> Runs a cohort-based accelerator end to end — sourcing founders, screening applications, matching mentors, running the curriculum, and staging demo day.
+
+This file is routed into every teammate's system prompt alongside `METHOD.md` (`context_routing::UNIVERSAL_DOCUMENTS`), so it is the one place a convention reaches the whole roster without being repeated in every agent's `context`.
+
+## Roster
+
+| Agent id | Role | Desk lead | Responsibility |
+| --- | --- | --- | --- |
+| `application_screener` | Application Screener |  | Score and shortlist applications against the thesis. |
+| `curriculum_designer` | Curriculum Designer |  | Design and schedule the program curriculum. |
+| `demo_day_producer` | Demo Day Producer |  | Prepare pitches and stage demo day. |
+| `investor_liaison` | Investor Liaison |  | Make warm, targeted investor introductions. |
+| `mentor_matcher` | Mentor Matcher |  | Pair startups with the right mentors and resources. |
+| `portfolio_support` | Portfolio Support |  | Support alumni after the program. |
+| `progress_coach` | Progress Coach |  | Track weekly milestones and unblock founders. |
+| `startup_scout` | Startup Scout | orchestrator | Source promising founders and startups into the pipeline. |
+
+`startup_scout` (Startup Scout) is this company's orchestrator: it holds the routing picture (`BRIEF.md`, `CLAIMS.md`, `THREADS.md`) and unrestricted ledger access, so it is the one that sets and revises goals and decisions rather than a specialist re-deciding them mid-task.
+
+Humans keep **investment and demo-day decisions**; everything else here is the roster's to run.
+
+## Workspace layout
+
+- `Standards/`, `Product/`, `Playbooks/` — shared, operator-seeded notes. Read them before proposing work that touches an area they cover; edit them on purpose, not as a side effect of an unrelated task.
+- `Agents/<your agent id>/` — your own folder, the default home for anything you produce. Always writable, whatever your `context` write scope says.
+- `derived/` — rendered ledger views (see below). Never hand-write anything here; it is regenerated on every ledger write.
+
+## Ledgers
+
+This company keeps the three built-in ledgers — `tasks` (the task board), `goals`, and `decisions` — and any teammate may declare another with `define_ledger` when a recurring axis (a pipeline, a promise, an experiment) does not fit one of these.
+
+- `startup_scout` has unrestricted ledger access (no `ledgers` grant declared) — it needs the full picture to route work.
+- Every other teammate is granted `record` on `tasks` and `read` on `goals` and `decisions`: each owns its own work on the board, and can see — but not unilaterally redefine — what the company has decided and is aiming for.
+- Read the relevant ledger with `read_ledger` before proposing or re-answering something; a closed row's reason is the cheapest way to avoid repeating a decision already made.
+

--- a/companies/startup_accelerator/agents/application_screener.toml
+++ b/companies/startup_accelerator/agents/application_screener.toml
@@ -1,2 +1,11 @@
 role = "Application Screener"
 description = "Score and shortlist applications against the thesis."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/application_screener.toml
+++ b/companies/startup_accelerator/agents/application_screener.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/curriculum_designer.toml
+++ b/companies/startup_accelerator/agents/curriculum_designer.toml
@@ -1,2 +1,11 @@
 role = "Curriculum Designer"
 description = "Design and schedule the program curriculum."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/curriculum_designer.toml
+++ b/companies/startup_accelerator/agents/curriculum_designer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/demo_day_producer.toml
+++ b/companies/startup_accelerator/agents/demo_day_producer.toml
@@ -1,2 +1,11 @@
 role = "Demo Day Producer"
 description = "Prepare pitches and stage demo day."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/demo_day_producer.toml
+++ b/companies/startup_accelerator/agents/demo_day_producer.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/investor_liaison.toml
+++ b/companies/startup_accelerator/agents/investor_liaison.toml
@@ -1,2 +1,11 @@
 role = "Investor Liaison"
 description = "Make warm, targeted investor introductions."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/investor_liaison.toml
+++ b/companies/startup_accelerator/agents/investor_liaison.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/mentor_matcher.toml
+++ b/companies/startup_accelerator/agents/mentor_matcher.toml
@@ -1,2 +1,11 @@
 role = "Mentor Matcher"
 description = "Pair startups with the right mentors and resources."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/mentor_matcher.toml
+++ b/companies/startup_accelerator/agents/mentor_matcher.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/portfolio_support.toml
+++ b/companies/startup_accelerator/agents/portfolio_support.toml
@@ -1,2 +1,11 @@
 role = "Portfolio Support"
 description = "Support alumni after the program."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/portfolio_support.toml
+++ b/companies/startup_accelerator/agents/portfolio_support.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/companies/startup_accelerator/agents/progress_coach.toml
+++ b/companies/startup_accelerator/agents/progress_coach.toml
@@ -1,2 +1,11 @@
 role = "Progress Coach"
 description = "Track weekly milestones and unblock founders."
+
+# Visibility/read-record scope (docs/spec/runtime/ledgers.md): this specialist
+# manages its own work on the board and sees, but does not redefine, company
+# direction. The orchestrator keeps unrestricted access.
+ledgers = [
+    { name = "tasks", access = "record" },
+    { name = "goals", access = "read" },
+    { name = "decisions", access = "read" },
+]

--- a/companies/startup_accelerator/agents/progress_coach.toml
+++ b/companies/startup_accelerator/agents/progress_coach.toml
@@ -9,3 +9,14 @@ ledgers = [
     { name = "goals", access = "read" },
     { name = "decisions", access = "read" },
 ]
+
+# Write scope (docs/spec/runtime/agents.md): confined to this company's
+# shared active-work document, plus the always-writable Agents/<id> home.
+# The bare entries below preserve this agent's existing (reasoning-tier)
+# routed context — only the last entry changes behavior, by adding a write
+# grant. Standards/ and Playbooks/ stay out: governance documents, left to
+# the operator and the unconfined orchestrator.
+context = [
+    "BRIEF.md", "CLAIMS.md",
+    { path = "Cohorts/Spring cohort.md", access = "write" },
+]

--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -77,9 +77,61 @@ prompt = """                            # appended to the generated persona
 Write for the reader, not the client.
 """
 prompt_files = ["prompts/house-style.md"]   # checked-in, bundle-relative
-context = ["Brand/Brand voice.md"]          # live workspace documents
+context = [                                 # live workspace documents
+    "Brand/Brand voice.md",                 #   read only (the bare-string shorthand)
+    { path = "Agents/copywriter/drafts", access = "write" },  # + workspace_write/workspace_create
+]
 classes = ["evidence"]                      # routing exclusions — see below
+
+ledgers = [                                 # per-agent ledger access (omit for unrestricted)
+    { name = "tasks", access = "record" },
+    { name = "decisions", access = "read" },
+]
+can_declare_ledgers = false                 # may this agent `define_ledger`? default true
 ```
+
+### `context` write access
+
+A bare string in `context` is read-only — routed into the prompt, nothing
+more. `{ path, access = "write" }` additionally puts that exact path in this
+agent's `workspace_write`/`workspace_create` scope.
+
+**Omitting every write entry is unconfined**, matching every manifest written
+before this existed: `workspace_write`/`workspace_create` reach anywhere in the
+company's tree, as they always could. Declaring **at least one** write entry
+confines this agent's `workspace_write`/`workspace_create` to exactly the paths
+it declared, plus its own `Agents/<id>/` home, which stays writable regardless
+— a role narrowed to a real access list must not also lose the ability to
+produce and revise its own work. See `src/harness/workspace_tools.rs` for the
+enforcement and why the pre-existing unconfined default is otherwise
+unchanged.
+
+### `ledgers`
+
+Which of the company's ledgers this agent's five ledger tools
+(`list_ledgers`, `read_ledger`, `record_entry`, `close_entry`,
+`define_ledger`) can see and use, and at what access.
+
+An omitted `ledgers` key is **unrestricted** — every ledger, at `record`
+access — the tool surface every agent had before this field existed. A
+declared list restricts `list_ledgers`/`read_ledger` to exactly the slugs
+named (an undeclared slug is invisible, not merely unwritable), and
+`record_entry`/`close_entry` additionally require `access = "record"` on that
+entry. A bare `{ name = "tasks" }` with no `access` key defaults to `read` —
+the safer of the two.
+
+This is the **visibility and read/record** half of ledger access; a ledger's
+own `writers` list (`docs/spec/runtime/ledgers.md`) stays the authoritative
+check for whether a write actually lands. Declaring `access = "record"` for a
+built-in ledger whose `writers` excludes this agent is a manifest validation
+error — the two must not silently disagree. A company-declared ledger is not
+cross-checked at manifest-load time, since it may not exist yet; any
+disagreement there is an ordinary tool refusal at call time.
+
+`can_declare_ledgers` (default `true`) governs `define_ledger` alone — a
+company discovers which axes it needs while running, so declaring one is
+unrestricted by default; set it `false` to keep a narrow role from growing the
+registry.
 
 ## The prompt
 

--- a/docs/spec/runtime/ledgers.md
+++ b/docs/spec/runtime/ledgers.md
@@ -219,6 +219,30 @@ mid-run is reachable by every tool immediately and named in the *prompt* from th
 next build. That is the honest limit: system prompts are assembled once, and
 nothing can retroactively edit one already in flight.
 
+### Per-agent visibility and access: `[[agent]].ledgers`
+
+The five tools above are the whole company's surface, uniform across every
+agent. `[[agent]].ledgers` narrows that per teammate: a list of
+`{ name, access = "read" | "record" }` grants, omitted by default.
+
+An omitted `ledgers` key is **unrestricted** — every ledger, at `record` — the
+tool surface every agent had before this field existed, so adding it to a
+manifest is a no-op for a company that never opts in. A declared list confines
+`list_ledgers`/`read_ledger` to exactly the slugs it names (an undeclared slug
+is invisible, not merely unwritable) and requires `access = "record"` for
+`record_entry`/`close_entry`; a bare `{ name = "tasks" }` defaults to `read`,
+the safer of the two.
+
+This is visibility and read/record — a different axis from
+[`writers`](#agents-create-and-record-only-people-delete), which stays the
+authoritative check on whether a write actually lands. An `access = "record"`
+grant to a built-in ledger whose `writers` excludes that agent is a manifest
+validation error, not a disagreement discovered at call time; a
+company-declared ledger cannot be checked that early, since it may not exist
+yet, so any conflict there is an ordinary tool refusal. `can_declare_ledgers`
+(default `true`) gates `define_ledger` alone. See
+`docs/spec/runtime/agents.md`.
+
 ## Storage
 
 `LedgerStore` (`ports/ledgers.rs`) keeps two things with very different

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -26,7 +26,9 @@ calls it has to think to make.
 > record why each exclusion is an exclusion.
 
 `role_context` MUST decide, per role, which workspace documents enter the system
-prompt. Exactly one document is universal: the company's method policy.
+prompt. Two documents are universal: the company's method policy (`METHOD.md`)
+and its per-workspace working agreement (`AGENTS.md`) — see
+[`UNIVERSAL_DOCUMENTS`](../../../src/company/context_routing.rs).
 
 **This is data, not code.** The sibling runtime encodes its table as a Rust
 `match` on role name, which is right for 22 compiled-in roles and wrong for us:

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -267,8 +267,8 @@ no bearing on cache-prefix stability.
 - **An omitted `context` and an explicit `context = []` do not collapse.** Two
   fixtures, because one value cannot prove both: an agent with no `context` key
   receives its per-tier default in full, and an agent with `context = []`
-  receives nothing beyond the universal method policy. This is the entire reason
-  the field is `Option<Vec<String>>` rather than a defaulted `Vec<String>`, so
+  receives nothing beyond the two universal documents. This is the entire reason
+  the field is `Option<Vec<ContextEntry>>` rather than a defaulted `Vec`, so
   a suite that asserts only the empty case would pass against an implementation
   that had silently lost the distinction.
 - **An agent with no `tier` receives the `reasoning` row**, not an empty

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -43,12 +43,12 @@ context = ["GOAL.md", "INDEX.md", "CLAIMS.md"]
 ```
 
 An omitted `context` key takes a per-tier default. `context = []` means the role
-gets the universal document and nothing else.
+gets the universal documents and nothing else.
 
 **The per-tier default table**, keyed on the [tier](../../glossary.md) a
 role's `[[agent]]` entry declares (unqualified "context" below means the
-routed-workspace-documents section only, on top of the universal method
-policy every role always gets):
+routed-workspace-documents section only, on top of the universal `METHOD.md`
+and `AGENTS.md` every role always gets):
 
 | Tier | Default `context` | Why |
 | --- | --- | --- |

--- a/docs/spec/runtime/orchestration/context-routing.md
+++ b/docs/spec/runtime/orchestration/context-routing.md
@@ -147,9 +147,10 @@ into, not of the manifest text**:
 
 An exclusion **outranks** both the tier default and an explicit `context` list.
 That is what makes a declared class a control rather than a routing line
-somebody can edit away. The universal method document is the one exemption — it
-is method, not assertion, so no class has cause to withhold it, and a role
-excluded from the method could not follow it.
+somebody can edit away. The two universal documents are the exemption — neither
+asserts anything about the work in progress, so no class has cause to withhold
+either, and a role excluded from the method or the working agreement could not
+follow it.
 
 The rule this preserves: an exclusion applies because something *declared* the
 role's job, and a company can add one but cannot silently remove one by

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -20,7 +20,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::company::{Agent, ContextEntry};
+use crate::company::Agent;
 use crate::error::{OpenCompanyError, Result};
 
 /// The bundle subdirectory holding one TOML file per roster teammate.

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -497,7 +497,12 @@ classes = ["judge", "evidence"]
         );
         assert_eq!(
             agent.context.as_deref(),
-            Some(&[crate::company::ContextEntry::from("GOAL.md"), crate::company::ContextEntry::from("CLAIMS.md")][..])
+            Some(
+                &[
+                    crate::company::ContextEntry::from("GOAL.md"),
+                    crate::company::ContextEntry::from("CLAIMS.md")
+                ][..]
+            )
         );
         assert_eq!(agent.classes, ["judge", "evidence"]);
     }

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -20,7 +20,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::company::Agent;
+use crate::company::{Agent, ContextEntry};
 use crate::error::{OpenCompanyError, Result};
 
 /// The bundle subdirectory holding one TOML file per roster teammate.

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -497,7 +497,7 @@ classes = ["judge", "evidence"]
         );
         assert_eq!(
             agent.context.as_deref(),
-            Some(&["GOAL.md".to_string(), "CLAIMS.md".to_string()][..])
+            Some(&[ContextEntry::from("GOAL.md"), ContextEntry::from("CLAIMS.md")][..])
         );
         assert_eq!(agent.classes, ["judge", "evidence"]);
     }

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -86,7 +86,7 @@ struct AgentFile {
     #[serde(default)]
     delegates_to: Vec<String>,
     #[serde(default)]
-    context: Option<Vec<String>>,
+    context: Option<Vec<crate::company::ContextEntry>>,
     #[serde(default)]
     budget_usd_daily: Option<f64>,
     #[serde(default)]
@@ -95,6 +95,10 @@ struct AgentFile {
     prompt_files: Vec<String>,
     #[serde(default)]
     classes: Vec<String>,
+    #[serde(default)]
+    ledgers: Option<Vec<crate::company::LedgerGrant>>,
+    #[serde(default = "crate::company::types::default_can_declare_ledgers")]
+    can_declare_ledgers: bool,
 }
 
 /// Loads every agent definition under `<dir>/agents/`, in roster order.

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -497,7 +497,7 @@ classes = ["judge", "evidence"]
         );
         assert_eq!(
             agent.context.as_deref(),
-            Some(&[ContextEntry::from("GOAL.md"), ContextEntry::from("CLAIMS.md")][..])
+            Some(&[crate::company::ContextEntry::from("GOAL.md"), crate::company::ContextEntry::from("CLAIMS.md")][..])
         );
         assert_eq!(agent.classes, ["judge", "evidence"]);
     }

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -241,6 +241,8 @@ fn parse_agent_file(
         prompt_files: file.prompt_files,
         prompt_files_resolved,
         classes: file.classes,
+        ledgers: file.ledgers,
+        can_declare_ledgers: file.can_declare_ledgers.unwrap_or(true),
     })
 }
 

--- a/src/company/agent_file.rs
+++ b/src/company/agent_file.rs
@@ -97,8 +97,8 @@ struct AgentFile {
     classes: Vec<String>,
     #[serde(default)]
     ledgers: Option<Vec<crate::company::LedgerGrant>>,
-    #[serde(default = "crate::company::types::default_can_declare_ledgers")]
-    can_declare_ledgers: bool,
+    #[serde(default)]
+    can_declare_ledgers: Option<bool>,
 }
 
 /// Loads every agent definition under `<dir>/agents/`, in roster order.

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -243,6 +243,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         }
     }
 

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -129,18 +129,18 @@ pub fn excluded_documents(classes: &[String]) -> Vec<&'static str> {
 ///
 /// Resolution order:
 ///
-/// 1. the universal document, always;
+/// 1. [`UNIVERSAL_DOCUMENTS`], always;
 /// 2. the agent's explicit `context` list if it declared one, else its tier's
 ///    default row;
 /// 3. minus anything its classes exclude.
 ///
 /// `Some(vec![])` (an explicit `context = []`) and `None` (an omitted key) are
-/// deliberately different: the first means "the universal document and nothing
-/// else", the second means "take the default". `Agent::context` is
-/// `Option<Vec<String>>` precisely so that distinction is representable.
+/// deliberately different: the first means "the universal documents and
+/// nothing else", the second means "take the default". `Agent::context` is
+/// `Option<Vec<ContextEntry>>` precisely so that distinction is representable.
 ///
 /// Returned in routing order with duplicates removed, so a manifest that lists
-/// the universal document explicitly does not get it twice.
+/// a universal document explicitly does not get it twice.
 pub fn routed_documents(agent: &Agent) -> Vec<String> {
     let excluded = excluded_documents(&agent.classes);
 
@@ -152,17 +152,19 @@ pub fn routed_documents(agent: &Agent) -> Vec<String> {
             .collect(),
     };
 
-    let mut routed = Vec::with_capacity(chosen.len() + 1);
+    let mut routed = Vec::with_capacity(chosen.len() + UNIVERSAL_DOCUMENTS.len());
     let mut seen = std::collections::HashSet::new();
-    for document in std::iter::once(UNIVERSAL_DOCUMENT.to_string()).chain(chosen) {
+    let universal = UNIVERSAL_DOCUMENTS.iter().map(|doc| doc.to_string());
+    for document in universal.chain(chosen) {
         let document = document.trim().to_string();
         if document.is_empty() {
             continue;
         }
-        // The universal document is exempt from exclusion: it is method, not
-        // assertion, so no class has a reason to withhold it — and a role
-        // excluded from the method could not follow it.
-        if document != UNIVERSAL_DOCUMENT && excluded.contains(&document.as_str()) {
+        // The universal documents are exempt from exclusion: neither asserts
+        // anything about the work in progress, so no class has a reason to
+        // withhold either — and a role excluded from the method or the
+        // working agreement could not follow it.
+        if !UNIVERSAL_DOCUMENTS.contains(&document.as_str()) && excluded.contains(&document.as_str()) {
             continue;
         }
         if seen.insert(document.clone()) {

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -33,6 +33,21 @@ use crate::company::Agent;
 /// about the work in progress, so no exclusion can apply to it.
 pub const UNIVERSAL_DOCUMENT: &str = "METHOD.md";
 
+/// The company's per-workspace working agreement, routed to every role
+/// alongside [`UNIVERSAL_DOCUMENT`].
+///
+/// Distinct from `METHOD.md`: `METHOD.md` is the company's method policy,
+/// authored per company; `AGENTS.md` is the bundle-level agreement every
+/// teammate in the roster shares — which files exist and what they are for,
+/// how work is expected to be handed off, conventions a person and every
+/// agent are both bound by. Also asserts nothing about work in progress, so it
+/// is exempt from class exclusions the same way `METHOD.md` is.
+pub const AGENTS_DOC: &str = "AGENTS.md";
+
+/// Every document routed to every role, whatever its tier, classes, or
+/// explicit `context` list — in the order they are placed in the prompt.
+pub const UNIVERSAL_DOCUMENTS: &[&str] = &[UNIVERSAL_DOCUMENT, AGENTS_DOC];
+
 /// The company's summarized picture: what is established, what is ruled out.
 pub const BRIEF: &str = "BRIEF.md";
 /// The evidence ledger — what already holds true, with its derivation.

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -130,7 +130,7 @@ pub fn routed_documents(agent: &Agent) -> Vec<String> {
     let excluded = excluded_documents(&agent.classes);
 
     let chosen: Vec<String> = match agent.context.as_deref() {
-        Some(explicit) => explicit.to_vec(),
+        Some(explicit) => explicit.iter().map(|entry| entry.path().to_string()).collect(),
         None => tier_defaults(agent.tier.as_deref())
             .iter()
             .map(|doc| doc.to_string())

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -145,7 +145,10 @@ pub fn routed_documents(agent: &Agent) -> Vec<String> {
     let excluded = excluded_documents(&agent.classes);
 
     let chosen: Vec<String> = match agent.context.as_deref() {
-        Some(explicit) => explicit.iter().map(|entry| entry.path().to_string()).collect(),
+        Some(explicit) => explicit
+            .iter()
+            .map(|entry| entry.path().to_string())
+            .collect(),
         None => tier_defaults(agent.tier.as_deref())
             .iter()
             .map(|doc| doc.to_string())
@@ -164,7 +167,9 @@ pub fn routed_documents(agent: &Agent) -> Vec<String> {
         // anything about the work in progress, so no class has a reason to
         // withhold either — and a role excluded from the method or the
         // working agreement could not follow it.
-        if !UNIVERSAL_DOCUMENTS.contains(&document.as_str()) && excluded.contains(&document.as_str()) {
+        if !UNIVERSAL_DOCUMENTS.contains(&document.as_str())
+            && excluded.contains(&document.as_str())
+        {
             continue;
         }
         if seen.insert(document.clone()) {
@@ -338,7 +343,10 @@ mod tests {
     fn an_explicit_context_overrides_the_tier_default() {
         let mut a = agent(Some("orchestrator"));
         a.context = Some(vec!["GOAL.md".into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, "GOAL.md"]);
+        assert_eq!(
+            routed_documents(&a),
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, "GOAL.md"]
+        );
     }
 
     #[test]
@@ -377,7 +385,10 @@ mod tests {
         let mut a = agent(None);
         a.classes = vec!["judge".into()];
         a.context = Some(vec![SCRATCH.into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
+        assert_eq!(
+            routed_documents(&a),
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]
+        );
     }
 
     #[test]
@@ -390,7 +401,10 @@ mod tests {
             CLAIMS.into(),
             BRIEF.into(),
         ]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
+        assert_eq!(
+            routed_documents(&a),
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]
+        );
     }
 
     /// The method policy is exempt: it is how the company works, not something
@@ -407,14 +421,20 @@ mod tests {
     fn a_document_listed_twice_is_routed_once() {
         let mut a = agent(None);
         a.context = Some(vec![UNIVERSAL_DOCUMENT.into(), BRIEF.into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
+        assert_eq!(
+            routed_documents(&a),
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]
+        );
     }
 
     #[test]
     fn blank_context_entries_are_ignored() {
         let mut a = agent(None);
         a.context = Some(vec!["".into(), "  ".into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
+        assert_eq!(
+            routed_documents(&a),
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]
+        );
     }
 
     /// An unknown class imposes no exclusion. Manifest validation refuses one

--- a/src/company/context_routing.rs
+++ b/src/company/context_routing.rs
@@ -287,23 +287,23 @@ mod tests {
     fn the_per_tier_default_table_matches_the_spec() {
         assert_eq!(
             routed_documents(&agent(Some("orchestrator"))),
-            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS, THREADS]
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF, CLAIMS, THREADS]
         );
         assert_eq!(
             routed_documents(&agent(Some("reasoning"))),
-            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS]
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF, CLAIMS]
         );
         assert_eq!(
             routed_documents(&agent(Some("frontend"))),
-            [UNIVERSAL_DOCUMENT, BRIEF]
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]
         );
         assert_eq!(
             routed_documents(&agent(Some("compress"))),
-            [UNIVERSAL_DOCUMENT]
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC]
         );
         assert_eq!(
             routed_documents(&agent(Some("subconscious"))),
-            [UNIVERSAL_DOCUMENT]
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC]
         );
     }
 
@@ -323,13 +323,13 @@ mod tests {
         explicit.context = Some(Vec::new());
         assert_eq!(
             routed_documents(&explicit),
-            [UNIVERSAL_DOCUMENT],
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC],
             "`context = []` means the universal document and nothing else"
         );
 
         assert_eq!(
             routed_documents(&agent(Some("orchestrator"))),
-            [UNIVERSAL_DOCUMENT, BRIEF, CLAIMS, THREADS],
+            [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF, CLAIMS, THREADS],
             "an omitted key takes the tier default"
         );
     }
@@ -338,7 +338,7 @@ mod tests {
     fn an_explicit_context_overrides_the_tier_default() {
         let mut a = agent(Some("orchestrator"));
         a.context = Some(vec!["GOAL.md".into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, "GOAL.md"]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, "GOAL.md"]);
     }
 
     #[test]
@@ -356,7 +356,7 @@ mod tests {
         let mut a = agent(Some("reasoning"));
         a.classes = vec!["judge".into()];
         a.context = Some(vec![SCRATCH.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC]);
     }
 
     #[test]
@@ -377,7 +377,7 @@ mod tests {
         let mut a = agent(None);
         a.classes = vec!["judge".into()];
         a.context = Some(vec![SCRATCH.into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
     }
 
     #[test]
@@ -390,7 +390,7 @@ mod tests {
             CLAIMS.into(),
             BRIEF.into(),
         ]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
     }
 
     /// The method policy is exempt: it is how the company works, not something
@@ -400,21 +400,21 @@ mod tests {
         let mut a = agent(None);
         a.classes = vec!["judge".into(), "evidence".into(), "directive".into()];
         a.context = Some(Vec::new());
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC]);
     }
 
     #[test]
     fn a_document_listed_twice_is_routed_once() {
         let mut a = agent(None);
         a.context = Some(vec![UNIVERSAL_DOCUMENT.into(), BRIEF.into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
     }
 
     #[test]
     fn blank_context_entries_are_ignored() {
         let mut a = agent(None);
         a.context = Some(vec!["".into(), "  ".into(), BRIEF.into()]);
-        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, BRIEF]);
+        assert_eq!(routed_documents(&a), [UNIVERSAL_DOCUMENT, AGENTS_DOC, BRIEF]);
     }
 
     /// An unknown class imposes no exclusion. Manifest validation refuses one

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -466,6 +466,7 @@ impl CompanyManifest {
     }
 
     /// Validates `[users]`: the sign-in mode, and the bootstrap list that mode
+    /// PLACEHOLDER_KEEP_DOC_BELOW
     /// actually reads.
     ///
     /// Split out because the interesting failures are not malformed values but

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -622,7 +622,10 @@ pub(crate) fn is_snake_case(id: &str) -> bool {
 /// disagreement there surfaces as an ordinary tool refusal at call time
 /// instead. A free function, not a `CompanyManifest` method, so it can be
 /// pointed at a synthetic ledger list in a test without a real registry.
-fn ledger_grant_problems(agents: &[crate::company::Agent], builtin_ledgers: &[LedgerSpec]) -> Vec<String> {
+fn ledger_grant_problems(
+    agents: &[crate::company::Agent],
+    builtin_ledgers: &[crate::ledger::LedgerSpec],
+) -> Vec<String> {
     let mut problems = Vec::new();
     for agent in agents {
         let label = if agent.id.is_empty() {

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -1100,6 +1100,65 @@ mod tests {
         }
     }
 
+    /// An `access = "record"` grant to a built-in ledger whose `writers`
+    /// excludes this agent must not silently disagree — it is a manifest
+    /// error, not a refusal the agent discovers at call time.
+    #[test]
+    fn a_record_grant_disagreeing_with_a_builtins_writers_is_rejected() {
+        let agents = vec![toml::from_str::<crate::company::Agent>(
+            "id = \"intern\"\nrole = \"Intern\"\nledgers = [{ name = \"risks\", access = \"record\" }]\n",
+        )
+        .unwrap()];
+        let risks = crate::ledger::parse(
+            &serde_json::json!({
+                "slug": "risks",
+                "title": "Risks",
+                "fields": [
+                    { "name": "id", "role": "id" },
+                    { "name": "risk", "role": "title" },
+                    { "name": "status", "role": "status" }
+                ],
+                "statuses": [{ "name": "open" }, { "name": "closed", "closed": true }],
+                "writers": ["cfo"]
+            }),
+            true,
+        )
+        .unwrap();
+
+        let problems = ledger_grant_problems(&agents, &[risks]);
+        assert_eq!(problems.len(), 1, "{problems:?}");
+        assert!(problems[0].contains("agent `intern`"), "{}", problems[0]);
+        assert!(problems[0].contains("`risks`"), "{}", problems[0]);
+        assert!(problems[0].contains("writers"), "{}", problems[0]);
+    }
+
+    /// A `read` grant never conflicts with `writers` — only `record` implies
+    /// write access, so only `record` is checked.
+    #[test]
+    fn a_read_grant_never_conflicts_with_writers() {
+        let agents = vec![toml::from_str::<crate::company::Agent>(
+            "id = \"intern\"\nrole = \"Intern\"\nledgers = [{ name = \"risks\", access = \"read\" }]\n",
+        )
+        .unwrap()];
+        let risks = crate::ledger::parse(
+            &serde_json::json!({
+                "slug": "risks",
+                "title": "Risks",
+                "fields": [
+                    { "name": "id", "role": "id" },
+                    { "name": "risk", "role": "title" },
+                    { "name": "status", "role": "status" }
+                ],
+                "statuses": [{ "name": "open" }, { "name": "closed", "closed": true }],
+                "writers": ["cfo"]
+            }),
+            true,
+        )
+        .unwrap();
+
+        assert!(ledger_grant_problems(&agents, &[risks]).is_empty());
+    }
+
     /// A `delegates_to` entry must name a real desk (issue #176).
     ///
     /// The failure this catches is silent at runtime rather than loud: a member

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -610,6 +610,52 @@ pub(crate) fn is_snake_case(id: &str) -> bool {
         .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_')
 }
 
+/// Problems from every agent's `[[agent]].ledgers` grants, checked against
+/// `builtin_ledgers`.
+///
+/// An `access = "record"` grant that a built-in ledger's `writers` excludes is
+/// a manifest error rather than a silent tool refusal at call time — the two
+/// sources of truth (the agent's grant, the ledger's `writers`) must not
+/// disagree for a slug the manifest can actually see. A company-declared
+/// ledger is not checked here: it may not exist yet when the manifest is
+/// validated (the same reasoning as `context`'s missing-document rule), so any
+/// disagreement there surfaces as an ordinary tool refusal at call time
+/// instead. A free function, not a `CompanyManifest` method, so it can be
+/// pointed at a synthetic ledger list in a test without a real registry.
+fn ledger_grant_problems(agents: &[crate::company::Agent], builtin_ledgers: &[LedgerSpec]) -> Vec<String> {
+    let mut problems = Vec::new();
+    for agent in agents {
+        let label = if agent.id.is_empty() {
+            "an agent".to_string()
+        } else {
+            format!("agent `{}`", agent.id)
+        };
+        let Some(grants) = &agent.ledgers else {
+            continue;
+        };
+        for grant in grants {
+            if grant.access != crate::company::LedgerAccess::Record {
+                continue;
+            }
+            let Some(spec) = builtin_ledgers
+                .iter()
+                .find(|spec| spec.slug.eq_ignore_ascii_case(grant.name.trim()))
+            else {
+                continue;
+            };
+            if !spec.writable_by(&agent.id) {
+                problems.push(format!(
+                    "{label} declares `ledgers` access `record` to `{}`, but that ledger's \
+                     `writers` does not name this agent — the two must agree. Either add `{}` to \
+                     `{}`'s `writers`, or change this grant to `read`.",
+                    spec.slug, agent.id, spec.slug
+                ));
+            }
+        }
+    }
+    problems
+}
+
 /// Parses a decimal USD string, rejecting anything non-numeric or negative.
 fn parse_usd(value: &str) -> Option<f64> {
     match value.trim().parse::<f64>() {

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -303,45 +303,9 @@ impl CompanyManifest {
             }
         }
 
-        // `ledgers` grants (per-agent ledger access): an `access = "record"`
-        // grant that a built-in ledger's `writers` excludes is a manifest
-        // error rather than a silent tool refusal at call time — the two
-        // sources of truth (the agent's grant, the ledger's `writers`) must
-        // not disagree for a slug the manifest can actually see. A
-        // company-declared ledger is not checked here: it may not exist yet
-        // when the manifest is validated (the same reasoning as `context`'s
-        // missing-document rule), so any disagreement there surfaces as an
-        // ordinary tool refusal at call time instead.
+        // `ledgers` grants (per-agent ledger access): see `ledger_grant_problems`.
         let (builtin_ledgers, _) = crate::ledger::builtins();
-        for agent in &self.agents {
-            let label = if agent.id.is_empty() {
-                "an agent".to_string()
-            } else {
-                format!("agent `{}`", agent.id)
-            };
-            let Some(grants) = &agent.ledgers else {
-                continue;
-            };
-            for grant in grants {
-                if grant.access != crate::company::LedgerAccess::Record {
-                    continue;
-                }
-                let Some(spec) = builtin_ledgers
-                    .iter()
-                    .find(|spec| spec.slug.eq_ignore_ascii_case(grant.name.trim()))
-                else {
-                    continue;
-                };
-                if !spec.writable_by(&agent.id) {
-                    problems.push(format!(
-                        "{label} declares `ledgers` access `record` to `{}`, but that ledger's \
-                         `writers` does not name this agent — the two must agree. Either add \
-                         `{}` to `{}`'s `writers`, or change this grant to `read`.",
-                        spec.slug, agent.id, spec.slug
-                    ));
-                }
-            }
-        }
+        problems.extend(ledger_grant_problems(&self.agents, &builtin_ledgers));
 
         // Connections: a provider is required; a stated priority must be known.
         for (index, connection) in self.connections.iter().enumerate() {

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -303,6 +303,46 @@ impl CompanyManifest {
             }
         }
 
+        // `ledgers` grants (per-agent ledger access): an `access = "record"`
+        // grant that a built-in ledger's `writers` excludes is a manifest
+        // error rather than a silent tool refusal at call time — the two
+        // sources of truth (the agent's grant, the ledger's `writers`) must
+        // not disagree for a slug the manifest can actually see. A
+        // company-declared ledger is not checked here: it may not exist yet
+        // when the manifest is validated (the same reasoning as `context`'s
+        // missing-document rule), so any disagreement there surfaces as an
+        // ordinary tool refusal at call time instead.
+        let (builtin_ledgers, _) = crate::ledger::builtins();
+        for agent in &self.agents {
+            let label = if agent.id.is_empty() {
+                "an agent".to_string()
+            } else {
+                format!("agent `{}`", agent.id)
+            };
+            let Some(grants) = &agent.ledgers else {
+                continue;
+            };
+            for grant in grants {
+                if grant.access != crate::company::LedgerAccess::Record {
+                    continue;
+                }
+                let Some(spec) = builtin_ledgers
+                    .iter()
+                    .find(|spec| spec.slug.eq_ignore_ascii_case(grant.name.trim()))
+                else {
+                    continue;
+                };
+                if !spec.writable_by(&agent.id) {
+                    problems.push(format!(
+                        "{label} declares `ledgers` access `record` to `{}`, but that ledger's \
+                         `writers` does not name this agent — the two must agree. Either add \
+                         `{}` to `{}`'s `writers`, or change this grant to `read`.",
+                        spec.slug, agent.id, spec.slug
+                    ));
+                }
+            }
+        }
+
         // Connections: a provider is required; a stated priority must be known.
         for (index, connection) in self.connections.iter().enumerate() {
             let label = if connection.provider.trim().is_empty() {

--- a/src/company/manifest.rs
+++ b/src/company/manifest.rs
@@ -466,7 +466,6 @@ impl CompanyManifest {
     }
 
     /// Validates `[users]`: the sign-in mode, and the bootstrap list that mode
-    /// PLACEHOLDER_KEEP_DOC_BELOW
     /// actually reads.
     ///
     /// Split out because the interesting failures are not malformed values but

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -123,10 +123,9 @@ pub use types::{
     DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat,
     INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS, LedgerAccess, LedgerGrant,
     MAX_DELEGATION_DEPTH_BOUNDS, McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS,
-    POLICY_MODES, PROMPT_CLASSES,
-    PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
-    TOOL_PROVIDERS, Tools, grants_chargebee_explicit, grants_composio_explicit,
-    grants_media_explicit, grants_paypal_explicit, grants_repo_explicit,
+    POLICY_MODES, PROMPT_CLASSES, PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan,
+    Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_chargebee_explicit,
+    grants_composio_explicit, grants_media_explicit, grants_paypal_explicit, grants_repo_explicit,
     grants_repo_write_explicit, grants_search_explicit, grants_workspace_write_explicit,
     orchestrator_id,
 };

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -119,10 +119,11 @@ pub use manifest::{DELEGATES_TO_WILDCARD, LEGACY_MANIFEST_FILE, Located, MANIFES
 pub use skill_file::{SkillDoc, load_dir_skills, parse_skill_md, render_skill_md};
 pub use types::{
     Agent, BRAIN_MODES, Brain, Budget, ChannelConfig, Company, CompanyManifest, ComposioTools,
-    Connection, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_DELEGATION_DEPTH, DEFAULT_MAX_IN_FLIGHT_RUNS,
-    DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat, INFERENCE_PROVIDERS,
-    INFERENCE_TIERS, Inference, KNOWN_CHANNELS, MAX_DELEGATION_DEPTH_BOUNDS, McpServer,
-    ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
+    Connection, ContextAccess, ContextEntry, DEFAULT_ALWAYS_APPROVE, DEFAULT_MAX_DELEGATION_DEPTH,
+    DEFAULT_MAX_IN_FLIGHT_RUNS, DEFAULT_SEARCH_DAILY_CALLS, GATEABLE_NAMESPACES, GroupChat,
+    INFERENCE_PROVIDERS, INFERENCE_TIERS, Inference, KNOWN_CHANNELS, LedgerAccess, LedgerGrant,
+    MAX_DELEGATION_DEPTH_BOUNDS, McpServer, ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS,
+    POLICY_MODES, PROMPT_CLASSES,
     PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
     TOOL_PROVIDERS, Tools, grants_chargebee_explicit, grants_composio_explicit,
     grants_media_explicit, grants_paypal_explicit, grants_repo_explicit,

--- a/src/company/prompt.rs
+++ b/src/company/prompt.rs
@@ -174,6 +174,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         }
     }
 

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -654,10 +654,6 @@ pub enum LedgerAccess {
     Record,
 }
 
-fn default_true() -> bool {
-    true
-}
-
 impl Agent {
     /// This agent's `workspace_write`/`workspace_create` scope.
     ///

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1526,6 +1526,64 @@ mod test {
         assert_eq!(back.context, None);
     }
 
+    /// A bare `context` string is `Read`; `{ path, access = "write" }` is the
+    /// only way to grant `Write`. `write_scope` collects exactly the write
+    /// entries, and `None` — either an omitted `context` key or a `context`
+    /// with no write entry — is unconfined, not "confined to nothing".
+    #[test]
+    fn write_scope_is_none_unless_a_context_entry_declares_write() {
+        let mut agent = base_agent();
+
+        agent.context = None;
+        assert_eq!(agent.write_scope(), None, "an omitted context key is unconfined");
+
+        agent.context = Some(vec!["Brand/Voice.md".into()]);
+        assert_eq!(
+            agent.write_scope(),
+            None,
+            "a read-only context list is unconfined, not confined to nothing"
+        );
+
+        let write_entry: Agent = toml::from_str(
+            r#"
+            id = "critic"
+            role = "Critic"
+            context = ["Brand/Voice.md", { path = "Agents/critic/notes.md", access = "write" }]
+            "#,
+        )
+        .expect("parse toml");
+        assert_eq!(
+            write_entry.write_scope(),
+            Some(vec!["Agents/critic/notes.md".to_string()]),
+            "only the declared write entry is in scope, not the read one"
+        );
+    }
+
+    /// An omitted `ledgers` key is unrestricted `Record` access to every slug
+    /// — the tool surface every agent had before this field existed. A
+    /// declared list answers only for the slugs it names.
+    #[test]
+    fn ledger_access_defaults_to_unrestricted_record() {
+        let mut agent = base_agent();
+        agent.ledgers = None;
+        assert_eq!(agent.ledger_access("tasks"), Some(LedgerAccess::Record));
+        assert_eq!(agent.ledger_access("anything"), Some(LedgerAccess::Record));
+
+        agent.ledgers = Some(vec![
+            LedgerGrant {
+                name: "tasks".into(),
+                access: LedgerAccess::Record,
+            },
+            LedgerGrant {
+                name: "decisions".into(),
+                access: LedgerAccess::Read,
+            },
+        ]);
+        assert_eq!(agent.ledger_access("tasks"), Some(LedgerAccess::Record));
+        assert_eq!(agent.ledger_access("DECISIONS"), Some(LedgerAccess::Read));
+        assert_eq!(agent.ledger_access("goals"), None, "an undeclared slug is unreachable");
+    }
+
     /// The `[plan]` section (issue #108) survives a TOML → struct → JSON → struct
     /// round-trip, and an absent section deserializes to the not-set default.
     #[test]

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1516,7 +1516,10 @@ mod test {
         .expect("parse toml");
         assert_eq!(
             populated.context,
-            Some(vec![ContextEntry::from("GOAL.md"), ContextEntry::from("CLAIMS.md")])
+            Some(vec![
+                ContextEntry::from("GOAL.md"),
+                ContextEntry::from("CLAIMS.md")
+            ])
         );
 
         // The distinction survives a JSON round-trip too, since the routing
@@ -1533,12 +1536,15 @@ mod test {
     #[test]
     fn write_scope_is_none_unless_a_context_entry_declares_write() {
         let omitted: Agent = toml::from_str("id = \"critic\"\nrole = \"Critic\"\n").unwrap();
-        assert_eq!(omitted.write_scope(), None, "an omitted context key is unconfined");
+        assert_eq!(
+            omitted.write_scope(),
+            None,
+            "an omitted context key is unconfined"
+        );
 
-        let read_only: Agent = toml::from_str(
-            "id = \"critic\"\nrole = \"Critic\"\ncontext = [\"Brand/Voice.md\"]\n",
-        )
-        .unwrap();
+        let read_only: Agent =
+            toml::from_str("id = \"critic\"\nrole = \"Critic\"\ncontext = [\"Brand/Voice.md\"]\n")
+                .unwrap();
         assert_eq!(
             read_only.write_scope(),
             None,
@@ -1566,8 +1572,14 @@ mod test {
     #[test]
     fn ledger_access_defaults_to_unrestricted_record() {
         let unrestricted: Agent = toml::from_str("id = \"critic\"\nrole = \"Critic\"\n").unwrap();
-        assert_eq!(unrestricted.ledger_access("tasks"), Some(LedgerAccess::Record));
-        assert_eq!(unrestricted.ledger_access("anything"), Some(LedgerAccess::Record));
+        assert_eq!(
+            unrestricted.ledger_access("tasks"),
+            Some(LedgerAccess::Record)
+        );
+        assert_eq!(
+            unrestricted.ledger_access("anything"),
+            Some(LedgerAccess::Record)
+        );
 
         let scoped: Agent = toml::from_str(
             r#"
@@ -1582,7 +1594,11 @@ mod test {
         .unwrap();
         assert_eq!(scoped.ledger_access("tasks"), Some(LedgerAccess::Record));
         assert_eq!(scoped.ledger_access("DECISIONS"), Some(LedgerAccess::Read));
-        assert_eq!(scoped.ledger_access("goals"), None, "an undeclared slug is unreachable");
+        assert_eq!(
+            scoped.ledger_access("goals"),
+            None,
+            "an undeclared slug is unreachable"
+        );
     }
 
     /// A bare `{ name = "tasks" }` grant, with no `access` key, defaults to

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1532,14 +1532,15 @@ mod test {
     /// with no write entry — is unconfined, not "confined to nothing".
     #[test]
     fn write_scope_is_none_unless_a_context_entry_declares_write() {
-        let mut agent = base_agent();
+        let omitted: Agent = toml::from_str("id = \"critic\"\nrole = \"Critic\"\n").unwrap();
+        assert_eq!(omitted.write_scope(), None, "an omitted context key is unconfined");
 
-        agent.context = None;
-        assert_eq!(agent.write_scope(), None, "an omitted context key is unconfined");
-
-        agent.context = Some(vec!["Brand/Voice.md".into()]);
+        let read_only: Agent = toml::from_str(
+            "id = \"critic\"\nrole = \"Critic\"\ncontext = [\"Brand/Voice.md\"]\n",
+        )
+        .unwrap();
         assert_eq!(
-            agent.write_scope(),
+            read_only.write_scope(),
             None,
             "a read-only context list is unconfined, not confined to nothing"
         );

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1516,7 +1516,7 @@ mod test {
         .expect("parse toml");
         assert_eq!(
             populated.context,
-            Some(vec!["GOAL.md".to_string(), "CLAIMS.md".to_string()])
+            Some(vec![ContextEntry::from("GOAL.md"), ContextEntry::from("CLAIMS.md")])
         );
 
         // The distinction survives a JSON round-trip too, since the routing

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -473,8 +473,13 @@ pub struct Agent {
     /// `harness::context_routing` before the (synchronous) agent build, and a
     /// change to one moves the roster fingerprint so it reaches the next turn
     /// rather than the next restart.
+    ///
+    /// An entry is either a bare path (routes the document into the prompt,
+    /// read-only — the pre-existing shorthand) or `{ path, access = "write" }`,
+    /// which additionally grants this agent `workspace_write`/`workspace_create`
+    /// on that path. See [`ContextEntry`] and [`Agent::write_scope`].
     #[serde(default)]
-    pub context: Option<Vec<String>>,
+    pub context: Option<Vec<ContextEntry>>,
     /// Per-agent daily spend cap in USD.
     #[serde(default)]
     pub budget_usd_daily: Option<f64>,

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -537,6 +537,162 @@ pub struct Agent {
     /// here rather than having it guessed from the free-text `role`.
     #[serde(default)]
     pub classes: Vec<String>,
+    /// Declared ledgers this agent may reach through the ledger tools, with
+    /// per-ledger read/record access.
+    ///
+    /// `None` (the default, omitted key) means **unrestricted** — every ledger
+    /// the company has, at `record` access — which is the tool surface every
+    /// agent had before this field existed, so adding it is a no-op for an
+    /// existing company. `Some(vec![])` restricts the agent to no ledgers at
+    /// all, distinct from taking the default; `Option<Vec<LedgerGrant>>` rather
+    /// than a defaulted `Vec` is what makes that distinction representable, the
+    /// same reasoning as [`context`](Self::context).
+    ///
+    /// This is the **visibility and read/record** half of ledger access.
+    /// [`LedgerSpec::writers`](crate::ledger::LedgerSpec::writers) stays the
+    /// authoritative check for whether a `record`/`close` call actually lands —
+    /// declaring `access = "record"` here for a built-in ledger whose writers
+    /// exclude this agent is a manifest validation error (the two must not
+    /// silently disagree); for a company-declared ledger, which may not exist
+    /// yet when the manifest is validated, the same conflict surfaces as an
+    /// ordinary tool refusal at call time.
+    #[serde(default)]
+    pub ledgers: Option<Vec<LedgerGrant>>,
+    /// Whether this agent may declare a new ledger with `define_ledger`.
+    ///
+    /// Defaults to `true` — declaring an axis a company discovers it needs
+    /// while running is deliberately unrestricted by default (see
+    /// `docs/spec/runtime/ledgers.md`), and every manifest written before this
+    /// field existed relied on that. Set `false` to keep a narrow role from
+    /// growing the company's ledger registry.
+    #[serde(default = "default_true")]
+    pub can_declare_ledgers: bool,
+}
+
+/// One [`Agent::context`] entry.
+///
+/// A bare TOML string (`"Brand/Voice.md"`) deserializes as [`Self::Path`], read
+/// access, matching every manifest written before write access existed. The
+/// table form (`{ path = "...", access = "write" }`) is [`Self::Detailed`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ContextEntry {
+    /// Read access, the pre-existing shorthand.
+    Path(String),
+    /// Explicit access, most commonly `write`.
+    Detailed {
+        path: String,
+        #[serde(default)]
+        access: ContextAccess,
+    },
+}
+
+impl ContextEntry {
+    /// The workspace-relative path, whichever form declared it.
+    pub fn path(&self) -> &str {
+        match self {
+            ContextEntry::Path(path) => path,
+            ContextEntry::Detailed { path, .. } => path,
+        }
+    }
+
+    /// This entry's access — `Read` unless a `Detailed` form says otherwise.
+    pub fn access(&self) -> ContextAccess {
+        match self {
+            ContextEntry::Path(_) => ContextAccess::Read,
+            ContextEntry::Detailed { access, .. } => *access,
+        }
+    }
+}
+
+impl From<&str> for ContextEntry {
+    fn from(path: &str) -> Self {
+        ContextEntry::Path(path.to_string())
+    }
+}
+
+impl From<String> for ContextEntry {
+    fn from(path: String) -> Self {
+        ContextEntry::Path(path)
+    }
+}
+
+/// Whether a routed [`ContextEntry`] is read-only or additionally writable.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextAccess {
+    /// Routed into the prompt; no write grant on this path.
+    #[default]
+    Read,
+    /// Routed into the prompt, and this exact path is in the agent's
+    /// `workspace_write`/`workspace_create` scope.
+    Write,
+}
+
+/// One [`Agent::ledgers`] entry: a ledger slug and this agent's access to it.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LedgerGrant {
+    /// The ledger's slug, as declared or built in — not validated against the
+    /// registry at manifest-load time, since a company-declared ledger may not
+    /// exist yet (the same reasoning as `Agent::context`'s missing-document
+    /// rule).
+    pub name: String,
+    /// This agent's access to it.
+    #[serde(default)]
+    pub access: LedgerAccess,
+}
+
+/// Read or record access to one ledger.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LedgerAccess {
+    /// `list_ledgers` and `read_ledger` only.
+    #[default]
+    Read,
+    /// Read, plus `record_entry` and `close_entry` — still subject to
+    /// [`LedgerSpec::writers`](crate::ledger::LedgerSpec::writers).
+    Record,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Agent {
+    /// This agent's `workspace_write`/`workspace_create` scope.
+    ///
+    /// `None` means **unconfined** — every path in the company's tree, which is
+    /// the behaviour every agent had before per-path write access existed (see
+    /// `src/harness/workspace_tools.rs`), so a manifest that declares no
+    /// `access = "write"` entry is unaffected by this field's existence.
+    /// `Some(paths)` — returned as soon as `context` names at least one write
+    /// entry — confines `workspace_write`/`workspace_create` to exactly those
+    /// paths, plus this agent's own `Agents/<id>/` home, which the workspace
+    /// tools always allow regardless of this scope.
+    pub fn write_scope(&self) -> Option<Vec<String>> {
+        let entries = self.context.as_ref()?;
+        let paths: Vec<String> = entries
+            .iter()
+            .filter(|entry| entry.access() == ContextAccess::Write)
+            .map(|entry| entry.path().to_string())
+            .collect();
+        if paths.is_empty() { None } else { Some(paths) }
+    }
+
+    /// This agent's declared access to ledger `slug`, or `None` if it may not
+    /// reach it at all.
+    ///
+    /// An omitted `ledgers` key answers `Some(Record)` for every slug —
+    /// unrestricted, matching the tool surface before this field existed.
+    pub fn ledger_access(&self, slug: &str) -> Option<LedgerAccess> {
+        match &self.ledgers {
+            None => Some(LedgerAccess::Record),
+            Some(grants) => grants
+                .iter()
+                .find(|grant| grant.name.eq_ignore_ascii_case(slug.trim()))
+                .map(|grant| grant.access),
+        }
+    }
 }
 
 /// The `[[agent]].tier` value that marks a roster's orchestrator.

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -1565,24 +1565,36 @@ mod test {
     /// declared list answers only for the slugs it names.
     #[test]
     fn ledger_access_defaults_to_unrestricted_record() {
-        let mut agent = base_agent();
-        agent.ledgers = None;
-        assert_eq!(agent.ledger_access("tasks"), Some(LedgerAccess::Record));
-        assert_eq!(agent.ledger_access("anything"), Some(LedgerAccess::Record));
+        let unrestricted: Agent = toml::from_str("id = \"critic\"\nrole = \"Critic\"\n").unwrap();
+        assert_eq!(unrestricted.ledger_access("tasks"), Some(LedgerAccess::Record));
+        assert_eq!(unrestricted.ledger_access("anything"), Some(LedgerAccess::Record));
 
-        agent.ledgers = Some(vec![
-            LedgerGrant {
-                name: "tasks".into(),
-                access: LedgerAccess::Record,
-            },
-            LedgerGrant {
-                name: "decisions".into(),
-                access: LedgerAccess::Read,
-            },
-        ]);
-        assert_eq!(agent.ledger_access("tasks"), Some(LedgerAccess::Record));
-        assert_eq!(agent.ledger_access("DECISIONS"), Some(LedgerAccess::Read));
-        assert_eq!(agent.ledger_access("goals"), None, "an undeclared slug is unreachable");
+        let scoped: Agent = toml::from_str(
+            r#"
+            id = "critic"
+            role = "Critic"
+            ledgers = [
+                { name = "tasks", access = "record" },
+                { name = "decisions", access = "read" },
+            ]
+            "#,
+        )
+        .unwrap();
+        assert_eq!(scoped.ledger_access("tasks"), Some(LedgerAccess::Record));
+        assert_eq!(scoped.ledger_access("DECISIONS"), Some(LedgerAccess::Read));
+        assert_eq!(scoped.ledger_access("goals"), None, "an undeclared slug is unreachable");
+    }
+
+    /// A bare `{ name = "tasks" }` grant, with no `access` key, defaults to
+    /// `Read` — the safer of the two, so declaring a `ledgers` list without
+    /// stating an access level does not silently hand out write access.
+    #[test]
+    fn a_ledger_grant_with_no_access_key_defaults_to_read() {
+        let agent: Agent = toml::from_str(
+            "id = \"critic\"\nrole = \"Critic\"\nledgers = [{ name = \"tasks\" }]\n",
+        )
+        .unwrap();
+        assert_eq!(agent.ledger_access("tasks"), Some(LedgerAccess::Read));
     }
 
     /// The `[plan]` section (issue #108) survives a TOML → struct → JSON → struct

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -740,6 +740,8 @@ pub fn build_agent(
                 .with_tasks_opt(deps.tasks.clone())
                 .with_workspace_opt(deps.workspace.clone()),
             manifest_agent.id.clone(),
+            manifest_agent.ledgers.clone(),
+            manifest_agent.can_declare_ledgers,
         ));
     }
 

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -718,6 +718,7 @@ pub fn build_agent(
                 company.clone(),
                 manifest_agent.id.clone(),
                 workspace_writes,
+                manifest_agent.write_scope(),
             ))
         }
         _ => None,

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -1434,6 +1434,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         }
     }
 
@@ -1627,6 +1629,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1672,6 +1676,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1713,6 +1719,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1752,6 +1760,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -1953,6 +1963,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -2585,6 +2597,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         // `full` so the sandboxed write executes without a supervised prompt.
         let policy = ApprovalPolicy::new(

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -39,6 +39,7 @@ use oh::tools::traits::{PermissionLevel, Tool, ToolResult};
 use openhuman_core::openhuman as oh;
 
 use crate::company::ledgers::{self, Ledgers, Query};
+use crate::company::{LedgerAccess, LedgerGrant};
 use crate::ledger::{LedgerAuthor, LedgerSource, LedgerSpec, ORDERS};
 
 /// Names every ledger this company has.
@@ -52,21 +53,62 @@ pub const CLOSE_ENTRY_TOOL: &str = "close_entry";
 /// Declares a new ledger.
 pub const DEFINE_LEDGER_TOOL: &str = "define_ledger";
 
+/// This agent's access to slug `slug`, from its manifest-declared grants.
+///
+/// `None` grants (an omitted `[[agent]].ledgers` key) means every slug answers
+/// `Some(Record)` — unrestricted, the tool surface every agent had before this
+/// field existed. `Some(list)` answers only for the slugs it names, so an
+/// agent that declares a `ledgers` list at all is confined to exactly what it
+/// lists — the same opt-in-confinement shape as `Agent::write_scope`. Mirrors
+/// [`crate::company::Agent::ledger_access`], duplicated here rather than
+/// called through an `&Agent` because these tools are built once and held
+/// `'static`, past the manifest's own lifetime.
+fn ledger_access(grants: &Option<Vec<LedgerGrant>>, slug: &str) -> Option<LedgerAccess> {
+    match grants {
+        None => Some(LedgerAccess::Record),
+        Some(list) => list
+            .iter()
+            .find(|grant| grant.name.eq_ignore_ascii_case(slug.trim()))
+            .map(|grant| grant.access),
+    }
+}
+
 /// Builds the five tools for one agent.
-pub fn ledger_tools(ctx: Ledgers, agent_id: String) -> Vec<Box<dyn Tool>> {
+///
+/// `ledger_grants` and `can_declare_ledgers` are the manifest's
+/// `[[agent]].ledgers` and `.can_declare_ledgers` — see
+/// [`crate::company::Agent::ledger_access`] for what an omitted `ledgers` key
+/// means.
+pub fn ledger_tools(
+    ctx: Ledgers,
+    agent_id: String,
+    ledger_grants: Option<Vec<LedgerGrant>>,
+    can_declare_ledgers: bool,
+) -> Vec<Box<dyn Tool>> {
     let author = LedgerAuthor::agent(agent_id);
     vec![
-        Box::new(ListLedgers { ctx: ctx.clone() }),
-        Box::new(ReadLedger { ctx: ctx.clone() }),
+        Box::new(ListLedgers {
+            ctx: ctx.clone(),
+            ledger_grants: ledger_grants.clone(),
+        }),
+        Box::new(ReadLedger {
+            ctx: ctx.clone(),
+            ledger_grants: ledger_grants.clone(),
+        }),
         Box::new(RecordEntry {
             ctx: ctx.clone(),
             author: author.clone(),
+            ledger_grants: ledger_grants.clone(),
         }),
         Box::new(CloseEntry {
             ctx: ctx.clone(),
             author: author.clone(),
+            ledger_grants,
         }),
-        Box::new(DefineLedger { ctx }),
+        Box::new(DefineLedger {
+            ctx,
+            can_declare_ledgers,
+        }),
     ]
 }
 

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -523,6 +523,7 @@ impl Tool for RecordEntry {
 struct CloseEntry {
     ctx: Ledgers,
     author: LedgerAuthor,
+    ledger_grants: Option<Vec<LedgerGrant>>,
 }
 
 #[async_trait]

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -320,6 +320,7 @@ impl Tool for ListLedgers {
 
 struct ReadLedger {
     ctx: Ledgers,
+    ledger_grants: Option<Vec<LedgerGrant>>,
 }
 
 #[async_trait]

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -378,6 +378,9 @@ impl Tool for ReadLedger {
             Ok(spec) => spec,
             Err(message) => return Ok(ToolResult::error(message)),
         };
+        if let Err(message) = require_access(&self.ledger_grants, &spec.slug, LedgerAccess::Read) {
+            return Ok(ToolResult::error(message));
+        }
         let query = Query {
             entry: optional(&arguments, "entry"),
             status: optional(&arguments, "status"),

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -486,6 +486,10 @@ impl Tool for RecordEntry {
             Ok(spec) => spec,
             Err(message) => return Ok(ToolResult::error(message)),
         };
+        if let Err(message) = require_access(&self.ledger_grants, &spec.slug, LedgerAccess::Record)
+        {
+            return Ok(ToolResult::error(message));
+        }
         let id = text(&arguments, "id");
         match ledgers::record(
             &self.ctx,

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -259,7 +259,11 @@ impl Tool for ListLedgers {
             }
         };
         let mut out = String::new();
-        for spec in registry.specs() {
+        for spec in registry
+            .specs()
+            .iter()
+            .filter(|spec| ledger_access(&self.ledger_grants, &spec.slug).is_some())
+        {
             let entries = ledgers::entries(&self.ctx, spec).await.unwrap_or_default();
             out.push_str(&format!(
                 "- `{}` — {}\n  statuses: {}\n  {} open, {} closed\n",

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -440,6 +440,7 @@ impl Tool for ReadLedger {
 struct RecordEntry {
     ctx: Ledgers,
     author: LedgerAuthor,
+    ledger_grants: Option<Vec<LedgerGrant>>,
 }
 
 #[async_trait]

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -601,6 +601,7 @@ impl Tool for CloseEntry {
 
 struct DefineLedger {
     ctx: Ledgers,
+    can_declare_ledgers: bool,
 }
 
 #[async_trait]

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -225,6 +225,7 @@ fn ledger_argument() -> Value {
 
 struct ListLedgers {
     ctx: Ledgers,
+    ledger_grants: Option<Vec<LedgerGrant>>,
 }
 
 #[async_trait]

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -570,6 +570,10 @@ impl Tool for CloseEntry {
             Ok(spec) => spec,
             Err(message) => return Ok(ToolResult::error(message)),
         };
+        if let Err(message) = require_access(&self.ledger_grants, &spec.slug, LedgerAccess::Record)
+        {
+            return Ok(ToolResult::error(message));
+        }
         match ledgers::close(
             &self.ctx,
             &spec,

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -170,6 +170,30 @@ async fn spec_for(ctx: &Ledgers, arguments: &Value) -> Result<LedgerSpec, String
         .map_err(|error| format!("{error}"))
 }
 
+/// Refuses `slug` when `grants` does not give at least `need`.
+///
+/// `Record` implies `Read` — recording requires reading nothing extra. Named
+/// so every ledger tool refuses in the same words, whether the reason is "not
+/// in your declared list" or "declared read-only for you".
+fn require_access(
+    grants: &Option<Vec<LedgerGrant>>,
+    slug: &str,
+    need: LedgerAccess,
+) -> Result<(), String> {
+    match ledger_access(grants, slug) {
+        Some(LedgerAccess::Record) => Ok(()),
+        Some(LedgerAccess::Read) if need == LedgerAccess::Read => Ok(()),
+        Some(LedgerAccess::Read) => Err(format!(
+            "Refused: your manifest grants only read access to `{slug}`. Recording or closing a \
+             row needs `record` access — ask the operator to change your `ledgers` grant."
+        )),
+        None => Err(format!(
+            "Refused: `{slug}` is not in your declared `ledgers` grant. `list_ledgers` names what \
+             you can reach."
+        )),
+    }
+}
+
 fn text(arguments: &Value, key: &str) -> String {
     arguments
         .get(key)

--- a/src/harness/ledger_tools.rs
+++ b/src/harness/ledger_tools.rs
@@ -692,6 +692,13 @@ impl Tool for DefineLedger {
     }
 
     async fn execute(&self, arguments: Value) -> anyhow::Result<ToolResult> {
+        if !self.can_declare_ledgers {
+            return Ok(ToolResult::error(
+                "Refused: your manifest sets `can_declare_ledgers = false`. Ask the operator to \
+                 declare this axis, or to grant you `define_ledger`."
+                    .to_string(),
+            ));
+        }
         match ledgers::define(&self.ctx, &arguments).await {
             Ok(spec) => Ok(ToolResult::success(format!(
                 "Declared `{}`. It renders into `{}` and takes `record_entry` with \

--- a/src/harness/ledger_tools_test.rs
+++ b/src/harness/ledger_tools_test.rs
@@ -15,7 +15,7 @@ fn ctx(home: &tempfile::TempDir) -> Ledgers {
 }
 
 fn tools(ctx: &Ledgers) -> Vec<Box<dyn Tool>> {
-    ledger_tools(ctx.clone(), "ceo".to_string())
+    ledger_tools(ctx.clone(), "ceo".to_string(), None, true)
 }
 
 fn tool<'a>(tools: &'a [Box<dyn Tool>], name: &str) -> &'a dyn Tool {

--- a/src/harness/ledger_tools_test.rs
+++ b/src/harness/ledger_tools_test.rs
@@ -309,3 +309,107 @@ fn every_schema_requires_the_ledger_argument() {
         assert!(required.contains(&"ledger"), "`{name}`: {schema}");
     }
 }
+
+// -- per-agent ledger grants (`[[agent]].ledgers`) ---------------------------
+
+/// An omitted `ledgers` grant is unrestricted: `list_ledgers` names every
+/// ledger, matching the tool surface before this field existed.
+#[tokio::test]
+async fn an_unscoped_agent_lists_every_ledger() {
+    let home = tempfile::tempdir().unwrap();
+    let ctx = ctx(&home);
+    let tools = ledger_tools(ctx, "ceo".to_string(), None, true);
+    let result = tool(&tools, LIST_LEDGERS_TOOL)
+        .execute(json!({}))
+        .await
+        .unwrap();
+    let text = format!("{result:?}");
+    for slug in ["tasks", "goals", "decisions"] {
+        assert!(text.contains(slug), "`{slug}` missing: {text}");
+    }
+}
+
+/// A declared `ledgers` grant confines `list_ledgers` to exactly what it
+/// names — a ledger left off the list does not appear.
+#[tokio::test]
+async fn a_scoped_agent_lists_only_its_declared_ledgers() {
+    let home = tempfile::tempdir().unwrap();
+    let ctx = ctx(&home);
+    let grants = vec![crate::company::LedgerGrant {
+        name: "tasks".to_string(),
+        access: crate::company::LedgerAccess::Record,
+    }];
+    let tools = ledger_tools(ctx, "ceo".to_string(), Some(grants), true);
+    let result = tool(&tools, LIST_LEDGERS_TOOL)
+        .execute(json!({}))
+        .await
+        .unwrap();
+    let text = format!("{result:?}");
+    assert!(text.contains("tasks"), "{text}");
+    assert!(!text.contains("goals"), "{text}");
+    assert!(!text.contains("decisions"), "{text}");
+}
+
+/// `read_ledger` on a slug this agent's grant does not name is refused —
+/// visibility, not merely write access, is what the grant governs.
+#[tokio::test]
+async fn reading_an_undeclared_ledger_is_refused() {
+    let home = tempfile::tempdir().unwrap();
+    let ctx = ctx(&home);
+    let grants = vec![crate::company::LedgerGrant {
+        name: "tasks".to_string(),
+        access: crate::company::LedgerAccess::Record,
+    }];
+    let tools = ledger_tools(ctx, "ceo".to_string(), Some(grants), true);
+    let result = tool(&tools, READ_LEDGER_TOOL)
+        .execute(json!({ "ledger": "goals" }))
+        .await
+        .unwrap();
+    assert!(result.is_error);
+    let text = format!("{result:?}");
+    assert!(text.contains("goals"), "{text}");
+}
+
+/// A `read`-only grant answers `read_ledger` but refuses `record_entry`.
+#[tokio::test]
+async fn a_read_only_grant_refuses_record_entry() {
+    let home = tempfile::tempdir().unwrap();
+    let ctx = ctx(&home);
+    let grants = vec![crate::company::LedgerGrant {
+        name: "goals".to_string(),
+        access: crate::company::LedgerAccess::Read,
+    }];
+    let tools = ledger_tools(ctx, "ceo".to_string(), Some(grants), true);
+
+    let read = tool(&tools, READ_LEDGER_TOOL)
+        .execute(json!({ "ledger": "goals" }))
+        .await
+        .unwrap();
+    assert!(!read.is_error, "{read:?}");
+
+    let record = tool(&tools, RECORD_ENTRY_TOOL)
+        .execute(json!({
+            "ledger": "goals",
+            "id": "grow-mrr",
+            "fields": { "goal": "grow MRR", "status": "open" }
+        }))
+        .await
+        .unwrap();
+    assert!(record.is_error);
+    assert!(format!("{record:?}").contains("record"));
+}
+
+/// `can_declare_ledgers = false` refuses `define_ledger` outright, whatever
+/// the manifest's other ledger grants say.
+#[tokio::test]
+async fn can_declare_ledgers_false_refuses_define_ledger() {
+    let home = tempfile::tempdir().unwrap();
+    let ctx = ctx(&home);
+    let tools = ledger_tools(ctx, "ceo".to_string(), None, false);
+    let result = tool(&tools, DEFINE_LEDGER_TOOL)
+        .execute(risks())
+        .await
+        .unwrap();
+    assert!(result.is_error);
+    assert!(format!("{result:?}").contains("can_declare_ledgers"));
+}

--- a/src/harness/mcp.rs
+++ b/src/harness/mcp.rs
@@ -667,6 +667,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         }
     }
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -2797,6 +2797,8 @@ fn overlay_agent_to_manifest(overlay: &OverlayAgent) -> ManifestAgent {
         prompt_files: Vec::new(),
         prompt_files_resolved: Vec::new(),
         classes: Vec::new(),
+        ledgers: None,
+        can_declare_ledgers: true,
     }
 }
 
@@ -6131,6 +6133,8 @@ budget_usd_daily = 0.0
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let policy = ApprovalPolicy::new(&Policy::default(), None);
         let grants: Vec<String> = grants.iter().map(|g| g.to_string()).collect();
@@ -6247,6 +6251,8 @@ budget_usd_daily = 0.0
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         };
         let agent = build::build_agent(
             &CompanyId::new("acme"),

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -4589,6 +4589,8 @@ mod tests {
             prompt_files: Vec::new(),
             prompt_files_resolved: Vec::new(),
             classes: Vec::new(),
+            ledgers: None,
+            can_declare_ledgers: true,
         }
     }
 

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -404,12 +404,22 @@ impl CompanyWorkspace {
         let Some(scope) = &self.write_scope else {
             return true;
         };
-        if let Ok(segments) = super::workspace_paths::split_logical_path(path)
-            && (self.is_own_home(&segments) || self.is_strictly_inside_own_home(&segments))
-        {
+        let Ok(segments) = super::workspace_paths::split_logical_path(path) else {
+            // A traversal-shaped or malformed path is refused by the tool's own
+            // validation before this is reached; treating it as out of scope
+            // here is the same answer by the same reasoning.
+            return false;
+        };
+        if self.is_own_home(&segments) || self.is_strictly_inside_own_home(&segments) {
             return true;
         }
-        scope.iter().any(|allowed| allowed.trim() == path.trim())
+        let key = segments.join("/");
+        scope.iter().any(|allowed| {
+            super::workspace_paths::split_logical_path(allowed)
+                .map(|allowed_segments| allowed_segments.join("/"))
+                .as_deref()
+                == Ok(key.as_str())
+        })
     }
 
     /// This agent's origin, for stamping [`WorkspaceNode::created_by`] /

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -2029,8 +2029,11 @@ pub fn workspace_tools(
     company: CompanyId,
     agent_id: String,
     can_write: bool,
+    write_scope: Option<Vec<String>>,
 ) -> Vec<Box<dyn Tool>> {
-    let workspace = CompanyWorkspace::new(store, company, agent_id).with_artifacts(artifacts);
+    let workspace = CompanyWorkspace::new(store, company, agent_id)
+        .with_artifacts(artifacts)
+        .with_write_scope(write_scope);
     let mut tools: Vec<Box<dyn Tool>> = vec![
         Box::new(WorkspaceListTool::new(workspace.clone())),
         Box::new(WorkspaceReadTool::new(workspace.clone())),

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -4879,7 +4879,11 @@ mod tests {
         let out = text(&result);
         assert!(out.contains("write scope"), "{out}");
 
-        let (node, body) = store.read(&id, "n-eng").await.unwrap().expect("still there");
+        let (node, body) = store
+            .read(&id, "n-eng")
+            .await
+            .unwrap()
+            .expect("still there");
         assert_eq!(node.updated_at_millis, 2_000, "untouched");
         assert_eq!(body, "# Engineering\nReview every PR.");
     }
@@ -4889,9 +4893,8 @@ mod tests {
     async fn workspace_write_allows_a_path_inside_the_declared_write_scope() {
         let (_dir, store) = seeded("acme").await;
         let id = CompanyId::new("acme");
-        let workspace = ws(store.clone(), id.clone()).with_write_scope(Some(vec![
-            "Standards/Engineering standards.md".to_string(),
-        ]));
+        let workspace = ws(store.clone(), id.clone())
+            .with_write_scope(Some(vec!["Standards/Engineering standards.md".to_string()]));
         let tool = WorkspaceWriteTool::new(workspace);
 
         let result = tool

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -1561,6 +1561,15 @@ impl Tool for WorkspaceWriteTool {
             Err(e) => return Ok(ToolResult::error(e.message())),
         };
 
+        if !self.workspace.write_allowed(&entry.path) {
+            return Ok(ToolResult::error(format!(
+                "Refused: `{}` is outside your declared write scope. Your manifest confines \
+                 `workspace_write` to specific paths — ask the operator to add this one, or work \
+                 in `Agents/<your agent id>/`, which is always writable.",
+                entry.path
+            )));
+        }
+
         if entry.node.kind == NodeKind::Folder {
             return Ok(ToolResult::error(format!(
                 "Refused: `{}` is a folder, not a note. Only notes have a body to overwrite.",

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -32,21 +32,34 @@
 //! session cache, so a note edited in the console between two turns changes
 //! what the agent quotes on the next turn with no agent rebuild.
 //!
-//! # Agents write unconfined — and why that is the right call (issue #551)
+//! # Agents write unconfined by default — and per-path scope is opt-in (issue #551, revisited)
 //!
-//! There is no prefix gate here. An agent may create and overwrite anywhere in
-//! the company's tree, exactly as `workspace_write` always could. Confining
+//! There is still no prefix gate by default. An agent may create and overwrite
+//! anywhere in the company's tree, exactly as `workspace_write` always could,
+//! unless its manifest opts into a narrower scope — see below. Confining
 //! *create* to `Agents/<id>/` while leaving *overwrite* free would protect
 //! nothing — overwriting an existing standard is the strictly more destructive
-//! of the two operations — so the confinement would be theatre with a
-//! maintenance cost.
+//! of the two operations — so a confinement that stopped at create alone would
+//! be theatre with a maintenance cost.
 //!
-//! What replaces it is a steering-plus-attribution pair. [`workspace_brief`]
-//! and the tool descriptions name `Agents/<your agent id>/` as the default home
-//! for anything an agent produces and mark shared guidance as something to
-//! touch only on purpose; and every node records who created it and who last
-//! wrote it (issue #326), so a mess is legible and reversible rather than
-//! anonymous.
+//! What replaces that as the default is a steering-plus-attribution pair.
+//! [`workspace_brief`] and the tool descriptions name `Agents/<your agent id>/`
+//! as the default home for anything an agent produces and mark shared guidance
+//! as something to touch only on purpose; and every node records who created
+//! it and who last wrote it (issue #326), so a mess is legible and reversible
+//! rather than anonymous.
+//!
+//! A manifest may narrow this for one agent by declaring at least one
+//! `context` entry with `access = "write"` (see
+//! [`crate::company::Agent::write_scope`]). That agent's `workspace_write` and
+//! `workspace_create` are then confined to exactly the paths it declared, plus
+//! its own `Agents/<id>/` home, which stays writable regardless — a role given
+//! a real access list keeps its ability to produce and revise its own work.
+//! **This is opt-in, not the default**: a manifest that declares no write
+//! entry is unaffected, so every company written before this existed keeps the
+//! unconfined behaviour above. A role written to scope real risk — e.g. a
+//! narrow specialist that should touch only its own briefs — can now have that
+//! enforced rather than merely asked for in a description.
 //!
 //! Issue #671 added the other half of that bargain. An agent that can only
 //! produce leaves every superseded draft in place forever, under whatever name

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -4837,6 +4837,121 @@ mod tests {
         assert_eq!(node.size, Some(6));
     }
 
+    /// A manifest that declares no write-scoped `context` entry is unconfined
+    /// — `workspace_write` reaches anywhere in the tree, exactly as before this
+    /// existed. This is the regression the opt-in confinement must not cause.
+    #[tokio::test]
+    async fn workspace_write_stays_unconfined_by_default() {
+        let (_dir, store) = seeded("acme").await;
+        let tool = WorkspaceWriteTool::new(ws(store.clone(), CompanyId::new("acme")));
+
+        let result = tool
+            .execute(json!({
+                "id": "n-eng",
+                "content": "# Engineering\nRevised.",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text(&result));
+    }
+
+    /// A manifest that declares a write-scoped `context` entry confines
+    /// `workspace_write` to exactly those paths — a path outside the scope is
+    /// refused, and the tree is untouched.
+    #[tokio::test]
+    async fn workspace_write_refuses_a_path_outside_the_declared_write_scope() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let workspace = ws(store.clone(), id.clone())
+            .with_write_scope(Some(vec!["Somewhere/Else.md".to_string()]));
+        let tool = WorkspaceWriteTool::new(workspace);
+
+        let result = tool
+            .execute(json!({
+                "id": "n-eng",
+                "content": "# Engineering\nRevised.",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(result.is_error, "{}", text(&result));
+        let out = text(&result);
+        assert!(out.contains("write scope"), "{out}");
+
+        let (node, body) = store.read(&id, "n-eng").await.unwrap().expect("still there");
+        assert_eq!(node.updated_at_millis, 2_000, "untouched");
+        assert_eq!(body, "# Engineering\nReview every PR.");
+    }
+
+    /// A path that *is* in the declared write scope still succeeds.
+    #[tokio::test]
+    async fn workspace_write_allows_a_path_inside_the_declared_write_scope() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let workspace = ws(store.clone(), id.clone()).with_write_scope(Some(vec![
+            "Standards/Engineering standards.md".to_string(),
+        ]));
+        let tool = WorkspaceWriteTool::new(workspace);
+
+        let result = tool
+            .execute(json!({
+                "id": "n-eng",
+                "content": "# Engineering\nRevised.",
+                "expected_updated_at": 2_000,
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text(&result));
+    }
+
+    /// A write-scoped agent may still create inside its own `Agents/<id>/`
+    /// home — the scope narrows the shared tree, not the ability to produce
+    /// and revise its own work.
+    #[tokio::test]
+    async fn a_write_scoped_agent_can_still_create_in_its_own_home() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let workspace = ws(store.clone(), id.clone())
+            .with_write_scope(Some(vec!["Somewhere/Else.md".to_string()]));
+        let tool = WorkspaceCreateTool::new(workspace);
+
+        let result = tool
+            .execute(json!({
+                "path": "Agents/ceo/Notes.md",
+                "kind": "file",
+                "content": "# Notes"
+            }))
+            .await
+            .unwrap();
+        assert!(!result.is_error, "{}", text(&result));
+    }
+
+    /// The other half: `workspace_create` at a shared path outside scope is
+    /// refused before anything is written.
+    #[tokio::test]
+    async fn workspace_create_refuses_a_path_outside_the_declared_write_scope() {
+        let (_dir, store) = seeded("acme").await;
+        let id = CompanyId::new("acme");
+        let workspace = ws(store.clone(), id.clone())
+            .with_write_scope(Some(vec!["Somewhere/Else.md".to_string()]));
+        let tool = WorkspaceCreateTool::new(workspace);
+
+        let result = tool
+            .execute(json!({
+                "path": "Standards/New standard.md",
+                "kind": "file",
+                "content": "# New"
+            }))
+            .await
+            .unwrap();
+        assert!(result.is_error, "{}", text(&result));
+        assert!(text(&result).contains("write scope"));
+
+        let tree = store.tree(&id).await.unwrap();
+        assert!(!tree.iter().any(|n| n.name == "New standard.md"));
+    }
+
     /// The listing marks a payload, so an agent never spends a `workspace_read`
     /// call to discover that a file is not text.
     #[tokio::test]

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -404,7 +404,7 @@ impl CompanyWorkspace {
         let Some(scope) = &self.write_scope else {
             return true;
         };
-        let Ok(segments) = super::workspace_paths::split_logical_path(path) else {
+        let Ok(segments) = crate::company::workspace_paths::split_logical_path(path) else {
             // A traversal-shaped or malformed path is refused by the tool's own
             // validation before this is reached; treating it as out of scope
             // here is the same answer by the same reasoning.
@@ -415,7 +415,7 @@ impl CompanyWorkspace {
         }
         let key = segments.join("/");
         scope.iter().any(|allowed| {
-            super::workspace_paths::split_logical_path(allowed)
+            crate::company::workspace_paths::split_logical_path(allowed)
                 .map(|allowed_segments| allowed_segments.join("/") == key)
                 .unwrap_or(false)
         })

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -416,9 +416,8 @@ impl CompanyWorkspace {
         let key = segments.join("/");
         scope.iter().any(|allowed| {
             super::workspace_paths::split_logical_path(allowed)
-                .map(|allowed_segments| allowed_segments.join("/"))
-                .as_deref()
-                == Ok(key.as_str())
+                .map(|allowed_segments| allowed_segments.join("/") == key)
+                .unwrap_or(false)
         })
     }
 

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -352,6 +352,11 @@ pub struct CompanyWorkspace {
     /// default, and every construction site but the agent builder's — means the
     /// write tool behaves exactly as it did before #552.
     artifacts: Option<Arc<dyn ArtifactStore>>,
+    /// This agent's `workspace_write`/`workspace_create` scope — see
+    /// [`crate::company::Agent::write_scope`]. `None` (the default, and every
+    /// construction site but the agent builder's) is unconfined, the behaviour
+    /// this module had before per-path write scope existed.
+    write_scope: Option<Vec<String>>,
 }
 
 impl CompanyWorkspace {
@@ -362,6 +367,7 @@ impl CompanyWorkspace {
             company,
             agent_id,
             artifacts: None,
+            write_scope: None,
         }
     }
 
@@ -375,6 +381,35 @@ impl CompanyWorkspace {
     pub fn with_artifacts(mut self, artifacts: Option<Arc<dyn ArtifactStore>>) -> Self {
         self.artifacts = artifacts;
         self
+    }
+
+    /// Confine `workspace_write`/`workspace_create` to `scope` (see
+    /// [`crate::company::Agent::write_scope`]) — another builder for the same
+    /// reason `with_artifacts` is: irrelevant to the read tools, and every
+    /// existing construction site should keep the unconfined default.
+    pub fn with_write_scope(mut self, scope: Option<Vec<String>>) -> Self {
+        self.write_scope = scope;
+        self
+    }
+
+    /// Whether `path` is inside this agent's write scope.
+    ///
+    /// `None` scope is unconfined — every path is in scope, matching the
+    /// behaviour every agent had before this existed. `Some(paths)` allows an
+    /// exact match against a declared path, or anything under this agent's own
+    /// `Agents/<id>/` home, which stays writable regardless of scope: a role
+    /// narrowed to a real access list must not also lose the ability to
+    /// produce and revise its own work.
+    fn write_allowed(&self, path: &str) -> bool {
+        let Some(scope) = &self.write_scope else {
+            return true;
+        };
+        if let Ok(segments) = super::workspace_paths::split_logical_path(path)
+            && self.is_own_home(&segments) || self.is_strictly_inside_own_home(&segments)
+        {
+            return true;
+        }
+        scope.iter().any(|allowed| allowed.trim() == path.trim())
     }
 
     /// This agent's origin, for stamping [`WorkspaceNode::created_by`] /

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -4599,6 +4599,7 @@ mod tests {
             CompanyId::new("acme"),
             TEST_AGENT.to_string(),
             false,
+            None,
         );
         let names: Vec<&str> = read_only.iter().map(|t| t.name()).collect();
         assert_eq!(
@@ -4619,6 +4620,7 @@ mod tests {
             CompanyId::new("acme"),
             TEST_AGENT.to_string(),
             true,
+            None,
         );
         let names: Vec<&str> = writable.iter().map(|t| t.name()).collect();
         assert_eq!(
@@ -4649,6 +4651,7 @@ mod tests {
             CompanyId::new("acme"),
             TEST_AGENT.to_string(),
             true,
+            None,
         );
         assert_eq!(tools[0].permission_level(), PermissionLevel::ReadOnly);
         assert_eq!(tools[1].permission_level(), PermissionLevel::ReadOnly);

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -1855,6 +1855,15 @@ impl Tool for WorkspaceCreateTool {
             Err(why) => return Ok(ToolResult::error(format!("Invalid `path`: {why}."))),
         };
         let normalized = segments.join("/");
+
+        if !self.workspace.write_allowed(&normalized) {
+            return Ok(ToolResult::error(format!(
+                "Refused: `{normalized}` is outside your declared write scope. Your manifest \
+                 confines `workspace_create` to specific paths — ask the operator to add this \
+                 one, or work in `Agents/<your agent id>/`, which is always writable."
+            )));
+        }
+
         let (parent_segments, name) = segments.split_at(segments.len() - 1);
         let name = name[0];
 

--- a/src/harness/workspace_tools.rs
+++ b/src/harness/workspace_tools.rs
@@ -405,7 +405,7 @@ impl CompanyWorkspace {
             return true;
         };
         if let Ok(segments) = super::workspace_paths::split_logical_path(path)
-            && self.is_own_home(&segments) || self.is_strictly_inside_own_home(&segments)
+            && (self.is_own_home(&segments) || self.is_strictly_inside_own_home(&segments))
         {
             return true;
         }

--- a/src/metering/mod.rs
+++ b/src/metering/mod.rs
@@ -121,6 +121,8 @@ mod tests {
                 prompt_files: Vec::new(),
                 prompt_files_resolved: Vec::new(),
                 classes: Vec::new(),
+                ledgers: None,
+                can_declare_ledgers: true,
             },
             Agent {
                 id: "creative".into(),
@@ -135,6 +137,8 @@ mod tests {
                 prompt_files: Vec::new(),
                 prompt_files_resolved: Vec::new(),
                 classes: Vec::new(),
+                ledgers: None,
+                can_declare_ledgers: true,
             },
         ];
         let overlay = vec![OverlayAgent {


### PR DESCRIPTION
## Summary

Extends the per-agent manifest schema (`company.toml` `[[agent]]` / `agents/<id>.toml`) with three related access-control primitives, plus a shared `AGENTS.md` working-agreement document:

- **`AGENTS.md`** joins `METHOD.md` as a universal routed document (`context_routing::UNIVERSAL_DOCUMENTS`) — every agent gets both, unconditionally and exempt from class exclusions, the same way `METHOD.md` already was. Missing is skipped, not an error, same as any other routed document.
- **`context` write access** — a `context` entry can now be `{ path, access = "write" }` instead of a bare string (`ContextEntry`, backward compatible: a bare string still deserializes as `Read`). Declaring at least one `access = "write"` entry opts an agent into a **confined** `workspace_write`/`workspace_create` scope — exactly the declared paths, plus its own `Agents/<id>/` home, which stays writable regardless. Declaring **no** write entry (or omitting `context` entirely) is unconfined, matching every manifest written before this existed. This deliberately narrows the documented "agents write unconfined" decision from `src/harness/workspace_tools.rs` (issue #551) — the module doc now explains the reversal and why it's opt-in.
- **`ledgers` grants** — a new `[[agent]].ledgers = [{ name, access = "read" | "record" }]` list scopes which of the company's ledgers an agent's five ledger tools (`list_ledgers`, `read_ledger`, `record_entry`, `close_entry`, `define_ledger`) can see and use. Omitted `ledgers` is unrestricted (today's behavior, no-op for existing companies). This is the **visibility/read-record** axis; `LedgerSpec.writers` stays authoritative for whether a write actually lands — an `access = "record"` grant that a built-in ledger's `writers` excludes is now a manifest validation error rather than a silent runtime refusal. `can_declare_ledgers` (default `true`) separately gates `define_ledger`.

## Why

Per-workspace `AGENTS.md` plus per-agent declared file/ledger access, inspired by a similar pattern in another repo in this workspace. Design was scoped with the user up front (universal routed doc, extend `context` rather than add a parallel key, agent-side ledger grants layered on top of the existing `LedgerSpec.writers`, and explicit sign-off to reverse the #551 unconfined-write default as an opt-in).

## Changes

- `src/company/types.rs`: `ContextEntry`/`ContextAccess`, `LedgerGrant`/`LedgerAccess`, `Agent::write_scope()`, `Agent::ledger_access()`, `Agent.ledgers`, `Agent.can_declare_ledgers`.
- `src/company/context_routing.rs`: `AGENTS_DOC` + `UNIVERSAL_DOCUMENTS`.
- `src/company/agent_file.rs`, `src/company/mod.rs`: wire the new fields through the per-file roster form and public exports.
- `src/company/manifest.rs`: `ledger_grant_problems` — validates `record` grants against built-in ledgers' `writers`.
- `src/harness/workspace_tools.rs`: `CompanyWorkspace::write_scope` / `write_allowed`, enforced in `WorkspaceWriteTool` and `WorkspaceCreateTool`; module doc updated to explain the opt-in reversal of issue #551.
- `src/harness/ledger_tools.rs`, `src/harness/build.rs`: per-agent grant enforcement across all five ledger tools.
- `docs/spec/runtime/agents.md`, `docs/spec/runtime/ledgers.md`, `docs/spec/runtime/orchestration/context-routing.md`: schema and behavior docs.

## Test plan

- `cargo fmt --all -- --check`
- `cargo clippy --all-targets --features openhuman -- -D warnings`
- `RUST_MIN_STACK=16777216 cargo test --features openhuman --lib` — 4115 passed, 0 failed
- `cargo check --all-features`
- New unit tests: `Agent::write_scope`/`ledger_access` (types.rs), workspace write/create scope enforcement incl. own-home exemption (workspace_tools.rs), per-agent ledger grant visibility/read-vs-record/`can_declare_ledgers` (ledger_tools_test.rs), manifest validation for grant/writers disagreement (manifest.rs).