### PR TITLE
fix(tour): clamp the spotlight card into the viewport on both axes (#583)

### DIFF
--- a/frontend/src/tour/TourController.tsx
+++ b/frontend/src/tour/TourController.tsx
@@ -217,6 +217,27 @@ export function TourController({
             initialStepIndex={startIndex}
             continuous
             tooltipComponent={TourTooltip}
+            // Clamp the card into the viewport on BOTH axes (issue #583).
+            //
+            // joyride positions with floating-ui, and neither of its two
+            // defaults can save a stop anchored to a full-viewport element —
+            // which the Overview graph is (`h-svh`, top edge at y=0). Asking
+            // for `placement: "top"` there resolves to `0 - height - offset`,
+            // measured at y=-238: rendered, visible, mounted, and entirely
+            // above the fold. Which is what gets reported as "the tour is
+            // stuck on step 2".
+            //
+            // `flip` cannot fix it: against a full-height anchor the *bottom*
+            // side overflows by exactly as much as the top, so floating-ui's
+            // best-fit tie-break keeps the side it started on. And `shift`
+            // clamps only its main axis, which for a top/bottom placement is
+            // the horizontal one — the broken axis is the one left alone.
+            //
+            // Turning on `crossAxis` is the missing half: the card slides back
+            // inside on the axis the placement runs along. It may then overlap
+            // the element it points at, which for a full-bleed anchor is
+            // unavoidable and strictly better than being unreachable.
+            floatingOptions={{ shiftOptions: { crossAxis: true } }}
             options={{
               zIndex: 1200,
               overlayColor: "rgba(0,0,0,0.45)",

--- a/frontend/test/e2e/tour-popover-in-viewport.spec.ts
+++ b/frontend/test/e2e/tour-popover-in-viewport.spec.ts
@@ -1,0 +1,127 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Issue #583 — every tour stop's card must be reachable, at any window size.
+ *
+ * The reported symptom was "the tour is stuck at step 2", and the issue blamed
+ * the step's target never mounting. It does mount. The card is rendered,
+ * `visible`, `opacity: 1`, with working Skip/Next buttons — it is positioned
+ * **off the top of the viewport**, measured on staging at `y = -238` for a card
+ * 222px tall. Nothing about it is reachable, so the tour reads as vanished.
+ *
+ * The cause is placement, not lifecycle. Step 2 anchors to the Overview graph,
+ * which is `h-svh` — a full-viewport-height element whose top edge sits at
+ * `y = 0`. Asking for `placement: "top"` puts the card at `0 - height - offset`.
+ * Neither of react-joyride's positioning middlewares can recover it:
+ *
+ * - `flip` (top → bottom) compares overflow both ways. Against a full-height
+ *   anchor, *bottom* overflows by exactly as much as *top*, so floating-ui's
+ *   best-fit tie-break keeps the original side.
+ * - `shift` clamps only its main axis, which for a `top`/`bottom` placement is
+ *   the **horizontal** one. The broken axis is unclamped.
+ *
+ * So this asserts the property the tour actually needs — every stop's card lies
+ * fully inside the viewport — rather than the mechanism, which leaves the fix
+ * free to change without the test rotting. Step 1 (a sidebar anchor) and the
+ * later nav-row stops pass on both HEAD and the fix; step 2 is the one that
+ * fails before it.
+ *
+ * Two window sizes because the bug is a function of the anchor's size relative
+ * to the viewport: a stop that fits at one height can overflow at another.
+ */
+
+type Page = import("@playwright/test").Page;
+
+/**
+ * How many stops `src/tour/steps.ts` declares.
+ *
+ * Hard-coded because the e2e project has no `@/*` alias and cannot import app
+ * modules (see `tsconfig.e2e.json`). It does not silently rot: the per-step
+ * assertion below reads the card's own "Step N of M" chip and fails if M ever
+ * stops matching, which is the signal to widen this constant rather than let a
+ * new stop go uncovered.
+ */
+const TOUR_STOPS = 8;
+
+/** Window sizes to walk the tour at. The first is the one measured on staging. */
+const VIEWPORTS = [
+  { width: 1512, height: 772 },
+  { width: 1280, height: 800 },
+] as const;
+
+/**
+ * Start a fresh tour from the welcome dialog.
+ *
+ * The suite's usual `oc-tour:` localStorage shim (which marks the tour skipped
+ * so it stays out of other specs' way) is deliberately NOT installed here —
+ * this spec is the one that wants the tour.
+ */
+async function startTour(page: Page): Promise<void> {
+  await page.goto("/#/overview");
+  const start = page.getByRole("button", { name: "Take the tour" });
+  await expect(start, "first run should offer the tour").toBeVisible();
+  await start.click();
+}
+
+for (const viewport of VIEWPORTS) {
+  test(`every tour stop's card is inside a ${viewport.width}x${viewport.height} viewport`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ ...viewport });
+    await startTour(page);
+
+    // `tooltipProps` gives the card `role="alertdialog"`. The welcome dialog is
+    // a `dialog`, so this cannot match it — and by here it is closed anyway.
+    const card = page.getByRole("alertdialog");
+
+    for (let step = 1; step <= TOUR_STOPS; step += 1) {
+      // Each stop switches the console's view first, so wait for THIS step's
+      // chip rather than for any card: a stale card from the previous stop is
+      // still mounted for a frame or two while the next view mounts.
+      await expect(
+        card.getByText(`Step ${step} of ${TOUR_STOPS}`),
+        `step ${step} should render (and the tour should still have ${TOUR_STOPS} stops)`,
+      ).toBeVisible();
+
+      // Let placement settle: floating-ui positions on a later frame than the
+      // one that mounts the card, and `autoUpdate` re-runs it when the target
+      // finishes laying out. Measuring the first frame would flake in both
+      // directions.
+      await page.waitForTimeout(300);
+
+      const box = await card.boundingBox();
+      expect(box, `step ${step}'s card should have a box`).not.toBeNull();
+      const { x, y, width, height } = box!;
+
+      // The whole assertion. `toBeGreaterThanOrEqual(0)` on `y` is what fails on
+      // HEAD for step 2 — measured `-238`.
+      const where = `step ${step} at ${Math.round(x)},${Math.round(y)} ${Math.round(
+        width,
+      )}x${Math.round(height)} in ${viewport.width}x${viewport.height}`;
+      expect(y, `${where}: card starts above the top edge`).toBeGreaterThanOrEqual(0);
+      expect(x, `${where}: card starts left of the viewport`).toBeGreaterThanOrEqual(0);
+      expect(y + height, `${where}: card runs past the bottom edge`).toBeLessThanOrEqual(
+        viewport.height,
+      );
+      expect(x + width, `${where}: card runs past the right edge`).toBeLessThanOrEqual(
+        viewport.width,
+      );
+
+      // And it is genuinely operable, not merely on-screen: a card the user
+      // cannot advance is the same stall by another route. Playwright's
+      // actionability check covers hit-testing, so this also catches a card
+      // painted under the overlay.
+      //
+      // Matched on the rendered label rather than the accessible name: joyride
+      // puts its own locale string on `primaryProps`' `aria-label` (`"Next"`,
+      // and `"Last"` on the final stop), which wins over the text `TourTooltip`
+      // renders. The label the operator reads is the one worth asserting.
+      const advance = card.locator("button", { hasText: step === TOUR_STOPS ? "Done" : "Next" });
+      await expect(advance, `step ${step}: the advance button should be usable`).toBeEnabled();
+      await advance.click();
+    }
+
+    // The run finished rather than dead-ending on a stop.
+    await expect(card).toHaveCount(0);
+  });
+}


### PR DESCRIPTION
## Summary

The onboarding tour appears to die on step 2. The card is not missing — it is
rendered, mounted, `opacity: 1`, with working Skip/Next buttons, positioned
entirely **above the top edge of the viewport**. Measured at `340x222` at
`y = -238` in a `1512x772` window, on staging and again locally.

Step 2 anchors to the Overview graph, which is `h-svh` — a full-viewport-height
element whose top edge is `y = 0`. Asking for `placement: "top"` there resolves
to `0 - height - offset`, and nothing clamps it back:

- **`flip` (top → bottom) cannot help.** Against a full-height anchor the bottom
  side overflows by exactly as much as the top, so floating-ui's best-fit
  tie-break keeps the side it started on.
- **`shift` clamps the wrong axis.** react-joyride enables its main axis only,
  which for a top/bottom placement is the *horizontal* one. The broken axis is
  the one left alone.

This turns on `shiftOptions: { crossAxis: true }` for the tour, so a card whose
placement resolves past a viewport edge slides back inside on that axis too. It
is a property of the tour, not a patch for one stop: any future stop anchored to
a large or edge-adjacent element is covered by the same clamp.

Step 2 now lands at `y = 10` — readable, with Skip/Back/Next reachable. It
overlaps the element it points at, which for a full-bleed anchor is unavoidable
and strictly better than being unreachable.

The issue body described a different mechanism (a step whose target never mounts
being shown anyway, via `waitForTarget()`'s boolean). That is not what happens on
current `main` — the target mounts. The body has been rewritten to describe the
measured behaviour so the next reader is not sent after the wrong bug.

## API Or Behavior Changes

No API change. Behavior: a tour card whose computed position falls outside the
viewport is now pulled inside it instead of rendering off-screen. Stops that
already fit are positioned exactly as before — the clamp only engages on
overflow.

## Tests

New Playwright spec `frontend/test/e2e/tour-popover-in-viewport.spec.ts` walks
all 8 stops at two window sizes and asserts each card's rect lies fully inside
the viewport and that its advance button is operable.

**Proven red before the fix**, on both sizes, with the exact staging numbers:

```
step 2 at 694,-238 340x222 in 1512x772: card starts above the top edge
step 2 at 578,-238 340x222 in 1280x800: card starts above the top edge
```

Green after, along with the existing tour spec:

```
✓ every tour stop's card is inside a 1512x772 viewport
✓ every tour stop's card is inside a 1280x800 viewport
✓ oauth-onboarding-resume.spec.ts (4 tests)
```

The spec asserts the property (every card is reachable) rather than the
mechanism, so a future change to how placement is computed still has to keep the
tour usable.

Run locally from `frontend/`:

- [x] `npm run typecheck`
- [x] `npm run typecheck:unit`
- [x] `npm run typecheck:e2e`
- [x] `npm run build`
- [x] `npx vitest run` — 887 passed
- [x] `npx playwright test tour-popover-in-viewport oauth-onboarding-resume` — 6 passed
- [x] N/A `cargo fmt --all -- --check` — no Rust changed; frontend-only.
- [x] N/A `cargo clippy --all-targets -- -D warnings` — no Rust changed.
- [x] N/A `cargo build --all-targets` — no Rust changed.
- [x] N/A `cargo test` — no Rust changed.

## Documentation

None needed — no operator-facing surface or configuration changed. The reasoning
lives next to the code it explains, in `TourController.tsx` and the spec's
header.

Closes #583


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tour popover positioning so cards remain fully visible within the viewport, including when anchored to full-screen elements.
  * Enhanced tour navigation reliability across different screen sizes.

* **Tests**
  * Added end-to-end coverage verifying all tour steps display correctly, remain usable, and complete without leaving stale popovers behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->