### PR TITLE
fix(console): name teammates in the workspace tree, not their ids (#973)

### DIFF
--- a/frontend/src/lib/roster-names.ts
+++ b/frontend/src/lib/roster-names.ts
@@ -1,0 +1,35 @@
+// One shared way to turn a roster id into the name a human recognizes it by
+// (issue #973). #931 hit this once already: an operator-added teammate's id is
+// a minted internal string (a ULID for the eight teammates created before
+// #686 started minting a readable slug), and printing it told a reader
+// nothing. #939 fixed the two connections surfaces by having the host pair
+// each id with a name server-side (`RosterAgent`, in `@/api/types`) — but that
+// only works where the host is already walking the roster to answer the
+// request. A surface that only has the roster listing (`GET …/team`) and a
+// bare id to look up in it — the workspace tree chief among them, since the id
+// is also that teammate's real folder name — needs the client-side twin: build
+// one lookup from the roster read, then resolve every id through it. Route any
+// new id-bearing surface through this rather than growing a fifth per-surface
+// fix.
+
+import type { RosterAgent } from "@/api/types";
+
+/** id -> display name, built from a roster listing. */
+export type RosterNames = ReadonlyMap<string, string>;
+
+/** Build the lookup {@link rosterDisplayName} needs, from a roster read. */
+export function rosterNameMap(agents: readonly Pick<RosterAgent, "id" | "name">[]): RosterNames {
+  return new Map(agents.map((a) => [a.id, a.name]));
+}
+
+/**
+ * Resolve a roster id to its display name.
+ *
+ * Falls back to the id itself — never a blank label — when the roster has
+ * nothing to say about it: an id the roster does not carry (the roster has not
+ * loaded yet, or the id names something else entirely) or an entry whose name
+ * is genuinely empty.
+ */
+export function rosterDisplayName(id: string, names: RosterNames): string {
+  return names.get(id) || id;
+}

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -1545,7 +1545,13 @@ function isAgentsFolder(folder: FsNode | undefined): boolean {
 function sortRosterFolders(items: FsNode[], names: RosterNames): FsNode[] {
   return [...items].sort((a, b) => {
     if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
-    return rosterDisplayName(a.name, names).localeCompare(rosterDisplayName(b.name, names));
+    // Only a roster folder's name is an id worth resolving. A direct file
+    // under `Agents/` is unusual but not impossible, and its raw name could
+    // coincidentally collide with a roster id — that must not reorder it by
+    // a display name it was never given one for.
+    return a.kind === "folder"
+      ? rosterDisplayName(a.name, names).localeCompare(rosterDisplayName(b.name, names))
+      : a.name.localeCompare(b.name);
   });
 }
 

--- a/frontend/src/views/WorkspaceView.tsx
+++ b/frontend/src/views/WorkspaceView.tsx
@@ -73,6 +73,8 @@ import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { Skeleton } from "@/components/ui/skeleton";
+import { rosterDisplayName, rosterNameMap, type RosterNames } from "@/lib/roster-names";
+import { fromDto } from "@/lib/team";
 import { cn } from "@/lib/utils";
 import {
   applyRepair,
@@ -338,6 +340,10 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // The roster names the `Agents/` folders resolve against (issue #973). Best
+  // effort and never blocking: a host predating the roster route 404s, and the
+  // tree simply falls back to the raw ids it has always shown.
+  const [rosterNames, setRosterNames] = useState<RosterNames>(() => new Map());
 
   const [openId, setOpenId] = useState<string | null>(null);
   const [openFile, setOpenFile] = useState<WorkspaceFile | null>(null);
@@ -392,6 +398,7 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
   const treeGen = useRef(0);
   const fileGen = useRef(0);
   const searchGen = useRef(0);
+  const rosterGen = useRef(0);
   // Whether the explorer's initial folder expansion has happened yet, so a later
   // refresh never re-opens folders the operator collapsed.
   const expandedSeeded = useRef(false);
@@ -438,6 +445,24 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
     },
     [client, company],
   );
+
+  /* ---- roster names (#973) ---- */
+
+  // Best effort, and deliberately separate from `loadTree`: a host with no
+  // roster route (or a request that simply fails) must not stop the workspace
+  // itself from loading — it only means the `Agents/` folders keep showing raw
+  // ids, exactly as they did before this issue.
+  const loadRoster = useCallback(async () => {
+    const mine = ++rosterGen.current;
+    try {
+      const team = await client.listTeam(company);
+      if (mine !== rosterGen.current) return;
+      setRosterNames(rosterNameMap(team.map(fromDto)));
+    } catch {
+      if (mine !== rosterGen.current) return;
+      setRosterNames(new Map());
+    }
+  }, [client, company]);
 
   /* ---- search (#607) ---- */
 
@@ -509,12 +534,18 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
     // be saved into the wrong workspace is worse than no offer at all.
     setRescued(null);
     setExpanded(new Set());
+    // Another company's roster is another set of names; carrying the old map
+    // across a switch would resolve this company's ids against that one's
+    // teammates.
+    setRosterNames(new Map());
     void loadTree();
+    void loadRoster();
     return () => {
       treeGen.current++;
       fileGen.current++;
+      rosterGen.current++;
     };
-  }, [loadTree]);
+  }, [loadTree, loadRoster]);
 
   /* ---- the open note ---- */
 
@@ -1260,6 +1291,7 @@ export function WorkspaceView({ client, company, event, initialNodeId }: Props) 
               depth={0}
               expanded={expanded}
               openId={openId}
+              rosterNames={rosterNames}
               onToggle={toggle}
               onOpen={(id) => void open(id)}
               onRename={(node) => setPrompt({ mode: "rename", node })}
@@ -1485,6 +1517,8 @@ interface TreeProps {
   depth: number;
   expanded: Set<string>;
   openId: string | null;
+  /** id -> display name for roster ids (issue #973). See {@link isAgentsFolder}. */
+  rosterNames: RosterNames;
   onToggle: (id: string) => void;
   onOpen: (id: string) => void;
   onRename: (node: FsNode) => void;
@@ -1492,11 +1526,37 @@ interface TreeProps {
   onDelete: (node: FsNode) => void;
 }
 
+/**
+ * Whether `folder` is the workspace's `Agents/` root — the one folder whose
+ * direct children are named by roster id rather than anything an operator
+ * chose (issue #973). Root-scoped (`parentId === null`) so a note or folder an
+ * operator names "Agents" somewhere else in the tree is never mistaken for it.
+ */
+function isAgentsFolder(folder: FsNode | undefined): boolean {
+  return folder?.kind === "folder" && folder.name === "Agents" && folder.parentId === null;
+}
+
+/**
+ * `Agents/`'s children, sorted by display name rather than the lexical id
+ * {@link childrenOf} sorts everywhere else (issue #973). The pre-#686 ULID ids
+ * all sort before every readable slug under the plain id ordering, which is
+ * not an order an operator can read anything into.
+ */
+function sortRosterFolders(items: FsNode[], names: RosterNames): FsNode[] {
+  return [...items].sort((a, b) => {
+    if (a.kind !== b.kind) return a.kind === "folder" ? -1 : 1;
+    return rosterDisplayName(a.name, names).localeCompare(rosterDisplayName(b.name, names));
+  });
+}
+
 function Tree(props: TreeProps) {
   const items = childrenOf(props.nodes, props.parentId);
+  const ordered = isAgentsFolder(nodeById(props.nodes, props.parentId))
+    ? sortRosterFolders(items, props.rosterNames)
+    : items;
   return (
     <>
-      {items.map((node) => (
+      {ordered.map((node) => (
         <TreeRow key={node.id} node={node} {...props} />
       ))}
     </>
@@ -1551,10 +1611,17 @@ function sameOrigin(a: WorkspaceOrigin, b: WorkspaceOrigin): boolean {
 }
 
 function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
-  const { depth, expanded, openId, onToggle, onOpen } = props;
+  const { depth, expanded, openId, onToggle, onOpen, nodes, rosterNames } = props;
   const isFolder = node.kind === "folder";
   const isOpen = expanded.has(node.id);
   const active = node.id === openId;
+  // A direct child of `Agents/` is named by roster id — its real folder path,
+  // and the identity every artifact it holds is stamped with — but an operator
+  // recognizes the teammate by name, not by that id (issue #973). The id stays
+  // the label everywhere else in the tree: it is only ever a roster id one
+  // level below `Agents/`.
+  const isRosterFolder = isFolder && isAgentsFolder(nodeById(nodes, node.parentId));
+  const displayName = isRosterFolder ? rosterDisplayName(node.name, rosterNames) : node.name;
 
   return (
     <>
@@ -1577,7 +1644,9 @@ function TreeRow({ node, ...props }: TreeProps & { node: FsNode }) {
           ) : (
             <FileText className="ml-3.5 size-4 shrink-0 text-muted-foreground" />
           )}
-          <span className="truncate">{isFolder ? node.name : titleOf(node)}</span>
+          <span className="truncate" title={isRosterFolder ? node.name : undefined}>
+            {isFolder ? displayName : titleOf(node)}
+          </span>
           {/* Agent-created nodes get a marker in the tree itself, so "what has
               the company been writing" is answerable by scanning rather than by
               opening each note. Only the agent case — badging the operator's

--- a/frontend/test/unit/roster-names.test.ts
+++ b/frontend/test/unit/roster-names.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { rosterDisplayName, rosterNameMap } from "@/lib/roster-names";
+
+/**
+ * The shared roster id -> display name resolver (issue #973).
+ *
+ * #931 was the same class of bug — an operator-added teammate's id is a
+ * minted internal string (a ULID for the eight teammates created before #686
+ * started minting a readable slug), and a surface that prints it instead of
+ * the name is telling the reader nothing. #939 fixed the two connections
+ * surfaces; this is the resolver every id-bearing surface should route
+ * through from here on, so a fifth surface cannot regress the same way.
+ */
+
+describe("rosterDisplayName", () => {
+  it("resolves a known id to its name", () => {
+    const names = rosterNameMap([
+      { id: "019fa75dbc9b-000000000005", name: "Mark" },
+      { id: "backend_engineer", name: "backend dev" },
+    ]);
+    expect(rosterDisplayName("019fa75dbc9b-000000000005", names)).toBe("Mark");
+    expect(rosterDisplayName("backend_engineer", names)).toBe("backend dev");
+  });
+
+  it("falls back to the id itself for an id the roster does not carry", () => {
+    // Roster not loaded yet, or an id that names something else entirely —
+    // either way, the label must never go blank.
+    const names = rosterNameMap([]);
+    expect(rosterDisplayName("019fa75dbc9b-000000000005", names)).toBe(
+      "019fa75dbc9b-000000000005",
+    );
+  });
+
+  it("falls back to the id when the roster's name for it is empty", () => {
+    // A genuinely nameless entry must still render something, not a blank
+    // label — the id is the honest fallback everywhere else here.
+    const names = rosterNameMap([{ id: "member-7", name: "" }]);
+    expect(rosterDisplayName("member-7", names)).toBe("member-7");
+  });
+});
+
+describe("rosterNameMap", () => {
+  it("last write wins on a duplicate id", () => {
+    const names = rosterNameMap([
+      { id: "cmo", name: "First" },
+      { id: "cmo", name: "Second" },
+    ]);
+    expect(rosterDisplayName("cmo", names)).toBe("Second");
+  });
+});

--- a/frontend/test/unit/workspace-tree-roster-names.test.ts
+++ b/frontend/test/unit/workspace-tree-roster-names.test.ts
@@ -132,6 +132,29 @@ describe("the workspace tree", () => {
     expect(container.textContent).not.toContain("Backend Engineer");
   });
 
+  it("sorts a direct Agents/ file by its raw name, not a roster id it happens to match", async () => {
+    // Only a roster *folder*'s name is an id worth resolving into a display
+    // name for sorting. A file living directly under `Agents/` is unusual but
+    // legal, and its raw name could coincidentally collide with a roster id —
+    // that collision must not reorder it by a display name it was never given
+    // one for (it still renders under its raw name either way; only the sort
+    // key is at stake here).
+    const tree = [
+      node({ id: "agents-root", name: "Agents", kind: "folder" }),
+      node({ id: "f-alpha", name: "alpha-id", kind: "file", parentId: "agents-root" }),
+      node({ id: "f-zeta", name: "zeta-id", kind: "file", parentId: "agents-root" }),
+    ];
+    // Display-name order (if files were wrongly resolved) is reversed:
+    // zeta-id -> "Alex" sorts before alpha-id -> "Zoe".
+    const team = [member("alpha-id", "Zoe"), member("zeta-id", "Alex")];
+
+    await render(client(tree, team));
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("alpha-id")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("zeta-id")).toBeGreaterThan(text.indexOf("alpha-id"));
+  });
+
   it("falls back to the raw id when the roster has no name for it", async () => {
     // An id the roster does not carry (not loaded, deleted, or a host with no
     // `/team` route at all) must still render something — never a blank row.

--- a/frontend/test/unit/workspace-tree-roster-names.test.ts
+++ b/frontend/test/unit/workspace-tree-roster-names.test.ts
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { OpenCompanyClient } from "@/api/client";
+import type { TeamMemberDto } from "@/api/types";
+import { ConnectionScopeProvider } from "@/connections/ConnectionContext";
+import { WorkspaceView } from "@/views/WorkspaceView";
+
+/**
+ * The workspace tree names roster ids (issue #973).
+ *
+ * #931 was the same class of bug — the eight teammates minted before #686
+ * (before it started slugging a name into the id) carry ULID-style ids, and a
+ * surface that prints the id instead of the name tells the operator nothing.
+ * #939 fixed the two connections surfaces (`McpServersSection`,
+ * `ProviderDetail`, `RepositoriesCard`) but never touched this one, so the
+ * `Agents/` folders kept showing raw ids one tab over. This is the guard for
+ * this surface, so a sixth one cannot regress the same way silently: it
+ * renders the real tree component against a fake host and reads the DOM the
+ * operator actually sees, the same way `provider-detail-render.test.ts` pins
+ * #931's fix on the connections panel.
+ */
+
+/** A minimal `FsNode` off the wire — only the fields the tree reads. */
+function node(over: {
+  id: string;
+  name: string;
+  kind: "folder" | "file";
+  parentId?: string;
+}) {
+  return { ...over, updatedAt: 1 };
+}
+
+function member(id: string, name: string): TeamMemberDto {
+  return { id, name, role: name };
+}
+
+/** A fake host: `get` answers the workspace tree read, `listTeam` the roster. */
+function client(tree: ReturnType<typeof node>[], team: TeamMemberDto[]): OpenCompanyClient {
+  return {
+    scopeFor: () => "/api/v1/company/acme",
+    get: vi.fn().mockResolvedValue(tree),
+    listTeam: vi.fn().mockResolvedValue(team),
+  } as unknown as OpenCompanyClient;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function render(host: OpenCompanyClient) {
+  await act(async () => {
+    root.render(
+      createElement(ConnectionScopeProvider, {
+        scope: { connection: "c1", company: "acme" },
+        children: createElement(WorkspaceView, { client: host, company: "acme" }),
+      }),
+    );
+  });
+  // The tree read and the roster read are two separate effects; give both a
+  // further tick to settle rather than assuming one `act` flush covers both.
+  await act(async () => {});
+}
+
+describe("the workspace tree", () => {
+  it("names a teammate's Agents/ folder instead of its raw roster id", async () => {
+    const tree = [
+      node({ id: "agents-root", name: "Agents", kind: "folder" }),
+      node({ id: "n-zeta", name: "zeta-id", kind: "folder", parentId: "agents-root" }),
+      node({ id: "n-alpha", name: "alpha-id", kind: "folder", parentId: "agents-root" }),
+    ];
+    const team = [member("zeta-id", "Alex"), member("alpha-id", "Zoe")];
+
+    await render(client(tree, team));
+
+    expect(container.textContent).toContain("Alex");
+    expect(container.textContent).toContain("Zoe");
+    // The id is still real — the folder's actual path and the identity every
+    // artifact it holds is stamped with — but it is not what the operator
+    // reads on the row; it lives in the tooltip only.
+    expect(container.textContent).not.toContain("zeta-id");
+    expect(container.textContent).not.toContain("alpha-id");
+    const zeta = container.querySelector('[title="zeta-id"]');
+    expect(zeta?.textContent).toBe("Alex");
+  });
+
+  it("sorts Agents/ folders by display name, not by the lexical id", async () => {
+    // Chosen so id order and name order disagree in both directions: raw-id
+    // order is [alpha-id, zeta-id], name order must be [Alex, Zoe].
+    const tree = [
+      node({ id: "agents-root", name: "Agents", kind: "folder" }),
+      node({ id: "n-alpha", name: "alpha-id", kind: "folder", parentId: "agents-root" }),
+      node({ id: "n-zeta", name: "zeta-id", kind: "folder", parentId: "agents-root" }),
+    ];
+    const team = [member("alpha-id", "Zoe"), member("zeta-id", "Alex")];
+
+    await render(client(tree, team));
+
+    const text = container.textContent ?? "";
+    expect(text.indexOf("Alex")).toBeGreaterThanOrEqual(0);
+    expect(text.indexOf("Zoe")).toBeGreaterThan(text.indexOf("Alex"));
+  });
+
+  it("keeps a raw folder name outside Agents/ unresolved even if it matches a roster id", async () => {
+    // The resolver is scoped to Agents/'s direct children, not a blanket
+    // find-and-replace over every folder name in the tree — a folder an
+    // operator happened to name after a teammate's id elsewhere in the tree
+    // must not be relabeled.
+    const tree = [
+      node({ id: "standards-root", name: "Standards", kind: "folder" }),
+      node({ id: "n-be", name: "backend_engineer", kind: "folder", parentId: "standards-root" }),
+    ];
+    const team = [member("backend_engineer", "Backend Engineer")];
+
+    await render(client(tree, team));
+
+    expect(container.textContent).toContain("backend_engineer");
+    expect(container.textContent).not.toContain("Backend Engineer");
+  });
+
+  it("falls back to the raw id when the roster has no name for it", async () => {
+    // An id the roster does not carry (not loaded, deleted, or a host with no
+    // `/team` route at all) must still render something — never a blank row.
+    const tree = [
+      node({ id: "agents-root", name: "Agents", kind: "folder" }),
+      node({ id: "n-unknown", name: "019fadd6f457-000000000099", kind: "folder", parentId: "agents-root" }),
+    ];
+
+    await render(client(tree, []));
+
+    expect(container.textContent).toContain("019fadd6f457-000000000099");
+  });
+});


### PR DESCRIPTION
## Summary

The Workspace notes tree renders `Agents/<id>/` folders by raw roster id for the eight teammates created before #686 (before it started minting a readable slug into the id), so the tree showed ULID-style ids like `019fa75dbc9b-000000000005` instead of "Mark". #931 was the same class of bug; its fix in #939 only touched the connections surfaces (`McpServersSection.tsx`, `ProviderDetail.tsx`, `RepositoriesCard.tsx`, `ops/mcp.rs`, `ops/repos.rs`) and never reached `WorkspaceView.tsx`.

This adds one shared `id -> display name` resolver in `frontend/src/lib/roster-names.ts` and uses it in the workspace tree: a folder directly under `Agents/` now shows the teammate's name, keeps the raw id as a tooltip (it is still the real folder path and the identity every artifact the teammate authors is stamped with), sorts those folders by display name instead of the lexical id, and falls back to the raw id when the roster has no name for it. Resolution is scoped to `Agents/`'s direct children only — a folder elsewhere in the tree that happens to share text with a roster id is left unresolved.

Renaming `Agents/<id>/` folders, migrating workspace data, or re-stamping artifact origins is explicitly out of scope — the id remains storage identity; this is a display-only fix.

Closes #973

## API Or Behavior Changes

Client-side display only. No API or wire changes. The workspace tree now shows a teammate's name (falling back to the raw id when the roster has none) for folders directly under `Agents/`, and sorts those folders by display name. Everything else in the tree — folder names elsewhere, file names, sort order outside `Agents/` — is unchanged.

## Tests

- [x] `npm ci`
- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` (886 tests passed across 87 files, including two new files: `roster-names.test.ts` pinning the resolver's fallback rules, and `workspace-tree-roster-names.test.ts` — a guard test rendering `WorkspaceView` against a fake host, modeled on `provider-detail-render.test.ts`'s #931 guard, asserting the tree names a teammate instead of its id, sorts by name, leaves an unrelated folder's raw text alone, and falls back to the id when the roster has nothing for it)
- N/A: `cargo fmt --all -- --check` / `cargo clippy --all-targets -- -D warnings` / `cargo build --all-targets` / `cargo test` — no Rust files changed, frontend-only fix

## Documentation

None needed — this is an internal display-layer fix with no public API, config, or architecture change to document.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace `Agents/` folders now display roster names instead of raw IDs.
  * Agent entries are sorted alphabetically by display name, with raw IDs available on hover.
  * Workspace loading remains available when roster information cannot be retrieved, using IDs as a fallback.

* **Tests**
  * Added coverage for name resolution, sorting, duplicate IDs, missing names, and roster-loading failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->