### PR TITLE
fix(workflows): serve only channels delivery accepts, and refuse an undeliverable destination at save (#981)

### DIFF
--- a/frontend/src/api/workflows.ts
+++ b/frontend/src/api/workflows.ts
@@ -78,8 +78,9 @@ export interface WorkflowNode {
  * `owner` is resolved server-side from the company's admins and carries no
  * target — the graph names nobody, which is what keeps it safe by construction.
  * `email` names an address and only sends when the company grants `email` AND
- * the recipient has already written in. `channel` must name a channel the
- * deployment already wired.
+ * the recipient has already written in. `channel` must name a channel this
+ * company can deliver to — a desk chat or a connected channel, never the
+ * operator surface (issue #981).
  */
 export interface WorkflowDestination {
   kind: "owner" | "email" | "channel";
@@ -505,12 +506,21 @@ interface WiredChannelsResponse {
 
 /**
  * The chat channels this running company can deliver to — the real targets an
- * output node's `channel` destination may name (issue #813). `operator` is
- * always present; the rest are the enabled OpenHuman-provider manifest channels.
+ * output node's `channel` destination may name (issue #813): its desk chats and
+ * its enabled OpenHuman-provider manifest channels.
+ *
+ * **`operator` is not one of them** (issue #981). It is an in-memory response
+ * surface with no durable reader, so workflow delivery refuses it by name; the
+ * host used to include it here anyway, which offered authors the one target
+ * guaranteed to fail.
+ *
  * The console reads this to offer a picker instead of a free-text box that only
- * fails at delivery with `ChannelNotWired`. A host predating the route 404s; the
- * caller degrades to an empty list (the picker then falls back to free text)
- * rather than blocking authoring.
+ * fails at delivery with `ChannelNotWired`. An empty list has two causes and the
+ * fallback is the same for both: a host predating the route 404s, and a company
+ * with no desks and no connected channels genuinely has nowhere to deliver. The
+ * caller degrades to an empty list (the picker falls back to free text, and the
+ * save is refused server-side if the target is not deliverable) rather than
+ * blocking authoring.
  */
 export function listWiredChannels(
   client: OpenCompanyClient,

--- a/frontend/src/views/WorkflowCreateDialog.tsx
+++ b/frontend/src/views/WorkflowCreateDialog.tsx
@@ -194,17 +194,23 @@ export function destinationTargetProblem(
   if (kind === "channel" && !value) {
     return "A channel destination needs a channel id — name the channel to post the report to.";
   }
-  // #813: when the host told us which channels are wired, a target that is not
-  // one of them would only fail at delivery (`ChannelNotWired`) — catch it at
-  // author time instead. Skipped when the list is empty (host offered none), so
-  // a degraded free-text box is never wrongly rejected.
+  // #813: when the host told us which channels it can deliver to, a target that
+  // is not one of them is refused when the workflow is saved (#981) and, for a
+  // graph saved before a desk went away, fails at delivery (`ChannelNotWired`) —
+  // catch it at author time instead. Skipped when the list is empty (host
+  // offered none), so a degraded free-text box is never wrongly rejected.
+  //
+  // #981: the same sentence the host's save-time rejection carries, so an author
+  // who trips the pre-flight and an author who trips the 400 are told the same
+  // thing. `operator` is no longer in the list the host serves — it never was a
+  // delivery target — so this is what now catches it.
   if (
     kind === "channel" &&
     value &&
     wiredChannels.length > 0 &&
     !wiredChannels.includes(value)
   ) {
-    return `\`${value}\` is not a wired channel — this deployment has: ${wiredChannels.join(", ")}.`;
+    return `\`${value}\` is not a workflow delivery channel — this runtime has: ${wiredChannels.join(", ")}.`;
   }
   return null;
 }
@@ -1524,8 +1530,12 @@ function NodeRow({
             </Select>
             {node.destinationKind === "channel" && wiredChannels.length > 0 && (
               <>
-                {/* #813: pick from the channels actually wired for this company,
-                    instead of a free-text box that only fails at delivery time. */}
+                {/* #813: pick from the channels this company can actually
+                    deliver to, instead of a free-text box that only fails at
+                    delivery time. #981: the host no longer includes `operator`
+                    in that list — it is an in-memory response surface with no
+                    durable reader, and delivery refuses it by name — so the
+                    picker can no longer offer it. */}
                 <Select
                   value={node.destinationTarget || ""}
                   onValueChange={(v) => {
@@ -1570,6 +1580,17 @@ function NodeRow({
               <p className="text-2xs leading-snug text-muted-foreground">
                 Only sends if this company grants email and the recipient has
                 already written in.
+              </p>
+            )}
+            {/* #981: an empty list is now a legitimate answer — a company with
+                no desks and no connected channels has nowhere to post a report,
+                so the free-text box above is the honest fallback rather than a
+                picker of one bad option. Say why it is empty; without this the
+                author sees a blank box and no reason. */}
+            {node.destinationKind === "channel" && wiredChannels.length === 0 && (
+              <p className="text-2xs leading-snug text-muted-foreground">
+                No delivery channels are wired for this company — add a desk, or
+                connect a channel, before a report can be posted to one.
               </p>
             )}
           </>

--- a/frontend/test/e2e/workflow-dialog-feedback.spec.ts
+++ b/frontend/test/e2e/workflow-dialog-feedback.spec.ts
@@ -318,8 +318,12 @@ test("the channel destination is a picker of wired channels, not free text (#813
   page,
 }) => {
   // #813 defect 4: typing a channel id that isn't wired only failed at delivery.
-  // The target is now a picker whose options are the company's wired channels
-  // (`operator` is always wired), so an unwired id can't be entered at all.
+  // The target is now a picker whose options are the company's wired channels.
+  // #981: `operator` is deliberately never one of them — it is an in-memory
+  // response surface with no durable reader, so delivery refuses it by name
+  // and the picker no longer offers it. `engineering` is the e2e harness
+  // company's desk channel (`companies/e2e_harness/company.toml`), so it is
+  // always in the wired set instead.
   const dialog = await openCreateDialog(page);
   await dialog.getByRole("button", { name: "Add node" }).click();
   const kind = dialog.getByLabel("Node kind").nth(1);
@@ -328,9 +332,11 @@ test("the channel destination is a picker of wired channels, not free text (#813
   await dialog.getByLabel("Send report to").click();
   await page.getByRole("option", { name: /^Channel/ }).click();
 
-  // The channel target is a combobox offering the wired `operator` channel.
+  // The channel target is a combobox offering the wired desk channel, never
+  // the undeliverable `operator` surface.
   await dialog.getByLabel("Channel id").click();
-  await expect(page.getByRole("option", { name: "operator" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "engineering" })).toBeVisible();
+  await expect(page.getByRole("option", { name: "operator" })).not.toBeVisible();
 });
 
 test("submitting with an empty id surfaces the validation message on-screen (#813)", async ({

--- a/frontend/test/unit/workflow-destination-target.test.ts
+++ b/frontend/test/unit/workflow-destination-target.test.ts
@@ -14,7 +14,7 @@ describe("destinationTargetProblem — unwired channel", () => {
   it("rejects a channel that is not in the wired set, naming what is", () => {
     const problem = destinationTargetProblem("channel", "ghost", wired);
     expect(problem).toBe(
-      "`ghost` is not a wired channel — this deployment has: operator, email.",
+      "`ghost` is not a workflow delivery channel — this runtime has: operator, email.",
     );
   });
 

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -614,16 +614,33 @@ impl CompanyRuntime {
         &self.store
     }
 
-    /// The ids of the chat channels actually wired for this running company —
-    /// exactly what an `output` node's `channel` destination may target
-    /// (issue #813). `operator` is always present; the rest are the enabled
-    /// OpenHuman-provider manifest channels. The console reads this to offer a
-    /// picker of real targets instead of a free-text box that only fails at
-    /// delivery time with `ChannelNotWired`.
-    pub fn wired_channel_ids(&self) -> Vec<String> {
+    /// The ids of this running company's channels a workflow may actually
+    /// deliver to — exactly what an `output` node's `channel` destination may
+    /// target (issues #813, #981). Desk channels (one per `[[group_chat]]` and
+    /// per operator-created desk) and enabled OpenHuman-provider manifest
+    /// channels; **never `operator`**, whose adapter is an in-memory response
+    /// spy with no durable reader
+    /// ([`is_deliverable_channel`](crate::runtime::is_deliverable_channel)).
+    ///
+    /// The console reads this to offer a picker of real targets, and the
+    /// workflow write routes reject a channel destination outside it, instead
+    /// of a free-text box that only fails at delivery time with
+    /// `ChannelNotWired`.
+    ///
+    /// The set is empty when a company has no desks and no provider channels.
+    /// That is a legitimate state, not a degraded one: it means there is
+    /// nowhere to deliver, and the honest answer is to say so rather than to
+    /// name a target that would be discarded.
+    ///
+    /// This was `wired_channel_ids`, which returned every adapter and claimed
+    /// in its own doc comment that `operator` was always a valid target. The
+    /// rename is deliberate: it is what made the mistake plausible, and every
+    /// call site is worth re-reading against the delivery rule.
+    pub fn deliverable_channel_ids(&self) -> Vec<String> {
         self.channels
             .iter()
             .map(|channel| channel.channel_id().to_string())
+            .filter(|id| crate::runtime::channel::is_deliverable_channel(id))
             .collect()
     }
 

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -2429,10 +2429,18 @@ impl RuntimeBuilder {
                                     // response surface, not a workflow delivery
                                     // destination: its buffer has no durable
                                     // reader. Desk and provider adapters are the
-                                    // accepted workflow write paths.
+                                    // accepted workflow write paths. The rule
+                                    // itself lives next to the operator-channel
+                                    // constant (issue #981) so this set, the
+                                    // set the console's picker offers and the
+                                    // set delivery accepts cannot disagree.
                                     channels: channels
                                         .iter()
-                                        .filter(|channel| channel.channel_id() != OPERATOR_CHANNEL)
+                                        .filter(|channel| {
+                                            crate::runtime::channel::is_deliverable_channel(
+                                                channel.channel_id(),
+                                            )
+                                        })
                                         .cloned()
                                         .collect(),
                                     // Issue #227: the same gate and journal the
@@ -4953,12 +4961,12 @@ mod test {
         assert_eq!(runtime.channels.len(), 2);
         assert!(runtime.channels.iter().any(|c| c.channel_id() == "email"));
 
-        // The #813 accessor the console's channel picker reads names BOTH: the
-        // always-wired `operator` and the openhuman-backed provider channel, so
-        // a workflow author can target either.
-        let wired = runtime.wired_channel_ids();
-        assert!(wired.contains(&"operator".to_string()));
-        assert!(wired.contains(&"email".to_string()));
+        // The accessor the console's channel picker reads (#813) names the
+        // openhuman-backed provider channel and NOT `operator`: delivery
+        // refuses the operator adapter by name, so offering it as a
+        // destination would offer the one target guaranteed to fail (#981).
+        let deliverable = runtime.deliverable_channel_ids();
+        assert_eq!(deliverable, vec!["email".to_string()], "{deliverable:?}");
 
         // A granted call routes through the OpenHuman transport.
         let result = runtime
@@ -4989,9 +4997,17 @@ mod test {
         // No openhuman channel is added when the daemon is unreachable.
         assert_eq!(runtime.channels.len(), 1);
         assert_eq!(runtime.channels[0].channel_id(), "operator");
-        // The #813 accessor the console's channel picker reads: `operator` is
-        // always wired, so a workflow always has at least one real target.
-        assert_eq!(runtime.wired_channel_ids(), vec!["operator".to_string()]);
+        // The accessor the console's channel picker reads (#813): `operator` is
+        // the only wired adapter here, and it is not a delivery target — so a
+        // workflow on this runtime has NOWHERE to deliver, and the honest
+        // answer is an empty picker (#981). It previously answered
+        // `["operator"]`, which is what put the guaranteed-to-fail target in
+        // front of authors.
+        assert!(
+            runtime.deliverable_channel_ids().is_empty(),
+            "an operator-only runtime has no workflow delivery channel: {:?}",
+            runtime.deliverable_channel_ids()
+        );
 
         // Tools degrade to the grant-enforcing built-in: ungranted rejected,
         // granted returns a well-formed not-implemented result — and the RPC
@@ -5082,6 +5098,108 @@ mod test {
             .collect();
         assert!(ids.contains(&"engineering"));
         assert!(ids.contains(&"research"));
+
+        // Both desks are real delivery targets — they write to the company's
+        // durable event log — and `operator` is not one of them (#981).
+        let deliverable = runtime.deliverable_channel_ids();
+        assert!(
+            deliverable.contains(&"engineering".to_string()),
+            "{deliverable:?}"
+        );
+        assert!(
+            deliverable.contains(&"research".to_string()),
+            "{deliverable:?}"
+        );
+        assert!(
+            !deliverable.contains(&"operator".to_string()),
+            "{deliverable:?}"
+        );
+    }
+
+    /// **The invariant that would have caught #981.** The picker's set and the
+    /// delivery layer's set are produced by the same `build()`, from the same
+    /// adapters, and must be the same list.
+    ///
+    /// They were not. `WorkflowDeliveryDeps.channels` dropped `operator` with an
+    /// inline filter while the accessor the console reads returned every adapter
+    /// — so an author was offered a destination the runner refuses by name, and
+    /// nothing in the build asserted the two agreed. Pinning them together is
+    /// what makes a future divergence a test failure rather than a run that
+    /// reports `channel-not-wired` for a target the console suggested.
+    ///
+    /// Needs the harness arm, because that is the only site that wires
+    /// `WorkflowDeliveryDeps` at all.
+    #[cfg(feature = "openhuman")]
+    #[tokio::test]
+    async fn the_picker_set_equals_the_delivery_deps_the_same_build_wired() {
+        use crate::harness::HarnessPool;
+
+        let home_dir = tmp_home("oc-981-invariant-");
+        let home = home_dir.path().to_path_buf();
+        let id = CompanyId::new("invariant-co");
+        let manifest = parse(
+            r#"
+            [company]
+            name = "Invariant Co"
+
+            [policy]
+            mode = "full"
+
+            [[agent]]
+            id = "eng1"
+            role = "Engineer One"
+
+            [[group_chat]]
+            id = "engineering"
+            name = "Engineering"
+            members = ["eng1"]
+            "#,
+        );
+
+        let stub = spawn_stub("ack").await;
+        let runtime = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .with_harness(Arc::new(HarnessPool::new()))
+            .with_harness_inference(
+                HostedProviderConfig {
+                    base_url: stub,
+                    credential: crate::company::Credential::from_value("k"),
+                    extra_headers: Vec::new(),
+                },
+                None,
+            )
+            .build()
+            .await
+            .unwrap();
+
+        let delivery = runtime
+            .workflow_harness_deps
+            .as_ref()
+            .expect("the harness arm wires workflow deps")
+            .delivery
+            .as_ref()
+            .expect("the harness arm wires delivery deps");
+        let deps_channels: Vec<String> = delivery
+            .channels
+            .iter()
+            .map(|channel| channel.channel_id().to_string())
+            .collect();
+
+        assert_eq!(
+            runtime.deliverable_channel_ids(),
+            deps_channels,
+            "the destination picker offers a set the delivery layer does not accept"
+        );
+        // Not vacuous in either direction: the runtime really did wire the
+        // operator adapter, and the desk really is deliverable.
+        assert!(
+            runtime
+                .channels
+                .iter()
+                .any(|channel| channel.channel_id() == OPERATOR_CHANNEL),
+            "the operator adapter must be wired, or the exclusion proves nothing"
+        );
+        assert_eq!(deps_channels, vec!["engineering".to_string()]);
     }
 
     /// A desk added to `company.toml` since the last boot is wired on this one.

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -250,6 +250,30 @@ mod test {
         );
     }
 
+    /// The console's own pre-flight tells an author the same thing the host
+    /// does, and this fails if either side is reworded alone — the same
+    /// contract `destination_messages_match_the_console` holds for the other
+    /// destination rules (issue #260).
+    ///
+    /// It matters more here than elsewhere: the console's list and the host's
+    /// refusal disagreeing about which channels are real is exactly issue #981.
+    #[test]
+    fn the_consoles_pre_flight_says_the_same_thing() {
+        const CONSOLE_DIALOG: &str = include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/frontend/src/views/WorkflowCreateDialog.tsx"
+        ));
+        const TAIL: &str = "is not a workflow delivery channel — this runtime has:";
+
+        assert!(undeliverable_channel_message("operator", &["engineering"]).contains(TAIL));
+        assert!(
+            CONSOLE_DIALOG.contains(TAIL),
+            "frontend/src/views/WorkflowCreateDialog.tsx no longer says `{TAIL}` — the console's \
+             client-side pre-flight has drifted from the host's rule. Reword both sides together, \
+             or drop the pre-flight and surface the host's message on the failed save."
+        );
+    }
+
     #[tokio::test]
     async fn buffers_sent_messages() {
         let channel = OperatorChannel::new();

--- a/src/runtime/channel.rs
+++ b/src/runtime/channel.rs
@@ -19,6 +19,42 @@ use crate::ports::types::{CompanyEvent, CompanyId, EventSeq, InboundMessage, Out
 /// The channel id of the always-present operator surface.
 pub const OPERATOR_CHANNEL: &str = "operator";
 
+/// Whether a channel with this id may be named as the target of an `output`
+/// node's `channel` delivery destination.
+///
+/// The operator channel is the single exclusion, and it is deliberate:
+/// [`OperatorChannel`] is an in-memory response spy with no durable reader.
+/// Interactive chat journals its own replies after the cycle, but a workflow
+/// report posted here reaches nobody — accepting it would report a successful
+/// discard. Everything else that is wired (desk channels, provider channels) is
+/// a real write path.
+///
+/// Issue #981: this is the one place the rule is stated. It previously lived as
+/// an inline `!=` where the builder assembles the delivery deps, as a `by name`
+/// refusal in [`crate::workflows::delivery`], and as a prose sentence in the
+/// accessor the console's destination picker reads — and that third copy said
+/// the opposite, so the picker offered authors the one target guaranteed to
+/// fail. Call this instead of re-deciding.
+pub fn is_deliverable_channel(channel_id: &str) -> bool {
+    channel_id != OPERATOR_CHANNEL
+}
+
+/// The operator-readable sentence for a `channel` destination that names
+/// something outside the deliverable set, built from the set that is live right
+/// now so the fix is legible without a second lookup.
+///
+/// Shared by the delivery-time refusal and the save-time rejection (issue
+/// #981), so an author who trips the guard at save and an author who reads a
+/// failed delivery row are told the same thing about the same runtime.
+pub fn undeliverable_channel_message(target: &str, deliverable: &[&str]) -> String {
+    let has = if deliverable.is_empty() {
+        "no durable channels".to_string()
+    } else {
+        deliverable.join(", ")
+    };
+    format!("`{target}` is not a workflow delivery channel — this runtime has: {has}")
+}
+
 /// A desk-backed [`ChannelAdapter`]. Sending appends an agent reply to the
 /// company's durable event log, which is the existing read path for desk chat
 /// history. The adapter is deliberately one-per-desk so channel lookup and
@@ -184,6 +220,35 @@ impl ChannelAdapter for RecordingChannel {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    /// The operator channel is excluded from workflow delivery, and every other
+    /// wired id is not. The rule reads the same for a desk, a provider channel
+    /// and an id nobody wired — deliverability is about `operator`, not about
+    /// whether the caller has already checked the adapter exists.
+    #[test]
+    fn only_the_operator_channel_is_undeliverable() {
+        assert!(!is_deliverable_channel(OPERATOR_CHANNEL));
+        assert!(is_deliverable_channel("engineering"));
+        assert!(is_deliverable_channel("email"));
+        assert!(is_deliverable_channel("Operator"));
+    }
+
+    /// The shared refusal sentence names what IS deliverable, and says so
+    /// plainly when the answer is nothing — a desk-less company is a legitimate
+    /// state (issue #963), not a malformed one, so the empty case gets a
+    /// sentence rather than a dangling `has: `.
+    #[test]
+    fn the_refusal_sentence_names_the_live_set() {
+        let message = undeliverable_channel_message("operator", &["engineering", "product"]);
+        assert!(message.contains("`operator` is not a workflow delivery channel"));
+        assert!(message.ends_with("this runtime has: engineering, product"));
+
+        let empty = undeliverable_channel_message("engineering", &[]);
+        assert!(
+            empty.ends_with("this runtime has: no durable channels"),
+            "{empty}"
+        );
+    }
 
     #[tokio::test]
     async fn buffers_sent_messages() {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -120,7 +120,10 @@ pub mod workspace_quota;
 pub use advance::{SYSTEM_ATTRIBUTION, advance_settled_card, append_result};
 pub use board_events::{BoardAnnouncer, CHANGE_OPENED, CHANGE_REMOVED, CHANGE_UPDATED};
 pub use builder::{RuntimeBuilder, company_id_from_name};
-pub use channel::{DeskChannel, OPERATOR_CHANNEL, OperatorChannel};
+pub use channel::{
+    DeskChannel, OPERATOR_CHANNEL, OperatorChannel, is_deliverable_channel,
+    undeliverable_channel_message,
+};
 pub use cron::{CivilTime, CronExpr};
 pub use cycle::CycleRunner;
 pub use derived_guard::DerivedGuardWorkspace;

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -2082,22 +2082,29 @@ async fn workflow_tool_slugs(
 }
 
 /// The `GET …/workflows/wired-channels` answer (issue #813): the chat channel
-/// ids this running company can deliver to, so the output-node destination
-/// editor offers a picker of real targets. `operator` is always present. Not
-/// feature-gated — the wired-channel set exists on every build.
+/// ids this running company can actually deliver to, so the output-node
+/// destination editor offers a picker of real targets. Not feature-gated — the
+/// channel set exists on every build.
+///
+/// **`operator` is not among them** (issue #981). This used to say the opposite
+/// and serve the unfiltered adapter list, which offered authors the one target
+/// workflow delivery refuses by name. An empty list is a truthful answer for a
+/// company with no desks and no provider channels: there is nowhere to deliver.
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct WiredChannelsResponse {
-    /// The channel ids an `output` node's `channel` destination may target;
-    /// anything else fails at delivery with `ChannelNotWired`.
+    /// The channel ids an `output` node's `channel` destination may target.
+    /// Anything else is rejected when the workflow is saved, and — for a graph
+    /// saved before the desk went away — fails at delivery with
+    /// `ChannelNotWired`.
     channels: Vec<String>,
 }
 
 /// `GET …/workflows/wired-channels` (both scope forms). Reads the running
-/// company's wired channels directly — infallible, no record load needed.
+/// company's deliverable channels directly — infallible, no record load needed.
 async fn workflow_wired_channels(company: ScopedCompany) -> Json<WiredChannelsResponse> {
     Json(WiredChannelsResponse {
-        channels: company.runtime.wired_channel_ids(),
+        channels: company.runtime.deliverable_channel_ids(),
     })
 }
 

--- a/src/server/ops/workflows.rs
+++ b/src/server/ops/workflows.rs
@@ -678,6 +678,54 @@ impl TryFrom<CreateWorkflowBody> for RawWorkflow {
     }
 }
 
+/// Rejects a draft whose `output` node routes its report to a channel this
+/// runtime cannot deliver to (issue #981).
+///
+/// The delivery layer already refuses such a target at run time with a
+/// `ChannelNotWired` row, and that row stays — desks come and go, so a graph
+/// valid at save can be invalid at run, and this is a guard rather than a
+/// guarantee. What it removes is the case the QA pass found: a workflow saved
+/// against `operator`, which delivery refuses **by name** on every runtime and
+/// so can never succeed, discovered only after a scheduled run nobody watched
+/// silently dropped its report.
+///
+/// Both write routes run it, from the same set the destination picker is served
+/// from and with the same sentence the failed delivery would have carried, so
+/// an author who trips it is told what a run would have told them.
+///
+/// Deliberately narrow. A missing target, a `destination` on a non-`output`
+/// node and an unknown `kind` are [`parse_workflow`](crate::company::parse_workflow)'s
+/// to report — it says something more specific about each, and reporting the
+/// wrong problem first is worse than reporting it second. This is also NOT run
+/// at TOML parse time: seed templates are parsed with no runtime in hand, and
+/// checking there would refuse to boot a template on a company whose desks are
+/// not resolved yet.
+fn reject_undeliverable_channel_destinations(
+    company: &ScopedCompany,
+    draft: &RawWorkflow,
+) -> Result<(), ApiError> {
+    let deliverable = company.runtime.deliverable_channel_ids();
+    for node in &draft.nodes {
+        let Some(destination) = &node.destination else {
+            continue;
+        };
+        if destination.kind.trim() != "channel" || node.kind.trim() != "output" {
+            continue;
+        }
+        let target = destination.target.as_deref().map(str::trim).unwrap_or("");
+        if target.is_empty() || deliverable.iter().any(|id| id == target) {
+            continue;
+        }
+        let live: Vec<&str> = deliverable.iter().map(String::as_str).collect();
+        return Err(ApiError(OpenCompanyError::InvalidRequest(format!(
+            "node `{}`: {}",
+            node.id,
+            crate::runtime::undeliverable_channel_message(target, &live)
+        ))));
+    }
+    Ok(())
+}
+
 /// `POST …/workflows` — authors a new workflow graph (issues #69, #112, #168):
 /// the console's form creator, or any direct API caller, posts the graph shape
 /// and it is persisted on the company record.
@@ -697,6 +745,7 @@ async fn create_workflow(
     Json(body): Json<CreateWorkflowBody>,
 ) -> Result<Json<WorkflowGraph>, ApiError> {
     let draft = RawWorkflow::try_from(body)?;
+    reject_undeliverable_channel_destinations(&company, &draft)?;
     let file = create_company_workflow(
         company.id(),
         company.runtime.source_dir(),
@@ -789,6 +838,7 @@ async fn update_workflow(
 
     let expected = body.expected_version.clone();
     let draft = RawWorkflow::try_from(body.graph)?;
+    reject_undeliverable_channel_destinations(&company, &draft)?;
     let file = update_company_workflow(
         company.id(),
         company.runtime.source_dir(),
@@ -3545,6 +3595,252 @@ mod tests {
             let graph = json_body(response).await;
             assert_eq!(graph["id"], "greeter");
             assert_eq!(graph["edges"][0]["label"], "ok");
+        }
+
+        // --- Save-time channel-destination guard (issue #981) ---------------
+
+        /// A hosted tenant WITH a desk, so it has one real delivery channel.
+        /// `hosted_state`'s manifest declares none, which makes its deliverable
+        /// set empty — fine for the nowhere-to-deliver case below, useless for
+        /// telling an accepted target from a refused one.
+        fn desk_manifest() -> CompanyManifest {
+            toml::from_str(
+                "[company]\nname = \"Acme\"\n[policy]\nmode = \"full\"\n\
+                 [[agent]]\nid = \"ceo\"\nrole = \"Chief\"\n\
+                 [[group_chat]]\nid = \"engineering\"\nname = \"Engineering\"\nmembers = [\"ceo\"]\n",
+            )
+            .unwrap()
+        }
+
+        /// `hosted_state` over [`desk_manifest`] — a running company whose
+        /// deliverable set is exactly `["engineering"]`.
+        async fn desk_state(home: &std::path::Path) -> AppState {
+            let store = FsCompanyStore::new(home.to_path_buf());
+            let id = CompanyId::new("acme");
+            store
+                .save(&CompanyRecord {
+                    id: id.clone(),
+                    manifest: desk_manifest(),
+                    ledger: Vec::new(),
+                    lifecycle: "running".to_string(),
+                    overlay_agents: Vec::new(),
+                    overlay_desk_members: Vec::new(),
+                    overlay_desk_order: Vec::new(),
+                    overlay_desks: Vec::new(),
+                    overlay_workflows: Vec::new(),
+                    overlay_budgets: Vec::new(),
+                    overlay_policy: None,
+                    overlay_desk_tools: Default::default(),
+                    disabled_workflows: Vec::new(),
+                    template_provenance: None,
+                })
+                .await
+                .unwrap();
+            let runtime = RuntimeBuilder::new(home.to_path_buf(), desk_manifest())
+                .with_id(id.clone())
+                .build()
+                .await
+                .unwrap();
+            assert_eq!(
+                runtime.deliverable_channel_ids(),
+                vec!["engineering".to_string()],
+                "the fixture must have exactly one delivery channel, or these tests prove nothing"
+            );
+            let state = AppState::new(AppConfig::default());
+            state
+                .registry()
+                .insert(id.clone(), std::sync::Arc::new(runtime));
+            crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+            state
+        }
+
+        /// [`create_body`] with the output node routing its report to `target`
+        /// on `kind`.
+        fn body_with_destination(kind: &str, target: Option<&str>) -> serde_json::Value {
+            let mut destination = serde_json::json!({ "kind": kind });
+            if let Some(target) = target {
+                destination["target"] = serde_json::Value::String(target.to_string());
+            }
+            let mut body = create_body();
+            body["nodes"][1]["destination"] = destination;
+            body
+        }
+
+        async fn post_create(state: AppState, body: serde_json::Value) -> axum::response::Response {
+            router(state)
+                .oneshot(request("POST", "/api/v1/company/workflows", Some(body)))
+                .await
+                .unwrap()
+        }
+
+        /// **The #981 regression.** `operator` was in the picker the console
+        /// showed the author, and delivery refuses it by name on every runtime —
+        /// so the graph saved, ran green, and dropped its report. It is now
+        /// refused at save, naming the channels that would work.
+        #[tokio::test]
+        async fn a_report_routed_to_operator_is_refused_at_save() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            let response =
+                post_create(state, body_with_destination("channel", Some("operator"))).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let message = json_body(response).await.to_string();
+            assert!(
+                message.contains("is not a workflow delivery channel"),
+                "{message}"
+            );
+            // The live set, so the fix is legible from the refusal alone.
+            assert!(message.contains("engineering"), "{message}");
+            assert!(
+                message.contains("done"),
+                "the refusal must name the node: {message}"
+            );
+        }
+
+        /// A channel nobody wired is refused the same way. The author's typo and
+        /// the author's `operator` are the same mistake — a destination this
+        /// company cannot deliver to — and get one answer.
+        #[tokio::test]
+        async fn a_report_routed_to_an_unwired_channel_is_refused_at_save() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            let response =
+                post_create(state, body_with_destination("channel", Some("enginering"))).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let message = json_body(response).await.to_string();
+            assert!(
+                message.contains("is not a workflow delivery channel"),
+                "{message}"
+            );
+            assert!(message.contains("engineering"), "{message}");
+        }
+
+        /// The guard refuses what delivery would refuse and nothing more: a real
+        /// desk saves, and reads back with its destination intact.
+        #[tokio::test]
+        async fn a_report_routed_to_a_real_desk_saves() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            let response = post_create(
+                state.clone(),
+                body_with_destination("channel", Some("engineering")),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::OK);
+
+            let response = router(state)
+                .oneshot(request("GET", "/api/v1/company/workflows/greeter", None))
+                .await
+                .unwrap();
+            let graph = json_body(response).await;
+            assert_eq!(graph["nodes"][1]["destination"]["kind"], "channel");
+            assert_eq!(graph["nodes"][1]["destination"]["target"], "engineering");
+        }
+
+        /// An edit is a save too. The create route was never the only way in —
+        /// `PUT` replaces the graph wholesale, so a destination refused on
+        /// create must not be reachable by saving a clean graph and then
+        /// editing it.
+        #[tokio::test]
+        async fn an_edit_cannot_introduce_an_undeliverable_destination() {
+            let home_dir = home();
+            let state = desk_state(home_dir.path()).await;
+
+            assert_eq!(
+                post_create(state.clone(), create_body()).await.status(),
+                StatusCode::OK
+            );
+
+            let response = router(state)
+                .oneshot(request(
+                    "PUT",
+                    "/api/v1/company/workflows/greeter",
+                    Some(body_with_destination("channel", Some("operator"))),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let message = json_body(response).await.to_string();
+            assert!(
+                message.contains("is not a workflow delivery channel"),
+                "{message}"
+            );
+        }
+
+        /// A company with no desks and no provider channels has nowhere to
+        /// deliver (#963), and says so in its own words rather than trailing off
+        /// after `has: `. The destinations that do NOT depend on a channel still
+        /// save — the guard is about channels, and a company with no desks can
+        /// still mail its owner.
+        #[tokio::test]
+        async fn a_company_with_no_delivery_channel_says_so_and_still_saves_an_owner_report() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            let response = post_create(
+                state.clone(),
+                body_with_destination("channel", Some("engineering")),
+            )
+            .await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let message = json_body(response).await.to_string();
+            assert!(message.contains("no durable channels"), "{message}");
+
+            // …and the picker it was offered is empty, not `["operator"]`.
+            let response = router(state.clone())
+                .oneshot(request(
+                    "GET",
+                    "/api/v1/company/workflows/wired-channels",
+                    None,
+                ))
+                .await
+                .unwrap();
+            assert_eq!(json_body(response).await["channels"], serde_json::json!([]));
+
+            let response = post_create(state, body_with_destination("owner", None)).await;
+            assert_eq!(
+                response.status(),
+                StatusCode::OK,
+                "an `owner` report needs no channel"
+            );
+        }
+
+        /// The guard stays out of everything that is not a channel destination
+        /// on an `output` node: a graph that routes nowhere saves, and a
+        /// `destination` on a non-`output` node is still `parse_workflow`'s
+        /// refusal to report — reporting the wrong problem first would send an
+        /// author looking for a channel that was never their mistake (#947).
+        #[tokio::test]
+        async fn the_guard_leaves_non_channel_graphs_alone() {
+            let home_dir = home();
+            let home = home_dir.path().to_path_buf();
+            let (state, _store, _id) = hosted_state(&home).await;
+
+            // No destination at all: unchanged, saves.
+            assert_eq!(
+                post_create(state.clone(), create_body()).await.status(),
+                StatusCode::OK
+            );
+
+            // A channel destination on the TRIGGER node, on a company with no
+            // delivery channels at all: still rejected for being on the wrong
+            // kind of node, not for the channel.
+            let mut body = create_body();
+            body["id"] = serde_json::Value::String("second".into());
+            body["name"] = serde_json::Value::String("Second".into());
+            body["nodes"][0]["destination"] =
+                serde_json::json!({ "kind": "channel", "target": "engineering" });
+            let response = post_create(state, body).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            let message = json_body(response).await.to_string();
+            assert!(
+                message.contains("only `output` nodes route a report"),
+                "the structural problem must be the one reported: {message}"
+            );
         }
 
         /// A duplicate id is a clean 409, not a 500 — the id-uniqueness check

--- a/src/workflows/delivery.rs
+++ b/src/workflows/delivery.rs
@@ -1291,24 +1291,20 @@ async fn post_to_channel(
     // The built-in operator adapter is an in-memory response spy, not a
     // durable delivery surface. Interactive chat journals its own replies
     // after the cycle; workflow delivery has no such reader, so naming
-    // `operator` must fail rather than report a successful discard.
-    if channel_id == crate::runtime::channel::OPERATOR_CHANNEL {
-        let wired: Vec<&str> = delivery
+    // `operator` must fail rather than report a successful discard. The rule
+    // and this sentence both live beside the operator-channel constant (issue
+    // #981) — the save-time guard on the write routes reads the same two, so a
+    // destination this refuses is one the author was never offered.
+    if !crate::runtime::channel::is_deliverable_channel(channel_id) {
+        let deliverable: Vec<&str> = delivery
             .channels
             .iter()
-            .filter(|channel| channel.channel_id() != crate::runtime::channel::OPERATOR_CHANNEL)
             .map(|channel| channel.channel_id())
+            .filter(|id| crate::runtime::channel::is_deliverable_channel(id))
             .collect();
         return Err((
             DeliveryReason::ChannelNotWired,
-            format!(
-                "`{channel_id}` is not a workflow delivery channel — this runtime has: {}",
-                if wired.is_empty() {
-                    "no durable channels".to_string()
-                } else {
-                    wired.join(", ")
-                }
-            ),
+            crate::runtime::channel::undeliverable_channel_message(channel_id, &deliverable),
         ));
     }
     let Some(adapter) = delivery


### PR DESCRIPTION
## Summary

Three surfaces disagreed about which channels a workflow may deliver to. The runtime advertised every adapter — documenting that `operator` "is always present" — while the builder stripped `operator` from the delivery deps and the delivery layer refused it by name. So the destination picker, and the console editor reading it, offered authors the one target guaranteed to fail.

That is exactly what smoke1 was doing: `daily-release-readiness` finished with every node `ok` and its report undelivered, `target: "operator"`, `reason: "channel-not-wired"`.

This is **PR-1 of two**. It unifies the channel set and refuses a bad destination while the author can still act on it. The run-verdict half — so a dropped report stops reading as a green run — is PR-2 and is deliberately not here.

## Approach

The exclusion rule now exists **once**, beside `OPERATOR_CHANNEL`, with its reason attached: the operator adapter is an in-memory response spy with no durable reader, so accepting it would report a successful discard. The builder, the picker and the delivery layer all read that one function, and a shared `undeliverable_channel_message` makes the save-time rejection and the delivery-time detail literally the same sentence.

`wired_channel_ids` is renamed `deliverable_channel_ids` rather than patched in place — the old name is what made the mistake plausible, and forcing every call site to be re-read is the point. Its doc comment claimed `operator` is always present (false) and never mentioned desks, which is where the real channels come from; both are corrected.

## API Or Behavior Changes

- `GET .../workflows/tool-slugs` destination picker no longer offers `operator`. A desk-less company now legitimately returns an **empty** set; the console keeps its free-text fallback and now says why the list is empty.
- `POST`/`PUT` workflow save returns `InvalidRequest` when an `output` node's channel destination names a target outside the deliverable set. Empty targets, non-`output` nodes and non-`channel` kinds are skipped so the existing parser still reports the more specific problem first.
- No change to `nodes[].status`, the run `error` field, or `DeliveryReason`. The run-time `ChannelNotWired` row is byte-identical and stays as the backstop — desks come and go, so a graph valid at save can still be invalid at run. This does not eliminate that failure and does not claim to.

## Tests

Every new assertion was proven to fail with only the fix reverted, tests untouched:

- Dropping the filter from `deliverable_channel_ids` → 6 fail, including the invariant pin reporting the exact #981 divergence: `left: ["operator", "engineering"] / right: ["engineering"]`.
- Removing both guard call sites → exactly the 4 guard tests fail (400 expected, 200 received), while `a_report_routed_to_a_real_desk_saves` and `the_guard_leaves_non_channel_graphs_alone` stay green — so the no-over-reach tests are not passing for the wrong reason.
- Restoring the old console wording → the parity test fails on drift. That test `include_str!`s the dialog, so the editor and the host cannot be reworded independently again.

The invariant pin is the one that would have caught this originally: the picker's set must equal the channel ids in the `WorkflowDeliveryDeps` the same builder produced.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings`, plus the gated lane with `--no-deps --features openhuman,tinycortex`
- [x] `cargo build --all-targets`
- [x] `cargo test --locked` — 2778 passed; gated `--features openhuman,tinycortex --tests` — 4219 passed
- [x] `npm run typecheck` / `:unit` / `:e2e` / `npm run build`

The gated lane matters here: the invariant pin is `#[cfg(feature = "openhuman")]`, because only that arm wires `WorkflowDeliveryDeps` at all.

## Documentation

Doc comments corrected where they stated the falsehood that caused this — `deliverable_channel_ids`, the picker response, and the console api types. No spec file needed changing.

## Known gaps, stated rather than left to be found

- The orchestrator's `create_workflow` tool calls the store helper directly rather than the HTTP route, so the save-time guard does not cover that path. Delivery-time refusal still does.
- `check_workflow` in the copilot was investigated and dropped: its context carries no runtime handle and therefore no channel list. `gather_company_evidence` does take the runtime, so threading the set in is possible as a follow-up.
- Seed TOML parsing is deliberately untouched — validating there would refuse to boot a template on a runtime whose desks are not yet resolved (#947 / #963).

Part of #981

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workflow channel destinations now show only channels capable of receiving workflow output.
  - Channel discovery includes supported desk and connected provider channels while excluding the operator surface.
  - When no channels are available, the destination field remains available for manual entry with guidance.

- **Bug Fixes**
  - Invalid channel targets are rejected when workflows are saved or updated.
  - Delivery errors now clearly identify the invalid target and available channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->