### PR TITLE
feat(chat): make an accepted turn exist and be readable while it runs (#983)

### DIFF
--- a/docs/spec/runtime/events.md
+++ b/docs/spec/runtime/events.md
@@ -69,7 +69,8 @@ that have no business holding agent prompts or destination addresses),
 `WorkflowRunFinished` (issue #228 — the durable record of what a run did, from
 every entry point) and, from issue #371/#382, `WorkflowRunStarted` /
 `WorkflowNodeStarted` / `WorkflowNodeFinished` (the per-node progress trail; see
-[Workflow run progress](#workflow-run-progress-issue-371)).
+[Workflow run progress](#workflow-run-progress-issue-371)), and, from issue
+#983, `TurnStarted` / `TurnFailed` (see [Chat turn brackets](#chat-turn-brackets-issue-983)).
 
 ### Per-task event correlation (issue #185)
 
@@ -434,6 +435,42 @@ has ever parked an approval from operator chat.
 into `in_progress` (`company/runtime.rs`, `upsert_task` → `dispatch_task`) — has
 the same shape and now has this read available to it, and is deliberately left
 for a follow-up rather than half-gated here.
+
+## Chat turn brackets (issue #983)
+
+An operator chat turn brackets itself the way a workflow run does.
+`TurnStarted` is appended the instant the request is accepted — before the turn
+takes the per-company serial lock, which is the whole point: the operator's
+message is journaled at the same moment, so `chat/history` is right from
+acceptance rather than from whenever the turn wins that lock. `TurnFailed`
+closes the bracket when the turn errors, and the boot sweep
+(`runtime::sweep_interrupted_turns`) writes one for any start left unmatched by
+a dead host.
+
+Both are structural. `TurnStarted` carries the turn id, the desk, the thread
+parent and the asker; there is no message text on it, because the text is on the
+`OperatorMessage` it brackets. `TurnFailed` carries a tenant-scoped reason that
+is deliberately **not** projected onto the operator SSE stream.
+
+The turn also mints a `RunRecord` (see [ports-runs.md](ports-runs.md)), and the
+two are not redundant. The row answers *status* and is read by a poll; the event
+is the *transcript*, and "a turn was accepted for this message" cannot be
+inferred from the log without it — an `OperatorMessage` with no reply after it
+is indistinguishable from a chatter message that legitimately produced none, so
+silence is not evidence of a lost turn until the acceptance is explicit.
+
+Retention (see [Retention](ports-state.md#retention-issue-275)) splits them
+deliberately: `TurnStarted` is **prunable** — it is not evidence, nothing is
+addressed by its sequence (the turn is joined by `turn_id`), and the only thing
+that reads it back is a boot sweep that by construction runs before any
+retention pass on that host. `TurnFailed` is **permanent**, being the only
+record that a question was accepted and never answered.
+
+Like every sweep of this shape, the boot sweep is **suppressed on a live runtime
+rebuild** — and here the mis-fire is worse than for a workflow run, because
+`rebuild_company` drains the cycle lock but a turn's spawned task journals its
+replies and settles its row after the cycle returns. Sweeping mid-life would
+tell the operator their turn failed moments before its answer arrived.
 
 ## Workflow run progress (issue #371)
 

--- a/docs/spec/runtime/ports-runs.md
+++ b/docs/spec/runtime/ports-runs.md
@@ -4,11 +4,21 @@ The attempt record behind the Task Detail **Attempts** tab. Part of the port
 contracts indexed by [ports.md](ports.md); the console-surface stores it sits
 alongside are in [ports-console.md](ports-console.md).
 
-One attempt at a task, and its trace (`src/ports/runs.rs`). A `RunRecord`
-carries the task and agent it belongs to, its 1-based `attempt` ordinal, a
-status, the cost it accrued, and — on failure — why. A `RunStepRecord` is one
-entry of its trace, keyed `(run_id, step_seq)` on a run-scoped dense counter
-rather than an `EventSeq`.
+One attempt at work, and its trace (`src/ports/runs.rs`). A `RunRecord`
+carries the agent it belongs to, its 1-based `attempt` ordinal, a status, the
+cost it accrued, and — on failure — why. A `RunStepRecord` is one entry of its
+trace, keyed `(run_id, step_seq)` on a run-scoped dense counter rather than an
+`EventSeq`.
+
+Since issue #983 the **card is optional** (`task_id: Option<String>`) and a
+`chat_id` sits beside it, because a chat turn is an attempt at work that
+frequently opens no card. A card-less run is always `attempt` 1 — with no card
+there is nothing for a second attempt to be the second of — and it never answers
+a per-card filter, which is what keeps the Attempts tab honest (see below). Both
+fields are `#[serde(default, skip_serializing_if = "Option::is_none")]`, so a row
+written before them loads and a dispatch row serializes byte-identically; the
+sqlite mirror column needed a table rebuild to drop its `NOT NULL`, run
+idempotently on open.
 
 ```rust
 pub trait RunStore: Send + Sync {
@@ -133,16 +143,37 @@ Old `RunRecord`s are never synthesised from historical `AgentReply` events:
 fabricating identity for attempts nobody recorded would be worse than a
 pre-existing card honestly showing zero of them.
 
-Nor is one synthesised for an **operator chat turn** (issue #806). A turn that
-produces something from chat — authoring a workflow inline with
-`create_workflow`, say — has no attempt behind it, and minting a run row so its
-card could carry a `TaskOutput` would make the Attempts tab claim work was
-attempted. Run records stay reserved for actual work attempts, so the Attempts
-list shows turns that did something (epic #183 §4). `TaskOutput` instead names
-*what produced it* as a closed set — `TaskOutputSource::Run` or
-`TaskOutputSource::ChatTurn` — which keeps the board's "every card in Done links
-to what it produced" (#339) true without weakening what a run means. See
-[ports-state.md](ports-state.md) for the task record itself.
+### A chat turn does get a row — and still not a card's attempt (#806, #983)
+
+Issue #806 refused to synthesise a run **for a card**, so that a turn which
+authored something inline (`create_workflow`, say) could hang a `TaskOutput` off
+it. That would have made the Attempts tab claim work was attempted at a card
+when none was. `TaskOutput` names *what produced it* as a closed set instead —
+`TaskOutputSource::Run` or `TaskOutputSource::ChatTurn` — which keeps "every card
+in Done links to what it produced" (#339) true without weakening what a run
+means.
+
+Issue #983 mints a row for the **turn itself**, prospectively, and that is a
+different claim: the turn *is* a work attempt, it has a status worth reading, and
+before this nothing durable recorded that one was owed — so a turn killed with
+the pod left no trace at all. The two coexist because the row names no card:
+`RunFilter::for_task` does not match an absent `task_id`, so a chat turn never
+appears in `GET …/tasks/{task_id}` → `runs[]` and the Attempts tab is exactly
+what #806 left it as. The turn is reachable through the company-wide
+`GET …/runs`, and by desk through its `chat_id`.
+
+`create_run` at accept, `begin_run` once the cycle holds the per-company serial
+lock, `finish_run` when the turn settles. That placement is deliberate: `Pending`
+therefore means *queued behind other turns* and `Running` means *owns the lock*,
+which is the distinction an operator on a busy company needs. Reusing this store
+is what makes the feature small — transition legality, the step trace,
+`list_stale_active` and `reap_orphaned_runs` all apply unchanged, and the boot
+reaper's proof (a turn is a process-local spawn, one process owns the journal,
+turns serialise on one mutex) holds for a chat turn verbatim.
+
+Old `RunRecord`s are still never synthesised from historical events. See
+[ports-state.md](ports-state.md) for the task record itself; a card a chat turn
+opens now carries that turn's id in `origin_run_id`.
 
 ## Reading runs back
 

--- a/src/brain/medulla/effects.rs
+++ b/src/brain/medulla/effects.rs
@@ -169,6 +169,26 @@ pub(crate) fn wire_event(seq: u64, event: &CompanyEvent) -> WireEvent {
             },
             "tool_access.changed",
         ),
+        // Issue #983. Written for completeness on the same terms as
+        // `ReactionToggled` above, not for a live path: these bracket a chat
+        // turn and are appended beside it rather than driving a cycle, so a
+        // brain never sees one here. The turn id is the whole payload — the
+        // message text rides the `OperatorMessage` this brackets, and the
+        // failure reason is tenant-scoped, so neither is copied here.
+        CompanyEvent::TurnStarted {
+            turn_id, chat_id, ..
+        } => (
+            Role::System,
+            "operator".to_string(),
+            format!("[{chat_id}] turn {turn_id} accepted"),
+            "turn.started",
+        ),
+        CompanyEvent::TurnFailed { turn_id, .. } => (
+            Role::System,
+            "operator".to_string(),
+            format!("Turn {turn_id} did not finish"),
+            "turn.failed",
+        ),
         CompanyEvent::TaskDispatched { task_id, .. } => (
             Role::System,
             "board".to_string(),

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -1094,7 +1094,13 @@ impl CompanyRuntime {
     /// durable lifecycle an operator chose (paused, archived) and renders `409`;
     /// this one is a process-local window that clears itself within a turn and
     /// renders `503`.
-    fn ensure_accepting(&self) -> Result<()> {
+    /// `pub(crate)` since issue #983 rather than private: a caller that journals
+    /// its own input has to be able to ask this **before** it writes, since a
+    /// refusal ordered after the append would leave a message in the transcript
+    /// that no turn will ever answer. Every in-tree caller still goes through
+    /// one of the cycle entry points below; this exists so the chat route can
+    /// run the same check one step earlier.
+    pub(crate) fn ensure_accepting(&self) -> Result<()> {
         if self.is_quiesced() {
             return Err(OpenCompanyError::Quiescing(self.id.as_ref().to_string()));
         }
@@ -1105,6 +1111,31 @@ impl CompanyRuntime {
     pub async fn run_cycle(&self, events: Vec<CompanyEvent>) -> Result<CycleReport> {
         self.ensure_accepting()?;
         CycleRunner::new(self).run(events).await
+    }
+
+    /// [`run_cycle`](Self::run_cycle), for inputs the caller has **already**
+    /// appended to the journal (issue #983).
+    ///
+    /// The chat route journals the operator's message the instant the request
+    /// is accepted, so the transcript is correct from acceptance rather than
+    /// from whenever the cycle wins the per-company serial lock — behind a busy
+    /// company, an unbounded time later. Handing the seq over here is what stops
+    /// the same message being appended a second time.
+    ///
+    /// `run_id` is a run row moved `Pending` → `Running` once that lock is
+    /// actually held; see [`CycleRunner::run_journaled`].
+    ///
+    /// Deliberately a second entry point rather than a parameter on the first:
+    /// every other trigger — scheduler, cron, webhooks, telegram, delegation,
+    /// approval follow-ups — keeps `run_cycle` byte-unchanged, so the append
+    /// they rely on cannot be turned off by a mistake at a call site.
+    pub async fn run_journaled_cycle(
+        &self,
+        events: Vec<(EventSeq, CompanyEvent)>,
+        run_id: Option<String>,
+    ) -> Result<CycleReport> {
+        self.ensure_accepting()?;
+        CycleRunner::new(self).run_journaled(events, run_id).await
     }
 
     /// Resolves a parked approval and runs a follow-up cycle so the brain learns

--- a/src/company/runtime.rs
+++ b/src/company/runtime.rs
@@ -903,11 +903,11 @@ impl CompanyRuntime {
     /// [`RunStatus::Pending`]: crate::ports::runs::RunStatus::Pending
     #[cfg(feature = "openhuman")]
     async fn open_run(&self, task: &TaskRecord) -> Option<String> {
-        let spec = crate::ports::runs::NewRun {
-            id: crate::ports::generate_id(),
-            task_id: task.id.clone(),
-            agent_id: task.assignee.clone(),
-        };
+        let spec = crate::ports::runs::NewRun::for_task(
+            crate::ports::generate_id(),
+            task.id.clone(),
+            task.assignee.clone(),
+        );
         match self.ops.runs.create_run(&self.id, spec).await {
             Ok(run) => {
                 tracing::debug!(

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -4712,16 +4712,9 @@ members = ["engineer"]
             .upsert(&company, &card("t-1", assignee))
             .await
             .expect("seed");
-        runs.create_run(
-            &company,
-            NewRun {
-                id: "run-1".to_string(),
-                task_id: "t-1".to_string(),
-                agent_id: assignee.to_string(),
-            },
-        )
-        .await
-        .expect("mint");
+        runs.create_run(&company, NewRun::for_task("run-1", "t-1", assignee))
+            .await
+            .expect("mint");
         (brain.with_runs(Arc::clone(&runs)), tasks, runs)
     }
 
@@ -4829,16 +4822,9 @@ members = ["engineer"]
         let runs: Arc<dyn crate::ports::RunStore> = Arc::new(FsOps::new(dir.path()));
         let brain = brain.with_runs(Arc::clone(&runs));
         let company = CompanyId::new("acme");
-        runs.create_run(
-            &company,
-            NewRun {
-                id: "run-1".to_string(),
-                task_id: "t-gone".to_string(),
-                agent_id: "engineer".to_string(),
-            },
-        )
-        .await
-        .expect("mint");
+        runs.create_run(&company, NewRun::for_task("run-1", "t-gone", "engineer"))
+            .await
+            .expect("mint");
 
         assert!(
             brain

--- a/src/harness/orchestrator.rs
+++ b/src/harness/orchestrator.rs
@@ -1573,6 +1573,14 @@ fn truncate_chars(s: &str, max: usize) -> String {
 fn summarize_event(event: &CompanyEvent) -> String {
     match event {
         CompanyEvent::OperatorMessage { .. } => "operator message".to_string(),
+        // Issue #983. Structural only, like every arm here: the turn id, which
+        // is a minted identifier, and nothing else. Neither the desk nor the
+        // failure reason is named — the desk is operator-authored free text on
+        // an overlay-created chat, and the reason is our own prose about the
+        // host, which is exactly what a non-sensitive one-liner should not
+        // carry.
+        CompanyEvent::TurnStarted { turn_id, .. } => format!("turn accepted: {turn_id}"),
+        CompanyEvent::TurnFailed { turn_id, .. } => format!("turn unanswered: {turn_id}"),
         CompanyEvent::AgentReply { agent_id, .. } => format!("reply from {agent_id}"),
         CompanyEvent::TaskDispatched { task_id, .. } => format!("task dispatched: {task_id}"),
         // Issue #464. Structural only, like every arm here: the id, the change

--- a/src/harness/publish_turn_test.rs
+++ b/src/harness/publish_turn_test.rs
@@ -387,17 +387,9 @@ fn brain_with(
 async fn mint_run(ops: &Arc<FsOps>, run_id: &str, task_id: &str) {
     use crate::ports::RunStore;
     use crate::ports::runs::NewRun;
-    RunStore::create_run(
-        &**ops,
-        &company(),
-        NewRun {
-            id: run_id.to_string(),
-            task_id: task_id.to_string(),
-            agent_id: AGENT.to_string(),
-        },
-    )
-    .await
-    .expect("mint the attempt row");
+    RunStore::create_run(&**ops, &company(), NewRun::for_task(run_id, task_id, AGENT))
+        .await
+        .expect("mint the attempt row");
 }
 
 fn company() -> CompanyId {

--- a/src/harness/run_trace.rs
+++ b/src/harness/run_trace.rs
@@ -203,14 +203,7 @@ mod tests {
         let company = CompanyId::new("acme");
         let runs: Arc<dyn RunStore> = Arc::new(FsOps::new(home.to_path_buf()));
         let run = runs
-            .create_run(
-                &company,
-                NewRun {
-                    id: "run-1".to_string(),
-                    task_id: "t-1".to_string(),
-                    agent_id: "ceo".to_string(),
-                },
-            )
+            .create_run(&company, NewRun::for_task("run-1", "t-1", "ceo"))
             .await
             .expect("mint");
         let sink = RunTraceSink::new(company.clone(), run.id, Arc::clone(&runs));
@@ -305,6 +298,7 @@ mod tests {
                     id: spec.id,
                     company: company.clone(),
                     task_id: spec.task_id,
+                    chat_id: spec.chat_id,
                     agent_id: spec.agent_id,
                     attempt: 1,
                     status: RunStatus::Pending,

--- a/src/harness/workflow_build/test.rs
+++ b/src/harness/workflow_build/test.rs
@@ -806,11 +806,7 @@ async fn open_run(runtime: &Arc<CompanyRuntime>, task_id: &str) -> String {
         .runs()
         .create_run(
             runtime.id(),
-            NewRun {
-                id: crate::ports::generate_id(),
-                task_id: task_id.to_string(),
-                agent_id: "maya".to_string(),
-            },
+            NewRun::for_task(crate::ports::generate_id(), task_id, "maya"),
         )
         .await
         .expect("mint the attempt row")

--- a/src/ports/runs.rs
+++ b/src/ports/runs.rs
@@ -223,10 +223,23 @@ pub struct RunRecord {
     /// The company that owns the attempt. Carried on the record as well as in
     /// the store key so an exported/streamed row is self-describing.
     pub company: CompanyId,
-    /// The board card this attempt is an attempt *at*.
-    pub task_id: String,
+    /// The board card this attempt is an attempt *at*, when there is one.
+    ///
+    /// Optional since issue #983: an operator chat turn is a recorded attempt at
+    /// *work*, and the work frequently opens no card. Serialized with
+    /// `skip_serializing_if` rather than as an explicit `null`, matching how
+    /// every other optional field on this record is written, so a dispatch row
+    /// is byte-identical to the ones written before the field could be absent —
+    /// and `#[serde(default)]` is what lets every row already on disk, which
+    /// carries a plain string here, still load.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
     /// The desk/teammate the card was dispatched to.
     pub agent_id: String,
+    /// The conversation this attempt belongs to, when one raised it
+    /// (issue #983) — the only handle a card-less chat turn has.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chat_id: Option<String>,
     /// Which attempt at `task_id` this is, **1-based** — the first run of a card
     /// is `Attempt 1`. Assigned by the backend at create time; see
     /// [`RunStore::create_run`] for the concurrency contract.
@@ -305,10 +318,54 @@ pub struct RunStepRecord {
 pub struct NewRun {
     /// The caller-minted run id.
     pub id: String,
-    /// The card being attempted.
-    pub task_id: String,
+    /// The card being attempted, when there is one.
+    ///
+    /// `None` for a run that attempts no card — an operator chat turn
+    /// (issue #983) frequently opens none, and inventing a synthetic card id to
+    /// keep this required would put a card on the board that nobody asked for
+    /// and that every `RunStore` consumer would then have to know was a
+    /// fiction. A card-less run still carries a status, a step trace, a cost and
+    /// an orphan reaper, which is the whole of what this store is for.
+    pub task_id: Option<String>,
     /// The desk it was dispatched to.
     pub agent_id: String,
+    /// The conversation the run belongs to, when one raised it (issue #983).
+    ///
+    /// What makes a card-less chat turn *findable*: without a `task_id` there is
+    /// no other handle on it, so a desk asking "what is running for me" would
+    /// have nothing to filter on. `None` for a dispatch, which is already
+    /// reachable through its card.
+    pub chat_id: Option<String>,
+}
+
+impl NewRun {
+    /// A run that attempts a board card — the dispatch shape (issue #242).
+    pub fn for_task(
+        id: impl Into<String>,
+        task_id: impl Into<String>,
+        agent_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            task_id: Some(task_id.into()),
+            agent_id: agent_id.into(),
+            chat_id: None,
+        }
+    }
+
+    /// A run that attempts no card — the chat-turn shape (issue #983).
+    pub fn for_chat(
+        id: impl Into<String>,
+        chat_id: impl Into<String>,
+        agent_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            task_id: None,
+            agent_id: agent_id.into(),
+            chat_id: Some(chat_id.into()),
+        }
+    }
 }
 
 /// The settle of an attempt, as handed to [`RunStore::finish_run`].
@@ -393,7 +450,7 @@ impl RunFilter {
     /// filter in memory apply it after [`sort_newest_first`].
     pub fn matches(&self, run: &RunRecord) -> bool {
         if let Some(task_id) = &self.task_id
-            && &run.task_id != task_id
+            && run.task_id.as_deref() != Some(task_id.as_str())
         {
             return false;
         }
@@ -826,7 +883,8 @@ mod test {
         RunRecord {
             id: id.to_string(),
             company: CompanyId::new("alpha"),
-            task_id: "card".to_string(),
+            task_id: Some("card".to_string()),
+            chat_id: None,
             agent_id: "ceo".to_string(),
             attempt,
             status: RunStatus::Pending,
@@ -859,7 +917,7 @@ mod test {
         let mut pending = run("a", 10, 1);
         let mut done = run("b", 10, 2);
         done.status = RunStatus::Succeeded;
-        done.task_id = "other".to_string();
+        done.task_id = Some("other".to_string());
 
         assert!(RunFilter::default().matches(&pending));
         assert!(RunFilter::default().matches(&done));

--- a/src/ports/tasks.rs
+++ b/src/ports/tasks.rs
@@ -983,10 +983,21 @@ pub struct TaskRecord {
     /// that path, and the only run row a console can navigate to. Pinned by test
     /// rather than left to be rediscovered.
     ///
-    /// `None` for every card opened from chat, from a dispatched card, straight
-    /// on the board, and for every card written before this field existed —
-    /// additive on the wire like [`Self::parent_task_id`], so no stored board
-    /// needs migrating.
+    /// # A card opened from chat stamps its **turn's** id (issue #983)
+    ///
+    /// A chat turn now mints a run row of its own, so the field's meaning is
+    /// "the machine act that opened this card" rather than "the workflow run
+    /// that did". A card raised from a DM used to be the only visible sign that
+    /// a long turn was under way and had nothing pointing back at it, so an
+    /// operator staring at a card in Planning could not reach the attempt
+    /// working it. [`origin_workflow_id`](Self::origin_workflow_id) stays `None`
+    /// on that path — there is no graph behind a chat turn — so the two fields
+    /// are no longer set together, and a reader wanting *the workflow* must
+    /// check that one rather than infer it from this.
+    ///
+    /// `None` for a dispatched card, a card opened straight on the board, and
+    /// for every card written before this field existed — additive on the wire
+    /// like [`Self::parent_task_id`], so no stored board needs migrating.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin_run_id: Option<String>,
     /// The workflow graph whose run opened this card (issue #661 / M5).

--- a/src/ports/types.rs
+++ b/src/ports/types.rs
@@ -276,6 +276,62 @@ pub enum CompanyEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         deliverable: Option<crate::ports::tasks::TaskDeliverable>,
     },
+    /// A turn was **accepted** for an operator message (issue #983) — the
+    /// transcript line that says the company took the work on.
+    ///
+    /// # Why this is not the run row
+    ///
+    /// Stage 1 mints a [`RunRecord`](crate::ports::runs::RunRecord) for the same
+    /// turn, and the two answer different questions. The row answers *status* —
+    /// pending, running, failed, what it cost — and is read by a poll. This is
+    /// the *transcript*: the log is the one place a reader reconstructs what
+    /// happened in a conversation from, and "a turn was accepted for this
+    /// message" cannot be inferred from the log without it. An
+    /// [`OperatorMessage`](Self::OperatorMessage) with no reply after it is
+    /// indistinguishable from a chatter message that legitimately produced none,
+    /// so the absence of an answer is not evidence of a lost turn — until this
+    /// event makes the acceptance explicit.
+    ///
+    /// **Structural only.** No message text: the text is already on the
+    /// `OperatorMessage` this brackets, and putting it here would be a second
+    /// copy to redact.
+    ///
+    /// Additive: an entirely new `kind`, so no journal written before it existed
+    /// carries it, and its presence changes how no existing variant serializes.
+    TurnStarted {
+        /// The turn's id — the same id its
+        /// [`RunRecord`](crate::ports::runs::RunRecord) is keyed on, so a
+        /// transcript line and a status row join without a second scheme.
+        turn_id: String,
+        /// The desk / chat thread the message was addressed to.
+        chat_id: String,
+        /// The message being replied to, when the turn answers a thread reply —
+        /// the same sequence position
+        /// [`OperatorMessage::parent`](Self::OperatorMessage) carries.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent: Option<EventSeq>,
+        /// Who asked, mirroring
+        /// [`OperatorMessage`](Self::OperatorMessage)'s `by`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        by: Option<Actor>,
+    },
+    /// A turn that was accepted did not produce an answer (issue #983).
+    ///
+    /// The closing bracket of [`TurnStarted`](Self::TurnStarted), written by the
+    /// turn itself when its cycle errors and by the boot sweep
+    /// ([`crate::runtime::sweep_interrupted_turns`]) for a turn the host died
+    /// under. Without it a turn killed with the pod is permanent silence: the
+    /// question is in the transcript, no answer ever follows it, and nothing
+    /// says why.
+    TurnFailed {
+        /// The turn this settles — the id its
+        /// [`TurnStarted`](Self::TurnStarted) carries.
+        turn_id: String,
+        /// Why, in plain language. Tenant-scoped like
+        /// [`WorkflowRunFinished::error`](Self::WorkflowRunFinished), and
+        /// deliberately **not** projected onto the operator SSE stream.
+        error: String,
+    },
     /// An inbound webhook fired.
     WebhookReceived {
         /// The channel the webhook arrived on.
@@ -1314,6 +1370,8 @@ impl CompanyEvent {
     pub fn kind(&self) -> &'static str {
         match self {
             Self::OperatorMessage { .. } => "OperatorMessage",
+            Self::TurnStarted { .. } => "TurnStarted",
+            Self::TurnFailed { .. } => "TurnFailed",
             Self::WebhookReceived { .. } => "WebhookReceived",
             Self::ScheduleFired { .. } => "ScheduleFired",
             Self::A2aTaskReceived { .. } => "A2aTaskReceived",
@@ -1410,9 +1468,29 @@ impl CompanyEvent {
             // history is not kept here at all: for a published deliverable it
             // lives on the artifact chain (#552), and for an ordinary note it
             // is not kept anywhere, which pruning this does not change.
-            | Self::WorkspaceChanged { .. } => Prunable,
+            | Self::WorkspaceChanged { .. }
+            // Issue #983, and classified deliberately rather than swept in with
+            // its neighbours — the doc above asks for all three questions.
+            //
+            // Is it evidence? No: it says a turn was accepted, and what the turn
+            // did is on its `AgentReply`, its `TurnFailed`, or its run row — all
+            // of which outlive it. Does anything point at it? No: nothing is
+            // addressed by its sequence the way a reaction or a redaction
+            // tombstone addresses a chat message; the turn is joined by
+            // `turn_id`, which pruning does not disturb. Does anything read it
+            // back? The boot sweep does — and only for turns *this* host left
+            // open, which by construction predate no retention pass, since a
+            // pass runs on a live company and the sweep runs before one is.
+            //
+            // What it is instead is one frame per operator message on a
+            // high-traffic desk, whose meaning is entirely spent once the turn
+            // settles. `TurnFailed` is Permanent below for the opposite reason:
+            // it is the only record that a question was accepted and never
+            // answered.
+            | Self::TurnStarted { .. } => Prunable,
 
             Self::OperatorMessage { .. }
+            | Self::TurnFailed { .. }
             | Self::WebhookReceived { .. }
             | Self::ScheduleFired { .. }
             | Self::A2aTaskReceived { .. }

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1618,6 +1618,28 @@ impl RuntimeBuilder {
         if handover.is_none() {
             crate::runtime::sweep_interrupted_runs(&events, &id).await;
 
+            // Issue #983, the chat-turn equivalent, resting on the same three
+            // invariants: a turn journals a `TurnStarted` before it takes the
+            // serial lock, every turn is driven in this process, and one process
+            // owns this journal. So a start with no terminal at boot is a turn
+            // that died with the last host — and without this the operator's
+            // question sits in the transcript with no answer after it and no
+            // explanation, which is indistinguishable from a message that never
+            // warranted a reply.
+            //
+            // The row half of the same turn is reclaimed by
+            // `reap_orphaned_runs` above; this is the transcript half. Both are
+            // needed: the row makes a status query honest, the event makes the
+            // conversation honest, and neither can be derived from the other.
+            //
+            // Gated on the handover for exactly the reason the sweeps above are,
+            // and here the mis-fire is the worst of the three: a chat turn
+            // survives a live runtime swap — the drain covers its *cycle*, but
+            // the spawned task journals the replies and settles the row after
+            // that cycle returns — so sweeping mid-life would tell the operator
+            // their turn failed and then answer it.
+            crate::runtime::sweep_interrupted_turns(&events, &id).await;
+
             // Issue #390, the cycle-level equivalent, resting on the same three
             // invariants: a cycle journals a start before it takes the serial
             // lock, every cycle is driven in this process, and one process owns
@@ -3991,6 +4013,187 @@ mod test {
         assert_eq!(review.error, None);
 
         assert!(runs.list_stale_active(&id).await.unwrap().is_empty());
+    }
+
+    /// Issue #983: a chat turn the host died under is reclaimed on **both**
+    /// halves — a `Failed` row carrying the orphan reason, and a `TurnFailed`
+    /// line closing the transcript bracket.
+    ///
+    /// Both are needed and neither is derivable from the other. The row makes
+    /// `GET {scope}/runs` honest; the event makes the *conversation* honest,
+    /// and without it the operator's question sits there with no answer and no
+    /// explanation — which is what a message that never warranted a reply looks
+    /// like too. The turn names no card, which is exactly why the row sweep
+    /// alone leaves nothing an operator would ever find.
+    #[tokio::test]
+    async fn boot_reclaims_a_chat_turn_stranded_by_a_previous_host() {
+        use crate::ports::runs::{NewRun, ORPHAN_ERROR, RunStatus};
+        use crate::ports::types::{CompanyEvent, EventSeq};
+
+        let home_dir = tmp_home("oc-turn-reap-");
+        let home = home_dir.path().to_path_buf();
+        let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
+        let id = CompanyId::new("acme");
+
+        let first_boot = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        first_boot
+            .runs()
+            .create_run(&id, NewRun::for_chat("turn-dead", "general", "general"))
+            .await
+            .unwrap();
+        first_boot
+            .runs()
+            .begin_run(&id, "turn-dead", EventSeq::new(1))
+            .await
+            .unwrap();
+        first_boot
+            .events()
+            .append(
+                &id,
+                CompanyEvent::TurnStarted {
+                    turn_id: "turn-dead".to_string(),
+                    chat_id: "general".to_string(),
+                    parent: None,
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // The host dies here: no settle, no reply, no failure line.
+        drop(first_boot);
+
+        let second_boot = RuntimeBuilder::new(home.clone(), manifest)
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+
+        let row = second_boot
+            .runs()
+            .get_run(&id, "turn-dead")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(row.status, RunStatus::Failed);
+        assert_eq!(row.error.as_deref(), Some(ORPHAN_ERROR));
+        assert_eq!(row.task_id, None, "a chat turn attempted no card");
+
+        let swept: Vec<String> = second_boot
+            .events()
+            .read_from(&id, EventSeq::new(0), usize::MAX)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|s| match s.event {
+                CompanyEvent::TurnFailed { turn_id, error } if turn_id == "turn-dead" => {
+                    Some(error)
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            swept,
+            vec![crate::runtime::TURN_INTERRUPTED_BY_RESTART.to_string()],
+            "the transcript bracket was left open by the boot sweep"
+        );
+    }
+
+    /// **The negative half, and the one that matters most.** A live runtime
+    /// rebuild must sweep *neither* half of a chat turn.
+    ///
+    /// This is the #290 lesson in its sharpest form. A rebuild happens in a
+    /// process that has been serving, so "nothing from this process can be in
+    /// flight" — the whole proof both sweeps rest on — is false. And a chat turn
+    /// is more exposed than a workflow run: `rebuild_company` quiesces and
+    /// drains the *cycle* lock, but the spawned turn task journals its replies
+    /// and settles its row **after** the cycle returns, so a turn is routinely
+    /// live at exactly the moment a rebuild reaches here. Sweeping would fail
+    /// the row out from under it — its own settle is then rejected by the
+    /// transition table — and tell the operator in the transcript that the turn
+    /// failed, moments before its answer arrives.
+    #[tokio::test]
+    async fn a_rebuild_sweeps_no_live_chat_turn() {
+        use crate::ports::runs::{NewRun, RunStatus};
+        use crate::ports::types::{CompanyEvent, EventSeq};
+
+        let home_dir = tmp_home("oc-turn-rebuild-");
+        let home = home_dir.path().to_path_buf();
+        let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
+        let id = CompanyId::new("acme");
+
+        let live = RuntimeBuilder::new(home.clone(), manifest.clone())
+            .with_id(id.clone())
+            .build()
+            .await
+            .unwrap();
+        live.runs()
+            .create_run(&id, NewRun::for_chat("turn-live", "general", "general"))
+            .await
+            .unwrap();
+        live.runs()
+            .begin_run(&id, "turn-live", EventSeq::new(1))
+            .await
+            .unwrap();
+        live.events()
+            .append(
+                &id,
+                CompanyEvent::TurnStarted {
+                    turn_id: "turn-live".to_string(),
+                    chat_id: "general".to_string(),
+                    parent: None,
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // The swap, as `rebuild_company` performs it: quiesce, hand over, build.
+        live.quiesce().await;
+        let successor = RuntimeBuilder::new(home, manifest)
+            .with_id(id.clone())
+            .with_handover(live.handover())
+            .build()
+            .await
+            .unwrap();
+
+        let row = successor
+            .runs()
+            .get_run(&id, "turn-live")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(
+            row.status,
+            RunStatus::Running,
+            "a rebuild failed a turn that is still working"
+        );
+        assert!(
+            !successor
+                .events()
+                .read_from(&id, EventSeq::new(0), usize::MAX)
+                .await
+                .unwrap()
+                .iter()
+                .any(|s| matches!(&s.event, CompanyEvent::TurnFailed { .. })),
+            "a rebuild told the operator a live turn had failed"
+        );
+
+        // And the turn's own settle still lands, because nothing took the row
+        // to a terminal state behind its back.
+        successor
+            .runs()
+            .finish_run(
+                &id,
+                "turn-live",
+                crate::ports::runs::RunOutcome::new(RunStatus::Succeeded),
+            )
+            .await
+            .expect("the live turn can still settle itself");
     }
 
     /// Issue #337, the crash-truthfulness half: reaping the *row* is not enough

--- a/src/runtime/builder.rs
+++ b/src/runtime/builder.rs
@@ -1521,10 +1521,18 @@ impl RuntimeBuilder {
             match crate::ports::runs::reap_orphaned_runs(ops.runs.as_ref(), &id).await {
                 Ok(reaped) => {
                     for run in reaped {
+                        // Issue #983: a reaped chat turn names no card, so the
+                        // row settle above was the whole of its cleanup. The
+                        // transcript half — folding its unterminated
+                        // `TurnStarted` into a `TurnFailed` — is the journal
+                        // sweep further down, not this one.
+                        let Some(task_id) = run.task_id.as_deref() else {
+                            continue;
+                        };
                         match crate::runtime::advance::advance_settled_card(
                             ops.tasks.as_ref(),
                             &id,
-                            &run.task_id,
+                            task_id,
                             crate::ports::runs::RunStatus::Failed,
                             crate::ports::runs::ORPHAN_ERROR,
                         )
@@ -1533,7 +1541,7 @@ impl RuntimeBuilder {
                             Ok(Some(column)) => tracing::info!(
                                 company = %id,
                                 run = %run.id,
-                                task = %run.task_id,
+                                task = %task_id,
                                 column,
                                 "returned a card stranded by a previous host process"
                             ),
@@ -1544,7 +1552,7 @@ impl RuntimeBuilder {
                             Err(err) => tracing::warn!(
                                 company = %id,
                                 run = %run.id,
-                                task = %run.task_id,
+                                task = %task_id,
                                 error = %err,
                                 "reaped an orphaned run but could not return its card"
                             ),
@@ -3394,16 +3402,9 @@ mod test {
                 .await
                 .expect("first boot");
             let runs = rt.runs();
-            runs.create_run(
-                &id,
-                NewRun {
-                    id: "run-1".to_string(),
-                    task_id: "t-1".to_string(),
-                    agent_id: "ceo".to_string(),
-                },
-            )
-            .await
-            .expect("mint");
+            runs.create_run(&id, NewRun::for_task("run-1", "t-1", "ceo"))
+                .await
+                .expect("mint");
             runs.begin_run(&id, "run-1", EventSeq::new(3))
                 .await
                 .expect("begin");
@@ -3933,11 +3934,7 @@ mod test {
         let home = home_dir.path().to_path_buf();
         let manifest = parse("[company]\nname=\"Acme\"\n[policy]\nmode=\"full\"\n");
         let id = CompanyId::new("acme");
-        let spec = |run: &str, task: &str| NewRun {
-            id: run.to_string(),
-            task_id: task.to_string(),
-            agent_id: "ceo".to_string(),
-        };
+        let spec = |run: &str, task: &str| NewRun::for_task(run, task, "ceo");
 
         let first_boot = RuntimeBuilder::new(home.clone(), manifest.clone())
             .with_id(id.clone())
@@ -4051,29 +4048,15 @@ mod test {
             .upsert(&id, &card("card-b", COLUMN_PAUSED))
             .await
             .unwrap();
-        runs.create_run(
-            &id,
-            NewRun {
-                id: "run-a".to_string(),
-                task_id: "card-a".to_string(),
-                agent_id: "ceo".to_string(),
-            },
-        )
-        .await
-        .unwrap();
+        runs.create_run(&id, NewRun::for_task("run-a", "card-a", "ceo"))
+            .await
+            .unwrap();
         runs.begin_run(&id, "run-a", crate::ports::types::EventSeq::new(1))
             .await
             .unwrap();
-        runs.create_run(
-            &id,
-            NewRun {
-                id: "run-b".to_string(),
-                task_id: "card-b".to_string(),
-                agent_id: "ceo".to_string(),
-            },
-        )
-        .await
-        .unwrap();
+        runs.create_run(&id, NewRun::for_task("run-b", "card-b", "ceo"))
+            .await
+            .unwrap();
         runs.begin_run(&id, "run-b", crate::ports::types::EventSeq::new(2))
             .await
             .unwrap();
@@ -4130,14 +4113,7 @@ mod test {
             RunStatus::Failed
         );
         let next = runs
-            .create_run(
-                &id,
-                NewRun {
-                    id: "run-a2".to_string(),
-                    task_id: "card-a".to_string(),
-                    agent_id: "ceo".to_string(),
-                },
-            )
+            .create_run(&id, NewRun::for_task("run-a2", "card-a", "ceo"))
             .await
             .unwrap();
         assert_eq!(

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -1814,6 +1814,13 @@ fn cycle_task_id(
             // work merely by existing, and that work's own card writes would
             // announce again.
             | CompanyEvent::TaskCardChanged { .. }
+            // Issue #983: the accept/settle brackets of a chat turn. Records of
+            // something that already happened, exactly like the workflow-run
+            // brackets above — they name no card, and they are appended by the
+            // route that already started the turn they describe, so treating
+            // either as a stimulus would make a turn re-trigger itself.
+            | CompanyEvent::TurnStarted { .. }
+            | CompanyEvent::TurnFailed { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };
@@ -1986,6 +1993,13 @@ fn cycle_conversation(
             // work merely by existing, and that work's own card writes would
             // announce again.
             | CompanyEvent::TaskCardChanged { .. }
+            // Issue #983: the accept/settle brackets of a chat turn. Records of
+            // something that already happened, exactly like the workflow-run
+            // brackets above — they name no card, and they are appended by the
+            // route that already started the turn they describe, so treating
+            // either as a stimulus would make a turn re-trigger itself.
+            | CompanyEvent::TurnStarted { .. }
+            | CompanyEvent::TurnFailed { .. }
             | CompanyEvent::DeskTaskCompleted { .. } => continue,
         };
         let Some(candidate) = candidate else { continue };

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -534,10 +534,16 @@ impl<'a> CycleRunner<'a> {
             // The reason goes onto the note so the board says why, and the move
             // is guarded: a card an operator has since dragged, or that a later
             // attempt parked, is left exactly where it is.
+            // Issue #983: a card-less run has no card to strand, so there is
+            // nothing here to make truthful. Settling the row above was the
+            // whole of this run's cleanup.
+            let Some(task_id) = run.task_id.as_deref() else {
+                continue;
+            };
             match crate::runtime::advance::advance_settled_card(
                 self.rt.tasks().as_ref(),
                 company,
-                &run.task_id,
+                task_id,
                 RunStatus::Failed,
                 &reason,
             )
@@ -546,7 +552,7 @@ impl<'a> CycleRunner<'a> {
                 Ok(Some(column)) => tracing::info!(
                     company = %company,
                     run = %id,
-                    task = %run.task_id,
+                    task = %task_id,
                     column,
                     "[runs] the terminality backstop returned a stranded card"
                 ),
@@ -557,7 +563,7 @@ impl<'a> CycleRunner<'a> {
                 Err(err) => tracing::warn!(
                     company = %company,
                     run = %id,
-                    task = %run.task_id,
+                    task = %task_id,
                     error = %err,
                     "[runs] the terminality backstop settled an attempt but could not move its card"
                 ),
@@ -3026,11 +3032,7 @@ mod test {
         rt.runs()
             .create_run(
                 rt.id(),
-                crate::ports::runs::NewRun {
-                    id: crate::ports::generate_id(),
-                    task_id: task.to_string(),
-                    agent_id: "ceo".to_string(),
-                },
+                crate::ports::runs::NewRun::for_task(crate::ports::generate_id(), task, "ceo"),
             )
             .await
             .expect("mint a run")

--- a/src/runtime/cycle.rs
+++ b/src/runtime/cycle.rs
@@ -179,6 +179,13 @@ impl ResolveReceipt {
 /// Deliberately coarse and deliberately not the event's payload: this lands in a
 /// durable record, and a label is not the place for message text or tool
 /// arguments.
+fn cycle_trigger_of(events: &[(Option<EventSeq>, CompanyEvent)]) -> String {
+    match events.first() {
+        Some((_, first)) => cycle_trigger(std::slice::from_ref(first)),
+        None => "empty".to_string(),
+    }
+}
+
 fn cycle_trigger(events: &[CompanyEvent]) -> String {
     let Some(first) = events.first() else {
         return "empty".to_string();
@@ -229,8 +236,63 @@ impl<'a> CycleRunner<'a> {
     /// deliberate — a banked decision is *correctly* not running, and giving it
     /// a bracket would leave an open cycle that never closes and never should.
     pub async fn run(&self, events: Vec<CompanyEvent>) -> Result<CycleReport> {
+        // Every input still needs appending — this is the wrapper every trigger
+        // but the chat route uses, and it is byte-unchanged from its pre-#983
+        // self.
+        self.run_bracketed(
+            events.into_iter().map(|event| (None, event)).collect(),
+            None,
+        )
+        .await
+    }
+
+    /// [`run`](Self::run), for inputs whose journal append has **already
+    /// happened** (issue #983).
+    ///
+    /// The chat route appends the operator's message the instant the request is
+    /// accepted, before it takes this lock, so `chat/history` is correct from
+    /// acceptance rather than from whenever the cycle wins the per-company
+    /// mutex — which, behind a busy company, is an unbounded time later. That
+    /// append must not then happen a second time in here, so the caller hands
+    /// over each event together with the [`EventSeq`] it was appended under and
+    /// this skips the write.
+    ///
+    /// **Everything downstream stays keyed on the supplied seqs.** The
+    /// `TaskDispatched` → `begin_run` handling, `CycleReport::input_seqs` (and
+    /// therefore the chat response's `messageId`), and the seq list the brain
+    /// sees are all built from them, so a pre-journaled cycle is
+    /// indistinguishable from an appending one everywhere except in who wrote
+    /// the line.
+    ///
+    /// `run_id` is a run row to move `Pending` → `Running` once the serial lock
+    /// is actually held. That placement is the point: a chat turn's row is
+    /// minted at accept time, so `Pending` means "queued behind other turns" and
+    /// `Running` means "owns the lock" — a distinction the caller cannot make
+    /// from outside, because the wait on the lock happens in here.
+    pub async fn run_journaled(
+        &self,
+        events: Vec<(EventSeq, CompanyEvent)>,
+        run_id: Option<String>,
+    ) -> Result<CycleReport> {
+        self.run_bracketed(
+            events
+                .into_iter()
+                .map(|(seq, event)| (Some(seq), event))
+                .collect(),
+            run_id,
+        )
+        .await
+    }
+
+    /// The shared body of both entry points: open the journal bracket, take the
+    /// serial lock, run, close the bracket.
+    async fn run_bracketed(
+        &self,
+        events: Vec<(Option<EventSeq>, CompanyEvent)>,
+        run_id: Option<String>,
+    ) -> Result<CycleReport> {
         let cycle_id = crate::ports::generate_id();
-        let trigger = cycle_trigger(&events);
+        let trigger = cycle_trigger_of(&events);
 
         // Best-effort, and it must stay that way: record-keeping does not get to
         // refuse a cycle. A failed open simply means this cycle is unbracketed,
@@ -250,7 +312,7 @@ impl<'a> CycleRunner<'a> {
         }
 
         let guard = self.rt.serial.lock().await;
-        let outcome = self.run_locked(events, cycle_id.clone()).await;
+        let outcome = self.run_locked(events, cycle_id.clone(), run_id).await;
         // Closed while the lock is still held, so the bracket cannot outlive the
         // critical section it describes.
         let error = outcome.as_ref().err().map(|err| err.to_string());
@@ -273,19 +335,28 @@ impl<'a> CycleRunner<'a> {
 
     async fn run_locked(
         &self,
-        mut events: Vec<CompanyEvent>,
+        inputs: Vec<(Option<EventSeq>, CompanyEvent)>,
         cycle_id: String,
+        run_id: Option<String>,
     ) -> Result<CycleReport> {
         let company = self.rt.id.clone();
 
         // 2. Persist input — durable before any thinking.
         let mut persisted_seq = None;
-        let mut event_seqs = Vec::with_capacity(events.len());
+        let mut event_seqs = Vec::with_capacity(inputs.len());
         // Issue #242: the attempt rows this cycle is about to run, moved
         // `Pending` → `Running` below and backstopped after the brain returns.
         let mut dispatched_runs: Vec<String> = Vec::new();
-        for event in &events {
-            let seq = self.rt.events.append(&company, event.clone()).await?;
+        let mut events: Vec<CompanyEvent> = Vec::with_capacity(inputs.len());
+        for (journaled, event) in inputs {
+            // Issue #983: an input the caller already appended keeps the seq it
+            // was appended under. Everything below is keyed on `seq` and not on
+            // who wrote it, so the two entry points diverge here and nowhere
+            // else.
+            let seq = match journaled {
+                Some(seq) => seq,
+                None => self.rt.events.append(&company, event.clone()).await?,
+            };
             event_seqs.push(seq);
             persisted_seq = Some(seq);
             // Start the run here, not inside the brain: the serial lock is held,
@@ -296,7 +367,7 @@ impl<'a> CycleRunner<'a> {
             if let CompanyEvent::TaskDispatched {
                 run_id: Some(run_id),
                 ..
-            } = event
+            } = &event
             {
                 match self.rt.runs().begin_run(&company, run_id, seq).await {
                     Ok(_) => dispatched_runs.push(run_id.clone()),
@@ -314,6 +385,34 @@ impl<'a> CycleRunner<'a> {
                     ),
                 }
             }
+            events.push(event);
+        }
+
+        // Issue #983: the caller's own run row, moved `Pending` → `Running`
+        // here — inside the serial lock — because that is what makes the two
+        // statuses mean anything. A row started at accept time would read
+        // `Running` while it was in fact queued behind another turn, which is
+        // precisely the wait an operator staring at a slow company needs to see.
+        //
+        // Deliberately **not** added to `dispatched_runs`: the terminality
+        // backstop settles what it started as soon as this cycle ends, and the
+        // chat turn's settle belongs to the task that also journals its replies,
+        // which outlives this call. A cycle error still settles the row — the
+        // caller sees the `Err` and settles it `Failed` — and a panic is the
+        // boot reaper's job, exactly as it is for a dispatch.
+        //
+        // Best-effort and logged, on the same terms as the dispatch rows above:
+        // record-keeping does not get to fail the work it records.
+        if let Some(run_id) = run_id.as_deref()
+            && let Some(seq) = event_seqs.first().copied()
+            && let Err(err) = self.rt.runs().begin_run(&company, run_id, seq).await
+        {
+            tracing::warn!(
+                company = %company,
+                run = %run_id,
+                error = %err,
+                "[runs] could not start a turn row; the turn runs untracked"
+            );
         }
 
         // 3. Load — history, context index, roster.
@@ -6890,6 +6989,171 @@ mod test {
         assert!(
             !rt.pending_approvals()[0].broadly_grantable,
             "sending mail stays a per-call decision"
+        );
+    }
+
+    // ── Issue #983: the pre-journaled entry point ────────────────────────────
+
+    /// Every input of a cycle appears in the journal **exactly once**, whichever
+    /// entry point drove it.
+    ///
+    /// This is the pin the plumbing change is worth having. `run_cycle` is what
+    /// every other trigger in the tree uses — the scheduler, cron, webhooks, the
+    /// telegram poller, delegation, approval follow-ups — so the append it does
+    /// must stay exactly one per input; and `run_journaled_cycle`, which exists
+    /// so the chat route can append at accept time instead, must do none. Either
+    /// half getting it wrong is invisible at the call site and shows up as a
+    /// duplicated (or missing) message in somebody's transcript.
+    ///
+    /// It also pins `CycleReport::input_seqs`, and therefore the chat response's
+    /// `messageId`: the pre-journaled path reports back the seqs it was handed,
+    /// not seqs of its own.
+    #[tokio::test]
+    async fn each_input_is_journaled_exactly_once_by_either_entry_point() {
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let seen = Arc::new(StdMutex::new(Vec::new()));
+        let rt = RuntimeBuilder::new(home, manifest("full"))
+            .with_brain(Arc::new(CapturingBrain {
+                seen: Arc::clone(&seen),
+            }))
+            .build()
+            .await
+            .unwrap();
+
+        let ask = |text: &str| CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        };
+        let messages = |stored: &[crate::ports::types::StoredEvent]| -> Vec<String> {
+            stored
+                .iter()
+                .filter_map(|s| match &s.event {
+                    CompanyEvent::OperatorMessage { text, .. } => Some(text.clone()),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        // The appending wrapper: one line per input, and the report names them.
+        let appended = rt.run_cycle(vec![ask("first")]).await.unwrap();
+        let stored = rt
+            .events()
+            .read_from(rt.id(), EventSeq::new(0), 1_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            messages(&stored),
+            ["first"],
+            "the appending entry point wrote its input exactly once"
+        );
+        assert_eq!(appended.input_seqs.len(), 1);
+        assert_eq!(
+            stored
+                .iter()
+                .find(|s| matches!(&s.event, CompanyEvent::OperatorMessage { text, .. } if text == "first"))
+                .map(|s| s.seq),
+            appended.input_seqs.first().copied(),
+            "the reported seq is the one the message was appended under"
+        );
+
+        // The pre-journaled entry point: the caller's append is the only one.
+        let pre = rt.events().append(rt.id(), ask("second")).await.unwrap();
+        let journaled = rt
+            .run_journaled_cycle(vec![(pre, ask("second"))], None)
+            .await
+            .unwrap();
+        let stored = rt
+            .events()
+            .read_from(rt.id(), EventSeq::new(0), 1_000)
+            .await
+            .unwrap();
+        assert_eq!(
+            messages(&stored),
+            ["first", "second"],
+            "the pre-journaled entry point appended its input a second time"
+        );
+        assert_eq!(
+            journaled.input_seqs,
+            vec![pre],
+            "the report carries the seq the caller supplied, not one of its own"
+        );
+
+        // And the brain saw both, so skipping the append did not skip the input.
+        assert_eq!(*seen.lock().expect("seen"), ["first", "second"]);
+    }
+
+    /// A pre-journaled cycle moves the caller's run row to `Running` **inside**
+    /// the serial lock, and leaves settling it to the caller.
+    ///
+    /// Both halves matter. Starting the row outside the lock would make
+    /// `Running` mean "accepted" rather than "owns the lock", which is exactly
+    /// the queued-behind-another-turn wait an operator needs to see. And letting
+    /// the cycle's terminality backstop settle it would close the row while the
+    /// task that journals the turn's replies is still running.
+    #[tokio::test]
+    async fn a_journaled_cycle_starts_the_callers_run_and_leaves_it_running() {
+        use crate::ports::runs::{NewRun, RunStatus};
+
+        let home_dir = tmp_home();
+        let home = home_dir.path().to_path_buf();
+        let rt = RuntimeBuilder::new(home, manifest("full"))
+            .build()
+            .await
+            .unwrap();
+        rt.runs()
+            .create_run(rt.id(), NewRun::for_chat("turn-1", "general", "ceo"))
+            .await
+            .unwrap();
+
+        let seq = rt
+            .events()
+            .append(
+                rt.id(),
+                CompanyEvent::OperatorMessage {
+                    text: "hello".into(),
+                    by: None,
+                    chat: None,
+                    parent: None,
+                    deliverable: None,
+                },
+            )
+            .await
+            .unwrap();
+        rt.run_journaled_cycle(
+            vec![(
+                seq,
+                CompanyEvent::OperatorMessage {
+                    text: "hello".into(),
+                    by: None,
+                    chat: None,
+                    parent: None,
+                    deliverable: None,
+                },
+            )],
+            Some("turn-1".to_string()),
+        )
+        .await
+        .unwrap();
+
+        let row = rt
+            .runs()
+            .get_run(rt.id(), "turn-1")
+            .await
+            .unwrap()
+            .expect("the row survives the cycle");
+        assert_eq!(
+            row.status,
+            RunStatus::Running,
+            "the cycle started the row and must not have settled it"
+        );
+        assert_eq!(
+            row.trigger_event_seq,
+            Some(seq),
+            "the row is stamped with the seq the caller supplied"
         );
     }
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -95,6 +95,9 @@ pub mod scheduler;
 /// path that needs no public URL, mirroring OpenHuman. See [`telegram_poller`].
 pub mod telegram_poller;
 pub mod tools;
+/// Issue #983: settling chat turns a previous host process left open, the
+/// transcript-side twin of the run reaper. See [`turn_sweep`].
+pub mod turn_sweep;
 pub mod types;
 /// Issue #228: the single place a finished workflow run is journaled, shared by
 /// the console's run route and the cron [`WorkflowScheduler`] so a run's history
@@ -136,6 +139,7 @@ pub use scheduler::{
     missed_instant,
 };
 pub use tools::StubToolProvider;
+pub use turn_sweep::{TURN_INTERRUPTED_BY_RESTART, sweep_interrupted_turns};
 pub use types::{ApprovalSummary, CompanyStatus, CycleReport};
 pub use workflow_outcome::{
     delivered_by_unsettled_runs, record_run_finished, sweep_interrupted_runs,

--- a/src/runtime/turn_sweep.rs
+++ b/src/runtime/turn_sweep.rs
@@ -1,0 +1,260 @@
+//! Issue #983: settle chat turns a previous host process left open.
+//!
+//! The tenant-side half of "a turn that was accepted must be readable". A chat
+//! turn journals a [`CompanyEvent::TurnStarted`] the moment the request is
+//! accepted and a [`CompanyEvent::TurnFailed`] if it errors, so the pair is a
+//! bracket the way `WorkflowRunStarted` / `WorkflowRunFinished` is — and a start
+//! with no terminal at boot is a turn that died with the last host.
+//!
+//! Kept beside the workflow sweep it mirrors rather than folded into it, because
+//! the two read different brackets and neither wants the other's shape.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::ports::EventLog;
+use crate::ports::types::{CompanyEvent, CompanyId, EventSeq};
+
+/// The reason stamped on a turn the host never got to finish.
+///
+/// Phrased as a host fact, like [`INTERRUPTED_BY_RESTART`][super::INTERRUPTED_BY_RESTART]:
+/// nothing about the question went wrong, the process holding the answer went
+/// away. Without this line the transcript holds the operator's question, no
+/// answer after it, and no explanation — which is indistinguishable from a
+/// message that never warranted a reply.
+pub const TURN_INTERRUPTED_BY_RESTART: &str = concat!(
+    "this turn was interrupted by a host restart and never answered; ",
+    "ask again — nothing it did before stopping is lost, but no reply was produced"
+);
+
+/// Terminates chat turns a previous host process left open.
+///
+/// # Why an unterminated start is provably dead
+///
+/// The same three invariants
+/// [`reap_orphaned_runs`](crate::ports::runs::reap_orphaned_runs) rests on, and
+/// they hold for a chat turn verbatim: a turn is a process-local `tokio::spawn`
+/// so it cannot outlive the process that spawned it; exactly one process owns a
+/// company's journal (it is a documented single-writer log); and every turn
+/// serialises on the per-company cycle mutex, so no turn from *this* process is
+/// in flight before boot completes. So at boot an unmatched `TurnStarted` cannot
+/// belong to a live turn: there are no live turns. No timeout heuristic is
+/// needed, for exactly the reason none is needed there.
+///
+/// # It must NOT run on a rebuild
+///
+/// The argument above holds at boot and is false the moment a company has been
+/// serving — and here the consequence is worse than it is for a workflow run. A
+/// chat turn survives a live runtime swap ([`rebuild_company`](super::rebuild_company)):
+/// `rebuild_company` quiesces and drains the *cycle* lock, but the spawned turn
+/// task owns the reply journaling and the row settle **after** its cycle
+/// returns, and the successor adopts the same mutex. Sweeping mid-life would
+/// therefore stamp "interrupted by a host restart" on a turn that is still
+/// working, and its real answer would land afterwards — leaving the operator a
+/// transcript that says the turn failed and then answers it. The caller gates on
+/// the handover being absent; see the call site in the runtime builder. Same
+/// lesson as #290.
+///
+/// Best-effort throughout: a read or append failure is logged and swallowed,
+/// because record-keeping must never stop a company from booting.
+pub async fn sweep_interrupted_turns(events: &Arc<dyn EventLog>, company: &CompanyId) {
+    let stored = match events
+        .read_from(company, EventSeq::new(0), usize::MAX)
+        .await
+    {
+        Ok(stored) => stored,
+        Err(err) => {
+            tracing::warn!(
+                %company,
+                %err,
+                "could not read the journal to sweep interrupted turns"
+            );
+            return;
+        }
+    };
+
+    // One pass keyed on turn id: a start inserts, a failure removes. Whatever is
+    // left was accepted and never settled. `HashMap` rather than a set because
+    // the log line names the desk, which lives only on the start.
+    let mut open: HashMap<String, String> = HashMap::new();
+    for stored in stored {
+        match stored.event {
+            CompanyEvent::TurnStarted {
+                turn_id, chat_id, ..
+            } => {
+                open.insert(turn_id, chat_id);
+            }
+            CompanyEvent::TurnFailed { turn_id, .. } => {
+                open.remove(&turn_id);
+            }
+            _ => {}
+        }
+    }
+
+    if open.is_empty() {
+        return;
+    }
+
+    // Sorted so the appended order is deterministic — a `HashMap` iteration
+    // order would make the journal's tail differ run to run for no reason.
+    let mut interrupted: Vec<(String, String)> = open.into_iter().collect();
+    interrupted.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (turn_id, chat_id) in interrupted {
+        tracing::info!(
+            %company,
+            turn = %turn_id,
+            chat = %chat_id,
+            "settling a chat turn left open by a previous host process"
+        );
+        if let Err(err) = events
+            .append(
+                company,
+                CompanyEvent::TurnFailed {
+                    turn_id: turn_id.clone(),
+                    error: TURN_INTERRUPTED_BY_RESTART.to_string(),
+                },
+            )
+            .await
+        {
+            tracing::warn!(
+                %company,
+                turn = %turn_id,
+                %err,
+                "could not settle an interrupted turn; the next boot sweeps it again"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::store::FsEventLog;
+
+    fn log() -> (tempfile::TempDir, Arc<dyn EventLog>) {
+        let dir = tempfile::Builder::new()
+            .prefix("oc-turn-sweep-")
+            .tempdir()
+            .expect("tempdir");
+        let events: Arc<dyn EventLog> = Arc::new(FsEventLog::new(dir.path()));
+        (dir, events)
+    }
+
+    async fn started(events: &Arc<dyn EventLog>, company: &CompanyId, turn_id: &str) {
+        events
+            .append(
+                company,
+                CompanyEvent::TurnStarted {
+                    turn_id: turn_id.to_string(),
+                    chat_id: "general".to_string(),
+                    parent: None,
+                    by: None,
+                },
+            )
+            .await
+            .expect("append");
+    }
+
+    async fn failures(events: &Arc<dyn EventLog>, company: &CompanyId) -> Vec<(String, String)> {
+        events
+            .read_from(company, EventSeq::new(0), usize::MAX)
+            .await
+            .expect("read")
+            .into_iter()
+            .filter_map(|s| match s.event {
+                CompanyEvent::TurnFailed { turn_id, error } => Some((turn_id, error)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// The case the sweep exists for: the host died holding a turn, so the
+    /// operator's question sits in the transcript with nothing after it.
+    #[tokio::test]
+    async fn an_unterminated_turn_is_settled_at_boot() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        started(&events, &company, "turn-dead").await;
+
+        sweep_interrupted_turns(&events, &company).await;
+
+        assert_eq!(
+            failures(&events, &company).await,
+            vec![(
+                "turn-dead".to_string(),
+                TURN_INTERRUPTED_BY_RESTART.to_string()
+            )]
+        );
+    }
+
+    /// A turn that settled itself is left alone, and the sweep is idempotent —
+    /// its own synthetic failure closes the bracket, so a second boot after an
+    /// unclean one does not stack a second line onto the same turn.
+    #[tokio::test]
+    async fn a_settled_turn_is_never_swept_twice() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        started(&events, &company, "turn-ok").await;
+        events
+            .append(
+                &company,
+                CompanyEvent::TurnFailed {
+                    turn_id: "turn-ok".to_string(),
+                    error: "the brain refused".to_string(),
+                },
+            )
+            .await
+            .expect("append");
+        started(&events, &company, "turn-dead").await;
+
+        sweep_interrupted_turns(&events, &company).await;
+        sweep_interrupted_turns(&events, &company).await;
+
+        assert_eq!(
+            failures(&events, &company).await,
+            vec![
+                ("turn-ok".to_string(), "the brain refused".to_string()),
+                (
+                    "turn-dead".to_string(),
+                    TURN_INTERRUPTED_BY_RESTART.to_string()
+                ),
+            ],
+            "the sweep re-settled a turn it had already settled"
+        );
+    }
+
+    /// A company with nothing open appends nothing at all — the sweep must not
+    /// leave a trace of having run on every boot of every company.
+    #[tokio::test]
+    async fn a_quiet_company_is_untouched() {
+        let (_home, events) = log();
+        let company = CompanyId::new("acme");
+        sweep_interrupted_turns(&events, &company).await;
+        assert!(
+            events
+                .read_from(&company, EventSeq::new(0), usize::MAX)
+                .await
+                .expect("read")
+                .is_empty()
+        );
+    }
+
+    /// One company's dead turn is not another's.
+    #[tokio::test]
+    async fn the_sweep_is_scoped_to_one_company() {
+        let (_home, events) = log();
+        let acme = CompanyId::new("acme");
+        let other = CompanyId::new("other");
+        started(&events, &acme, "turn-a").await;
+        started(&events, &other, "turn-b").await;
+
+        sweep_interrupted_turns(&events, &acme).await;
+
+        assert_eq!(failures(&events, &acme).await.len(), 1);
+        assert!(
+            failures(&events, &other).await.is_empty(),
+            "another company's live turn was settled"
+        );
+    }
+}

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1177,7 +1177,12 @@ async fn run_chat(
     message: ChatMessage,
     by: Option<Actor>,
     parent: Option<EventSeq>,
+    accepted: &AcceptedTurn,
 ) -> Result<(CycleReport, Option<String>), ApiError> {
+    // Re-checked here rather than only at accept: this is also reachable
+    // directly, and a lifecycle can change between accepting a turn and running
+    // it. `accept_chat_turn` runs the same check *before* the append, so a
+    // refusal never leaves a message in the transcript that no turn answers.
     runtime.ensure_running().await?;
     // Whether this is a workflow copilot thread (issue #416): a conversation
     // ABOUT one graph, not a request to the company. Read once, because both
@@ -1318,32 +1323,222 @@ async fn run_chat(
             // here infers the choice from the text (decision D2a).
             deliverable: message.deliverable.unwrap_or_default(),
             workflow_proposal: None,
-            origin_run_id: None,
+            // Issue #983: the turn that opened it. A card raised from chat used
+            // to be the *only* visible sign that a long turn was under way, and
+            // it had nothing pointing back at the turn — so an operator looking
+            // at a card in Planning could not reach the attempt working it, and
+            // a turn that opened a card was indistinguishable from one that
+            // opened none. `origin_workflow_id` stays `None`: there is no graph
+            // behind a chat turn, and inventing one would be a lie the board
+            // then carries forever.
+            origin_run_id: accepted.turn_id.clone(),
             origin_workflow_id: None,
         };
         if let Err(err) = runtime.upsert_task(&record).await {
             tracing::warn!(error = %err, "failed to open task card for chat request");
         }
     }
+    // Issue #983: the message is already in the journal — `accept_chat_turn`
+    // appended it when the request was accepted, which is the whole point, so
+    // `chat/history` is right from that instant rather than from whenever this
+    // cycle wins the per-company serial lock. The cycle is handed the seq it
+    // landed under and skips the append; everything downstream, `input_seqs` and
+    // the response's `messageId` included, is keyed on that same seq.
     let report = runtime
-        .run_cycle(vec![CompanyEvent::OperatorMessage {
-            text: message.text,
-            by,
-            // Thread the addressed desk through so the orchestrator brain can
-            // route to that desk's lead member (issue #53).
-            chat: message.chat,
-            // …and the message being replied to, so the thread is a fact about
-            // the transcript rather than about one browser (issue #364).
-            parent,
-            // Issue #845: and the once-vs-workflow choice, so the turn that
-            // answers this message knows whether the builder pass owns the
-            // authoring. Without it the turn ran blind and denied a capability
-            // that was being exercised on the very same message — see the field
-            // docs on `CompanyEvent::OperatorMessage`.
-            deliverable: message.deliverable,
-        }])
+        .run_journaled_cycle(
+            vec![(accepted.message_seq, accepted.message_event.clone())],
+            accepted.turn_id.clone(),
+        )
         .await?;
     Ok((report, feedback_note))
+}
+
+/// What accepting a chat turn produced, before any of the turn's work runs
+/// (issue #983).
+///
+/// The three facts that have to exist the moment a request is accepted, rather
+/// than whenever the turn eventually gets the lock: the operator's message is in
+/// the transcript, a durable row says a turn is owed, and the journal carries a
+/// line saying the company took the work on.
+struct AcceptedTurn {
+    /// The seq the operator's message was appended under. The turn's own
+    /// `messageId`, and what the pre-journaled cycle is keyed on.
+    message_seq: EventSeq,
+    /// The event itself, so the cycle can hand the brain what was journaled
+    /// rather than a reconstruction of it.
+    message_event: CompanyEvent,
+    /// The turn's durable row, when one could be minted. `None` means the run
+    /// store refused — the turn still runs, untracked, because record-keeping
+    /// does not get to fail the work it records.
+    turn_id: Option<String>,
+}
+
+/// Journals an operator message and mints the turn owed for it (issue #983).
+///
+/// # Everything that can refuse, refuses first
+///
+/// `ensure_running` (a lifecycle an operator chose — paused, archived) and
+/// `ensure_accepting` (a runtime being replaced) are both checked **before** the
+/// append. Ordered the other way, a refused request would still leave the
+/// operator's question in the transcript with nothing that will ever answer it —
+/// which is worse than the pre-#983 behaviour, not better, because a message
+/// that is visibly there and permanently unanswered reads as lost work.
+///
+/// # The row is `Pending`, deliberately
+///
+/// `create_run` here, `begin_run` inside the cycle once it actually holds the
+/// serial lock. So `Pending` means "queued behind other turns" — the serial
+/// train five concurrent messages produce — and `Running` means "owns the lock".
+/// Starting the row here would collapse the two and hide exactly the wait an
+/// operator on a busy company is trying to understand.
+///
+/// The row is a [`RunRecord`](crate::ports::runs::RunRecord) rather than a store
+/// of its own, which is what makes this small: it inherits transition legality,
+/// the step trace, `list_stale_active`, the boot reaper — whose boot-only proof
+/// holds verbatim for a chat turn, since a turn is a process-local
+/// `tokio::spawn` serialising on the same per-company mutex — and the
+/// `GET {scope}/runs` / `GET {scope}/runs/{run_id}` routes that already exist.
+/// There is no new route here, and no new poll endpoint to design.
+///
+/// Best-effort on the row and on the transcript line, never on the append: the
+/// message is the thing the operator can lose, and the other two are how we
+/// describe it.
+async fn accept_chat_turn(
+    runtime: &Arc<CompanyRuntime>,
+    id: &CompanyId,
+    message: &ChatMessage,
+    by: Option<&Actor>,
+    parent: Option<EventSeq>,
+    desk: &str,
+) -> Result<AcceptedTurn, ApiError> {
+    runtime.ensure_running().await?;
+    runtime.ensure_accepting().map_err(ApiError)?;
+
+    let message_event = CompanyEvent::OperatorMessage {
+        text: message.text.clone(),
+        by: by.cloned(),
+        // Thread the addressed desk through so the orchestrator brain can
+        // route to that desk's lead member (issue #53).
+        chat: message.chat.clone(),
+        // …and the message being replied to, so the thread is a fact about
+        // the transcript rather than about one browser (issue #364).
+        parent,
+        // Issue #845: and the once-vs-workflow choice, so the turn that
+        // answers this message knows whether the builder pass owns the
+        // authoring. Without it the turn ran blind and denied a capability
+        // that was being exercised on the very same message — see the field
+        // docs on `CompanyEvent::OperatorMessage`.
+        deliverable: message.deliverable,
+    };
+    let message_seq = runtime
+        .events()
+        .append(id, message_event.clone())
+        .await
+        .map_err(ApiError)?;
+
+    let turn_id = crate::ports::generate_id();
+    let turn_id = match runtime
+        .runs()
+        .create_run(
+            id,
+            crate::ports::runs::NewRun::for_chat(turn_id.clone(), desk, desk),
+        )
+        .await
+    {
+        Ok(run) => Some(run.id),
+        Err(err) => {
+            tracing::warn!(
+                company = %id,
+                turn = %turn_id,
+                error = %err,
+                "[runs] could not open a turn row; the turn runs untracked"
+            );
+            None
+        }
+    };
+
+    // The transcript line. Separate from the row on purpose: the row answers
+    // "what is the status", and this answers "was a turn accepted for this
+    // message at all" — which the log cannot otherwise say, because an
+    // `OperatorMessage` with no reply after it is indistinguishable from a
+    // chatter message that legitimately produced none.
+    if let Some(turn_id) = turn_id.clone()
+        && let Err(err) = runtime
+            .events()
+            .append(
+                id,
+                CompanyEvent::TurnStarted {
+                    turn_id,
+                    chat_id: desk.to_string(),
+                    parent,
+                    by: by.cloned(),
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %id,
+            error = %err,
+            "could not journal a turn's acceptance; its row still records it"
+        );
+    }
+
+    Ok(AcceptedTurn {
+        message_seq,
+        message_event,
+        turn_id,
+    })
+}
+
+/// Settles a chat turn's durable row, and says so in the transcript when it
+/// failed (issue #983).
+///
+/// Runs inside the spawned turn, beside the reply journaling and for the same
+/// reason: a client that walked away must not take the record with it. A turn
+/// whose row is left active is not silently forgiven either — the boot reaper
+/// fails it on the next start, on exactly the proof it uses for a dispatch.
+async fn settle_chat_turn(
+    runtime: &Arc<CompanyRuntime>,
+    id: &CompanyId,
+    turn_id: Option<&str>,
+    failure: Option<&ApiError>,
+) {
+    let Some(turn_id) = turn_id else { return };
+    let outcome = match failure {
+        None => crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Succeeded),
+        Some(err) => crate::ports::runs::RunOutcome::new(crate::ports::runs::RunStatus::Failed)
+            .with_error(err.0.to_string()),
+    };
+    if let Err(err) = runtime.runs().finish_run(id, turn_id, outcome).await {
+        tracing::warn!(
+            company = %id,
+            turn = %turn_id,
+            error = %err,
+            "[runs] could not settle a turn row; the next boot reaps it"
+        );
+    }
+    // Only a failure gets a transcript line. A turn that answered has an
+    // `AgentReply` right there saying so, and a second "it finished" line would
+    // be one more thing to read for no information.
+    if let Some(failure) = failure
+        && let Err(err) = runtime
+            .events()
+            .append(
+                id,
+                CompanyEvent::TurnFailed {
+                    turn_id: turn_id.to_string(),
+                    error: failure.0.to_string(),
+                },
+            )
+            .await
+    {
+        tracing::warn!(
+            company = %id,
+            turn = %turn_id,
+            error = %err,
+            "could not journal a turn's failure; its row still records it"
+        );
+    }
 }
 
 /// Runs a chat cycle and emits any implied webhooks, rendering the responses.
@@ -1382,6 +1577,15 @@ async fn chat_and_emit(
     // (`CompanyRuntime::resolve_approval_spawned`, issue #380 defect 3) and the
     // workflow runner (`WorkflowSpawn::spawn_admitted`), which is why a 504'd
     // workflow run kept executing while a 504'd chat turn did not.
+    // Issue #983: the operator's message reaches the journal here, before the
+    // turn is spawned and therefore before it queues on the per-company serial
+    // lock. It used to be appended inside that lock, so five concurrent messages
+    // became a serial train in which the fifth operator's question was invisible
+    // — a reload showed an empty conversation — until the four ahead of it had
+    // finished. A durable row and a transcript line are minted alongside it, so
+    // a turn killed with the pod becomes a `Failed` row and a `TurnFailed` line
+    // rather than permanent silence.
+    let accepted = accept_chat_turn(&runtime, id, &message, by.as_ref(), parent, &desk).await?;
     let (report, feedback_note) = join_chat_turn(spawn_chat_turn(ChatTurn {
         runtime,
         company: id.clone(),
@@ -1389,6 +1593,7 @@ async fn chat_and_emit(
         message,
         by,
         parent,
+        accepted,
     }))
     .await?;
     emit_cycle_webhooks(state, id, &report).await;
@@ -1417,6 +1622,9 @@ struct ChatTurn {
     message: ChatMessage,
     by: Option<Actor>,
     parent: Option<EventSeq>,
+    /// What accepting the turn already wrote (issue #983): the journaled
+    /// message, and the row this task owes a settle.
+    accepted: AcceptedTurn,
 }
 
 /// Runs a chat turn and journals its replies on a task of its own (issue #882).
@@ -1435,10 +1643,24 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
             message,
             by,
             parent,
+            accepted,
         } = turn;
-        let (mut report, feedback_note) =
-            run_chat(Arc::clone(&runtime), message, by, parent).await?;
+        let turn_id = accepted.turn_id.clone();
+        // Issue #983: the settle lives on this side of the spawn for the same
+        // reason the reply journaling does — a proxy that gave up must not leave
+        // a row claiming to be live. Both outcomes settle: an error here is a
+        // turn that was accepted and produced no answer, which is precisely the
+        // state that used to be indistinguishable from silence.
+        let outcome = run_chat(Arc::clone(&runtime), message, by, parent, &accepted).await;
+        let (mut report, feedback_note) = match outcome {
+            Ok(both) => both,
+            Err(err) => {
+                settle_chat_turn(&runtime, &company, turn_id.as_deref(), Some(&err)).await;
+                return Err(err);
+            }
+        };
         journal_chat_replies(&runtime, &company, &desk, parent, &mut report).await;
+        settle_chat_turn(&runtime, &company, turn_id.as_deref(), None).await;
         Ok((report, feedback_note))
     })
 }
@@ -2738,19 +2960,25 @@ mod test {
             let id = CompanyId::new("acme");
             let runtime = state.registry().get(&id).unwrap();
 
-            run_chat(
-                runtime.clone(),
-                ChatMessage {
-                    text: ask.to_string(),
-                    chat: None,
-                    parent: None,
-                    deliverable: None,
-                },
-                by,
+            let message = ChatMessage {
+                text: ask.to_string(),
+                chat: None,
+                parent: None,
+                deliverable: None,
+            };
+            let accepted = accept_chat_turn(
+                &runtime,
+                &id,
+                &message,
+                by.as_ref(),
                 None,
+                crate::server::ops::language::DEFAULT_DESK,
             )
             .await
-            .expect("the chat cycle runs");
+            .expect("the turn is accepted");
+            run_chat(runtime.clone(), message, by, None, &accepted)
+                .await
+                .expect("the chat cycle runs");
 
             let tasks = runtime.tasks().list(&id).await.unwrap();
             assert_eq!(tasks.len(), 1, "{label}: one ask opens one card");

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -5384,6 +5384,18 @@ mod test {
             "the reply was journaled before the turn was released"
         );
 
+        // Issue #983: the turn was recorded the instant it was accepted, and
+        // the record is what a re-read resolves — so at this point the operator
+        // has walked away and the turn is still `Running` rather than absent.
+        let row = turn_rows(&runtime)
+            .await
+            .pop()
+            .expect("accepting the turn minted a row");
+        assert_eq!(
+            row.1, "running",
+            "a turn whose caller is gone must still read as under way"
+        );
+
         // The work must survive the caller giving up.
         release.notify_one();
         assert!(
@@ -5392,6 +5404,325 @@ mod test {
              message is journaled, the answer is not, and the turn can neither \
              be read back nor resumed (issue #882)"
         );
+
+        // Issue #983: and so must the settle. The row is written by the spawned
+        // task, not by the handler, so a dropped connection leaving it
+        // `Running` forever would be the #882 bug one layer down — the turn
+        // finishes, the answer lands, and the status surface still claims work
+        // is in flight until the next boot reaps it.
+        until("the settle died with the dropped connection", async || {
+            turn_rows(&runtime)
+                .await
+                .iter()
+                .all(|(_, status)| status == "succeeded")
+        })
+        .await;
+    }
+
+    // ── Issue #983: an accepted turn exists and can be read back ────────────
+
+    /// A brain that blocks every operator turn on a semaphore the test holds.
+    ///
+    /// Deliberately a `Semaphore` rather than a `Notify`: these tests run two
+    /// turns at once and release both, and `notify_one` wakes exactly one
+    /// waiter while `notify_waiters` wakes only those already parked. Permits
+    /// are held whether or not anybody is waiting yet, so the release cannot
+    /// race the turns into a hang.
+    struct BlockingChatBrain {
+        /// One permit added per turn that has entered the brain.
+        entered: Arc<tokio::sync::Semaphore>,
+        /// The test's permission for a turn to finish — one permit each.
+        release: Arc<tokio::sync::Semaphore>,
+    }
+
+    impl BlockingChatBrain {
+        fn new() -> (
+            Arc<Self>,
+            Arc<tokio::sync::Semaphore>,
+            Arc<tokio::sync::Semaphore>,
+        ) {
+            let entered = Arc::new(tokio::sync::Semaphore::new(0));
+            let release = Arc::new(tokio::sync::Semaphore::new(0));
+            (
+                Arc::new(Self {
+                    entered: Arc::clone(&entered),
+                    release: Arc::clone(&release),
+                }),
+                entered,
+                release,
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::ports::brain::Brain for BlockingChatBrain {
+        async fn run_cycle(
+            &self,
+            req: crate::ports::types::CycleRequest,
+            _host: &dyn crate::ports::brain::CycleHost,
+        ) -> crate::Result<crate::ports::types::CycleResult> {
+            let mut channel_responses = Vec::new();
+            for event in &req.events {
+                if let CompanyEvent::OperatorMessage { text, .. } = event {
+                    self.entered.add_permits(1);
+                    self.release.acquire().await.expect("released").forget();
+                    channel_responses.push(crate::ports::types::OutboundMessage {
+                        message_id: None,
+                        task_id: None,
+                        channel: "operator".into(),
+                        agent: None,
+                        text: format!("answered: {text}"),
+                        steps: Vec::new(),
+                        reply_to: None,
+                    });
+                }
+            }
+            Ok(crate::ports::types::CycleResult {
+                channel_responses,
+                new_traces: vec![crate::ports::types::CompressedTrace::now(
+                    &req.cycle_id,
+                    "blocking chat",
+                )],
+                ledger_deltas: Vec::new(),
+                token_usage: crate::ports::types::TokenUsage::default(),
+            })
+        }
+    }
+
+    /// Polls `f` until it holds, or fails the test.
+    async fn until(label: &str, mut f: impl AsyncFnMut() -> bool) {
+        let ok = tokio::time::timeout(std::time::Duration::from_secs(10), async {
+            while !f().await {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .is_ok();
+        assert!(ok, "{label}");
+    }
+
+    /// The operator messages `chat/history` currently shows for the main desk.
+    async fn history_texts(app: &axum::Router) -> Vec<String> {
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/api/v1/company/chat/history")
+                    .header("cookie", crate::server::test_support::fixed_cookie("acme"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+        body.as_array()
+            .expect("the history route answers with an array")
+            .iter()
+            .filter_map(|m| m["text"].as_str().map(str::to_string))
+            .collect()
+    }
+
+    /// The company's turn rows, id → status.
+    async fn turn_rows(runtime: &Arc<CompanyRuntime>) -> Vec<(String, String)> {
+        let mut rows = runtime
+            .runs()
+            .list_runs(runtime.id(), &crate::ports::runs::RunFilter::default())
+            .await
+            .unwrap();
+        rows.sort_by(|a, b| a.created_at_millis.cmp(&b.created_at_millis));
+        rows.into_iter()
+            .map(|r| (r.id, r.status.to_string()))
+            .collect()
+    }
+
+    /// **Issue #983 — the direct regression for the observed empty history.**
+    ///
+    /// The operator's message used to be appended *inside* the per-company
+    /// serial lock, so a message sent while another turn held that lock did not
+    /// exist anywhere until the turn ahead of it finished. Reloading during a
+    /// long turn showed an empty conversation: the operator could not see their
+    /// own question, could not tell whether it had been received, and re-sent it.
+    ///
+    /// The blocking first turn is what makes this a real test. With a single
+    /// turn the lock is free and the cycle appends immediately, so the bug is
+    /// invisible — which is exactly why it survived. Two turns reproduce the
+    /// serial train the field report saw with five.
+    #[tokio::test]
+    async fn a_queued_message_is_in_the_transcript_before_its_turn_runs() {
+        let home_dir = home();
+        let (brain, entered, release) = BlockingChatBrain::new();
+        let state = build_state_with_brain(
+            home_dir.path(),
+            "running",
+            AppConfig::default(),
+            Some(brain),
+        )
+        .await;
+        let app = router(state);
+
+        // Turn one takes the lock and stops inside the brain.
+        let first = tokio::spawn({
+            let app = app.clone();
+            async move { app.oneshot(chat_request("the first question")).await }
+        });
+        entered.acquire().await.expect("turn one entered").forget();
+
+        // Turn two is accepted while turn one still owns the lock.
+        let second = tokio::spawn({
+            let app = app.clone();
+            async move { app.oneshot(chat_request("the second question")).await }
+        });
+
+        until(
+            "the queued message never reached the transcript",
+            async || {
+                history_texts(&app)
+                    .await
+                    .iter()
+                    .any(|t| t == "the second question")
+            },
+        )
+        .await;
+
+        // …and it is there while its turn is provably not finished: no answer
+        // has been journaled for either message.
+        let texts = history_texts(&app).await;
+        assert!(
+            texts.contains(&"the first question".to_string()),
+            "the running turn's own message is missing: {texts:?}"
+        );
+        assert!(
+            !texts.iter().any(|t| t.starts_with("answered:")),
+            "a turn finished before the assertion could run: {texts:?}"
+        );
+
+        release.add_permits(2);
+        for turn in [first, second] {
+            let response = turn.await.unwrap().unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+    }
+
+    /// One POST journals **exactly one** `OperatorMessage`, and the response's
+    /// `messageId` is that message's own sequence.
+    ///
+    /// The pin for the pre-journaled cycle path. The route now appends the
+    /// message itself and hands the cycle the seq; a cycle that appended again
+    /// would double every operator message in every transcript, and one that
+    /// reported a seq of its own would hand the console an id that resolves to
+    /// the wrong line — both silent, both only visible here.
+    #[tokio::test]
+    async fn one_post_journals_one_message_and_reports_its_seq() {
+        let home_dir = home();
+        let state = state_with_company(home_dir.path(), "running").await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let app = router(state);
+
+        let response = app
+            .clone()
+            .oneshot(chat_request("just the one"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value = serde_json::from_slice(
+            &axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap(),
+        )
+        .unwrap();
+
+        let journaled: Vec<(EventSeq, String)> = runtime
+            .events()
+            .read_from(runtime.id(), EventSeq::new(0), 10_000)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|s| match s.event {
+                CompanyEvent::OperatorMessage { text, .. } => Some((s.seq, text)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            journaled.len(),
+            1,
+            "one POST must journal one message, got {journaled:?}"
+        );
+        assert_eq!(journaled[0].1, "just the one");
+        assert_eq!(
+            body["messageId"].as_str(),
+            Some(journaled[0].0.value().to_string().as_str()),
+            "messageId must resolve to the message's own line"
+        );
+    }
+
+    /// **Issue #983 — the direct regression for the serial train.**
+    ///
+    /// The per-company cycle lock is held for a whole turn with unbounded
+    /// waiters, so five concurrent messages became a queue and the fifth
+    /// inherited the whole queue's latency. Nothing recorded that, so an
+    /// operator watching a slow company could not tell "my turn is queued" from
+    /// "my turn is wedged" from "nothing was received".
+    ///
+    /// The two statuses are what makes the wait legible, which is why the row
+    /// is created at accept and started only once the cycle holds the lock.
+    /// Collapsing them — starting the row where it is created — would make both
+    /// turns read `Running`, and this assertion is what stops that.
+    #[tokio::test]
+    async fn a_queued_turn_is_pending_while_the_running_one_holds_the_lock() {
+        let home_dir = home();
+        let (brain, entered, release) = BlockingChatBrain::new();
+        let state = build_state_with_brain(
+            home_dir.path(),
+            "running",
+            AppConfig::default(),
+            Some(brain),
+        )
+        .await;
+        let runtime = state.registry().get(&CompanyId::new("acme")).unwrap();
+        let app = router(state);
+
+        let first = tokio::spawn({
+            let app = app.clone();
+            async move { app.oneshot(chat_request("first")).await }
+        });
+        entered.acquire().await.expect("turn one entered").forget();
+        let second = tokio::spawn({
+            let app = app.clone();
+            async move { app.oneshot(chat_request("second")).await }
+        });
+
+        until(
+            "the second turn never queued behind the first",
+            async || {
+                let statuses: Vec<String> = turn_rows(&runtime)
+                    .await
+                    .into_iter()
+                    .map(|(_, status)| status)
+                    .collect();
+                statuses == ["running", "pending"]
+            },
+        )
+        .await;
+
+        release.add_permits(2);
+        for turn in [first, second] {
+            assert_eq!(turn.await.unwrap().unwrap().status(), StatusCode::OK);
+        }
+
+        until("both turns must reach a terminal status", async || {
+            turn_rows(&runtime)
+                .await
+                .iter()
+                .all(|(_, status)| status == "succeeded")
+        })
+        .await;
+        assert_eq!(turn_rows(&runtime).await.len(), 2, "one row per POST");
     }
 
     /// The same proof over a **real socket**, so the keystone rests on hyper's

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -1051,6 +1051,44 @@ fn project_event(stored: &StoredEvent) -> Option<serde_json::Value> {
             o["elapsedMs"] = json!(elapsed_ms);
             o
         }
+        // Issue #983: a turn was accepted, so a console watching the
+        // conversation can show it as under way instead of showing the
+        // operator's question with nothing after it. Three keys, all
+        // structural, and every one already reachable by the same operator
+        // through `GET {scope}/runs`.
+        //
+        // Deliberately **no message text and no actor**: the text is on the
+        // `OperatorMessage` this brackets — which stays dropped, see the
+        // module note above — and `by` is a user id, dropped here exactly as
+        // every other attributed arm drops it. The console reacts by reading
+        // the row it already knows how to read.
+        CompanyEvent::TurnStarted {
+            turn_id,
+            chat_id,
+            parent,
+            ..
+        } => {
+            let mut o = envelope("turn_started");
+            o["turnId"] = json!(turn_id);
+            o["chatId"] = json!(chat_id);
+            // Omitted rather than null for a turn answering the channel
+            // itself, so "is this in a thread?" is a presence check — the same
+            // discipline `agent_reply` above uses for the same field.
+            if let Some(parent) = parent {
+                o["parentId"] = json!(parent.value().to_string());
+            }
+            o
+        }
+        // The closing bracket. Structural for a sharper reason than its
+        // sibling: the event's `error` is a failure reason in our own words
+        // that can name internals, and this stream is the one place it must
+        // not be forwarded to. A console learns *that* the turn is over here
+        // and reads *why* from the run row, which is tenant-scoped.
+        CompanyEvent::TurnFailed { turn_id, .. } => {
+            let mut o = envelope("turn_settled");
+            o["turnId"] = json!(turn_id);
+            o
+        }
         // Not an attention signal, or carries a raw payload we never put on the
         // wire — dropped.
         _ => return None,
@@ -1172,11 +1210,14 @@ struct ChatResponse {
 /// Runs one operator-chat cycle, returning the report and, when a complaint
 /// intent captured feedback, the note that was captured (so the caller can emit
 /// the `feedback.created` webhook).
+///
+/// Takes the [`AcceptedTurn`] rather than a thread parent since issue #983: the
+/// message this cycle runs is already journaled, so the parent it carries is a
+/// fact about the event rather than something this function decides.
 async fn run_chat(
     runtime: Arc<CompanyRuntime>,
     message: ChatMessage,
     by: Option<Actor>,
-    parent: Option<EventSeq>,
     accepted: &AcceptedTurn,
 ) -> Result<(CycleReport, Option<String>), ApiError> {
     // Re-checked here rather than only at accept: this is also reachable
@@ -1651,7 +1692,7 @@ fn spawn_chat_turn(turn: ChatTurn) -> JoinHandle<Result<(CycleReport, Option<Str
         // a row claiming to be live. Both outcomes settle: an error here is a
         // turn that was accepted and produced no answer, which is precisely the
         // state that used to be indistinguishable from silence.
-        let outcome = run_chat(Arc::clone(&runtime), message, by, parent, &accepted).await;
+        let outcome = run_chat(Arc::clone(&runtime), message, by, &accepted).await;
         let (mut report, feedback_note) = match outcome {
             Ok(both) => both,
             Err(err) => {
@@ -2976,7 +3017,7 @@ mod test {
             )
             .await
             .expect("the turn is accepted");
-            run_chat(runtime.clone(), message, by, None, &accepted)
+            run_chat(runtime.clone(), message, by, &accepted)
                 .await
                 .expect("the chat cycle runs");
 
@@ -5809,6 +5850,94 @@ mod test {
         }))
         .expect("agent_reply is an attention signal");
         assert_eq!(v["parentId"], "4");
+    }
+
+    /// Issue #983: the accept frame carries the turn, the desk and the thread —
+    /// and **nothing else**.
+    ///
+    /// The negative half is what this test is for. `TurnStarted` is the first
+    /// frame on this stream that brackets an operator's own message, so it is
+    /// the obvious place for somebody to "helpfully" add the text or the asker
+    /// — which is exactly the payload the deny-by-default projection exists to
+    /// keep off the wire, and which `OperatorMessage` is dropped to avoid.
+    #[test]
+    fn projects_turn_started_with_structural_keys_only() {
+        use crate::ports::types::{Actor, ActorKind};
+        let v = super::project_event(&stored(CompanyEvent::TurnStarted {
+            turn_id: "turn-1".into(),
+            chat_id: "General".into(),
+            parent: Some(EventSeq::new(4)),
+            by: Some(Actor {
+                kind: ActorKind::User,
+                id: "u-1".into(),
+            }),
+        }))
+        .expect("an accepted turn is an attention signal");
+        assert_eq!(v["type"], "turn_started");
+        assert_eq!(v["turnId"], "turn-1");
+        assert_eq!(v["chatId"], "General");
+        assert_eq!(v["parentId"], "4");
+        let keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            ["type", "seq", "atMillis", "turnId", "chatId", "parentId"],
+            "the accept frame grew a key: {v}"
+        );
+
+        // A turn answering the channel itself omits the thread rather than
+        // sending null, so the console's check is a presence check.
+        let v = super::project_event(&stored(CompanyEvent::TurnStarted {
+            turn_id: "turn-2".into(),
+            chat_id: "General".into(),
+            parent: None,
+            by: None,
+        }))
+        .expect("an accepted turn is an attention signal");
+        assert!(v.get("parentId").is_none(), "unexpected parentId: {v}");
+    }
+
+    /// The settle frame says a turn is over and **not why**.
+    ///
+    /// `TurnFailed::error` is a reason in our own words that can name
+    /// internals; the console learns the reason from the tenant-scoped run row.
+    #[test]
+    fn projects_turn_settled_without_the_failure_reason() {
+        let v = super::project_event(&stored(CompanyEvent::TurnFailed {
+            turn_id: "turn-1".into(),
+            error: "connection to db-primary.internal refused".into(),
+        }))
+        .expect("a settled turn is an attention signal");
+        assert_eq!(v["type"], "turn_settled");
+        assert_eq!(v["turnId"], "turn-1");
+        let keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        assert_eq!(
+            keys,
+            ["type", "seq", "atMillis", "turnId"],
+            "the settle frame grew a key: {v}"
+        );
+    }
+
+    /// The operator's own message is **still** dropped (issue #983).
+    ///
+    /// Pinned because #983 added the two arms above right beside it, and the
+    /// natural next step — "the console needs the message too, project it" —
+    /// would put operator-authored free text onto this stream for the first
+    /// time. It does not need it: the message is already in the POST's own
+    /// response and in `chat/history`, which is the point of journaling it at
+    /// accept time. If somebody later decides otherwise, they say so here.
+    #[test]
+    fn projects_nothing_for_the_operators_own_message() {
+        assert!(
+            super::project_event(&stored(CompanyEvent::OperatorMessage {
+                text: "the operator's own words".into(),
+                by: None,
+                chat: Some("General".into()),
+                parent: None,
+                deliverable: None,
+            }))
+            .is_none(),
+            "the operator's own message must not reach the console over SSE"
+        );
     }
 
     /// A reaction is deliberately NOT on the attention stream (issue #364).

--- a/src/server/operator.rs
+++ b/src/server/operator.rs
@@ -5535,7 +5535,7 @@ mod test {
             .list_runs(runtime.id(), &crate::ports::runs::RunFilter::default())
             .await
             .unwrap();
-        rows.sort_by(|a, b| a.created_at_millis.cmp(&b.created_at_millis));
+        rows.sort_by_key(|r| r.created_at_millis);
         rows.into_iter()
             .map(|r| (r.id, r.status.to_string()))
             .collect()
@@ -5697,15 +5697,20 @@ mod test {
             async move { app.oneshot(chat_request("second")).await }
         });
 
+        // Compared as a sorted pair rather than in row order: two POSTs a
+        // millisecond apart can tie on `created_at_millis`, and what is being
+        // asserted is that the two turns hold *different* statuses at once, not
+        // which row the store lists first.
         until(
             "the second turn never queued behind the first",
             async || {
-                let statuses: Vec<String> = turn_rows(&runtime)
+                let mut statuses: Vec<String> = turn_rows(&runtime)
                     .await
                     .into_iter()
                     .map(|(_, status)| status)
                     .collect();
-                statuses == ["running", "pending"]
+                statuses.sort();
+                statuses == ["pending", "running"]
             },
         )
         .await;

--- a/src/server/ops/runs.rs
+++ b/src/server/ops/runs.rs
@@ -139,7 +139,18 @@ pub(crate) struct RunSummary {
     /// Stable id for the attempt.
     id: String,
     /// The card this is an attempt at.
-    task_id: String,
+    ///
+    /// **Omitted, never `null`**, when the attempt is at no card — an operator
+    /// chat turn (issue #983) — matching how every other absent field in this
+    /// module is written, so a reader's "is there a card?" test is a presence
+    /// check rather than a null check.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    task_id: Option<String>,
+    /// The conversation this attempt belongs to, when one raised it
+    /// (issue #983). Omitted for a dispatch, which is reachable through its
+    /// card instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    chat_id: Option<String>,
     /// The desk/teammate it was dispatched to.
     agent_id: String,
     /// Which attempt at the card this is, 1-based.
@@ -196,6 +207,7 @@ impl From<RunRecord> for RunSummary {
         Self {
             id: run.id,
             task_id: run.task_id,
+            chat_id: run.chat_id,
             agent_id: run.agent_id,
             attempt: run.attempt,
             status: run.status,
@@ -522,16 +534,9 @@ mod tests {
         run_id: &str,
         task_id: &str,
     ) -> RunRecord {
-        runs.create_run(
-            id,
-            NewRun {
-                id: run_id.to_string(),
-                task_id: task_id.to_string(),
-                agent_id: "ceo".to_string(),
-            },
-        )
-        .await
-        .expect("mint")
+        runs.create_run(id, NewRun::for_task(run_id, task_id, "ceo"))
+            .await
+            .expect("mint")
     }
 
     fn step(seq: u32, kind: TurnStepKind, status: TurnStepStatus, label: &str) -> TurnStep {

--- a/src/server/ops/write_test.rs
+++ b/src/server/ops/write_test.rs
@@ -6399,14 +6399,7 @@ async fn the_attempt_id_outranks_the_card_link_when_both_are_present() {
     for (id, task) in [("run-a", "t-1"), ("run-b", "t-1"), ("run-c", "t-other")] {
         runtime
             .runs()
-            .create_run(
-                &company,
-                NewRun {
-                    id: id.to_string(),
-                    task_id: task.to_string(),
-                    agent_id: "ceo".to_string(),
-                },
-            )
+            .create_run(&company, NewRun::for_task(id, task, "ceo"))
             .await
             .unwrap();
     }

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -3733,11 +3733,7 @@ pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
 
     let alpha = CompanyId::new("alpha");
     let beta = CompanyId::new("beta");
-    let spec = |id: &str, task: &str| NewRun {
-        id: id.to_string(),
-        task_id: task.to_string(),
-        agent_id: "ceo".to_string(),
-    };
+    let spec = |id: &str, task: &str| NewRun::for_task(id, task, "ceo");
 
     // -- create: a fresh run is Pending and nothing else ---------------------
 
@@ -3745,7 +3741,8 @@ pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
     assert_eq!(first.status, RunStatus::Pending);
     assert_eq!(first.attempt, 1, "the first attempt at a card is 1-based");
     assert_eq!(first.company, alpha);
-    assert_eq!(first.task_id, "card");
+    assert_eq!(first.task_id.as_deref(), Some("card"));
+    assert_eq!(first.chat_id, None, "a dispatch names no conversation");
     assert_eq!(first.agent_id, "ceo");
     assert_eq!(first.trigger_event_seq, None);
     assert_eq!(first.started_at_millis, None);
@@ -4106,6 +4103,117 @@ pub async fn assert_run_store(runs: Arc<dyn crate::ports::runs::RunStore>) {
         runs.list_stale_active(&alpha).await.unwrap().is_empty(),
         "parked is not active: a run waiting on a person is not stale"
     );
+
+    // -- a run at no card (issue #983) ---------------------------------------
+    //
+    // The chat-turn shape: an attempt at work that opened no board card. It has
+    // to round-trip, it has to be reachable, and — the part a backend gets wrong
+    // by accident — it must not answer a per-card filter, because `task_id`
+    // being absent is not the same as it matching.
+
+    let chat = runs
+        .create_run(&alpha, NewRun::for_chat("t1", "general", "ceo"))
+        .await
+        .unwrap();
+    assert_eq!(chat.task_id, None);
+    assert_eq!(chat.chat_id.as_deref(), Some("general"));
+    assert_eq!(
+        chat.attempt, 1,
+        "with no card there is nothing for a second attempt to be the second of"
+    );
+    assert_eq!(runs.get_run(&alpha, "t1").await.unwrap(), Some(chat));
+
+    let second_chat = runs
+        .create_run(&alpha, NewRun::for_chat("t2", "general", "ceo"))
+        .await
+        .unwrap();
+    assert_eq!(
+        second_chat.attempt, 1,
+        "card-less runs do not share one anonymous attempt counter"
+    );
+
+    for card in ["card", "other", "no-such-card"] {
+        let matched = runs
+            .list_runs(&alpha, &RunFilter::for_task(card))
+            .await
+            .unwrap();
+        assert!(
+            !matched.iter().any(|r| r.id == "t1" || r.id == "t2"),
+            "a card-less run answered the filter for card '{card}'"
+        );
+    }
+    let all = runs.list_runs(&alpha, &RunFilter::default()).await.unwrap();
+    assert!(
+        all.iter().any(|r| r.id == "t1"),
+        "an unfiltered list must still reach a card-less run"
+    );
+
+    // It moves through the state machine like any other row, so the orphan
+    // reaper and the terminality backstop need no card-less special case.
+    runs.begin_run(&alpha, "t1", EventSeq::new(31))
+        .await
+        .unwrap();
+    assert_eq!(
+        runs.list_stale_active(&alpha)
+            .await
+            .unwrap()
+            .iter()
+            .filter(|r| r.id == "t1")
+            .count(),
+        1,
+        "a running card-less run is active"
+    );
+    let settled = runs
+        .finish_run(&alpha, "t1", RunOutcome::new(RunStatus::Succeeded))
+        .await
+        .unwrap();
+    assert_eq!(settled.status, RunStatus::Succeeded);
+    assert_eq!(settled.task_id, None, "the settle invented no card");
+}
+
+/// Asserts a [`RunRecord`](crate::ports::runs::RunRecord) written before
+/// `task_id` could be absent still loads (issue #983).
+///
+/// This is a pure serde property, so it is asserted once here rather than per
+/// backend: all three store the record as the same JSON blob, so a row written
+/// by a pre-#983 host is a `"taskId": "<string>"` whichever backend holds it.
+/// It is in the conformance module because that is where the round-trip
+/// contract lives, and because a backend that ever stops using the record's own
+/// serialization is exactly what this would catch.
+pub fn assert_legacy_run_row_loads() {
+    use crate::ports::runs::{RunRecord, RunStatus};
+
+    let legacy = serde_json::json!({
+        "id": "run-1",
+        "company": "acme",
+        "taskId": "card-7",
+        "agentId": "ceo",
+        "attempt": 2,
+        "status": "running",
+        "createdAtMillis": 1_700_000_000_000u64,
+    });
+    let loaded: RunRecord = serde_json::from_value(legacy).expect("a pre-#983 row still loads");
+    assert_eq!(loaded.task_id.as_deref(), Some("card-7"));
+    assert_eq!(loaded.chat_id, None, "an absent conversation reads as None");
+    assert_eq!(loaded.status, RunStatus::Running);
+
+    // And the new shape omits the key rather than writing `null`, so a dispatch
+    // row is byte-identical to the ones already on disk.
+    let card_less = RunRecord {
+        task_id: None,
+        chat_id: Some("general".to_string()),
+        ..loaded
+    };
+    let written = serde_json::to_value(&card_less).unwrap();
+    assert!(
+        written.get("taskId").is_none(),
+        "an absent card must be omitted, never null: {written}"
+    );
+    assert_eq!(
+        serde_json::from_value::<RunRecord>(written).unwrap(),
+        card_less,
+        "the card-less row round-trips"
+    );
 }
 
 /// Asserts the boot-reaper contract
@@ -4117,11 +4225,7 @@ pub async fn assert_run_reaper(runs: Arc<dyn crate::ports::runs::RunStore>) {
 
     let alpha = CompanyId::new("alpha");
     let beta = CompanyId::new("beta");
-    let spec = |id: &str, task: &str| NewRun {
-        id: id.to_string(),
-        task_id: task.to_string(),
-        agent_id: "ceo".to_string(),
-    };
+    let spec = |id: &str, task: &str| NewRun::for_task(id, task, "ceo");
 
     // One of each state the reaper has an opinion about.
     runs.create_run(&alpha, spec("pending", "a")).await.unwrap();
@@ -4171,7 +4275,7 @@ pub async fn assert_run_reaper(runs: Arc<dyn crate::ports::runs::RunStore>) {
     // Issue #337: the caller gets the records, not a count, because it has to
     // return each reaped run's *card* to To-do — and for that it needs the
     // `task_id`s. A count would leave the board claiming work nothing is doing.
-    let mut reaped_tasks: Vec<&str> = reaped.iter().map(|r| r.task_id.as_str()).collect();
+    let mut reaped_tasks: Vec<&str> = reaped.iter().filter_map(|r| r.task_id.as_deref()).collect();
     reaped_tasks.sort_unstable();
     assert_eq!(
         reaped_tasks,

--- a/src/store/conformance.rs
+++ b/src/store/conformance.rs
@@ -668,6 +668,76 @@ pub async fn assert_event_retention(events: Arc<dyn EventLog>) {
     let unique = seqs.len();
     seqs.dedup();
     assert_eq!(unique, seqs.len(), "duplicate sequences after prune+append");
+
+    // 6. Issue #983: a turn's accept bracket is prunable, its failure bracket is
+    //    not, and pruning the accept must not break a live turn's read-back.
+    //
+    //    The pairing is the point. `TurnStarted` is one frame per operator
+    //    message on a busy desk and its meaning is spent once the turn settles;
+    //    `TurnFailed` is the only record that a question was accepted and never
+    //    answered, so losing it would silently un-report a lost turn. And the
+    //    two are joined by `turn_id`, not by sequence — which is what makes the
+    //    accept safe to discard: nothing points *at* it, so a turn still reads
+    //    back through its row and its failure line after its start is gone.
+    let bravo = CompanyId::new("bravo");
+    for n in 0..4u64 {
+        events
+            .append(
+                &bravo,
+                CompanyEvent::TurnStarted {
+                    turn_id: format!("turn-{n}"),
+                    chat_id: "general".to_string(),
+                    parent: None,
+                    by: None,
+                },
+            )
+            .await
+            .unwrap();
+    }
+    events
+        .append(
+            &bravo,
+            CompanyEvent::TurnFailed {
+                turn_id: "turn-0".to_string(),
+                error: "the host restarted".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+
+    let report = events
+        .prune(&bravo, &RetentionPolicy::with_max_entries_per_kind(1))
+        .await
+        .unwrap();
+    assert_eq!(
+        report.removed, 3,
+        "TurnStarted must be prunable, keeping only the newest"
+    );
+
+    let kept = events
+        .read_from(&bravo, EventSeq::new(0), usize::MAX)
+        .await
+        .unwrap();
+    let starts: Vec<&str> = kept
+        .iter()
+        .filter_map(|e| match &e.event {
+            CompanyEvent::TurnStarted { turn_id, .. } => Some(turn_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(starts, ["turn-3"], "the newest accept must survive");
+    let settles: Vec<&str> = kept
+        .iter()
+        .filter_map(|e| match &e.event {
+            CompanyEvent::TurnFailed { turn_id, .. } => Some(turn_id.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        settles,
+        ["turn-0"],
+        "a turn's failure is the record that it was never answered; it is permanent"
+    );
 }
 
 /// Everything written through the ports reads back through the ports,

--- a/src/store/fs_ops.rs
+++ b/src/store/fs_ops.rs
@@ -798,18 +798,26 @@ impl RunStore for FsOps {
                 spec.id
             )));
         }
-        let attempt = runs
-            .iter()
-            .filter(|r| r.task_id == spec.task_id)
-            .map(|r| r.attempt)
-            .max()
-            .unwrap_or(0)
-            .saturating_add(1);
+        // A card-less run (issue #983) is always attempt 1: the ordinal counts
+        // attempts *at a card*, and with no card there is nothing for a second
+        // attempt to be the second of. Folding them all into one anonymous
+        // bucket would make every chat turn the Nth attempt at nothing.
+        let attempt = match &spec.task_id {
+            Some(task_id) => runs
+                .iter()
+                .filter(|r| r.task_id.as_deref() == Some(task_id.as_str()))
+                .map(|r| r.attempt)
+                .max()
+                .unwrap_or(0)
+                .saturating_add(1),
+            None => 1,
+        };
         let run = RunRecord {
             id: spec.id,
             company: company.clone(),
             task_id: spec.task_id,
             agent_id: spec.agent_id,
+            chat_id: spec.chat_id,
             attempt,
             status: RunStatus::Pending,
             trigger_event_seq: None,
@@ -2331,6 +2339,14 @@ mod test {
         let root_dir = tmp_root();
         let root = root_dir.path().to_path_buf();
         conformance::assert_run_store(Arc::new(FsOps::new(&root))).await;
+    }
+
+    /// A run row written before `task_id` could be absent still loads
+    /// (issue #983). Backend-independent — see the assertion's own docs — so it
+    /// is driven from the one backend every lane builds.
+    #[test]
+    fn conformance_legacy_run_row_loads() {
+        conformance::assert_legacy_run_row_loads();
     }
 
     #[tokio::test]

--- a/src/store/mongodb.rs
+++ b/src/store/mongodb.rs
@@ -2055,15 +2055,23 @@ impl crate::ports::runs::RunStore for MongoStore {
         // usage sequences use, keyed per card — so concurrent creates cannot
         // collide even across processes. `next_seq` is 0-based; attempts are
         // 1-based (`Attempt 1` is the first).
-        let attempt = self
-            .next_seq(company, &format!("run:{}", spec.task_id))
-            .await?
-            .saturating_add(1);
+        // A card-less run (issue #983) is always attempt 1 — see the fs
+        // backend's `create_run` for why the ordinal is not shared across them,
+        // and note that a shared counter here would be worse still: it is
+        // durable, so every chat turn a company ever ran would keep counting up.
+        let attempt = match &spec.task_id {
+            Some(task_id) => self
+                .next_seq(company, &format!("run:{task_id}"))
+                .await?
+                .saturating_add(1),
+            None => 1,
+        };
         let run = RunRecord {
             id: spec.id,
             company: company.clone(),
             task_id: spec.task_id,
             agent_id: spec.agent_id,
+            chat_id: spec.chat_id,
             attempt: attempt as u32,
             status: RunStatus::Pending,
             trigger_event_seq: None,
@@ -2092,7 +2100,7 @@ impl crate::ports::runs::RunStore for MongoStore {
             .insert_one(doc! {
                 "company_id": company.as_ref(),
                 "run_id": &run.id,
-                "task_id": &run.task_id,
+                "task_id": run.task_id.as_deref(),
                 "status": run.status.as_str(),
                 "attempt": run.attempt as i64,
                 "created_ms": run.created_at_millis as i64,
@@ -2128,7 +2136,7 @@ impl crate::ports::runs::RunStore for MongoStore {
             .update_one(
                 doc! {"company_id": company.as_ref(), "run_id": &run.id},
                 doc! {"$set": {
-                    "task_id": &run.task_id,
+                    "task_id": run.task_id.as_deref(),
                     "status": run.status.as_str(),
                     "attempt": run.attempt as i64,
                     "created_ms": run.created_at_millis as i64,

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -3733,6 +3733,88 @@ mod test {
         .expect("adding an existing column is a no-op, not an error");
     }
 
+    /// Issue #983: a database created while `runs.task_id` was `NOT NULL` must
+    /// end up able to hold a card-less run.
+    ///
+    /// `MIGRATIONS` is all `CREATE TABLE IF NOT EXISTS`, so the relaxed DDL is a
+    /// no-op against an existing deployment — and SQLite cannot drop a column
+    /// constraint in place. Without the rebuild the *first chat turn* on any
+    /// upgraded self-hosted install fails its insert, which is a failure mode
+    /// that appears only in production and never in a test that starts fresh.
+    #[tokio::test]
+    async fn a_legacy_runs_table_learns_to_hold_a_card_less_run() {
+        use crate::ports::runs::{NewRun, RunStore};
+
+        // The table exactly as it shipped before #983, with an attempt in it.
+        let conn = Connection::open_in_memory().expect("open in-memory sqlite");
+        conn.execute_batch(
+            "CREATE TABLE runs (
+                 company_id TEXT NOT NULL,
+                 id         TEXT NOT NULL,
+                 task_id    TEXT NOT NULL,
+                 status     TEXT NOT NULL,
+                 attempt    INTEGER NOT NULL,
+                 created_ms INTEGER NOT NULL,
+                 run_json   TEXT NOT NULL,
+                 PRIMARY KEY (company_id, id)
+             );
+             INSERT INTO runs (company_id, id, task_id, status, attempt, created_ms, run_json)
+             VALUES ('acme', 'old-run', 'card-7', 'succeeded', 1, 1700000000000,
+                     '{\"id\":\"old-run\",\"company\":\"acme\",\"taskId\":\"card-7\",\
+                       \"agentId\":\"ceo\",\"attempt\":1,\"status\":\"succeeded\",\
+                       \"createdAtMillis\":1700000000000}');",
+        )
+        .expect("seed a pre-#983 database");
+
+        let store = SqliteStore::from_conn(conn).expect("migrations run on a legacy database");
+        let id = CompanyId::new("acme");
+
+        // The rebuild copied the history rather than dropping it.
+        let old = store
+            .get_run(&id, "old-run")
+            .await
+            .expect("read after the rebuild")
+            .expect("the legacy attempt survived");
+        assert_eq!(old.task_id.as_deref(), Some("card-7"));
+        assert_eq!(old.attempt, 1);
+
+        // …and the constraint is gone, so a chat turn can be recorded at all.
+        let turn = store
+            .create_run(&id, NewRun::for_chat("turn-1", "general", "general"))
+            .await
+            .expect("a card-less run must be insertable after the rebuild");
+        assert_eq!(turn.task_id, None);
+        assert_eq!(
+            store.get_run(&id, "turn-1").await.unwrap().as_ref(),
+            Some(&turn)
+        );
+
+        // The per-card filter still works over the rebuilt indexes, and the
+        // card-less row does not answer it.
+        let for_card = store
+            .list_runs(&id, &crate::ports::runs::RunFilter::for_task("card-7"))
+            .await
+            .expect("list by card");
+        assert_eq!(
+            for_card.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+            ["old-run"]
+        );
+
+        // Re-running the migration is a no-op: the constraint check is what
+        // stops it rewriting the whole run history on every single open.
+        relax_runs_task_id_nullability(&store.conn())
+            .expect("the rebuild is idempotent once the constraint is gone");
+        assert_eq!(
+            store
+                .list_runs(&id, &Default::default())
+                .await
+                .unwrap()
+                .len(),
+            2,
+            "a second pass duplicated or dropped rows"
+        );
+    }
+
     /// **Issue #392 through the port**: the host-durable append really does
     /// commit under `synchronous=FULL`, and really does put it back.
     ///

--- a/src/store/sqlite.rs
+++ b/src/store/sqlite.rs
@@ -160,7 +160,12 @@ CREATE INDEX IF NOT EXISTS artifacts_by_task ON artifacts (company_id, task_id);
 CREATE TABLE IF NOT EXISTS runs (
     company_id TEXT NOT NULL,
     id         TEXT NOT NULL,
-    task_id    TEXT NOT NULL,
+    -- Nullable since issue #983: a chat turn is a recorded attempt at work that
+    -- opens no card. This column is only the index mirror of `run_json`'s own
+    -- `taskId`, so NULL here reads as "no card" in exactly the way the record
+    -- does, and `task_id = ?` never matches it — which is what a per-card
+    -- filter wants.
+    task_id    TEXT,
     status     TEXT NOT NULL,
     attempt    INTEGER NOT NULL,
     created_ms INTEGER NOT NULL,
@@ -355,6 +360,61 @@ fn add_column_if_missing(conn: &Connection, table: &str, column: &str, decl: &st
         .map_err(sql_err)
 }
 
+/// Drops the `NOT NULL` constraint on `runs.task_id` (issue #983).
+///
+/// A column constraint cannot be altered in place in SQLite, so this is the
+/// documented rebuild: create the new shape, copy, drop, rename, recreate the
+/// indexes — all inside one transaction, so a database is never left with two
+/// half-populated tables. The rows themselves need no rewriting: their
+/// `task_id` values are already non-`NULL` strings, and the record's `task_id`
+/// is `#[serde(default)]`, so the blob column loads unchanged either way.
+///
+/// Gated on `PRAGMA table_info`'s `notnull` flag rather than run unconditionally
+/// — the rebuild would otherwise fire on every open of every database forever,
+/// rewriting the whole run history each time.
+fn relax_runs_task_id_nullability(conn: &Connection) -> Result<()> {
+    let not_null = {
+        let mut stmt = conn.prepare("PRAGMA table_info(runs)").map_err(sql_err)?;
+        // `table_info` column 1 is the name and column 3 is the `notnull` flag.
+        let rows = stmt
+            .query_map([], |r| Ok((r.get::<_, String>(1)?, r.get::<_, i64>(3)?)))
+            .map_err(sql_err)?;
+        let mut flagged = false;
+        for row in rows {
+            let (name, notnull) = row.map_err(sql_err)?;
+            if name == "task_id" && notnull != 0 {
+                flagged = true;
+                break;
+            }
+        }
+        flagged
+    };
+    if !not_null {
+        return Ok(());
+    }
+    conn.execute_batch(
+        "BEGIN;
+         CREATE TABLE runs_rebuilt (
+             company_id TEXT NOT NULL,
+             id         TEXT NOT NULL,
+             task_id    TEXT,
+             status     TEXT NOT NULL,
+             attempt    INTEGER NOT NULL,
+             created_ms INTEGER NOT NULL,
+             run_json   TEXT NOT NULL,
+             PRIMARY KEY (company_id, id)
+         );
+         INSERT INTO runs_rebuilt
+             SELECT company_id, id, task_id, status, attempt, created_ms, run_json FROM runs;
+         DROP TABLE runs;
+         ALTER TABLE runs_rebuilt RENAME TO runs;
+         CREATE INDEX IF NOT EXISTS runs_by_task ON runs (company_id, task_id);
+         CREATE INDEX IF NOT EXISTS runs_by_status ON runs (company_id, status);
+         COMMIT;",
+    )
+    .map_err(sql_err)
+}
+
 /// Runs `write` with `synchronous=FULL`, so its commit is fsynced, and restores
 /// `NORMAL` afterwards no matter how `write` ended.
 ///
@@ -422,6 +482,12 @@ impl SqliteStore {
         // exactly the "this node is not binary" test the reads use, and needs no
         // backfill.
         add_column_if_missing(&conn, "workspace_nodes", "blob", "BLOB")?;
+        // Issue #983: `runs.task_id` was `NOT NULL`, and SQLite has no way to
+        // drop a column constraint — so a database created before this needs the
+        // twelve-step table rebuild, or the first card-less chat turn fails its
+        // insert on a constraint the record no longer has. Idempotent: it reads
+        // the live schema and does nothing once the constraint is gone.
+        relax_runs_task_id_nullability(&conn)?;
         Ok(Self {
             conn: Arc::new(StdMutex::new(conn)),
             senders: Arc::new(StdMutex::new(HashMap::new())),
@@ -2153,19 +2219,25 @@ impl crate::ports::runs::RunStore for SqliteStore {
                 spec.id
             )));
         }
-        let attempt: i64 = tx
-            .query_row(
-                "SELECT COALESCE(MAX(attempt), 0) + 1 FROM runs \
-                 WHERE company_id = ?1 AND task_id = ?2",
-                params![company.as_ref(), spec.task_id],
-                |r| r.get(0),
-            )
-            .map_err(sql_err)?;
+        // A card-less run (issue #983) is always attempt 1 — see the fs
+        // backend's `create_run` for why the ordinal is not shared across them.
+        let attempt: i64 = match &spec.task_id {
+            Some(task_id) => tx
+                .query_row(
+                    "SELECT COALESCE(MAX(attempt), 0) + 1 FROM runs \
+                     WHERE company_id = ?1 AND task_id = ?2",
+                    params![company.as_ref(), task_id],
+                    |r| r.get(0),
+                )
+                .map_err(sql_err)?,
+            None => 1,
+        };
         let run = RunRecord {
             id: spec.id,
             company: company.clone(),
             task_id: spec.task_id,
             agent_id: spec.agent_id,
+            chat_id: spec.chat_id,
             attempt: attempt as u32,
             status: RunStatus::Pending,
             trigger_event_seq: None,


### PR DESCRIPTION
## Summary

A chat turn that does real work is invisible while it runs, and if the host dies mid-turn the journal keeps the question with no answer, forever. On staging, five concurrent turns returned `504` at 120s while the work carried on server-side; four were still running fifteen minutes later, and the only evidence any of them existed was a card that happened to be written before the cycle.

This is **stage 1 of #983**: it does not change the wire shape and does not stop the 504. It makes the turn *exist and be readable* — which is what turns a lost response into something recoverable instead of a data-loss event. Stage 2 (`detach` → `202`) is a separate PR that builds on this.

Three independent causes of the invisibility, all addressed:

- the operator's message was journaled **inside** the per-company cycle lock, so `chat/history` showed nothing until the cycle won the lock
- nothing durable recorded that a turn was working
- a host restart left an unterminated turn with no record at all

## API Or Behavior Changes

- The operator's message is journaled at **accept** time, before the lock. `messageId` and the response shape are unchanged.
- A durable turn record is minted per chat turn, reusing `RunStore`: `Pending` while queued behind another turn, `Running` once the cycle owns the lock, then `Succeeded`/`Failed`. Readable through the **existing** `GET {scope}/runs` and `GET {scope}/runs/{id}` — no new route.
- `NewRun.task_id` / `RunRecord.task_id` are now optional, with `chat_id` beside them, because a chat turn frequently opens no card. Two constructors (`for_task`, `for_chat`) replaced every literal. A card-less run is always attempt 1 and never answers a per-card filter.
- New `TurnStarted` (prunable) and `TurnFailed` (permanent) transcript events, and `turn_started` / `turn_settled` SSE frames carrying **structural keys only**. `OperatorMessage` stays dropped from the projection, now pinned by a test so the deny-by-default rule is not widened by accident.
- A chat-opened card carries its turn in `origin_run_id`.
- Boot-only sweep folds an unterminated `TurnStarted` into `TurnFailed`, gated on there being no live handover — so a runtime rebuild never tells an operator that a live turn failed.

`run_cycle` is **byte-unchanged**: the scheduler, cron, webhooks, the telegram poller, delegation and approval follow-ups all take exactly the path they did. `run_journaled` is the new pre-journaled entry point, and both funnel into one body keyed on the sequence rather than on who wrote it.

## Migration note reviewers should not skim

SQLite's mirrored `task_id` column was `NOT NULL`, and SQLite cannot relax that in place. `relax_runs_task_id_nullability` rebuilds the table idempotently on open. Without it, **the first chat turn on any upgraded self-hosted install fails its insert** — a failure invisible to a test suite that starts from an empty database.

## Tests

Every regression was proven red first, and two of them only bite under conditions worth stating:

- **The queued message reaches the transcript** — reverting the append to inside the cycle fails with "the queued message never reached the transcript". It needs *two* turns to bite at all: with one, the lock is free and the cycle appends immediately, which is exactly why this survived until now.
- **A queued turn reads `Pending`** — adding `begin_run` at accept time fails with "the second turn never queued behind the first".
- **A rebuild must not report a live turn as failed** — ungating the sweep fails with "a rebuild told the operator a live turn had failed".
- **The SQLite rebuild** — removing the call fails on the card-less insert.
- `each_input_is_journaled_exactly_once_by_either_entry_point` pins that both cycle entry points agree.

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --no-deps -- -D warnings`
- [x] `cargo test` — 2784 + 10 + 1 passed, 0 failed
- [x] `--all-features --all-targets`; `--features sqlite,mongodb` (check, clippy, sqlite suite); `--features openhuman,mcp,telegram` — 1256 gated tests on touched modules

A trap worth recording for the next person adding a `CompanyEvent` variant: `summarize_event` in `src/harness/orchestrator.rs` is an exhaustive match that **no default-feature lane compiles**. Default gates were green here while `--features openhuman,mcp,telegram` was broken.

## Documentation

`docs/spec/runtime/events.md` and `docs/spec/runtime/ports-runs.md` updated for the turn brackets and the card-less run.

## Related

Conflicts with #997 (#982) in one line: this sets `origin_run_id` on the card literal in `run_chat`, which #982 also edits. Resolution when the second of the two merges: keep #982's assignee and column logic, take this branch's `origin_run_id` line. This branch also drops `run_chat`'s now-unused `parent` parameter. `assignment_matches` was not touched.

Part of #983