### PR TITLE
fix(chat): assign a chat card to the thread it was addressed to (#982)

### DIFF
--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -2140,7 +2140,8 @@ impl HarnessBrain {
     ///
     /// Desks are tried first so a desk whose id happens to match an agent id
     /// keeps routing as a desk; the DM case only ever claims ids that resolve to
-    /// no desk at all. Without step 2 a DM thread would silently reach the
+    /// no desk at all. The console's `dm:<teammate-id>` channel key is resolved
+    /// last, after both (issue #982) — see the comment on that arm. Without step 2 a DM thread would silently reach the
     /// orchestrator instead of the teammate the operator opened — the console
     /// would look like it were addressing an agent while talking to someone
     /// else.
@@ -2184,6 +2185,21 @@ impl HarnessBrain {
         }
         if let Some(agent) = self.record().resolve_roster_agent_id(chat) {
             return agent;
+        }
+        // Issue #982, step 3: the console's DM channel id, `dm:<teammate-id>`.
+        // Tried LAST, and for the same reason the case-folding above is safe —
+        // it can only claim a key that resolves to nothing today, so no existing
+        // thread moves, and a company that really does have a desk or teammate
+        // called `dm:x` keeps it. Without it a `dm:`-keyed thread reached arm 4
+        // and the orchestrator answered a DM addressed to somebody else, which
+        // is the same misroute #884 closed for a bare key.
+        if let Some(key) = crate::runtime::assignee::dm_key(chat) {
+            if let Some(lead) = self.desk_lead(key) {
+                return lead;
+            }
+            if let Some(agent) = self.record().resolve_roster_agent_id(key) {
+                return agent;
+            }
         }
         tracing::warn!(
             company = %self.record().id,
@@ -5364,15 +5380,18 @@ members = ["engineer"]
     fn responder_for_warns_before_falling_back_to_the_orchestrator() {
         let dir = tempfile::tempdir().unwrap();
         let (brain, _tasks) = brain_with_desk(dir.path());
+        // `dm:engineer` was this fixture until issue #982 made it resolve; the
+        // key here has to be one that names nothing at all, or the test would
+        // pass by asserting the wrong fact and #884's coverage would be gone.
         let logs = logs_from(|| {
             assert_eq!(
-                brain.responder_for(Some("dm:engineer")),
+                brain.responder_for(Some("dm:nobody_by_that_name")),
                 "chief",
                 "the fallback itself is unchanged"
             );
         });
         assert!(
-            logs.contains("dm:engineer"),
+            logs.contains("dm:nobody_by_that_name"),
             "the unresolved key must be named so the fall-through is greppable: {logs}"
         );
         assert!(logs.contains("WARN"), "{logs}");
@@ -5384,6 +5403,30 @@ members = ["engineer"]
             assert_eq!(brain.responder_for(Some("eng_desk")), "engineer");
         });
         assert!(quiet.is_empty(), "a resolved key must not warn: {quiet}");
+    }
+
+    /// Issue #982: the console mints a DM channel id as `dm:<teammate-id>`, and
+    /// a sibling route documents that form as a valid channel key — so a thread
+    /// keyed on it has to be answered by the teammate it names, not by the
+    /// orchestrator.
+    ///
+    /// The prefix is stripped **after** the desk and roster attempts, so this
+    /// can only ever claim a key that resolved to nothing: `engineer` and
+    /// `eng_desk` still route exactly as they did, which the test above pins.
+    #[test]
+    fn responder_for_answers_a_console_dm_channel_key_as_the_teammate() {
+        let dir = tempfile::tempdir().unwrap();
+        let (brain, _tasks) = brain_with_desk(dir.path());
+        assert_eq!(
+            brain.responder_for(Some("dm:engineer")),
+            "engineer",
+            "a DM channel key addresses the teammate it names"
+        );
+        assert_eq!(
+            brain.responder_for(Some("dm:")),
+            "chief",
+            "a prefix with nothing after it names nobody"
+        );
     }
 
     /// A human- or console-typed teammate key resolves case-insensitively to the

--- a/src/harness/planning.rs
+++ b/src/harness/planning.rs
@@ -371,13 +371,7 @@ pub async fn run_planning_pass(runtime: Arc<CompanyRuntime>, task_id: String) {
         planned_at_millis: now_millis(),
     };
 
-    // The assignee gate. A plan may *fill in* a blank assignee but never
-    // reassign one a person chose — the operator's routing decision is not the
-    // planner's to overrule.
-    let assignee = match evidence.card_assignee.as_str() {
-        "" => proposed,
-        existing => Some(existing.to_string()),
-    };
+    let assignee = settled_assignee(&evidence.card_assignee, proposed);
     let Some(assignee) = assignee.filter(|a| evidence.assignee_is_valid(a)) else {
         settle_blocked(
             &runtime,
@@ -667,6 +661,23 @@ impl Evidence {
         let resolution = assignee::resolve(&self.record, key);
         let working = resolution.working_agent()?;
         self.teammates.iter().find(|t| t.id == working)
+    }
+}
+
+/// The assignee gate. A plan may *fill in* a blank assignee but never reassign
+/// one a person chose — the operator's routing decision is not the planner's to
+/// overrule.
+///
+/// Load-bearing on both sides since issue #982. The card a chat opens is no
+/// longer born blank when the operator addressed a teammate or a desk, so this
+/// is now the arm that most chat cards take: what used to be a rare "somebody
+/// typed a name into the board" case is the ordinary DM. `proposed` — a content
+/// match of the card's title against teammate roles — remains the answer for a
+/// genuinely unaddressed card, and *only* for one.
+fn settled_assignee(card_assignee: &str, proposed: Option<String>) -> Option<String> {
+    match card_assignee {
+        "" => proposed,
+        existing => Some(existing.to_string()),
     }
 }
 

--- a/src/harness/planning/test.rs
+++ b/src/harness/planning/test.rs
@@ -226,6 +226,62 @@ fn evidence() -> Evidence {
     }
 }
 
+/// Issue #982: the gate keeps its promise now that the assignee it is being
+/// handed usually came from the operator addressing a thread.
+///
+/// The pairing is the test. A blank card takes the planner's content-derived
+/// guess — which is the behaviour every unaddressed card still wants — and a
+/// card that already names somebody keeps them even when the planner proposed a
+/// different, perfectly plausible teammate. That second row is the whole of the
+/// bug: the addressee is written before the pass runs, so the pass has to be the
+/// thing that does not overwrite it.
+#[test]
+fn the_gate_fills_a_blank_assignee_and_never_overrules_one() {
+    assert_eq!(
+        settled_assignee("", Some("maya".to_string())).as_deref(),
+        Some("maya"),
+        "a blank card is what the planner's proposal is for"
+    );
+    assert_eq!(
+        settled_assignee("sam", Some("maya".to_string())).as_deref(),
+        Some("sam"),
+        "an assignee the operator chose outranks a content match"
+    );
+    assert_eq!(
+        settled_assignee("sam", None).as_deref(),
+        Some("sam"),
+        "…and stands on its own when the planner proposed nobody"
+    );
+    assert_eq!(
+        settled_assignee("", None),
+        None,
+        "nobody either way still blocks, exactly as before"
+    );
+}
+
+/// …and the assignee a chat card now arrives with is one the gate accepts, so
+/// nothing newly settles as blocked.
+///
+/// Both shapes the chat route can write are checked: a teammate id, and a
+/// **desk** id, which is what a desk-addressed message opens its card with.
+#[test]
+fn an_addressed_chat_cards_assignee_passes_the_gates_validity_check() {
+    let e = evidence();
+    assert_eq!(e.card_assignee, "maya", "the fixture card names a teammate");
+    assert!(
+        e.assignee_is_valid(&e.card_assignee),
+        "a teammate-addressed card dispatches rather than blocking"
+    );
+    assert!(
+        e.assignee_is_valid("studio"),
+        "a desk-addressed card carries the desk id, and that is valid too"
+    );
+    assert!(
+        !e.assignee_is_valid("nobody_by_that_name"),
+        "…and the check still refuses a name nobody answers to"
+    );
+}
+
 fn claim(kind: PrereqKind, name: &str) -> PrereqClaim {
     PrereqClaim {
         kind,

--- a/src/runtime/assignee.rs
+++ b/src/runtime/assignee.rs
@@ -142,6 +142,27 @@ to tell which one you meant — rename one of them, or assign the card by teamma
     }
 }
 
+/// The console's DM channel-key prefix: `#/chat/dm:designer` addresses the
+/// teammate `designer`.
+pub const DM_PREFIX: &str = "dm:";
+
+/// The roster key a `dm:`-prefixed channel id addresses, or `None` when the key
+/// carries no prefix (or nothing after it).
+///
+/// The console mints a DM channel id as `dm:<teammate-id>` (`chat/model.ts`'s
+/// `dmChannelId`), and that id is a *documented* channel key on the chat route —
+/// so it reaches both the responder lookup and the card the route opens, and
+/// both used to read it as naming nothing. This is the one place that shape is
+/// spelled, so the two cannot drift.
+///
+/// Callers must try the key **as sent** first and fall back to this only when it
+/// resolves to nothing: stripping unconditionally would let `dm:x` claim a desk
+/// or teammate literally named `dm:x`, which is a key that resolves today.
+pub fn dm_key(chat: &str) -> Option<&str> {
+    let key = chat.strip_prefix(DM_PREFIX)?.trim();
+    (!key.is_empty()).then_some(key)
+}
+
 /// Resolves `assignee` against `record`'s full roster.
 ///
 /// Resolution order, and the order matters: **desks first**, mirroring

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -2443,7 +2443,11 @@ fn first_line(text: &str, max: usize) -> String {
 /// assignee is the addressed desk's lead — so a hand-off recorded against a desk
 /// id surfaces when the operator addresses that desk by id or name, and a card
 /// assigned to a person surfaces when that person is addressed.
-fn assignment_matches(record: &CompanyRecord, target: &str, assignee: &str) -> bool {
+///
+/// `pub(crate)` since issue #982 for a second caller — `chat_handler_card`'s
+/// adoption predicate, which has to ask the same question about the card the
+/// REST handler just wrote. One comparator, so the two cannot drift.
+pub(crate) fn assignment_matches(record: &CompanyRecord, target: &str, assignee: &str) -> bool {
     if assignee.eq_ignore_ascii_case(target) {
         return true;
     }

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -1072,8 +1072,9 @@ impl<'a> DelegationRunner<'a> {
     ///
     /// The card is stamped with a [`TaskOutput`] whose source is
     /// [`TaskOutputSource::ChatTurn`] — the conversation this turn happened in,
-    /// which is `chat_id`, not the card's `origin_chat_id` (always `None` on an
-    /// adopted handler card) — carrying the workflows this turn authored.
+    /// which is `chat_id`, not the card's `origin_chat_id` (which since issue
+    /// #982 may carry the same thread, and never a different one) — carrying the
+    /// workflows this turn authored.
     /// The note stays — it is prose a person reads — but the *link* is what the
     /// board's contract is written in terms of (#339), and until #806 this card
     /// could not have one: `TaskOutput` required a `run_id` and an operator chat
@@ -1146,9 +1147,11 @@ impl<'a> DelegationRunner<'a> {
         // is the weakest producer, never one that outranks an attempt.
         //
         // The TURN's own `chat_id` is what addresses it — deliberately not the
-        // card's `origin_chat_id`, which is always `None` here by construction:
-        // `chat_handler_card` only adopts a card whose `origin_chat_id.is_none()`,
-        // so the #463 handler card this settles can never carry one. A turn with
+        // card's `origin_chat_id`. Since issue #982 an adopted handler card may
+        // carry one, and when it does it is this same thread by construction
+        // (adoption requires it), so the two agree; reading the turn's is still
+        // the honest source, because it is the conversation this stamp is about
+        // and it is defined even for a card that carries no origin. A turn with
         // no thread at all (a dispatched path) keeps the note-only behaviour
         // rather than getting a stamp pointing nowhere.
         match chat_id {
@@ -1889,8 +1892,9 @@ impl<'a> DelegationRunner<'a> {
     /// runs the same detector over the same words moments earlier. The match is
     /// deliberately narrow, and every clause is a property of a card **that
     /// handler** writes: its landing column, an assignee it is entitled to have,
-    /// no origin chat. `list` is newest-first, so the first match is the one just
-    /// written rather than a months-old card that happens to share a title.
+    /// and an origin thread that is this one. `list` is newest-first, so the
+    /// first match is the one just written rather than a months-old card that
+    /// happens to share a title.
     ///
     /// # The assignee clause is no longer "blank" (issue #982)
     ///
@@ -1909,6 +1913,11 @@ impl<'a> DelegationRunner<'a> {
     /// [`assignment_matches`] — the comparator the direct-card path already uses
     /// (issue #176) rather than a second one that could drift. A card assigned to
     /// somebody *else* is still refused, which is what the clause was protecting.
+    ///
+    /// The origin clause moved for the same reason and reads the same way: the
+    /// handler now stamps the thread it opened the card from, so `None` (an
+    /// unaddressed message) **or** this very thread is the handler's write, and
+    /// a card carrying somebody else's thread is still not ours to adopt.
     ///
     /// **Two landing columns, not one** (issue #576). The handler opens a
     /// person's card directly in Planning and a machine's in To-do, so pinning
@@ -1945,7 +1954,7 @@ impl<'a> DelegationRunner<'a> {
                 card.title == title
                     && (card.column == COLUMN_TODO || card.column == COLUMN_PLANNING)
                     && (card.assignee.is_empty() || self.addressed_to(chat_id, &card.assignee))
-                    && card.origin_chat_id.is_none()
+                    && (card.origin_chat_id.is_none() || card.origin_chat_id.as_deref() == chat_id)
             })
             .map(|card| card.id))
     }
@@ -4119,11 +4128,11 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
         let title = crate::company::task_intent::detect_task_intent(imperative)
             .expect("fixture must be a message the chat handler cards");
         let fx = Fixture::new();
-        // NOTE: no `origin_chat_id` on the seeded card, and that is not an
-        // oversight — `chat_handler_card` only adopts a card whose
-        // `origin_chat_id.is_none()`, so setting one here makes the card
-        // unadoptable and nothing settles at all. The conversation the stamp
-        // addresses is the TURN's, passed to `handle_operator_message` below.
+        // NOTE: no `origin_chat_id` on the seeded card. Since issue #982 one
+        // naming THIS turn's thread would be adopted too, but a card carrying a
+        // different thread is still unadoptable and nothing would settle at all.
+        // The conversation the stamp addresses is the TURN's, passed to
+        // `handle_operator_message` below.
         let handler = handler_card_in(title, COLUMN_TODO);
         TaskStore::upsert(&*fx.tasks, &fx.record.id, &handler)
             .await
@@ -4525,6 +4534,95 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             .expect("operator message handled");
 
         assert_eq!(turn.spawned_task.as_deref(), Some("handler-card"));
+    }
+
+    /// Issue #982 again, and the same shape one field over: the handler now
+    /// stamps the thread it opened the card from, so the origin clause has to
+    /// accept **this** thread as well as none. Without it the chip disappears
+    /// on exactly the messages the stamp was added for.
+    #[tokio::test]
+    async fn a_handler_card_stamped_with_this_turns_thread_is_adopted() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "handler-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_PLANNING.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: "engineer".to_string(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: Some("dm:engineer".to_string()),
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                    deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                    workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
+                },
+            )
+            .await
+            .expect("seed the handler's card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(turn.spawned_task.as_deref(), Some("handler-card"));
+    }
+
+    /// …and a card opened from a *different* conversation is still not ours,
+    /// which is the property that clause has always been holding.
+    #[tokio::test]
+    async fn a_handler_card_from_another_thread_is_not_adopted() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "another-threads-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_PLANNING.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: "".to_string(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: Some("eng_desk".to_string()),
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                    deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                    workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
+                },
+            )
+            .await
+            .expect("seed the card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", imperative, Some("dm:engineer"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turn.spawned_task, None,
+            "another conversation's card is not this message's card"
+        );
     }
 
     /// …and the relaxation is exactly as wide as it needs to be: a card

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -38,7 +38,7 @@ use crate::ports::tasks::{
 use crate::ports::types::{CompanyId, CompanyRecord, OutboundMessage, TurnStep};
 use crate::ports::{TaskRecord, TaskStore, generate_id, now_millis};
 use crate::runtime::assignee;
-use crate::runtime::cycle::{BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION};
+use crate::runtime::cycle::{BUILDER_ANNOTATION, OPEN_WORK_ANNOTATION, assignment_matches};
 
 /// One agent turn, abstracted so delegation orchestration never touches the
 /// harness-specific [`HarnessDeps`](crate::harness::HarnessDeps).
@@ -879,7 +879,7 @@ impl<'a> DelegationRunner<'a> {
         // authored. Run records stay reserved for actual work attempts (#183
         // §4), so this turn mints none — see `TaskOutputSource`.
         let handler_card = match carded_by_handler {
-            true => self.chat_handler_card(message).await?,
+            true => self.chat_handler_card(message, chat_id).await?,
             false => None,
         };
         // Issue #442, path one: a desk lead or teammate asked DIRECTLY carries
@@ -1865,6 +1865,22 @@ impl<'a> DelegationRunner<'a> {
             .await
     }
 
+    /// Whether a card assigned to `assignee` is assigned to whoever `chat_id`
+    /// addresses (issue #982).
+    ///
+    /// The comparison itself is [`assignment_matches`] — the one comparator on
+    /// this seam — asked twice: once for the key as the console sent it, and
+    /// once for the `dm:<teammate-id>` form with its prefix stripped, which the
+    /// chat route resolves the same way and in the same order.
+    fn addressed_to(&self, chat_id: Option<&str>, assignee: &str) -> bool {
+        let Some(chat) = chat_id else {
+            return false;
+        };
+        assignment_matches(self.record, chat, assignee)
+            || assignee::dm_key(chat)
+                .is_some_and(|key| assignment_matches(self.record, key, assignee))
+    }
+
     /// The card the REST chat handler opened for this message, when it opened
     /// one and it is still on the board (issue #463).
     ///
@@ -1872,9 +1888,27 @@ impl<'a> DelegationRunner<'a> {
     /// title it derives is byte-for-byte the one the handler wrote — the handler
     /// runs the same detector over the same words moments earlier. The match is
     /// deliberately narrow, and every clause is a property of a card **that
-    /// handler** writes: its landing column, no assignee, no origin chat. `list`
-    /// is newest-first, so the first match is the one just written rather than a
-    /// months-old card that happens to share a title.
+    /// handler** writes: its landing column, an assignee it is entitled to have,
+    /// no origin chat. `list` is newest-first, so the first match is the one just
+    /// written rather than a months-old card that happens to share a title.
+    ///
+    /// # The assignee clause is no longer "blank" (issue #982)
+    ///
+    /// It was, and it had to stop being, in the same change that made the
+    /// handler assign the card to the thread it was addressed to. A blank-only
+    /// clause and an assigning handler do not fail loudly together: they stop
+    /// matching, `spawned_task` falls back, the "Card opened" chip silently
+    /// disappears from every carded chat message, and
+    /// `settle_authored_workflow_card` stops running so a workflow the turn
+    /// authored strands its card in To-do. Nothing errors, and the
+    /// duplicate-card guard is keyed on the detector rather than on adoption, so
+    /// there is not even a second card to notice.
+    ///
+    /// What replaces it is the same question one narrower: blank, **or** an
+    /// assignee that is who this message was addressed to, compared with
+    /// [`assignment_matches`] — the comparator the direct-card path already uses
+    /// (issue #176) rather than a second one that could drift. A card assigned to
+    /// somebody *else* is still refused, which is what the clause was protecting.
     ///
     /// **Two landing columns, not one** (issue #576). The handler opens a
     /// person's card directly in Planning and a machine's in To-do, so pinning
@@ -1891,7 +1925,11 @@ impl<'a> DelegationRunner<'a> {
     /// and for every non-REST caller of this seam, none of which have a chat
     /// handler in front of them. Callers must not read `None` as "the handler
     /// did not fire": the stand-down is keyed on the detector, not on this.
-    async fn chat_handler_card(&self, message: &str) -> Result<Option<String>> {
+    async fn chat_handler_card(
+        &self,
+        message: &str,
+        chat_id: Option<&str>,
+    ) -> Result<Option<String>> {
         let Some(tasks) = self.tasks else {
             return Ok(None);
         };
@@ -1906,7 +1944,7 @@ impl<'a> DelegationRunner<'a> {
             .find(|card| {
                 card.title == title
                     && (card.column == COLUMN_TODO || card.column == COLUMN_PLANNING)
-                    && card.assignee.is_empty()
+                    && (card.assignee.is_empty() || self.addressed_to(chat_id, &card.assignee))
                     && card.origin_chat_id.is_none()
             })
             .map(|card| card.id))
@@ -4389,6 +4427,149 @@ members = ["brand_strategist", "seo_specialist", "copywriter"]
             turn.spawned_task.as_deref(),
             Some("handler-card"),
             "a Planning card is the handler's card too — the reply must link to it"
+        );
+    }
+
+    /// Issue #982, and the half of it that fails silently: since the REST
+    /// handler assigns the card it opens to the thread the message was
+    /// addressed to, the card this seam has to adopt is no longer blank.
+    ///
+    /// A test that only asserted the assignee would not see this. What breaks
+    /// when the two halves ship apart is `spawned_task` — the reply's "Card
+    /// opened" chip, and the handle `settle_authored_workflow_card` needs to
+    /// settle a workflow the turn authored — and nothing anywhere errors.
+    #[tokio::test]
+    async fn a_handler_card_assigned_to_the_addressed_teammate_is_still_adopted() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        // Exactly what the REST handler writes for a person who DM'd a teammate.
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "handler-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_PLANNING.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: "engineer".to_string(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: None,
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                    deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                    workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
+                },
+            )
+            .await
+            .expect("seed the handler's card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("engineer", imperative, Some("engineer"))
+            .await
+            .expect("operator message handled");
+
+        let cards = fx.cards().await;
+        assert_eq!(cards.len(), 1, "one message, one card: {cards:?}");
+        assert_eq!(
+            turn.spawned_task.as_deref(),
+            Some("handler-card"),
+            "an assigned handler card is still the handler's card — the reply must link to it"
+        );
+    }
+
+    /// …including when the console addressed the teammate by their DM channel
+    /// id, which is the form the chat route resolves the card's assignee from.
+    #[tokio::test]
+    async fn a_dm_channel_id_adopts_the_card_it_addressed() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "handler-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_PLANNING.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: "engineer".to_string(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: None,
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                    deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                    workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
+                },
+            )
+            .await
+            .expect("seed the handler's card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("engineer", imperative, Some("dm:engineer"))
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(turn.spawned_task.as_deref(), Some("handler-card"));
+    }
+
+    /// …and the relaxation is exactly as wide as it needs to be: a card
+    /// assigned to somebody the message was NOT addressed to is still refused,
+    /// which is the property the blank-only clause was really protecting.
+    #[tokio::test]
+    async fn a_handler_card_assigned_to_somebody_else_is_not_adopted() {
+        let imperative = "draft the launch plan for next quarter";
+        let title = crate::company::task_intent::detect_task_intent(imperative)
+            .expect("fixture must be a message the chat handler cards");
+        let fx = Fixture::new();
+        fx.tasks
+            .upsert(
+                &fx.record.id,
+                &TaskRecord {
+                    id: "someone-elses-card".to_string(),
+                    title,
+                    note: None,
+                    column: COLUMN_PLANNING.to_string(),
+                    priority: "medium".to_string(),
+                    assignee: "engineer".to_string(),
+                    updated_at_millis: now_millis(),
+                    origin_chat_id: None,
+                    parent_task_id: None,
+                    output: None,
+                    plan: None,
+                    deliverable: crate::ports::tasks::TaskDeliverable::Once,
+                    workflow_proposal: None,
+                    origin_run_id: None,
+                    origin_workflow_id: None,
+                },
+            )
+            .await
+            .expect("seed the card");
+
+        let turns = ScriptedTurns::new(&fx, vec![Turn::reply("on it")]);
+        let turn = fx
+            .runner(&turns)
+            .handle_operator_message("chief", imperative, None)
+            .await
+            .expect("operator message handled");
+
+        assert_eq!(
+            turn.spawned_task, None,
+            "a card assigned to a teammate this message did not address is not ours to adopt"
         );
     }
 

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1169,6 +1169,62 @@ struct ChatResponse {
     still_awaiting: Option<usize>,
 }
 
+/// The canonical assignee for a card opened from a chat message: whoever the
+/// thread was addressed to (issue #982).
+///
+/// `""` — today's unconditional behaviour, and still the answer for most
+/// messages — for an unaddressed message, for a key that names nothing on the
+/// roster, for an ambiguous one, and for a company record that will not load.
+/// A teammate resolves to their canonical id; a **desk** resolves to the desk
+/// id, never to its lead: a desk assignment is ownership, and
+/// [`AssigneeResolution::canonical`] is where that invariant lives (issue #214),
+/// so this reads it rather than restating it. An empty desk resolves to the desk
+/// too, which dispatch refuses visibly with a reason — a better outcome than the
+/// silent misroute this replaces.
+///
+/// The `dm:` fallback is tried **last** and only on a key that resolved to
+/// nothing, so it can never take a thread that routes somewhere today.
+async fn addressed_assignee(runtime: &Arc<CompanyRuntime>, chat: Option<&str>) -> String {
+    use crate::runtime::assignee::{self, AssigneeResolution};
+
+    let Some(chat) = chat.map(str::trim).filter(|c| !c.is_empty()) else {
+        return String::new();
+    };
+    let company = match runtime.store().load(runtime.id()).await {
+        Ok(Some(company)) => company,
+        Ok(None) => {
+            tracing::warn!(
+                company = %runtime.id(),
+                "no company record while assigning a chat card; leaving it unassigned"
+            );
+            return String::new();
+        }
+        Err(err) => {
+            tracing::warn!(
+                error = %err,
+                company = %runtime.id(),
+                "failed to read the roster while assigning a chat card; leaving it unassigned"
+            );
+            return String::new();
+        }
+    };
+    let mut resolution = assignee::resolve(&company, chat);
+    if matches!(resolution, AssigneeResolution::Unknown(_))
+        && let Some(key) = assignee::dm_key(chat)
+    {
+        resolution = assignee::resolve(&company, key);
+    }
+    if let Some(reason) = resolution.rejection() {
+        tracing::debug!(
+            company = %runtime.id(),
+            chat = %chat,
+            reason = %reason,
+            "[chat] the addressed thread names nobody the card can be handed to"
+        );
+    }
+    resolution.canonical().unwrap_or_default().to_string()
+}
+
 /// Runs one operator-chat cycle, returning the report and, when a complaint
 /// intent captured feedback, the note that was captured (so the caller can emit
 /// the `feedback.created` webhook).
@@ -1296,13 +1352,27 @@ async fn run_chat(
         } else {
             crate::ports::tasks::COLUMN_TODO
         };
+        // Issue #982: the card is handed to whoever the operator addressed, and
+        // it is resolved HERE — before the single `upsert_task` below, which is
+        // the write that fires the planning pass. That ordering is the whole of
+        // the fix. A card born blank is a card the planning pass is entitled to
+        // fill in from a content match of its title against teammate roles, and
+        // that guess is what a DM to a named teammate was losing to; patching
+        // the assignee on afterwards would not fix it, it would race it, and
+        // cost a second board event besides.
+        //
+        // Best-effort in exactly one direction: every case that does not resolve
+        // to a real teammate or desk degrades to `""`, which is what this site
+        // wrote unconditionally before. A chat must never 400 and must never
+        // lose its card over who it was addressed to.
+        let assignee = addressed_assignee(&runtime, message.chat.as_deref()).await;
         let record = crate::ports::tasks::TaskRecord {
             id: crate::ports::generate_id(),
             title,
             note,
             column: column.to_string(),
             priority: "medium".to_string(),
-            assignee: String::new(),
+            assignee,
             updated_at_millis: crate::ports::now_millis(),
             origin_chat_id: None,
             parent_task_id: None,
@@ -2598,6 +2668,248 @@ mod test {
         assert_eq!(r.status(), StatusCode::OK);
         let tasks = runtime.tasks().list(&id).await.unwrap();
         assert_eq!(tasks.len(), 1, "a greeting must not open a card");
+    }
+
+    // ── Issue #982: the card goes to whoever was addressed ──────────────────
+
+    /// A roster with three teammates and one desk, so a chat can be addressed
+    /// to something that exists.
+    ///
+    /// The ids are the ones the smoke that found #982 used, and the roles are
+    /// deliberately distinct words, so a test can address one teammate in a
+    /// message whose text points at another.
+    fn roster_manifest() -> CompanyManifest {
+        toml::from_str(
+            r#"
+[company]
+name = "Acme"
+
+[[agent]]
+id = "product_manager"
+role = "Product Manager"
+
+[[agent]]
+id = "backend_engineer"
+role = "Backend Engineer"
+
+[[agent]]
+id = "designer"
+role = "Designer"
+
+[[group_chat]]
+id = "engineering"
+name = "Engineering"
+members = ["backend_engineer"]
+
+[policy]
+mode = "full"
+"#,
+        )
+        .unwrap()
+    }
+
+    /// [`state_with_company`] over [`roster_manifest`]. Written out rather than
+    /// threaded through the shared builders above, which several other suites
+    /// call with the roster-less fixture.
+    async fn state_with_roster(home: &std::path::Path) -> AppState {
+        let store = FsCompanyStore::new(home.to_path_buf());
+        let id = CompanyId::new("acme");
+        use crate::ports::CompanyStore;
+        store
+            .save(&CompanyRecord {
+                id: id.clone(),
+                manifest: roster_manifest(),
+                ledger: Vec::new(),
+                lifecycle: "running".to_string(),
+                overlay_agents: Vec::new(),
+                overlay_desk_members: Vec::new(),
+                overlay_desk_order: Vec::new(),
+                overlay_desks: Vec::new(),
+                overlay_workflows: Vec::new(),
+                overlay_budgets: Vec::new(),
+                overlay_policy: None,
+                overlay_desk_tools: Default::default(),
+                disabled_workflows: Vec::new(),
+                template_provenance: None,
+            })
+            .await
+            .unwrap();
+        let runtime = RuntimeBuilder::new(home.to_path_buf(), roster_manifest())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        let state = AppState::new(AppConfig::default());
+        state.registry().insert(id, Arc::new(runtime));
+        crate::server::test_support::seed_fixed_admin(&state, "acme").await;
+        state
+    }
+
+    /// One chat request, optionally addressed to a thread.
+    fn chat_to(text: &str, chat: Option<&str>) -> Request<Body> {
+        Request::builder()
+            .method("POST")
+            .uri("/api/v1/company/chat")
+            .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+            .header("content-type", "application/json")
+            .body(Body::from(
+                serde_json::json!({ "text": text, "chat": chat }).to_string(),
+            ))
+            .unwrap()
+    }
+
+    /// The message the smoke sent: an actionable ask whose *text* points at one
+    /// teammate, addressed to a different one.
+    const CROSSED: &str = "build the backend deployment pipeline";
+
+    /// The card a chat opens is handed to the teammate the operator addressed.
+    ///
+    /// The fixture is the whole test. `CROSSED` names *backend* work and is
+    /// addressed to the **product manager**, so the two candidate answers are
+    /// distinguishable: pre-fix this card was born blank and the planning pass
+    /// filled it from a content match of the title against teammate roles —
+    /// which is exactly the wrong answer here. A message whose text and
+    /// addressee agree would pass on pre-fix code and prove nothing; that is
+    /// what the two "right" rows of the issue's table were.
+    #[tokio::test]
+    async fn chat_addressed_to_a_teammate_assigns_that_teammate() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        assert!(
+            matches!(
+                crate::company::task_intent::triage_message(CROSSED),
+                crate::company::task_intent::MessageTriage::Track(_)
+            ),
+            "fixture must be a message the handler cards, or this proves nothing"
+        );
+
+        let r = app
+            .oneshot(chat_to(CROSSED, Some("product_manager")))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1, "an actionable ask opens one card");
+        assert_eq!(
+            tasks[0].assignee, "product_manager",
+            "the card belongs to the teammate the operator addressed"
+        );
+        assert_ne!(
+            tasks[0].assignee, "backend_engineer",
+            "…and not to whoever the message text happens to name"
+        );
+    }
+
+    /// A desk-addressed chat is assigned to the **desk**, not to its lead.
+    ///
+    /// Writing the lead would erase the desk from the board the moment the card
+    /// was created — the invariant `AssigneeResolution::canonical` holds for
+    /// every other write site (issue #214), now held here too.
+    #[tokio::test]
+    async fn chat_addressed_to_a_desk_assigns_the_desk() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        let r = app
+            .oneshot(chat_to(CROSSED, Some("engineering")))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(
+            tasks[0].assignee, "engineering",
+            "picking a desk IS the operator's routing decision"
+        );
+    }
+
+    /// Everything that addresses nobody in particular still opens a blank card:
+    /// no thread at all, the empty string, the console's legacy fallback desk
+    /// id, and the default "General" desk this company does not have.
+    ///
+    /// This pins the direction of the change — *more* cards are operator-chosen,
+    /// none fewer — and it is the clause that keeps the orchestrator's own queue
+    /// working: a blank assignee is what hands a card to it.
+    #[tokio::test]
+    async fn an_unaddressed_chat_leaves_the_card_unassigned() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        for thread in [None, Some(""), Some("main"), Some(DEFAULT_DESK)] {
+            let r = app.clone().oneshot(chat_to(CROSSED, thread)).await.unwrap();
+            assert_eq!(r.status(), StatusCode::OK, "thread {thread:?}");
+        }
+
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 4, "one card per message: {tasks:?}");
+        for card in &tasks {
+            assert_eq!(
+                card.assignee, "",
+                "an unaddressed message leaves the card for the orchestrator"
+            );
+        }
+    }
+
+    /// A thread key that names nothing on the roster is not an error: the card
+    /// is opened, unassigned, exactly as it was before this route resolved
+    /// anything. A chat must never 400 — and must never lose its card — over who
+    /// it was addressed to.
+    #[tokio::test]
+    async fn an_unknown_addressee_leaves_the_card_unassigned() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        let r = app
+            .oneshot(chat_to(CROSSED, Some("nobody_by_that_name")))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK, "an unknown thread is not a 400");
+
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1, "…and the card is still opened");
+        assert_eq!(tasks[0].assignee, "", "…with nobody guessed onto it");
+    }
+
+    /// The console mints a DM channel id as `dm:<teammate-id>`, and that form is
+    /// documented as a valid channel key — so it has to address the teammate
+    /// here as well as in the responder lookup.
+    #[tokio::test]
+    async fn a_console_dm_channel_id_addresses_the_teammate() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        let r = app
+            .oneshot(chat_to(CROSSED, Some("dm:designer")))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(tasks.len(), 1);
+        assert_eq!(tasks[0].assignee, "designer");
     }
 
     /// Issue #845: an explicit "Build me the workflow" opens a card even when

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1374,7 +1374,14 @@ async fn run_chat(
             priority: "medium".to_string(),
             assignee,
             updated_at_millis: crate::ports::now_millis(),
-            origin_chat_id: None,
+            // Issue #982: the thread this card was opened from, so the settle
+            // marker lands back in the conversation that asked for the work
+            // rather than only on the board. This is the field #151 added for
+            // exactly that (`relay_reply` answers in the origin thread), and the
+            // console already renders a marker in a DM channel — nothing there
+            // changes. `None` for an unaddressed message, which is every card
+            // this site opened before and therefore no change for one.
+            origin_chat_id: message.chat.clone(),
             parent_task_id: None,
             // Nothing has run yet, so there is no deliverable to point at
             // (issue #339). The first successful settle stamps it.
@@ -2887,6 +2894,51 @@ mode = "full"
         let tasks = runtime.tasks().list(&id).await.unwrap();
         assert_eq!(tasks.len(), 1, "…and the card is still opened");
         assert_eq!(tasks[0].assignee, "", "…with nobody guessed onto it");
+    }
+
+    /// The card remembers the thread it was opened from, so the marker that says
+    /// it settled lands back in the conversation that asked for the work.
+    ///
+    /// `origin_chat_id` is the field issue #151 added for exactly this, and the
+    /// console already renders the marker in whatever channel it names — the
+    /// route was simply never filling it in. An unaddressed message still opens
+    /// a card with no origin, which is every card this route opened before.
+    #[tokio::test]
+    async fn a_chat_card_remembers_the_thread_it_was_opened_from() {
+        let home_dir = home();
+        let home = home_dir.path().to_path_buf();
+        let state = state_with_roster(&home).await;
+        let id = CompanyId::new("acme");
+        let runtime = state.registry().get(&id).unwrap();
+        let app = router(state);
+
+        let r = app
+            .clone()
+            .oneshot(chat_to(CROSSED, Some("dm:designer")))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        assert_eq!(
+            tasks[0].origin_chat_id.as_deref(),
+            Some("dm:designer"),
+            "the thread as the console addressed it"
+        );
+
+        let r = app
+            .oneshot(chat_to("draft the investor update", None))
+            .await
+            .unwrap();
+        assert_eq!(r.status(), StatusCode::OK);
+        let tasks = runtime.tasks().list(&id).await.unwrap();
+        let unaddressed = tasks
+            .iter()
+            .find(|c| c.title == "Draft the investor update")
+            .expect("the second card");
+        assert_eq!(
+            unaddressed.origin_chat_id, None,
+            "an unaddressed message has no thread to answer in"
+        );
     }
 
     /// The console mints a DM channel id as `dm:<teammate-id>`, and that form is


### PR DESCRIPTION
## Summary

A card opened from a chat message was built with a literal empty assignee, and `message.chat` — the thread the operator addressed — was never read. The card was born blank, the planning pass fired immediately, and the planner filled the blank by matching the card's text against teammate roles. The addressee was consulted by nothing on this path.

On staging that meant a GitHub-report request sent to the **Product Manager** produced a card assigned to `backend_engineer`, and an onboarding request sent to the **HR Manager** produced one assigned to `frontend_engineer` — both plausible content matches, neither the person addressed. Two other DMs looked correct only because the content match happened to coincide with the addressee.

The existing rule — a plan may fill in a blank assignee but never overrule one a person chose — was already right. It just never had the operator's choice to protect, because nothing wrote it down.

## API Or Behavior Changes

- A card opened from a chat message now carries the addressed thread's assignee: a teammate id for a DM, the **desk** id for a desk (never the desk lead, which would erase the desk from the board — #214), and `""` for an unaddressed, unknown or ambiguous thread, exactly as today.
- A record-load failure logs and degrades to `""`. This path is best-effort by design, so every unresolvable case behaves as it does now.
- `responder_for` resolves a console-style `dm:<id>` channel key to the teammate it names. Placed **last**, after desk-lead and roster lookup, so it can only claim keys that resolve to nothing today — no existing thread moves.
- A chat card now records the thread it was opened from, which is what routes the settle marker back into that thread. The console half already existed.
- Assigning desk-addressed cards to the desk is a deliberate behaviour change, not a no-op: picking a desk *is* the operator's routing. A company whose desk members are off-roster now gets a card dispatch refuses visibly, with a reason, rather than one a content match quietly worked.

Forward-only. Cards already on a board keep the assignee they were given; nothing back-fills, and nothing should — historical cards carry no thread to re-derive from.

## The trap this PR had to avoid, and why two commits are one shipment

The card-adoption predicate required an empty assignee. Fixing only the creation site compiles, fixes the reported bug, and **silently stops the "Card opened" chip appearing on every carded chat message** — stranding workflow cards. Nothing errors, and the duplicate-card guard is keyed on the detector rather than adoption, so there is no second card to notice either.

That was proven rather than argued: with the assignee clause reverted to blank-only, `a_handler_card_assigned_to_the_addressed_teammate_is_still_adopted` fails with `spawned_task: None`. Commits 1 and 2 must not be split.

## Tests

Red-first, with only the production line reverted and the tests kept: the three positive route tests failed with `left: ""`, while the two "stays blank" tests passed either way — so they are not passing for the wrong reason.

The decisive fixture is deliberately adversarial: the message names **backend** work and is addressed to the **product manager**, so a content match and the addressee give different answers. A fixture where they agree would pass on pre-fix code and prove nothing — which is exactly what the two coincidental rows in #982 were.

- `chat_addressed_to_a_teammate_assigns_that_teammate`
- `chat_addressed_to_a_desk_assigns_the_desk`
- `an_unaddressed_chat_leaves_the_card_unassigned`
- `an_unknown_addressee_leaves_the_card_unassigned`
- `a_console_dm_channel_id_addresses_the_teammate`
- `a_handler_card_assigned_to_the_addressed_teammate_is_still_adopted` — the chip guard

The #884 warn fixture used `dm:engineer`, which this change makes resolve. It was **re-pointed** at a genuinely unresolvable key rather than weakened, so that coverage survives, and a positive `dm:engineer → engineer` case was added beside it.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`, and the same with `--features openhuman,tinycortex`
- [x] `cargo test` — 2775 passed
- [x] `cargo test --features openhuman,tinycortex --tests` — 4223 passed
- [x] `tests/one_card_per_message.rs` — 11 passed
- [x] `cargo check --all-features --all-targets`

Worth flagging for reviewers: `src/runtime/delegation.rs` and `src/harness/**` are `#[cfg(feature = "openhuman")]`, so a default `cargo test` compiles none of three of these commits. The gated run is not optional here.

## Documentation

Doc comments corrected where they asserted invariants this overturns — the adoption predicate's "no assignee" claim, and three comments asserting the card's originating thread is always absent.

## Related

`assignment_matches` is now `pub(crate)` so the adoption check reuses the one comparator rather than growing a second that can drift. It must not be narrowed back.

#984 (an ordinary message opens a card at all) touches the same regions and is deliberately sequenced after this.

Closes #982