### PR TITLE
test: declare the harness stack floor in .cargo/config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,77 @@
+# Repo-level Cargo configuration.
+
+# ────────────────────────────────────────────────────────────────────────────
+# Thread stack floor for the test harness (issue #895)
+# ────────────────────────────────────────────────────────────────────────────
+# `cargo test` on the gated feature set aborts the WHOLE test binary with
+#
+#   thread '…' has overflowed its stack
+#   fatal runtime error: stack overflow, aborting        (SIGABRT)
+#
+# unless the harness threads get more than libtest's 2 MiB default. Because it
+# is an abort rather than a failed assertion, every test after it in that binary
+# is skipped — so the visible damage is not one red test but a truncated run,
+# and the natural reading is "I broke the harness" rather than "this needs a
+# bigger stack". Two separate work streams lost time to exactly that.
+#
+# CI already set this, on the `Rust (openhuman, tinycortex)` job alone, so the
+# requirement was real, load-bearing and invisible to anyone running the suite
+# locally. Declaring it here makes a local run and CI agree BY CONSTRUCTION
+# rather than by tribal knowledge.
+#
+# ── Where the depth actually is ─────────────────────────────────────────────
+# Cumulative `async fn` composition, NOT recursion: a state machine is inlined
+# into its caller's, so a nested chain sums into one frame. On the gated build
+# the vendored OpenHuman turn chain dominates (`-Zprint-type-sizes`, test
+# profile):
+#
+#   run_turn_via_tinyagents_session          ~117 KiB
+#   with_turn_collector<run_chat_turn_graph> ~116 KiB
+#   run_chat_turn_graph                       ~58 KiB
+#   with_current_sandbox_mode                 ~56 KiB
+#
+# against a largest OpenCompany-owned future of ~32 KiB — which is not even on
+# this path. This is therefore not our depth to bound from here, and that was
+# tested rather than assumed: `Box::pin` on both `agent.turn(...)` awaits in
+# `CompanyAgent::run_with_steer` moved the threshold by nothing at all. The real
+# fix belongs upstream in OpenHuman.
+#
+# ── How the number below was chosen ─────────────────────────────────────────
+# Measured on aarch64-darwin, debug/test profile, by bisection:
+#
+#   * one test alone   — 2176 KiB aborts, 2304 KiB passes
+#   * WHOLE gated suite at default parallelism
+#     (`cargo test --locked --features openhuman,tinycortex --tests`)
+#                      — 2 MiB aborts, 3 MiB passes 4182/4182
+#
+# So the measured suite floor is 3 MiB, and 8 MiB is **2.7x** that. The margin
+# is not decoration; it covers three things the measurement cannot:
+#
+#   1. CI is x86-64 Linux, this was aarch64-darwin — frame layout differs.
+#   2. CI runners have more cores, so more harness threads run concurrently.
+#   3. Headroom for growth, because the failure mode of guessing low is not a
+#      clear error but an abort that hides every test behind it.
+#
+# It is deliberately NOT the 16 MiB the CI job uses. That value predates any
+# measurement and is ~5x the suite floor; the comment above it claims OpenHuman
+# "requires the same stack its production runtimes allocate", which this
+# measurement does not support. Re-examining it is its own change on its own
+# evidence — this file does not touch the CI job.
+#
+# If you raise this, say what you measured. An unexplained ceiling is the exact
+# ratchet #895 was filed about: silent headroom absorbs growth until the first
+# signal is again a local abort.
+#
+# `force` is deliberately absent (the default): an explicitly exported
+# `RUST_MIN_STACK` still wins, so CI's own value and a developer bisecting the
+# real depth both override this without editing the file.
+#
+# ── If you kept a cargo path-override here ──────────────────────────────────
+# This file used to be gitignored so a developer could drop in a path-override
+# pointing at a sibling openhuman checkout. It is tracked now, because a floor
+# that cannot ship is not a floor. Put that override in `$CARGO_HOME/config.toml`
+# or in a PARENT-directory `.cargo/config.toml` instead — Cargo merges both with
+# this file automatically, so nothing is lost and this file stays conflict-free.
+# The openhuman repo documents the same arrangement in its own `.cargo/config.toml`.
+[env]
+RUST_MIN_STACK = "8388608"

--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,15 @@ lcov.info
 worktrees/*
 !worktrees/.gitkeep
 
-# Local dev cargo path-override (points at a sibling openhuman checkout)
-.cargo/config.toml
+# `.cargo/config.toml` is TRACKED as of issue #895: it carries the
+# `RUST_MIN_STACK` floor the gated test suite needs, so a local run and CI agree
+# by construction instead of by tribal knowledge. It used to be ignored so a
+# developer could drop in a cargo path-override pointing at a sibling openhuman
+# checkout; that override now belongs in `$CARGO_HOME/config.toml` or a
+# PARENT-directory `.cargo/config.toml`, both of which Cargo merges with this
+# one automatically — the same arrangement the openhuman repo documents in its
+# own `.cargo/config.toml`. Keeping it ignored would mean the stack floor could
+# never ship, which is the whole point of the change.
 
 # Instance runtime state, written into the data root — which is the repo root
 # when a `serve` runs with neither OPENCOMPANY_DATA_DIR nor HOME set. A

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,24 @@ dedicated `test.rs` file when they grow.
 Run commands from the repository root unless a future workspace layout changes
 the module location.
 
+`.cargo/config.toml` sets `RUST_MIN_STACK = 8388608` for every cargo-invoked
+process (issue #895). Do not drop it. The gated suite exceeds libtest's 2 MiB
+default thread stack, and when it does the failure is a `SIGABRT` that aborts
+the **whole test binary** — so every test after it is skipped, and the symptom
+reads as "I broke the harness" rather than "this needs a bigger stack".
+
+8 MiB is 2.7x the measured floor: the whole gated suite aborts at 2 MiB and
+passes 4182/4182 at 3 MiB (aarch64-darwin, default parallelism). The margin
+covers x86-64 CI frame layout, higher CI parallelism, and growth. The depth is
+cumulative `async fn` composition in the vendored OpenHuman turn chain (~117 KiB
+for its largest single future, against ~32 KiB for the largest OpenCompany-owned
+one), so it is not bounded from this repo — `Box::pin` at our own seam was tried
+and moved it by nothing. Full evidence is in `.cargo/config.toml`.
+
+If you change the value, say what you measured; an unexplained ceiling is the
+ratchet #895 exists to complain about. Export `RUST_MIN_STACK` yourself to
+override it — the file does not use `force`.
+
 ## Coding Style & Naming Conventions
 
 Use standard `rustfmt` output and Rust 2024 idioms. Module and file names should


### PR DESCRIPTION
## Summary

The gated suite overflows the stack and **SIGABRTs the whole test binary**, so every test behind the
overflow is skipped. The visible damage is not one red test — it is a truncated run that still looks
like a run. And because it is an abort rather than a failed assertion, the natural reading is "I broke
the harness", not "this needs a bigger stack". Two work streams lost time to exactly that before
finding the CI variable.

This declares the floor in a tracked `.cargo/config.toml` so a local run and CI agree **by
construction** instead of by tribal knowledge.

## The number is derived, not copied

Bisected on aarch64-darwin, debug/test profile, exit codes captured to files (a SIGABRT is easy to
lose through a pipe):

| Scope | Aborts at | Passes at |
| --- | --- | --- |
| `a_cancelled_delegated_card_records_no_artifact` alone | 2176 KiB | 2304 KiB |
| **whole gated `--tests` run, default parallelism** | **2 MiB** | **3 MiB** — 4182/4182 |

**Measured suite floor: 3 MiB. Shipped value: 8 MiB — 2.7x.** The margin covers three things the
measurement cannot: CI is x86-64 Linux and this was aarch64 (frame layout differs), CI runners have
more cores so more harness threads run at once, and growth — because guessing low does not produce a
clear error, it produces an abort that hides everything behind it.

The suite misses libtest's 2 MiB default by a hair, not by an order of magnitude.

## Negative result: `Box::pin` at our own seam does nothing

Recorded because without it the next person retries it.

The obvious fix looked like boxing the turn future — `src/harness/mod.rs:742` already carries a
`Box::pin` commented as "the nested-scope stack-overflow trap", and `agent.turn(...)` sits *inside*
that boxed block, so boxing the outer scope cannot shrink the inner future. Both `agent.turn(...)`
awaits in `CompanyAgent::run_with_steer` were boxed and re-bisected:

| `RUST_MIN_STACK` | before boxing | after boxing |
| --- | --- | --- |
| 2176 KiB | abort | **abort** |
| 2304 KiB | pass | **pass** |

**Identical.** `Box::pin` still builds the future in the caller's frame before moving it to the heap,
and it does not shorten the poll chain. The change was reverted rather than shipped: a no-op carrying
a comment that claims to fix the trap is worse than no change.

That is the evidence for "not ours to bound", so it is a measurement rather than an opinion.

## Where the depth actually is

Cumulative `async fn` composition, **not** recursion — a state machine is inlined into its caller's,
so a nested chain sums into one frame. From `-Zprint-type-sizes` (local diagnostic via
`RUSTC_BOOTSTRAP`; nothing shipped, no nightly in the toolchain):

| Future | Size |
| --- | --- |
| `openhuman…run_turn_via_tinyagents_session()` | **119,856 B** |
| `openhuman…with_turn_collector<…run_chat_turn_graph…>` | 118,888 B |
| `openhuman…run_chat_turn_graph()` | 59,424 B |
| `openhuman…with_current_sandbox_mode<…>` | 57,744 B |
| largest **OpenCompany-owned** future (`server::ops::workflows::fix_from_run`) | 32,856 B — and not on this path |

The vendored chain is ~4x anything this crate owns, and the largest thing we own is not even involved.

### ⚠️ One caveat on the lldb frame, so nobody chases it

Catching the fault under lldb (`EXC_BAD_ACCESS`, guard page) reports one frame:

```
openhuman_core::openhuman::config::schema::load::impl_load::parse_toml_off_worker::{closure#0}
```

**That frame is not the culprit.** It is simply where the last few bytes ran out, and lldb cannot
unwind past a guard page, so the backtrace is one frame deep by construction. Reading it as "TOML
parsing is the bug" would send the next person into `parse_toml_off_worker` — which already does the
right thing (`spawn_blocking` around `toml::from_str`, i.e. the parse is not even on this stack). The
frame is a symptom of a stack already nearly exhausted by its callers.

## API Or Behavior Changes

No source change; no runtime behaviour changes. Test-harness configuration only.

**`.cargo/config.toml` is now tracked.** It was gitignored for local cargo path-overrides pointing at
a sibling openhuman checkout. Those move to `$CARGO_HOME/config.toml` or a **parent-directory**
`.cargo/config.toml` — Cargo merges both with this file automatically, so nothing is lost — which is
the arrangement the openhuman repo documents in its own `.cargo/config.toml`. A floor that cannot ship
is not a floor.

**`force` is deliberately absent**, so an explicitly exported `RUST_MIN_STACK` still wins: CI's own
value is unaffected and a developer bisecting the real depth can override without editing the file.

**The CI job is deliberately untouched.** `ci.yml:626` still sets 16 MiB. That value predates any
measurement and is ~5x the suite floor, and the comment above it — "OpenHuman's agent loop requires
the same stack its production runtimes allocate" — is **not supported by this measurement**. Lowering
a CI floor on evidence gathered from one suite on one architecture is how you buy an untraceable
flake, so it is filed as a follow-up to be re-examined on its own evidence rather than changed here.

## Tests

- [x] `cargo fmt --all -- --check` — exit 0.
- [x] `cargo clippy --all-targets -- -D warnings` — run as CI runs it:
  `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`,
  exit 0. `--no-deps` mirrors the gated lane, where it is load-bearing.
- [x] `cargo build --all-targets` — `cargo build --locked --features openhuman,tinycortex
  --all-targets`, exit 0.
- [x] `cargo test` — `cargo test --locked --features openhuman,tinycortex --tests` with
  **`RUST_MIN_STACK` explicitly unset**, so the run proves the committed file carries the floor:
  **4182 passed, 0 failed, 3 ignored, 0 stack overflows**. Default features are not sufficient here —
  they skip roughly a third of the code, including this path.

### Verified to gate

Reverting is the test: `mv .cargo/config.toml` aside, re-run with no env var, and the suite aborts
with the exact reported symptom —

```
thread 'harness::brain::tests::a_cancelled_delegated_card_records_no_artifact' has overflowed its stack
fatal runtime error: stack overflow, aborting
process didn't exit successfully: … (signal: 6, SIGABRT: process abort signal)
```

Restoring it returns the suite to 4182/0. The 4158-test binary that used to abort partway now reports
a full count, which is the user-visible fix: not one test going green, but everything behind it no
longer being silently skipped.

No new `#[test]` is added, and none would help: the failure aborts the process, so a test asserting it
would take its own binary down with it. The revert check above is the gate.

## Documentation

`AGENTS.md` (which `CLAUDE.md` symlinks to) gains the floor in its Build/Test section with the measured
numbers, since "nothing tells a contributor about it" is half of what #895 reports. The full evidence —
sizes, both bisections, the failed boxing experiment, and why the value is 8 MiB and not 16 — is in the
comments of `.cargo/config.toml`, next to the value it justifies.

Closes tinyhumansai/opencompany#895
