### PR TITLE
fix(harness): settle a not-automatable verdict as an answer, not a failure

### DIFF
--- a/docs/spec/runtime/workflow-build.md
+++ b/docs/spec/runtime/workflow-build.md
@@ -39,15 +39,34 @@ and it stays off the wire so a one-off card is byte-identical to a pre-#580 card
 | **Cost** | one `SampleKind::Inference` sample, charged to the card's **assignee**, carrying the attempt's `run_id` |
 | **Run row** | one — building the workflow *is* the card's In-Progress work |
 | **Locks** | none |
-| **Exit** | automatic, three-way (below) — the card never stays in `in_progress` |
+| **Exit** | automatic, four-way (below) — the card never stays in `in_progress` |
 
-### The three exits
+### The four exits
 
 | Outcome | Landing | Card carries | Attempt |
 |---|---|---|---|
 | a graph that could be created | `in_review` | the `TaskWorkflowProposal` awaiting approval | Succeeded |
-| the plan is not automatable | `todo` | the model's reason, no proposal (decision D2c) | Failed |
-| the pass itself failed | `todo` | the reason only, no proposal | Failed |
+| the plan is not automatable | `todo` | the model's reason, no proposal (decision D2c), and `deliverable: once` | Succeeded |
+| the model decided nothing | `todo` | the reason only, no proposal; stays `deliverable: workflow` | Failed |
+| the pass itself failed | `todo` | the reason only, no proposal; stays `deliverable: workflow` | Failed |
+
+A **not-automatable verdict is an answer, not a fault** (issue #873). The builder
+was asked whether the work should be automated and it decided; that settles
+**Succeeded**, with the reason on the card note and **no** `error` on the run row
+— the same convention the [draft-from-description endpoint](../../../src/server/ops/workflows.rs)
+already follows in answering `200` for the identical verdict.
+
+The verdict also **converts the card to `deliverable: once`**. This is what lets
+the card proceed: dispatch routes a `workflow`-deliverable card to this pass
+rather than to its assignee, so a declined card left carrying `workflow` would
+re-enter the builder on its next dispatch, draw the same verdict, and fail again
+— builder → To-do → builder, with no path to the person who could simply do the
+work. As `once`, the next dispatch reaches the card's assignee.
+
+A build that could not be *attempted* — an unreadable company state, a model
+timeout or error, or a draft that parsed but decided nothing — keeps
+`deliverable: workflow` on purpose, because retrying the **build** is the right
+next move for a fault.
 
 An operator who moves the card out from under the pass wins: the pass discards
 its result and the attempt settles **Cancelled** — the tokens stay metered

--- a/src/harness/workflow_build.rs
+++ b/src/harness/workflow_build.rs
@@ -429,18 +429,37 @@ pub async fn run_workflow_build_pass(
     };
     record_usage(&runtime, &builder, &agent, &run_id, &usage).await;
 
-    // The model's two answers: a graph, or "this is not automatable".
+    // The model's answers: a graph, a reasoned "this is not automatable", or
+    // — split out by #873 — a draft that decided nothing at all.
     let spec = match draft.into_outcome() {
         BuildOutcome::NotAutomatable(reason) => {
-            settle_to_todo(
+            // Issue #873: a verdict, not a fault. `settle_not_automatable`
+            // settles the attempt Succeeded and converts the card to a `once`
+            // deliverable so the next dispatch reaches its assignee instead of
+            // re-entering this pass to draw the same conclusion again.
+            settle_not_automatable(
                 &runtime,
                 &task_id,
                 token,
                 &run_id,
-                &format!("this is better done once than built into a workflow: {reason}"),
+                // The operator-facing half of #873: the note has to say what
+                // happened to the card, not only what the builder concluded.
+                // Before this, the card read as a verdict while the run row next
+                // to it read as a failure, and nothing said the card had been
+                // converted or where it goes next.
+                &format!(
+                    "this is better done once than built into a workflow: {reason} — this card is \
+                     now a one-off for its assignee to do by hand, not a workflow to build"
+                ),
                 usage,
             )
             .await;
+            return;
+        }
+        // Parsed, but decided nothing — a fault, so it keeps the Failed settle
+        // and stays builder-routed for a retry (issue #873).
+        BuildOutcome::NoAnswer(reason) => {
+            settle_to_todo(&runtime, &task_id, token, &run_id, &reason, usage).await;
             return;
         }
         BuildOutcome::Graph { summary, mut spec } => {
@@ -641,9 +660,17 @@ async fn settle_to_review(
     finish_run(runtime, run_id, RunStatus::Succeeded, None, usage).await;
 }
 
-/// Not-automatable, or the pass failed: the card returns to To-do with the reason
-/// and **no** proposal (decision D2c), and the attempt settles Failed. A card
-/// moved out from under the pass cancels the attempt instead.
+/// The pass **failed**: the card returns to To-do with the reason and **no**
+/// proposal (decision D2c), and the attempt settles Failed. A card moved out
+/// from under the pass cancels the attempt instead.
+///
+/// Issue #873: this is now the fault path only. A build that could not be
+/// *attempted* — an unreadable company state, a model timeout, a model error —
+/// belongs here, and its card keeps `deliverable: workflow` on purpose, because
+/// retrying the build is the right next move for a fault.
+///
+/// A build that ran and concluded "don't automate this" is not a fault and no
+/// longer comes through this door — see [`settle_not_automatable`].
 async fn settle_to_todo(
     runtime: &Arc<CompanyRuntime>,
     task_id: &str,
@@ -683,6 +710,77 @@ async fn settle_to_todo(
         );
     }
     finish_run(runtime, run_id, RunStatus::Failed, Some(&reason), usage).await;
+}
+
+/// The builder ran and decided the work should be **done once** rather than
+/// automated (issue #873). A verdict, not a fault, and settled as one.
+///
+/// Three things separate this from [`settle_to_todo`], and all three are the
+/// bug: the same door served both, so a correct refusal was filed as a failure
+/// and then retried forever.
+///
+/// 1. **The attempt settles `Succeeded`.** The builder was asked a question and
+///    answered it. Filing that as `Failed` made an honest "don't automate this"
+///    indistinguishable from a model timeout — to the console, to the attempt
+///    history, and to anything counting failures.
+/// 2. **The card's deliverable flips to `once`.** This is what breaks the loop.
+///    `CompanyRuntime::dispatch_task` routes a `workflow`-deliverable card to
+///    this very pass instead of to its assignee, so returning the card to To-do
+///    still carrying `workflow` guaranteed the next dispatch re-entered the
+///    builder, drew the same verdict, and failed the same way. As `once`, the
+///    next dispatch reaches the assignee named on the card — the person who can
+///    simply do the work, which is what the verdict asked for.
+/// 3. **No `error` on the run row.** The reason goes on the card note, where the
+///    issue reports it already reads sensibly. Putting it in `error` would keep
+///    the operator-facing half of this bug alive: a surface rendering `error` as
+///    a failure would still show red for a reasoned decision.
+///
+/// The card still lands in To-do rather than somewhere new. That column is only
+/// a trap while the deliverable says `workflow`; once it says `once`, To-do is
+/// the ordinary place for work waiting on a person.
+async fn settle_not_automatable(
+    runtime: &Arc<CompanyRuntime>,
+    task_id: &str,
+    token: u64,
+    run_id: &str,
+    reason: &str,
+    usage: TokenUsage,
+) {
+    let Some(mut card) = claim_settle(runtime, task_id, token).await else {
+        finish_run(
+            runtime,
+            run_id,
+            RunStatus::Cancelled,
+            Some("the card moved while its workflow was being built"),
+            usage,
+        )
+        .await;
+        return;
+    };
+    let reason = cap(reason, MAX_REASON_CHARS);
+    card.note = Some(append_result(
+        card.note.as_deref(),
+        SYSTEM_ATTRIBUTION,
+        &reason,
+    ));
+    // No proposal was made, and any earlier one must not read as current.
+    card.workflow_proposal = None;
+    // The loop-breaker. Ordered after `claim_settle`, which requires the card to
+    // still be a `workflow` card — so the guard sees the deliverable this pass
+    // was started for, and only the write below changes it.
+    card.deliverable = TaskDeliverable::Once;
+    card.column = COLUMN_TODO.to_string();
+    card.updated_at_millis = now_millis();
+    if let Err(err) = runtime.tasks().upsert(runtime.id(), &card).await {
+        tracing::warn!(
+            company = %runtime.id(),
+            task = %task_id,
+            error = %err,
+            "[builder] decided this is better done once but could not convert the card; it stays \
+             In Progress until the next boot"
+        );
+    }
+    finish_run(runtime, run_id, RunStatus::Succeeded, None, usage).await;
 }
 
 /// Settles the attempt row. Best-effort: the work (or its failure) has already
@@ -929,7 +1027,18 @@ enum BuildOutcome {
         spec: WorkflowGraphSpec,
     },
     /// The plan is not worth building into a reusable workflow; the string is why.
+    ///
+    /// A **decision** — the builder was asked and answered. Issue #873 settles
+    /// this as a succeeded attempt and converts the card to a one-off.
     NotAutomatable(String),
+    /// The draft parsed but decided nothing: no graph, and no reason either.
+    ///
+    /// Split out from [`NotAutomatable`](Self::NotAutomatable) by issue #873.
+    /// The two used to share a variant, which was harmless while both settled
+    /// Failed — but a verdict now converts the card and files a success, and a
+    /// model that returned an empty object has concluded nothing that would
+    /// justify either. This is a fault, and settles like one.
+    NoAnswer(String),
 }
 
 impl BuildDraft {
@@ -944,13 +1053,22 @@ impl BuildDraft {
                     spec,
                 }
             }
+            // No usable graph. Whether that is a verdict or a non-answer turns
+            // on whether the model actually decided anything (issue #873).
             _ => {
-                let reason = if self.reason.trim().is_empty() {
-                    "the model did not return a workflow graph".to_string()
-                } else {
-                    self.reason
-                };
-                BuildOutcome::NotAutomatable(reason)
+                if !self.reason.trim().is_empty() {
+                    // It gave a reason — a decision, whatever `automatable` said.
+                    return BuildOutcome::NotAutomatable(self.reason);
+                }
+                if self.automatable == Some(false) {
+                    // An explicit "no" with no prose is still an explicit no.
+                    return BuildOutcome::NotAutomatable(
+                        "the builder declined to automate this but gave no reason".to_string(),
+                    );
+                }
+                // Neither a graph, nor a reason, nor a refusal: nothing was
+                // decided, so this must not convert the card or read as success.
+                BuildOutcome::NoAnswer("the model did not return a workflow graph".to_string())
             }
         }
     }

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -403,7 +403,8 @@ fn the_outcome_resolves_graph_versus_not_automatable() {
             assert!(summary.contains("digest"));
             assert_eq!(spec.nodes.len(), 2);
         }
-        BuildOutcome::NotAutomatable(_) => panic!("a valid graph must build"),
+        BuildOutcome::NotAutomatable(r) => panic!("a valid graph must build, declined: {r}"),
+        BuildOutcome::NoAnswer(r) => panic!("a valid graph must build, no answer: {r}"),
     }
 
     let refused = parse_draft(r#"{"automatable":false,"reason":"only runs once"}"#)
@@ -418,11 +419,20 @@ fn the_outcome_resolves_graph_versus_not_automatable() {
             .into_outcome();
     assert!(matches!(both, BuildOutcome::NotAutomatable(_)));
 
-    // No workflow, no reason → a truthful default reason rather than an empty one.
+    // Issue #873: no workflow, no reason and no refusal decided NOTHING, so it
+    // is a non-answer rather than a verdict. The distinction is load-bearing —
+    // a verdict now settles Succeeded and converts the card to a one-off, and an
+    // empty object must do neither.
     let empty = parse_draft(r#"{"automatable":true}"#)
         .unwrap()
         .into_outcome();
-    assert!(matches!(empty, BuildOutcome::NotAutomatable(r) if !r.is_empty()));
+    assert!(matches!(empty, BuildOutcome::NoAnswer(r) if !r.is_empty()));
+
+    // An explicit refusal with no prose is still a refusal, not a non-answer.
+    let bare_no = parse_draft(r#"{"automatable":false}"#)
+        .unwrap()
+        .into_outcome();
+    assert!(matches!(bare_no, BuildOutcome::NotAutomatable(r) if !r.is_empty()));
 }
 
 /// Untrusted text embedded in the fix prompt cannot open or close a markdown
@@ -881,7 +891,11 @@ async fn a_card_with_no_plan_builds_from_title_and_note() {
 }
 
 /// A not-automatable answer returns the card to To-do with the reason and no
-/// proposal (decision D2c); the attempt settles Failed.
+/// proposal (decision D2c).
+///
+/// Issue #873: the attempt settles **Succeeded**, and the card is converted to a
+/// `once` deliverable. It used to settle Failed and keep `workflow`, which is
+/// what trapped the card — see the loop test below.
 #[tokio::test]
 async fn a_not_automatable_answer_returns_the_card_to_todo() {
     let reply = r#"{"automatable":false,"reason":"this only ever runs once"}"#;
@@ -907,7 +921,126 @@ async fn a_not_automatable_answer_returns_the_card_to_todo() {
         "no proposal on a not-automatable card"
     );
     assert!(after.note.unwrap().contains("done once"));
+    assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Succeeded);
+}
+
+/// The loop #873 reports, asserted at the seam that closes it.
+///
+/// `CompanyRuntime::dispatch_task` sends a `workflow`-deliverable card to the
+/// builder pass rather than to its assignee. So a verdict that returned the card
+/// to To-do still carrying `workflow` guaranteed the next dispatch re-entered
+/// the builder, drew the same verdict, and failed again — builder → To-do →
+/// builder, with a red error on every pass and no way for the card to reach the
+/// person who could just do the work.
+///
+/// Converting the deliverable is what breaks it: the card keeps its assignee and
+/// becomes ordinary one-off work.
+#[tokio::test]
+async fn a_not_automatable_verdict_converts_the_card_so_it_stops_re_entering_the_builder() {
+    let reply = r#"{"automatable":false,"reason":"a workflow for this already exists"}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    let before = card("t-loop", None);
+    assert_eq!(
+        before.deliverable,
+        TaskDeliverable::Workflow,
+        "the card starts as builder-routed work"
+    );
+    runtime.tasks().upsert(runtime.id(), &before).await.unwrap();
+    let run_id = open_run(&runtime, "t-loop").await;
+
+    run_workflow_build_pass(
+        Arc::clone(&runtime),
+        "t-loop".to_string(),
+        Some(run_id.clone()),
+    )
+    .await;
+
+    let after = read(&runtime, "t-loop").await;
+    assert_eq!(
+        after.deliverable,
+        TaskDeliverable::Once,
+        "a declined card must stop routing to the builder, or it loops forever"
+    );
+    assert_eq!(
+        after.assignee, "maya",
+        "the assignee is who the verdict hands the work to; it must survive"
+    );
+    assert_eq!(after.column, COLUMN_TODO);
+}
+
+/// The operator-facing half. The reason is on the card, and the run row carries
+/// **no** error — a decision filed with an error is how the console showed red
+/// for a reasoned "do this by hand" in the first place.
+#[tokio::test]
+async fn a_not_automatable_verdict_files_no_error_and_says_what_happened_to_the_card() {
+    let reply = r#"{"automatable":false,"reason":"the search tool is not wired here"}"#;
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(reply)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-note", None))
+        .await
+        .unwrap();
+    let run_id = open_run(&runtime, "t-note").await;
+
+    run_workflow_build_pass(
+        Arc::clone(&runtime),
+        "t-note".to_string(),
+        Some(run_id.clone()),
+    )
+    .await;
+
+    let row = runtime
+        .runs()
+        .get_run(runtime.id(), &run_id)
+        .await
+        .expect("read")
+        .expect("the attempt row exists");
+    assert_eq!(row.status, RunStatus::Succeeded);
+    assert!(
+        row.error.is_none(),
+        "a verdict is not an error: {:?}",
+        row.error
+    );
+
+    let note = read(&runtime, "t-note").await.note.expect("a note");
+    assert!(note.contains("the search tool is not wired here"), "{note}");
+    assert!(
+        note.contains("one-off"),
+        "the note must say what became of the card, not only the verdict: {note}"
+    );
+}
+
+/// The discrimination that makes the change safe: a build that could not be
+/// *attempted* is still a failure, and its card still routes to the builder so a
+/// retry re-attempts the build rather than landing on a person.
+#[tokio::test]
+async fn a_genuine_build_failure_still_fails_and_stays_builder_routed() {
+    // A draft that parses and decides nothing: no graph, no reason, no refusal.
+    // This is the `BuildOutcome::NoAnswer` path — the case that used to share a
+    // variant with a real verdict and would otherwise now convert the card.
+    let (_home, runtime) = runtime_with(ScriptedModel::replying(r#"{"automatable":true}"#)).await;
+    runtime
+        .tasks()
+        .upsert(runtime.id(), &card("t-fault", None))
+        .await
+        .unwrap();
+    let run_id = open_run(&runtime, "t-fault").await;
+
+    run_workflow_build_pass(
+        Arc::clone(&runtime),
+        "t-fault".to_string(),
+        Some(run_id.clone()),
+    )
+    .await;
+
     assert_eq!(run_status(&runtime, &run_id).await, RunStatus::Failed);
+    let after = read(&runtime, "t-fault").await;
+    assert_eq!(
+        after.deliverable,
+        TaskDeliverable::Workflow,
+        "a fault must stay builder-routed — retrying the build is the right next move"
+    );
+    assert_eq!(after.column, COLUMN_TODO);
 }
 
 /// An unparseable answer returns the card to To-do with no proposal; the attempt


### PR DESCRIPTION
## Summary

A `NotAutomatable` verdict from the workflow builder was recorded as a **failed run**,
and the card kept its `workflow` deliverable. Together those trapped the card:
`dispatch_task` routes a `workflow`-deliverable card to the builder pass rather than to
its assignee (`src/company/runtime.rs:755`), so a declined card returned to To-do
re-entered the builder on its next dispatch, drew the same verdict, and failed the same
way — builder → To-do → builder, a red error to the operator every pass, and no path to
the person who could simply do the work.

The builder's judgement in the reported case was **correct** — the workflow really did
already exist and the search tool really was unwired. So this is a legitimate, terminal,
*successful* outcome of the builder: a decision, not a crash. The defect was entirely in
what happened to the answer.

This fixes all three halves named in #873:

1. **Not recorded as a failed run.** A new `settle_not_automatable` settles the attempt
   `Succeeded` with **no** `error` on the run row; the reason goes on the card note.
   `settle_to_todo` becomes the fault-only door. This matches the convention the
   sibling draft-from-description endpoint already follows — `src/server/ops/workflows.rs:1608`
   answers **200** for this same verdict, documented as "neither is an error the operator
   fixes by retrying differently".
2. **The `workflow` deliverable is cleared.** The verdict converts the card to
   `TaskDeliverable::Once`. This is the loop-breaker: the write is ordered after
   `claim_settle`, which guards on `deliverable == Workflow`, so the guard still sees the
   deliverable the pass was started for and only this write changes it.
3. **The card reaches someone who can act.** As `once`, the next dispatch falls through
   to an ordinary dispatch on the card's `assignee`, which the conversion preserves — the
   card becomes plain one-off work instead of a build request nobody can satisfy.

### Why `BuildOutcome::NoAnswer` exists — a regression this change had to avoid

This is the least obvious part of the diff, so stating it plainly.

`BuildOutcome::NotAutomatable` was absorbing **two different things**: a reasoned refusal
("don't automate this, because…"), and a draft that parsed but decided nothing at all —
no graph, no reason, no refusal, e.g. the model returning `{"automatable":true}`.

Collapsing those two was **harmless while both settled `Failed`**: the card went back to
To-do with a reason either way, and nothing downstream distinguished them. It stops being
harmless the moment a verdict starts *converting the card and filing a success*. Without
a split, an empty or malformed model response would flip a card to `once`, hand it to a
human as though the builder had deliberated, and record the attempt as successful — a
worse bug than the one being fixed, and a silent one.

So `NoAnswer` is split out and keeps the old behaviour exactly: settles `Failed`, and the
card stays `deliverable: workflow`, because retrying the **build** is the right next move
for a fault. Only a genuine decision converts the card. `BuildOutcome` is private to
`workflow_build.rs`, so the new variant has no callers outside this file.

### How the routing claim was verified

The three fixes were each checked against **current `main`**, not inferred from the
original working notes:

- `src/company/runtime.rs:755` dispatch-routes on exactly `task.deliverable ==
  TaskDeliverable::Workflow`, and everything else falls through to an ordinary dispatch on
  `task.assignee`. **That is what makes the `once` flip the loop-breaker** rather than a
  cosmetic field change — it is the single condition standing between the card and its
  assignee.
- `TaskDeliverable::Once` (`src/ports/tasks.rs:790`) is documented as "the card dispatches
  to its assignee", so the converted card lands where the verdict says it should.
- `claim_settle` (`src/harness/workflow_build.rs:601`) guards on `deliverable == Workflow`,
  and the conversion is ordered *after* it — so the guard still sees the deliverable the
  pass was started for, and only the settle changes it.

## API Or Behavior Changes

- A not-automatable verdict now settles its attempt **Succeeded** (was `Failed`) and files
  **no** `error` on the run row. Anything counting builder failures will see fewer.
- Such a card's `deliverable` flips `workflow` → `once`. It still lands in To-do; that
  column was only a trap while the deliverable said `workflow`.
- The card note now also states what became of the card, not only the verdict.
- Unchanged: the human `workflow-proposal/reject` endpoint still keeps the `workflow`
  deliverable, so an operator dragging a rejected card back into In Progress rebuilds
  deliberately. That is an explicit human action, not a loop.

## Tests

Scoped to the gated lane, since default features skip this code.

- [x] `cargo fmt --all -- --check` — clean; changed nothing in the touched files.
- [x] `cargo clippy --no-deps -p opencompany --features openhuman,tinycortex --all-targets -- -D warnings`
      — mirrors CI's `--no-deps`; no findings in the touched files.
- [x] `cargo check -p opencompany --features openhuman,tinycortex --tests` — clean.
      Ran `check --tests` rather than `build --all-targets`; it type-checks the same targets.
- [x] `cargo test -p opencompany --features openhuman,tinycortex workflow_build` — 54/54 pass.
      Scoped to this module rather than the whole suite. Needs `RUST_MIN_STACK=16777216`:
      the unrelated `a_cap_hit_folds_to_not_automatable` overflows its stack at the default
      size, which I confirmed reproduces identically on unmodified `main` — pre-existing and
      independent of this change.

### Every new test proven to fail with its fix reverted

Four separate reverts, each run on its own:

| Reverted | Test that fails |
|---|---|
| the `deliverable = Once` write | `a_not_automatable_verdict_converts_the_card_so_it_stops_re_entering_the_builder` |
| the `Succeeded`/no-error settle | `a_not_automatable_verdict_files_no_error_and_says_what_happened_to_the_card`, `a_not_automatable_answer_returns_the_card_to_todo` |
| the `NoAnswer` split | `a_genuine_build_failure_still_fails_and_stays_builder_routed`, `the_outcome_resolves_graph_versus_not_automatable` |
| the note's "what happened to the card" clause | `a_not_automatable_verdict_files_no_error_and_says_what_happened_to_the_card` |

## Documentation

`docs/spec/runtime/workflow-build.md` — the exit table documented the old behaviour
(both non-graph outcomes as `Failed`). Updated to four exits, with the attempt status and
deliverable per outcome, and why a fault deliberately stays builder-routed.

Closes tinyhumansai/opencompany#873
