### PR TITLE
feat(harness): nudge a capped chat turn about unpublished work (#989)

### DIFF
--- a/docs/spec/runtime/agents.md
+++ b/docs/spec/runtime/agents.md
@@ -196,6 +196,31 @@ An empty or whitespace-only document is dropped rather than rendered as a bare
 heading. An empty section reads to the model as a source that exists and says
 nothing, which is worse than its absence.
 
+## The step budget, and what a paused turn looks like
+
+A single turn may make at most a fixed number of tool iterations — the
+`max_tool_iterations` an agent is built with, which today is the vendored
+runtime's default of 10. Reaching it is **a pause, not a failure**: the runtime
+stops the tool loop, asks the model once more (with tools withheld) for a
+resumable "Done so far / Next steps" checkpoint, and returns that as an ordinary
+successful reply. There is no error to catch and no error to match on, which is
+precisely why a capped turn used to be invisible — the operator read a tidy plan
+with no deliverable behind it and no way to tell the agent had been cut off
+mid-task. So the harness now reads the runtime's cap flag while the turn's agent
+lock is still held and carries it out on the turn's outcome, OR'd across every
+turn behind one operator bubble (the responder, any desk lead it handed work to,
+and the relay turn that folds their answers back together). When any of them
+paused, the operator gets a **second, unauthored bubble** after the reply saying
+the turn stopped at its step limit, that nothing errored, and that replying
+"continue" asks the agent to pick up from there. It is a separate bubble rather
+than an addition to the reply because the reply — and only the reply — is
+written back to the context store as memory; appending would file the platform's
+notice as something the agent said and recall it into later turns. The cap
+itself is unchanged by this: the turn stops in the same place, it just says so.
+See `src/harness/mod.rs` (`TurnOutcome::hit_iteration_cap`),
+`src/runtime/delegation.rs` for the fold, and `src/harness/brain.rs` for the
+notice.
+
 ## `classes`
 
 The explicit epistemic classification

--- a/src/harness/acp_run_turn.rs
+++ b/src/harness/acp_run_turn.rs
@@ -199,7 +199,14 @@ pub fn fold(turn: AcpTurn) -> TurnOutcome {
         }
     }
 
-    TurnOutcome { reply, steps }
+    TurnOutcome {
+        reply,
+        steps,
+        // Issue #926: an ACP turn runs behind an external agent process, whose
+        // protocol carries no iteration-cap signal — there is nothing to read,
+        // and inventing `true` here would label every ACP reply a pause.
+        hit_iteration_cap: false,
+    }
 }
 
 #[async_trait]

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -60,6 +60,29 @@ const NO_TASK_STORE: &str = "this company has no task board wired, so the card c
 /// time the cycle reaches it (deleted, or never persisted).
 const CARD_VANISHED: &str = "the card was gone by the time its dispatch ran";
 
+/// The system bubble appended when a turn paused at its tool-iteration cap
+/// (issue #926).
+///
+/// Three things it must say, and one it must not:
+///
+/// - **It paused** — the reply above is a checkpoint, so it reads like a plan
+///   the agent simply chose not to carry out. QA reported this as agents
+///   "getting permanently stuck mid-task", which is what an unexplained pause
+///   looks like from the outside.
+/// - **Nothing failed** — a cap is a budget, not an error. Without saying so,
+///   the notice reads as a crash report for a turn that worked fine.
+/// - **How to carry on** — the operator's move is to reply.
+///
+/// What it must NOT do is promise the agent resumes where it left off. The
+/// pooled `Agent` keeps its history in memory, and `HarnessPool::ensure`
+/// rebuilds the agent whenever the roster / skill / MCP fingerprint moves — so
+/// "continue" is an instruction to the operator, phrased as a request to the
+/// agent, never a durability guarantee this layer cannot make.
+pub(crate) const ITERATION_CAP_PAUSE_NOTICE: &str = "\
+The reply above is a pause, not a finished answer: this turn reached the maximum number of steps \
+it may take for a single reply, so it stopped and wrote up where it had got to. Nothing errored — \
+the work so far stands. Reply \"continue\" to ask it to pick up from there.";
+
 use crate::harness::run_trace::RunTraceSink;
 use crate::ports::artifacts::{ArtifactAuthor, ArtifactRecord};
 use crate::ports::brain::{Brain, CycleHost};
@@ -2716,6 +2739,35 @@ impl HarnessBrain {
                         reply_to: None,
                         steps: operator_steps,
                     });
+                    // Issue #926: a turn that paused at its step cap says so,
+                    // in its own bubble.
+                    //
+                    // A SIBLING bubble rather than text appended to the reply,
+                    // for the reason the approval-overflow notice below gives:
+                    // the reply is the agent's answer and this is the system
+                    // saying the agent was cut off. Here that separation is
+                    // load-bearing rather than tidy — `HarnessPool::run`
+                    // persists `outcome.reply` to the context store, so
+                    // appending would write "you hit the step limit" into
+                    // memory and recall it as something the agent said in a
+                    // later turn.
+                    //
+                    // Unauthored (`agent: None`) for the same reason: no
+                    // teammate said this, and attributing it to the responder
+                    // would put the platform's words in its mouth. Empty steps
+                    // — the turn's timeline is already on the bubble above, and
+                    // repeating it would double every row in the console.
+                    if turn.hit_iteration_cap {
+                        channel_responses.push(OutboundMessage {
+                            message_id: None,
+                            task_id: None,
+                            channel: "operator".to_string(),
+                            agent: None,
+                            text: ITERATION_CAP_PAUSE_NOTICE.to_string(),
+                            steps: Vec::new(),
+                            reply_to: None,
+                        });
+                    }
                     channel_responses.extend(turn.bubbles);
                 }
                 CompanyEvent::TaskDispatched { task_id, run_id } => {

--- a/src/harness/brain.rs
+++ b/src/harness/brain.rs
@@ -23,7 +23,7 @@ use async_trait::async_trait;
 
 use crate::Result;
 use crate::company::artifact_mirror;
-use crate::company::steer::{InflightEntry, InflightKind, SteerAction, cap_redirect};
+use crate::company::steer::{InflightEntry, InflightKind, SteerAction, SteerControl, cap_redirect};
 use crate::harness::build::agent_workspace;
 use crate::harness::confine;
 // The note shape is shared with the ungated system paths (issue #337): the
@@ -1965,6 +1965,85 @@ impl HarnessBrain {
         Ok(written)
     }
 
+    /// Files one drained batch of conversation publishes onto the right card —
+    /// same destination rule (`spawned_task` vs a fresh card), same
+    /// publisher-attribution fallback, same failure escalation into the
+    /// operator's own reply (issue #445) — and returns the card it landed on.
+    ///
+    /// `claimed` mirrors the belt-and-suspenders guard every call site already
+    /// used inline (`!published.is_empty() && publish_claim.is_some()`): an
+    /// unclaimed queue can only ever drain empty, so this is defensive rather
+    /// than load-bearing, but it keeps both conditions visible together instead
+    /// of only at the call site.
+    ///
+    /// Extracted for issue #989: a capped chat turn's unpublished-work nudge
+    /// (below) is a **second** turn that can ALSO publish, staged into the same
+    /// queue while the same claim is still live. Filing its batch through this
+    /// exact path — rather than a re-derived one — is what keeps a publish made
+    /// during the nudge from being the one publish in this whole module that
+    /// silently drops on the floor.
+    async fn file_conversation_batch(
+        &self,
+        responder: &str,
+        spawned_task: Option<&str>,
+        chat_id: Option<&str>,
+        claimed: bool,
+        published: Vec<publish::PendingPublish>,
+        operator_reply: &mut String,
+    ) -> Option<String> {
+        if published.is_empty() || !claimed {
+            return None;
+        }
+        let count = published.len();
+        // Issue #463: the agent that actually called the tool, not the turn's
+        // responder. A desk lead publishing inside a hand-off used to be filed
+        // under the orchestrator that relayed for it — the card named the wrong
+        // person for work it did not do.
+        //
+        // The **card** takes one owner, so one agent is picked; each artifact
+        // keeps its own author further down, in `record_published_artifacts`,
+        // because a turn can stage publishes from more than one agent.
+        let publisher = published
+            .first()
+            .map(|p| p.agent.clone())
+            .filter(|agent| !agent.is_empty())
+            .unwrap_or_else(|| responder.to_string());
+        // Issue #463: file onto the card THIS message already opened when
+        // there is one. Minting is the no-card-in-scope case, and the fallback
+        // inside `file_publishes_on_card` for a card deleted mid-turn.
+        let filed = match spawned_task {
+            Some(card_id) => {
+                self.file_publishes_on_card(card_id, &publisher, chat_id, published)
+                    .await
+            }
+            None => {
+                self.record_conversation_publishes(&publisher, chat_id, published)
+                    .await
+            }
+        };
+        match filed {
+            Ok(card_id) => Some(card_id),
+            Err(err) => {
+                // The agent has already been told the file was published, and
+                // that receipt is now wrong. This is the one remaining way that
+                // can happen — a store write failing under a claim that was
+                // honestly made — so it is said out loud in the conversation
+                // rather than left in a log the operator will never read.
+                // Saying nothing here would reproduce #445 exactly: a
+                // confident delivery claim over nothing recorded.
+                tracing::error!(
+                    agent = %responder,
+                    staged = count,
+                    error = %err,
+                    "[publish] a conversation published files but they could not be recorded; \
+                     telling the operator in the reply"
+                );
+                operator_reply.push_str(&publish::recording_failed_notice(count));
+                None
+            }
+        }
+    }
+
     /// Files what a conversation turn published onto the card that turn already
     /// opened (issue #463). Returns that card's id.
     ///
@@ -2587,6 +2666,23 @@ impl HarnessBrain {
                     // in this cycle rides the same operator thread, so it gets the
                     // same id.
                     let chat_id = chat.as_deref();
+                    // Issue #989: the dispatch-start baseline for "did this
+                    // responder write anything it did not publish?" — taken
+                    // before the turn runs, for the same reason run_task's own
+                    // `workspace_at_dispatch` is (a snapshot taken after the
+                    // turn would already include whatever it wrote).
+                    //
+                    // Only consulted below when the turn reports
+                    // `hit_iteration_cap`: an ordinary chat reply that finishes
+                    // on its own is not this issue's scope. #244's scan already
+                    // covers the task-dispatch path unconditionally; widening
+                    // it to every chat turn is a separate, unscoped change.
+                    // Taken unconditionally anyway (cap status is not known
+                    // until the turn returns), the same trade-off run_task
+                    // already makes for every dispatch.
+                    let cap_scan_workspace =
+                        agent_workspace(&self.deps.workspace_root, &self.record().id, &responder);
+                    let cap_scan_baseline = WorkspaceSnapshot::take(&cap_scan_workspace);
                     // Clear stale MCP failures so nothing leaks from a prior turn
                     // (the delegation queue is cleared inside the runner, right
                     // before the orchestrator turn).
@@ -2641,63 +2737,99 @@ impl HarnessBrain {
                     // when the claim was actually taken — an unclaimed queue can
                     // only be empty here, because the tool refuses without one.
                     let published = self.deps.pending_publishes.drain();
-                    let mut published_card = None;
-                    if !published.is_empty() && publish_claim.is_some() {
-                        let count = published.len();
-                        // Issue #463: the agent that actually called the tool,
-                        // not the turn's responder. A desk lead publishing
-                        // inside a hand-off used to be filed under the
-                        // orchestrator that relayed for it — the card named the
-                        // wrong person for work it did not do.
-                        //
-                        // The **card** takes one owner, so one agent is picked;
-                        // each artifact keeps its own author further down, in
-                        // `record_published_artifacts`, because a turn can stage
-                        // publishes from more than one agent.
-                        let publisher = published
-                            .first()
-                            .map(|p| p.agent.clone())
-                            .filter(|agent| !agent.is_empty())
-                            .unwrap_or_else(|| responder.clone());
-                        // Issue #463: file onto the card THIS message already
-                        // opened when there is one. `turn.spawned_task` holds it
-                        // by construction — it is seeded from the direct-answer
-                        // card, from each hand-off's card and from the chat
-                        // handler's — which is exactly why the reply linked
-                        // there while the deliverable sat on a second, orphaned
-                        // card nothing pointed at. Minting is the
-                        // no-card-in-scope case, and the fallback inside
-                        // `file_publishes_on_card` for a card deleted mid-turn.
-                        let filed = match turn.spawned_task.as_deref() {
-                            Some(card_id) => {
-                                self.file_publishes_on_card(card_id, &publisher, chat_id, published)
-                                    .await
+                    // Issue #989: the paths this turn actually offered, captured
+                    // before `file_conversation_batch` below moves `published` —
+                    // the cap-pause scan's "staged" side of `publish::unpublished`
+                    // needs this list and cannot re-read the queue for it: by the
+                    // time that scan runs the queue has already been drained here.
+                    let published_sources: Vec<String> =
+                        published.iter().map(|p| p.source.clone()).collect();
+                    let mut published_card = self
+                        .file_conversation_batch(
+                            &responder,
+                            turn.spawned_task.as_deref(),
+                            chat_id,
+                            publish_claim.is_some(),
+                            published,
+                            &mut operator_reply,
+                        )
+                        .await;
+
+                    // Issue #989: on a turn that paused at its iteration cap, run
+                    // the same unpublished-work scan the task-dispatch path
+                    // (`run_task`) already runs, and — if it wrote something it
+                    // never offered — the same one follow-up nudge turn (issue
+                    // #244's `nudge_for_unpublished`, unchanged). A capped turn
+                    // returns `Ok` with a checkpoint reply, so nothing above
+                    // treats it as interrupted; without this, a file the agent
+                    // had already written sits in its sandbox with nothing
+                    // anywhere saying so.
+                    //
+                    // The publish claim is still live here — `drop(publish_claim)`
+                    // is below this block, not above it — so a publish the nudge
+                    // turn itself makes stages exactly like any other and is
+                    // filed through the same `file_conversation_batch` path
+                    // rather than being silently discarded when the claim
+                    // releases.
+                    if turn.hit_iteration_cap {
+                        let changed = cap_scan_baseline.changed_since(&cap_scan_workspace);
+                        let unpublished = publish::unpublished(&changed.files, &published_sources);
+                        if !unpublished.is_empty() {
+                            let nudge_control = SteerControl::new();
+                            let declined = self
+                                .nudge_for_unpublished(
+                                    &run_turn,
+                                    &responder,
+                                    text,
+                                    &operator_reply,
+                                    &unpublished,
+                                    changed.partial,
+                                    &nudge_control,
+                                    None,
+                                )
+                                .await;
+                            let nudge_published = self.deps.pending_publishes.drain();
+                            if let Some(card_id) = self
+                                .file_conversation_batch(
+                                    &responder,
+                                    turn.spawned_task.as_deref(),
+                                    chat_id,
+                                    publish_claim.is_some(),
+                                    nudge_published,
+                                    &mut operator_reply,
+                                )
+                                .await
+                            {
+                                published_card = published_card.or(Some(card_id));
                             }
-                            None => {
-                                self.record_conversation_publishes(&publisher, chat_id, published)
-                                    .await
-                            }
-                        };
-                        match filed {
-                            Ok(card_id) => published_card = Some(card_id),
-                            Err(err) => {
-                                // The agent has already been told the file was
-                                // published, and that receipt is now wrong. This
-                                // is the one remaining way that can happen — a
-                                // store write failing under a claim that was
-                                // honestly made — so it is said out loud in the
-                                // conversation rather than left in a log the
-                                // operator will never read. Saying nothing here
-                                // would reproduce #445 exactly: a confident
-                                // delivery claim over nothing recorded.
-                                tracing::error!(
+                            // The fallback's file list is the pre-nudge diff
+                            // minus whatever is staged now — the same "not a
+                            // fresh scan" argument `run_task`'s own fallback
+                            // documents: a scratch file written *while
+                            // answering the nudge* is an artifact of being
+                            // asked, and naming it here would make the nudge
+                            // generate its own noise.
+                            let still_unpublished = publish::unpublished(
+                                &unpublished,
+                                &self.deps.pending_publishes.sources(),
+                            );
+                            if !still_unpublished.is_empty() {
+                                // A plain chat turn has no card to note a
+                                // decline on unless one happened to be opened
+                                // (`turn.spawned_task`) — unlike a dispatched
+                                // task, which always has one. The warning is
+                                // therefore the whole of what happens here,
+                                // exactly as it is in `run_task` whenever the
+                                // nudge itself produced no reply to note.
+                                tracing::warn!(
+                                    company = %self.record().id,
                                     agent = %responder,
-                                    staged = count,
-                                    error = %err,
-                                    "[publish] a conversation published files but they could not \
-                                     be recorded; telling the operator in the reply"
+                                    files = %publish::name_files(&still_unpublished),
+                                    declined = declined.is_some(),
+                                    partial_scan = changed.partial,
+                                    "[publish] a capped chat turn changed sandbox files and \
+                                     published none of them; no artifact was recorded"
                                 );
-                                operator_reply.push_str(&publish::recording_failed_notice(count));
                             }
                         }
                     }

--- a/src/harness/cap_publish_test.rs
+++ b/src/harness/cap_publish_test.rs
@@ -1,0 +1,537 @@
+//! Issue #989 (Part 2a of #926): a **chat** turn that pauses at its
+//! tool-iteration cap runs the same #244 unpublished-work scan and nudge a
+//! dispatched task already gets.
+//!
+//! Two features already exist and, before this, never met:
+//!
+//! - Part 1 (#926) taught the chat path to say "I paused" —
+//!   `ITERATION_CAP_PAUSE_NOTICE`, proven end to end in
+//!   [`cap_turn_test`](crate::harness::cap_turn_test).
+//! - #244 taught the **task-dispatch** path (`run_task`) to scan the agent's
+//!   sandbox for files it wrote and never published, and to ask about them in
+//!   one follow-up turn — proven end to end in
+//!   [`publish_turn_test`](crate::harness::publish_turn_test).
+//!
+//! A capped turn returns `Ok` with a checkpoint reply ("Done so far / Next
+//! steps"), so nothing downstream treated it as interrupted, and the scan only
+//! ever ran on the dispatch path — so a chat turn that hit the cap after
+//! writing a file got the pause notice and nothing else. The file just sat in
+//! its sandbox with nothing anywhere saying so.
+//!
+//! This reuses the same lever [`cap_turn_test`] and [`publish_turn_test`] both
+//! do: a real [`HarnessBrain`], real `build_agent`, real [`HostedProvider`]
+//! against a scripted loopback endpoint, real `FsOps` stores, and a real agent
+//! workspace on disk — only the model's *choices* are scripted.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::build::agent_workspace;
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::publish::PUBLISH_ARTIFACT_TOOL;
+use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+use crate::ports::artifacts::ArtifactStore;
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::tasks::TaskStore;
+use crate::ports::types::{
+    ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
+    Effect, EffectDisposition, ToolCall, ToolResult,
+};
+use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+/// The agent every test here talks to.
+const AGENT: &str = "ceo";
+
+/// `build_agent` never calls `.config(...)`, so the agent falls back to
+/// openhuman's `AgentConfig::default()`, whose `max_tool_iterations` is 10 —
+/// the same constant [`cap_turn_test`](crate::harness::cap_turn_test) pins and
+/// checks the observed call count against, for the same reason: if a vendor
+/// bump moves it, this test must fail loudly rather than silently script the
+/// wrong turn shape and pass for it.
+const CAP: usize = 10;
+
+/// The checkpoint the scripted model writes when asked to wrap up.
+const CHECKPOINT: &str = "Done so far: read the standards and drafted most of the outline. \
+Next steps: finish the outline and publish it.";
+
+/// A slice of [`publish::nudge_instruction`](crate::harness::publish::nudge_instruction)
+/// unique to it, used to detect a nudge turn on the wire the same way
+/// [`publish_turn_test`](crate::harness::publish_turn_test) does.
+const NUDGE_MARKER: &str = "published none of them";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Debug)]
+enum Turn {
+    Call { tool: &'static str, args: Value },
+    Say(&'static str),
+}
+
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    seen: Mutex<Vec<Value>>,
+}
+
+impl Script {
+    fn calls(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+}
+
+async fn spawn_script(turns: Vec<Turn>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                let next = next.unwrap_or(Turn::Say("done"));
+                let message = match next {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(tool, &args),
+                };
+                (
+                    axum::http::StatusCode::OK,
+                    Json(json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    })),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+fn tool_call_message(tool: &str, args: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{
+            "id": format!("call-{tool}"),
+            "type": "function",
+            "function": { "name": tool, "arguments": args.to_string() }
+        }]
+    })
+}
+
+/// How many **nudge turns** ran — counts requests whose last message is the
+/// user message carrying the nudge instruction, the same discriminator
+/// [`publish_turn_test::nudge_turns`](crate::harness::publish_turn_test) uses
+/// and for the same reason: the follow-up turn continues the same
+/// conversation, so counting "requests that mention the nudge" would also
+/// count its own tool round trips.
+fn nudge_turns(script: &Script) -> usize {
+    script
+        .seen
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|body| {
+            body.get("messages")
+                .and_then(Value::as_array)
+                .and_then(|m| m.last())
+                .is_some_and(|last| {
+                    last.get("role").and_then(Value::as_str) == Some("user")
+                        && last
+                            .get("content")
+                            .and_then(Value::as_str)
+                            .is_some_and(|c| c.contains(NUDGE_MARKER))
+                })
+        })
+        .count()
+}
+
+/// One successful `file_write` to a distinct path — distinct per step so
+/// openhuman's repeated-failure breaker never halts the run (a breaker halt is
+/// not a cap hit) and so no no-progress heuristic reads the ten calls as a loop.
+fn step(n: usize) -> Turn {
+    Turn::Call {
+        tool: "file_write",
+        args: json!({ "path": format!("step-{n}.md"), "content": format!("step {n}") }),
+    }
+}
+
+/// One `file_read` of a distinct pre-existing file — distinct per step for
+/// the same reason [`step`] writes to a distinct path: openhuman's
+/// no-progress/loop heuristic can read ten identical calls as a stall and cut
+/// the turn short through a different breaker than the iteration cap, which
+/// would prove nothing about the cap-pause path this issue is about.
+fn read_note(n: usize) -> Turn {
+    Turn::Call {
+        tool: "file_read",
+        args: json!({ "path": format!("notes-{n}.md") }),
+    }
+}
+
+/// `CAP` tool round trips that WRITE, then the tools-disabled wrap-up call —
+/// the shape that reaches the cap having left something unpublished.
+fn capped_script_writing() -> Vec<Turn> {
+    let mut turns: Vec<Turn> = (1..=CAP).map(step).collect();
+    turns.push(Turn::Say(CHECKPOINT));
+    turns
+}
+
+/// `CAP` tool round trips that only READ pre-existing files, then the
+/// wrap-up call — the shape that reaches the cap having changed nothing.
+fn capped_script_reading() -> Vec<Turn> {
+    let mut turns: Vec<Turn> = (1..=CAP).map(read_note).collect();
+    turns.push(Turn::Say(CHECKPOINT));
+    turns
+}
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+struct NoopHost;
+
+#[async_trait]
+impl CycleHost for NoopHost {
+    async fn call_tool(&self, _call: ToolCall) -> crate::Result<ToolResult> {
+        Ok(ToolResult {
+            ok: true,
+            output: Value::Null,
+        })
+    }
+    async fn context_op(&self, _op: ContextOp) -> crate::Result<ContextOpResult> {
+        Ok(ContextOpResult::Text(String::new()))
+    }
+    async fn emit_effect(&self, _effect: Effect) -> crate::Result<EffectDisposition> {
+        Ok(EffectDisposition::Executed)
+    }
+    async fn park_effect(&self, _effect: Effect) -> crate::Result<ApprovalId> {
+        Ok(ApprovalId::new("appr-parked"))
+    }
+}
+
+fn company() -> CompanyId {
+    CompanyId::new("acme")
+}
+
+/// A one-agent company on `full` policy (an ordinary turn is not parked for
+/// approval — the gate under test is the iteration cap and the publish scan,
+/// not the approval one) with every tool granted, so both `file_write` /
+/// `file_read` and `publish_artifact` are on the wire.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["*"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        id: company(),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        overlay_desk_tools: Default::default(),
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Real deps pointed at the scripted endpoint, with task and artifact stores
+/// wired — unlike [`cap_turn_test::deps_for`](crate::harness::cap_turn_test),
+/// this needs `artifacts: Some(..)` too, or the publish claim this issue
+/// depends on is never taken and `publish_artifact` is never even offered.
+fn deps_for(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc<FsOps>) {
+    let ops = Arc::new(FsOps::new(dir));
+    let deps = HarnessDeps {
+        ledgers: None,
+        ledger_registry: Default::default(),
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: Some(ops.clone()),
+        workspace_root: dir.to_path_buf(),
+        workspace_git_enabled: false,
+        audit_root: dir.to_path_buf(),
+        model_override: Some("stub-model".to_string()),
+        tasks: Some(ops.clone()),
+        artifacts: Some(ops.clone() as Arc<dyn ArtifactStore>),
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: Arc::from([]),
+        default_mcp_servers: Vec::new(),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
+        run_outputs: Default::default(),
+        run_output_store: None,
+        workflow_revisions: None,
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        #[cfg(feature = "chargebee")]
+        chargebee: None,
+        #[cfg(feature = "paypal")]
+        paypal: None,
+        hosting: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        workspace: None,
+        repos: None,
+        repo_bindings: Vec::new(),
+        checkouts: crate::harness::repo::CheckoutLedger::default(),
+        search: None,
+    };
+    (deps, ops)
+}
+
+/// An operator message, the shape a chat turn arrives as.
+fn chat(text: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The headline
+// ---------------------------------------------------------------------------
+
+/// **The headline.** A chat turn spends its whole iteration budget writing
+/// files and never publishes any of them. It must get the same one follow-up
+/// nudge the task-dispatch path already gets.
+///
+/// Before issue #989 this scan never ran on the chat path at all, so the
+/// assertion below (`nudge_turns == 1`) is the prove-red target: on the
+/// pre-fix code the turn still reaches the cap and returns its checkpoint, but
+/// no nudge ever fires — `nudge_turns(&script)` reads `0` and `script.calls()`
+/// stops at `CAP + 1` (the wrap-up, and nothing after it).
+#[tokio::test]
+async fn a_capped_chat_turn_that_wrote_unpublished_work_gets_the_nudge() {
+    let mut turns = capped_script_writing();
+    // The nudge turn: a clean decline. The recovery case — the nudge
+    // *publishing* the file — is its own test below.
+    turns.push(Turn::Say(
+        "step-10.md is a work-in-progress outline, not the finished draft yet.",
+    ));
+    let (base_url, script) = spawn_script(turns).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Draft the launch outline."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert_eq!(
+        nudge_turns(&script),
+        1,
+        "a capped chat turn that wrote unpublished work must get exactly one nudge"
+    );
+    assert_eq!(
+        script.calls(),
+        CAP + 2,
+        "expected {CAP} tool iterations, one wrap-up call, and one nudge turn: {} calls",
+        script.calls()
+    );
+}
+
+/// **The recovery case.** The nudge turn does not just get asked — it can
+/// actually publish, and the file it recovers must be filed exactly like any
+/// other conversation publish (issue #445): a card minted to carry it, the
+/// artifact reachable on that card.
+///
+/// This is the property that makes the nudge worth adding rather than a
+/// cosmetic "did you mean to publish?" with no way to act on it: the publish
+/// claim is still live when the nudge runs, so a `publish_artifact` call here
+/// stages and drains exactly like the primary turn's own would.
+#[tokio::test]
+async fn the_nudge_can_recover_the_file_a_capped_turn_wrote() {
+    let mut turns = capped_script_writing();
+    turns.push(Turn::Call {
+        tool: PUBLISH_ARTIFACT_TOOL,
+        args: json!({ "path": "step-10.md" }),
+    });
+    turns.push(Turn::Say("Published the outline draft."));
+    let (base_url, script) = spawn_script(turns).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain =
+        HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops.clone());
+
+    brain
+        .run_cycle(chat("Draft the launch outline."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert_eq!(nudge_turns(&script), 1);
+
+    let cards = TaskStore::list(&*ops, &company()).await.expect("list");
+    assert_eq!(
+        cards.len(),
+        1,
+        "the nudge's publish must mint a card the same way a primary-turn \
+         conversation publish would: {cards:?}"
+    );
+    let artifacts = ArtifactStore::list(&*ops, &company(), Some(&cards[0].id))
+        .await
+        .expect("list artifacts");
+    assert_eq!(
+        artifacts.len(),
+        1,
+        "the file the nudge published must actually be recorded, not silently dropped \
+         once the primary turn's own drain already ran"
+    );
+    assert_eq!(artifacts[0].source.as_deref(), Some("step-10.md"));
+}
+
+// ---------------------------------------------------------------------------
+// The negative controls
+// ---------------------------------------------------------------------------
+
+/// **No false positives on the common case.** A capped turn that wrote
+/// nothing — it only *read* an existing file, ten times over, to reach the
+/// cap — must not be nudged. The cap is about to be hit routinely once #988
+/// raises it into everyday reach; a nudge on every capped turn would be noise
+/// nobody could act on.
+#[tokio::test]
+async fn a_capped_chat_turn_that_wrote_nothing_gets_no_nudge() {
+    let (base_url, script) = spawn_script(capped_script_reading()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    // Pre-existing files the scripted turn only reads. `file_read` cannot move
+    // their mtime or size, so the #244 scan's diff sees no change at all —
+    // proving the negative control is real read traffic, not an empty script.
+    let workspace = agent_workspace(dir.path(), &company(), AGENT);
+    std::fs::create_dir_all(&workspace).expect("create workspace");
+    for n in 1..=CAP {
+        std::fs::write(
+            workspace.join(format!("notes-{n}.md")),
+            format!("pre-existing note {n}"),
+        )
+        .expect("seed notes file");
+    }
+
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Summarize the notes."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert_eq!(
+        nudge_turns(&script),
+        0,
+        "a capped turn that wrote nothing must not be nudged"
+    );
+    assert_eq!(
+        script.calls(),
+        CAP + 1,
+        "expected {CAP} tool iterations plus exactly one wrap-up call, and nothing after it: \
+         {} calls",
+        script.calls()
+    );
+}
+
+/// **Existing #244 non-capped behaviour is unchanged.** A chat turn that
+/// finishes well inside the cap and leaves unpublished work is not this
+/// issue's scope — #244 never scanned an ordinary chat reply before, and this
+/// change must not make it start. Widening chat-turn coverage beyond the
+/// cap-pause trigger is a separate, unscoped change.
+#[tokio::test]
+async fn an_uncapped_chat_turn_with_unpublished_work_gets_no_nudge() {
+    let (base_url, script) = spawn_script(vec![step(1), step(2), Turn::Say(CHECKPOINT)]).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Draft the launch outline."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    assert_eq!(
+        script.calls(),
+        3,
+        "well inside the cap: two tool calls plus the reply, no wrap-up and no nudge"
+    );
+    assert_eq!(
+        nudge_turns(&script),
+        0,
+        "an ordinary chat reply's unpublished files are #244's existing, unchanged scope — \
+         issue #989 only widens the cap-pause path"
+    );
+}

--- a/src/harness/cap_turn_test.rs
+++ b/src/harness/cap_turn_test.rs
@@ -1,0 +1,606 @@
+//! Issue #926: end-to-end proof that a turn which runs out of tool iterations
+//! **says so** — and that the way it says so cannot poison the next turn.
+//!
+//! The bug this pins is a silence, which is why nothing shorter than a real
+//! turn loop can show it. Hitting the cap is not an error and never surfaces as
+//! one: openhuman stops the tool loop, makes one extra tools-disabled call
+//! asking the model for a resumable "Done so far / Next steps" checkpoint, and
+//! returns that as an ordinary `Ok(reply)`. So the operator receives a tidy
+//! plan, no deliverable, and nothing anywhere saying the turn was cut off —
+//! reported by QA as agents "getting permanently stuck mid-task".
+//!
+//! [`MockProvider`](crate::harness::provider::MockProvider) cannot reach this:
+//! it never issues a tool call, so it can never reach an iteration cap. The
+//! lever is the same loopback OpenAI-compatible endpoint
+//! [`publish_turn_test`](crate::harness::publish_turn_test) uses — a real
+//! [`HostedProvider`], real `build_agent`, real tool dispatch, real pool, real
+//! brain. Only the model's *choices* are scripted.
+//!
+//! What each test is for:
+//!
+//! - the flag is `true` on a capped turn, and — the negative control that stops
+//!   a hardcoded `true` passing — `false` on a turn that simply finishes;
+//! - a capped turn is still `Ok` with a non-empty reply, pinning "a cap is a
+//!   pause, not an error" so a future reader does not go looking for an error
+//!   arm to match on;
+//! - the brain emits the pause as a **second** bubble;
+//! - and the memory the turn writes back carries the agent's checkpoint but
+//!   **not** the platform's notice.
+
+use std::sync::{Arc, Mutex};
+
+use async_trait::async_trait;
+use axum::Json;
+use axum::routing::post;
+use serde_json::{Value, json};
+
+use crate::company::CompanyManifest;
+use crate::company::credentials::Credential;
+use crate::harness::brain::ITERATION_CAP_PAUSE_NOTICE;
+use crate::harness::mcp_probe::McpFailureQueue;
+use crate::harness::memory_loop;
+use crate::harness::orchestrator::{DelegationQueue, WorkflowRunnerHandle};
+use crate::harness::policy::ApprovalRequestQueue;
+use crate::harness::provider::{HostedProvider, HostedProviderConfig};
+use crate::harness::{HarnessBrain, HarnessDeps, HarnessPool};
+use crate::ports::ContextStore;
+use crate::ports::brain::{Brain, CycleHost};
+use crate::ports::types::{
+    ApprovalId, CompanyEvent, CompanyId, CompanyRecord, ContextOp, ContextOpResult, CycleRequest,
+    Effect, EffectDisposition, OutboundMessage, ToolCall, ToolResult,
+};
+use crate::store::{FsCompanyStore, FsContextStore, FsOps};
+
+/// The agent every test here talks to.
+const AGENT: &str = "ceo";
+
+/// The tool-iteration cap a turn actually runs under.
+///
+/// `build_agent` never calls `.config(...)`, so the agent falls back to
+/// openhuman's `AgentConfig::default()`, whose `max_tool_iterations` is 10
+/// (`config/schema/agent.rs`, `default_agent_max_tool_iterations`).
+///
+/// Hardcoding it is deliberate and it is checked, not assumed: the scripts
+/// below depend on knowing exactly which model call is the wrap-up, and
+/// [`capped_script`] asserts the observed call count matches. If a vendor bump
+/// or a `.config(...)` call moves the cap, these tests fail with a message that
+/// says the cap moved — rather than silently scripting the wrong turn shape and
+/// passing for the wrong reason.
+const CAP: usize = 10;
+
+/// The checkpoint the scripted model writes when it is asked to wrap up.
+///
+/// Distinctive so the memory assertion can look for the agent's words rather
+/// than for "some text landed".
+const CHECKPOINT: &str = "Done so far: read the standards and the prior spec. \
+Next steps: draft the spec and publish it.";
+
+/// A slice of [`ITERATION_CAP_PAUSE_NOTICE`] unique to the platform's voice.
+///
+/// Used to prove the notice is *absent* from memory. A substring rather than
+/// the whole notice because an absence assertion on the full string would pass
+/// the moment the wording changed by a comma.
+const NOTICE_MARKER: &str = "pause, not a finished answer";
+
+// ---------------------------------------------------------------------------
+// The scripted model
+// ---------------------------------------------------------------------------
+
+/// What the scripted model does on each successive call.
+#[derive(Clone, Debug)]
+enum Turn {
+    /// Emit a native tool call with these literal arguments.
+    Call { tool: String, args: Value },
+    /// Finish with plain assistant text.
+    Say(String),
+}
+
+/// A scripted OpenAI-compatible `/chat/completions` endpoint.
+struct Script {
+    turns: Mutex<Vec<Turn>>,
+    /// Every request body the harness sent, for post-hoc assertions.
+    seen: Mutex<Vec<Value>>,
+}
+
+impl Script {
+    /// How many model calls the turn actually made.
+    fn calls(&self) -> usize {
+        self.seen.lock().unwrap().len()
+    }
+
+    /// Whether the wrap-up call was made with tools **withheld** — the tell that
+    /// openhuman took the cap branch rather than simply running out of script.
+    fn last_call_had_tools(&self) -> bool {
+        self.seen
+            .lock()
+            .unwrap()
+            .last()
+            .and_then(|body| body.get("tools").and_then(Value::as_array).cloned())
+            .is_some_and(|tools| !tools.is_empty())
+    }
+}
+
+/// Serve the script on loopback and return its base URL plus the shared handle.
+async fn spawn_script(turns: Vec<Turn>) -> (String, Arc<Script>) {
+    let script = Arc::new(Script {
+        turns: Mutex::new(turns),
+        seen: Mutex::new(Vec::new()),
+    });
+    let handle = Arc::clone(&script);
+    let app = axum::Router::new().route(
+        "/chat/completions",
+        post(move |Json(body): Json<Value>| {
+            let script = Arc::clone(&handle);
+            async move {
+                script.seen.lock().unwrap().push(body.clone());
+                let next = {
+                    let mut turns = script.turns.lock().unwrap();
+                    if turns.is_empty() {
+                        None
+                    } else {
+                        Some(turns.remove(0))
+                    }
+                };
+                // Running off the end means the turn looped more than the
+                // script expected. End it with text rather than hanging — the
+                // call-count assertions are what report the mismatch.
+                let next = next.unwrap_or_else(|| Turn::Say("done".to_string()));
+                let message = match next {
+                    Turn::Say(text) => json!({ "role": "assistant", "content": text }),
+                    Turn::Call { tool, args } => tool_call_message(&tool, &args),
+                };
+                (
+                    axum::http::StatusCode::OK,
+                    Json(json!({
+                        "choices": [{ "index": 0, "message": message }],
+                        "usage": { "prompt_tokens": 12, "completion_tokens": 4 }
+                    })),
+                )
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{addr}"), script)
+}
+
+/// One assistant message carrying a native `tool_calls` array — the shape the
+/// provider's `tool_calling: true` profile puts the turn loop on.
+fn tool_call_message(tool: &str, args: &Value) -> Value {
+    json!({
+        "role": "assistant",
+        "content": null,
+        "tool_calls": [{
+            "id": format!("call-{tool}"),
+            "type": "function",
+            "function": { "name": tool, "arguments": args.to_string() }
+        }]
+    })
+}
+
+/// One successful `file_write`.
+///
+/// A **distinct path and body per step** on purpose: the tool has to succeed
+/// every time, or openhuman's repeated-failure breaker halts the run — and a
+/// breaker halt is explicitly *not* a cap hit, so the test would prove nothing.
+/// Distinct arguments also keep any no-progress heuristic from reading ten
+/// identical calls as a loop.
+fn step(n: usize) -> Turn {
+    Turn::Call {
+        tool: "file_write".to_string(),
+        args: json!({ "path": format!("step-{n}.md"), "content": format!("step {n}") }),
+    }
+}
+
+/// A script that reaches the cap: exactly [`CAP`] tool round trips, then the
+/// checkpoint the tools-disabled wrap-up call asks for.
+///
+/// The wrap-up is what makes the `Say` land where it does — at call `CAP + 1`,
+/// after the loop has already paused.
+fn capped_script() -> Vec<Turn> {
+    let mut turns: Vec<Turn> = (1..=CAP).map(step).collect();
+    turns.push(Turn::Say(CHECKPOINT.to_string()));
+    turns
+}
+
+/// A script that finishes normally, well inside the cap — the negative control.
+fn uncapped_script() -> Vec<Turn> {
+    vec![step(1), step(2), Turn::Say(CHECKPOINT.to_string())]
+}
+
+// ---------------------------------------------------------------------------
+// The fixture
+// ---------------------------------------------------------------------------
+
+/// An inert `CycleHost` — these tests are about the turn, not the effect gate.
+struct NoopHost;
+
+#[async_trait]
+impl CycleHost for NoopHost {
+    async fn call_tool(&self, _call: ToolCall) -> crate::Result<ToolResult> {
+        Ok(ToolResult {
+            ok: true,
+            output: Value::Null,
+        })
+    }
+    async fn context_op(&self, _op: ContextOp) -> crate::Result<ContextOpResult> {
+        Ok(ContextOpResult::Text(String::new()))
+    }
+    async fn emit_effect(&self, _effect: Effect) -> crate::Result<EffectDisposition> {
+        Ok(EffectDisposition::Executed)
+    }
+    async fn park_effect(&self, _effect: Effect) -> crate::Result<ApprovalId> {
+        Ok(ApprovalId::new("appr-parked"))
+    }
+}
+
+fn company() -> CompanyId {
+    CompanyId::new("acme")
+}
+
+/// A one-agent company on `full` policy, so an ordinary turn is not parked for
+/// approval — the gate under test is the iteration cap, not the approval one.
+fn manifest() -> CompanyManifest {
+    toml::from_str(
+        r#"
+[company]
+name = "Acme"
+
+[policy]
+mode = "full"
+
+[tools]
+allow = ["*"]
+
+[[agent]]
+id = "ceo"
+role = "Chief Executive"
+tier = "orchestrator"
+"#,
+    )
+    .expect("manifest parses")
+}
+
+fn record() -> CompanyRecord {
+    CompanyRecord {
+        id: company(),
+        manifest: manifest(),
+        ledger: Vec::new(),
+        lifecycle: "running".to_string(),
+        overlay_agents: Vec::new(),
+        overlay_desk_members: Vec::new(),
+        overlay_desk_order: Vec::new(),
+        overlay_desks: Vec::new(),
+        overlay_workflows: Vec::new(),
+        overlay_budgets: Vec::new(),
+        overlay_policy: None,
+        overlay_desk_tools: Default::default(),
+        disabled_workflows: Vec::new(),
+        template_provenance: None,
+    }
+}
+
+/// Real deps pointed at the scripted endpoint, with a workspace on disk so
+/// `file_write` genuinely succeeds.
+fn deps_for(base_url: String, dir: &std::path::Path) -> (HarnessDeps, Arc<FsOps>) {
+    let ops = Arc::new(FsOps::new(dir));
+    let deps = HarnessDeps {
+        ledgers: None,
+        ledger_registry: Default::default(),
+        provider: Arc::new(HostedProvider::new(HostedProviderConfig {
+            base_url,
+            credential: Credential::from_value("stub-key"),
+            extra_headers: Vec::new(),
+        })),
+        provider_slug: "managed".to_string(),
+        context: Arc::new(FsContextStore::new(dir)),
+        store: Arc::new(FsCompanyStore::new(dir)),
+        meter: Some(ops.clone()),
+        workspace_root: dir.to_path_buf(),
+        workspace_git_enabled: false,
+        audit_root: dir.to_path_buf(),
+        model_override: Some("stub-model".to_string()),
+        tasks: Some(ops.clone()),
+        artifacts: None,
+        skills: None,
+        skills_source_dir: None,
+        skills_registry: Arc::from([]),
+        default_mcp_servers: Vec::new(),
+        mcp_servers: Vec::new(),
+        facts: None,
+        events: None,
+        delegations: DelegationQueue::default(),
+        workflow_runner: WorkflowRunnerHandle::default(),
+        mcp_failures: McpFailureQueue::default(),
+        pending_publishes: Default::default(),
+        workflow_refs: Default::default(),
+        run_outputs: Default::default(),
+        run_output_store: None,
+        workflow_revisions: None,
+        approval_requests: ApprovalRequestQueue::default(),
+        secrets: None,
+        web_allowed_domains: Vec::new(),
+        capabilities: crate::harness::toolbelt::CapabilityFilter::AllowAll,
+        workflow_source_dir: None,
+        plan: None,
+        media: None,
+        composio: None,
+        #[cfg(feature = "chargebee")]
+        chargebee: None,
+        #[cfg(feature = "paypal")]
+        paypal: None,
+        hosting: None,
+        steer: crate::company::steer::InflightRegistry::default(),
+        run_supervisor: crate::runtime::RunSupervisor::default(),
+        delivery: None,
+        workspace: None,
+        repos: None,
+        repo_bindings: Vec::new(),
+        checkouts: crate::harness::repo::CheckoutLedger::default(),
+        search: None,
+    };
+    (deps, ops)
+}
+
+/// An operator message, the shape a chat turn arrives as.
+fn chat(text: &str) -> CycleRequest {
+    CycleRequest {
+        cycle_id: "cycle-1".to_string(),
+        company_id: company(),
+        events: vec![CompanyEvent::OperatorMessage {
+            text: text.to_string(),
+            by: None,
+            chat: None,
+            parent: None,
+            deliverable: None,
+        }],
+        event_seqs: Vec::new(),
+        compressed_history: Vec::new(),
+        roster: Vec::new(),
+        context_index: Vec::new(),
+    }
+}
+
+/// Everything the turn wrote back to memory, newest-agnostic.
+async fn memory_bodies(context: &FsContextStore) -> Vec<String> {
+    let metas = context
+        .list(&company(), memory_loop::OUTCOME_LABEL_PREFIX)
+        .await
+        .expect("list memory");
+    let mut bodies = Vec::new();
+    for meta in metas {
+        bodies.push(
+            context
+                .peek(&company(), &meta.addr, None)
+                .await
+                .expect("peek memory"),
+        );
+    }
+    bodies
+}
+
+/// The operator-channel bubbles a cycle produced.
+fn operator_bubbles(responses: &[OutboundMessage]) -> Vec<&OutboundMessage> {
+    responses
+        .iter()
+        .filter(|m| m.channel == "operator")
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// The flag
+// ---------------------------------------------------------------------------
+
+/// **The headline.** A turn that spends its whole iteration budget on tool
+/// calls reports that it paused — and still comes back `Ok` with the
+/// checkpoint, because a cap is a pause and not an error.
+///
+/// Three assertions in one test on purpose: they are three readings of the same
+/// single turn, and splitting them would run the same eleven-call loop three
+/// times to learn nothing more.
+#[tokio::test]
+async fn a_turn_that_exhausts_its_iteration_budget_reports_the_pause() {
+    let (base_url, script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record();
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("a cap is a pause, not an error — the turn must return Ok");
+
+    // 1. The flag the whole feature hangs on.
+    assert!(
+        outcome.hit_iteration_cap,
+        "a turn that spent all {CAP} iterations on tool calls must report the cap"
+    );
+
+    // 2. It is still an ordinary, useful reply.
+    assert!(
+        !outcome.reply.trim().is_empty(),
+        "a capped turn still carries the checkpoint openhuman asked the model for"
+    );
+    assert_eq!(
+        outcome.reply.trim(),
+        CHECKPOINT,
+        "the reply is the model's checkpoint, verbatim"
+    );
+
+    // 3. The turn shape really was the cap branch, not the script running dry.
+    //    `CAP` tool round trips plus exactly one tools-disabled wrap-up.
+    assert_eq!(
+        script.calls(),
+        CAP + 1,
+        "expected {CAP} tool iterations plus one wrap-up call; if this moved, so did \
+         openhuman's max_tool_iterations default and `CAP` needs updating"
+    );
+    assert!(
+        !script.last_call_had_tools(),
+        "the wrap-up call must withhold tools — that is what makes it a checkpoint \
+         request rather than another iteration"
+    );
+}
+
+/// **The negative control.** The same fixture, a turn that finishes on its own,
+/// and the flag stays `false`.
+///
+/// Without this, `hit_iteration_cap: true` hardcoded at the read site would
+/// pass every other test in this file.
+#[tokio::test]
+async fn a_turn_that_finishes_on_its_own_reports_no_pause() {
+    let (base_url, script) = spawn_script(uncapped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, _ops) = deps_for(base_url, dir.path());
+    let rec = record();
+    let pool = HarnessPool::new();
+    pool.ensure(&rec, &deps).await.expect("pool ensures");
+
+    let outcome = pool
+        .run(&rec.id, AGENT, "Write a short feature spec.", &deps, None)
+        .await
+        .expect("turn runs");
+
+    assert!(
+        !outcome.hit_iteration_cap,
+        "two tool calls is well inside the cap — reporting a pause here would put the \
+         notice on turns that finished perfectly well"
+    );
+    assert_eq!(outcome.reply.trim(), CHECKPOINT);
+    assert!(
+        script.calls() < CAP,
+        "the control must finish inside the cap to be a control at all: {} calls",
+        script.calls()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What the operator sees
+// ---------------------------------------------------------------------------
+
+/// A capped chat turn reaches the operator as **two** bubbles: the agent's
+/// checkpoint, then the system saying it was cut off.
+///
+/// The second bubble is unauthored — no teammate said it — and carries no
+/// steps, because the timeline already rode in on the first.
+#[tokio::test]
+async fn a_capped_chat_turn_says_so_in_a_second_bubble() {
+    let (base_url, _script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        2,
+        "a capped turn owes the operator the reply AND the pause notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+
+    // The agent's answer, attributed to the agent.
+    assert_eq!(bubbles[0].text.trim(), CHECKPOINT);
+    assert_eq!(bubbles[0].agent.as_deref(), Some(AGENT));
+
+    // The system's notice, attributed to nobody.
+    assert_eq!(bubbles[1].text, ITERATION_CAP_PAUSE_NOTICE);
+    assert!(
+        bubbles[1].agent.is_none(),
+        "the platform's words must not be put in the agent's mouth"
+    );
+    assert!(
+        bubbles[1].steps.is_empty(),
+        "the timeline is already on the reply bubble; repeating it doubles every row"
+    );
+
+    // It has to actually say the three things the operator needs.
+    let notice = ITERATION_CAP_PAUSE_NOTICE;
+    assert!(notice.contains("pause"), "it must name the pause: {notice}");
+    assert!(
+        notice.contains("Nothing errored"),
+        "it must say nothing failed, or a budget reads as a crash: {notice}"
+    );
+    assert!(
+        notice.contains("continue"),
+        "it must tell the operator how to carry on: {notice}"
+    );
+}
+
+/// The same cycle, uncapped: exactly **one** bubble.
+///
+/// The pair is the real assertion — a notice that fires on every turn is as
+/// useless as one that never fires.
+#[tokio::test]
+async fn an_uncapped_chat_turn_says_nothing_extra() {
+    let (base_url, _script) = spawn_script(uncapped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    let result = brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bubbles = operator_bubbles(&result.channel_responses);
+    assert_eq!(
+        bubbles.len(),
+        1,
+        "a turn that finished owes no pause notice: {:?}",
+        bubbles.iter().map(|b| &b.text).collect::<Vec<_>>()
+    );
+    assert!(
+        !bubbles[0].text.contains(NOTICE_MARKER),
+        "and it must not be smuggled into the reply either"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// What memory keeps
+// ---------------------------------------------------------------------------
+
+/// The turn's memory write carries the agent's checkpoint and **not** the
+/// platform's notice.
+///
+/// This is why the notice is a sibling bubble rather than text appended to the
+/// reply. `HarnessPool::run` persists `outcome.reply` to the context store, so
+/// appending would file "you hit the step limit" as something the agent said —
+/// and the memory loop would recall it into a later turn as prior work.
+#[tokio::test]
+async fn the_pause_notice_never_reaches_memory() {
+    let (base_url, _script) = spawn_script(capped_script()).await;
+    let dir = tempfile::tempdir().unwrap();
+    let (deps, ops) = deps_for(base_url, dir.path());
+    let context = FsContextStore::new(dir.path());
+    let brain = HarnessBrain::new(Arc::new(HarnessPool::new()), deps, record()).with_runs(ops);
+
+    brain
+        .run_cycle(chat("Write a short feature spec."), &NoopHost)
+        .await
+        .expect("cycle runs");
+
+    let bodies = memory_bodies(&context).await;
+    assert!(
+        !bodies.is_empty(),
+        "the turn must have written its outcome back, or this proves nothing"
+    );
+    assert!(
+        bodies.iter().any(|b| b.contains(CHECKPOINT)),
+        "the agent's checkpoint is what compounds into later turns: {bodies:?}"
+    );
+    assert!(
+        bodies.iter().all(|b| !b.contains(NOTICE_MARKER)),
+        "the platform's pause notice must never be recalled as something the agent \
+         said: {bodies:?}"
+    );
+}

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -634,6 +634,25 @@ pub struct TurnOutcome {
     /// The scrubbed, folded processing steps (empty for a memory-served or
     /// tool-less turn — the zero-steps tell).
     pub steps: Vec<TurnStep>,
+    /// Whether this turn **paused at its tool-iteration cap** rather than
+    /// finishing what it set out to do (issue #926).
+    ///
+    /// A capped turn is not an error and never has been: openhuman stops the
+    /// tool loop, makes one extra tools-disabled call asking the model for a
+    /// resumable "Done so far / Next steps" checkpoint, and returns that as an
+    /// ordinary `Ok(reply)`. So the reply reads like a finished answer, and
+    /// nothing in the text, the steps or the error channel distinguishes "I
+    /// answered you" from "I ran out of steps mid-task" — which is exactly what
+    /// the operator could not tell.
+    ///
+    /// Read from openhuman's public
+    /// [`Agent::last_turn_hit_cap`](oh::agent::Agent::last_turn_hit_cap) while
+    /// the agent lock is still held, the same under-lock idiom
+    /// [`read_turn_usage`] uses. `false` on every path that returns an outcome
+    /// **without** running a model turn (the two pre-turn budget refusals, the
+    /// ACP fold) — a refusal is not a pause, and labelling one as a cap hit
+    /// would tell the operator to reply "continue" to a turn that never ran.
+    pub hit_iteration_cap: bool,
 }
 
 impl CompanyAgent {
@@ -795,12 +814,45 @@ impl CompanyAgent {
         // still runs this cleanup before propagating, so the collector never
         // leaks.
         agent.set_on_progress(None);
+        // Issue #926: read the cap flag while the lock is still held, the same
+        // under-lock idiom `read_turn_usage` uses above. Not draining, so the
+        // retry path's second attempt simply overwrites the first's value —
+        // which is right: the outcome describes the attempt that produced the
+        // reply being returned.
+        let hit_iteration_cap = agent.last_turn_hit_cap();
         drop(agent);
         let events = collector.await.unwrap_or_default();
+        // The cap openhuman was actually enforcing, for the trace only. Taken
+        // from the last `IterationStarted` rather than from config, so the log
+        // reports the number the turn ran under instead of the one this crate
+        // believes it configured. Deliberately NOT plumbed into the operator
+        // notice: one notice can cover a responder turn, a desk turn and a
+        // relay turn, and naming one of their caps would be a number the
+        // operator cannot map back to anything.
+        let iteration_cap = events.iter().rev().find_map(|event| match event {
+            oh::agent::progress::AgentProgress::IterationStarted { max_iterations, .. } => {
+                Some(*max_iterations)
+            }
+            _ => None,
+        });
+        if hit_iteration_cap {
+            tracing::info!(
+                agent = %self.agent_id,
+                iteration_cap,
+                "[turn] paused at the tool-iteration cap; the reply is a resumable checkpoint, not a finished answer"
+            );
+        }
         let steps = steps::fold_steps(events);
 
         let reply = reply?;
-        Ok((TurnOutcome { reply, steps }, usages))
+        Ok((
+            TurnOutcome {
+                reply,
+                steps,
+                hit_iteration_cap,
+            },
+            usages,
+        ))
     }
 
     /// Classify one `agent.turn` result for the retry wrapper.
@@ -1938,6 +1990,9 @@ impl HarnessPool {
                             return Some(TurnOutcome {
                                 reply: TOTAL_BUDGET_EXHAUSTED_NOTICE.to_string(),
                                 steps: Vec::new(),
+                                // No model call ran, so no cap was reached
+                                // (issue #926). A refusal is not a pause.
+                                hit_iteration_cap: false,
                             });
                         }
                     }
@@ -2181,6 +2236,9 @@ impl HarnessPool {
                                 return Ok(TurnOutcome {
                                     reply: agent_budget_exhausted_notice(agent_id, cap),
                                     steps: Vec::new(),
+                                    // No model call ran, so no cap was reached
+                                    // (issue #926). A refusal is not a pause.
+                                    hit_iteration_cap: false,
                                 });
                             }
                         }

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -50,6 +50,12 @@ pub mod acp_run_turn;
 pub mod audit;
 pub mod brain;
 pub mod build;
+/// Issue #989 (Part 2a of #926): end-to-end proof that a **chat** turn which
+/// pauses at its tool-iteration cap runs the same #244 unpublished-work scan
+/// and nudge the task-dispatch path (`run_task`) already gets — and that a
+/// capped turn which wrote nothing is not nudged on top of it. Test-only.
+#[cfg(test)]
+mod cap_publish_test;
 /// Issue #926: end-to-end proof that a turn which exhausts its tool-iteration
 /// budget pauses **visibly** — the flag is read, the operator gets a second
 /// bubble saying so, and the notice never reaches memory. Test-only.

--- a/src/harness/mod.rs
+++ b/src/harness/mod.rs
@@ -50,6 +50,11 @@ pub mod acp_run_turn;
 pub mod audit;
 pub mod brain;
 pub mod build;
+/// Issue #926: end-to-end proof that a turn which exhausts its tool-iteration
+/// budget pauses **visibly** — the flag is read, the operator gets a second
+/// bubble saying so, and the notice never reaches memory. Test-only.
+#[cfg(test)]
+mod cap_turn_test;
 pub mod capability_budget;
 #[cfg(feature = "chargebee")]
 pub mod chargebee;

--- a/src/runtime/delegation.rs
+++ b/src/runtime/delegation.rs
@@ -300,6 +300,13 @@ pub(crate) struct DeskReply {
     pub(crate) member: String,
     pub(crate) reply: String,
     pub(crate) steps: Vec<TurnStep>,
+    /// Whether this teammate's turn — or any turn nested beneath it — paused at
+    /// its tool-iteration cap (issue #926).
+    ///
+    /// Folded the same way `reply` and `steps` are: a deeper delegate's work is
+    /// folded INTO this member's answer rather than surfacing on its own, so a
+    /// cap two levels down is a cap on what the operator reads here.
+    pub(crate) hit_iteration_cap: bool,
 }
 
 /// What was already decided about the operator message a drain belongs to,
@@ -387,6 +394,16 @@ pub(crate) struct OperatorTurn {
     /// on. The resulting claim is incomplete but never wrong, and the bubble's
     /// step timeline still shows every `spawn_task` the turn made.
     pub(crate) spawned_task: Option<String>,
+    /// Whether **any** turn behind this bubble paused at its tool-iteration cap
+    /// (issue #926) — the responder's, a desk lead's, or the CEO relay's.
+    ///
+    /// A sticky OR rather than "the last turn's value", because one operator
+    /// message can run several turns and the operator gets exactly ONE bubble
+    /// for the whole chain. The relay turn in particular *replaces* the reply
+    /// text, so tracking the last value would erase a cap the responder or a
+    /// delegate hit — the operator would read a relayed answer that quietly
+    /// omits that a branch of it stopped half-done.
+    pub(crate) hit_iteration_cap: bool,
 }
 
 /// What a **dispatched card's** turn handed off (issue #204).
@@ -916,6 +933,10 @@ impl<'a> DelegationRunner<'a> {
         // case the relay turn's reply replaces it (below).
         let mut operator_steps = outcome.steps;
         let mut operator_reply = outcome.reply;
+        // Issue #926: sticky from here to the `OperatorTurn` below — never
+        // reassigned, only OR'd — so a cap the responder hit survives the relay
+        // turn replacing the reply text.
+        let mut hit_iteration_cap = outcome.hit_iteration_cap;
         // Settle the direct-answer card from the turn that just ran. Done before
         // the delegation drain because a direct responder queues nothing — it
         // has no delegation tools — so there is no relay turn coming that could
@@ -962,6 +983,7 @@ impl<'a> DelegationRunner<'a> {
             // Fold the teammate's activity onto the operator timeline, then
             // remember the answer to relay.
             operator_steps.extend(desk.steps);
+            hit_iteration_cap |= desk.hit_iteration_cap;
             desk_replies.push((desk.member, desk.reply));
         }
         // CEO-relay hand-back: when a synchronous desk delegation answered, run
@@ -1030,6 +1052,7 @@ impl<'a> DelegationRunner<'a> {
             }
             operator_reply = relay.reply;
             operator_steps.extend(relay.steps);
+            hit_iteration_cap |= relay.hit_iteration_cap;
         }
         // Drained after the relay, not before it: a relay turn carries the same
         // inline `create_workflow` tool, so draining at the responder's turn
@@ -1053,6 +1076,7 @@ impl<'a> DelegationRunner<'a> {
             steps: operator_steps,
             bubbles,
             spawned_task,
+            hit_iteration_cap,
         })
     }
 
@@ -1593,12 +1617,17 @@ impl<'a> DelegationRunner<'a> {
         // the operator's timeline shows the deeper member working.
         let mut reply = outcome.reply;
         let mut steps = outcome.steps;
+        // Issue #926: the cap folds in exactly as the reply and steps do. A
+        // deeper delegate that stopped half-done is folded into THIS member's
+        // answer, so its pause is a pause on what the operator ends up reading.
+        let mut hit_iteration_cap = outcome.hit_iteration_cap;
         for deeper in nested.desk_replies {
             reply.push_str(&format!(
                 "\n\n{} (delegated by {member}) replied:\n{}",
                 deeper.member, deeper.reply
             ));
             steps.extend(deeper.steps);
+            hit_iteration_cap |= deeper.hit_iteration_cap;
         }
         // A cancelled nested run folds in as a cancellation, NEVER as a
         // reply: the member said it was handing that slice on, and an
@@ -1638,6 +1667,7 @@ impl<'a> DelegationRunner<'a> {
                 member,
                 reply,
                 steps,
+                hit_iteration_cap,
             }),
             cancelled: false,
             // Issue #442: the hand-off's own card, reported the same way
@@ -3105,6 +3135,9 @@ one-off, so a card for it has been opened and the workflow builder owns authorin
             TurnOutcome {
                 reply: turn.reply,
                 steps: Vec::new(),
+                // These fixtures script delegation shapes, not cap behaviour;
+                // the cap path is proved end-to-end in `cap_turn_test`.
+                hit_iteration_cap: false,
             }
         }
     }


### PR DESCRIPTION
## Summary

Part 2a of #926. #244 already added a scan that notices an agent wrote something to its sandbox but never called `publish_artifact`, and nudges about it — but that scan only ever ran on the task-dispatch path (`run_task`). A **chat** turn that pauses at its tool-iteration cap (Part 1 of #926, `TurnOutcome::hit_iteration_cap`) got the "I paused" notice and nothing else — a file it had already written was left unmentioned, with the operator having no way to know it exists.

This wires the same scan and the same one follow-up nudge (`nudge_for_unpublished`, unchanged) into the chat path, gated on `turn.hit_iteration_cap`. The publish claim stays live through the nudge, so if the agent actually publishes in response to the nudge, that recovery is filed exactly like any other conversation publish rather than being silently dropped once the primary turn's own drain already ran — extracted the shared filing logic (`file_conversation_batch`) so both drains go through one path.

**Note:** this PR's diff includes Part 1's commits (`caee7fab`..`7677ebc3`) until #996 merges, since this branch is stacked on top of it.

**Honest scoping note:** this does **not** fix the incident originally reported in #926 — in that turn nothing had been written to the sandbox when the cap landed, so there was no partial artifact to recover. That repro is addressed by #988 (raising the cap). #989 stands on its own merits: a capped turn that *did* write something must not have that work silently dropped.

## API Or Behavior Changes

A chat turn that pauses at its tool-iteration cap after writing unpublished files to its sandbox now gets one follow-up nudge asking whether any of them is the deliverable — the same nudge a dispatched task's cap-free path already gets. A capped turn that wrote nothing, and any turn that finishes without hitting the cap, are unaffected (no new nudge on either).

## Tests

- `cargo fmt --all -- --check`
- `cargo clippy --locked --no-deps --features openhuman,tinycortex --all-targets -- -D warnings`
- `cargo test --locked --features openhuman,tinycortex --lib harness::` (1046 passed)

New end-to-end coverage in `src/harness/cap_publish_test.rs` (real `HarnessBrain`, real `HostedProvider` against a scripted loopback endpoint):
- a capped chat turn that wrote unpublished work gets exactly one nudge
- the nudge can actually recover a deliverable (files onto a minted card, artifact reachable)
- a capped turn that wrote nothing gets no nudge (no false positives — the cap will be hit routinely once #988 lands)
- an uncapped chat turn with unpublished work is unaffected (existing #244 scope, unchanged)

Prove-red: stashed the `brain.rs` implementation and reran the new tests against pre-fix code. The headline test failed as expected (`nudge_turns` read `0`, expected `1`); the two negative controls stayed green.

## Documentation

None needed — this extends an existing, already-documented mechanism (#244) to a new trigger condition; no new public surface.

## Related

Closes #989
Part of #926
