### PR TITLE
fix(workflows): continue a gated run once per run, not once per approval (#978)

### DIFF
--- a/docs/spec/company-brain/approvals.md
+++ b/docs/spec/company-brain/approvals.md
@@ -196,6 +196,55 @@ for now; it is a real constraint on where a gate belongs in a graph.
 A gate nobody decides ages out on the ordinary TTL to a default deny. Since the
 paused run settled long ago, that costs nothing and cancels nothing.
 
+### One run is continued once (issue #978)
+
+The continuation unit is the **run**, not the node. A graph whose trigger fans
+out to three gated nodes parks three cards, and before this each approval
+independently re-dispatched the whole run: the spawn hung off `perform_effect`,
+which fires once per approved effect, and each replay carried an `approvals`
+array naming only its own node, so the other two paused and parked again.
+Approving N gave N runs and N(N-1) new cards — 3 → 6 → 12 → 24. A staging tenant
+accumulated 77 runs of one *disabled* workflow, 17 of which executed exactly one
+node.
+
+Three rules close it, and all three are needed — the first two on their own make
+the console read correctly while the run table keeps growing.
+
+1. **Every gate of one run shares a turn key**, `workflow-run:<run id>`, written
+   by the park. Before, a workflow park recorded no key at all, so
+   `approval_cycle` answered `Some(None)` and every branch believed it was the
+   only decision outstanding: `stillAwaiting` read `0` on all three of three.
+   It now counts down 2, 1, 0.
+2. **The run is re-dispatched once**, when the last of its decisions lands,
+   through the same `ContinuationQueue` an agent turn uses. A workflow run has no
+   brain turn to continue, so the release re-runs the graph instead of running a
+   cycle.
+3. **The replay carries every approval the batch cleared**, so a sibling gate
+   does not pause it and park itself again.
+
+**Denials are final.** A refused node rides a third lineage ledger beside the
+delivery (#438) and outward-call (#846) ones, under the reserved trigger-input
+key `__opencompany_denied`. A listed node is not asked about again: the branch
+below it simply never completes. Without it a mixed verdict would still net new
+cards, and the invariant this issue exists for — **approving never increases the
+number of pending approvals** — would be false. A TTL expiry is banked as a
+default-deny on exactly these terms. A batch whose every gate was refused starts
+no run at all; a mixed one runs, carrying the approvals it did get.
+
+`stillAwaiting` stays **advisory**: it is a snapshot read on the request path
+while the release runs detached. It is confirmation copy, not a control — the
+continuation itself is decided under the queue's own lock, where no such race
+exists.
+
+**Two limits, stated rather than discovered.** A restart mid-round comes back
+knowing only the gates still parked, so a batch released after it carries the
+last decision and not the ones banked before it, and those un-carried siblings
+re-park. That is inherited from #469 rather than added here — a workflow run is
+simply the first thing to feel it. And a batch gets **one** spawn attempt: where
+each approval used to have its own, a refusal at the concurrency ceiling (#401)
+now loses the run with every card consumed, so it is announced on the operator
+channel rather than only logged.
+
 ## Where the request is raised (issue #379)
 
 An approval is not only a queue entry; it is an interruption of a conversation.

--- a/docs/spec/runtime/workflow-vocabulary.md
+++ b/docs/spec/runtime/workflow-vocabulary.md
@@ -130,6 +130,26 @@ Every new field carries `#[serde(default)]`. `CompanyEvent::WorkflowRunFinished`
 is replayed at boot, so a field without one makes every pre-existing journal
 line fail to parse — silent history loss, not a compile error.
 
+### The reserved keys a continuation's trigger input carries
+
+Approving a gate does not resume a paused run — it starts a new one (see
+[approvals](../company-brain/approvals.md)). Four keys on that run's trigger
+input carry what the lineage already knows, three of them reserved and
+host-only: an author never writes them, the engine never reads them as anything
+but opaque trigger data, and all three are stripped before two parked gates are
+compared for dedupe.
+
+| Key | Issue | Carries |
+| --- | --- | --- |
+| `approvals` | #395 | the gate node ids the replay may proceed through. Since #978 this is **every** node the run's batch approved, not just the last one clicked |
+| `__opencompany_delivered` | #438 | `{node, kind}` per `output` node whose report already went out, so a continuation does not re-mail it |
+| `__opencompany_performed` | #846 | `{node, tool, result}` per `tool_call` node whose call already left the building, replayed instead of re-made |
+| `__opencompany_denied` | #978 | gate node ids the operator refused, or that expired to a default-deny. `park_pending_gates` skips them, so a refusal is final rather than re-asked |
+
+All four **accumulate down the lineage**: a two-gate graph unions what its own
+card carried with what the run added, or the second gate forgets the first's
+decisions and the third run re-sends, re-calls or re-asks.
+
 ## What an `agent` node receives from upstream, and its bound
 
 `translate()` binds `input = "=items"` on every `agent` node, so a node's turn

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1322,10 +1322,24 @@ impl CompanyRuntime {
             return CycleRunner::new(self).run(vec![event]).await;
         };
         let approval_id = approval_id.clone();
+        let verdict = match &event {
+            CompanyEvent::ApprovalResolved { verdict, .. } => *verdict,
+            _ => unreachable!("matched ApprovalResolved above"),
+        };
 
         // `Some(None)` is a park recorded before the turn key existed; `None` is
         // an id this journal never parked. Neither is gated.
         let turn = self.journal.approval_cycle(&approval_id).flatten();
+        // Issue #978: bank the verdict against the run's gate batch BEFORE the
+        // continuation queue is told, so that whichever decision turns out to be
+        // the last finds every sibling's verdict already recorded. Ordering is
+        // what makes that safe rather than lucky: each caller banks then counts,
+        // and the release is handed to the caller whose count reaches zero — by
+        // which time the other N-1 have necessarily banked. A no-op for a turn
+        // that is not a workflow run.
+        if let Some(turn) = turn.as_deref() {
+            self.workflow_gates.decide(turn, &approval_id, verdict);
+        }
         let batch = match &turn {
             Some(turn) => match self.continuations.decide(turn, Some(event)) {
                 Some(batch) => batch,
@@ -1342,6 +1356,15 @@ impl CompanyRuntime {
             },
             None => vec![event],
         };
+        // Issue #978: a workflow run is not a brain turn, so it is not continued
+        // like one. The fork is read off the turn key itself — see
+        // `continuation_target` — rather than from a side lookup that could
+        // disagree with the key the park wrote.
+        if let Some(turn) = turn.as_deref()
+            && crate::runtime::workflow_resume::run_id_from_turn(turn).is_some()
+        {
+            return self.resume_workflow_run(&approval_id, turn, batch).await;
+        }
         if batch.is_empty() {
             // Every approval the turn raised expired rather than being decided.
             // The sweep already appended each `ApprovalResolved` itself, so
@@ -1349,6 +1372,61 @@ impl CompanyRuntime {
             return Ok(CycleRunner::new(self).already_resolved_report());
         }
         self.run_continuation(&approval_id, batch).await
+    }
+
+    /// Re-dispatches the workflow run a released batch belongs to — **once**
+    /// (issue #978).
+    ///
+    /// The workflow arm of [`continue_turn`](Self::continue_turn), and the
+    /// counterpart to [`run_continuation`](Self::run_continuation): a run has no
+    /// agent turn to resume, so there is no cycle to run. What it owes is one
+    /// replay of the graph carrying every gate the batch approved.
+    ///
+    /// The decisions are still appended to the event log, because they happened
+    /// and the timeline should say so; what is deliberately **not** run is a
+    /// brain cycle per decision. Before this, every workflow gate approval spent
+    /// a full agent turn telling the brain about a resolution it can do nothing
+    /// with, on top of the duplicate run it started.
+    ///
+    /// A refused spawn is announced rather than only logged. Issue #401's
+    /// concurrency ceiling was survivable when each approval had its own spawn
+    /// attempt — one refusal left the other cards to retry with. A batch gets one
+    /// attempt and consumes every card, so a silent refusal loses the run with
+    /// nothing left to click; the operator has to be told to re-run it. Same
+    /// stance as issue #469 defect 4.
+    async fn resume_workflow_run(
+        &self,
+        approval_id: &ApprovalId,
+        turn: &str,
+        batch: Vec<CompanyEvent>,
+    ) -> Result<CycleReport> {
+        for event in batch {
+            if let Err(error) = self.events.append(&self.id, event).await {
+                tracing::warn!(
+                    company = %self.id,
+                    %approval_id,
+                    %error,
+                    "[approval] a workflow gate's resolution could not be appended to the event \
+                     log; the journal remains the binding record"
+                );
+            }
+        }
+        if let Err(error) = crate::runtime::workflow_resume::resume_run(self, turn).await {
+            tracing::error!(
+                company = %self.id,
+                %turn,
+                %error,
+                "[approval] the workflow run released by this decision could not be continued"
+            );
+            self.announce_to_operator(&format!(
+                "Every sign-off on that workflow step is in, but the run could not be \
+                 restarted: {error}. Nothing else is waiting on you — re-run the workflow to \
+                 pick it back up."
+            ))
+            .await;
+            return Err(error);
+        }
+        Ok(CycleRunner::new(self).already_resolved_report())
     }
 
     /// Runs one turn's continuation over the decisions it was blocked on, and
@@ -1652,21 +1730,42 @@ impl CompanyRuntime {
             // waited on. Spawned rather than awaited: the continuation is a full
             // agent turn behind the per-company cycle lock, and the maintenance
             // tick this runs on fires on a minute boundary for every company.
-            if let Some(turn) = self.journal.approval_cycle(id).flatten()
-                && let Some(batch) = self.continuations.decide(&turn, None)
-                && !batch.is_empty()
-            {
-                let rt = Arc::clone(self);
-                let released = id.clone();
-                tokio::spawn(async move {
-                    if let Err(error) = rt.run_continuation(&released, batch).await {
-                        tracing::error!(
-                            company = %rt.id,
-                            %error,
-                            "[approval] the continuation released by an expiry failed"
-                        );
+            if let Some(turn) = self.journal.approval_cycle(id).flatten() {
+                // Issue #978: an expiry is a default-DENY, and the run's batch
+                // has to hear it as one. Banked before the count is decremented,
+                // exactly as an operator's verdict is in `continue_turn` — an
+                // expired gate left in neither ledger would be replayed into,
+                // pause the continuation, and park a brand-new card for a
+                // decision that has already been made.
+                self.workflow_gates.decide(&turn, id, Verdict::Deny);
+                if let Some(batch) = self.continuations.decide(&turn, None) {
+                    let workflow_run =
+                        crate::runtime::workflow_resume::run_id_from_turn(&turn).is_some();
+                    // A workflow run releases even on an empty batch: every
+                    // decision may have been an expiry (which appends its own
+                    // event), and the run still has to be told so its approved
+                    // siblings are not stranded. A brain turn with nothing to
+                    // report owes no cycle, exactly as before.
+                    if workflow_run || !batch.is_empty() {
+                        let rt = Arc::clone(self);
+                        let released = id.clone();
+                        let turn = turn.clone();
+                        tokio::spawn(async move {
+                            let outcome = if workflow_run {
+                                rt.resume_workflow_run(&released, &turn, batch).await
+                            } else {
+                                rt.run_continuation(&released, batch).await
+                            };
+                            if let Err(error) = outcome {
+                                tracing::error!(
+                                    company = %rt.id,
+                                    %error,
+                                    "[approval] the continuation released by an expiry failed"
+                                );
+                            }
+                        });
                     }
-                });
+                }
             }
             if let Err(e) = self
                 .events

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -114,6 +114,7 @@ use crate::runtime::cycle::ResolveReceipt;
 use crate::runtime::grants::{GRANT_TTL_MILLIS, GrantId, GrantScope, GrantSet, StandingGrant};
 use crate::runtime::journal::{ApprovalOrigin, ExecutedEffect, RuntimeJournal};
 use crate::runtime::types::{ApprovalSummary, CompanyStatus, CycleReport};
+use crate::runtime::workflow_gates::WorkflowGateQueue;
 use crate::server::ops::mailer::MailSender;
 use crate::server::ops::smtp::SmtpCredentials;
 
@@ -274,6 +275,16 @@ pub struct CompanyRuntime {
     /// not forget that the turn is blocked, or the next decision continues it as
     /// though the others had never been owed.
     pub(crate) continuations: ContinuationQueue,
+    /// Issue #978: which gate node each parked **workflow** approval is
+    /// deciding, and the trigger input its run paused with.
+    ///
+    /// The run-scoped companion to [`continuations`](Self::continuations): that
+    /// queue counts a run's outstanding decisions, and this one holds the facts
+    /// the release needs to actually re-dispatch it. Live per-instance state and
+    /// inherited across a rebuild for the same reason both its neighbours are —
+    /// a swap mid-decision that forgot a run's parked gates would re-ask about
+    /// every one of them.
+    pub(crate) workflow_gates: WorkflowGateQueue,
     /// Held for the duration of a cycle so cycles never interleave per company.
     ///
     /// `Arc`-shared rather than owned so a rebuilt runtime can inherit the *same*
@@ -390,6 +401,7 @@ impl CompanyRuntime {
             repos: None,
             grants,
             continuations: ContinuationQueue::default(),
+            workflow_gates: WorkflowGateQueue::default(),
             serial: Arc::new(TokioMutex::new(())),
             task_writes: Arc::new(TokioMutex::new(())),
             quiesced: Arc::new(AtomicBool::new(false)),
@@ -605,6 +617,13 @@ impl CompanyRuntime {
     /// successor: a second `RuntimeJournal` over one path is the corruption
     /// hazard [`RuntimeHandover`](crate::runtime::RuntimeHandover) exists to
     /// prevent, and "we passed it along" is only checkable if it is readable.
+    /// The run-scoped workflow gate batches this runtime is holding (issue
+    /// #978). Delegated to rather than exposed as a field so the approve path in
+    /// `workflow_resume` can fork on whether a card's run is armed.
+    pub fn workflow_gates(&self) -> &WorkflowGateQueue {
+        &self.workflow_gates
+    }
+
     pub fn journal(&self) -> &Arc<RuntimeJournal> {
         &self.journal
     }
@@ -1086,6 +1105,19 @@ impl CompanyRuntime {
     /// only the approval path reads, matching how the locks are handed over.
     pub fn adopt_continuations(&mut self, continuations: ContinuationQueue) {
         self.continuations = continuations;
+    }
+
+    /// Installs the run-scoped workflow gate batches the builder prepared
+    /// (issue #978) — rehydrated from the journal's still-parked gates on a
+    /// boot, inherited live on a rebuild.
+    ///
+    /// Set through the builder for exactly
+    /// [`adopt_continuations`](Self::adopt_continuations)' reason, and always
+    /// alongside it: the two describe one run's decisions from opposite sides,
+    /// and a runtime holding a fresh copy of one and an inherited copy of the
+    /// other would release a batch it cannot re-dispatch.
+    pub fn adopt_workflow_gates(&mut self, gates: WorkflowGateQueue) {
+        self.workflow_gates = gates;
     }
 
     /// Rejects a cycle on a runtime that is being replaced.

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1697,6 +1697,27 @@ impl RuntimeBuilder {
             }
         };
 
+        // Issue #978: the run-scoped half of the same fact, on exactly the same
+        // terms. A boot rebuilds it from the gates the replay left parked — the
+        // journal keeps their whole effect while they are parked, which is what
+        // makes a rehydrated batch re-dispatchable — and a rebuild inherits the
+        // live one, because that one also knows the verdicts taken since the
+        // replay and a fresh copy would re-ask about them.
+        let workflow_gates = match handover.as_ref() {
+            Some(h) => h.workflow_gates.clone(),
+            None => {
+                let gates = crate::runtime::workflow_gates::WorkflowGateQueue::default();
+                let parked = journal.pending();
+                gates.rearm(parked.iter().filter_map(|entry| {
+                    entry
+                        .batch
+                        .clone()
+                        .map(|turn| (turn, entry.id.clone(), &entry.effect))
+                }));
+                gates
+            }
+        };
+
         // Brain selection, in precedence order:
         //   1. an explicit brain (test injection) always wins;
         //   2. under the `openhuman` feature, an attached harness pool + a
@@ -2445,6 +2466,13 @@ impl RuntimeBuilder {
                                     parking: Some(crate::workflows::DeliveryParking {
                                         approvals: gate.clone(),
                                         journal: journal.clone(),
+                                        // Issue #978: the SAME two queues the
+                                        // runtime gets below. A gate parked by a
+                                        // run has to arm the counters the
+                                        // resolve path releases, or the run is
+                                        // never continued at all.
+                                        continuations: continuations.clone(),
+                                        gates: workflow_gates.clone(),
                                     }),
                                     // Issue #529: the same journal the runner
                                     // writes its start/per-node trail to, so a
@@ -2702,6 +2730,7 @@ impl RuntimeBuilder {
             runtime.adopt_locks(h.serial.clone(), h.task_writes.clone());
         }
         runtime.adopt_continuations(continuations);
+        runtime.adopt_workflow_gates(workflow_gates);
 
         // MCP uses OpenHuman's process-global live connection registry. Keep a
         // runtime-owned config for this OpenCompany home so REST and agents see

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1196,6 +1196,19 @@ approval.]"
         // blocked, or its continuation fires on the next decision as though the
         // others had never been owed.
         self.rt.continuations.rearm(self.rt.journal.parked_turns());
+        // Issue #978: the run-scoped half, from the same replayed queue. A gate
+        // still parked keeps its whole effect in the journal, so a rehydrated
+        // batch is re-dispatchable; one already resolved is gone from both, and
+        // the run it belonged to is continued by whatever decision remains.
+        let parked = self.rt.journal.pending();
+        self.rt
+            .workflow_gates
+            .rearm(parked.iter().filter_map(|entry| {
+                entry
+                    .batch
+                    .clone()
+                    .map(|turn| (turn, entry.id.clone(), &entry.effect))
+            }));
         Ok(())
     }
 
@@ -1359,8 +1372,18 @@ async fn perform_effect(rt: &CompanyRuntime, effect: &Effect) -> Result<()> {
     // expiry never reach here, and since nothing was held open, nothing running
     // is the complete outcome. See `workflow_resume` for why this is a re-run
     // and what that costs.
+    //
+    // Issue #978: it no longer starts that run **here**, and the distinction is
+    // the whole of the amplification fix. This arm fires once per approved
+    // effect, so a run with three gated nodes ran it three times: three runs,
+    // each replaying the graph with one usable approval and re-parking the other
+    // two — 3 → 6 → 12 → 24. The spawn now belongs to the batch release in
+    // `continue_turn`, which happens once per run, and this only banks the
+    // decision. A card whose run is not armed (parked before #978, so its
+    // journal line carries no turn key) still re-dispatches immediately: there
+    // is no batch coming to release it.
     if effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND {
-        crate::runtime::workflow_resume::resume_from_effect(rt, effect).await?;
+        crate::runtime::workflow_resume::on_gate_approved(rt, effect).await?;
     }
     // Issue #735: an approved `repo_publish`. `execute` already staged the agent's
     // commits onto the mirror's `oc/<company>/<task>` ref (the reversible half);

--- a/src/runtime/handover.rs
+++ b/src/runtime/handover.rs
@@ -57,6 +57,7 @@ use crate::ports::{CompanyStore, ContextStore, EventLog, InboxStore, MemoryStore
 use crate::runtime::continuation::ContinuationQueue;
 use crate::runtime::grants::GrantSet;
 use crate::runtime::journal::RuntimeJournal;
+use crate::runtime::workflow_gates::WorkflowGateQueue;
 
 /// The live state a successor runtime adopts from the runtime it replaces.
 ///
@@ -86,6 +87,11 @@ pub struct RuntimeHandover {
     /// waiting would continue the next one on its first decision instead of its
     /// last.
     pub(crate) continuations: ContinuationQueue,
+    /// Issue #978: the parked gates of every workflow run still awaiting a
+    /// decision. Inherited for [`continuations`](Self::continuations)' reason
+    /// exactly — a successor that forgot them would re-ask about every gate of a
+    /// partly-decided run.
+    pub(crate) workflow_gates: WorkflowGateQueue,
     pub(crate) serial: Arc<TokioMutex<()>>,
     pub(crate) task_writes: Arc<TokioMutex<()>>,
     #[cfg(feature = "openhuman")]
@@ -121,6 +127,7 @@ impl CompanyRuntime {
             approval_gate: self.approval_gate.clone(),
             grants: self.grants.clone(),
             continuations: self.continuations.clone(),
+            workflow_gates: self.workflow_gates.clone(),
             serial: self.serial.clone(),
             task_writes: self.task_writes.clone(),
             #[cfg(feature = "openhuman")]

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -96,6 +96,11 @@ pub mod scheduler;
 pub mod telegram_poller;
 pub mod tools;
 pub mod types;
+/// Issue #978: which gate node each parked workflow approval is deciding, and
+/// the trigger input its run paused with — the two facts a run-scoped
+/// continuation needs and the journal cannot give back once an approval has
+/// resolved. See [`workflow_gates`].
+pub mod workflow_gates;
 /// Issue #228: the single place a finished workflow run is journaled, shared by
 /// the console's run route and the cron [`WorkflowScheduler`] so a run's history
 /// is uniform no matter what started it. See [`workflow_outcome`].

--- a/src/runtime/workflow_gates.rs
+++ b/src/runtime/workflow_gates.rs
@@ -1,0 +1,256 @@
+//! One workflow run, one continuation (issue #978).
+//!
+//! # The amplification this closes
+//!
+//! A run that fans out to N gated nodes parks N cards. Before this, approving
+//! one of them re-dispatched the **whole run** on the spot — the spawn lived in
+//! `perform_effect`, which fires once per approved effect — and the replay
+//! carried an `approvals` array naming only that one node, so the other N-1
+//! paused again and parked again. Three approvals produced three runs and six
+//! new cards; the reported staging tenant went 3 → 6 → 12 → 24 and accumulated
+//! 77 runs of one disabled workflow.
+//!
+//! [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue) already
+//! solves the shape of this problem for an agent turn: count the outstanding
+//! decisions, release once when the last lands. Issue #978 makes a workflow run
+//! a turn in exactly that sense, keyed by
+//! [`workflow_turn_key`](crate::runtime::workflow_resume::workflow_turn_key).
+//! This module is the half that queue cannot supply.
+//!
+//! # Why a second structure, and not a field on the batch
+//!
+//! `ContinuationQueue::decide` hands back `ApprovalResolved` events: an id, a
+//! verdict, an actor. To re-dispatch a run the host needs two things that are
+//! not in there — **which graph node** each id was gating, and the paused run's
+//! **trigger input** with its delivery / outward-call ledgers.
+//!
+//! Neither is recoverable from the journal at release time, and that is not an
+//! oversight to route around. `RuntimeJournal` drops the parked entry on resolve
+//! (`parked.remove`), and the record it *does* retain past resolution —
+//! `approval_effects` — is deliberately **payload-scrubbed** (issue #351), so a
+//! resolved gate's id, input and ledgers are all gone by construction. Widening
+//! that scrub to keep them would reopen a privacy rule for the benefit of one
+//! caller.
+//!
+//! So the facts are stashed here instead, at **park** time, from the one place
+//! gates are parked.
+//!
+//! # Why park time, and not approve time
+//!
+//! Because **deny** never reaches the approve path. A denied effect resolves to
+//! [`ResolveOutcome`](crate::policy::ResolveOutcome)`::Denied` and never touches
+//! `perform_effect`, so a stash populated when an approval is *performed* would
+//! hold no node id for a refusal — and the continuation, not knowing the node
+//! was refused, would replay into it, pause, and park a fresh card. An approval
+//! round that cleared three and created one is the same defect in miniature.
+//!
+//! Arming at park time covers approve, deny and TTL expiry with one mechanism,
+//! which is what makes the denial ledger
+//! ([`PAYLOAD_DENIED`](crate::runtime::workflow_resume::PAYLOAD_DENIED))
+//! expressible at all.
+//!
+//! # One representative effect per run, not one per gate
+//!
+//! Every gate of a single run is built by one `park_pending_gates` loop from one
+//! `trigger_input`, one run-level `deliveries` slice and one run-level
+//! `performed` slice, and `gate_effect` derives the two ledgers purely from
+//! those. So `input` / `delivered` / `performed` are byte-identical across
+//! siblings **by construction** — including the case where an earlier node
+//! already delivered before the fan-out, because that delivery is in the
+//! run-level list every sibling is handed, not in a per-branch subset. Only
+//! `node_id`, the call description and the per-gate upstream `content` vary, and
+//! a continuation needs none of those. Keeping one effect per run rather than
+//! one per gate is what stops this from holding N copies of a trigger input.
+//!
+//! # Durability, stated plainly
+//!
+//! In-memory, on exactly [`ContinuationQueue`]'s terms, and rehydrated at
+//! recovery from the journal's still-parked gates
+//! ([`rearm`](WorkflowGateQueue::rearm)) the way that queue is rehydrated from
+//! `parked_turns`. The limit is inherited rather than added: a restart in the
+//! middle of a partly-decided run comes back knowing only the gates still
+//! parked, so a batch released after it carries the last decision and not the
+//! ones banked before it. Those un-carried siblings re-park. That is pre-#469
+//! behaviour for agent turns; #978 is where a workflow run starts feeling it.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::ports::types::{ApprovalId, Effect, Verdict};
+use crate::runtime::workflow_resume::gate_node_id;
+
+/// What one workflow run's gate batch has settled into, handed to the caller
+/// that released it.
+#[derive(Clone, Debug)]
+pub struct ReleasedGates {
+    /// Any one of the run's parked gate effects — they agree on everything a
+    /// continuation reads. See the module docs for why one is enough.
+    pub effect: Effect,
+    /// The gate nodes the operator approved, in decision order.
+    pub approved: Vec<String>,
+    /// The gate nodes the operator refused, or that expired to a default-deny,
+    /// in decision order. A continuation neither runs these nor re-asks.
+    pub denied: Vec<String>,
+}
+
+/// One run's parked gates, and the verdicts landed on them so far.
+#[derive(Clone, Debug)]
+struct Batch {
+    effect: Effect,
+    /// Gate nodes still awaiting a verdict, by the approval deciding them.
+    undecided: HashMap<ApprovalId, String>,
+    approved: Vec<String>,
+    denied: Vec<String>,
+}
+
+/// Per-run gate state: which node each parked approval is gating, and what the
+/// run's trigger input was (issue #978).
+///
+/// Cheap to [`Clone`] — a shared handle like every other queue in the runtime —
+/// so the parking side (the workflow runner, through `DeliveryParking`) and the
+/// resolving side (the runtime) see one set of batches.
+#[derive(Clone, Default)]
+pub struct WorkflowGateQueue {
+    inner: Arc<Mutex<HashMap<String, Batch>>>,
+}
+
+impl WorkflowGateQueue {
+    /// Records that `turn` just parked one more gate, `id` deciding it.
+    ///
+    /// Called from the one place gates are parked and on its **successful-park
+    /// path only**, immediately beside
+    /// [`ContinuationQueue::arm`](crate::runtime::continuation::ContinuationQueue::arm),
+    /// so the two cannot disagree about how many decisions a run is blocked on.
+    /// Arming on a dedupe-skip or a failed park would leave the run waiting for
+    /// a decision no card can ever deliver.
+    ///
+    /// A non-gate effect is ignored rather than stored: `gate_node_id` checks the
+    /// kind, so nothing but a `workflow.approve` card can enter a batch.
+    ///
+    /// The first gate through sets the batch's representative effect; later ones
+    /// do not replace it, because they agree with it on everything read back.
+    pub fn arm(&self, turn: &str, id: &ApprovalId, effect: &Effect) {
+        let Some(node) = gate_node_id(effect) else {
+            return;
+        };
+        let node = node.to_string();
+        let mut guard = self.inner.lock().expect("workflow gate queue poisoned");
+        guard
+            .entry(turn.to_string())
+            .or_insert_with(|| Batch {
+                effect: effect.clone(),
+                undecided: HashMap::new(),
+                approved: Vec::new(),
+                denied: Vec::new(),
+            })
+            .undecided
+            .insert(id.clone(), node);
+    }
+
+    /// Banks one verdict on `turn`.
+    ///
+    /// Recorded here rather than derived from the released
+    /// [`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue)
+    /// batch because that batch cannot describe every decision: a TTL expiry
+    /// contributes no event at all (the sweep appends its own), so a run whose
+    /// last gate timed out would otherwise release with the expired node in
+    /// neither ledger — and the continuation would replay into it and park a
+    /// fresh card.
+    ///
+    /// A decision on a turn this queue is not tracking, or on an id it never
+    /// armed, is a no-op: the caller is deciding something that is not a
+    /// run-scoped workflow gate.
+    pub fn decide(&self, turn: &str, id: &ApprovalId, verdict: Verdict) {
+        let mut guard = self.inner.lock().expect("workflow gate queue poisoned");
+        let Some(batch) = guard.get_mut(turn) else {
+            return;
+        };
+        let Some(node) = batch.undecided.remove(id) else {
+            return;
+        };
+        let ledger = match verdict {
+            Verdict::Approve => &mut batch.approved,
+            Verdict::Deny => &mut batch.denied,
+        };
+        if !ledger.contains(&node) {
+            ledger.push(node);
+        }
+    }
+
+    /// Takes `turn`'s whole batch, dropping it from the queue.
+    ///
+    /// Called once, by whichever caller the continuation queue handed the
+    /// release to — that queue's counting decides who, under one lock, so this
+    /// cannot be entered twice for one run.
+    pub fn release(&self, turn: &str) -> Option<ReleasedGates> {
+        self.inner
+            .lock()
+            .expect("workflow gate queue poisoned")
+            .remove(turn)
+            .map(|batch| ReleasedGates {
+                effect: batch.effect,
+                approved: batch.approved,
+                denied: batch.denied,
+            })
+    }
+
+    /// Whether `turn` is a run-scoped batch this queue is holding.
+    ///
+    /// What the approve path forks on: a gate whose run is armed defers to the
+    /// batch release, and one that is not — a card parked by a build from before
+    /// this issue, whose journal line carries no turn key — re-dispatches
+    /// immediately, exactly as it always did.
+    pub fn is_armed(&self, turn: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("workflow gate queue poisoned")
+            .contains_key(turn)
+    }
+
+    /// How many of `turn`'s gates are still undecided. `0` for a turn this queue
+    /// is not tracking.
+    pub fn undecided(&self, turn: &str) -> usize {
+        self.inner
+            .lock()
+            .expect("workflow gate queue poisoned")
+            .get(turn)
+            .map(|batch| batch.undecided.len())
+            .unwrap_or(0)
+    }
+
+    /// Rebuilds the batches from every gate the journal still has parked, one
+    /// entry per approval.
+    ///
+    /// **Idempotent**, on
+    /// [`ContinuationQueue::rearm`](crate::runtime::continuation::ContinuationQueue::rearm)'s
+    /// terms: it *replaces* each turn it sees rather than adding to it, so
+    /// replaying twice (boot loads the journal, and `recover` can be driven
+    /// again) leaves a run blocked on the gates it is actually blocked on.
+    ///
+    /// Verdicts banked by **this** process are dropped along with the rest of
+    /// the turn, which is the honest reading: a rehydrate is only reached from a
+    /// journal replay, and the journal records that an approval resolved without
+    /// recording what it was gating. See the module docs on durability.
+    pub fn rearm<'e>(&self, gates: impl IntoIterator<Item = (String, ApprovalId, &'e Effect)>) {
+        let mut rebuilt: HashMap<String, Batch> = HashMap::new();
+        for (turn, id, effect) in gates {
+            let Some(node) = gate_node_id(effect) else {
+                continue;
+            };
+            rebuilt
+                .entry(turn)
+                .or_insert_with(|| Batch {
+                    effect: effect.clone(),
+                    undecided: HashMap::new(),
+                    approved: Vec::new(),
+                    denied: Vec::new(),
+                })
+                .undecided
+                .insert(id, node.to_string());
+        }
+        let mut guard = self.inner.lock().expect("workflow gate queue poisoned");
+        for (turn, batch) in rebuilt {
+            guard.insert(turn, batch);
+        }
+    }
+}

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -741,8 +741,128 @@ pub fn already_parked(journal: &crate::runtime::journal::RuntimeJournal, effect:
 /// watching for a run that will never appear. Same stance the `email.send` arm
 /// beside it takes.
 pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Result<()> {
-    let workflow_id = required_str(effect, PAYLOAD_WORKFLOW_ID)?;
     let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
+    // The legacy single-gate shape: one approval, one continuation. Issue #978's
+    // run-scoped path goes through [`resume_run`] and carries the whole batch;
+    // this arm stays exactly as it was for a card with no run turn key.
+    let approved = [node_id.to_string()];
+    spawn_continuation(runtime, effect, &approved, &[]).await
+}
+
+/// Re-dispatches a workflow run **once**, for every gate its batch approved
+/// (issue #978).
+///
+/// The run-scoped replacement for [`resume_from_effect`], and the half of the
+/// fix that stops the amplification rather than merely reporting it correctly.
+/// It is reached from `continue_turn` when the released turn key names a run
+/// (see [`run_id_from_turn`]), which happens exactly once per run — the
+/// continuation queue's counting decides who releases, under one lock.
+///
+/// Three things it does that N independent re-dispatches could not:
+///
+/// * **one run, not N.** The paused run is replayed once, so the run table stops
+///   growing by N per approval round.
+/// * **every approval, not one.** The trigger input carries the whole approved
+///   set, so a sibling gate does not pause the replay and park itself again.
+/// * **refusals are final.** Denied and expired nodes ride the denial ledger, so
+///   the replay neither runs them nor asks about them a second time. Without it
+///   a mixed verdict would still net new cards, which is the invariant this
+///   issue is about.
+///
+/// # Nothing approved
+///
+/// A batch whose every gate was denied or expired starts **no run**, and that is
+/// the complete outcome rather than a gap: the paused run settled long ago, so
+/// there is nothing to cancel, and replaying it would only pause at the first
+/// refused node. The approved work of a *mixed* verdict is not discarded — that
+/// case has a non-empty approved set and runs.
+pub async fn resume_run(runtime: &CompanyRuntime, turn: &str) -> Result<()> {
+    let Some(released) = runtime.workflow_gates().release(turn) else {
+        return Err(OpenCompanyError::InvalidRequest(format!(
+            "the decisions on `{turn}` are all in, but this host is no longer holding that run's \
+             parked gates, so there is nothing to continue — re-run the workflow"
+        )));
+    };
+    if released.approved.is_empty() {
+        tracing::info!(
+            company = %runtime.id(),
+            %turn,
+            denied = released.denied.len(),
+            "workflow: every gate on this run was refused, so no continuation runs"
+        );
+        return Ok(());
+    }
+    tracing::info!(
+        company = %runtime.id(),
+        %turn,
+        approved = released.approved.len(),
+        denied = released.denied.len(),
+        "workflow: the run's gates are all decided; starting ONE continuation for the batch"
+    );
+    spawn_continuation(
+        runtime,
+        &released.effect,
+        &released.approved,
+        &released.denied,
+    )
+    .await
+}
+
+/// What an approved workflow gate does at the moment its effect is performed
+/// (issue #978).
+///
+/// This is the seam the amplification lived on. `perform_effect` fires once per
+/// approved effect, so spawning here spawned **per approval** — three approvals
+/// on one run meant three runs, each replaying the graph with one usable
+/// approval and re-parking the rest. The spawn therefore moves to the batch
+/// release, and this arm only decides which of the two paths a card is on:
+///
+/// * **run-scoped** — the card's run has a batch armed, so the decision is
+///   banked and the continuation is owed by whichever decision turns out to be
+///   the last. Nothing runs now, and the operator is told so by the
+///   still-waiting receipt.
+/// * **unarmed** — a card parked by a build from before this issue (its journal
+///   line carries no turn key), or one whose batch this process no longer holds.
+///   It re-dispatches immediately, exactly as it always did, because there is no
+///   batch coming to release it and deferring would strand the run forever.
+pub async fn on_gate_approved(runtime: &CompanyRuntime, effect: &Effect) -> Result<()> {
+    if let Some(run_id) = effect.run_id.as_deref() {
+        let turn = workflow_turn_key(run_id);
+        if runtime.workflow_gates().is_armed(&turn) {
+            tracing::debug!(
+                company = %runtime.id(),
+                %run_id,
+                undecided = runtime.workflow_gates().undecided(&turn),
+                "workflow: gate approved; the run continues once its remaining gates are decided"
+            );
+            return Ok(());
+        }
+    }
+    resume_from_effect(runtime, effect).await
+}
+
+/// Starts one continuation run for `effect`'s workflow, with `approved` cleared
+/// and `denied` recorded.
+///
+/// Shared by the legacy per-card path and issue #978's run-scoped one so the two
+/// cannot drift on how a continuation is loaded, spawned or logged.
+///
+/// # Errors
+///
+/// Propagated rather than swallowed, and that is a deliberate choice about who
+/// hears about the failure. `execute_effect_once` has already committed the
+/// approval by the time this runs, so the runtime will never retry it — if the
+/// graph has since been deleted, or this build has no workflow execution, the
+/// operator must be told at the moment they click Approve rather than left
+/// watching for a run that will never appear. Same stance the `email.send` arm
+/// beside it takes.
+async fn spawn_continuation(
+    runtime: &CompanyRuntime,
+    effect: &Effect,
+    approved: &[String],
+    denied: &[String],
+) -> Result<()> {
+    let workflow_id = required_str(effect, PAYLOAD_WORKFLOW_ID)?;
 
     // Through the runtime's own accessor so a build without workflow execution
     // gives an honest error instead of a compile-time edge — this module is in
@@ -770,7 +890,7 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
             ))
         })?;
 
-    let input = continuation_input(effect)?;
+    let input = continuation_input(effect, approved, denied)?;
     // The handle is dropped on purpose. The task holds its own guard, journals
     // its own outcome and deregisters itself; awaiting it here would hold the
     // approvals request open for the length of a whole workflow run, which is
@@ -778,12 +898,16 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
     // Issue #542: resuming an approved gate is always a real run — `false`.
     // Issue #401: `spawn` refuses at the concurrency ceiling; propagate it so
     // the approval-resume caller surfaces the same `WorkflowRunLimit` refusal.
+    // Issue #978 sharpens why that must be surfaced rather than logged: a batch
+    // gets ONE spawn attempt, and every card that would have retried it is
+    // already consumed, so a swallowed refusal loses the run with no way back.
     let (run_id, _handle) =
         WorkflowSpawn::new(runtime, runner).spawn(workflow, input, false, false)?;
     tracing::info!(
         company = %runtime.id(),
         workflow = %workflow_id,
-        node = %node_id,
+        approved = ?approved,
+        denied = ?denied,
         %run_id,
         "workflow: an approved gate started a continuation run; upstream nodes re-execute"
     );
@@ -799,8 +923,18 @@ pub async fn resume_from_effect(runtime: &CompanyRuntime, effect: &Effect) -> Re
 /// `pub(crate)` so the run-level regression test can build a continuation
 /// exactly the way the approvals path does, rather than reconstructing it and
 /// proving only that the reconstruction works.
-pub(crate) fn continuation_input(effect: &Effect) -> Result<Value> {
-    let node_id = required_str(effect, PAYLOAD_NODE_ID)?;
+pub(crate) fn continuation_input(
+    effect: &Effect,
+    approved: &[String],
+    newly_denied: &[String],
+) -> Result<Value> {
+    if approved.is_empty() {
+        return Err(OpenCompanyError::InvalidRequest(
+            "a workflow continuation was asked for with no approved gate, so the run would \
+             pause again at the node it started for"
+                .to_string(),
+        ));
+    }
     let input = effect
         .payload
         .get(PAYLOAD_INPUT)
@@ -829,10 +963,57 @@ pub(crate) fn continuation_input(effect: &Effect) -> Result<Value> {
                 .collect()
         })
         .unwrap_or_default();
-    Ok(with_performed(
-        with_delivered(with_approval(input, node_id), &delivered),
-        &performed,
+    // Issue #978: the refusals this lineage has accumulated, plus the ones this
+    // batch just made. Unioned rather than replaced, on `delivery_ledger`'s
+    // reasoning exactly — a two-gate graph must not forget the first gate's
+    // denial when the second is decided.
+    let mut denied: Vec<String> = effect
+        .payload
+        .get(PAYLOAD_DENIED)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| row.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
+    for node in newly_denied {
+        if !denied.contains(node) {
+            denied.push(node.clone());
+        }
+    }
+    Ok(with_denied(
+        with_performed(
+            with_delivered(with_approvals(input, approved), &delivered),
+            &performed,
+        ),
+        &denied,
     ))
+}
+
+/// Writes `denied` onto the trigger input under [`CONTINUATION_DENIED_KEY`],
+/// replacing whatever was there (issue #978).
+///
+/// Replace rather than merge, on [`with_delivered`]'s reasoning: the union was
+/// already taken in [`continuation_input`], so this is the superset and merging
+/// again would be a second place for the rule to drift. An empty ledger writes
+/// nothing, keeping a first run's input shape untouched.
+fn with_denied(input: Value, denied: &[String]) -> Value {
+    if denied.is_empty() {
+        return input;
+    }
+    match input {
+        Value::Object(mut map) => {
+            map.insert(
+                CONTINUATION_DENIED_KEY.to_string(),
+                serde_json::json!(denied),
+            );
+            Value::Object(map)
+        }
+        // `with_approvals` always yields an object, so this is unreachable
+        // through `continuation_input`. Kept total rather than panicking.
+        other => other,
+    }
 }
 
 /// Writes `performed` onto the trigger input under
@@ -893,7 +1074,7 @@ fn with_delivered(input: Value, delivered: &[DeliveredReport]) -> Value {
     }
 }
 
-/// Unions `node_id` into the trigger input's `approvals` array.
+/// Unions `node_ids` into the trigger input's `approvals` array.
 ///
 /// Mirrors `engine::resume`'s own merge, including its tolerances: a non-object
 /// input is replaced by a fresh object carrying just the approvals (there is
@@ -904,7 +1085,7 @@ fn with_delivered(input: Value, delivered: &[DeliveredReport]) -> Value {
 /// Preserving prior approvals is what makes a graph with **two** gates work:
 /// approving the second must not un-approve the first, or the re-run pauses at
 /// the gate the operator already cleared and the workflow can never finish.
-fn with_approval(input: Value, node_id: &str) -> Value {
+fn with_approvals(input: Value, node_ids: &[String]) -> Value {
     let mut approvals: Vec<String> = input
         .get("approvals")
         .and_then(Value::as_array)
@@ -914,8 +1095,13 @@ fn with_approval(input: Value, node_id: &str) -> Value {
                 .collect()
         })
         .unwrap_or_default();
-    if !approvals.iter().any(|id| id == node_id) {
-        approvals.push(node_id.to_string());
+    // Issue #978: **every** gate the run's batch approved, not just the one
+    // whose card happened to be clicked last. Carrying one is what made a
+    // three-way fan-out re-park its two siblings on every continuation.
+    for node_id in node_ids {
+        if !approvals.iter().any(|id| id == node_id) {
+            approvals.push(node_id.clone());
+        }
     }
 
     match input {
@@ -951,6 +1137,15 @@ fn required_str<'e>(effect: &'e Effect, key: &str) -> Result<&'e str> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A continuation for a card's own single gate — the pre-#978 shape these
+    /// tests were written against, kept so they keep asserting what they were
+    /// written to assert. The run-scoped multi-gate form is exercised in
+    /// `crate::workflows::parallel_gate_fanout_test`.
+    fn single_continuation_input(effect: &Effect) -> Result<Value> {
+        let node_id = required_str(effect, PAYLOAD_NODE_ID)?.to_string();
+        continuation_input(effect, std::slice::from_ref(&node_id), &[])
+    }
 
     fn effect(workflow: &str, node: &str, input: Value) -> Effect {
         gate_effect(workflow, node, &input, "run-1", &[], &[], None)
@@ -1019,7 +1214,10 @@ mod tests {
 
     #[test]
     fn approving_a_gate_adds_it_to_the_trigger_inputs_approvals() {
-        let out = with_approval(serde_json::json!({ "request": "topic" }), "gate");
+        let out = with_approvals(
+            serde_json::json!({ "request": "topic" }),
+            &["gate".to_string()],
+        );
         assert_eq!(out["request"], "topic", "the original input is preserved");
         assert_eq!(out["approvals"], serde_json::json!(["gate"]));
     }
@@ -1028,15 +1226,18 @@ mod tests {
     fn a_second_gate_does_not_un_approve_the_first() {
         // The two-gate graph. Without the union the re-run pauses at the gate
         // the operator already cleared and the workflow can never finish.
-        let first = with_approval(serde_json::json!({ "request": "topic" }), "gate-a");
-        let second = with_approval(first, "gate-b");
+        let first = with_approvals(
+            serde_json::json!({ "request": "topic" }),
+            &["gate-a".to_string()],
+        );
+        let second = with_approvals(first, &["gate-b".to_string()]);
         assert_eq!(second["approvals"], serde_json::json!(["gate-a", "gate-b"]));
     }
 
     #[test]
     fn approving_the_same_gate_twice_does_not_duplicate_it() {
-        let once = with_approval(serde_json::json!({}), "gate");
-        let twice = with_approval(once, "gate");
+        let once = with_approvals(serde_json::json!({}), &["gate".to_string()]);
+        let twice = with_approvals(once, &["gate".to_string()]);
         assert_eq!(twice["approvals"], serde_json::json!(["gate"]));
     }
 
@@ -1053,7 +1254,7 @@ mod tests {
             // A malformed `approvals` starts an empty set rather than erroring.
             serde_json::json!({ "approvals": "gate" }),
         ] {
-            let out = with_approval(input.clone(), "gate");
+            let out = with_approvals(input.clone(), &["gate".to_string()]);
             assert_eq!(
                 out["approvals"],
                 serde_json::json!(["gate"]),
@@ -1064,7 +1265,10 @@ mod tests {
 
     #[test]
     fn non_string_entries_in_a_prior_approvals_array_are_dropped() {
-        let out = with_approval(serde_json::json!({ "approvals": ["a", 7, null] }), "b");
+        let out = with_approvals(
+            serde_json::json!({ "approvals": ["a", 7, null] }),
+            &["b".to_string()],
+        );
         assert_eq!(out["approvals"], serde_json::json!(["a", "b"]));
     }
 
@@ -1162,7 +1366,7 @@ mod tests {
             None,
         );
 
-        let input = continuation_input(&card).expect("a well-formed card continues");
+        let input = single_continuation_input(&card).expect("a well-formed card continues");
 
         assert_eq!(input["approvals"], serde_json::json!(["gate"]));
         assert_eq!(
@@ -1195,7 +1399,7 @@ mod tests {
             &[],
             None,
         );
-        let continuation = continuation_input(&first).expect("continues");
+        let continuation = single_continuation_input(&first).expect("continues");
 
         // Run 2 skips the summary (delivering nothing) and pauses on gate-b.
         let second = gate_effect("digest", "gate-b", &continuation, "run-2", &[], &[], None);
@@ -1209,7 +1413,7 @@ mod tests {
         );
 
         // And approving THAT still suppresses it, with both gates approved.
-        let next = continuation_input(&second).expect("continues");
+        let next = single_continuation_input(&second).expect("continues");
         assert_eq!(next["approvals"], serde_json::json!(["gate-a", "gate-b"]));
         assert_eq!(delivered_in_input(&next).len(), 1);
     }
@@ -1247,7 +1451,7 @@ mod tests {
             std::slice::from_ref(&posted),
             None,
         );
-        let continuation = continuation_input(&first).expect("continues");
+        let continuation = single_continuation_input(&first).expect("continues");
         assert_eq!(
             performed_in_input(&continuation),
             vec![posted.clone()],
@@ -1278,7 +1482,7 @@ mod tests {
             std::slice::from_ref(&also_posted),
             None,
         );
-        let next = continuation_input(&second).expect("continues");
+        let next = single_continuation_input(&second).expect("continues");
 
         assert_eq!(
             performed_in_input(&next),
@@ -1339,7 +1543,7 @@ mod tests {
             &[],
             None,
         );
-        let input = continuation_input(&card).expect("continues");
+        let input = single_continuation_input(&card).expect("continues");
         assert!(
             input.get(CONTINUATION_PERFORMED_KEY).is_none(),
             "nothing to suppress must write nothing: {input}"
@@ -1381,7 +1585,7 @@ mod tests {
     #[test]
     fn a_lineage_that_delivered_nothing_threads_no_reserved_key() {
         let card = effect("digest", "gate", serde_json::json!({ "request": "x" }));
-        let input = continuation_input(&card).expect("continues");
+        let input = single_continuation_input(&card).expect("continues");
         assert!(input.get(CONTINUATION_DELIVERED_KEY).is_none(), "{input}");
         assert!(delivered_in_input(&input).is_empty());
     }
@@ -1403,7 +1607,7 @@ mod tests {
         // The same gate, re-reached by the continuation the card started: same
         // input plus the approval… minus the approval, which the gate node
         // consumed. What differs is the ledger key alone.
-        let mut continuation = continuation_input(&paused).expect("continues");
+        let mut continuation = single_continuation_input(&paused).expect("continues");
         continuation
             .as_object_mut()
             .expect("object")

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -672,9 +672,11 @@ pub fn attach_upstream_content(
 /// `run_id` is deliberately **not** part of it: it differs by construction on
 /// every re-run, so including it would make the dedupe a no-op. Neither is the
 /// [`PAYLOAD_DELIVERED`] ledger, nor the [`CONTINUATION_DELIVERED_KEY`] the
-/// input carries it under (issue #438) — both differ by construction between a
-/// paused run and the continuation it started, and both describe what has
-/// *already happened* rather than what is being decided. Counting either would
+/// input carries it under (issue #438), nor either of their siblings — the
+/// outward-call ledger (#846) and the denial ledger (#978). All of them differ
+/// by construction between a paused run and the continuation it started, and
+/// all describe what has *already happened* rather than what is being decided
+/// (a decision already made is the clearest case of that). Counting any would
 /// make every continuation gate read as a new decision, which is precisely the
 /// duplicate-card failure this function exists to prevent.
 fn is_same_gate(a: &Effect, b: &Effect) -> bool {
@@ -699,9 +701,11 @@ fn decided_input(effect: &Effect) -> Option<Value> {
 /// `input` with the reserved host-threaded ledger keys removed. A non-object
 /// input is returned as-is — there is nothing to strip.
 ///
-/// Both keys, and neither is optional: a continuation's input differs from the
-/// paused run's by exactly these, so letting either difference count would make
-/// every continuation gate a "new" decision and stack a duplicate card.
+/// All three keys, and none is optional: a continuation's input differs from
+/// the paused run's by exactly these — the delivery ledger (#438), the
+/// outward-call ledger (#846) and the denial ledger (#978) — so letting any of
+/// those differences count would make every continuation gate a "new" decision
+/// and stack a duplicate card.
 fn without_ledger(mut input: Value) -> Value {
     if let Value::Object(map) = &mut input {
         map.remove(CONTINUATION_DELIVERED_KEY);

--- a/src/runtime/workflow_resume.rs
+++ b/src/runtime/workflow_resume.rs
@@ -130,6 +130,51 @@ use crate::runtime::workflow_spawn::WorkflowSpawn;
 /// fail silently, which for this kind means an approval nobody acts on.
 pub const WORKFLOW_APPROVE_KIND: &str = "workflow.approve";
 
+/// The prefix a workflow run's continuation turn key carries (issue #978).
+///
+/// Namespaced rather than the bare run id because the turn key space is shared
+/// with the cycle ids a chat turn arms
+/// ([`ContinuationQueue`](crate::runtime::continuation::ContinuationQueue)), and
+/// the release side has to fork on which kind it is holding — a brain turn is
+/// continued, a workflow run is re-dispatched, and running the wrong one is
+/// silent. The prefix is what makes that question answerable from the key
+/// alone, with no side lookup that could disagree.
+pub const WORKFLOW_TURN_PREFIX: &str = "workflow-run:";
+
+/// The continuation turn key **every gate one workflow run parked** shares
+/// (issue #978).
+///
+/// This is the whole of the fix's accounting change. Before it,
+/// `park_and_journal` recorded no turn key for a workflow gate at all, so
+/// [`approval_cycle`](crate::runtime::journal::RuntimeJournal::approval_cycle)
+/// answered `Some(None)` and every branch of a fan-out believed it was the only
+/// decision outstanding: `decisions_still_awaited` read 0 on all three of three,
+/// and all three re-dispatched. Keying on the **run** rather than the node is
+/// what makes "approving never increases pending approvals" expressible — N
+/// gates of one run are one decision batch, released once.
+///
+/// The run id is already on every parked gate ([`gate_effect`] stamps
+/// `Effect::run_id`), so nothing new has to be threaded to mint this.
+pub fn workflow_turn_key(run_id: &str) -> String {
+    format!("{WORKFLOW_TURN_PREFIX}{run_id}")
+}
+
+/// The run behind a turn key minted by [`workflow_turn_key`], or `None` for a
+/// key that names a brain turn instead (issue #978).
+///
+/// Paired with its writer in one module, deliberately: a reader that rebuilt the
+/// prefix from a literal is a second place for the format to drift, and drift
+/// here does not fail loudly — it reads a workflow key as a brain turn and runs
+/// an agent cycle over a run that then never continues.
+///
+/// An empty remainder is rejected rather than returned: `workflow-run:` with no
+/// run behind it names nothing, and treating it as a run id would spawn a
+/// continuation for a graph that cannot be found.
+pub fn run_id_from_turn(turn: &str) -> Option<&str> {
+    turn.strip_prefix(WORKFLOW_TURN_PREFIX)
+        .filter(|run_id| !run_id.is_empty())
+}
+
 /// The payload key holding the workflow whose run paused.
 pub const PAYLOAD_WORKFLOW_ID: &str = "workflow_id";
 /// The payload key holding the gate node awaiting sign-off.
@@ -148,6 +193,22 @@ pub const PAYLOAD_DELIVERED: &str = "delivered";
 /// guarded a `send` / `publish` / `repo_publish` the graph made as a node of its
 /// own. See [`PerformedCall`].
 pub const PAYLOAD_PERFORMED: &str = "performed";
+/// The payload key holding this lineage's **denial** ledger (issue #978) — the
+/// gate nodes an operator has refused, so a continuation neither runs them nor
+/// asks about them again.
+///
+/// The third ledger, and the one that makes a *mixed* verdict safe. A run that
+/// fans out to three gates and is approved twice and denied once re-dispatches
+/// once, carrying two approvals; the denied node is not in that set, so without
+/// this the replay would reach it, pause on it, and park a **new** card — an
+/// approval round that cleared three and created one, which is the invariant
+/// this issue exists to restore. Listed here, `park_pending_gates` skips it: the
+/// refusal is final, and the branch below it simply never completes.
+///
+/// Accumulates down the lineage exactly as [`PAYLOAD_DELIVERED`] and
+/// [`PAYLOAD_PERFORMED`] do — a two-gate graph must not forget the first gate's
+/// denial when it parks the second.
+pub const PAYLOAD_DENIED: &str = "denied";
 /// The payload key holding the plain-prose statement of what approving costs.
 pub const PAYLOAD_NOTE: &str = "note";
 /// The payload key holding the verbatim output of the gate's upstream nodes —
@@ -228,6 +289,17 @@ pub const CONTINUATION_DELIVERED_KEY: &str = "__opencompany_delivered";
 /// already happened, not what is being decided, so counting it would make every
 /// continuation gate read as a new decision and stack a duplicate card.
 pub const CONTINUATION_PERFORMED_KEY: &str = "__opencompany_performed";
+
+/// The reserved trigger-input key the **denial** ledger rides into a
+/// continuation run under (issue #978).
+///
+/// Reserved on exactly [`CONTINUATION_DELIVERED_KEY`]'s terms: host-written,
+/// host-read, never authored and opaque to the engine. Stripped before two
+/// parked gates are compared ([`is_same_gate`]) for the same reason both its
+/// siblings are — it records what has already been decided, not what is being
+/// decided, so counting it would make every continuation's gate read as a new
+/// question and stack a duplicate card.
+pub const CONTINUATION_DENIED_KEY: &str = "__opencompany_denied";
 
 /// What approving a workflow gate actually does, in the operator's own terms.
 ///
@@ -342,6 +414,44 @@ pub fn delivered_in_input(input: &Value) -> Vec<DeliveredReport> {
         .unwrap_or_default()
 }
 
+/// The gate nodes this lineage has already refused, read off a trigger input
+/// (issue #978).
+///
+/// Tolerant on [`delivered_in_input`]'s terms and for its reason: a missing key,
+/// a non-array or a non-string row yields "nothing known to be denied", which is
+/// the pre-#978 behaviour (ask about it). Being wrong in the other direction —
+/// inventing a denial — would silently strand a branch the operator never
+/// refused.
+pub fn denied_in_input(input: &Value) -> Vec<String> {
+    input
+        .get(CONTINUATION_DENIED_KEY)
+        .and_then(Value::as_array)
+        .map(|rows| {
+            rows.iter()
+                .filter_map(|row| row.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// The gate node a parked [`WORKFLOW_APPROVE_KIND`] effect is asking about, or
+/// `None` for any other effect (issue #978).
+///
+/// The kind is checked as well as the key, so a non-gate effect that happens to
+/// carry a `node_id` payload cannot be mistaken for one. This is what the
+/// run-scoped stash keys its batch on — see
+/// [`WorkflowGateQueue`](crate::runtime::workflow_gates::WorkflowGateQueue).
+pub fn gate_node_id(effect: &Effect) -> Option<&str> {
+    if effect.kind != WORKFLOW_APPROVE_KIND {
+        return None;
+    }
+    effect
+        .payload
+        .get(PAYLOAD_NODE_ID)
+        .and_then(Value::as_str)
+        .filter(|node| !node.trim().is_empty())
+}
+
 /// The ledger a gate parked on this run should carry: what the run just
 /// delivered, unioned with what its own trigger input already listed.
 ///
@@ -441,6 +551,11 @@ pub fn gate_effect(
         PAYLOAD_PERFORMED.to_string(),
         json!(performed_ledger(input, performed)),
     );
+    // Issue #978: what must NOT be *asked about* again when this card is
+    // approved. Purely inherited — a denial is made at resolve time, never at
+    // park time — but it has to ride the card, or a two-gate graph forgets the
+    // first gate's refusal the moment it parks the second.
+    payload.insert(PAYLOAD_DENIED.to_string(), json!(denied_in_input(input)));
     // What approving costs, in the operator's own terms.
     payload.insert(PAYLOAD_NOTE.to_string(), json!(CONTINUATION_NOTE));
     // Issue #460: which call the policy stopped, and why. The keys are ABSENT
@@ -591,6 +706,7 @@ fn without_ledger(mut input: Value) -> Value {
     if let Value::Object(map) = &mut input {
         map.remove(CONTINUATION_DELIVERED_KEY);
         map.remove(CONTINUATION_PERFORMED_KEY);
+        map.remove(CONTINUATION_DENIED_KEY);
     }
     input
 }

--- a/src/workflows/caps/mod.rs
+++ b/src/workflows/caps/mod.rs
@@ -1002,6 +1002,13 @@ impl HarnessAgentRunner {
                     request.effect,
                     crate::runtime::journal::TaskLink::Unlinked,
                     None,
+                    // Issue #978: no run turn key, deliberately. These cards are
+                    // tool-call-shaped — `ApprovalPolicy::effect_for` stamps an
+                    // `agent` on them — so approving mints a grant and
+                    // re-dispatches the agent; it never re-dispatches the run.
+                    // Batching them under the run would owe a continuation
+                    // nothing performs.
+                    None,
                 )
                 .await
             {

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -250,6 +250,23 @@ pub struct DeliveryParking {
     /// The durable record of the park. This is what `/approvals` lists and what
     /// boot replay rehydrates, so it is what makes the card survive a restart.
     pub journal: Arc<RuntimeJournal>,
+    /// How many decisions each turn is still blocked on (issue #469), so a park
+    /// raised **outside** a cycle can join a batch too.
+    ///
+    /// Added by issue #978. Before it, this path armed nothing and passed no
+    /// turn key, so every gate of a fan-out was its own batch of one: each
+    /// believed it was the last decision outstanding and each re-dispatched the
+    /// whole run. The same handle the runtime resolves against — a second queue
+    /// would count parks nobody releases.
+    pub continuations: crate::runtime::continuation::ContinuationQueue,
+    /// Which gate node each parked workflow approval is deciding, and the
+    /// trigger input its run paused with (issue #978).
+    ///
+    /// Armed in lockstep with [`continuations`](Self::continuations) and for the
+    /// same reason they are one struct rather than two options: a run whose
+    /// decisions are counted but whose gates are not recorded releases a batch
+    /// the host cannot re-dispatch.
+    pub gates: crate::runtime::workflow_gates::WorkflowGateQueue,
 }
 
 impl std::fmt::Debug for WorkflowDeliveryDeps {
@@ -915,6 +932,10 @@ async fn park_cold_recipient(
             effect,
             crate::runtime::journal::TaskLink::Unlinked,
             None,
+            // Issue #978: no turn. A cold-recipient card is one delivery's own
+            // decision, not one of a run's batch — it resolves and sends on its
+            // own, exactly as before.
+            None,
         )
         .await
     {
@@ -1032,6 +1053,7 @@ impl DeliveryParking {
         effect: Effect,
         task_link: crate::runtime::journal::TaskLink,
         thread: Option<String>,
+        turn: Option<String>,
     ) -> Result<ApprovalId, crate::error::OpenCompanyError> {
         let approval_id = self.approvals.park(company, effect.clone()).await?;
         if let Err(err) = self
@@ -1050,12 +1072,22 @@ impl DeliveryParking {
                     thread,
                     parent: None,
                 },
-                // No turn key (issue #469): a workflow node's request is not
-                // raised by a cycle, so there is no turn holding a continuation
-                // for it. It resolves and continues on its own, exactly as it
-                // always has — the gate only ever groups approvals a single
-                // cycle parked together.
-                None,
+                // The turn this park belongs to, when it belongs to one
+                // (issues #469, #978).
+                //
+                // `None` for a cold-recipient delivery and for an agent node's
+                // gated tool call: neither is raised by anything that holds a
+                // continuation, so each resolves and continues on its own,
+                // exactly as it always has.
+                //
+                // `Some` for a `requires_approval` gate, where issue #978 found
+                // the opposite: the N gates one run pauses on ARE a batch, and
+                // recording no key for them is what let every branch of a
+                // fan-out believe it was the last decision and re-dispatch the
+                // whole run. A run is a turn in precisely the sense #469 means —
+                // one unit of work, blocked on several decisions, owed exactly
+                // one continuation when the last of them lands.
+                turn.clone(),
             )
             .await
         {
@@ -1086,6 +1118,19 @@ impl DeliveryParking {
             // with.
             let _ = self.journal.record_resolved(&approval_id).await;
             return Err(err);
+        }
+        // Issues #469 / #978: arm the counters, STRICTLY AFTER the journal write
+        // and only on the path where the park actually succeeded.
+        //
+        // The ordering mirrors the cycle host's own arm: a crash between the two
+        // replays as "still parked" and is re-armed from the journal by
+        // recovery, whereas arming first would leave a run blocked on a decision
+        // no durable card can deliver. The rollback arm above returns before
+        // reaching here for the same reason, and so does `park_pending_gates`'
+        // dedupe skip — it never calls this function at all.
+        if let Some(turn) = turn {
+            self.continuations.arm(&turn);
+            self.gates.arm(&turn, &approval_id, &effect);
         }
         Ok(approval_id)
     }
@@ -1688,6 +1733,12 @@ admins = [{list}]
             self.deps.parking = Some(DeliveryParking {
                 approvals: gate.clone(),
                 journal: journal.clone(),
+                // Issue #978: a test fixture parks into its own queues. The
+                // production wiring is `RuntimeBuilder`, which hands the
+                // runtime's own handles in so a park arms what the resolve
+                // path releases.
+                continuations: Default::default(),
+                gates: Default::default(),
             });
             self.gate = Some(gate);
             self.journal = Some(journal);
@@ -1712,6 +1763,12 @@ admins = [{list}]
             self.deps.parking = Some(DeliveryParking {
                 approvals: gate.clone(),
                 journal: journal.clone(),
+                // Issue #978: a test fixture parks into its own queues. The
+                // production wiring is `RuntimeBuilder`, which hands the
+                // runtime's own handles in so a park arms what the resolve
+                // path releases.
+                continuations: Default::default(),
+                gates: Default::default(),
             });
             self.gate = Some(gate);
             self.journal = Some(journal);

--- a/src/workflows/gated_tool_call_test.rs
+++ b/src/workflows/gated_tool_call_test.rs
@@ -356,8 +356,12 @@ async fn the_parked_card_produces_a_continuation_that_approves_the_node() {
         .find(|p| p.effect.kind == WORKFLOW_APPROVE_KIND)
         .expect("a gate card");
 
-    let input = crate::runtime::workflow_resume::continuation_input(&card.effect)
-        .expect("a policy-gated card is a well-formed continuation");
+    let input = crate::runtime::workflow_resume::continuation_input(
+        &card.effect,
+        &["work".to_string()],
+        &[],
+    )
+    .expect("a policy-gated card is a well-formed continuation");
     let approvals = input["approvals"]
         .as_array()
         .expect("the continuation carries an approvals array");

--- a/src/workflows/gated_tool_turn_test.rs
+++ b/src/workflows/gated_tool_turn_test.rs
@@ -257,6 +257,12 @@ pub(super) fn deps(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc
             parking: Some(DeliveryParking {
                 approvals: gate,
                 journal: journal.clone(),
+                // Issue #978: a test fixture parks into its own queues. The
+                // production wiring is `RuntimeBuilder`, which hands the
+                // runtime's own handles in so a park arms what the resolve
+                // path releases.
+                continuations: Default::default(),
+                gates: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         }),

--- a/src/workflows/mod.rs
+++ b/src/workflows/mod.rs
@@ -41,6 +41,11 @@ mod gated_tool_call_test;
 /// node reaches the Approvals page and survives the next chat cycle.
 #[cfg(test)]
 mod gated_tool_turn_test;
+/// Issue #978: a run that fans out to N gated nodes is cleared by approving,
+/// not multiplied by it — the composition of #395, #243 and #469 that each of
+/// their own suites is blind to.
+#[cfg(test)]
+mod parallel_gate_fanout_test;
 /// Issue #846: a continuation replays the outward calls its lineage already
 /// made, instead of making them a second time.
 pub mod replay;

--- a/src/workflows/parallel_gate_fanout_test.rs
+++ b/src/workflows/parallel_gate_fanout_test.rs
@@ -1,0 +1,689 @@
+//! Issue #978 — a run that fans out to N gated nodes is cleared by approving,
+//! not multiplied by it.
+//!
+//! # The defect, and why nothing already in the suite caught it
+//!
+//! Every part worked alone, which is exactly why this needed a test at this
+//! altitude. The policy gated each `tool_call` node (#460). The engine paused
+//! and `park_pending_gates` wrote a card each (#395). `resume_from_effect`
+//! replayed the graph with the approved gate cleared (#243). The continuation
+//! queue continued a turn once (#469). Approving still made things worse:
+//!
+//! * the park recorded **no turn key**, so `approval_cycle` answered
+//!   `Some(None)` and each of the three branches believed it was the only
+//!   decision outstanding — `stillAwaiting: 0` on all three, including the
+//!   first;
+//! * the re-dispatch lived in `perform_effect`, which fires **once per approved
+//!   effect**, so three approvals started three runs;
+//! * each of those replays carried an `approvals` array naming one node, so the
+//!   other two paused and parked again.
+//!
+//! Net for a three-way fan-out: clear 3, create 6. Then 12, then 24. The
+//! reported staging tenant accumulated 77 runs of one *disabled* workflow, 17 of
+//! which executed exactly one node — the fingerprint of a re-dispatch fragment.
+//!
+//! Each of the three mechanisms is individually correct and individually tested.
+//! Only their composition is wrong, so only a test that drives the whole
+//! composition can see it.
+//!
+//! # What this drives
+//!
+//! Nothing is stubbed on the path under test. A real graph, the real engine
+//! through [`HarnessWorkflowRunner`](super::runner::HarnessWorkflowRunner), the
+//! real [`WorkflowToolInvoker`](super::caps), the real `ApprovalPolicy` gate, a
+//! real on-disk journal, and a real [`CompanyRuntime`] resolving through
+//! `resolve_approval` — the same call the console's Approvals route makes.
+//!
+//! A `tool_call` graph is the right shape for that: it has no agent node, so
+//! there is no model to script and no scripted turn to disagree with the engine.
+//! The base URL handed to the provider is a dead port, which is itself an
+//! assertion — if anything dispatched a turn, the run would fail rather than
+//! quietly pass.
+//!
+//! # Reading the counts
+//!
+//! Two numbers carry the whole issue, and both are asserted as **equalities**
+//! rather than bounds, because the defect is that they were larger:
+//! `runs_started` (3 before the fix, 1 after) and the pending-approval count
+//! after each resolve (3 → 6 before, 3 → 2 → 1 → 0 after).
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+
+use serde_json::{Value, json};
+
+use crate::company::{CompanyManifest, parse_workflow};
+use crate::ports::types::{Actor, ActorKind, ApprovalId, CompanyId, CompanyRecord, Verdict};
+use crate::ports::{WorkflowRun, WorkflowRunContext, WorkflowRunner};
+use crate::runtime::RuntimeBuilder;
+use crate::runtime::workflow_resume::{
+    PAYLOAD_NODE_ID, WORKFLOW_APPROVE_KIND, denied_in_input, workflow_turn_key,
+};
+
+/// The reported shape, minimised: one trigger fanning out to three `tool_call`
+/// nodes over **one** gated slug, converging on a single downstream node.
+///
+/// `shell` rather than `web_fetch` so the side effect is a file this test can
+/// look for — the distinction between "the call was stopped" and "the call ran
+/// and the run stopped afterwards" is not visible in the run outcome alone.
+const FANOUT_TOML: &str = r#"
+id = "fanout"
+name = "Fan out"
+[[node]]
+id = "start"
+kind = "trigger"
+name = "Start"
+[[node]]
+id = "fetch_bbc"
+kind = "tool_call"
+name = "Fetch BBC"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo bbc > bbc.txt"
+[[node]]
+id = "fetch_espn"
+kind = "tool_call"
+name = "Fetch ESPN"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo espn > espn.txt"
+[[node]]
+id = "fetch_guardian"
+kind = "tool_call"
+name = "Fetch Guardian"
+[node.config]
+slug = "shell"
+[node.config.args]
+command = "echo guardian > guardian.txt"
+[[node]]
+id = "rank"
+kind = "output"
+name = "Rank"
+[[edge]]
+from = "start"
+to = "fetch_bbc"
+[[edge]]
+from = "start"
+to = "fetch_espn"
+[[edge]]
+from = "start"
+to = "fetch_guardian"
+[[edge]]
+from = "fetch_bbc"
+to = "rank"
+[[edge]]
+from = "fetch_espn"
+to = "rank"
+[[edge]]
+from = "fetch_guardian"
+to = "rank"
+"#;
+
+/// The three gated nodes, in graph order.
+const FETCHES: [&str; 3] = ["fetch_bbc", "fetch_espn", "fetch_guardian"];
+
+/// What the host actually asked the engine to run.
+#[derive(Clone, Debug)]
+struct StartedRun {
+    input: Value,
+}
+
+/// The real runner, wrapped so the test can count dispatches and read the
+/// trigger input each one carried.
+///
+/// A decorator rather than a double: the engine underneath is the production
+/// one, so a continuation really does replay the graph and really would re-park
+/// its siblings if it were handed the wrong `approvals`. What the wrapper adds
+/// is the only two observations the run history cannot give back — **how many
+/// runs the host started** (the reported symptom: three, where one was owed) and
+/// **what input each carried** (the cause: one approval, where three were owed).
+struct RecordingRunner {
+    inner: super::runner::HarnessWorkflowRunner,
+    started: Mutex<Vec<StartedRun>>,
+}
+
+impl RecordingRunner {
+    fn started(&self) -> Vec<StartedRun> {
+        self.started.lock().expect("recording runner").clone()
+    }
+}
+
+#[async_trait]
+impl WorkflowRunner for RecordingRunner {
+    async fn run(
+        &self,
+        company: &CompanyId,
+        workflow: &crate::company::WorkflowFile,
+        input: Value,
+        ctx: &WorkflowRunContext,
+    ) -> crate::Result<WorkflowRun> {
+        self.started
+            .lock()
+            .expect("recording runner")
+            .push(StartedRun {
+                input: input.clone(),
+            });
+        self.inner.run(company, workflow, input, ctx).await
+    }
+}
+
+/// A company that grants `shell` and gates it, under `full` autonomy.
+///
+/// `full` rather than `supervised` for `gated_tool_call_test`'s reason: it is the
+/// stronger claim (the call is stopped whatever the tier) and it keeps
+/// exec-security out of the way, so the only thing that can stop the call is the
+/// gate this issue is about.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+always_approve = ["shell"]
+
+[tools]
+allow = ["shell"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        manifest: manifest(),
+        ..super::gated_tool_turn_test::record()
+    }
+}
+
+fn operator() -> Actor {
+    Actor {
+        kind: ActorKind::Operator,
+        id: "owner".into(),
+    }
+}
+
+/// A home whose `workflows/` directory holds the fan-out graph, so the
+/// continuation's loader finds it exactly as the console run route would.
+fn seed_home() -> tempfile::TempDir {
+    let dir = tempfile::Builder::new()
+        .prefix("opencompany-fanout-")
+        .tempdir()
+        .expect("tempdir");
+    let workflows = dir.path().join("workflows");
+    std::fs::create_dir_all(&workflows).expect("workflows dir");
+    std::fs::write(workflows.join("fanout.toml"), FANOUT_TOML).expect("seed graph");
+    dir
+}
+
+/// A runtime wired to the **real** workflow runner, parking into its own gate,
+/// journal and continuation queues.
+///
+/// The parking bundle is rebuilt over the runtime's handles rather than left as
+/// the deps fixture's own, and that is the point of the fixture: a card has to
+/// land in the queue the runtime resolves from, and the park has to arm the
+/// counters the resolve releases. Two sets of handles would make every
+/// assertion here vacuous.
+async fn runtime(
+    home: &std::path::Path,
+) -> (
+    Arc<crate::company::runtime::CompanyRuntime>,
+    Arc<RecordingRunner>,
+) {
+    let mut rt = RuntimeBuilder::new(home.to_path_buf(), manifest())
+        .with_seed_dir(home.to_path_buf())
+        .build()
+        .await
+        .expect("runtime builds");
+
+    // A base URL nothing calls: this graph has no agent node, so no model is
+    // reached. A dead address is the assertion.
+    let (mut deps, _unused) =
+        super::gated_tool_turn_test::deps("http://127.0.0.1:1/unused".to_string(), home);
+    let delivery = deps.delivery.as_mut().expect("the fixture wires delivery");
+    delivery.parking = Some(super::delivery::DeliveryParking {
+        approvals: rt.approvals.clone(),
+        journal: rt.journal().clone(),
+        continuations: rt.continuations.clone(),
+        gates: rt.workflow_gates().clone(),
+    });
+
+    let pool = Arc::new(crate::harness::HarnessPool::new());
+    pool.ensure(&record(), &deps).await.expect("roster builds");
+    let runner = Arc::new(RecordingRunner {
+        inner: super::runner::HarnessWorkflowRunner::new(pool, deps, record()),
+        started: Mutex::new(Vec::new()),
+    });
+    rt.set_workflow_runner(runner.clone());
+    (Arc::new(rt), runner)
+}
+
+/// Starts the fan-out graph through the runtime's own runner — the path the
+/// console run route takes — and returns the run id.
+async fn cold_run(rt: &Arc<crate::company::runtime::CompanyRuntime>) -> String {
+    let file = parse_workflow(FANOUT_TOML).expect("graph parses");
+    let ctx = WorkflowRunContext::new(false);
+    let run_id = ctx.run_id.clone();
+    let runner = rt.workflow_runner().cloned().expect("a runner is wired");
+    let run = runner
+        .run(rt.id(), &file, json!({ "topic": "sports" }), &ctx)
+        .await
+        .expect("the run settles — a gated node pauses it, it does not error");
+    assert_eq!(
+        sorted(run.pending_approvals.clone()),
+        FETCHES.map(str::to_string).to_vec(),
+        "the cold run must pause on all three fan-out branches"
+    );
+    run_id
+}
+
+fn sorted(mut items: Vec<String>) -> Vec<String> {
+    items.sort();
+    items
+}
+
+/// The gate cards currently on the Approvals page, oldest first.
+fn gate_cards(
+    rt: &Arc<crate::company::runtime::CompanyRuntime>,
+) -> Vec<(ApprovalId, String, Option<String>)> {
+    rt.journal()
+        .pending()
+        .into_iter()
+        .filter(|entry| entry.effect.kind == WORKFLOW_APPROVE_KIND)
+        .map(|entry| {
+            let node = entry.effect.payload[PAYLOAD_NODE_ID]
+                .as_str()
+                .expect("a gate card names its node")
+                .to_string();
+            (entry.id, node, entry.batch)
+        })
+        .collect()
+}
+
+/// How many gate cards are waiting. The number issue #978 says must never go up
+/// when an operator works through the queue.
+fn pending_gates(rt: &Arc<crate::company::runtime::CompanyRuntime>) -> usize {
+    gate_cards(rt).len()
+}
+
+/// How many runs the host has started. The reported symptom, counted directly.
+fn runs_started(runner: &Arc<RecordingRunner>) -> usize {
+    runner.started().len()
+}
+
+/// A resolve, plus the settling window the detached continuation needs.
+///
+/// The continuation is spawned rather than awaited (issue #380's drop safety),
+/// so a test that asserted immediately would race it. Bounded, so a genuine
+/// failure fails rather than hangs.
+async fn resolve_and_settle(
+    rt: &Arc<crate::company::runtime::CompanyRuntime>,
+    id: &ApprovalId,
+    verdict: Verdict,
+) {
+    rt.resolve_approval(id, verdict, operator())
+        .await
+        .expect("the verdict is recorded");
+    settle().await;
+}
+
+async fn settle() {
+    tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+}
+
+/// Whether a `shell` node's side effect landed anywhere under the workspace
+/// root. The per-run workspace is a hashed path, so this looks for the file.
+fn wrote(root: &std::path::Path, name: &str) -> bool {
+    fn walk(dir: &std::path::Path, name: &str) -> bool {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return false;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if walk(&path, name) {
+                    return true;
+                }
+            } else if path.file_name().is_some_and(|n| n == name) {
+                return true;
+            }
+        }
+        false
+    }
+    walk(root, name)
+}
+
+/// **T1** — a cold run of a three-way fan-out parks exactly three cards and runs
+/// no node, and all three cards name **one** batch: the run.
+///
+/// The batch key is the accounting fix in one assertion. Before #978 every card
+/// carried `None` here, which is what made three branches each believe they were
+/// the last decision outstanding.
+#[tokio::test]
+async fn a_cold_fanout_parks_three_gates_under_one_run_batch() {
+    let home = seed_home();
+    let (rt, _runner) = runtime(home.path()).await;
+    let run_id = cold_run(&rt).await;
+
+    let cards = gate_cards(&rt);
+    assert_eq!(cards.len(), 3, "one card per gated branch: {cards:?}");
+    assert_eq!(
+        sorted(cards.iter().map(|(_, node, _)| node.clone()).collect()),
+        FETCHES.map(str::to_string).to_vec()
+    );
+
+    // No branch executed. This is the gate doing its job, and it is what makes
+    // the counts below about approvals rather than about work already done.
+    for file in ["bbc.txt", "espn.txt", "guardian.txt"] {
+        assert!(
+            !wrote(home.path(), file),
+            "{file} must not have been written"
+        );
+    }
+
+    let want = Some(workflow_turn_key(&run_id));
+    for (id, node, batch) in &cards {
+        assert_eq!(
+            batch, &want,
+            "gate {node} ({id}) must be batched under its run, not left unbatched"
+        );
+    }
+}
+
+/// **T2** — the first two approvals release **nothing**: no new run, no new
+/// card, and the outstanding count counts down honestly.
+///
+/// `decisions_still_awaited` is the number the console renders as "the agent
+/// picks this up once N more are decided". It read `0` on all three of three
+/// before this issue, which is what told an operator their first click had
+/// completed the action.
+#[tokio::test]
+async fn the_first_two_approvals_release_nothing_and_count_down() {
+    let home = seed_home();
+    let (rt, runner) = runtime(home.path()).await;
+    cold_run(&rt).await;
+    let before = runs_started(&runner);
+    let cards = gate_cards(&rt);
+
+    assert_eq!(
+        rt.decisions_still_awaited(&cards[0].0),
+        2,
+        "three parked, one being decided — two others outstanding"
+    );
+    resolve_and_settle(&rt, &cards[0].0, Verdict::Approve).await;
+    assert_eq!(
+        runs_started(&runner),
+        before,
+        "the first approval starts no run"
+    );
+    assert_eq!(pending_gates(&rt), 2, "and creates no card");
+
+    assert_eq!(rt.decisions_still_awaited(&cards[1].0), 1);
+    resolve_and_settle(&rt, &cards[1].0, Verdict::Approve).await;
+    assert_eq!(runs_started(&runner), before, "nor does the second");
+    assert_eq!(pending_gates(&rt), 1);
+
+    assert_eq!(
+        rt.decisions_still_awaited(&cards[2].0),
+        0,
+        "the last decision is the one that releases the run"
+    );
+}
+
+/// **T3** — the headline. The **last** approval starts exactly **one** run.
+///
+/// The bug is that three appeared, so this asserts the count rather than merely
+/// that something ran. Run three of three is the only one that may start
+/// anything at all.
+#[tokio::test]
+async fn approving_all_three_starts_exactly_one_continuation_run() {
+    let home = seed_home();
+    let (rt, runner) = runtime(home.path()).await;
+    cold_run(&rt).await;
+    let before = runs_started(&runner);
+
+    for (id, _, _) in gate_cards(&rt) {
+        resolve_and_settle(&rt, &id, Verdict::Approve).await;
+    }
+
+    assert_eq!(
+        runs_started(&runner) - before,
+        1,
+        "three approvals owe ONE continuation; before #978 each started its own"
+    );
+}
+
+/// **T4** — that one run carries all three approvals, so every branch executes
+/// and the graph converges instead of re-gating its siblings.
+///
+/// The three side-effect files are the proof that the replay actually ran the
+/// branches rather than merely being handed their ids.
+#[tokio::test]
+async fn the_continuation_carries_every_approval_and_runs_every_branch() {
+    let home = seed_home();
+    let (rt, runner) = runtime(home.path()).await;
+    cold_run(&rt).await;
+
+    for (id, _, _) in gate_cards(&rt) {
+        resolve_and_settle(&rt, &id, Verdict::Approve).await;
+    }
+    settle().await;
+
+    let started = runner.started();
+    let continuation = started.last().expect("a continuation ran");
+    assert_eq!(
+        sorted(
+            continuation.input["approvals"]
+                .as_array()
+                .expect("the continuation carries an approvals array")
+                .iter()
+                .map(|id| id.as_str().expect("node ids are strings").to_string())
+                .collect()
+        ),
+        FETCHES.map(str::to_string).to_vec(),
+        "the ONE continuation must clear all three gates, not just the last clicked: {:?}",
+        continuation.input
+    );
+
+    for file in ["bbc.txt", "espn.txt", "guardian.txt"] {
+        assert!(
+            wrote(home.path(), file),
+            "every approved branch must have executed; {file} is missing"
+        );
+    }
+    assert_eq!(
+        pending_gates(&rt),
+        0,
+        "and the queue is empty rather than refilled"
+    );
+}
+
+/// **T5** — the invariant, by name: **approving never increases the number of
+/// pending approvals.**
+///
+/// Asserted as a monotone sequence rather than only at the end, because the
+/// reported failure is a *growth curve* (3 → 6 → 12 → 24) and an end-state
+/// assertion would pass on a run that spiked in the middle.
+#[tokio::test]
+async fn the_pending_approval_count_never_increases_across_a_round() {
+    let home = seed_home();
+    let (rt, _runner) = runtime(home.path()).await;
+    cold_run(&rt).await;
+
+    let mut seen = vec![pending_gates(&rt)];
+    for (id, _, _) in gate_cards(&rt) {
+        resolve_and_settle(&rt, &id, Verdict::Approve).await;
+        seen.push(pending_gates(&rt));
+    }
+
+    assert_eq!(
+        seen,
+        vec![3, 2, 1, 0],
+        "each decision must clear one card and create none; before #978 this read [3, 6, ..]"
+    );
+    for pair in seen.windows(2) {
+        assert!(
+            pair[1] <= pair[0],
+            "approving increased the queue from {} to {}: {seen:?}",
+            pair[0],
+            pair[1]
+        );
+    }
+}
+
+/// **T6** — a mixed verdict is still one run, and a refusal is **final**.
+///
+/// The trap this pins: the denied node is not in the approved set, so a
+/// continuation that knew only about approvals would replay into it, pause, and
+/// park a brand-new card — an approval round that cleared three and created one.
+/// The denial ledger is what makes the refusal stick.
+#[tokio::test]
+async fn a_denied_branch_does_not_re_park_and_still_yields_one_run() {
+    let home = seed_home();
+    let (rt, runner) = runtime(home.path()).await;
+    cold_run(&rt).await;
+    let before = runs_started(&runner);
+
+    let cards = gate_cards(&rt);
+    let denied = cards
+        .iter()
+        .find(|(_, node, _)| node == "fetch_guardian")
+        .expect("the guardian branch is parked")
+        .clone();
+    for (id, node, _) in &cards {
+        let verdict = if node == &denied.1 {
+            Verdict::Deny
+        } else {
+            Verdict::Approve
+        };
+        resolve_and_settle(&rt, id, verdict).await;
+    }
+    settle().await;
+
+    assert_eq!(
+        runs_started(&runner) - before,
+        1,
+        "a mixed verdict owes one continuation, not one per approval"
+    );
+    assert_eq!(
+        pending_gates(&rt),
+        0,
+        "the refused branch must NOT come back as a fresh card"
+    );
+
+    let started = runner.started();
+    let continuation = started.last().expect("the continuation ran");
+    assert_eq!(
+        denied_in_input(&continuation.input),
+        vec!["fetch_guardian".to_string()],
+        "the continuation must carry the refusal: {:?}",
+        continuation.input
+    );
+    // The approved work is not discarded by one refusal…
+    assert!(wrote(home.path(), "bbc.txt"));
+    assert!(wrote(home.path(), "espn.txt"));
+    // …and the refused call never happened.
+    assert!(
+        !wrote(home.path(), "guardian.txt"),
+        "a denied branch must not execute"
+    );
+}
+
+/// **T7** — recovery. A restart with two of three decided comes back blocked on
+/// **one**, not zero.
+///
+/// The failure this guards is the opposite of the headline and just as bad: a
+/// rehydrate that forgot the run was partly decided would fire its continuation
+/// on the next decision regardless of how many were still owed — or, if it
+/// re-armed all three, would wait forever for two decisions that already
+/// happened.
+#[tokio::test]
+async fn a_restart_mid_round_comes_back_blocked_on_what_is_left() {
+    let home = seed_home();
+    let remaining = {
+        let (rt, _runner) = runtime(home.path()).await;
+        cold_run(&rt).await;
+        let cards = gate_cards(&rt);
+        resolve_and_settle(&rt, &cards[0].0, Verdict::Approve).await;
+        resolve_and_settle(&rt, &cards[1].0, Verdict::Approve).await;
+        assert_eq!(pending_gates(&rt), 1);
+        cards[2].1.clone()
+    }; // the "process" goes away
+
+    let (rt, _runner) = runtime(home.path()).await;
+    rt.recover().await.expect("replay rehydrates the parks");
+
+    let cards = gate_cards(&rt);
+    assert_eq!(
+        cards.len(),
+        1,
+        "only the undecided gate survives the restart: {cards:?}"
+    );
+    assert_eq!(cards[0].1, remaining);
+    assert_eq!(
+        rt.decisions_still_awaited(&cards[0].0),
+        0,
+        "one gate left, so deciding it is what releases the run"
+    );
+    let turn = cards[0]
+        .2
+        .clone()
+        .expect("the rehydrated card keeps its batch");
+    assert_eq!(
+        rt.workflow_gates().undecided(&turn),
+        1,
+        "the rehydrated batch is blocked on exactly the gate still parked"
+    );
+}
+
+/// The unit companion to T1's batching, on the default lane: the turn key a park
+/// writes is the one the release reads.
+///
+/// A round-trip rather than two literals, because drift here does not fail
+/// loudly — it reads a workflow key as a brain turn and runs an agent cycle over
+/// a run that then never continues.
+#[test]
+fn a_run_turn_key_round_trips() {
+    let key = workflow_turn_key("01a013e576f7");
+    assert_eq!(
+        crate::runtime::workflow_resume::run_id_from_turn(&key),
+        Some("01a013e576f7")
+    );
+    // A brain turn's cycle id is not a run, and must not be read as one.
+    assert_eq!(
+        crate::runtime::workflow_resume::run_id_from_turn("cycle-1"),
+        None
+    );
+    // Nor is a prefix with nothing behind it.
+    assert_eq!(
+        crate::runtime::workflow_resume::run_id_from_turn("workflow-run:"),
+        None
+    );
+}
+
+/// The denial ledger's own round-trip: what a continuation writes is what the
+/// next park reads back.
+#[test]
+fn the_denial_ledger_round_trips_through_a_trigger_input() {
+    assert!(denied_in_input(&json!({})).is_empty());
+    let input: Value = json!({ "__opencompany_denied": ["fetch_guardian", "fetch_espn"] });
+    assert_eq!(
+        denied_in_input(&input),
+        vec!["fetch_guardian".to_string(), "fetch_espn".to_string()]
+    );
+    // Tolerant, on `delivered_in_input`'s terms: a malformed row is not a denial.
+    assert!(denied_in_input(&json!({ "__opencompany_denied": "nope" })).is_empty());
+    assert_eq!(
+        denied_in_input(&json!({ "__opencompany_denied": ["ok", 7, null] })),
+        vec!["ok".to_string()]
+    );
+}

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -3569,8 +3569,17 @@ to = "gate"
             .find(|p| p.effect.kind == crate::runtime::WORKFLOW_APPROVE_KIND)
             .expect("the paused gate is waiting on the operator")
             .effect;
-        let continuation = crate::runtime::workflow_resume::continuation_input(&card)
-            .expect("a well-formed card continues");
+        let continuation = crate::runtime::workflow_resume::continuation_input(
+            &card,
+            &[
+                card.payload[crate::runtime::workflow_resume::PAYLOAD_NODE_ID]
+                    .as_str()
+                    .expect("the card names its gate")
+                    .to_string(),
+            ],
+            &[],
+        )
+        .expect("a well-formed card continues");
 
         // --- run 2: the same graph, from the trigger, with the gate approved.
         let second = run_workflow(

--- a/src/workflows/runner.rs
+++ b/src/workflows/runner.rs
@@ -1158,7 +1158,28 @@ async fn park_pending_gates(
         return;
     };
 
+    // Issue #978: the gates this lineage has already refused. A denied node is
+    // decided and final — replaying into it must not raise the question a second
+    // time, or a mixed verdict still nets new cards and "approving never
+    // increases pending approvals" is false again.
+    let denied = crate::runtime::workflow_resume::denied_in_input(trigger_input);
+
+    // Issue #978: every gate this run parks shares ONE turn key, so the N of a
+    // fan-out are one decision batch owed exactly one continuation. Keyed on the
+    // run because the run is what gets re-dispatched.
+    let turn = crate::runtime::workflow_resume::workflow_turn_key(run_id);
+
     for node_id in pending {
+        if denied.iter().any(|refused| refused == node_id) {
+            tracing::info!(
+                company = %record.id,
+                workflow = %workflow_id,
+                node = %node_id,
+                %run_id,
+                "workflow: this gate was already refused, so it is not asked about again"
+            );
+            continue;
+        }
         // Issue #460: when the policy is what stopped this node, the card says
         // which tool and why.
         //
@@ -1224,6 +1245,7 @@ async fn park_pending_gates(
                 effect,
                 crate::runtime::journal::TaskLink::Unlinked,
                 None,
+                Some(turn.clone()),
             )
             .await
         {
@@ -3185,6 +3207,12 @@ to = "done"
             parking: Some(super::super::delivery::DeliveryParking {
                 approvals: gate,
                 journal: journal.clone(),
+                // Issue #978: a test fixture parks into its own queues. The
+                // production wiring is `RuntimeBuilder`, which hands the
+                // runtime's own handles in so a park arms what the resolve
+                // path releases.
+                continuations: Default::default(),
+                gates: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         });
@@ -3478,6 +3506,12 @@ to = "gate"
             parking: Some(super::super::delivery::DeliveryParking {
                 approvals: Arc::new(crate::policy::ManifestApprovalGate::new(policy)),
                 journal: journal.clone(),
+                // Issue #978: a test fixture parks into its own queues. The
+                // production wiring is `RuntimeBuilder`, which hands the
+                // runtime's own handles in so a park arms what the resolve
+                // path releases.
+                continuations: Default::default(),
+                gates: Default::default(),
             }),
             events: Arc::new(crate::store::FsEventLog::new(dir)),
         });


### PR DESCRIPTION
## Summary

A workflow run that fans out to N gated nodes could not be cleared by approving — each approval made the queue **longer**. Approving three gates produced three runs and six new cards, then twelve, then twenty-four.

Three mechanisms, each individually correct and individually tested, composed into an amplifier:

- **#395** parks one card per paused gate — but recorded **no turn key**, so `approval_cycle` answered `Some(None)` and every branch of a fan-out believed it was the only decision outstanding. `stillAwaiting` read `0` on all three of three, including the first.
- **#243** re-dispatches on approve — from `perform_effect`, which fires **once per approved effect**. Three approvals, three runs.
- Each replay carried an `approvals` array naming **one** node, so its two siblings paused and parked again.

The fix makes the **run** the continuation unit:

1. Every gate one run parks shares a turn key, `workflow-run:<run id>`, so the N are one batch on the existing #469 continuation queue.
2. The run is re-dispatched **once**, when the last of its decisions lands. The spawn moves out of `perform_effect` and into the batch release.
3. The replay carries **every** approval the batch cleared, so a sibling gate does not re-park itself.

A new `WorkflowGateQueue` holds what the release needs and the journal cannot give back: which node each parked approval is deciding, and the trigger input the run paused with. It is armed at **park** time — the only moment that covers deny and expiry as well as approve — and rehydrated at recovery from the journal's still-parked gates, mirroring how `ContinuationQueue` is re-armed from `parked_turns`.

Two design points a reviewer will otherwise have to reverse-engineer from the diff:

**Why the queue records verdicts itself, rather than deriving them from the released batch.** A TTL expiry contributes **no event** to that batch — `ContinuationQueue::decide` is called with `None`, because the sweep appends its own `ApprovalResolved`. A run whose last gate timed out would therefore release with the expired node in neither the approved nor the denied ledger, and the continuation would replay into it, pause, and park a fresh card. Banking the verdict at the point of decision covers approve, deny and expiry with one mechanism.

**Why one representative effect per run is sound, not an approximation.** `park_pending_gates` is called once per settled run with a single `trigger_input` and single run-level `deliveries` / `performed` slices (`runner.rs:767`), and its loop hands those same slices unchanged to `gate_effect` for every node — where `delivery_ledger` and `performed_ledger` are pure functions of them. So `input` / `delivered` / `performed` are byte-identical across siblings **by construction**, including when an earlier node already delivered before the fan-out: that delivery is in the run-level list every sibling receives, not in a per-branch subset. Only `node_id`, the call description and the per-gate upstream `content` vary, and a continuation reads none of those. Storing one effect per run rather than one per gate is what keeps this from holding N copies of a trigger input.

Closes #978

## API Or Behavior Changes

**Deny strategy: the denials ledger** (not the abandon-the-run fallback). A refused gate rides a third lineage ledger beside #438's deliveries and #846's outward calls, under the reserved trigger-input key `__opencompany_denied`. `park_pending_gates` skips a listed node, so the refusal is final and the branch below it never completes. A TTL expiry is banked as a default-deny on the same terms. This required no engine-side change. A mixed verdict therefore runs once, carrying the approvals it did get, and nets **zero** new cards; a batch with nothing approved starts no run at all.

**Restart limitation — stated here rather than discovered later.** After a restart mid-round, `ContinuationQueue::rearm` restores each turn's *count* from the journal but not the decisions already banked in the lost process. A batch released after such a restart therefore carries only the last decision, and the siblings it could not carry re-park. This is **pre-existing #469 behaviour** for agent turns — a workflow run is simply the first thing to feel it, because the journal drops a parked entry on resolve and payload-scrubs the record it retains (#351), so a resolved gate's node id is unrecoverable by design. Not addressed here; closing it needs durable per-decision state that does not exist yet.

**One spawn attempt per batch.** Where each approval used to have its own spawn, a batch gets one. A refusal at the concurrency ceiling (#401) now loses the run with every card already consumed, so it is announced on the operator channel rather than only logged — the operator has to know to re-run it.

**No brain cycle per workflow gate.** A workflow run has no agent turn to continue, so the release re-runs the graph instead of running a cycle. The resolutions are still appended to the event log; what is dropped is a full agent turn per approval spent telling the brain about a resolution it could not act on.

**Unchanged:** `DeliveryParking` gains two fields, so cold-recipient delivery and an agent node's gated tool call (#395) both keep passing `None` — the latter carries an `agent`, mints a grant and re-dispatches the agent, never the run, so batching it under the run would owe a continuation nothing performs. A gate card parked before this change carries no turn key and re-dispatches immediately, exactly as it did.

`stillAwaiting` stays advisory: a snapshot read on the request path while the release runs detached. It is confirmation copy, not a control.

## Tests

New `src/workflows/parallel_gate_fanout_test.rs` — seven tests over the real engine, the real gate, a real on-disk journal and a real `CompanyRuntime` resolving through `resolve_approval`. Only the runner is decorated, to count dispatches and read the input each carried. A `tool_call` graph has no model to script, so it is deterministic.

T1 cold fan-out parks exactly 3 under one batch, runs 0 nodes · T2 the first two approvals release nothing and count 2, 1, 0 · T3 the third starts exactly one run · T4 that run carries all three approvals and every branch executes · T5 the queue is non-increasing across the round · T6 mixed verdict is one run and the denied branch does not re-park · T7 a restart mid-round comes back blocked on what is left. Two unit companions cover the turn-key round trip and the denial ledger's tolerances.

**Verified red before the fix.** Reverting only the turn key and the deferred spawn:

```
approving_all_three_starts_exactly_one_continuation_run
  assertion `left == right` failed: three approvals owe ONE continuation
  left: 3
 right: 1

the_pending_approval_count_never_increases_across_a_round
  assertion `left == right` failed: each decision must clear one card and create none
  left: [3, 4, 5, 6]
 right: [3, 2, 1, 0]
```

The suite lands on the gated `Test (openhuman, tinycortex)` lane, which is unfiltered.

Commands run locally, unpiped, on this branch rebased onto current `upstream/main`:

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- [x] `cargo build --all-targets` — N/A: covered by `--all-targets` on the clippy and test runs above, which build every target on both lanes.
- [x] `cargo test` — 2769 passed, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — 4216 passed, 0 failed

## Documentation

Retargeted from the two files the issue plan named: `pausing-workflows.md` covers the `enabled` switch and `workflow-events.md` covers journal event variants, so neither owns gate approvals — `approvals.md` already owns the "Approving a paused gate re-runs the workflow" section this extends.

- `docs/spec/company-brain/approvals.md` — new "One run is continued once (issue #978)" section: the three rules, the denial ledger, and both limits above.
- `docs/spec/runtime/workflow-vocabulary.md` — tables the four keys a continuation's trigger input carries, including the new `__opencompany_denied`, and the rule that all four accumulate down the lineage.

Both stay under the repo's 500-line Markdown cap (364 and 249).
