### PR TITLE
fix(chat): collapse approval receipts per turn

### DIFF
--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -75,9 +75,12 @@ function settledReceipt(approvals: ApprovalSummary[], decided: Record<string, Ve
   const declined = approvals.length - approved;
 
   // Preserve #561's established singular wording exactly. A one-action turn
-  // earns no extra count or disclosure furniture.
+  // earns no extra count or disclosure furniture. `undefined`, not `0`: this
+  // card only knows its own item settled, not that the turn's stillAwaiting
+  // count is zero — a sibling approval elsewhere in the same turn could still
+  // be open, and claiming "picking it up now" here would be a guess.
   if (approvals.length === 1) {
-    return approved === 1 ? approvedLine(0) : "Declined — recorded, and nothing will run";
+    return approved === 1 ? approvedLine(undefined) : "Declined — recorded, and nothing will run";
   }
   if (approved === approvals.length) {
     return `Approved ${actionCount(approved)} — the agent is picking it up now`;

--- a/frontend/src/views/chat/ApprovalRow.tsx
+++ b/frontend/src/views/chat/ApprovalRow.tsx
@@ -55,21 +55,37 @@ import { approvedLine } from "@/lib/approval-wording";
 import { approvalAction, payloadLines } from "@/lib/language";
 import { cn } from "@/lib/utils";
 
-/** What the card says once a verdict has been witnessed. */
-function settledLabel(verdict: Verdict): string {
-  // Mirrors the wording the Approvals page files into the transcript, and for
-  // the same reason: approving is not "done", it hands the agent a single-use
-  // grant and re-dispatches it. A decline IS terminal.
-  //
-  // `undefined` rather than a count, because this card is not the surface that
-  // made the request — the verdict reaches it through the witnessed map, which
-  // carries no `stillAwaiting`. It therefore cannot know whether this decision
-  // released the turn, and issue #561 is precisely about not guessing: on a
-  // turn that parked four calls, three of four approves release nothing, and
-  // this sentence claimed otherwise for every one of them.
-  return verdict === "approve"
-    ? approvedLine(undefined)
-    : "Declined — recorded, and nothing will run";
+/** One count written with the noun it qualifies. */
+function actionCount(count: number): string {
+  return `${count} action${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * The one permanent receipt a fully settled turn leaves in the transcript
+ * (#970).
+ *
+ * A batch's individual decisions are clicks; the turn only resumes once, when
+ * the last one lands. By the time every item is in `decided`, that final
+ * decision has happened, so this is the only point in chat that may honestly
+ * say the agent is picking the work up. The toast and Approvals page remain
+ * per-click feedback — this is deliberately the shared-channel summary.
+ */
+function settledReceipt(approvals: ApprovalSummary[], decided: Record<string, Verdict>): string {
+  const approved = approvals.filter((a) => decided[a.id] === "approve").length;
+  const declined = approvals.length - approved;
+
+  // Preserve #561's established singular wording exactly. A one-action turn
+  // earns no extra count or disclosure furniture.
+  if (approvals.length === 1) {
+    return approved === 1 ? approvedLine(0) : "Declined — recorded, and nothing will run";
+  }
+  if (approved === approvals.length) {
+    return `Approved ${actionCount(approved)} — the agent is picking it up now`;
+  }
+  if (declined === approvals.length) {
+    return `Declined ${actionCount(declined)} — the agent will not take them`;
+  }
+  return `Approved ${actionCount(approved)} and declined ${actionCount(declined)} — the agent is picking it up now`;
 }
 
 /**
@@ -210,6 +226,16 @@ export function ApprovalRow({
     </>
   );
 
+  // Keep a completed turn visible, but compact it into one receipt instead of
+  // leaving a full approval form permanently embedded in every shared channel.
+  // The disclosure preserves the individual verdicts without making them the
+  // transcript's primary story.
+  if (done) {
+    return (
+      <SettledApprovalReceipt approvals={approvals} decided={decided} />
+    );
+  }
+
   return (
     <div className="px-4 py-2">
       <div
@@ -217,12 +243,7 @@ export function ApprovalRow({
         aria-label={approvals.length > 1 ? "Approval request for several actions" : "Approval request"}
         data-approval-id={lead.id}
         data-approval-count={approvals.length}
-        className={cn(
-          "rounded-xl border bg-card px-4 py-3 shadow-sm",
-          // A settled card steps back rather than disappearing: the operator
-          // has to be able to see their own decision land.
-          done && "opacity-70",
-        )}
+        className="rounded-xl border bg-card px-4 py-3 shadow-sm"
       >
         <div className="flex flex-col gap-3">
           {approvals.length > 1 ? (
@@ -283,14 +304,7 @@ export function ApprovalRow({
             now={now}
             askerNames={askerNames}
             status={
-              done
-                ? approvals.length > 1
-                  ? `All ${approvals.length} decided`
-                  : // A single-item card says what it always said. `pending` is
-                    // empty here, so the lead's verdict is present — the `??`
-                    // only satisfies the type, it is not a reachable state.
-                    settledLabel(decided[lead.id] ?? "deny")
-                : busy
+              busy
                   ? awaiting("approve")
                     ? "Waiting for the agent…"
                     : "Recording…"
@@ -307,6 +321,50 @@ export function ApprovalRow({
           />
         </div>
       </div>
+    </div>
+  );
+}
+
+/** The compact, inspectable receipt a settled turn leaves in chat (#970). */
+function SettledApprovalReceipt({
+  approvals,
+  decided,
+}: {
+  approvals: ApprovalSummary[];
+  decided: Record<string, Verdict>;
+}) {
+  const lead = approvals[0];
+  const multiple = approvals.length > 1;
+
+  return (
+    <div className="px-4 py-2">
+      <section
+        aria-label={multiple ? "Approval receipt for several actions" : "Approval receipt"}
+        data-approval-receipt="true"
+        data-approval-id={lead.id}
+        data-approval-count={approvals.length}
+        className="rounded-xl border bg-card px-4 py-3 text-sm shadow-sm"
+      >
+        <p className="font-medium">{settledReceipt(approvals, decided)}</p>
+        {multiple && (
+          <details className="mt-2">
+            <summary className="cursor-pointer text-xs text-muted-foreground">
+              Show individual decisions
+            </summary>
+            <ul className="mt-2 flex flex-col gap-1.5">
+              {approvals.map((approval) => (
+                <BatchItem
+                  key={approval.id}
+                  approval={approval}
+                  verdict={decided[approval.id] ?? null}
+                  deciding={null}
+                  failure={null}
+                />
+              ))}
+            </ul>
+          </details>
+        )}
+      </section>
     </div>
   );
 }

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -88,6 +88,11 @@ function items(): HTMLElement[] {
   return [...container.querySelectorAll<HTMLElement>("[data-approval-item]")];
 }
 
+/** The one compact transcript row a fully settled turn leaves behind (#970). */
+function receipts(): HTMLElement[] {
+  return [...container.querySelectorAll<HTMLElement>("[data-approval-receipt]")];
+}
+
 function button(label: string): HTMLButtonElement {
   const match = [...container.querySelectorAll("button")].find((b) =>
     (b.textContent ?? "").includes(label),
@@ -270,14 +275,59 @@ describe("the consolidated approval card", () => {
     expect(decisions.map((d) => d.id)).toEqual(["a3"]);
   });
 
-  it("settles rather than vanishing once every item is decided", async () => {
+  it("leaves one expandable release receipt for a fully approved turn", async () => {
+    await render([ESPN, BBC, GUARDIAN], { a1: "approve", a2: "approve", a3: "approve" });
+
+    // Three decisions from one parked turn do not become three permanent
+    // transcript rows. The receipt is about the one release, not the clicks.
+    expect(receipts()).toHaveLength(1);
+    expect(receipts()[0].textContent).toContain(
+      "Approved 3 actions — the agent is picking it up now",
+    );
+    expect(container.querySelectorAll("button")).toHaveLength(0);
+
+    // The individual verdicts remain inspectable, but do not flood the channel
+    // until the operator asks for them.
+    const disclosure = receipts()[0].querySelector("details");
+    expect(disclosure?.open).toBe(false);
+    expect(disclosure?.textContent).toContain("Show individual decisions");
+    expect(items()).toHaveLength(3);
+    expect(items().map((item) => item.textContent)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("https://espn.com/nba"),
+        expect.stringContaining("https://bbc.com/sport"),
+        expect.stringContaining("https://theguardian.com/uk"),
+      ]),
+    );
+  });
+
+  it("summarizes mixed verdicts honestly once the turn releases", async () => {
     await render([ESPN, BBC], { a1: "approve", a2: "deny" });
 
-    const text = container.textContent ?? "";
-    expect(text).toContain("All 2 decided");
-    expect(text).toContain("Declined");
+    expect(receipts()).toHaveLength(1);
+    expect(receipts()[0].textContent).toContain(
+      "Approved 1 action and declined 1 action — the agent is picking it up now",
+    );
     // Nothing left to decide, so nothing left to press.
     expect(container.querySelectorAll("button")).toHaveLength(0);
+  });
+
+  it("says plainly when every action in a settled turn was declined", async () => {
+    await render([ESPN, BBC], { a1: "deny", a2: "deny" });
+
+    expect(receipts()).toHaveLength(1);
+    expect(receipts()[0].textContent).toContain(
+      "Declined 2 actions — the agent will not take them",
+    );
+    expect(receipts()[0].querySelector("details")?.open).toBe(false);
+  });
+
+  it("keeps a settled single approval natural", async () => {
+    await render([ESPN], { a1: "approve" });
+
+    expect(receipts()).toHaveLength(1);
+    expect(receipts()[0].textContent).toBe("Approved — the agent is picking it up now");
+    expect(receipts()[0].querySelector("details")).toBeNull();
   });
 
   it("renders a single-call turn exactly as it did before batching", async () => {

--- a/frontend/test/unit/approval-batch-card.test.ts
+++ b/frontend/test/unit/approval-batch-card.test.ts
@@ -325,8 +325,11 @@ describe("the consolidated approval card", () => {
   it("keeps a settled single approval natural", async () => {
     await render([ESPN], { a1: "approve" });
 
+    // Unlike the multi-item receipts above, a single-item card cannot know the
+    // turn's stillAwaiting count is zero — #561's neutral "recorded" wording,
+    // not a "picking it up now" claim this card has no basis for.
     expect(receipts()).toHaveLength(1);
-    expect(receipts()[0].textContent).toBe("Approved — the agent is picking it up now");
+    expect(receipts()[0].textContent).toBe("Approved — recorded");
     expect(receipts()[0].querySelector("details")).toBeNull();
   });
 

--- a/frontend/test/unit/approval-batch.test.ts
+++ b/frontend/test/unit/approval-batch.test.ts
@@ -115,4 +115,26 @@ describe("buildTimelineItems — batching a turn's gated calls (#842)", () => {
 
     expect(items[0].decided).toEqual({ a1: "approve", a2: "deny" });
   });
+
+  it("keeps a fully settled turn as one transcript entry", () => {
+    const espn = approval({ id: "a1", batch: "turn-1" });
+    const bbc = approval({ id: "a2", batch: "turn-1", at_millis: T0 + 1 });
+    const guardian = approval({ id: "a3", batch: "turn-1", at_millis: T0 + 2 });
+
+    const items = cards(
+      buildTimelineItems(
+        [],
+        [espn, bbc, guardian],
+        decidedMap([
+          [espn, "approve"],
+          [bbc, "approve"],
+          [guardian, "approve"],
+        ]),
+      ),
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0].approvals).toHaveLength(3);
+    expect(items[0].decided).toEqual({ a1: "approve", a2: "approve", a3: "approve" });
+  });
 });


### PR DESCRIPTION
## Summary

- Collapse a fully settled inline approval batch into one per-turn chat receipt.
- Keep individual verdicts available behind an expandable disclosure while pending and partially decided cards remain actionable.
- Closes #970.

## API Or Behavior Changes

Chat now leaves one compact receipt per released approval turn instead of a permanent full approval card per decision. No API changes.

## Tests

- [x] Frontend typecheck, unit and end-to-end TypeScript checks
- [x] Frontend production build
- [x] Full frontend unit suite (87 files, 890 tests)
- [x] N/A — Rust formatting, clippy, build, and tests; this is a frontend-only change.

## Documentation

No documentation update needed; this is an operator-console presentation change with no public API or workflow contract change.