### PR TITLE
fix(store): give sqlite a sibling-name guard on workspace create (#894)

### DIFF
--- a/src/ports/workspace.rs
+++ b/src/ports/workspace.rs
@@ -248,6 +248,37 @@ pub fn folder_claim_ambiguous_refusal(name: &str, count: usize) -> String {
     format!("{count} nodes under this folder are named `{name}`, so the path is ambiguous")
 }
 
+/// Whether a **file** already occupies `(parent, name)` (issue #894).
+///
+/// The sibling-uniqueness predicate every backend's [`WorkspaceStore::create`]
+/// applies, shared so the three cannot drift on what "taken" means.
+///
+/// # Files only, and that is the rule rather than an omission
+///
+/// A folder is not consulted and does not block, so a folder and a file may
+/// still share a name in one parent exactly as they always could. Folder-vs-
+/// folder claims are [`adopt_or_create_folder`]'s job (issue #759), which
+/// adopts rather than refuses. Widening this to every kind would be a **new
+/// tree rule** rather than the race fix issue #894 asks for, and it would break
+/// MongoDB, whose guard is a partial index over file documents alone.
+///
+/// [`adopt_or_create_folder`]: WorkspaceStore::adopt_or_create_folder
+pub fn file_name_taken<'a>(
+    nodes: impl Iterator<Item = &'a WorkspaceNode>,
+    parent: Option<&str>,
+    name: &str,
+) -> bool {
+    nodes.into_iter().any(|node| {
+        node.kind == NodeKind::File && node.parent_id.as_deref() == parent && node.name == name
+    })
+}
+
+/// The refusal every backend gives when a file already carries the name a
+/// [`create`](WorkspaceStore::create) asked for.
+pub fn duplicate_file_refusal(name: &str) -> String {
+    format!("workspace already contains a note named `{name}` in that folder")
+}
+
 /// One node in the workspace tree. `id` is a stable ULID; `parent_id` is `None`
 /// at the workspace root.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -460,6 +491,28 @@ pub trait WorkspaceStore: Send + Sync {
     /// Creates a node (folder or file). The node's `id` must be fresh; the
     /// `parent_id`, when set, must name an existing folder. `content` seeds a
     /// file body.
+    ///
+    /// # A file's name must be free among its siblings (issue #894)
+    ///
+    /// Creating a **file** whose `(parent_id, name)` a file already occupies is
+    /// an [`OpenCompanyError::Conflict`](crate::error::OpenCompanyError). The
+    /// predicate is [`file_name_taken`] and the refusal is
+    /// [`duplicate_file_refusal`], shared so the backends cannot disagree about
+    /// either.
+    ///
+    /// **This is a store guarantee, not a caller convention, and the difference
+    /// is the whole of issue #894.** `workspace_create` checks the path index
+    /// and then calls this — check-then-act, which two concurrent callers both
+    /// pass. Only the store can decide the loser: fs under the index lock,
+    /// SQLite inside an `IMMEDIATE` transaction, MongoDB against a partial
+    /// unique index. A caller-side check is a narrowing of the window, never a
+    /// closing of it, so nothing above this line may be trusted to enforce it.
+    ///
+    /// Folders are deliberately exempt — see [`file_name_taken`]. A tree that
+    /// *already* holds duplicates keeps them: this refuses new collisions and
+    /// repairs no history, so a store carrying pre-existing duplicates opens
+    /// and serves exactly as before (`read` still answers that path
+    /// `Ambiguous`, `list` still shows both).
     ///
     /// No `author` argument: the node arrives fully formed, so the caller sets
     /// [`WorkspaceNode::created_by`] and [`WorkspaceNode::updated_by`] on it

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -3459,6 +3459,128 @@ pub async fn assert_workspace_folder_claims(ws: Arc<dyn WorkspaceStore>) {
 ///   a document, the agent grounds an answer in it, and nothing anywhere says
 ///   so.
 ///
+/// Sibling-name uniqueness for files, which every backend must enforce **in the
+/// store** (issue #894).
+///
+/// SQLite had no equivalent of fs's `reject_path_collision` or MongoDB's partial
+/// unique index: `workspace_nodes` is `PRIMARY KEY (company_id, id)` and nothing
+/// else, so `create` checked only that the *id* was fresh. Two nodes could share
+/// `(company_id, parent_id, name)`, and from then on `render_path` yields one
+/// path for two nodes — `read` answers `Ambiguous` while `list` still shows
+/// both, and one duplicated ancestor folder poisons every descendant path.
+///
+/// This case is the contract, not the race: it runs sequentially, so it holds
+/// every backend to the *rule* without depending on scheduling. The race itself
+/// is decided by machinery only each backend has — see the SQLite store's
+/// `two_stores_racing_one_name_have_one_winner`, which is where the guard
+/// actually earns its transaction.
+///
+/// **Files only, deliberately.** Folder-vs-folder is `adopt_or_create_folder`'s
+/// to adopt rather than refuse (issue #759), and file-vs-folder is left
+/// unasserted because the backends genuinely disagree — see the note at the end
+/// of the body. Asserting more here would make this a new tree rule rather than
+/// a race fix, and would fail one backend or the other whichever way it went.
+pub async fn assert_workspace_sibling_names(ws: Arc<dyn WorkspaceStore>) {
+    use crate::ports::workspace::WorkspaceOrigin;
+
+    let alpha = CompanyId::new("alpha");
+    let beta = CompanyId::new("beta");
+    let agent = || WorkspaceOrigin::Agent {
+        id: "ceo".to_string(),
+    };
+    let file = |id: &str, name: &str, parent: Option<&str>| WorkspaceNode {
+        id: id.to_string(),
+        name: name.to_string(),
+        kind: NodeKind::File,
+        parent_id: parent.map(str::to_string),
+        created_by: agent(),
+        updated_by: agent(),
+        updated_at_millis: now_millis(),
+        mime: None,
+        size: None,
+        sha256: None,
+    };
+
+    // A folder to hold the contended name, plus the root as a second scope.
+    let folder = WorkspaceNode {
+        kind: NodeKind::Folder,
+        ..file("dup-folder", "Reports", None)
+    };
+    ws.create(&alpha, &folder, None)
+        .await
+        .expect("a folder at a free root name");
+
+    ws.create(
+        &alpha,
+        &file("dup-a", "report.md", Some("dup-folder")),
+        Some("A"),
+    )
+    .await
+    .expect("the first file claims the name");
+
+    // -- The rule ---------------------------------------------------------
+    let err = ws
+        .create(
+            &alpha,
+            &file("dup-b", "report.md", Some("dup-folder")),
+            Some("B"),
+        )
+        .await
+        .expect_err("a second file at one path must be refused by the store");
+    assert!(
+        matches!(err, crate::error::OpenCompanyError::Conflict(_)),
+        "a taken sibling name is a Conflict, not a storage fault: {err:?}"
+    );
+
+    // -- And it left nothing behind ---------------------------------------
+    let tree = ws.tree(&alpha).await.expect("tree reads");
+    let named: Vec<&WorkspaceNode> = tree
+        .iter()
+        .filter(|n| n.name == "report.md" && n.parent_id.as_deref() == Some("dup-folder"))
+        .collect();
+    assert_eq!(
+        named.len(),
+        1,
+        "exactly one node may hold the path; the loser must not be stored: {named:?}"
+    );
+    assert_eq!(named[0].id, "dup-a", "the first writer keeps the name");
+    let (_, winner_body) = ws
+        .read(&alpha, "dup-a")
+        .await
+        .expect("winner reads")
+        .expect("the winner is still there");
+    assert_eq!(
+        winner_body, "A",
+        "the winner's payload is untouched by the refusal"
+    );
+
+    // -- Scope: the same name under a different parent is a different path -
+    ws.create(&alpha, &file("dup-root", "report.md", None), None)
+        .await
+        .expect("the root is a different folder, so the name is free there");
+
+    // -- Scope: and a different company shares nothing ---------------------
+    let beta_folder = WorkspaceNode {
+        kind: NodeKind::Folder,
+        ..file("dup-folder", "Reports", None)
+    };
+    ws.create(&beta, &beta_folder, None)
+        .await
+        .expect("beta's own folder");
+    ws.create(&beta, &file("dup-a", "report.md", Some("dup-folder")), None)
+        .await
+        .expect("another company's tree is not consulted");
+
+    // A folder taking a file's name is deliberately NOT asserted either way.
+    // The backends genuinely disagree and always have: fs's
+    // `reject_path_collision` compares the rendered path and so refuses it,
+    // while MongoDB keys files and folders under separate partial indexes and
+    // so permits it. Pinning either answer here would force one of them to
+    // change behaviour — loosening the strictest backend, or widening a race
+    // fix into a new tree rule. The suite states the rule all three must keep
+    // and stays silent on the rest.
+}
+
 /// A retry only ever addresses the first. So the body is deliberately built from
 /// multi-byte characters and checked for **equality with a whole revision**
 /// rather than for decodability: length and content, not just "no error".

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -2444,6 +2444,13 @@ mod test {
         conformance::assert_workspace_folder_claims(Arc::new(FsOps::new(&root))).await;
     }
 
+    #[tokio::test]
+    async fn conformance_workspace_sibling_names() {
+        let root_dir = tmp_root();
+        let root = root_dir.path().to_path_buf();
+        conformance::assert_workspace_sibling_names(Arc::new(FsOps::new(&root))).await;
+    }
+
     /// Issue #887, and the backend the case was written against: this is the
     /// one that failed it. Node content was written with a bare
     /// `tokio::fs::write`, so a reader inside the `O_TRUNC` window saw a

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -3106,7 +3106,20 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         self.collection("workspace_nodes")
             .insert_one(document)
             .await
-            .map_err(mongo_err)?;
+            // Issue #894: the index refusing a second file at one path is a
+            // *contract* outcome, not a storage fault. It reached callers as
+            // `Store("mongodb error: E11000 …")` — a 500 carrying a driver
+            // string — where fs and SQLite both answer `Conflict`. The users
+            // -email index has been mapped this way since it was added.
+            .map_err(|e| {
+                if is_duplicate_key(&e) {
+                    OpenCompanyError::Conflict(crate::ports::workspace::duplicate_file_refusal(
+                        &node.name,
+                    ))
+                } else {
+                    mongo_err(e)
+                }
+            })?;
         Ok(())
     }
 
@@ -3252,7 +3265,16 @@ impl crate::ports::workspace::WorkspaceStore for MongoStore {
         self.collection("workspace_nodes")
             .insert_one(document)
             .await
-            .map_err(mongo_err)?;
+            // Issue #894, as in `create`.
+            .map_err(|e| {
+                if is_duplicate_key(&e) {
+                    OpenCompanyError::Conflict(crate::ports::workspace::duplicate_file_refusal(
+                        &node.name,
+                    ))
+                } else {
+                    mongo_err(e)
+                }
+            })?;
         // The stamped node, so the digest a caller records can only have come
         // from the store (issue #668).
         Ok(node)
@@ -4472,6 +4494,13 @@ mod test {
     async fn conformance_workspace_store() {
         let Some(s) = store().await else { return };
         conformance::assert_workspace_store(s.clone()).await;
+        drop_db(&s).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_workspace_sibling_names() {
+        let Some(s) = store().await else { return };
+        conformance::assert_workspace_sibling_names(s.clone()).await;
         drop_db(&s).await;
     }
 

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3000,9 +3000,23 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         node: &crate::ports::workspace::WorkspaceNode,
         content: Option<&str>,
     ) -> Result<()> {
-        use crate::ports::workspace::NodeKind;
-        let conn = self.conn();
-        let nodes = self.workspace_nodes(&conn, company)?;
+        use crate::ports::workspace::{NodeKind, duplicate_file_refusal, file_name_taken};
+        let mut conn = self.conn();
+        // Issue #894: the write reservation is taken BEFORE the read, exactly as
+        // `adopt_or_create_folder` and `swap_files` already do on this backend.
+        //
+        // The `StdMutex` around the connection makes this function atomic within
+        // one `SqliteStore`, and that is not the race: two `SqliteStore`
+        // instances can point at one database file, and against a second
+        // instance a plain read-then-`INSERT` has both callers see the name free
+        // and both insert. `IMMEDIATE` is what makes the loser wait for the
+        // winner's commit and then observe it — `busy_timeout` (see
+        // `apply_pragmas`) turns the contention into a bounded block rather than
+        // an immediate `SQLITE_BUSY`.
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let nodes = self.workspace_nodes(&tx, company)?;
         if nodes.contains_key(&node.id) {
             return Err(OpenCompanyError::Conflict(format!(
                 "workspace node {} already exists",
@@ -3024,7 +3038,17 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
                 }
             }
         }
-        conn.execute(
+        // The sibling-name guard this backend never had. Files only — a folder
+        // sharing a name with a file stays legal, and folder-vs-folder is
+        // `adopt_or_create_folder`'s to decide.
+        if node.kind == NodeKind::File
+            && file_name_taken(nodes.values(), node.parent_id.as_deref(), &node.name)
+        {
+            return Err(OpenCompanyError::Conflict(duplicate_file_refusal(
+                &node.name,
+            )));
+        }
+        tx.execute(
             "INSERT INTO workspace_nodes (company_id, id, node_json, content, updated_ms) \
              VALUES (?1, ?2, ?3, ?4, ?5)",
             params![
@@ -3036,6 +3060,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ],
         )
         .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
         Ok(())
     }
 
@@ -3113,10 +3138,16 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
         node: &crate::ports::workspace::WorkspaceNode,
         bytes: &[u8],
     ) -> Result<crate::ports::workspace::WorkspaceNode> {
-        use crate::ports::workspace::NodeKind;
+        use crate::ports::workspace::{NodeKind, duplicate_file_refusal, file_name_taken};
         let node = crate::ports::workspace::stamped_binary(node, bytes)?;
-        let conn = self.conn();
-        let nodes = self.workspace_nodes(&conn, company)?;
+        let mut conn = self.conn();
+        // Issue #894, the same reservation-before-read as `create`. A binary
+        // node is a file, so it contends for a name exactly like a note does —
+        // MongoDB's `create_binary` stamps the same path key for this reason.
+        let tx = conn
+            .transaction_with_behavior(TransactionBehavior::Immediate)
+            .map_err(sql_err)?;
+        let nodes = self.workspace_nodes(&tx, company)?;
         if nodes.contains_key(&node.id) {
             return Err(OpenCompanyError::Conflict(format!(
                 "workspace node {} already exists",
@@ -3138,7 +3169,14 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
                 }
             }
         }
-        conn.execute(
+        if node.kind == NodeKind::File
+            && file_name_taken(nodes.values(), node.parent_id.as_deref(), &node.name)
+        {
+            return Err(OpenCompanyError::Conflict(duplicate_file_refusal(
+                &node.name,
+            )));
+        }
+        tx.execute(
             "INSERT INTO workspace_nodes (company_id, id, node_json, content, updated_ms, blob) \
              VALUES (?1, ?2, ?3, '', ?4, ?5)",
             params![
@@ -3150,6 +3188,7 @@ impl crate::ports::workspace::WorkspaceStore for SqliteStore {
             ],
         )
         .map_err(sql_err)?;
+        tx.commit().map_err(sql_err)?;
         // The stamped node, so the digest a caller records can only have come
         // from the store (issue #668).
         Ok(node)
@@ -3760,6 +3799,103 @@ mod test {
     #[tokio::test]
     async fn conformance_workspace_folder_claims() {
         conformance::assert_workspace_folder_claims(store()).await;
+    }
+
+    #[tokio::test]
+    async fn conformance_workspace_sibling_names() {
+        conformance::assert_workspace_sibling_names(store()).await;
+    }
+
+    /// **The race issue #894 is actually about**, and the reason the guard is an
+    /// `IMMEDIATE` transaction rather than a check in `create`'s caller.
+    ///
+    /// One `SqliteStore` cannot reproduce it: `conn()` holds a `StdMutex` across
+    /// the read and the `INSERT`, so two tasks on one store serialize and the
+    /// old code passes. The reachable shape is **two stores over one file** —
+    /// the case `apply_pragmas`' `busy_timeout` note and
+    /// `adopt_or_create_folder`'s header both name. Before the fix both callers
+    /// read "free" and both inserted; after it the loser waits on the winner's
+    /// commit, then sees the name taken.
+    ///
+    /// A barrier makes the overlap deterministic rather than hoping the
+    /// scheduler interleaves: neither task may enter `create` until both have
+    /// arrived.
+    #[tokio::test]
+    async fn two_stores_racing_one_name_have_one_winner() {
+        use crate::ports::workspace::{NodeKind, WorkspaceOrigin, WorkspaceStore};
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("opencompany.db");
+        let one: Arc<dyn WorkspaceStore> =
+            Arc::new(SqliteStore::open(&path).expect("first store over the file"));
+        let two: Arc<dyn WorkspaceStore> =
+            Arc::new(SqliteStore::open(&path).expect("second store over the SAME file"));
+
+        let company = CompanyId::new("alpha");
+        let origin = WorkspaceOrigin::Agent {
+            id: "ceo".to_string(),
+        };
+        let node = |id: &str| crate::ports::workspace::WorkspaceNode {
+            id: id.to_string(),
+            name: "report.md".to_string(),
+            kind: NodeKind::File,
+            parent_id: None,
+            created_by: origin.clone(),
+            updated_by: origin.clone(),
+            updated_at_millis: crate::ports::now_millis(),
+            mime: None,
+            size: None,
+            sha256: None,
+        };
+
+        let gate = Arc::new(tokio::sync::Barrier::new(2));
+        let mut tasks = Vec::new();
+        for (store, id) in [(one.clone(), "racer-a"), (two.clone(), "racer-b")] {
+            let gate = gate.clone();
+            let node = node(id);
+            let company = company.clone();
+            tasks.push(tokio::task::spawn_blocking(move || {
+                let rt = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("racer runtime");
+                rt.block_on(async move {
+                    gate.wait().await;
+                    store.create(&company, &node, Some("payload")).await
+                })
+            }));
+        }
+        let mut outcomes = Vec::new();
+        for task in tasks {
+            outcomes.push(task.await.expect("racer did not panic"));
+        }
+
+        let winners = outcomes.iter().filter(|r| r.is_ok()).count();
+        assert_eq!(
+            winners, 1,
+            "exactly one create may take the name, got {outcomes:?}"
+        );
+        let loser = outcomes
+            .iter()
+            .find_map(|r| r.as_ref().err())
+            .expect("the other create must fail");
+        assert!(
+            matches!(loser, OpenCompanyError::Conflict(_)),
+            "the loser is refused, not broken: {loser:?}"
+        );
+
+        // The durable state is the real assertion: a passing error code with two
+        // rows in the table would still be the bug.
+        let tree = one
+            .tree(&CompanyId::new("alpha"))
+            .await
+            .expect("tree reads");
+        let named: Vec<_> = tree.iter().filter(|n| n.name == "report.md").collect();
+        assert_eq!(
+            named.len(),
+            1,
+            "one name, one node — a second row is the poisoned path #894 describes: {named:?}"
+        );
     }
 
     /// Issue #887's no-torn-read contract. This backend passed it before the


### PR DESCRIPTION
## Summary

Two nodes could share `(company_id, parent_id, name)` on **sqlite**. `workspace_nodes` is
`PRIMARY KEY (company_id, id)` and nothing else, so `create` checked only that the node **id** was
fresh. fs refuses the loser under its index lock and MongoDB against a partial unique index; sqlite
refused nothing. `workspace_create` is check-then-act, so two callers both pass its check and both
insert — and from then on `render_path` yields one path for two nodes: `read` answers `Ambiguous`
while `list` still shows both, and one duplicated **ancestor folder** poisons every descendant path.

The damage outlives the race, which is what makes this data integrity rather than a UI defect.

## Why there is no index, no migration, and nothing that can fail on boot

**Taking this first, because it is the reviewable decision and "why not just add
`UNIQUE(company_id, parent_id, name)`?" is the obvious first question.**

`CREATE UNIQUE INDEX` over a table that **already holds duplicates fails**, and it fails *during
index setup* — so store startup goes down for that tenant. That is not hypothetical: PR #733
documented exactly this failure mode for MongoDB and is why its guard is a **partial** index, keyed
on a field only new writes carry, deliberately ignoring history it cannot repair.

The sqlite equivalent of that partial index needs a `file_path_key` column maintained at **four**
sites — `create`, `create_binary`, `rename_move`, `swap_files`. A key left stale by a rename would
keep guarding the path the file *left*, refusing that path to every later write forever. That is a
worse and more permanent failure than the race being fixed, and MongoDB's own `rename_move` comment
says so about the folder key for the same reason.

**And `workspace_repair` cannot pre-fold the way in.** A "fold first, then add the index" migration
is unavailable: that pass folds duplicate **folders** and explicitly refuses to resolve *two files at
one path* — which is precisely the shape a file-uniqueness index would trip over.

So this PR adds **no schema change and no index**. A database already holding duplicates opens and
serves exactly as it does today (`read` still `Ambiguous`, `list` still shows both, `workspace_repair`
still the folder-only fold). The guard refuses **new** collisions only.

**Residual, stated plainly:** a *future* `INSERT` path added outside `create` would not be caught by
a transaction the way it would by a table constraint. That is the cost of this trade and it is
deliberate.

## Why the transaction, and why this is reuse rather than invention

sqlite did not "miss" #733's treatment — **its constraint model made an index awkward, and #733/#759
already worked around that.** Name and parent live inside the `node_json` text blob, so there is no
column to constrain. Both issues gave sqlite the **transaction** device
(`TransactionBehavior::Immediate`) and gave MongoDB the **index** device. Plain `create` is simply
the one entry point neither issue routed — `adopt_or_create_folder`'s own header says it outright:

> plain `create` checks only that the node **id** is fresh and has never had a sibling-name guard at all.

So `create` and `create_binary` now take the write reservation **before** the read, exactly as
`adopt_or_create_folder` and `swap_files` already do in the same file.

**One `SqliteStore` cannot reproduce the race**: `conn()` holds a `StdMutex` across the read and the
`INSERT`, so two tasks on one store serialize and the old code passes. The reachable shape is **two
stores over one database file** — named in `adopt_or_create_folder`'s header and in the
`busy_timeout` note in `apply_pragmas`. `IMMEDIATE` makes the loser wait for the winner's commit and
then observe it; `busy_timeout=5000` makes that a bounded block rather than an immediate
`SQLITE_BUSY`.

`create_binary` needs the same treatment: a binary node is a file and contends for a name
identically — MongoDB stamps the same path key there for that reason.

## Files only, and the divergence this surfaced

The rule enforced is **file-vs-file**. Folder-vs-folder stays `adopt_or_create_folder`'s to *adopt*
rather than refuse (#759).

File-vs-folder is deliberately **left unasserted**, and finding out why was worth the round trip: the
conformance case first asserted that a folder may take a file's name, and **fs failed it**. fs's
`reject_path_collision` compares the rendered path and refuses it; MongoDB keys files and folders
under separate partial indexes and permits it. They genuinely disagree and always have. That
assertion was stating a *permission* rather than a *rule* — pinning either answer would have forced
one backend to change behaviour, either loosening the strictest one or widening a race fix into a new
tree rule. The suite now states the rule all three must keep and is explicit about staying silent on
the rest.

The port contract for `create` previously mentioned no sibling rule at all, so sqlite was
*contract-conformant*. It now states the rule, that it is a **store** guarantee — a caller-side check
narrows the window, never closes it — and that pre-existing duplicates are kept rather than repaired.

## API Or Behavior Changes

- **`WorkspaceStore::create` / `create_binary` on sqlite** refuse a **file** whose `(parent, name)` a
  file already holds, with `Conflict`. Previously accepted silently.
- **MongoDB** maps its duplicate-key violation on those two inserts to `Conflict` instead of
  `Store("mongodb error: E11000 …")` — a contract outcome that was reaching callers as a 500 carrying
  a driver string, where fs and sqlite both answer `Conflict`. The users-email index has been mapped
  this way since it was added.
- New shared helpers `file_name_taken` / `duplicate_file_refusal` in `ports::workspace`, so the three
  backends cannot drift on what "taken" means or how they word the refusal.
- No schema change, no migration, no index. Existing data is untouched.

## Tests

- **`two_stores_racing_one_name_have_one_winner`** (`store::sqlite`) — the race itself: two
  `SqliteStore`s over one temp file, barrier-synchronised so neither enters `create` until both have
  arrived. Asserts one `Ok`, a `Conflict` loser, and — the real assertion — **one** node in the tree
  with that name. A passing error code with two rows would still be the bug.
- **`assert_workspace_sibling_names`** (`store::conformance`) — the contract, wired into **all three**
  backends. Sequential on purpose: it holds every backend to the rule without depending on scheduling.

**Teeth proved by reverting, not asserted.** With both guard blocks removed,
**2 of 2 new sqlite tests fail**, the race test with exactly the defect:

```
assertion `left == right` failed: exactly one create may take the name, got [Ok(()), Ok(())]
  left: 2
 right: 1
```

Both new tests were confirmed to *actually run* by name — a filter that selects nothing exits 0, and
`store::sqlite` is behind `--features sqlite` (`scripts/ci/feature-lanes.txt:56`), so the default
lane cannot execute them.

- [x] `cargo fmt --all -- --check` — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean. Run in **both** forms: CI's default-feature
      form verbatim, and `--locked --no-deps --features sqlite --all-targets`, which is the one that
      actually compiles `store::sqlite`.
- [x] `cargo build --all-targets` — N/A as a separate step: the `--all-targets` clippy and the test
      compiles below build the same targets, including under `--features sqlite`, which a default
      `build` cannot reach.
- [x] `cargo test` — default lane green. Plus the lanes that reach this code:
      `--features sqlite --lib store::` **162 passed / 0 failed**; `--lib store::fs_ops` 24 passed;
      and the MongoDB arm run against a **live local mongod** (`OPENCOMPANY_TEST_MONGODB_URI`),
      **39 passed** — genuinely executed rather than skipped, which matters because that lane
      no-ops silently without a server.

## Documentation

- `WorkspaceStore::create`'s port doc now carries the sibling rule, the store-vs-caller distinction,
  the folder exemption, and the pre-existing-duplicates statement.
- `file_name_taken` documents why the rule is files-only.
- `assert_workspace_sibling_names` documents the fs/MongoDB divergence and why the suite stays silent
  on file-vs-folder.
- No `docs/spec/` change: the storage spec describes backends in terms of the port contract, which
  this tightens rather than reshapes.

Closes tinyhumansai/opencompany#894
