### PR TITLE
feat(harness): say when a turn paused at its step limit (#926)

### DIFF
--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -196,6 +196,31 @@ An empty or whitespace-only document is dropped rather than rendered as a bare
 heading. An empty section reads to the model as a source that exists and says
 nothing, which is worse than its absence.
 
+## The step budget, and what a paused turn looks like
+
+A single turn may make at most a fixed number of tool iterations — the
+`max_tool_iterations` an agent is built with, which today is the vendored
+runtime's default of 10. Reaching it is **a pause, not a failure**: the runtime
+stops the tool loop, asks the model once more (with tools withheld) for a
+resumable "Done so far / Next steps" checkpoint, and returns that as an ordinary
+successful reply. There is no error to catch and no error to match on, which is
+precisely why a capped turn used to be invisible — the operator read a tidy plan
+with no deliverable behind it and no way to tell the agent had been cut off
+mid-task. So the harness now reads the runtime's cap flag while the turn's agent
+lock is still held and carries it out on the turn's outcome, OR'd across every
+turn behind one operator bubble (the responder, any desk lead it handed work to,
+and the relay turn that folds their answers back together). When any of them
+paused, the operator gets a **second, unauthored bubble** after the reply saying
+the turn stopped at its step limit, that nothing errored, and that replying
+"continue" asks the agent to pick up from there. It is a separate bubble rather
+than an addition to the reply because the reply — and only the reply — is
+written back to the context store as memory; appending would file the platform's
+notice as something the agent said and recall it into later turns. The cap
+itself is unchanged by this: the turn stops in the same place, it just says so.
+See `src/harness/mod.rs` (`TurnOutcome::hit_iteration_cap`),
+`src/runtime/delegation.rs` for the fold, and `src/harness/brain.rs` for the
+notice.
+
 ## `classes`
 
 The explicit epistemic classification

--- a/src/harness/acp_run_turn.rs
+++ b/src/harness/acp_run_turn.rs
@@ -199,7 +199,14 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         }
     }
 
-    TurnOutcome { reply, steps }
+    TurnOutcome {
+        reply,
+        steps,
+        // Issue #926: an ACP turn runs behind an external agent process, whose
+        // protocol carries no iteration-cap signal — there is nothing to read,
+        // and inventing `true` here would label every ACP reply a pause.
+        hit_iteration_cap: false,
+    }
 }
 
 #[async_trait]

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -60,6 +60,29 @@ const NO_TASK_STORE: &str = "this company has no task board wired, so the card c
 /// time the cycle reaches it (deleted, or never persisted).
 const CARD_VANISHED: &str = "the card was gone by the time its dispatch ran";
 
+/// The system bubble appended when a turn paused at its tool-iteration cap
+/// (issue #926).
+///
+/// Three things it must say, and one it must not:
+///
+/// - **It paused** — the reply above is a checkpoint, so it reads like a plan
+///   the agent simply chose not to carry out. QA reported this as agents
+///   "getting permanently stuck mid-task", which is what an unexplained pause
+///   looks like from the outside.
+/// - **Nothing failed** — a cap is a budget, not an error. Without saying so,
+///   the notice reads as a crash report for a turn that worked fine.
+/// - **How to carry on** — the operator's move is to reply.
+///
+/// What it must NOT do is promise the agent resumes where it left off. The
+/// pooled `Agent` keeps its history in memory, and `HarnessPool::ensure`
+/// rebuilds the agent whenever the roster / skill / MCP fingerprint moves — so
+/// "continue" is an instruction to the operator, phrased as a request to the
+/// agent, never a durability guarantee this layer cannot make.
+pub(crate) const ITERATION_CAP_PAUSE_NOTICE: &str = "\
+The reply above is a pause, not a finished answer: this turn reached the maximum number of steps \
+it may take for a single reply, so it stopped and wrote up where it had got to. Nothing errored — \
+the work so far stands. Reply \"continue\" to ask it to pick up from there.";
+
 use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
@@ -2716,6 +2739,35 @@ impl HarnessBrain {
                         reply_to: None,
                         steps: operator_steps,
                     });
+                    // Issue #926: a turn that paused at its step cap says so,
+                    // in its own bubble.
+                    //
+                    // A SIBLING bubble rather than text appended to the reply,
+                    // for the reason the approval-overflow notice below gives:
+                    // the reply is the agent's answer and this is the system
+                    // saying the agent was cut off. Here that separation is
+                    // load-bearing rather than tidy — `HarnessPool::run`
+                    // persists `outcome.reply` to the context store, so
+                    // appending would write "you hit the step limit" into
+                    // memory and recall it as something the agent said in a
+                    // later turn.
+                    //
+                    // Unauthored (`agent: None`) for the same reason: no
+                    // teammate said this, and attributing it to the responder
+                    // would put the platform's words in its mouth. Empty steps
+                    // — the turn's timeline is already on the bubble above, and
+                    // repeating it would double every row in the console.
+                    if turn.hit_iteration_cap {
+                        channel_responses.push(OutboundMessage {
+                            message_id: None,
+                            task_id: None,
+                            channel: "operator".to_string(),
+                            agent: None,
+                            text: ITERATION_CAP_PAUSE_NOTICE.to_string(),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        });
+                    }
                     channel_responses.extend(turn.bubbles);
                 }
                 CompanyEvent::TaskDispatched { task_id, run_id } => {

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -1,0 +1,606 @@
+//! Issue #926: end-to-end proof that a turn which runs out of tool iterations
+//! **says so** — and that the way it says so cannot poison the next turn.
+//!
+//! The bug this pins is a silence, which is why nothing shorter than a real
+//! turn loop can show it. Hitting the cap is not an error and never surfaces as
+//! one: openhuman stops the tool loop, makes one extra tools-disabled call
+//! asking the model for a resumable "Done so far / Next steps" checkpoint, and
+//! returns that as an ordinary `Ok(reply)`. So the operator receives a tidy
+//! plan, no deliverable, and nothing anywhere saying the turn was cut off —
+//! reported by QA as agents "getting permanently stuck mid-task".
+//!
+//! [`MockProvider`](crate::harness::provider::MockProvider) cannot reach this:
+//! it never issues a tool call, so it can never reach an iteration cap. The
+//! lever is the same loopback OpenAI-compatible endpoint
+//! [`publish_turn_test`](crate::harness::publish_turn_test) uses — a real
+//! [`HostedProvider`], real `build_agent`, real tool dispatch, real pool, real
+//! brain. Only the model's *choices* are scripted.
+//!
+//! What each test is for:
+//!
+//! - the flag is `true` on a capped turn, and — the negative control that stops
+//!   a hardcoded `true` passing — `false` on a turn that simply finishes;
+//! - a capped turn is still `Ok` with a non-empty reply, pinning "a cap is a
+//!   pause, not an error" so a future reader does not go looking for an error
+//!   arm to match on;
+//! - the brain emits the pause as a **second** bubble;
+//! - and the memory the turn writes back carries the agent's checkpoint but
+//!   **not** the platform's notice.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::brain::ITERATION_CAP_PAUSE_NOTICE;
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::memory_loop;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+use crate::ports::ContextStore;
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::types::{
+    ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
+    Effect, EffectDisposition, OutboundMessage, ToolCall, ToolResult,
+};
+use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+/// The agent every test here talks to.
+const AGENT: &str = "ceo";
+
+/// The tool-iteration cap a turn actually runs under.
+///
+/// `build_agent` never calls `.config(...)`, so the agent falls back to
+/// openhuman's `AgentConfig::default()`, whose `max_tool_iterations` is 10
+/// (`config/schema/agent.rs`, `default_agent_max_tool_iterations`).
+///
+/// Hardcoding it is deliberate and it is checked, not assumed: the scripts
+/// below depend on knowing exactly which model call is the wrap-up, and
+/// [`capped_script`] asserts the observed call count matches. If a vendor bump
+/// or a `.config(...)` call moves the cap, these tests fail with a message that
+/// says the cap moved — rather than silently scripting the wrong turn shape and
+/// passing for the wrong reason.
+const CAP: usize = 10;
+
+/// The checkpoint the scripted model writes when it is asked to wrap up.
+///
+/// Distinctive so the memory assertion can look for the agent's words rather
+/// than for "some text landed".
+const CHECKPOINT: &str = "Done so far: read the standards and the prior spec. \
+Next steps: draft the spec and publish it.";
+
+/// A slice of [`ITERATION_CAP_PAUSE_NOTICE`] unique to the platform's voice.
+///
+/// Used to prove the notice is *absent* from memory. A substring rather than
+/// the whole notice because an absence assertion on the full string would pass
+/// the moment the wording changed by a comma.
+const NOTICE_MARKER: &str = "pause, not a finished answer";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+/// What the scripted model does on each successive call.
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Emit a native tool call with these literal arguments.
+    Call { tool: String, args: Value },
+    /// Finish with plain assistant text.
+    Say(String),
+}
+
+/// A scripted OpenAI-compatible `/chat/completions` endpoint.
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    /// Every request body the harness sent, for post-hoc assertions.
+    seen: Mutex<Vec<Value>>,
+}
+
+impl Script {
+    /// How many model calls the turn actually made.
+    fn calls(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+
+    /// Whether the wrap-up call was made with tools **withheld** — the tell that
+    /// openhuman took the cap branch rather than simply running out of script.
+    fn last_call_had_tools(&self) -> bool {
+        self.seen
+            .lock()
+            .unwrap()
+            .last()
+            .and_then(|body| body.get("tools").and_then(Value::as_array).cloned())
+            .is_some_and(|tools| !tools.is_empty())
+    }
+}
+
+/// Serve the script on loopback and return its base URL plus the shared handle.
+async fn spawn_script(turns: Vec<Turn>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                // Running off the end means the turn looped more than the
+                // script expected. End it with text rather than hanging — the
+                // call-count assertions are what report the mismatch.
+                let next = next.unwrap_or_else(|| Turn::Say("done".to_string()));
+                let message = match next {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(&tool, &args),
+                };
+                (
+                    axum::http::StatusCode::OK,
+                    Json(json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    })),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+/// One assistant message carrying a native `tool_calls` array — the shape the
+/// provider's `tool_calling: true` profile puts the turn loop on.
+fn tool_call_message(tool: &str, args: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{
+            "id": format!("call-{tool}"),
+            "type": "function",
+            "function": { "name": tool, "arguments": args.to_string() }
+        }]
+    })
+}
+
+/// One successful `file_write`.
+///
+/// A **distinct path and body per step** on purpose: the tool has to succeed
+/// every time, or openhuman's repeated-failure breaker halts the run — and a
+/// breaker halt is explicitly *not* a cap hit, so the test would prove nothing.
+/// Distinct arguments also keep any no-progress heuristic from reading ten
+/// identical calls as a loop.
+fn step(n: usize) -> Turn {
+    Turn::Call {
+        tool: "file_write".to_string(),
+        args: json!({ "path": format!("step-{n}.md"), "content": format!("step {n}") }),
+    }
+}
+
+/// A script that reaches the cap: exactly [`CAP`] tool round trips, then the
+/// checkpoint the tools-disabled wrap-up call asks for.
+///
+/// The wrap-up is what makes the `Say` land where it does — at call `CAP + 1`,
+/// after the loop has already paused.
+fn capped_script() -> Vec<Turn> {
+    let mut turns: Vec<Turn> = (1..=CAP).map(step).collect();
+    turns.push(Turn::Say(CHECKPOINT.to_string()));
+    turns
+}
+
+/// A script that finishes normally, well inside the cap — the negative control.
+fn uncapped_script() -> Vec<Turn> {
+    vec![step(1), step(2), Turn::Say(CHECKPOINT.to_string())]
+}
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+/// An inert `CycleHost` — these tests are about the turn, not the effect gate.
+struct NoopHost;
+
+#[async_trait]
+impl CycleHost for NoopHost {
+    async fn call_tool(&self, _call: ToolCall) -> crate::Result<ToolResult> {
+        Ok(ToolResult {
+            ok: true,
+            output: Value::Null,
+        })
+    }
+    async fn context_op(&self, _op: ContextOp) -> crate::Result<ContextOpResult> {
+        Ok(ContextOpResult::Text(String::new()))
+    }
+    async fn emit_effect(&self, _effect: Effect) -> crate::Result<EffectDisposition> {
+        Ok(EffectDisposition::Executed)
+    }
+    async fn park_effect(&self, _effect: Effect) -> crate::Result<ApprovalId> {
+        Ok(ApprovalId::new("appr-parked"))
+    }
+}
+
+fn company() -> CompanyId {
+    CompanyId::new("acme")
+}
+
+/// A one-agent company on `full` policy, so an ordinary turn is not parked for
+/// approval — the gate under test is the iteration cap, not the approval one.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["*"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        id: company(),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        overlay_desk_tools: Default::default(),
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Real deps pointed at the scripted endpoint, with a workspace on disk so
+/// `file_write` genuinely succeeds.
+fn deps_for(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc<FsOps>) {
+    let ops = Arc::new(FsOps::new(dir));
+    let deps = HarnessDeps {
+        ledgers: None,
+        ledger_registry: Default::default(),
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: Some(ops.clone()),
+        workspace_root: dir.to_path_buf(),
+        workspace_git_enabled: false,
+        audit_root: dir.to_path_buf(),
+        model_override: Some("stub-model".to_string()),
+        tasks: Some(ops.clone()),
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: Arc::from([]),
+        default_mcp_servers: Vec::new(),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
+        run_outputs: Default::default(),
+        run_output_store: None,
+        workflow_revisions: None,
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        #[cfg(feature = "chargebee")]
+        chargebee: None,
+        #[cfg(feature = "paypal")]
+        paypal: None,
+        hosting: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        workspace: None,
+        repos: None,
+        repo_bindings: Vec::new(),
+        checkouts: crate::harness::repo::CheckoutLedger::default(),
+        search: None,
+    };
+    (deps, ops)
+}
+
+/// An operator message, the shape a chat turn arrives as.
+fn chat(text: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+/// Everything the turn wrote back to memory, newest-agnostic.
+async fn memory_bodies(context: &FsContextStore) -> Vec<String> {
+    let metas = context
+        .list(&company(), memory_loop::OUTCOME_LABEL_PREFIX)
+        .await
+        .expect("list memory");
+    let mut bodies = Vec::new();
+    for meta in metas {
+        bodies.push(
+            context
+                .peek(&company(), &meta.addr, None)
+                .await
+                .expect("peek memory"),
+        );
+    }
+    bodies
+}
+
+/// The operator-channel bubbles a cycle produced.
+fn operator_bubbles(responses: &[OutboundMessage]) -> Vec<&OutboundMessage> {
+    responses
+        .iter()
+        .filter(|m| m.channel == "operator")
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The flag
+// ---------------------------------------------------------------------------
+
+/// **The headline.** A turn that spends its whole iteration budget on tool
+/// calls reports that it paused — and still comes back `Ok` with the
+/// checkpoint, because a cap is a pause and not an error.
+///
+/// Three assertions in one test on purpose: they are three readings of the same
+/// single turn, and splitting them would run the same eleven-call loop three
+/// times to learn nothing more.
+#[tokio::test]
+async fn a_turn_that_exhausts_its_iteration_budget_reports_the_pause() {
+    let (base_url, script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record();
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("a cap is a pause, not an error — the turn must return Ok");
+
+    // 1. The flag the whole feature hangs on.
+    assert!(
+        outcome.hit_iteration_cap,
+        "a turn that spent all {CAP} iterations on tool calls must report the cap"
+    );
+
+    // 2. It is still an ordinary, useful reply.
+    assert!(
+        !outcome.reply.trim().is_empty(),
+        "a capped turn still carries the checkpoint openhuman asked the model for"
+    );
+    assert_eq!(
+        outcome.reply.trim(),
+        CHECKPOINT,
+        "the reply is the model's checkpoint, verbatim"
+    );
+
+    // 3. The turn shape really was the cap branch, not the script running dry.
+    //    `CAP` tool round trips plus exactly one tools-disabled wrap-up.
+    assert_eq!(
+        script.calls(),
+        CAP + 1,
+        "expected {CAP} tool iterations plus one wrap-up call; if this moved, so did \
+         openhuman's max_tool_iterations default and `CAP` needs updating"
+    );
+    assert!(
+        !script.last_call_had_tools(),
+        "the wrap-up call must withhold tools — that is what makes it a checkpoint \
+         request rather than another iteration"
+    );
+}
+
+/// **The negative control.** The same fixture, a turn that finishes on its own,
+/// and the flag stays `false`.
+///
+/// Without this, `hit_iteration_cap: true` hardcoded at the read site would
+/// pass every other test in this file.
+#[tokio::test]
+async fn a_turn_that_finishes_on_its_own_reports_no_pause() {
+    let (base_url, script) = spawn_script(uncapped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record();
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    assert!(
+        !outcome.hit_iteration_cap,
+        "two tool calls is well inside the cap — reporting a pause here would put the \
+         notice on turns that finished perfectly well"
+    );
+    assert_eq!(outcome.reply.trim(), CHECKPOINT);
+    assert!(
+        script.calls() < CAP,
+        "the control must finish inside the cap to be a control at all: {} calls",
+        script.calls()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What the operator sees
+// ---------------------------------------------------------------------------
+
+/// A capped chat turn reaches the operator as **two** bubbles: the agent's
+/// checkpoint, then the system saying it was cut off.
+///
+/// The second bubble is unauthored — no teammate said it — and carries no
+/// steps, because the timeline already rode in on the first.
+#[tokio::test]
+async fn a_capped_chat_turn_says_so_in_a_second_bubble() {
+    let (base_url, _script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        2,
+        "a capped turn owes the operator the reply AND the pause notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+
+    // The agent's answer, attributed to the agent.
+    assert_eq!(bubbles[0].text.trim(), CHECKPOINT);
+    assert_eq!(bubbles[0].agent.as_deref(), Some(AGENT));
+
+    // The system's notice, attributed to nobody.
+    assert_eq!(bubbles[1].text, ITERATION_CAP_PAUSE_NOTICE);
+    assert!(
+        bubbles[1].agent.is_none(),
+        "the platform's words must not be put in the agent's mouth"
+    );
+    assert!(
+        bubbles[1].steps.is_empty(),
+        "the timeline is already on the reply bubble; repeating it doubles every row"
+    );
+
+    // It has to actually say the three things the operator needs.
+    let notice = ITERATION_CAP_PAUSE_NOTICE;
+    assert!(notice.contains("pause"), "it must name the pause: {notice}");
+    assert!(
+        notice.contains("Nothing errored"),
+        "it must say nothing failed, or a budget reads as a crash: {notice}"
+    );
+    assert!(
+        notice.contains("continue"),
+        "it must tell the operator how to carry on: {notice}"
+    );
+}
+
+/// The same cycle, uncapped: exactly **one** bubble.
+///
+/// The pair is the real assertion — a notice that fires on every turn is as
+/// useless as one that never fires.
+#[tokio::test]
+async fn an_uncapped_chat_turn_says_nothing_extra() {
+    let (base_url, _script) = spawn_script(uncapped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        1,
+        "a turn that finished owes no pause notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+    assert!(
+        !bubbles[0].text.contains(NOTICE_MARKER),
+        "and it must not be smuggled into the reply either"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What memory keeps
+// ---------------------------------------------------------------------------
+
+/// The turn's memory write carries the agent's checkpoint and **not** the
+/// platform's notice.
+///
+/// This is why the notice is a sibling bubble rather than text appended to the
+/// reply. `HarnessPool::run` persists `outcome.reply` to the context store, so
+/// appending would file "you hit the step limit" as something the agent said —
+/// and the memory loop would recall it into a later turn as prior work.
+#[tokio::test]
+async fn the_pause_notice_never_reaches_memory() {
+    let (base_url, _script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let context = FsContextStore::new(dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bodies = memory_bodies(&context).await;
+    assert!(
+        !bodies.is_empty(),
+        "the turn must have written its outcome back, or this proves nothing"
+    );
+    assert!(
+        bodies.iter().any(|b| b.contains(CHECKPOINT)),
+        "the agent's checkpoint is what compounds into later turns: {bodies:?}"
+    );
+    assert!(
+        bodies.iter().all(|b| !b.contains(NOTICE_MARKER)),
+        "the platform's pause notice must never be recalled as something the agent \
+         said: {bodies:?}"
+    );
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -634,6 +634,25 @@ pub struct TurnOutcome {
     /// The scrubbed, folded processing steps (empty for a memory-served or
     /// tool-less turn — the zero-steps tell).
     pub steps: Vec<TurnStep>,
+    /// Whether this turn **paused at its tool-iteration cap** rather than
+    /// finishing what it set out to do (issue #926).
+    ///
+    /// A capped turn is not an error and never has been: openhuman stops the
+    /// tool loop, makes one extra tools-disabled call asking the model for a
+    /// resumable "Done so far / Next steps" checkpoint, and returns that as an
+    /// ordinary `Ok(reply)`. So the reply reads like a finished answer, and
+    /// nothing in the text, the steps or the error channel distinguishes "I
+    /// answered you" from "I ran out of steps mid-task" — which is exactly what
+    /// the operator could not tell.
+    ///
+    /// Read from openhuman's public
+    /// [`Agent::last_turn_hit_cap`](oh::agent::Agent::last_turn_hit_cap) while
+    /// the agent lock is still held, the same under-lock idiom
+    /// [`read_turn_usage`] uses. `false` on every path that returns an outcome
+    /// **without** running a model turn (the two pre-turn budget refusals, the
+    /// ACP fold) — a refusal is not a pause, and labelling one as a cap hit
+    /// would tell the operator to reply "continue" to a turn that never ran.
+    pub hit_iteration_cap: bool,
 }
 
 impl CompanyAgent {
@@ -795,12 +814,45 @@ impl CompanyAgent {
         // still runs this cleanup before propagating, so the collector never
         // leaks.
         agent.set_on_progress(None);
+        // Issue #926: read the cap flag while the lock is still held, the same
+        // under-lock idiom `read_turn_usage` uses above. Not draining, so the
+        // retry path's second attempt simply overwrites the first's value —
+        // which is right: the outcome describes the attempt that produced the
+        // reply being returned.
+        let hit_iteration_cap = agent.last_turn_hit_cap();
         drop(agent);
         let events = collector.await.unwrap_or_default();
+        // The cap openhuman was actually enforcing, for the trace only. Taken
+        // from the last `IterationStarted` rather than from config, so the log
+        // reports the number the turn ran under instead of the one this crate
+        // believes it configured. Deliberately NOT plumbed into the operator
+        // notice: one notice can cover a responder turn, a desk turn and a
+        // relay turn, and naming one of their caps would be a number the
+        // operator cannot map back to anything.
+        let iteration_cap = events.iter().rev().find_map(|event| match event {
+            oh::agent::progress::AgentProgress::IterationStarted { max_iterations, .. } => {
+                Some(*max_iterations)
+            }
+            _ => None,
+        });
+        if hit_iteration_cap {
+            tracing::info!(
+                agent = %self.agent_id,
+                iteration_cap,
+                "[turn] paused at the tool-iteration cap; the reply is a resumable checkpoint, not a finished answer"
+            );
+        }
         let steps = steps::fold_steps(events);
 
         let reply = reply?;
-        Ok((TurnOutcome { reply, steps }, usages))
+        Ok((
+            TurnOutcome {
+                reply,
+                steps,
+                hit_iteration_cap,
+            },
+            usages,
+        ))
     }
 
     /// Classify one `agent.turn` result for the retry wrapper.
@@ -1938,6 +1990,9 @@ impl HarnessPool {
                             return Some(TurnOutcome {
                                 reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
                                 steps: Vec::new(),
+                                // No model call ran, so no cap was reached
+                                // (issue #926). A refusal is not a pause.
+                                hit_iteration_cap: false,
                             });
                         }
                     }
@@ -2181,6 +2236,9 @@ impl HarnessPool {
                                 return Ok(TurnOutcome {
                                     reply: agent_budget_exhausted_notice(agent_id, cap),
                                     steps: Vec::new(),
+                                    // No model call ran, so no cap was reached
+                                    // (issue #926). A refusal is not a pause.
+                                    hit_iteration_cap: false,
                                 });
                             }
                         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -50,6 +50,11 @@ pub mod acp_run_turn;
 pub mod audit;
 pub mod brain;
 pub mod build;
+/// Issue #926: end-to-end proof that a turn which exhausts its tool-iteration
+/// budget pauses **visibly** — the flag is read, the operator gets a second
+/// bubble saying so, and the notice never reaches memory. Test-only.
+#[cfg(test)]
+mod cap_turn_test;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -300,6 +300,13 @@ pub(crate) struct DeskReply {
     pub(crate) member: String,
     pub(crate) reply: String,
     pub(crate) steps: Vec<TurnStep>,
+    /// Whether this teammate's turn — or any turn nested beneath it — paused at
+    /// its tool-iteration cap (issue #926).
+    ///
+    /// Folded the same way `reply` and `steps` are: a deeper delegate's work is
+    /// folded INTO this member's answer rather than surfacing on its own, so a
+    /// cap two levels down is a cap on what the operator reads here.
+    pub(crate) hit_iteration_cap: bool,
 }
 
 /// What was already decided about the operator message a drain belongs to,
@@ -387,6 +394,16 @@ pub(crate) struct OperatorTurn {
     /// on. The resulting claim is incomplete but never wrong, and the bubble's
     /// step timeline still shows every `spawn_task` the turn made.
     pub(crate) spawned_task: Option<String>,
+    /// Whether **any** turn behind this bubble paused at its tool-iteration cap
+    /// (issue #926) — the responder's, a desk lead's, or the CEO relay's.
+    ///
+    /// A sticky OR rather than "the last turn's value", because one operator
+    /// message can run several turns and the operator gets exactly ONE bubble
+    /// for the whole chain. The relay turn in particular *replaces* the reply
+    /// text, so tracking the last value would erase a cap the responder or a
+    /// delegate hit — the operator would read a relayed answer that quietly
+    /// omits that a branch of it stopped half-done.
+    pub(crate) hit_iteration_cap: bool,
 }
 
 /// What a **dispatched card's** turn handed off (issue #204).
@@ -916,6 +933,10 @@ impl<'a> DelegationRunner<'a> {
         // case the relay turn's reply replaces it (below).
         let mut operator_steps = outcome.steps;
         let mut operator_reply = outcome.reply;
+        // Issue #926: sticky from here to the `OperatorTurn` below — never
+        // reassigned, only OR'd — so a cap the responder hit survives the relay
+        // turn replacing the reply text.
+        let mut hit_iteration_cap = outcome.hit_iteration_cap;
         // Settle the direct-answer card from the turn that just ran. Done before
         // the delegation drain because a direct responder queues nothing — it
         // has no delegation tools — so there is no relay turn coming that could
@@ -962,6 +983,7 @@ impl<'a> DelegationRunner<'a> {
             // Fold the teammate's activity onto the operator timeline, then
             // remember the answer to relay.
             operator_steps.extend(desk.steps);
+            hit_iteration_cap |= desk.hit_iteration_cap;
             desk_replies.push((desk.member, desk.reply));
         }
         // CEO-relay hand-back: when a synchronous desk delegation answered, run
@@ -1030,6 +1052,7 @@ impl<'a> DelegationRunner<'a> {
             }
             operator_reply = relay.reply;
             operator_steps.extend(relay.steps);
+            hit_iteration_cap |= relay.hit_iteration_cap;
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -1053,6 +1076,7 @@ impl<'a> DelegationRunner<'a> {
             steps: operator_steps,
             bubbles,
             spawned_task,
+            hit_iteration_cap,
         })
     }
 
@@ -1593,12 +1617,17 @@ impl<'a> DelegationRunner<'a> {
         // the operator's timeline shows the deeper member working.
         let mut reply = outcome.reply;
         let mut steps = outcome.steps;
+        // Issue #926: the cap folds in exactly as the reply and steps do. A
+        // deeper delegate that stopped half-done is folded into THIS member's
+        // answer, so its pause is a pause on what the operator ends up reading.
+        let mut hit_iteration_cap = outcome.hit_iteration_cap;
         for deeper in nested.desk_replies {
             reply.push_str(&format!(
                 "\n\n{} (delegated by {member}) replied:\n{}",
                 deeper.member, deeper.reply
             ));
             steps.extend(deeper.steps);
+            hit_iteration_cap |= deeper.hit_iteration_cap;
         }
         // A cancelled nested run folds in as a cancellation, NEVER as a
         // reply: the member said it was handing that slice on, and an
@@ -1638,6 +1667,7 @@ impl<'a> DelegationRunner<'a> {
                 member,
                 reply,
                 steps,
+                hit_iteration_cap,
             }),
             cancelled: false,
             // Issue #442: the hand-off's own card, reported the same way
@@ -3105,6 +3135,9 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             TurnOutcome {
                 reply: turn.reply,
                 steps: Vec::new(),
+                // These fixtures script delegation shapes, not cap behaviour;
+                // the cap path is proved end-to-end in `cap_turn_test`.
+                hit_iteration_cap: false,
             }
         }
     }


### PR DESCRIPTION
## Summary

**Part 1 of three for #926.** This makes a paused turn *visible*. It does **not**
change the cap — the turn still stops in exactly the same place, it just says so.

Read this first, because it inverts the obvious assumption: **hitting the step
cap is not an error.** OpenHuman does not raise `MaxIterationsExceeded` on this
path. It stops the tool loop, makes one extra tools-disabled model call asking
for a resumable "Done so far / Next steps" checkpoint, and returns that
checkpoint as an ordinary `Ok(reply)`. There is no error to catch and no error
arm to match on — so please don't look for one in review. The signal is a
boolean the runtime already computes and we were dropping.

The bug, concretely: an agent turn spent its whole 10-iteration budget, returned
a tidy plan ending "Write the spec to a sandbox file and deliver it with
`publish_artifact`", and stopped. No spec, no artifact, no explanation. From the
operator's side that is indistinguishable from the agent losing interest, which
is what QA has been filing as "agents get permanently stuck mid-task".

The fix is to read openhuman's public `Agent::last_turn_hit_cap()` — under the
agent lock, alongside the existing `read_turn_usage` idiom — carry it on
`TurnOutcome`, OR it across every turn behind one operator bubble, and have the
brain append a second, unauthored bubble saying the turn paused, nothing errored,
and replying "continue" asks the agent to pick up from there.

Three details worth a reviewer's attention:

- **The notice is a sibling bubble, not appended to the reply.** This is
  load-bearing, not stylistic. `HarnessPool::run` persists `outcome.reply` to the
  context store; appending would file "you hit the step limit" as something the
  *agent* said and recall it into later turns as prior work. It follows the
  precedent the approval-overflow notice already set directly below it.
- **The flag is a sticky OR, never reassigned.** One operator message can run a
  responder turn, a desk hand-off and a relay turn. The relay *replaces* the
  reply text, so tracking "the last turn's value" would erase a pause the
  responder or a delegate hit — the operator would read a confident relayed
  answer that quietly omits that a branch of it stopped half-done.
- **`false` on every path that returns an outcome without running a model
  turn** — the two pre-turn budget refusals and the ACP fold. A refusal is not a
  pause, and labelling one as a cap hit would tell the operator to reply
  "continue" to a turn that never ran.

One deliberate omission, so it isn't read as an oversight: the notice does **not**
print the cap number. The real `max_iterations` is read off the turn's last
`IterationStarted` and logged in the trace, but a single notice can cover a
responder turn, a desk turn and a relay turn — naming one of their caps would
show the operator a number they cannot map back to anything. Trace, not notice.

Deliberately out of scope, to keep this reviewable and because they are separate
decisions: raising the cap (Part 3), and extending the unpublished-work nudge to
cap-pauses (Part 2a).

## API Or Behavior Changes

**Behavior** — a chat turn that pauses at its tool-iteration cap now produces
**two** operator bubbles instead of one: the agent's checkpoint (unchanged), then
an unauthored system notice. A turn that finishes normally is byte-identical to
before — one bubble, no notice. The cap value itself is unchanged.

**API** — `TurnOutcome` gains a public `hit_iteration_cap: bool`. Because that
type already crosses every seam, `RunTurn` and `HarnessRunTurn` needed no
signature change. Internal to the crate, `DeskReply` and `OperatorTurn` gain the
same field.

Nothing on the wire changed: no `OutboundMessage` schema change, no new event, no
vendor bump (every symbol used already exists at the pinned SHA).

## Tests

New `src/harness/cap_turn_test.rs` — an end-to-end module driving a real
`HostedProvider` against a scripted loopback `/chat/completions` endpoint, the
same lever `publish_turn_test` and `search_turn_test` use. `MockProvider` cannot
reach this path at all: it never issues a tool call, so it can never reach an
iteration cap.

It scripts exactly 10 successful `file_write` round trips (distinct paths, so
the repeated-failure breaker — which is explicitly *not* a cap hit — cannot fire
instead) plus the tools-disabled wrap-up, and asserts:

- the flag is `true`, and the turn still returns `Ok` with the model's
  checkpoint verbatim — pinning "a cap is a pause, not an error";
- **negative control**: two calls and a reply yields `false`, so a hardcoded
  `true` at the read site cannot pass;
- the turn shape really was the cap branch — `CAP + 1` model calls, with tools
  withheld on the last one — so a vendor bump that moves the default cap fails
  here with a message saying so, rather than silently scripting the wrong shape;
- a capped chat turn emits **two** operator bubbles, the second unauthored and
  step-less; an uncapped one emits **one**;
- the memory chunk the turn writes back contains the agent's checkpoint and
  **not** the notice.

Prove-red, actually run: with the brain's emission disabled, exactly one test
fails — `a_capped_chat_turn_says_so_in_a_second_bubble`, with `left: 1, right:
2` — while the other four still pass. So that assertion is pinned to the new
behavior and not to something incidental.

Also re-ran the pre-turn budget-refusal tests, the delegation fixtures and the
`acp` lane, all of which construct `TurnOutcome`.

Two things I checked against the pinned vendor SHA that the diff does not show,
and that the test's arithmetic depends on: `pause_at_cap: true` is hardcoded on
the session chat path (so the cap branch is genuinely reachable from
`Agent::turn`), and message triage is documented and implemented as making **no
model call** (so a chat cycle consumes exactly one turn's worth of script — if
triage were model-driven it would silently eat script entries and shift which
call is the wrap-up).

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings` — clean
- [x] `cargo test --locked --features openhuman,tinycortex --tests` — full gated lane, 4217 tests, 0 failed (the 5 new ones included)
- [x] `cargo test --locked --features openhuman,tinycortex --lib harness::` — 1042 passed, 0 failed
- [x] `cargo test --locked --features openhuman,tinycortex --lib runtime::delegation` — 83 passed, 0 failed

`--no-deps` on clippy per the repo's own gate — the vendored crates lint dirty
without it. Gates were run unpiped; a piped gate reports the pipe's exit code,
not its own.

No new `scripts/ci/feature-lanes.txt` row is owed: `src/harness/` is gated on
`openhuman`, already classified `tested`, and the `rust-gated` job runs
`--tests` unfiltered. The test is a sibling module under `src/harness/` rather
than a `tests/` target, so `assert-integration-targets-run.sh` does not apply.

## Documentation

`docs/spec/runtime/agents.md` gains a section — "The step budget, and what a
paused turn looks like" — covering that a capped turn is a pause returning a
successful reply rather than an error, how the flag is folded across delegated
turns, why the notice is a separate bubble, and where each piece lives. File is
263 lines, within the 500-line cap.

## Related

Part of #926
