### PR TITLE
Count a provider's accounts by one rule on the connections page

### DIFF
--- a/frontend/src/lib/provider-grid.ts
+++ b/frontend/src/lib/provider-grid.ts
@@ -159,6 +159,74 @@ export function disconnectRouteFor(
   return null;
 }
 
+/**
+ * How many of a toolkit's accounts an agent can actually act as, and how many
+ * exist but cannot be acted as yet.
+ *
+ * **The one rule for counting accounts** (issue #923). The page had two. The
+ * tile grid printed `accounts.length` — every account, whatever its state —
+ * under a badge gated on {@link GridProvider.connected}, which the host defines
+ * as *at least one account is `ACTIVE`*. Mixing those two reads produced a page
+ * that contradicted itself in both directions at once: a Gmail holding one
+ * `ACTIVE` account and five `INITIATED` ones announced "6 accounts connected",
+ * while a Notion holding three `INITIATED` ones and no `ACTIVE` one announced
+ * "not connected" directly above the three accounts it holds.
+ *
+ * Both facts come from the same per-account `connected` flag the host already
+ * sends, which it sets for `ACTIVE`/`CONNECTED` alone. Nothing new is derived
+ * here; the two numbers are simply counted once, in one place, for every
+ * surface that reports them.
+ */
+export interface AccountTally {
+  /** Accounts an agent can act as — the host's per-account `connected`. */
+  live: number;
+  /**
+   * Accounts the company holds that are not usable: mid-handshake
+   * (`INITIATED`), lapsed (`EXPIRED`), or any other state Composio may add.
+   *
+   * Counted rather than named. The host forwards `status` verbatim and leaves
+   * the vocabulary to the console precisely because it will not guess at values
+   * it has not seen, and a summary line that had to name them would have to
+   * guess too. What the operator needs from a tile is that these accounts
+   * *exist* — the states themselves are listed per account below it.
+   */
+  pending: number;
+}
+
+/** Count a toolkit's accounts by whether an agent can act as them. */
+export function tallyAccounts(accounts: ComposioConnectedAccount[] | undefined): AccountTally {
+  const rows = accounts ?? [];
+  const live = rows.filter((a) => a.connected).length;
+  return { live, pending: rows.length - live };
+}
+
+/**
+ * What a surface says about a toolkit's accounts, or `null` when it holds none
+ * and the caller should fall back to its own wording.
+ *
+ * Shared by the tile grid and the provider detail panel so the two cannot drift
+ * again (issue #923): they described the same accounts differently, and #582
+ * had already had to remove a *second grid* for saying "connected" where the
+ * first said otherwise. A third implementation of "connected" would not have
+ * helped, so there is one.
+ *
+ * "none connected" is deliberate for a toolkit holding only unusable accounts.
+ * "not connected" is what the tile said before, and it is false: an account
+ * mid-handshake is not the absence of an account, and the operator reading it
+ * could see three of them listed below. This states both halves — the accounts
+ * are there, and none of them is usable yet.
+ */
+export function accountSummary(accounts: ComposioConnectedAccount[] | undefined): string | null {
+  const { live, pending } = tallyAccounts(accounts);
+  if (live > 0) {
+    return live === 1 ? "1 account connected" : `${live} accounts connected`;
+  }
+  if (pending > 0) {
+    return pending === 1 ? "1 account, not connected" : `${pending} accounts, none connected`;
+  }
+  return null;
+}
+
 /** The local tile for a Composio slug, when the console has metadata for one. */
 function nativeTileFor(slug: string): ConnectionProvider | undefined {
   return CONNECTION_PROVIDERS.find((p) => toolkitSlug(p.toolkit) === slug);

--- a/frontend/src/views/connections/ProviderDetail.tsx
+++ b/frontend/src/views/connections/ProviderDetail.tsx
@@ -22,6 +22,7 @@ import {
   probedOn,
 } from "@/lib/connection-detail";
 import { toolkitSlug } from "@/lib/connections";
+import { accountSummary, tallyAccounts } from "@/lib/provider-grid";
 import type { GridProvider } from "@/lib/provider-grid";
 
 /**
@@ -269,7 +270,9 @@ function ComposioBody({
 }) {
   const { provider, noCredential, onConnectAnother, onDisconnectAccount } = subject;
   const accounts = provider.accounts ?? [];
-  const live = accounts.filter((a) => a.connected);
+  // Counted through the shared rule so this panel, the tile that opened it,
+  // and the summary line above all mean one thing by "connected" (issue #923).
+  const { live } = tallyAccounts(accounts);
 
   return (
     <>
@@ -285,13 +288,12 @@ function ComposioBody({
                 panel opened at all. */}
             Composio
           </Badge>
-          <span>
-            {live.length === 0
-              ? "not connected"
-              : live.length === 1
-                ? "1 account connected"
-                : `${live.length} accounts connected`}
-          </span>
+          {/* The same rule the tile grid states, so the panel and the tile that
+              opened it cannot describe one set of accounts two ways (issue
+              #923). This counted only live accounts already — correctly — but
+              collapsed "holds accounts, none usable" to "not connected", which
+              is the half the grid got wrong too. */}
+          <span>{accountSummary(accounts) ?? "not connected"}</span>
         </SheetDescription>
       </SheetHeader>
 
@@ -318,7 +320,7 @@ function ComposioBody({
           )}
         </section>
 
-        {live.length > 1 && (
+        {live > 1 && (
           // #819 wrote this paragraph to say the choice did not exist —
           // "`composio_execute` sends no connection id, so Composio resolves
           // it. Disconnect the one you do not want an agent to use." #820 is

--- a/frontend/src/views/connections/ProvidersSection.tsx
+++ b/frontend/src/views/connections/ProvidersSection.tsx
@@ -12,6 +12,7 @@ import {
   visibleProviderRows,
   type ProviderCategory,
 } from "@/lib/composio-catalog";
+import { accountSummary, tallyAccounts } from "@/lib/provider-grid";
 import type { GridProvider } from "@/lib/provider-grid";
 import { cn } from "@/lib/utils";
 
@@ -362,9 +363,21 @@ function ProviderTile({
   // answer than the tile's badge.
   const openable =
     row.route.kind === "composio" && (!row.connected || row.accounts.length > 0);
+  // One rule for counting accounts, shared with the detail panel (issue #923).
+  // Two reads used to meet here and disagree: the count was
+  // `row.accounts.length` — every account, whatever its state — while the badge
+  // gating it was `row.connected`, which the host defines as *at least one
+  // account ACTIVE*. So a Gmail holding one live account and five mid-handshake
+  // ones said "6 accounts connected", and a Notion holding three mid-handshake
+  // ones and no live one said "not connected" two inches above the three
+  // accounts it holds. Both now count through `tallyAccounts`.
+  const { live, pending } = tallyAccounts(row.accounts);
   const state = row.connected
-    ? row.accounts.length > 1
-      ? `${row.accounts.length} accounts connected`
+    ? live > 1
+      ? // Only the live ones. A host predating #404 sends no accounts at all
+        // while still reporting the toolkit connected, which is why the `via`
+        // wording below stays the answer for "connected, nothing to count".
+        (accountSummary(row.accounts) ?? "connected")
       : row.via.length > 0
         ? `connected via ${row.via.join(" + ")}`
         : "connected"
@@ -376,7 +389,12 @@ function ProviderTile({
           ? "managed by the platform"
           : row.route.kind === "unavailable"
             ? "not available here"
-            : "not connected";
+            : pending > 0
+              ? // Accounts held, none of them usable. "not connected" here is
+                // what contradicted the list below — an account mid-handshake
+                // is not the absence of an account.
+                (accountSummary(row.accounts) ?? "not connected")
+              : "not connected";
 
   const shell = cn(
     "flex size-full flex-col items-start justify-between gap-1 rounded-lg border p-2.5 text-left",

--- a/frontend/test/unit/provider-grid.test.ts
+++ b/frontend/test/unit/provider-grid.test.ts
@@ -11,7 +11,12 @@ import { describe, expect, it } from "vitest";
 
 import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
 import type { ConnectionState } from "@/api/types";
-import { buildGridProviders, disconnectRouteFor } from "@/lib/provider-grid";
+import {
+  accountSummary,
+  buildGridProviders,
+  disconnectRouteFor,
+  tallyAccounts,
+} from "@/lib/provider-grid";
 import { CONNECTION_PROVIDERS, type ComposioReach } from "@/lib/connections";
 
 /** A host where Composio is live and everything is reachable (open mode). */
@@ -419,5 +424,72 @@ describe("disconnect routing", () => {
     const tile = bySlug(providers, "gmail");
     expect(tile.account).toBeUndefined();
     expect(tile.accounts).toHaveLength(2);
+  });
+});
+
+// The one rule for counting accounts (issue #923).
+//
+// The bug these pin is #582's shape one level down. #582 removed a second
+// *grid*; this is two rules meeting inside the surviving one. The tile printed
+// `accounts.length` — every account, whatever its state — under a badge gated
+// on `connected`, which the host sets when at least one account is `ACTIVE`.
+// The two reads disagreed in both directions on one screen, and the account
+// list two inches below the grid showed the operator that they did.
+//
+// The counts below are the three rows the issue reported, verbatim.
+describe("accountSummary", () => {
+  function acct(id: string, connected: boolean): ComposioConnectedAccount {
+    return { id, status: connected ? "ACTIVE" : "INITIATED", connected };
+  }
+
+  it("counts only the accounts an agent can act as", () => {
+    // Gmail as reported: one ACTIVE, five INITIATED. The grid said "6 accounts
+    // connected" — it counted the five that no agent can use.
+    const gmail = [
+      acct("g1", true),
+      acct("g2", false),
+      acct("g3", false),
+      acct("g4", false),
+      acct("g5", false),
+      acct("g6", false),
+    ];
+    expect(tallyAccounts(gmail)).toEqual({ live: 1, pending: 5 });
+    expect(accountSummary(gmail)).toBe("1 account connected");
+
+    // GitHub as reported: three ACTIVE, two INITIATED. The grid said five.
+    const github = [
+      acct("h1", true),
+      acct("h2", true),
+      acct("h3", true),
+      acct("h4", false),
+      acct("h5", false),
+    ];
+    expect(tallyAccounts(github)).toEqual({ live: 3, pending: 2 });
+    expect(accountSummary(github)).toBe("3 accounts connected");
+  });
+
+  it("says a provider holds accounts even when none of them is usable", () => {
+    // Notion as reported: three INITIATED, none ACTIVE. The grid collapsed this
+    // to "not connected" — directly above the three accounts it listed. An
+    // account mid-handshake is not the absence of an account, which is the
+    // distinction the issue's Expected asks the grid to keep.
+    const notion = [acct("n1", false), acct("n2", false), acct("n3", false)];
+    expect(tallyAccounts(notion)).toEqual({ live: 0, pending: 3 });
+    expect(accountSummary(notion)).toBe("3 accounts, none connected");
+    expect(accountSummary(notion)).not.toBe("not connected");
+  });
+
+  it("leaves the wording to the caller when the host sent no accounts", () => {
+    // A host predating #404 answers without `accounts` while still reporting
+    // the toolkit connected. `null` is what lets the tile keep saying
+    // "connected via composio" rather than inventing a count of zero.
+    expect(accountSummary(undefined)).toBeNull();
+    expect(accountSummary([])).toBeNull();
+    expect(tallyAccounts(undefined)).toEqual({ live: 0, pending: 0 });
+  });
+
+  it("uses the singular for one of each", () => {
+    expect(accountSummary([acct("a", true)])).toBe("1 account connected");
+    expect(accountSummary([acct("a", false)])).toBe("1 account, not connected");
   });
 });

--- a/frontend/test/unit/providers-grid-render.test.ts
+++ b/frontend/test/unit/providers-grid-render.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import type { ComposioConnectedAccount, ComposioToolkitEntry } from "@/api/composio";
+import type { ComposioReach } from "@/lib/connections";
+import { buildGridProviders, type GridProvider } from "@/lib/provider-grid";
+import { ProvidersSection } from "@/views/connections/ProvidersSection";
+
+/**
+ * What a provider tile says about its accounts (issue #923).
+ *
+ * `provider-grid.test.ts` pins the counting rule as a function. This pins what
+ * the operator actually reads, which is where the two rules met and disagreed —
+ * the rule could be right and the tile still print the old sentence, and that is
+ * exactly the regression this file exists to catch.
+ *
+ * The three shapes below are the three rows the issue reported from
+ * `smoke1.staging`, and the strings asserted are what the grid said before the
+ * fix. A tile is a button, so its text is reachable without driving the page.
+ */
+
+const OPEN: ComposioReach = {
+  inBuild: true,
+  granted: true,
+  hasCredential: true,
+  openMode: true,
+  effectiveToolkits: [],
+};
+
+function entry(slug: string, name: string): ComposioToolkitEntry {
+  return { slug, name, description: "", logo: null, categories: [] };
+}
+
+function acct(id: string, connected: boolean): ComposioConnectedAccount {
+  return { id, status: connected ? "ACTIVE" : "INITIATED", connected };
+}
+
+/**
+ * A grid row built the way the page builds it.
+ *
+ * `connected` mirrors the host's own rule — at least one account `ACTIVE` — so
+ * the fixture cannot drift from `group_by_toolkit` in `src/server/ops/composio.rs`
+ * and quietly stop describing the reported bug.
+ */
+function row(slug: string, name: string, accounts: ComposioConnectedAccount[]): GridProvider {
+  const connected = accounts.some((a) => a.connected);
+  const rows = buildGridProviders(
+    [entry(slug, name)],
+    [],
+    { [slug]: { provider: slug, connected, via: connected ? ["composio"] : [] } },
+    OPEN,
+    false,
+    { [slug]: accounts },
+  );
+  return rows.find((p) => p.slug === slug)!;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => root.unmount());
+  container.remove();
+});
+
+async function render(providers: GridProvider[]) {
+  await act(async () => {
+    root.render(
+      createElement(ProvidersSection, {
+        providers,
+        canManage: true,
+        busy: null,
+        noCredential: false,
+        granted: true,
+        openMode: false,
+        degraded: null,
+        loading: false,
+        onConnect: () => {},
+        onDisconnect: () => {},
+        onOpen: () => {},
+        onConnectSlug: () => {},
+      }),
+    );
+  });
+}
+
+function text(): string {
+  return container.textContent ?? "";
+}
+
+describe("what a tile says about its accounts", () => {
+  it("does not count accounts no agent can act as", async () => {
+    // Gmail as reported: one ACTIVE, five INITIATED. The tile said
+    // "6 accounts connected" — `accounts.length`, under a badge that only
+    // required one of them to be live.
+    await render([
+      row("gmail", "Gmail", [
+        acct("g1", true),
+        acct("g2", false),
+        acct("g3", false),
+        acct("g4", false),
+        acct("g5", false),
+        acct("g6", false),
+      ]),
+    ]);
+    expect(text()).not.toContain("6 accounts connected");
+    expect(text()).toContain("connected");
+  });
+
+  it("counts the live accounts and not the rest when several are live", async () => {
+    // GitHub as reported: three ACTIVE, two INITIATED. The tile said five.
+    await render([
+      row("github", "GitHub", [
+        acct("h1", true),
+        acct("h2", true),
+        acct("h3", true),
+        acct("h4", false),
+        acct("h5", false),
+      ]),
+    ]);
+    expect(text()).toContain("3 accounts connected");
+    expect(text()).not.toContain("5 accounts connected");
+  });
+
+  it("does not call a provider that holds three accounts 'not connected'", async () => {
+    // Notion as reported: three INITIATED, none ACTIVE. The tile said
+    // "not connected", two inches above the three accounts the page listed.
+    await render([
+      row("notion", "Notion", [acct("n1", false), acct("n2", false), acct("n3", false)]),
+    ]);
+    expect(text()).toContain("3 accounts, none connected");
+    // The exact contradiction: the words the operator read while three accounts
+    // sat below them. `toContain` would also match the new sentence's tail, so
+    // this asserts the standalone phrase is gone.
+    expect(text()).not.toMatch(/(^|[^,] )not connected/);
+  });
+
+  it("still says a provider with nothing connected is not connected", async () => {
+    // The control. "none connected" must not leak onto a provider that holds no
+    // accounts at all — that one really is unconnected, and the old wording is
+    // the right wording for it.
+    await render([row("slack", "Slack", [])]);
+    expect(text()).toContain("not connected");
+    expect(text()).not.toContain("none connected");
+  });
+});


### PR DESCRIPTION
## Summary

The Connections page contradicted itself about the same accounts, in both directions at once. This is
#582's shape one level down: #582 removed a second *grid*; this is two rules meeting **inside the
surviving one**.

`ProvidersSection.tsx` gated the badge on `row.connected` — which the host sets when at least one
account is `ACTIVE` — and then printed `row.accounts.length`, every account whatever its state:

```js
const state = row.connected                              // ≥1 account ACTIVE
  ? row.accounts.length > 1
    ? `${row.accounts.length} accounts connected`        // every account, any state
```

Two reads of the same data in one expression:

| Provider | live | held | tile said | wrong by |
|---|---|---|---|---|
| Gmail | 1 | 6 | "6 accounts connected" | over-counts 5 |
| GitHub | 3 | 5 | "5 accounts connected" | over-counts 2 |
| Notion | 0 | 3 | "not connected" | three accounts vanish |

…while "Which account agents act as", directly below, listed all three Notion accounts.

## The rule

**An account counts as connected when an agent can act as it, and nothing else counts.**

That is the host's per-account `connected` flag, which it sets for `ACTIVE`/`CONNECTED` and nothing
else (`src/harness/composio.rs:350`). It is not a new definition — it is the one already on the wire,
now the only one the console applies.

### What `initiated` means, and why it is not counted as connected

`INITIATED` is Composio's **mid-handshake** state: the connection object exists, the OAuth round trip
has not completed, and **no agent can act as it**. It is not counted toward "connected" because
counting it would make the number a promise the product cannot keep — an operator picking that
account gets an agent that cannot use it, which is the same class of lie in the opposite direction.

**But it is not nothing, and the grid no longer says it is.** "Not connected" for a provider holding
three `INITIATED` accounts is false: an account mid-handshake is not the absence of an account, and
the operator could see three of them listed two inches below. A provider holding only unusable
accounts now reads **"3 accounts, none connected"** — both halves stated: they exist, none is live yet.

`EXPIRED` and any state Composio adds later are handled by the same rule, because the rule asks the
host's boolean rather than matching on status strings. The summary **counts** these accounts rather
than **naming** their states, deliberately: the host forwards `status` verbatim and leaves the
vocabulary to the console precisely because it will not guess at values it has not seen
(`src/harness/composio.rs:345-348`), and a tile that named them would have to guess too. The states
themselves are listed per account in the section below.

## One source of truth — not the grid's arithmetic patched to agree

The single source is the host's per-account `connected` flag. **No surface derives its own notion of
connected any more**, which is the part that matters — patching the grid's count to match the picker
would have left two implementations that happened to agree today.

| Surface | Before | After |
|---|---|---|
| Providers grid tile | `accounts.length`, badge on `row.connected` | `tallyAccounts` / `accountSummary` |
| Provider detail panel | its own `accounts.filter(a => a.connected)` (#821) | the same `tallyAccounts` / `accountSummary` |
| "Which account agents act as" | per-account `account.connected` | **unchanged — it was already right** |

The account picker is worth being precise about: it needed no change and got none. It never counted;
it lists every account, shows each raw `status`, and gates its button on that same per-account
`connected` ("This account is initiated — re-authorize it before agents can act as it."). It was
reading the source of truth correctly all along. The grid is what disagreed with it, and the grid now
reads the same flag.

`tallyAccounts` and `accountSummary` live in `frontend/src/lib/provider-grid.ts` — the module that
already owns the grid's model and helpers like `disconnectRouteFor` — and are shared by the two
surfaces that *count*. A third implementation would not have helped, so there is one.

## Why #582 did not cover this

From `git log -L` on the line, not inferred:

- **#582** unified the page onto one grid. At that point the tile had **no account count at all** —
  `const state = row.connected ? row.via.length > 0 ? …`.
- **#404** (`e3450db6`, 2026-08-13) added the count to the tile, using `accounts.length`.
- **#821** (`0932ac96`, **the same day**) gave the detail panel a *second* count, using the correct
  `filter(a => a.connected)`.

So #582's fix was complete for what existed when it landed. Two PRs then added counting to the same
page twice, with different rules, and the tile got the wrong one. The detail panel's count was right
but it shared the other half of the bug — it also collapsed "holds accounts, none usable" to
"not connected".

## API Or Behavior Changes

No API change. Console wording only, on two surfaces:

- A provider with **one** live account no longer claims the total. Gmail with 1 live + 5 mid-handshake
  reads "connected via composio" instead of "6 accounts connected".
- A provider with **several** live accounts counts only those. GitHub reads "3 accounts connected",
  not "5".
- A provider holding **only** unusable accounts reads "N accounts, none connected" instead of
  "not connected".
- A provider holding **no** accounts still reads "not connected" — unchanged, and covered by a test
  so the new wording cannot leak onto it.

**A lone account's name no longer hides its status** (CodeRabbit, `cd981198`). `buildGridProviders`
sets `row.account` whenever a toolkit holds exactly one account — whatever that account's own
`connected` is — and the tile rendered `row.account ?? state`, so a single *named* mid-handshake
account showed its address **instead of** its state and `"1 account, not connected"` never reached
the screen. That is this same defect one branch over: a surface showing a name where it should show
the truth. A label may still stand alone on a **connected** tile, where the green treatment already
carries the status; everywhere else the label and the state are shown together. The unnamed case is
untouched.

The counting rule above is unchanged by this — it governs what `state` says, and this governs
whether `state` is displayed at all.

Blast radius kept deliberately tight: the `live > 1` branch preserves the existing "connected via …"
wording for a single account, so only the two paths the issue reports change. A host predating #404
sends no `accounts` at all while still reporting the toolkit connected; `accountSummary` returns
`null` there and the caller keeps its old wording.

## Tests

- [x] `cargo fmt --all -- --check` — N/A. Frontend-only change; no Rust file is touched
      (`git diff --stat` is four files under `frontend/`).
- [x] `cargo clippy --all-targets -- -D warnings` — N/A. Frontend-only, as above.
- [x] `cargo build --all-targets` — N/A. Frontend-only, as above.
- [x] `cargo test` — N/A for the Rust suite, frontend-only. The console suite was run in full instead:
      `npx vitest run` → **871 passed / 84 files / 0 failed**.

The `Console` lane's four steps, all run locally from `frontend/`, all PASS:

| Command | Result |
|---|---|
| `npm run typecheck` | PASS |
| `npm run typecheck:e2e` | PASS |
| `npm run typecheck:unit` | PASS |
| `npm run build` | PASS |

`typecheck:unit` is called out because it is a separate CI step for a reason: `tsc -b` does not reach
`test/unit`, and Vitest strips types rather than checking them, so a unit test can otherwise go green
by coincidence (#434).

### Every new test proven to fail with the fix reverted

Reverting `ProvidersSection.tsx` to the pre-fix expression (and dropping the import) fails **3 of the
4** new render tests, reproducing all three reported rows:

```
× does not count accounts no agent can act as
× counts the live accounts and not the rest when several are live
× does not call a provider that holds three accounts 'not connected'
✓ still says a provider with nothing connected is not connected
```

**The fourth passes with the fix reverted, and is not coverage.** It is a control — a provider holding
no accounts must keep saying "not connected", so the new "none connected" wording cannot leak onto a
genuinely unconnected tile. Stating that rather than counting it, because a test that passes both ways
proves nothing about the fix.

`providers-grid-render.test.ts` exists precisely because the helper tests alone **would** have been
vacuous: `accountSummary` is new, so a suite that only exercised the function would pass while the tile
still printed the old sentence. The render tests assert what the operator actually reads.

The additions to `provider-grid.test.ts` pin the rule as a function, using the issue's three account
shapes verbatim; the render tests pin the rendering. `provider-grid.test.ts` is #582's own suite —
the same class of bug belongs in the same file.

## Documentation

`frontend/src/lib/provider-grid.ts` carries the reasoning inline: what the two disagreeing reads were,
why the rule asks the host's boolean instead of matching status strings, and why `pending` is counted
rather than named. `ProvidersSection.tsx` and `ProviderDetail.tsx` each state at their call site which
half of the contradiction they had.

No `docs/` change: this alters no route, no launcher behavior, and no `tiny*` integration. The
route's own contract is unchanged — this PR only makes the console apply it.

Closes tinyhumansai/opencompany#923


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved provider connection statuses to count only connected accounts.
  * Pending accounts are now clearly distinguished from active connections.
  * Providers with only pending accounts display an accurate account summary instead of “not connected.”
  * Added correct singular and plural wording for account counts.

* **Tests**
  * Added coverage for active, pending, empty, and partially connected account states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
