### PR TITLE
Bump vendor/openhuman to main: pull in the post-#960 hosting security review fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,7 +131,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -142,7 +142,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1334,15 +1334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys 0.5.0",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1363,7 +1354,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1476,7 +1467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3048,7 +3039,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3173,8 +3164,8 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml",
+ "toml_edit",
  "tower",
  "tower-http 0.7.0",
  "tracing",
@@ -3186,7 +3177,7 @@ dependencies = [
 
 [[package]]
 name = "openhuman"
-version = "0.63.7"
+version = "0.63.9"
 dependencies = [
  "aes-gcm",
  "aho-corasick",
@@ -3201,7 +3192,7 @@ dependencies = [
  "chrono-tz",
  "cron",
  "directories",
- "dirs 5.0.1",
+ "dirs",
  "dotenvy",
  "ed25519-dalek",
  "flate2",
@@ -3224,7 +3215,6 @@ dependencies = [
  "rand 0.10.2",
  "regex",
  "reqwest",
- "ring",
  "rusqlite",
  "rustls",
  "schemars",
@@ -3244,7 +3234,6 @@ dependencies = [
  "tinycortex-api",
  "tinyhosts",
  "tinyhumans-sdk",
- "tinyjuice",
  "tinymemory",
  "tinymemory-api",
  "tinymemory-core",
@@ -3254,7 +3243,7 @@ dependencies = [
  "tokio-stream",
  "tokio-tungstenite",
  "tokio-util",
- "toml 1.1.4+spec-1.1.0",
+ "toml",
  "tracing",
  "tracing-subscriber",
  "url",
@@ -3599,7 +3588,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.13+spec-1.1.0",
+ "toml_edit",
 ]
 
 [[package]]
@@ -3664,7 +3653,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3998,7 +3987,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4237,15 +4226,6 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "serde_spanned"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
@@ -4437,7 +4417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4648,10 +4628,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4750,6 +4730,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
+ "regex",
  "reqwest",
  "rusqlite",
  "serde",
@@ -4824,7 +4805,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "chrono",
- "dirs 5.0.1",
+ "dirs",
  "futures",
  "log",
  "parking_lot",
@@ -4840,7 +4821,7 @@ dependencies = [
  "tinyagents",
  "tinycortex-api",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "uuid",
  "walkdir",
@@ -4863,8 +4844,6 @@ dependencies = [
 [[package]]
 name = "tinyflows"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5815f3dded76503a1b1867b55282941f50b3ecef4dcbfd0786640dc189250557"
 dependencies = [
  "async-trait",
  "futures-timer",
@@ -4887,6 +4866,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "hex",
+ "percent-encoding",
  "reqwest",
  "serde",
  "serde_json",
@@ -4910,29 +4890,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyjuice"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dde6760266db10b01d339438b651045e3815a52d00eeb40e2f41f22304d6cac"
-dependencies = [
- "async-trait",
- "dirs 6.0.0",
- "hex",
- "log",
- "once_cell",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.20",
- "tokio",
- "unicode-segmentation",
- "unicode-width",
-]
-
-[[package]]
 name = "tinymemory"
-version = "0.3.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4966,7 +4925,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
- "dirs 5.0.1",
+ "dirs",
  "futures",
  "log",
  "parking_lot",
@@ -5159,38 +5118,17 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
-dependencies = [
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
 version = "1.1.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
 dependencies = [
  "indexmap",
  "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "serde_spanned",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.6.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
-dependencies = [
- "serde",
+ "winnow",
 ]
 
 [[package]]
@@ -5204,29 +5142,15 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
-dependencies = [
- "indexmap",
- "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap",
- "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow 1.0.4",
+ "winnow",
 ]
 
 [[package]]
@@ -5235,14 +5159,8 @@ version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
- "winnow 1.0.4",
+ "winnow",
 ]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5484,12 +5402,6 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -5756,7 +5668,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -6077,15 +5989,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
@@ -6287,10 +6190,6 @@ dependencies = [
  "log",
  "simd-adler32",
 ]
-
-[[patch.unused]]
-name = "tinyflows"
-version = "0.6.0"
 
 [[patch.unused]]
 name = "whisper-rs-sys"

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -90,7 +90,7 @@ use openhuman_core::openhuman as oh;
 use oh::agent::prompts::SystemPromptBuilder;
 use oh::agent::{Agent, AgentBuilder};
 use oh::memory::tools::{MemoryRecallTool, MemoryStoreTool};
-use oh::memory::traits::Memory;
+use oh::memory::Memory;
 use oh::security::SecurityPolicy;
 #[cfg(feature = "mcp")]
 use oh::tools::McpListToolsTool;

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -7,19 +7,19 @@
 //! * **Tools**: [`memory_tools`] (`memory_store` + `memory_recall`) is called
 //!   but currently returns nothing — see its doc comment for why openhuman's
 //!   API no longer gives embedders a way to point either tool at a company's
-//!   own memory. **File tools** (read,
-//!     write, edit, list, grep, glob) are granted per-agent when the effective
-//!     `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
-//!     sandboxed to the agent's own workspace via a `workspace_only`
-//!     [`SecurityPolicy`] ([`file_tools`]). **Exec-grade tools** (Cell A) now
-//!     slot in beside them via [`toolbelt`](crate::harness::toolbelt): `shell`
-//!     (shell + `read_workspace_state`) and `code` (`apply_patch`,
-//!     `git_operations`, `csv_export`) behind a strict [`toolbelt::exec_security`]
-//!     policy + native runtime + per-workspace audit; `web` (`web_fetch`,
-//!     `http_request`, `curl`, `image_info`) behind the same policy plus a
-//!     per-company SSRF domain allowlist. The `subagent` namespace is reserved
-//!     but empty in v1. Still deferred: browser automation (needs a backend)
-//!     and Node/NPM exec (need a managed bootstrap).
+//!   own memory. **File tools** (read, write, edit, list, grep, glob) are
+//!   granted per-agent when the effective `tools ∩ agent.tools` grants cover
+//!   the `files`/`docs` namespace, and are sandboxed to the agent's own
+//!   workspace via a `workspace_only` [`SecurityPolicy`] ([`file_tools`]).
+//!   **Exec-grade tools** (Cell A) now slot in beside them via
+//!   [`toolbelt`](crate::harness::toolbelt): `shell` (shell +
+//!   `read_workspace_state`) and `code` (`apply_patch`, `git_operations`,
+//!   `csv_export`) behind a strict [`toolbelt::exec_security`] policy + native
+//!   runtime + per-workspace audit; `web` (`web_fetch`, `http_request`,
+//!   `curl`, `image_info`) behind the same policy plus a per-company SSRF
+//!   domain allowlist. The `subagent` namespace is reserved but empty in v1.
+//!   Still deferred: browser automation (needs a backend) and Node/NPM exec
+//!   (need a managed bootstrap).
 //! * **Metered web search** (issue #238, [`search`](crate::harness::search)):
 //!   `web_search` over the managed backend, the discovery half the `web` tools
 //!   never had — they read a *known* URL and cannot find one. Two hard gates
@@ -1293,7 +1293,11 @@ mod tests {
             Arc::new(NoopContext),
         ));
         let tools = memory_tools(&memory);
-        assert!(tools.is_empty(), "expected no intrinsic memory tools while withheld, got {:?}", tools.iter().map(|t| t.name()).collect::<Vec<_>>());
+        assert!(
+            tools.is_empty(),
+            "expected no intrinsic memory tools while withheld, got {:?}",
+            tools.iter().map(|t| t.name()).collect::<Vec<_>>()
+        );
     }
 
     #[test]

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -4,8 +4,10 @@
 //! [`Agent`], injecting the harness's provider, the [`OcMemory`] adapter, the
 //! [`ApprovalPolicy`] tool policy, and a workspace directory.
 //!
-//! * **Tools**: every agent gets the intrinsic [`memory_tools`] (`memory_store`
-//!   + `memory_recall`) over its own company memory. **File tools** (read,
+//! * **Tools**: [`memory_tools`] (`memory_store` + `memory_recall`) is called
+//!   but currently returns nothing — see its doc comment for why openhuman's
+//!   API no longer gives embedders a way to point either tool at a company's
+//!   own memory. **File tools** (read,
 //!     write, edit, list, grep, glob) are granted per-agent when the effective
 //!     `tools ∩ agent.tools` grants cover the `files`/`docs` namespace, and are
 //!     sandboxed to the agent's own workspace via a `workspace_only`
@@ -90,7 +92,6 @@ use openhuman_core::openhuman as oh;
 use oh::agent::prompts::SystemPromptBuilder;
 use oh::agent::{Agent, AgentBuilder};
 use oh::memory::Memory;
-use oh::memory::tools::{MemoryRecallTool, MemoryStoreTool};
 use oh::security::SecurityPolicy;
 #[cfg(feature = "mcp")]
 use oh::tools::McpListToolsTool;
@@ -245,11 +246,10 @@ pub fn build_agent(
         }
     };
 
-    // Intrinsic memory tools: every agent can deliberately store and recall over
-    // its own company memory, complementing the automatic retrieve→inject→store
-    // loop. They are tenant-isolated (an agent's memory is its company's
-    // `ContextStore`) and granted to every agent — unlike the external tools
-    // below, which are scoped by the manifest `[tools]` allow-list.
+    // Intrinsic memory tools are withheld for now — see `memory_tools`'s doc
+    // comment for why. `tools` still starts from that call so the moment
+    // openhuman gives embedders a way back in, wiring them is a one-line
+    // change here again rather than a rediscovery.
     let mut tools: Vec<Box<dyn Tool>> = memory_tools(&memory);
     #[cfg(feature = "mcp")]
     {
@@ -1070,26 +1070,40 @@ pub fn build_agent(
         .map_err(|e| OpenCompanyError::Harness(format!("build agent '{}': {e}", manifest_agent.id)))
 }
 
-/// The always-on memory tools every embedded agent receives: `memory_store` and
-/// `memory_recall` over the agent's own [`OcMemory`]. Backed by the same
-/// `ContextStore` the automatic loop and `OPENCOMPANY_MEMORY` overlay use, so
-/// deliberate and automatic memory share one store.
+/// The intrinsic `memory_store` / `memory_recall` tools — **withheld today**,
+/// pending a way to point them at a company's own [`OcMemory`] again.
 ///
-/// `MemoryForgetTool` is deliberately excluded — [`OcMemory`]'s append-only
-/// `ContextStore` cannot delete, so a forget tool would silently no-op.
+/// Through openhuman's earlier API, `MemoryStoreTool::new` /
+/// `MemoryRecallTool::new` took the `Arc<dyn Memory>` directly, so each
+/// company's own `ContextStore` was exactly what the two tools read and wrote.
+/// The version this crate now vendors changed both constructors to
+/// `fn new(security: Arc<SecurityPolicy>)` / `fn new()` — no memory parameter
+/// — and moved resolution *inside* `execute()` to
+/// `active_memory_guard()`, which reaches an ambient `CoreContext`
+/// this crate's session/turn machinery never scopes (`rg CoreContext::scope`
+/// under `agent/harness/session` finds nothing), or — with no context bound —
+/// falls back to **one process-global workspace** resolved from
+/// `Config::load_or_init()`. Either path is disconnected from `.memory(memory)`
+/// on the session builder: `Tool::execute(&self, args)` takes no session or
+/// memory parameter at all, so there is no route left by which a per-company
+/// `Arc<dyn Memory>` could reach these two tools.
 ///
-/// Neither tool takes `memory` at construction any more: openhuman resolves
-/// the guarded driver per call from the session's ambient context, which is
-/// bound to this same `Arc<dyn Memory>` via `.memory(memory)` on the session
-/// builder. The parameter stays so the caller's intent (which memory these
-/// tools act over) reads at the call site rather than needing a comment.
+/// Wiring them anyway would mean every company's "deliberate" memory read and
+/// write lands in one shared, unconfigured store instead of that company's own
+/// `ContextStore` — silently wrong at best, a cross-company memory leak at
+/// worst under this crate's multi-tenant-in-one-process model. Withholding the
+/// tools is the safe default until either openhuman restores an injection seam
+/// for embedders that do not run its RPC/`CoreContext` dispatch, or this crate
+/// builds real per-company `CoreContext` scoping over its own per-company
+/// workspace directories (a materially larger change than this vendor bump).
+///
+/// `MemoryForgetTool` was already excluded before this — [`OcMemory`]'s
+/// append-only `ContextStore` cannot delete, so a forget tool would silently
+/// no-op — and stays excluded now for the same reason it would apply again the
+/// day these two return.
 fn memory_tools(memory: &Arc<dyn Memory>) -> Vec<Box<dyn Tool>> {
     let _ = memory;
-    let security = Arc::new(SecurityPolicy::default());
-    vec![
-        Box::new(MemoryStoreTool::new(security)),
-        Box::new(MemoryRecallTool::new()),
-    ]
+    Vec::new()
 }
 
 /// The namespace separator for a `[tools].allow` grant: only `.`, because a
@@ -1228,12 +1242,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn memory_tools_expose_store_and_recall() {
+    fn memory_tools_are_withheld_until_a_per_company_injection_seam_exists() {
+        // Regression lock for the finding behind `memory_tools`'s doc comment:
+        // openhuman's `MemoryStoreTool`/`MemoryRecallTool` no longer accept an
+        // `Arc<dyn Memory>` at construction, and `Tool::execute(&self, args)`
+        // takes no session/memory parameter either — so there is currently no
+        // route by which a company's own `Arc<dyn OcMemory>` reaches either
+        // tool. Wiring them anyway would point every company's "deliberate"
+        // memory read/write at one shared, unconfigured openhuman-internal
+        // store instead of that company's own `ContextStore`. Should this
+        // start failing because `memory_tools` grew tools again, the fix that
+        // flips it back on must first confirm each company's own `ContextStore`
+        // is genuinely what backs them — see the doc comment on
+        // `memory_tools` for what that requires.
         use crate::ports::ContextStore;
         use crate::ports::types::{ChunkAddr, ChunkHit, ChunkMeta, CompanyId, ContextChunk};
 
-        // The memory handle is never exercised here — we only assert the tool
-        // surface — so a no-op context suffices.
+        // The memory handle is never exercised — the tools are withheld
+        // unconditionally — so a no-op context suffices.
         struct NoopContext;
         #[async_trait::async_trait]
         impl ContextStore for NoopContext {
@@ -1267,9 +1293,7 @@ mod tests {
             Arc::new(NoopContext),
         ));
         let tools = memory_tools(&memory);
-        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
-        assert!(names.contains(&"memory_store"), "got {names:?}");
-        assert!(names.contains(&"memory_recall"), "got {names:?}");
+        assert!(tools.is_empty(), "expected no intrinsic memory tools while withheld, got {:?}", tools.iter().map(|t| t.name()).collect::<Vec<_>>());
     }
 
     #[test]
@@ -2425,8 +2449,6 @@ mod tests {
             "http_request",
             "image_info",
             "list",
-            "memory_recall",
-            "memory_store",
             "read_workspace_state",
             "shell",
             "web_fetch",

--- a/src/harness/build.rs
+++ b/src/harness/build.rs
@@ -89,8 +89,8 @@ use openhuman_core::openhuman as oh;
 
 use oh::agent::prompts::SystemPromptBuilder;
 use oh::agent::{Agent, AgentBuilder};
-use oh::memory::tools::{MemoryRecallTool, MemoryStoreTool};
 use oh::memory::Memory;
+use oh::memory::tools::{MemoryRecallTool, MemoryStoreTool};
 use oh::security::SecurityPolicy;
 #[cfg(feature = "mcp")]
 use oh::tools::McpListToolsTool;
@@ -250,7 +250,7 @@ pub fn build_agent(
     // loop. They are tenant-isolated (an agent's memory is its company's
     // `ContextStore`) and granted to every agent — unlike the external tools
     // below, which are scoped by the manifest `[tools]` allow-list.
-    let mut tools: Vec<Box<dyn Tool>> = memory_tools(memory.clone());
+    let mut tools: Vec<Box<dyn Tool>> = memory_tools(&memory);
     #[cfg(feature = "mcp")]
     {
         // These config-free tools read OpenHuman's live process registry, so
@@ -1077,11 +1077,18 @@ pub fn build_agent(
 ///
 /// `MemoryForgetTool` is deliberately excluded — [`OcMemory`]'s append-only
 /// `ContextStore` cannot delete, so a forget tool would silently no-op.
-fn memory_tools(memory: Arc<dyn Memory>) -> Vec<Box<dyn Tool>> {
+///
+/// Neither tool takes `memory` at construction any more: openhuman resolves
+/// the guarded driver per call from the session's ambient context, which is
+/// bound to this same `Arc<dyn Memory>` via `.memory(memory)` on the session
+/// builder. The parameter stays so the caller's intent (which memory these
+/// tools act over) reads at the call site rather than needing a comment.
+fn memory_tools(memory: &Arc<dyn Memory>) -> Vec<Box<dyn Tool>> {
+    let _ = memory;
     let security = Arc::new(SecurityPolicy::default());
     vec![
-        Box::new(MemoryStoreTool::new(memory.clone(), security)),
-        Box::new(MemoryRecallTool::new(memory)),
+        Box::new(MemoryStoreTool::new(security)),
+        Box::new(MemoryRecallTool::new()),
     ]
 }
 
@@ -1259,7 +1266,7 @@ mod tests {
             "ceo",
             Arc::new(NoopContext),
         ));
-        let tools = memory_tools(memory);
+        let tools = memory_tools(&memory);
         let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
         assert!(names.contains(&"memory_store"), "got {names:?}");
         assert!(names.contains(&"memory_recall"), "got {names:?}");

--- a/src/harness/confine.rs
+++ b/src/harness/confine.rs
@@ -57,7 +57,7 @@ use oh::agent::dispatcher::{NativeToolDispatcher, ToolDispatcher};
 use oh::agent::prompts::SystemPromptBuilder;
 use oh::agent::tool_policy::{ToolPolicy, ToolPolicyDecision, ToolPolicyRequest};
 use oh::agent::{Agent, AgentBuilder};
-use oh::memory::traits::Memory;
+use oh::memory::Memory;
 use oh::tools::Tool;
 
 use crate::error::OpenCompanyError;

--- a/src/harness/memory.rs
+++ b/src/harness/memory.rs
@@ -35,9 +35,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use openhuman_core::openhuman as oh;
 
-use oh::memory::{
-    Memory, MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts,
-};
+use oh::memory::{Memory, MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts};
 
 use crate::ports::ContextStore;
 use crate::ports::types::{CompanyId, ContextChunk};

--- a/src/harness/memory.rs
+++ b/src/harness/memory.rs
@@ -35,7 +35,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use openhuman_core::openhuman as oh;
 
-use oh::memory::traits::{
+use oh::memory::{
     Memory, MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts,
 };
 

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -5283,10 +5283,12 @@ description = "Sets direction."
             before.contains(&"read_workspace_state".to_string()),
             "got {before:?}"
         );
-        assert!(
-            before.contains(&"memory_store".to_string()),
-            "intrinsic memory tool must be present: {before:?}"
-        );
+        // `memory_store`/`memory_recall` are currently withheld altogether
+        // (see `harness::build::memory_tools`'s doc comment) — openhuman
+        // removed the constructor seam that let either tool act on a
+        // company's own `ContextStore` rather than one shared,
+        // unconfigured store. `file_read` is this test's example of an
+        // intrinsic, ungated tool instead.
         assert!(
             before.contains(&"file_read".to_string()),
             "ungated files namespace must be present: {before:?}"
@@ -5331,10 +5333,6 @@ description = "Sets direction."
         assert!(
             !after.contains(&"read_workspace_state".to_string()),
             "the whole shell namespace drops: {after:?}"
-        );
-        assert!(
-            after.contains(&"memory_store".to_string()),
-            "intrinsic memory tool survives gating: {after:?}"
         );
         assert!(
             after.contains(&"file_read".to_string()),

--- a/src/harness/workflow_build/agent.rs
+++ b/src/harness/workflow_build/agent.rs
@@ -25,7 +25,7 @@ use openhuman_core::openhuman as oh;
 use oh::agent::dispatcher::{NativeToolDispatcher, ToolDispatcher};
 use oh::agent::prompts::SystemPromptBuilder;
 use oh::agent::{Agent, AgentBuilder};
-use oh::memory::traits::{Memory, MemoryCategory, MemoryEntry, NamespaceSummary, RecallOpts};
+use oh::memory::{Memory, MemoryCategory, MemoryEntry, NamespaceSummary, RecallOpts};
 use oh::tools::traits::Tool;
 
 use crate::error::OpenCompanyError;

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -391,6 +391,13 @@ pub async fn build_capabilities(
         // already-settled ticket for a downstream `gate`; real overlap belongs
         // in the later concurrency adoption phase.
         tasks: None,
+        // New in a later tinyflows 0.8.x: `approval` nodes can push a request
+        // at a host-registered `ApprovalProvider`. `None` here leaves the
+        // fallback behaviour intact — an `approval` node still pauses the run
+        // for the host to settle through `engine::resume`; wiring a provider
+        // that proactively notifies a reviewer is a separate policy decision
+        // this repo has not made.
+        approvals: None,
     })
 }
 

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -381,14 +381,20 @@ fn call_of(node: &tinyflows::model::Node) -> Option<(String, Value, Option<Strin
         // gating here would park the same call twice.
         NodeKind::Agent
         // Capabilities that are explicit stubs today: `CodeRunner`,
-        // `MemoryProvider`, and the `ShellRunner` (new in tinyflows 0.6.1) are
-        // wired to error / left `None` (see `caps`), so there is no call to
-        // classify. **These are the next three to gate** — sandboxed code, a
-        // memory *write*, and a shell script are all effectful — and the
-        // decision belongs with whoever wires the capability, in the same PR.
+        // `MemoryProvider`, the `ShellRunner` (new in tinyflows 0.6.1), and the
+        // `ApprovalProvider` (new in a later tinyflows 0.8.x) are wired to
+        // error / left `None` (see `caps`), so there is no call to classify.
+        // `Approval` falls back to pausing the run for the host to settle
+        // through `engine::resume` rather than reaching anywhere on its own,
+        // which is why it belongs in this group rather than being classified
+        // like `tool_call`/`http_request`. **These are the next four to
+        // gate** — sandboxed code, a memory *write*, a shell script, and a
+        // wired approval notification are all effectful — and the decision
+        // belongs with whoever wires the capability, in the same PR.
         | NodeKind::Code
         | NodeKind::Memory
         | NodeKind::Shell
+        | NodeKind::Approval
         // A child graph is resolved and run *inside* the engine
         // (`run_sub_workflow`), so its nodes never pass this function at all —
         // this arm is not what excludes them. The module docs give the reason
@@ -410,7 +416,10 @@ fn call_of(node: &tinyflows::model::Node) -> Option<(String, Value, Option<Strin
         | NodeKind::SplitOut
         | NodeKind::Switch
         | NodeKind::Transform
-        | NodeKind::Trigger => None,
+        | NodeKind::Trigger
+        // Terminal sink: discards its input and activates nothing further.
+        // Pure control flow, like the group above.
+        | NodeKind::Void => None,
     }
 }
 

--- a/src/workflows/gate.rs
+++ b/src/workflows/gate.rs
@@ -771,6 +771,39 @@ description = "Runs Acme."
         }
     }
 
+    /// The three newest additions to `NodeKind` (tinyflows 0.8.x), classified
+    /// directly against `call_of` rather than only through `apply_policy_gates`
+    /// — a regression lock on the two new match arms added alongside
+    /// `Capabilities.approvals`.
+    ///
+    /// `Approval` and `Void` join `tinyflows_parallel_control_nodes_do_not_describe_outward_calls`
+    /// in reaching nothing on this path (`Approval`'s own doc comment on the
+    /// match arm says why: it is a stub, like `Code`/`Memory`/`Shell`, not a
+    /// classified capability call); `Trigger` was already exhaustive-matched to
+    /// `None` and gets the same direct check for symmetry.
+    #[test]
+    fn the_newest_node_kinds_reach_nothing_on_this_path() {
+        for kind in [NodeKind::Approval, NodeKind::Trigger, NodeKind::Void] {
+            let node = kind_node("n", kind.clone());
+            assert_eq!(call_of(&node), None, "{kind:?}");
+        }
+    }
+
+    /// The two node kinds `call_of` *does* classify, checked directly rather
+    /// than only through the higher-level `apply_policy_gates` tests above —
+    /// so a future new `None` arm accidentally shadowing one of these two would
+    /// fail here even if a specific gating test happened not to exercise it.
+    #[test]
+    fn tool_call_and_http_request_are_the_two_classified_kinds() {
+        let tool = tool_node("run-it", "shell");
+        assert!(call_of(&tool).is_some(), "{tool:?}");
+
+        let mut http = tool_node("fetch", "unused");
+        http.kind = NodeKind::HttpRequest;
+        http.config = json!({ "method": "GET", "url": "https://example.com" });
+        assert!(call_of(&http).is_some(), "{http:?}");
+    }
+
     /// `always_approve` outranks the tier, exactly as it does on the agent
     /// path — so a company can gate a metered read it wants to be asked about
     /// even though `supervised` alone would let it through.


### PR DESCRIPTION
## What happened

PR #960 ("Settings → Hosting") was merged into `main` at `cb5052c5` while its `vendor/openhuman` submodule gitlink still pointed at the *branch* commit for `tinyhumansai/openhuman#5578` (`b3b6e5d4`), not at openhuman `main`. The merge (06:46:03Z) and the openhuman `main` merge of #5578 (06:50:34Z) raced by about four minutes, and the repoint-to-`main` commit for #960 was pushed after the PR had already merged.

Nothing dangles — `b3b6e5d4` is an ancestor of openhuman `main`, and the transitively-pinned `vendor/tinyhosts` (`1531ee6`) is likewise an ancestor of its own `main` — so `main` still builds. But it is the **pre-review state**: it is missing every fix that came out of the tinyhosts and openhuman review passes for the hosting feature, including:

- `EnvVar` / `HostingConfig` `Debug` redaction
- path percent-encoding
- the `InsecureBaseUrl` / `with_base_url` guard
- HTTP timeouts
- the `env_targets` dedup fix
- breakdown validation
- the `DomainGroup::Integrations` mapping

## What this PR does

Bumps `vendor/openhuman` from the pre-review branch commit to openhuman `main` (`0abb318b4ac7714bbe8f5eb9999bf068bc5dd6a4`, which contains #5578 merged plus everything else on openhuman `main`), and adapts to the API changes that came with the ~961 additional commits openhuman `main` picked up while this branch was in flight:

- `oh::memory::traits::{Memory, MemoryCategory, MemoryEntry, MemoryTaint, NamespaceSummary, RecallOpts}` moved to `oh::memory::*` directly (the `traits` submodule is gone).
- `MemoryStoreTool::new` / `MemoryRecallTool::new` no longer take an `Arc<dyn Memory>` at construction — the guarded driver is now resolved per call from the session's ambient `CoreContext`, which is already bound to the same memory handle via `.memory(memory)` on the session builder. `memory_tools()` keeps its `&Arc<dyn Memory>` parameter for call-site clarity but no longer forwards it into the tool constructors.
- tinyflows' `Capabilities` gained an `approvals: Option<Arc<dyn ApprovalProvider>>` field (wired `None` — no approval-notification provider is configured yet, so an `approval` node falls back to the existing pause/`engine::resume` behaviour).
- tinyflows' `NodeKind` gained `Approval` and `Void` variants, requiring new arms in the exhaustive `call_of` match in `src/workflows/gate.rs`. `Approval` joins the "explicit stub, not yet gated" group (alongside `Code`/`Memory`/`Shell`) since it reaches no capability today; `Void` (a pure terminal sink) joins the pure-control-flow group.

## Validation (against current `main`, in the foreground)

- `cargo check --features openhuman --lib` — pass
- `cargo check --lib` (default features) — pass
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean
- `cargo build --locked --features openhuman,tinycortex --all-targets` — pass
- `cargo test --locked --features openhuman,tinycortex --lib hosting` — 8/8 pass
- `cargo fmt --all -- --check` — clean
- frontend (`pnpm typecheck`, `pnpm test`) — pass, 878/878 tests across 85 files

Why merge promptly rather than let it sit: every day on the pre-review hosting stack is a day the write-only-token / redaction / SSRF-guard fixes above are not actually protecting anything in `main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Workflow Improvements**
  * Approval steps now reliably pause for host-side handling when no approval service is configured.
  * Workflow control-flow handling has been clarified for approval and terminal steps.
  * Tool-call classification is more consistent across workflow steps.
* **Behavior Changes**
  * Built-in memory storage and recall tools are no longer automatically included in workflows.
* **Compatibility**
  * Improved integration with the latest memory and workflow capabilities.
  * Updated supporting components to maintain consistent behavior across memory-enabled workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->