### PR TITLE
Settings → Hosting: put a company's workspace on a real hosting provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "axum-macros",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -455,6 +456,17 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aa268c23bfbbd2c4363b9cd302a4f504fb2a9dfe7e3451d66f35dd392e20aca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1782,18 +1794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
-dependencies = [
- "bitflags 2.13.1",
- "libc",
- "libgit2-sys",
- "log",
-]
-
-[[package]]
 name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2643,18 +2643,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
-name = "libgit2-sys"
-version = "0.18.7+1.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2676,18 +2664,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
 dependencies = [
  "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bc9657773828b90eeb625adff10eeac83cc21bbfd8e23a03eaa8a33c9e28d9"
-dependencies = [
- "cc",
- "libc",
  "pkg-config",
  "vcpkg",
 ]
@@ -3232,7 +3208,6 @@ dependencies = [
  "fs2",
  "futures",
  "futures-util",
- "git2",
  "glob",
  "hex",
  "hkdf",
@@ -3267,8 +3242,13 @@ dependencies = [
  "tinychannels",
  "tinycortex",
  "tinycortex-api",
+ "tinyhosts",
  "tinyhumans-sdk",
  "tinyjuice",
+ "tinymemory",
+ "tinymemory-api",
+ "tinymemory-core",
+ "tinymemory-tinycortex",
  "tinyplace",
  "tokio",
  "tokio-stream",
@@ -4846,8 +4826,6 @@ dependencies = [
  "chrono",
  "dirs 5.0.1",
  "futures",
- "git2",
- "hex",
  "log",
  "parking_lot",
  "rand 0.10.2",
@@ -4903,6 +4881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyhosts"
+version = "0.1.5"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "hex",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "tinyhumans-sdk"
 version = "0.1.0"
 dependencies = [
@@ -4936,6 +4928,77 @@ dependencies = [
  "tokio",
  "unicode-segmentation",
  "unicode-width",
+]
+
+[[package]]
+name = "tinymemory"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "log",
+ "serde",
+ "serde_json",
+ "tinymemory-api",
+]
+
+[[package]]
+name = "tinymemory-api"
+version = "0.1.1"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "log",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.20",
+ "uuid",
+]
+
+[[package]]
+name = "tinymemory-core"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "dirs 5.0.1",
+ "futures",
+ "log",
+ "parking_lot",
+ "rand 0.8.7",
+ "regex",
+ "reqwest",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "thiserror 2.0.20",
+ "tinyagents",
+ "tinycortex",
+ "tinycortex-api",
+ "tinymemory",
+ "tinymemory-api",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "walkdir",
+]
+
+[[package]]
+name = "tinymemory-tinycortex"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "tinycortex",
+ "tinymemory",
+ "tinymemory-api",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,11 @@ tinyagents = { path = "vendor/openhuman/vendor/tinyagents", optional = true, fea
 # domain. The feature carries no extra deps (`skills = []` upstream) — it only
 # recompiles the skills domain modules. TinyAgents is consumed from OpenHuman's
 # own pin so both crates always share one trait identity and cannot drift.
-openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false, features = ["skills", "mcp"] }
+# `hosting` adds the `hosting_*` tools and the `tinyhosts` unified hosting API
+# behind them (`openhuman::hosting`), which is what lets a company put its
+# workspace on a real hosting provider. Taken without OpenHuman's TinyBus
+# module: `tinyhosts` is linked as a library, so nothing here loads a cdylib.
+openhuman_core = { package = "openhuman", path = "vendor/openhuman", optional = true, default-features = false, features = ["skills", "mcp", "hosting"] }
 # The openhuman `Provider`/`Memory` traits return `anyhow::Result` and log via
 # the `log` facade; both only link under the `openhuman` feature.
 anyhow = { version = "1", optional = true }

--- a/examples/live_company_turn.rs
+++ b/examples/live_company_turn.rs
@@ -144,6 +144,7 @@ async fn main() -> anyhow::Result<()> {
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: opencompany::company::steer::InflightRegistry::default(),
         run_supervisor: opencompany::runtime::RunSupervisor::default(),
         delivery: None,

--- a/frontend/src/api/hosting.ts
+++ b/frontend/src/api/hosting.ts
@@ -1,0 +1,75 @@
+// The hosting configuration API: where a company's hosting provider API key is
+// stored so its agents can deploy a workspace to the public internet.
+//
+// The key is write-only: it is sent on save into the host's secret store and is
+// never returned. The read shape carries booleans, the provider slug and the
+// team scope only, so there is no field on this type that could leak a key into
+// a rendered page.
+//
+// Standalone functions over the shared client, mirroring `api/billing.ts`, so
+// `OpenCompanyClient` needs no new methods.
+
+import type { OpenCompanyClient } from "./client";
+
+/**
+ * The non-secret view of a company's hosting configuration.
+ *
+ * Three separate flags rather than one `connected`, because they fail
+ * differently and a single boolean sends an operator to the wrong place for two
+ * of them — see `HostingView` for how each is worded.
+ */
+export interface HostingStatus {
+  /** Whether an API key is stored. Never the key. */
+  apiKeyConfigured: boolean;
+  /** The provider the key belongs to, e.g. `vercel`. Not secret. */
+  provider: string;
+  /** The team/organization scope, or null for a personal account. */
+  team: string | null;
+  /** Whether the company's manifest explicitly grants `hosting`. */
+  granted: boolean;
+  /** Whether the running host has the hosting tools compiled in. */
+  inBuild: boolean;
+  /** The providers a key can be stored for in this build. */
+  supportedProviders: string[];
+}
+
+/** The write-only save body. Omitted fields keep their stored value. */
+export interface HostingConfig {
+  /** Write-only. Omit to leave the stored key unchanged. */
+  apiKey?: string;
+  /** The provider slug. Omit to leave it unchanged. */
+  provider?: string;
+  /** The team/organization scope. Omit to leave it unchanged. */
+  team?: string;
+}
+
+/** Reads the company's hosting configuration status. */
+export async function getHosting(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<HostingStatus> {
+  return client.get<HostingStatus>(`${client.scopeFor(company)}/hosting`);
+}
+
+/**
+ * Saves whatever is supplied, and returns the resulting status.
+ *
+ * A patch, not a replace: the host applies only the fields present and
+ * non-empty, so correcting the team never means re-typing the API key — which an
+ * operator cannot do anyway, since it is never shown back to them.
+ */
+export async function saveHosting(
+  client: OpenCompanyClient,
+  company: string | null,
+  config: HostingConfig,
+): Promise<HostingStatus> {
+  return client.put<HostingStatus>(`${client.scopeFor(company)}/hosting`, config);
+}
+
+/** Clears every stored hosting credential. */
+export async function clearHosting(
+  client: OpenCompanyClient,
+  company: string | null,
+): Promise<HostingStatus> {
+  return client.del<HostingStatus>(`${client.scopeFor(company)}/hosting/key`);
+}

--- a/frontend/src/views/HostingView.tsx
+++ b/frontend/src/views/HostingView.tsx
@@ -1,0 +1,278 @@
+import { useCallback, useEffect, useState } from "react";
+import { Check, Globe, Loader2, TriangleAlert } from "lucide-react";
+import { toast } from "sonner";
+
+import {
+  clearHosting,
+  getHosting,
+  saveHosting,
+  type HostingStatus,
+} from "@/api/hosting";
+import type { OpenCompanyClient } from "@/api/client";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface Props {
+  client: OpenCompanyClient;
+  company: string | null;
+}
+
+/** The message out of a rejected request, whatever it was rejected with. */
+function reason(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Settings → Hosting: the company's hosting provider connection.
+ *
+ * With a key stored here and the `hosting` grant in the manifest, a teammate can
+ * put a site in this company's workspace on the public internet — with a managed
+ * database wired into it, environment variables set before the build, and a
+ * custom domain attached.
+ *
+ * # Why three states and not a "Connected ✓" badge
+ *
+ * Three separate things can each be missing, and two of them are invisible from
+ * this form's own fields:
+ *
+ *   - no key       — teammates have no hosting tools at all
+ *   - not granted  — the key is stored and STILL nothing reaches a teammate,
+ *                    because the manifest does not grant `hosting`. The fix is
+ *                    `company.toml`, not this page.
+ *   - not in build — the running host was compiled without the harness, so no
+ *                    amount of configuring will do anything.
+ *
+ * A single "Connected" badge would be green for the last two and send an
+ * operator hunting through this form for a problem that is not in it.
+ *
+ * # The key is write-only
+ *
+ * It is never returned by the host, so it is never rendered. A stored key shows
+ * as "Configured" and the input stays empty with a placeholder saying that
+ * typing replaces it — an input pre-filled with dots invites an operator to
+ * "correct" a value they cannot see, and submitting the dots would store the
+ * dots.
+ */
+export function HostingView({ client, company }: Props) {
+  const [status, setStatus] = useState<HostingStatus | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const [apiKey, setApiKey] = useState("");
+  const [team, setTeam] = useState("");
+
+  // Every piece of state here belongs to ONE company — including the
+  // typed-but-unsaved API key. `SettingsSection` renders this with
+  // `key={company}` so a company switch remounts rather than carrying a key
+  // typed for one company into another company's Save. See the same note in
+  // BillingView.
+  const load = useCallback(async () => {
+    try {
+      const next = await getHosting(client, company);
+      setStatus(next);
+      setLoadError(null);
+      // Seed the team box with what is stored — it is the one non-secret field,
+      // and an operator correcting a typo should not have to retype it.
+      setTeam(next.team ?? "");
+    } catch (err) {
+      setLoadError(reason(err));
+    }
+  }, [client, company]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function onSave() {
+    // Send only what was actually entered. The host treats this as a patch, so
+    // an untouched key keeps its stored value rather than being cleared.
+    const body: Record<string, string> = {};
+    if (apiKey.trim()) body.apiKey = apiKey.trim();
+    if (team.trim() && team.trim() !== (status?.team ?? "")) body.team = team.trim();
+
+    if (Object.keys(body).length === 0) {
+      toast.info("Nothing to save — fill in a field first.");
+      return;
+    }
+
+    setBusy(true);
+    try {
+      const next = await saveHosting(client, company, body);
+      setStatus(next);
+      // Clear the secret input on success: leaving a key sitting in a form field
+      // after it has been stored is one stray screen-share from a leak.
+      setApiKey("");
+      toast.success("Hosting settings saved.");
+    } catch (err) {
+      toast.error(reason(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onClear() {
+    setBusy(true);
+    try {
+      const next = await clearHosting(client, company);
+      setStatus(next);
+      setApiKey("");
+      setTeam("");
+      toast.success("Hosting credentials cleared.");
+    } catch (err) {
+      toast.error(reason(err));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (loadError) {
+    return (
+      <div className="mx-auto w-full max-w-5xl px-4 py-6">
+        <Alert variant="destructive" data-testid="hosting-load-error">
+          <TriangleAlert className="size-4" />
+          <AlertDescription>Could not load hosting settings: {loadError}</AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
+
+  if (!status) {
+    return (
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+        <Loader2 className="mr-2 size-4 animate-spin" /> Loading hosting…
+      </div>
+    );
+  }
+
+  const connected = status.apiKeyConfigured;
+
+  return (
+    <div className="flex-1 overflow-y-auto" data-testid="hosting-view">
+      <div className="mx-auto w-full max-w-5xl space-y-6 px-4 py-6">
+        <div>
+          <h2 className="flex items-center gap-2 text-lg font-medium">
+            <Globe className="size-5" /> Hosting
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            Connect a hosting provider so your teammates can put a site from this
+            company&rsquo;s workspace on the internet — with a managed database
+            behind it, and a custom domain in front.
+          </p>
+        </div>
+
+        {/* The two problems this form cannot fix, said before the form so an
+          operator does not fill it in and wonder why nothing happened. */}
+        {!status.inBuild ? (
+          <Alert data-testid="hosting-not-in-build">
+            <TriangleAlert className="size-4" />
+            <AlertDescription>
+              This host was built without the hosting tools, so these settings
+              will be stored and have no effect. Rebuild with the{" "}
+              <code>openhuman</code> feature.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {status.inBuild && !status.granted ? (
+          <Alert data-testid="hosting-not-granted">
+            <TriangleAlert className="size-4" />
+            <AlertDescription>
+              This company does not grant <code>hosting</code>, so no teammate
+              will get the deployment tools even once a key is saved. Add{" "}
+              <code>hosting</code> to <code>[tools].allow</code> in the
+              company&rsquo;s manifest — a catch-all <code>*</code> deliberately
+              does not confer it, and it cannot be fixed from this page.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        <Card>
+          <CardContent className="space-y-4 pt-6">
+            <div className="flex items-center justify-between">
+              <div className="space-y-1">
+                <p className="text-sm font-medium capitalize">{status.provider}</p>
+                <p className="text-xs text-muted-foreground">
+                  {connected
+                    ? status.team
+                      ? `Connected, deploying under ${status.team}.`
+                      : "Connected, deploying under the personal account."
+                    : "Not connected yet."}
+                </p>
+              </div>
+              {connected ? (
+                <Badge variant="secondary" data-testid="hosting-connected">
+                  <Check className="mr-1 size-3" /> Connected
+                </Badge>
+              ) : null}
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-2">
+                <Label htmlFor="hosting-key">API token</Label>
+                <Input
+                  id="hosting-key"
+                  data-testid="hosting-api-key"
+                  type="password"
+                  autoComplete="off"
+                  placeholder={
+                    status.apiKeyConfigured ? "Configured — type to replace" : "vercel_…"
+                  }
+                  value={apiKey}
+                  onChange={(e) => setApiKey(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Create one at vercel.com → Account Settings → Tokens. Stored
+                  write-only: it is never shown again, here or anywhere else.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="hosting-team">Team (optional)</Label>
+                <Input
+                  id="hosting-team"
+                  data-testid="hosting-team"
+                  placeholder="team_…"
+                  value={team}
+                  onChange={(e) => setTeam(e.target.value)}
+                />
+                <p className="text-xs text-muted-foreground">
+                  The team or organization to deploy under. Leave empty for a
+                  personal account.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button onClick={() => void onSave()} disabled={busy} data-testid="hosting-save">
+                {busy ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+                Save
+              </Button>
+              {status.apiKeyConfigured ? (
+                <Button
+                  variant="outline"
+                  onClick={() => void onClear()}
+                  disabled={busy}
+                  data-testid="hosting-clear"
+                >
+                  Disconnect
+                </Button>
+              ) : null}
+            </div>
+          </CardContent>
+        </Card>
+
+        <p className="text-xs text-muted-foreground">
+          A deployment publishes the files in a teammate&rsquo;s workspace to the
+          public internet under this account, and provisioning a database is a
+          bill this account pays. Nothing else in this app can read the
+          connection string a database produces — the provider injects it into
+          the site&rsquo;s own environment.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/views/SettingsSection.tsx
+++ b/frontend/src/views/SettingsSection.tsx
@@ -3,6 +3,7 @@ import {
   Blocks,
   ChartColumnBig,
   CreditCard,
+  Globe,
   Plug,
   type LucideIcon,
   Settings2,
@@ -15,6 +16,7 @@ import type { CompanyFeed } from "@/hooks/use-company";
 import { cn } from "@/lib/utils";
 import { BillingView } from "@/views/BillingView";
 import { ConnectionsView } from "@/views/ConnectionsView";
+import { HostingView } from "@/views/HostingView";
 import { McpServersView } from "@/views/McpServersView";
 import { PeopleView } from "@/views/PeopleView";
 import { SkillsView } from "@/views/SkillsView";
@@ -33,6 +35,9 @@ export const SETTINGS_PAGES = [
   // "where do I put my Chargebee key" searches for billing, not for a
   // third-party-accounts drawer.
   { id: "billing", label: "Billing", icon: CreditCard, hint: "Invoicing through Chargebee" },
+  // Beside Billing for the same reason it sits beside Connections: an operator
+  // looking for "where do I put my Vercel token" searches for hosting.
+  { id: "hosting", label: "Hosting", icon: Globe, hint: "Where this company's sites go live" },
   // "What this company knows how to do" read as capability the company performs
   // — the implication issue #569 exists to remove, set here *before* the tab
   // gets a chance to correct it. The siblings describe their content; so does
@@ -130,6 +135,12 @@ export function SettingsSection({ client, company, feed, sub, onNavigate, onFlag
             the note above `load` in BillingView. */}
         {page === "billing" && (
           <BillingView key={company ?? "self"} client={client} company={company} />
+        )}
+        {/* Same `key` remount as Billing, and for the same reason: a hosting
+            token typed for one company must not survive a company switch into
+            another company's Save. */}
+        {page === "hosting" && (
+          <HostingView key={company ?? "self"} client={client} company={company} />
         )}
         {page === "skills" && <SkillsView client={client} company={company} />}
         {page === "usage" && (

--- a/frontend/test/unit/hosting-view-branches.test.ts
+++ b/frontend/test/unit/hosting-view-branches.test.ts
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import { HostingView } from "@/views/HostingView";
+
+/**
+ * The conditional surfaces of `HostingView`, which are where its whole job is.
+ *
+ * Three separate things can each stop a teammate deploying, and two of them are
+ * invisible from this form's own fields: the company not granting `hosting`, and
+ * the host being built without the tools at all. A single "Connected" badge
+ * would be green for both and send an operator hunting through a form that is
+ * already correct — so each is reported on its own terms, and the ordering
+ * between them matters: granting `hosting` fixes nothing on a host compiled
+ * without the harness.
+ */
+
+const HOSTING_OK = {
+  apiKeyConfigured: true,
+  provider: "vercel",
+  team: "team_abc",
+  granted: true,
+  inBuild: true,
+  supportedProviders: ["vercel"],
+};
+
+/** A client answering the hosting read with a value or a rejection. */
+function clientWith(answer: unknown): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/companies/acme",
+    get: () =>
+      answer instanceof Error ? Promise.reject(answer) : Promise.resolve(answer ?? HOSTING_OK),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+async function show(client: OpenCompanyClient) {
+  await act(async () => {
+    root.render(createElement(HostingView, { client, company: "acme" }));
+  });
+}
+
+function at(testid: string): HTMLElement | null {
+  return container.querySelector<HTMLElement>(`[data-testid="${testid}"]`);
+}
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+describe("HostingView status surfaces", () => {
+  it("renders the connected badge and neither alert on the ordinary path", async () => {
+    // The control: the assertions below are only worth having if the working
+    // case does not produce either alert.
+    await show(clientWith(HOSTING_OK));
+
+    expect(at("hosting-view")).not.toBeNull();
+    expect(at("hosting-connected")).not.toBeNull();
+    expect(at("hosting-not-granted")).toBeNull();
+    expect(at("hosting-not-in-build")).toBeNull();
+  });
+
+  it("names the manifest, not the form, when the company does not grant hosting", async () => {
+    // A token stored and still nothing reaches a teammate. The remedy is
+    // `company.toml`, so saying "not connected" here would send the operator
+    // back through a form that is already correct.
+    await show(clientWith({ ...HOSTING_OK, granted: false }));
+
+    expect(at("hosting-not-granted")?.textContent).toContain("[tools].allow");
+    expect(at("hosting-not-in-build")).toBeNull();
+  });
+
+  it("says the host lacks the tools, and says only that", async () => {
+    // Not-in-build outranks not-granted: granting `hosting` in the manifest
+    // fixes nothing on a host compiled without the harness, and showing both
+    // alerts gives two remedies for one problem.
+    await show(clientWith({ ...HOSTING_OK, granted: false, inBuild: false }));
+
+    expect(at("hosting-not-in-build")).not.toBeNull();
+    expect(at("hosting-not-granted")).toBeNull();
+  });
+
+  it("shows the page-level error when the status cannot be read", async () => {
+    await show(clientWith(new Error("store unreachable")));
+
+    expect(at("hosting-load-error")?.textContent).toContain("store unreachable");
+    expect(at("hosting-api-key")).toBeNull();
+  });
+
+  it("never renders a stored token, and offers to replace rather than reveal it", async () => {
+    // The token is write-only end to end: the host does not return it, so the
+    // field stays empty with a placeholder. An input pre-filled with dots would
+    // invite an operator to "correct" a value they cannot see.
+    await show(clientWith(HOSTING_OK));
+
+    const key = at("hosting-api-key") as HTMLInputElement | null;
+    expect(key?.value).toBe("");
+    expect(key?.getAttribute("placeholder")).toContain("Configured");
+    expect(key?.getAttribute("type")).toBe("password");
+  });
+
+  it("seeds the team box with what is stored so a typo can be corrected", async () => {
+    // The one non-secret field. Leaving it empty would make an operator retype
+    // it to change anything else.
+    await show(clientWith(HOSTING_OK));
+
+    expect((at("hosting-team") as HTMLInputElement | null)?.value).toBe("team_abc");
+  });
+
+  it("offers no disconnect button before anything is stored", async () => {
+    await show(clientWith({ ...HOSTING_OK, apiKeyConfigured: false, team: null }));
+
+    expect(at("hosting-connected")).toBeNull();
+    expect(at("hosting-clear")).toBeNull();
+    expect(at("hosting-save")).not.toBeNull();
+  });
+});

--- a/src/company/hosting.rs
+++ b/src/company/hosting.rs
@@ -1,0 +1,32 @@
+//! Secret-store keys for a company's hosting provider connection.
+//!
+//! They live here, always compiled, rather than beside the harness wiring in
+//! [`crate::harness::hosting`]: that module is gated on the `openhuman` feature,
+//! but the **configuration surface** is not. An operator must be able to open
+//! Settings → Hosting and see "this build has no hosting support" rather than a
+//! 404. Sharing one definition is what keeps the write plane and the read plane
+//! from drifting onto two spellings of the same key — the same argument as
+//! [`crate::company::billing`].
+
+/// Holds a company's hosting provider slug — today, `vercel`.
+///
+/// Stored rather than assumed because it decides which API the key is presented
+/// to, and a key sent to the wrong provider fails in a way that reads like a bad
+/// key.
+pub const PROVIDER_SECRET: &str = "hosting/provider";
+
+/// Holds a company's hosting provider API key, written by the console's Hosting
+/// settings and read only to authenticate a call.
+pub const API_KEY_SECRET: &str = "hosting/api_key";
+
+/// Holds the team, organization, or account scope to deploy under. Optional: a
+/// personal account has none.
+pub const TEAM_SECRET: &str = "hosting/team";
+
+/// The provider used when a company saved a key without naming one.
+///
+/// A default is safe here in a way it would not be for the key: the console
+/// offers one provider today, and a company that saved a key through it meant
+/// that provider. Adding a second provider makes this the *migration* value for
+/// rows written before the field existed, which is exactly what it should be.
+pub const DEFAULT_PROVIDER: &str = "vercel";

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -33,9 +33,9 @@ pub mod copilot;
 // platform token vs a static key). Always compiled: the answer decides whether a
 // company can think at all, in every build.
 pub mod billing;
-pub mod hosting;
 pub mod credentials;
 pub mod dns;
+pub mod hosting;
 pub mod inference;
 /// Dynamic ledgers: the one place a ledger is read, written, declared or
 /// retired. Every surface routes through it, because the rules that matter —

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -33,6 +33,7 @@ pub mod copilot;
 // platform token vs a static key). Always compiled: the answer decides whether a
 // company can think at all, in every build.
 pub mod billing;
+pub mod hosting;
 pub mod credentials;
 pub mod dns;
 pub mod inference;
@@ -125,7 +126,7 @@ pub use types::{
     ORCHESTRATOR_TIER, PLAN_NAMES, PLAN_PERIODS, POLICY_MODES, PROMPT_CLASSES,
     PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan, Policy, Schedule, Skill, TIERS,
     TOOL_PROVIDERS, Tools, grants_chargebee_explicit, grants_composio_explicit,
-    grants_media_explicit, grants_paypal_explicit, grants_repo_explicit,
+    grants_hosting_explicit, grants_media_explicit, grants_paypal_explicit, grants_repo_explicit,
     grants_repo_write_explicit, grants_search_explicit, grants_workspace_write_explicit,
     orchestrator_id,
 };

--- a/src/company/mod.rs
+++ b/src/company/mod.rs
@@ -127,9 +127,8 @@ pub use types::{
     POLICY_MODES, PROMPT_CLASSES, PROMPT_FILE_BUDGET_CHARS, PROVISIONED_POLICY_MODE, Place, Plan,
     Policy, Schedule, Skill, TIERS, TOOL_PROVIDERS, Tools, grants_chargebee_explicit,
     grants_composio_explicit, grants_hosting_explicit, grants_media_explicit,
-    grants_paypal_explicit, grants_repo_explicit,
-    grants_repo_write_explicit, grants_search_explicit, grants_workspace_write_explicit,
-    orchestrator_id,
+    grants_paypal_explicit, grants_repo_explicit, grants_repo_write_explicit,
+    grants_search_explicit, grants_workspace_write_explicit, orchestrator_id,
 };
 pub use workflow_file::{
     WORKFLOW_DESTINATION_KINDS, WORKFLOW_NODE_KINDS, WorkflowDestinationDef, WorkflowEdgeDef,

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -2350,6 +2350,7 @@ mod tests {
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             search: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),

--- a/src/company/types.rs
+++ b/src/company/types.rs
@@ -174,6 +174,19 @@ pub fn grants_chargebee_explicit(grants: &[String]) -> bool {
         .any(|grant| grant == "chargebee" || grant.starts_with("chargebee."))
 }
 
+/// Whether a tool-grant list **explicitly** grants the `hosting` namespace.
+///
+/// Like its siblings, the catch-all `*` does **not** confer it. These tools
+/// publish a company's files to the public internet under its own name and can
+/// provision a managed database it is billed for, so they are opted into by
+/// name rather than ridden in on a wildcard a company set for its file and
+/// shell tools.
+pub fn grants_hosting_explicit(grants: &[String]) -> bool {
+    grants
+        .iter()
+        .any(|grant| grant == "hosting" || grant.starts_with("hosting."))
+}
+
 /// Whether a tool-grant list **explicitly** grants the `paypal` namespace
 /// (issue #789).
 ///

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2947,6 +2947,7 @@ description = "Runs Acme."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -3121,6 +3122,7 @@ description = "Builds it."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -3244,6 +3246,7 @@ members = ["engineer"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -5155,6 +5158,7 @@ members = ["engineer"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -6114,6 +6118,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -6261,6 +6266,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -6354,6 +6360,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -6687,6 +6694,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -7191,6 +7199,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -7516,6 +7525,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer,
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -7919,6 +7929,7 @@ members = ["eng1", "eng2"]
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer,
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -485,6 +485,38 @@ pub fn build_agent(
         }
     }
 
+    // Hosting: put this agent's workspace on a real hosting provider. Same
+    // fail-closed shape as `chargebee` and `paypal` above, and for both of their
+    // reasons at once — a deployment publishes the company's files to the public
+    // internet under its own account, and provisioning a database is a bill it
+    // pays. Two conditions, both required:
+    //
+    //  1. an **EXPLICIT** `hosting` grant. The catch-all `*` does NOT confer it.
+    //  2. a resolved per-company connection on the deps (`deps.hosting`), read
+    //     from THAT company's secret store by the runtime builder — never from
+    //     an environment variable, which under multi-tenancy could only ever be
+    //     somebody else's account.
+    //
+    // The tools are pinned to `workspace`, the same sandbox directory the file
+    // tools get, so an agent can only ever deploy what it can already read.
+    #[cfg(feature = "openhuman")]
+    if crate::company::grants_hosting_explicit(grants) {
+        match &deps.hosting {
+            Some(config) => {
+                tools.extend(crate::harness::hosting::hosting_tools(
+                    config,
+                    workspace.clone(),
+                ));
+            }
+            None => tracing::warn!(
+                company = %company,
+                agent = %manifest_agent.id,
+                "[build] agent explicitly grants `hosting` but no per-company hosting \
+                 credential is configured; hosting tools NOT wired (fail-closed)"
+            ),
+        }
+    }
+
     // Metered web search (issue #238) — the discovery tool the `web` namespace
     // never had. `web_fetch` / `http_request` / `curl` read a URL the agent
     // already has; nothing could find one, while three shipped skills instruct
@@ -1581,6 +1613,7 @@ mod tests {
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,

--- a/src/harness/composio_turn_test.rs
+++ b/src/harness/composio_turn_test.rs
@@ -367,6 +367,7 @@ async fn harness(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         composio: Some(TenantComposio::new(
             composio_url,
             Credential::from_value("stub-tenant-token"),

--- a/src/harness/hosting.rs
+++ b/src/harness/hosting.rs
@@ -1,0 +1,227 @@
+//! The agent-facing bridge for hosting (TinyHosts): six tools that put a
+//! company's workspace on a real hosting provider.
+//!
+//! # Why the credential is per company and resolved late
+//!
+//! Two companies on one host deploy to two different hosting accounts, so a
+//! process-wide key could only ever be wrong for one of them. The provider slug,
+//! API key and team are read from **that company's**
+//! [`SecretStore`](crate::ports::SecretStore), written by the console's Hosting
+//! settings. No environment variable is consulted — unlike a standalone
+//! OpenHuman, where `TINYHOSTS_VERCEL_TOKEN` is the ordinary source, a
+//! multi-tenant host must never let one company's deployment ride on an ambient
+//! credential.
+//!
+//! Resolution happens at roster-build time and is folded into the harness
+//! fingerprint, so an operator who sets or rotates the key in the console gets
+//! it on the next turn rather than after a restart — the same contract Chargebee
+//! and Composio have.
+//!
+//! # Fail closed
+//!
+//! Tools are wired only when a company **explicitly** grants `hosting` *and* a
+//! credential resolves. A catch-all `*` does not confer it: these tools publish
+//! a company's files to the public internet and can provision a database the
+//! company is billed for, so they are opted into by name rather than ridden in
+//! on a wildcard set for file and shell tools.
+//!
+//! # What crosses this boundary
+//!
+//! Only the workspace directory an agent names, and only downward: OpenHuman's
+//! `hosting` domain refuses an absolute path or a `..` escape before a single
+//! byte is read. Nothing comes back that is secret — a provisioned database's
+//! connection string is injected by the provider into the site's environment,
+//! and this process learns the variable's *name* and never its value.
+
+use std::sync::Arc;
+
+use crate::company::hosting::{API_KEY_SECRET, DEFAULT_PROVIDER, PROVIDER_SECRET, TEAM_SECRET};
+use crate::ports::SecretStore;
+use crate::ports::types::CompanyId;
+
+/// One company's resolved hosting connection.
+#[derive(Clone)]
+pub struct TenantHosting {
+    provider: String,
+    api_key: String,
+    team: Option<String>,
+}
+
+/// Prints the provider and team, never the key.
+impl std::fmt::Debug for TenantHosting {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("TenantHosting")
+            .field("provider", &self.provider)
+            .field("team", &self.team)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl TenantHosting {
+    /// Resolves a company's hosting credentials from its secret store.
+    ///
+    /// `Ok(None)` when no API key is stored: the key is the only required half.
+    /// A missing provider falls back to [`DEFAULT_PROVIDER`], which is the
+    /// migration value for a row written before the field existed; a missing
+    /// team means the personal account.
+    ///
+    /// A store **read failure** is an `Err`, not `Ok(None)`. Collapsing the two
+    /// would make an unhealthy secret store indistinguishable from "no
+    /// credential configured", and the caller's response differs completely:
+    /// absence should wire no tools, while a transient read error should keep
+    /// the connection it already had. See `HarnessPool::resolve_hosting`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the secret store cannot be read.
+    pub async fn resolve(
+        secrets: &Arc<dyn SecretStore>,
+        company: &CompanyId,
+    ) -> crate::error::Result<Option<TenantHosting>> {
+        let read = async |key: &str| -> crate::error::Result<Option<String>> {
+            Ok(secrets
+                .get(company, key)
+                .await?
+                .map(|value| value.0.trim().to_string())
+                .filter(|value| !value.is_empty()))
+        };
+
+        let Some(api_key) = read(API_KEY_SECRET).await? else {
+            return Ok(None);
+        };
+
+        Ok(Some(TenantHosting {
+            provider: read(PROVIDER_SECRET)
+                .await?
+                .unwrap_or_else(|| DEFAULT_PROVIDER.to_string()),
+            api_key,
+            team: read(TEAM_SECRET).await?,
+        }))
+    }
+
+    /// The provider this company deploys to. Never the key.
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// The team scope, when the company set one.
+    pub fn team(&self) -> Option<&str> {
+        self.team.as_deref()
+    }
+
+    /// A stable hash of the connection, for the roster staleness check.
+    ///
+    /// Covers the key as well as the provider and team, so rotating a key with
+    /// everything else unchanged still rebuilds the roster — otherwise a rotated
+    /// credential would keep authenticating with the old one until a restart.
+    pub fn fingerprint(config: &Option<TenantHosting>) -> u64 {
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        match config {
+            None => 0u8.hash(&mut hasher),
+            Some(hosting) => {
+                1u8.hash(&mut hasher);
+                hosting.provider.hash(&mut hasher);
+                hosting.api_key.hash(&mut hasher);
+                hosting.team.hash(&mut hasher);
+            }
+        }
+        hasher.finish()
+    }
+}
+
+#[cfg(feature = "openhuman")]
+pub use live::hosting_tools;
+
+#[cfg(feature = "openhuman")]
+mod live {
+    use super::TenantHosting;
+
+    use std::path::PathBuf;
+
+    use openhuman_core::openhuman::tools::Tool;
+
+    /// The hosting tools for one company, deploying out of `workspace`.
+    ///
+    /// `workspace` is the agent's own sandbox directory, the same one the file
+    /// tools are pinned to, so an agent can only ever deploy what it can already
+    /// read. An unusable credential — an unknown provider slug, a key the client
+    /// cannot be built for — wires nothing and warns rather than failing the
+    /// build: an agent that cannot deploy is a degraded agent, not a broken
+    /// company.
+    pub fn hosting_tools(config: &TenantHosting, workspace: PathBuf) -> Vec<Box<dyn Tool>> {
+        match openhuman_core::openhuman::hosting::Account::connect(
+            &config.provider,
+            &config.api_key,
+            config.team(),
+            workspace,
+        ) {
+            Ok(account) => account.tools(),
+            Err(error) => {
+                log::warn!(
+                    "[hosting] the stored hosting credential is unusable ({error}); hosting tools NOT wired"
+                );
+                Vec::new()
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_never_renders_the_api_key() {
+        let hosting = TenantHosting {
+            provider: "vercel".to_string(),
+            api_key: "vc_live_SUPERSECRET".to_string(),
+            team: Some("team_abc".to_string()),
+        };
+
+        let rendered = format!("{hosting:?}");
+
+        assert!(!rendered.contains("SUPERSECRET"), "{rendered}");
+        assert!(rendered.contains("<redacted>"), "{rendered}");
+        assert!(rendered.contains("team_abc"), "{rendered}");
+    }
+
+    #[test]
+    fn the_fingerprint_moves_when_any_half_of_the_credential_does() {
+        let base = TenantHosting {
+            provider: "vercel".to_string(),
+            api_key: "one".to_string(),
+            team: None,
+        };
+        let rotated = TenantHosting {
+            api_key: "two".to_string(),
+            ..base.clone()
+        };
+        let scoped = TenantHosting {
+            team: Some("team_abc".to_string()),
+            ..base.clone()
+        };
+
+        let of = |value: TenantHosting| TenantHosting::fingerprint(&Some(value));
+
+        assert_ne!(of(base.clone()), TenantHosting::fingerprint(&None));
+        // A rotated key with the same provider must rebuild the roster.
+        assert_ne!(of(base.clone()), of(rotated));
+        assert_ne!(of(base.clone()), of(scoped));
+        assert_eq!(of(base.clone()), of(base));
+    }
+
+    #[test]
+    fn a_connection_reports_its_provider_and_team() {
+        let hosting = TenantHosting {
+            provider: "vercel".to_string(),
+            api_key: "key".to_string(),
+            team: Some("team_abc".to_string()),
+        };
+
+        assert_eq!(hosting.provider(), "vercel");
+        assert_eq!(hosting.team(), Some("team_abc"));
+    }
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -54,8 +54,9 @@ pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
 /// Hosting (TinyHosts): the per-company connection and the agent tools over it.
-/// The credential half is always compiled — the console's Hosting settings write
-/// it in every build — while the tools themselves need `openhuman`.
+/// The keys it reads live in `company::hosting`, which is compiled in every
+/// build — the console's Hosting settings write them whether or not this
+/// harness exists to use them.
 pub mod hosting;
 mod checkpoint;
 pub mod composio;
@@ -3279,6 +3280,7 @@ description = "Builds the product."
                 chargebee: None,
                 #[cfg(feature = "paypal")]
                 paypal: None,
+                hosting: None,
                 steer: crate::company::steer::InflightRegistry::default(),
                 run_supervisor: crate::runtime::RunSupervisor::default(),
                 delivery: None,
@@ -3491,6 +3493,7 @@ description = "Builds the product."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -4185,6 +4188,7 @@ description = "Builds the product."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -4370,6 +4374,7 @@ description = "Builds the product."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -5040,6 +5045,7 @@ description = "Builds the product."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -5219,6 +5225,7 @@ description = "Sets direction."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),
             delivery: None,
@@ -5378,6 +5385,7 @@ description = "Sets direction."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             artifacts: None,
             steer: crate::company::steer::InflightRegistry::default(),
             run_supervisor: crate::runtime::RunSupervisor::default(),

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -53,6 +53,10 @@ pub mod build;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
+/// Hosting (TinyHosts): the per-company connection and the agent tools over it.
+/// The credential half is always compiled — the console's Hosting settings write
+/// it in every build — while the tools themselves need `openhuman`.
+pub mod hosting;
 mod checkpoint;
 pub mod composio;
 /// Issue #410: how a Composio action catalogue is narrowed and rendered for an
@@ -464,6 +468,14 @@ pub struct HarnessDeps {
     /// and re-resolved each turn, like `chargebee`.
     #[cfg(feature = "paypal")]
     pub paypal: Option<paypal::TenantPaypal>,
+
+    /// The per-company hosting connection. `None` (the default at every
+    /// construction site) fails closed — no hosting tools are wired. Resolved
+    /// from that company's own secret store and re-resolved each turn, like
+    /// `chargebee`: two companies on one host deploy to two different hosting
+    /// accounts, and a deployment publishes files to the internet under the
+    /// account's own name.
+    pub hosting: Option<hosting::TenantHosting>,
     /// The MANAGED web-search backend (issue #238). `None` (the default at every
     /// construction site but the production runtime builder) **fails closed** —
     /// no `web_search` tool is wired and agents behave exactly as before.
@@ -1157,18 +1169,20 @@ impl HarnessPool {
         let chargebee_config = self.resolve_chargebee(company, deps).await;
         #[cfg(feature = "paypal")]
         let paypal_config = self.resolve_paypal(company, deps).await;
+        // The hosting credential is set from the same settings surface and goes
+        // stale the same way, so it rides the same axis.
+        let hosting_config = self.resolve_hosting(company, deps).await;
         // A build without either feature has no billing axis to go stale on, so
         // the fingerprint is a constant and this company never rebuilds on it.
         let billing_fp = {
             use std::hash::Hasher;
-            // `mut` is only exercised when a billing feature is compiled in; a
-            // build with neither writes nothing and the hasher stays untouched.
-            #[cfg_attr(not(any(feature = "chargebee", feature = "paypal")), allow(unused_mut))]
+            // Always written to: the hosting axis below is ungated.
             let mut hasher = std::collections::hash_map::DefaultHasher::new();
             #[cfg(feature = "chargebee")]
             hasher.write_u64(chargebee::TenantChargebee::fingerprint(&chargebee_config));
             #[cfg(feature = "paypal")]
             hasher.write_u64(paypal::TenantPaypal::fingerprint(&paypal_config));
+            hasher.write_u64(hosting::TenantHosting::fingerprint(&hosting_config));
             hasher.finish()
         };
 
@@ -1257,6 +1271,7 @@ impl HarnessPool {
         {
             fresh_deps.paypal = paypal_config;
         }
+        fresh_deps.hosting = hosting_config;
         // And the freshly-read bindings (issue #245), so a repository bound or
         // revoked in the console is what the rebuilt agents' tools resolve
         // against — including the descriptions that name what is bound.
@@ -1460,6 +1475,42 @@ impl HarnessPool {
                      connection: {err}"
                 );
                 deps.chargebee.clone()
+            }
+        }
+    }
+
+    /// The hosting equivalent, for the same reasons.
+    ///
+    /// Only companies that **explicitly** grant `hosting` read at all: a
+    /// deployment publishes a company's files to the public internet and can
+    /// provision a database it is billed for, so the catch-all `*` does not
+    /// confer it.
+    ///
+    /// A transient read error keeps the last known connection with a warning,
+    /// like `chargebee` and for the same reason: a stale hosting key is refused
+    /// by the provider, which the agent surfaces as a tool error it can report,
+    /// whereas a tool that has vanished is invisible to the agent — it simply
+    /// stops being able to deploy and says nothing.
+    async fn resolve_hosting(
+        &self,
+        company: &CompanyRecord,
+        deps: &HarnessDeps,
+    ) -> Option<hosting::TenantHosting> {
+        if !crate::company::grants_hosting_explicit(&company.manifest.tools.allow) {
+            return None;
+        }
+        let Some(secrets) = &deps.secrets else {
+            return deps.hosting.clone();
+        };
+        match hosting::TenantHosting::resolve(secrets, &company.id).await {
+            Ok(resolved) => resolved,
+            Err(err) => {
+                tracing::warn!(
+                    company = %company.id,
+                    "[hosting] could not read the hosting credential; keeping the last known \
+                     connection: {err}"
+                );
+                deps.hosting.clone()
             }
         }
     }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -53,11 +53,6 @@ pub mod build;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;
-/// Hosting (TinyHosts): the per-company connection and the agent tools over it.
-/// The keys it reads live in `company::hosting`, which is compiled in every
-/// build — the console's Hosting settings write them whether or not this
-/// harness exists to use them.
-pub mod hosting;
 mod checkpoint;
 pub mod composio;
 /// Issue #410: how a Composio action catalogue is narrowed and rendered for an
@@ -81,6 +76,11 @@ pub mod cost;
 /// both the harness (`openhuman`) and the memory engine (`tinycortex`) are built.
 #[cfg(feature = "tinycortex")]
 pub mod embeddings;
+/// Hosting (TinyHosts): the per-company connection and the agent tools over it.
+/// The keys it reads live in `company::hosting`, which is compiled in every
+/// build — the console's Hosting settings write them whether or not this
+/// harness exists to use them.
+pub mod hosting;
 pub mod ledger_tools;
 pub mod lifecycle;
 pub mod mcp;

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -345,6 +345,7 @@ fn brain_with(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: None,

--- a/src/harness/search_turn_test.rs
+++ b/src/harness/search_turn_test.rs
@@ -306,6 +306,7 @@ async fn harness(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: None,

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -717,6 +717,7 @@ pub(crate) fn agent_deps(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         search: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),

--- a/src/harness/workspace_provision_turn_test.rs
+++ b/src/harness/workspace_provision_turn_test.rs
@@ -298,6 +298,7 @@ fn build_brain(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: None,

--- a/src/harness/workspace_turn_test.rs
+++ b/src/harness/workspace_turn_test.rs
@@ -309,6 +309,7 @@ async fn harness(
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: None,

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2183,6 +2183,30 @@ impl RuntimeBuilder {
                             } else {
                                 None
                             };
+                            // The per-company hosting connection, resolved
+                            // from this company's own secret store for the same
+                            // reason the billing pair above is: two companies on
+                            // one host deploy to two different hosting accounts,
+                            // and a deployment publishes files to the internet
+                            // under the account's own name. An ambient
+                            // environment variable could only ever be somebody
+                            // else's account, so none is consulted.
+                            let hosting_config = if crate::company::grants_hosting_explicit(
+                                &self.manifest.tools.allow,
+                            ) {
+                                crate::harness::hosting::TenantHosting::resolve(&secrets, &id)
+                                    .await
+                                    .unwrap_or_else(|err| {
+                                        tracing::warn!(
+                                            company = %id,
+                                            "[hosting] could not read the hosting credential at \
+                                             boot; wiring no hosting tools this turn: {err}"
+                                        );
+                                        None
+                                    })
+                            } else {
+                                None
+                            };
                             let composio_config = if crate::company::grants_composio_explicit(
                                 &self.manifest.tools.allow,
                             ) {
@@ -2377,6 +2401,7 @@ impl RuntimeBuilder {
                                 chargebee: chargebee_config,
                                 #[cfg(feature = "paypal")]
                                 paypal: paypal_config,
+                                hosting: hosting_config,
                                 steer,
                                 run_supervisor: supervisor,
                                 // Issue #170: the ports an `output` node's

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -2757,6 +2757,7 @@ mod test {
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             delivery: None,
             search: None,

--- a/src/server/ops/hosting.rs
+++ b/src/server/ops/hosting.rs
@@ -1,0 +1,230 @@
+//! The hosting configuration write-plane: store a company's hosting provider
+//! API key — **write-only** — and report what is configured without echoing it.
+//!
+//! `GET …/hosting` returns only [`HostingStatus`]: booleans, the provider slug,
+//! and the team scope. The API key is never serialized into any response, by
+//! construction. It lives in [`SecretStore`](crate::ports::SecretStore) and this
+//! module reads it back only to report *whether* it is there.
+//!
+//! # Why the team is stored beside the key but is not confidential
+//!
+//! A team scope is not a secret, and it *is* returned by `GET` — a settings form
+//! has to show which account it deploys to, and "Connected ✓" beside the wrong
+//! team is exactly the confusion this avoids. It shares the secret store with
+//! the key only because the pair is used together.
+//!
+//! # Three things can each be missing, and they fail differently
+//!
+//! [`HostingStatus`] reports them separately rather than as one "connected"
+//! flag, because the remedies differ: no key means the agents have no hosting
+//! tools at all; a missing `hosting` grant means the key is configured and still
+//! nothing reaches an agent; and a build without the `openhuman` feature has no
+//! hosting tools to wire in the first place. A single boolean would send an
+//! operator looking in the wrong place for two of those three.
+
+use axum::extract::State;
+use axum::routing::{delete, get};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::company::hosting::{API_KEY_SECRET, DEFAULT_PROVIDER, PROVIDER_SECRET, TEAM_SECRET};
+use crate::company::runtime::CompanyRuntime;
+use crate::ports::types::SecretValue;
+use crate::server::error::ApiError;
+use crate::server::ops::scope::{AdminScopedCompany, ScopedCompany, scoped};
+
+/// The providers this build can deploy to.
+///
+/// Kept here rather than derived from the crate so a settings form can render a
+/// picker in a build with no hosting tools compiled in at all.
+pub const SUPPORTED_PROVIDERS: [&str; 1] = ["vercel"];
+
+/// The non-secret view of a company's hosting configuration.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct HostingStatus {
+    /// Whether an API key is stored and non-empty. Never the key itself.
+    pub api_key_configured: bool,
+    /// The provider the key belongs to — shown so a settings form can say
+    /// *which* provider it is connected to rather than only that it is.
+    pub provider: String,
+    /// The team, organization, or account scope, when one is set. `None` means
+    /// the provider's personal account.
+    pub team: Option<String>,
+    /// Whether this company's manifest **explicitly** grants `hosting`. A key
+    /// can be present and still wire no tools without it.
+    pub granted: bool,
+    /// Whether this build has the hosting tools compiled in at all.
+    pub in_build: bool,
+    /// The providers a key can be stored for.
+    pub supported_providers: Vec<String>,
+}
+
+/// The ops router for hosting settings.
+pub fn router() -> Router<AppState> {
+    scoped("/hosting", get(get_hosting).put(put_hosting))
+        .merge(scoped("/hosting/key", delete(delete_hosting)))
+}
+
+/// Reads a stored secret, treating empty as absent.
+async fn read(runtime: &CompanyRuntime, key: &str) -> Result<Option<String>, ApiError> {
+    Ok(runtime
+        .secrets()
+        .get(runtime.id(), key)
+        .await?
+        .map(|value| value.expose().to_string())
+        .filter(|value| !value.trim().is_empty()))
+}
+
+/// Writes several secrets, rolling back what already landed if one fails.
+///
+/// Written one `?` at a time, a store that took the key and then failed on the
+/// provider would leave the key stored behind an error response — a company
+/// whose settings page reads "not connected" while an agent deploys with the
+/// key anyway.
+async fn write_all(runtime: &CompanyRuntime, writes: &[(&str, String)]) -> Result<(), ApiError> {
+    let mut prior: Vec<(&str, String)> = Vec::new();
+    for (key, value) in writes {
+        let before = read(runtime, key).await?.unwrap_or_default();
+        if let Err(err) = runtime
+            .secrets()
+            .set(runtime.id(), key, SecretValue(value.clone()))
+            .await
+        {
+            for (done, restore) in &prior {
+                if let Err(undo) = runtime
+                    .secrets()
+                    .set(runtime.id(), done, SecretValue(restore.clone()))
+                    .await
+                {
+                    tracing::error!(
+                        company = %runtime.id(),
+                        key = done,
+                        "[hosting] a credential write failed and could not be rolled back; this \
+                         company is now half configured: {undo}"
+                    );
+                }
+            }
+            return Err(ApiError(err));
+        }
+        prior.push((key, before));
+    }
+    Ok(())
+}
+
+/// Assembles the non-secret status.
+async fn status_of(runtime: &CompanyRuntime) -> Result<HostingStatus, ApiError> {
+    // The grant lives in the stored manifest, not on the runtime handle. A
+    // company that cannot be loaded reports `granted: false` rather than failing
+    // the whole status: the operator still needs to see what IS configured, and
+    // a settings page that 500s tells them nothing.
+    let granted = runtime
+        .store()
+        .load(runtime.id())
+        .await
+        .ok()
+        .flatten()
+        .map(|record| crate::company::grants_hosting_explicit(&record.manifest.tools.allow))
+        .unwrap_or(false);
+
+    Ok(HostingStatus {
+        api_key_configured: read(runtime, API_KEY_SECRET).await?.is_some(),
+        provider: read(runtime, PROVIDER_SECRET)
+            .await?
+            .unwrap_or_else(|| DEFAULT_PROVIDER.to_string()),
+        team: read(runtime, TEAM_SECRET).await?,
+        granted,
+        in_build: cfg!(feature = "openhuman"),
+        supported_providers: SUPPORTED_PROVIDERS.iter().map(|p| (*p).to_string()).collect(),
+    })
+}
+
+/// `GET …/hosting` — non-secret status only.
+async fn get_hosting(company: ScopedCompany) -> Result<Json<HostingStatus>, ApiError> {
+    Ok(Json(status_of(&company.runtime).await?))
+}
+
+/// The write-only config body. Every field is optional; only fields present and
+/// non-empty are applied, so the team can be corrected without re-entering the
+/// key.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct HostingConfigBody {
+    /// The provider API key (write-only). Omit to leave it unchanged.
+    #[serde(default)]
+    api_key: Option<String>,
+    /// The provider slug. Omit to leave it unchanged.
+    #[serde(default)]
+    provider: Option<String>,
+    /// The team, organization, or account scope. Omit to leave it unchanged.
+    #[serde(default)]
+    team: Option<String>,
+}
+
+/// `PUT …/hosting` — store any supplied credentials, return status.
+///
+/// Requires authority over the company: this key deploys the company's files to
+/// the public internet under its own account and can provision a database it is
+/// billed for, so pointing it at a different hosting account is not an ordinary
+/// member's edit.
+async fn put_hosting(
+    company: AdminScopedCompany,
+    State(_state): State<AppState>,
+    Json(body): Json<HostingConfigBody>,
+) -> Result<Json<HostingStatus>, ApiError> {
+    let runtime = &company.runtime;
+    let supplied = |value: Option<&str>| {
+        value
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(str::to_string)
+    };
+
+    let mut writes: Vec<(&str, String)> = Vec::new();
+    if let Some(api_key) = supplied(body.api_key.as_deref()) {
+        writes.push((API_KEY_SECRET, api_key));
+    }
+    if let Some(provider) = supplied(body.provider.as_deref()) {
+        let provider = provider.to_ascii_lowercase();
+        // Refused here rather than stored and discovered later: a slug this
+        // build cannot connect to would wire no tools at all, and the settings
+        // page would still read "Connected".
+        if !SUPPORTED_PROVIDERS.contains(&provider.as_str()) {
+            return Err(ApiError(crate::error::OpenCompanyError::InvalidRequest(
+                format!(
+                    "`{provider}` is not a hosting provider this build supports — one of: {}",
+                    SUPPORTED_PROVIDERS.join(", ")
+                ),
+            )));
+        }
+        writes.push((PROVIDER_SECRET, provider));
+    }
+    if let Some(team) = supplied(body.team.as_deref()) {
+        writes.push((TEAM_SECRET, team));
+    }
+    write_all(runtime, &writes).await?;
+
+    Ok(Json(status_of(runtime).await?))
+}
+
+/// `DELETE …/hosting/key` — clear every stored hosting credential.
+///
+/// The [`SecretStore`](crate::ports::SecretStore) port has no delete, so a
+/// cleared credential is stored as the empty string; every read site treats an
+/// empty value as unset, and the tools then fail closed.
+async fn delete_hosting(
+    company: AdminScopedCompany,
+    State(_state): State<AppState>,
+) -> Result<Json<HostingStatus>, ApiError> {
+    let runtime = &company.runtime;
+    // Together, and including the team: a clear that dropped the key but left a
+    // team behind would report the integration as disconnected while a later
+    // key, saved without a team, silently inherited the old account scope.
+    let cleared: Vec<(&str, String)> = [API_KEY_SECRET, PROVIDER_SECRET, TEAM_SECRET]
+        .into_iter()
+        .map(|key| (key, String::new()))
+        .collect();
+    write_all(runtime, &cleared).await?;
+    Ok(Json(status_of(runtime).await?))
+}

--- a/src/server/ops/hosting.rs
+++ b/src/server/ops/hosting.rs
@@ -136,7 +136,10 @@ async fn status_of(runtime: &CompanyRuntime) -> Result<HostingStatus, ApiError> 
         team: read(runtime, TEAM_SECRET).await?,
         granted,
         in_build: cfg!(feature = "openhuman"),
-        supported_providers: SUPPORTED_PROVIDERS.iter().map(|p| (*p).to_string()).collect(),
+        supported_providers: SUPPORTED_PROVIDERS
+            .iter()
+            .map(|p| (*p).to_string())
+            .collect(),
     })
 }
 
@@ -227,4 +230,280 @@ async fn delete_hosting(
         .collect();
     write_all(runtime, &cleared).await?;
     Ok(Json(status_of(runtime).await?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These drive the real router rather than the helpers, because the
+    // properties worth holding are route-level: that a credential goes in and
+    // never comes back out, that clearing clears all of it, and that a provider
+    // this build cannot use is refused at the door rather than stored.
+
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+
+    use crate::ports::types::CompanyId;
+
+    /// A running company with a manifest that grants `hosting`.
+    async fn state_with_company(home: &std::path::Path, grant_hosting: bool) -> AppState {
+        use crate::ports::CompanyStore;
+        use crate::ports::types::CompanyRecord;
+
+        let id = CompanyId::new("acme");
+        let allow = if grant_hosting {
+            "\n[tools]\nallow = [\"hosting\"]\n"
+        } else {
+            ""
+        };
+        let manifest: crate::company::CompanyManifest = ::toml::from_str(&format!(
+            "[company]\nname = \"Acme\"\n[[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n[policy]\nmode = \"full\"\n{allow}"
+        ))
+        .expect("manifest");
+        crate::store::FsCompanyStore::new(home.to_path_buf())
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: manifest.clone(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desk_tools: Default::default(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .expect("save");
+
+        let runtime = crate::runtime::RuntimeBuilder::new(home.to_path_buf(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .expect("runtime");
+        let state = AppState::new(crate::AppConfig::default());
+        state.registry().insert(id, std::sync::Arc::new(runtime));
+        state
+    }
+
+    async fn call(
+        state: &AppState,
+        method: &str,
+        uri: &str,
+        cookie: &str,
+        body: Option<Value>,
+    ) -> (StatusCode, Value) {
+        let request = Request::builder()
+            .method(method)
+            .uri(uri)
+            .header("cookie", cookie);
+        let request = match body {
+            Some(body) => request
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string())),
+            None => request.body(Body::empty()),
+        }
+        .expect("request");
+        let response = crate::server::router(state.clone())
+            .oneshot(request)
+            .await
+            .expect("routed");
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        (
+            status,
+            serde_json::from_slice(&bytes).unwrap_or(Value::Null),
+        )
+    }
+
+    #[tokio::test]
+    async fn a_saved_token_is_reported_as_configured_and_never_returned() {
+        let home = ::tempfile::tempdir().expect("tempdir");
+        let state = state_with_company(home.path(), true).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        let (status, before) = call(
+            &state,
+            "GET",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            None,
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{before}");
+        assert_eq!(before["apiKeyConfigured"], false);
+        // The default provider is reported before anything is stored, so a
+        // settings form can render its picker.
+        assert_eq!(before["provider"], "vercel");
+        assert_eq!(before["granted"], true);
+
+        let (status, saved) = call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({
+                "apiKey": "vercel_live_supersecret",
+                "provider": "Vercel",
+                "team": " team_abc ",
+            })),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{saved}");
+
+        let (_, after) = call(
+            &state,
+            "GET",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            None,
+        )
+        .await;
+        assert_eq!(after["apiKeyConfigured"], true);
+        // The provider is normalised, and the team — the one non-secret field —
+        // comes back trimmed.
+        assert_eq!(after["provider"], "vercel");
+        assert_eq!(after["team"], "team_abc");
+
+        // The whole contract of this surface: it reports WHETHER a token is
+        // stored, never what it is. A response that echoed it back would put it
+        // in the browser, the network log, and any screen share.
+        for rendered in [saved.to_string(), after.to_string()] {
+            assert!(!rendered.contains("supersecret"), "{rendered}");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_provider_this_build_cannot_use_is_refused_rather_than_stored() {
+        // Stored, it would leave the settings page reading "Connected" over a
+        // slug that wires no tools at all.
+        let home = ::tempfile::tempdir().expect("tempdir");
+        let state = state_with_company(home.path(), true).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        let (status, body) = call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({"apiKey": "k", "provider": "heroku"})),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::BAD_REQUEST, "{body}");
+
+        let (_, after) = call(
+            &state,
+            "GET",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            None,
+        )
+        .await;
+        // The rejected request stored nothing at all — not even the key that
+        // came with it.
+        assert_eq!(after["apiKeyConfigured"], false, "{after}");
+        assert_eq!(after["provider"], "vercel");
+    }
+
+    #[tokio::test]
+    async fn clearing_removes_the_team_too_not_just_the_token() {
+        // The route is named `…/key`, which reads as if it clears only the
+        // token. A team left behind would be silently inherited by the next
+        // token saved without one — deploying into the previous account's scope.
+        let home = ::tempfile::tempdir().expect("tempdir");
+        let state = state_with_company(home.path(), true).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({"apiKey": "vercel_key", "team": "team_abc"})),
+        )
+        .await;
+
+        let (status, cleared) = call(
+            &state,
+            "DELETE",
+            "/api/v1/companies/acme/hosting/key",
+            &admin,
+            None,
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::OK, "{cleared}");
+        assert_eq!(cleared["apiKeyConfigured"], false);
+        assert_eq!(cleared["team"], Value::Null, "{cleared}");
+        assert_eq!(cleared["provider"], "vercel", "{cleared}");
+    }
+
+    #[tokio::test]
+    async fn a_stored_token_without_the_grant_reports_that_it_reaches_nobody() {
+        // Both halves can be right and still nothing happens. The status says so
+        // separately, because the fix is the manifest rather than this page.
+        let home = ::tempfile::tempdir().expect("tempdir");
+        let state = state_with_company(home.path(), false).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({"apiKey": "vercel_key"})),
+        )
+        .await;
+
+        let (_, after) = call(
+            &state,
+            "GET",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            None,
+        )
+        .await;
+
+        assert_eq!(after["apiKeyConfigured"], true);
+        assert_eq!(after["granted"], false, "{after}");
+    }
+
+    #[tokio::test]
+    async fn saving_a_team_alone_leaves_the_token_alone() {
+        // A patch, not a replace: an operator correcting a team must not have to
+        // re-enter a token they can never see again.
+        let home = ::tempfile::tempdir().expect("tempdir");
+        let state = state_with_company(home.path(), true).await;
+        let admin = crate::server::test_support::seed_admin(&state, "acme").await;
+
+        call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({"apiKey": "vercel_key"})),
+        )
+        .await;
+        let (_, after) = call(
+            &state,
+            "PUT",
+            "/api/v1/companies/acme/hosting",
+            &admin,
+            Some(json!({"team": "team_xyz"})),
+        )
+        .await;
+
+        assert_eq!(after["apiKeyConfigured"], true, "{after}");
+        assert_eq!(after["team"], "team_xyz");
+    }
 }

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -17,6 +17,7 @@
 
 pub mod artifacts;
 pub mod billing;
+pub mod hosting;
 pub mod capabilities;
 pub mod channels;
 pub mod company_key;
@@ -171,6 +172,7 @@ pub fn router() -> Router<AppState> {
         .merge(connections_read::router())
         .merge(channels::router())
         .merge(billing::router())
+        .merge(hosting::router())
         .merge(company_key::router())
         .merge(composio::router())
         .merge(domain::router())

--- a/src/server/ops/mod.rs
+++ b/src/server/ops/mod.rs
@@ -17,7 +17,6 @@
 
 pub mod artifacts;
 pub mod billing;
-pub mod hosting;
 pub mod capabilities;
 pub mod channels;
 pub mod company_key;
@@ -26,6 +25,7 @@ pub mod composio_toolkits;
 pub mod connections_read;
 pub mod domain;
 pub mod finances;
+pub mod hosting;
 pub mod imap;
 pub mod inbox;
 pub mod inference;

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -245,6 +245,7 @@ pub(super) fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc
         chargebee: None,
         #[cfg(feature = "paypal")]
         paypal: None,
+        hosting: None,
         steer: crate::company::steer::InflightRegistry::default(),
         run_supervisor: crate::runtime::RunSupervisor::default(),
         delivery: Some(WorkflowDeliveryDeps {

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1452,6 +1452,7 @@ description = "Runs Acme."
             chargebee: None,
             #[cfg(feature = "paypal")]
             paypal: None,
+            hosting: None,
             steer: crate::company::steer::InflightRegistry::default(),
             delivery: None,
             search: None,


### PR DESCRIPTION
Completes the hosting chain: **tinyhosts** (the unified hosting API) →
**openhuman** (the `hosting_*` tools) → **opencompany** (a per-company
credential, and the settings page a user pastes it into).

Depends on tinyhumansai/openhuman#5578, which depends on
tinyhumansai/tinyhosts#2. The `vendor/openhuman` gitlink points at that PR's
branch and moves to `main` once it lands.

## What a user gets

Settings → **Hosting**, a Vercel API token, and `hosting` in `[tools].allow`.
Their teammates can then deploy a site from the company's workspace to the public
internet — with a managed Postgres provisioned and wired in before the build, a
custom domain attached, and traffic reported back.

## What changed

- **`company::hosting`** — the three secret-store keys (`hosting/provider`,
  `hosting/api_key`, `hosting/team`). Always compiled, beside
  `company::billing`, for the same reason: the settings surface exists in every
  build even when the harness does not.
- **`grants_hosting_explicit`** — a catch-all `*` deliberately does **not**
  confer it, following `media` / `composio` / `chargebee`. A deployment
  publishes the company's files under its own account and can provision a
  database it is billed for.
- **`harness::hosting::TenantHosting`** — resolved from *that company's* secret
  store, never an environment variable, and folded into the roster fingerprint
  so a token saved or rotated in the console takes effect on the next turn
  rather than at the next restart. Resolved at boot in `runtime::builder` too.
- **`harness::build`** — the tools are wired only on an explicit grant **and** a
  resolved credential, pinned to the agent's own workspace directory (the same
  sandbox the file tools get, so an agent can only deploy what it can read).
- **`server::ops::hosting`** — `GET`/`PUT`/`DELETE …/hosting`. The token is
  write-only; the status reports *whether* one is stored, the provider, and the
  team. Admin authority required to write.
- **Frontend** — `HostingView` + `api/hosting.ts`, routed as a Settings
  sub-page.

## Worth reviewing for

- **The token never comes back out.** `PUT` stores it, `GET` reports a boolean,
  `TenantHosting`'s `Debug` redacts, and a route test asserts no response body
  contains it.
- **An unsupported provider slug is refused at the door** rather than stored —
  stored, the settings page would read "Connected" over a slug that wires
  nothing.
- **Clearing clears the team too.** A team left behind would be silently
  inherited by the next token saved without one, deploying into the previous
  account's scope.
- **Three failure modes are reported separately** — no token, not granted, not
  in build — because a single "Connected" badge is green for two of them and
  sends an operator hunting through a form that is already correct.
- **No connection string ever reaches this process.** A provisioned database's
  credentials are injected by the provider into the site's own environment; the
  tools report the variable *names*.

## Validation

- `cargo check --lib` (default features) — clean.
- `cargo check --features openhuman --lib` — clean.
- `cargo clippy --features openhuman --lib --tests` — no findings in any file in
  this change.
- `cargo test --features openhuman --lib hosting` — 8 passed (5 route, 3 unit).
- `cargo fmt --all`.
- `pnpm typecheck` — clean; `pnpm test` — 863 passed across 83 files, including
  7 new `hosting-view-branches` tests.

No live call was made against a hosting provider.